### PR TITLE
[OSQuery] update Cypress initializeDataViews method

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/add_integration.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/add_integration.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { login } from '../../tasks/login';
 import { LIVE_QUERY_EDITOR } from '../../screens/live_query';
 import {
   ADD_PACK_HEADER_BUTTON,
@@ -14,8 +15,8 @@ import {
   TABLE_ROWS,
 } from '../../screens/packs';
 import {
-  cleanupPack,
   cleanupAgentPolicy,
+  cleanupPack,
   cleanupSavedQuery,
   loadSavedQuery,
 } from '../../tasks/api_fixtures';
@@ -29,13 +30,13 @@ import {
 } from '../../tasks/navigation';
 import {
   addCustomIntegration,
+  checkDataStreamsInPolicyDetails,
   closeModalIfVisible,
   generateRandomStringName,
   integrationExistsWithinPolicyDetails,
-  interceptPackId,
   interceptAgentPolicyId,
+  interceptPackId,
   policyContainsIntegration,
-  checkDataStreamsInPolicyDetails,
 } from '../../tasks/integrations';
 import { ServerlessRoleName } from '../../support/roles';
 
@@ -50,7 +51,7 @@ describe.skip('ALL - Add Integration', { tags: ['@ess', '@serverless'] }, () => 
   });
 
   beforeEach(() => {
-    cy.login(ServerlessRoleName.PLATFORM_ENGINEER);
+    login(ServerlessRoleName.PLATFORM_ENGINEER);
   });
 
   after(() => {
@@ -104,6 +105,7 @@ describe.skip('ALL - Add Integration', { tags: ['@ess', '@serverless'] }, () => 
       cy.contains(`version: ${oldVersion}`).should('not.exist');
     });
   });
+
   // FLAKY: https://github.com/elastic/kibana/issues/170593
   describe.skip('Add integration to policy', () => {
     const [integrationName, policyName] = generateRandomStringName(2);

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_automated_action_results.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_automated_action_results.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { initializeDataViews } from '../../tasks/login';
+import { login } from '../../tasks/login';
 import { cleanupRule, loadRule } from '../../tasks/api_fixtures';
 import { checkActionItemsInResults, loadRuleAlerts, navigateToRule } from '../../tasks/live_query';
 
@@ -19,7 +19,6 @@ describe(
     let ruleName: string;
 
     before(() => {
-      initializeDataViews();
       loadRule(true).then((data) => {
         ruleId = data.id;
         ruleName = data.name;
@@ -28,6 +27,7 @@ describe(
     });
 
     beforeEach(() => {
+      login();
       navigateToRule(ruleName);
     });
 

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_cases.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_cases.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { initializeDataViews } from '../../tasks/login';
+import { login } from '../../tasks/login';
 import { OSQUERY_FLYOUT_BODY_EDITOR } from '../../screens/live_query';
 import {
   cleanupCase,
@@ -36,7 +36,7 @@ describe.skip(
     const packData = packFixture();
 
     beforeEach(() => {
-      initializeDataViews();
+      login();
       loadPack(packData).then((data) => {
         packId = data.saved_object_id;
         packName = data.name;

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_linked_apps.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_linked_apps.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { initializeDataViews } from '../../tasks/login';
+import { login } from '../../tasks/login';
 import { cleanupRule, loadRule } from '../../tasks/api_fixtures';
 import { RESPONSE_ACTIONS_ITEM_0, RESPONSE_ACTIONS_ITEM_1 } from '../../tasks/response_actions';
 import {
@@ -26,8 +26,9 @@ describe.skip(
   () => {
     let ruleId: string;
     let ruleName: string;
+
     beforeEach(() => {
-      initializeDataViews();
+      login();
       loadRule().then((data) => {
         ruleId = data.id;
         ruleName = data.name;

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_multiple_agents.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_multiple_agents.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { initializeDataViews } from '../../tasks/login';
+import { login } from '../../tasks/login';
 import { cleanupRule, loadRule } from '../../tasks/api_fixtures';
 import {
   inputQuery,
@@ -25,19 +25,19 @@ describe(
     let ruleName: string;
 
     before(() => {
-      initializeDataViews();
       loadRule(true).then((data) => {
         ruleId = data.id;
         ruleName = data.name;
       });
     });
 
-    after(() => {
-      cleanupRule(ruleId);
+    beforeEach(() => {
+      login();
+      loadRuleAlerts(ruleName);
     });
 
-    beforeEach(() => {
-      loadRuleAlerts(ruleName);
+    after(() => {
+      cleanupRule(ruleId);
     });
 
     it('should substitute parameters in investigation guide', () => {

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_response_actions_form.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_response_actions_form.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { initializeDataViews } from '../../tasks/login';
+import { login } from '../../tasks/login';
 import {
   cleanupPack,
   cleanupRule,
@@ -15,8 +15,8 @@ import {
   packFixture,
 } from '../../tasks/api_fixtures';
 import {
-  RESPONSE_ACTIONS_ERRORS,
   OSQUERY_RESPONSE_ACTION_ADD_BUTTON,
+  RESPONSE_ACTIONS_ERRORS,
   RESPONSE_ACTIONS_ITEM_0,
   RESPONSE_ACTIONS_ITEM_1,
   RESPONSE_ACTIONS_ITEM_2,
@@ -36,10 +36,9 @@ describe(
     let packName: string;
     const packData = packFixture();
     const multiQueryPackData = multiQueryPackFixture();
-    before(() => {
-      initializeDataViews();
-    });
+
     beforeEach(() => {
+      login();
       loadPack(packData).then((data) => {
         packId = data.saved_object_id;
         packName = data.name;
@@ -53,6 +52,7 @@ describe(
         ruleName = data.name;
       });
     });
+
     afterEach(() => {
       cleanupPack(packId);
       cleanupPack(multiQueryPackId);

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/cases.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/cases.cy.ts
@@ -5,21 +5,20 @@
  * 2.0.
  */
 
-import { ServerlessRoleName } from '../../support/roles';
-import { initializeDataViews } from '../../tasks/login';
+import { login } from '../../tasks/login';
 import {
   addLiveQueryToCase,
   checkActionItemsInResults,
   viewRecentCaseAndCheckResults,
 } from '../../tasks/live_query';
 import { navigateTo } from '../../tasks/navigation';
-import { loadLiveQuery, loadCase, cleanupCase } from '../../tasks/api_fixtures';
+import { cleanupCase, loadCase, loadLiveQuery } from '../../tasks/api_fixtures';
 
 describe('Add to Cases', () => {
   let liveQueryId: string;
   let liveQueryQuery: string;
+
   before(() => {
-    initializeDataViews();
     loadLiveQuery({
       agent_all: true,
       query: 'SELECT * FROM os_version;',
@@ -30,15 +29,19 @@ describe('Add to Cases', () => {
     });
   });
 
+  beforeEach(() => {
+    login();
+  });
+
   describe('observability', { tags: ['@ess'] }, () => {
     let caseId: string;
     let caseTitle: string;
+
     beforeEach(() => {
       loadCase('observability').then((caseInfo) => {
         caseId = caseInfo.id;
         caseTitle = caseInfo.title;
       });
-      cy.login(ServerlessRoleName.SOC_MANAGER, false);
       navigateTo('/app/osquery');
     });
 
@@ -70,7 +73,6 @@ describe('Add to Cases', () => {
         caseId = caseInfo.id;
         caseTitle = caseInfo.title;
       });
-      cy.login(ServerlessRoleName.SOC_MANAGER, false);
       navigateTo('/app/osquery');
     });
 

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/custom_space.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/custom_space.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { initializeDataViews } from '../../tasks/login';
+import { login } from '../../tasks/login';
 import { navigateTo } from '../../tasks/navigation';
 import {
   checkActionItemsInResults,
@@ -14,8 +14,7 @@ import {
   selectAllAgents,
   submitQuery,
 } from '../../tasks/live_query';
-import { loadSpace, loadPack, cleanupPack, cleanupSpace } from '../../tasks/api_fixtures';
-import { ServerlessRoleName } from '../../support/roles';
+import { cleanupPack, cleanupSpace, loadPack, loadSpace } from '../../tasks/api_fixtures';
 
 const testSpaces = [
   { name: 'default', tags: ['@ess', '@serverless', '@brokenInServerless'] },
@@ -29,7 +28,6 @@ describe('ALL - Custom space', () => {
       let spaceId: string;
 
       before(() => {
-        initializeDataViews();
         cy.wrap(
           new Promise<string>((resolve) => {
             if (testSpace.name !== 'default') {
@@ -62,7 +60,7 @@ describe('ALL - Custom space', () => {
       });
 
       beforeEach(() => {
-        cy.login(ServerlessRoleName.SOC_MANAGER);
+        login();
         navigateTo(`/s/${spaceId}/app/osquery`);
       });
 

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/ecs_mappings.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/ecs_mappings.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { initializeDataViews } from '../../tasks/login';
+import { login } from '../../tasks/login';
 import { getAdvancedButton } from '../../screens/integrations';
 import { navigateTo } from '../../tasks/navigation';
 import {
@@ -21,7 +21,7 @@ import {
 // FLAKY: https://github.com/elastic/kibana/issues/218380
 describe.skip('EcsMapping', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
   beforeEach(() => {
-    initializeDataViews();
+    login();
   });
 
   it('should properly show static values in form and results', () => {

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/edit_saved_queries.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/edit_saved_queries.cy.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
+import { login } from '../../tasks/login';
 import { customActionEditSavedQuerySelector, UPDATE_QUERY_BUTTON } from '../../screens/packs';
 import { navigateTo } from '../../tasks/navigation';
-import { loadSavedQuery, cleanupSavedQuery } from '../../tasks/api_fixtures';
-import { ServerlessRoleName } from '../../support/roles';
+import { cleanupSavedQuery, loadSavedQuery } from '../../tasks/api_fixtures';
 
 describe('ALL - Edit saved query', { tags: ['@ess', '@serverless'] }, () => {
   let savedQueryName: string;
@@ -22,7 +22,7 @@ describe('ALL - Edit saved query', { tags: ['@ess', '@serverless'] }, () => {
   });
 
   beforeEach(() => {
-    cy.login(ServerlessRoleName.SOC_MANAGER);
+    login();
     navigateTo('/app/osquery/saved_queries');
   });
 

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { login } from '../../tasks/login';
 import { navigateTo } from '../../tasks/navigation';
 import {
   checkResults,
@@ -17,11 +18,10 @@ import {
 } from '../../tasks/live_query';
 import { LIVE_QUERY_EDITOR } from '../../screens/live_query';
 import { getAdvancedButton } from '../../screens/integrations';
-import { ServerlessRoleName } from '../../support/roles';
 
 describe('ALL - Live Query', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
-    cy.login(ServerlessRoleName.SOC_MANAGER);
+    login();
     navigateTo('/app/osquery');
   });
 

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query_packs.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query_packs.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { login } from '../../tasks/login';
 import { navigateTo } from '../../tasks/navigation';
 import {
   addToCase,
@@ -15,8 +16,7 @@ import {
   viewRecentCaseAndCheckResults,
 } from '../../tasks/live_query';
 import { LIVE_QUERY_EDITOR } from '../../screens/live_query';
-import { loadPack, cleanupPack, cleanupCase, loadCase } from '../../tasks/api_fixtures';
-import { ServerlessRoleName } from '../../support/roles';
+import { cleanupCase, cleanupPack, loadCase, loadPack } from '../../tasks/api_fixtures';
 
 // FLAKY: https://github.com/elastic/kibana/issues/169888
 describe.skip('ALL - Live Query Packs', { tags: ['@ess', '@serverless'] }, () => {
@@ -59,7 +59,7 @@ describe.skip('ALL - Live Query Packs', { tags: ['@ess', '@serverless'] }, () =>
   });
 
   beforeEach(() => {
-    cy.login(ServerlessRoleName.SOC_MANAGER);
+    login();
     navigateTo('/app/osquery');
   });
 

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query_run.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query_run.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { login } from '../../tasks/login';
 import { SAVED_QUERY_DROPDOWN_SELECT } from '../../screens/packs';
 import { navigateTo } from '../../tasks/navigation';
 import {
@@ -20,8 +21,7 @@ import {
 } from '../../tasks/live_query';
 import { LIVE_QUERY_EDITOR, RESULTS_TABLE, RESULTS_TABLE_BUTTON } from '../../screens/live_query';
 import { getAdvancedButton } from '../../screens/integrations';
-import { loadSavedQuery, cleanupSavedQuery } from '../../tasks/api_fixtures';
-import { ServerlessRoleName } from '../../support/roles';
+import { cleanupSavedQuery, loadSavedQuery } from '../../tasks/api_fixtures';
 
 describe(
   'ALL - Live Query run custom and saved',
@@ -42,7 +42,7 @@ describe(
     });
 
     beforeEach(() => {
-      cy.login(ServerlessRoleName.SOC_MANAGER);
+      login();
       navigateTo('/app/osquery');
     });
 

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/metrics.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/metrics.cy.ts
@@ -5,17 +5,18 @@
  * 2.0.
  */
 
+import { login } from '../../tasks/login';
 import { navigateTo } from '../../tasks/navigation';
 import { checkResults, inputQuery, submitQuery } from '../../tasks/live_query';
-import { loadSavedQuery, cleanupSavedQuery } from '../../tasks/api_fixtures';
+import { cleanupSavedQuery, loadSavedQuery } from '../../tasks/api_fixtures';
 import { triggerLoadData } from '../../tasks/inventory';
-import { ServerlessRoleName } from '../../support/roles';
 
 describe('ALL - Inventory', { tags: ['@ess'] }, () => {
   let savedQueryName: string;
   let savedQueryId: string;
 
   beforeEach(() => {
+    login();
     loadSavedQuery().then((data) => {
       savedQueryId = data.saved_object_id;
       savedQueryName = data.id;
@@ -28,7 +29,6 @@ describe('ALL - Inventory', { tags: ['@ess'] }, () => {
 
   describe('', () => {
     beforeEach(() => {
-      cy.login(ServerlessRoleName.SOC_MANAGER);
       navigateTo('/app/osquery');
     });
 

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/packs_create_edit.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/packs_create_edit.cy.ts
@@ -7,20 +7,21 @@
 
 import { recurse } from 'cypress-recurse';
 import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import { login } from '../../tasks/login';
 import {
   ADD_PACK_HEADER_BUTTON,
   ADD_QUERY_BUTTON,
-  SAVE_PACK_BUTTON,
-  FLYOUT_SAVED_QUERY_SAVE_BUTTON,
   customActionEditSavedQuerySelector,
-  POLICY_SELECT_COMBOBOX,
-  EDIT_PACK_HEADER_BUTTON,
-  SAVED_QUERY_DROPDOWN_SELECT,
-  UPDATE_PACK_BUTTON,
-  TABLE_ROWS,
-  formFieldInputSelector,
-  FLYOUT_SAVED_QUERY_CANCEL_BUTTON,
   customActionRunSavedQuerySelector,
+  EDIT_PACK_HEADER_BUTTON,
+  FLYOUT_SAVED_QUERY_CANCEL_BUTTON,
+  FLYOUT_SAVED_QUERY_SAVE_BUTTON,
+  formFieldInputSelector,
+  POLICY_SELECT_COMBOBOX,
+  SAVE_PACK_BUTTON,
+  SAVED_QUERY_DROPDOWN_SELECT,
+  TABLE_ROWS,
+  UPDATE_PACK_BUTTON,
 } from '../../screens/packs';
 import { API_VERSIONS } from '../../../common/constants';
 import { navigateTo } from '../../tasks/navigation';
@@ -34,9 +35,8 @@ import {
 } from '../../tasks/integrations';
 import { DEFAULT_POLICY } from '../../screens/fleet';
 import { getIdFormField, LIVE_QUERY_EDITOR } from '../../screens/live_query';
-import { loadSavedQuery, cleanupSavedQuery, cleanupPack, loadPack } from '../../tasks/api_fixtures';
+import { cleanupPack, cleanupSavedQuery, loadPack, loadSavedQuery } from '../../tasks/api_fixtures';
 import { request } from '../../tasks/common';
-import { ServerlessRoleName } from '../../support/roles';
 
 describe(
   'Packs - Create and Edit',
@@ -101,7 +101,7 @@ describe(
     });
 
     beforeEach(() => {
-      cy.login(ServerlessRoleName.SOC_MANAGER);
+      login();
       navigateTo('/app/osquery');
     });
 
@@ -129,7 +129,7 @@ describe(
         const packName = 'ResultType' + generateRandomStringName(1)[0];
 
         cy.contains('Packs').click();
-        cy.getBySel(ADD_PACK_HEADER_BUTTON).click();
+        cy.getBySel(ADD_PACK_HEADER_BUTTON).first().click();
         cy.get(formFieldInputSelector('name')).type(`${packName}{downArrow}{enter}`);
 
         cy.getBySel(ADD_QUERY_BUTTON).click();
@@ -258,7 +258,7 @@ describe(
       it('should add a pack from a saved query', () => {
         cy.contains('Packs').click();
 
-        cy.getBySel(ADD_PACK_HEADER_BUTTON).click();
+        cy.getBySel(ADD_PACK_HEADER_BUTTON).first().click();
         cy.get(formFieldInputSelector('name')).type(`${packName}{downArrow}{enter}`);
         cy.get(formFieldInputSelector('description')).type(`Pack description{downArrow}{enter}`);
         cy.getBySel(POLICY_SELECT_COMBOBOX).type(`${DEFAULT_POLICY} {downArrow}{enter}`);

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/packs_integration.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/packs_integration.cy.ts
@@ -7,14 +7,15 @@
 
 import { find } from 'lodash';
 import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import { login } from '../../tasks/login';
 import {
   ADD_PACK_HEADER_BUTTON,
   EDIT_PACK_HEADER_BUTTON,
-  SAVE_PACK_BUTTON,
+  formFieldInputSelector,
   POLICY_SELECT_COMBOBOX,
+  SAVE_PACK_BUTTON,
   TABLE_ROWS,
   UPDATE_PACK_BUTTON,
-  formFieldInputSelector,
 } from '../../screens/packs';
 import { API_VERSIONS } from '../../../common/constants';
 import { FLEET_AGENT_POLICIES, navigateTo } from '../../tasks/navigation';
@@ -31,12 +32,12 @@ import {
   closeModalIfVisible,
   closeToastIfVisible,
   generateRandomStringName,
-  interceptPackId,
   interceptAgentPolicyId,
+  interceptPackId,
 } from '../../tasks/integrations';
 import { DEFAULT_POLICY, OSQUERY_POLICY } from '../../screens/fleet';
 import { LIVE_QUERY_EDITOR } from '../../screens/live_query';
-import { cleanupPack, cleanupAgentPolicy } from '../../tasks/api_fixtures';
+import { cleanupAgentPolicy, cleanupPack } from '../../tasks/api_fixtures';
 import { request } from '../../tasks/common';
 import { ServerlessRoleName } from '../../support/roles';
 
@@ -53,7 +54,7 @@ describe.skip('ALL - Packs', { tags: ['@ess', '@serverless'] }, () => {
       let REMOVING_PACK: string;
 
       beforeEach(() => {
-        cy.login(ServerlessRoleName.PLATFORM_ENGINEER);
+        login();
         AGENT_POLICY_NAME = `PackTest` + generateRandomStringName(1)[0];
         REMOVING_PACK = 'removing-pack' + generateRandomStringName(1)[0];
       });
@@ -107,16 +108,18 @@ describe.skip('ALL - Packs', { tags: ['@ess', '@serverless'] }, () => {
   );
 
   describe('Load prebuilt packs', { tags: ['@ess', '@serverless'] }, () => {
+    const PREBUILD_PACK_NAME = 'it-compliance';
+
     afterEach(() => {
       cleanupAllPrebuiltPacks();
     });
-    const PREBUILD_PACK_NAME = 'it-compliance';
 
     describe('', () => {
       beforeEach(() => {
-        cy.login(ServerlessRoleName.SOC_MANAGER);
+        login();
         navigateTo('/app/osquery/packs');
       });
+
       it('should load prebuilt packs', () => {
         cy.contains('Load Elastic prebuilt packs').click();
         cy.contains('Load Elastic prebuilt packs').should('not.exist');
@@ -150,6 +153,7 @@ describe.skip('ALL - Packs', { tags: ['@ess', '@serverless'] }, () => {
         cy.contains('Add Query').should('not.exist');
         cy.get('.euiTableRowCell--hasActions').should('not.exist');
       });
+
       it('should be able to delete prebuilt pack and add it again', () => {
         cy.contains(PREBUILD_PACK_NAME).click();
         cy.getBySel(EDIT_PACK_HEADER_BUTTON).click();
@@ -187,7 +191,7 @@ describe.skip('ALL - Packs', { tags: ['@ess', '@serverless'] }, () => {
 
   describe('Global packs', { tags: ['@ess', '@serverless'] }, () => {
     beforeEach(() => {
-      cy.login(ServerlessRoleName.PLATFORM_ENGINEER);
+      login(ServerlessRoleName.PLATFORM_ENGINEER);
       navigateTo('/app/osquery/packs');
     });
 

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/saved_queries.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/saved_queries.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { login } from '../../tasks/login';
 import { closeToastIfVisible, generateRandomStringName } from '../../tasks/integrations';
 import {
   LIVE_QUERY_EDITOR,
@@ -33,14 +34,13 @@ import {
 } from '../../tasks/live_query';
 import { navigateTo } from '../../tasks/navigation';
 import {
-  loadCase,
   cleanupCase,
-  loadPack,
   cleanupPack,
-  loadSavedQuery,
   cleanupSavedQuery,
+  loadCase,
+  loadPack,
+  loadSavedQuery,
 } from '../../tasks/api_fixtures';
-import { ServerlessRoleName } from '../../support/roles';
 import { getAdvancedButton } from '../../screens/integrations';
 
 describe('ALL - Saved queries', { tags: ['@ess', '@serverless'] }, () => {
@@ -53,7 +53,7 @@ describe('ALL - Saved queries', { tags: ['@ess', '@serverless'] }, () => {
   });
 
   beforeEach(() => {
-    cy.login(ServerlessRoleName.SOC_MANAGER);
+    login();
     navigateTo('/app/osquery');
   });
 
@@ -228,7 +228,7 @@ describe('ALL - Saved queries', { tags: ['@ess', '@serverless'] }, () => {
     });
 
     beforeEach(() => {
-      cy.login(ServerlessRoleName.SOC_MANAGER);
+      login();
       navigateTo('/app/osquery/saved_queries');
       cy.getBySel('tablePaginationPopoverButton').click();
       cy.getBySel('tablePagination-50-rows').click();

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/timelines.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/timelines.cy.ts
@@ -5,17 +5,13 @@
  * 2.0.
  */
 
-import { initializeDataViews } from '../../tasks/login';
+import { login } from '../../tasks/login';
 import { takeOsqueryActionWithParams } from '../../tasks/live_query';
-import { ServerlessRoleName } from '../../support/roles';
 import { disableNewFeaturesTours } from '../../tasks/navigation';
 
 describe('ALL - Timelines', { tags: ['@ess'] }, () => {
-  before(() => {
-    initializeDataViews();
-  });
   beforeEach(() => {
-    cy.login(ServerlessRoleName.SOC_MANAGER);
+    login();
   });
 
   it('should substitute osquery parameter on non-alert event take action', () => {

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/api/live_query_results.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/api/live_query_results.cy.ts
@@ -5,17 +5,17 @@
  * 2.0.
  */
 
+import { login } from '../../tasks/login';
 import { request } from '../../tasks/common';
 import { loadLiveQuery } from '../../tasks/api_fixtures';
 import { API_VERSIONS } from '../../../common/constants';
-import { ServerlessRoleName } from '../../support/roles';
 
 describe('Live query', { tags: ['@ess', '@serverless'] }, () => {
   let liveQueryId: string;
   let queriesQueryActionId: string;
 
   beforeEach(() => {
-    cy.login(ServerlessRoleName.SOC_MANAGER);
+    login();
     loadLiveQuery().then((liveQuery) => {
       liveQueryId = liveQuery.action_id;
       queriesQueryActionId = liveQuery.queries?.[0].action_id;
@@ -34,6 +34,7 @@ describe('Live query', { tags: ['@ess', '@serverless'] }, () => {
       });
     });
   });
+
   context('GET getLiveQueryResultsRoute', () => {
     it('validates we get successful response', () => {
       request({

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/api/packs.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/api/packs.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ServerlessRoleName } from '../../support/roles';
+import { login } from '../../tasks/login';
 import {
   addOsqueryToAgentPolicy,
   cleanupAgentPolicy,
@@ -20,7 +20,7 @@ describe('Packs', { tags: ['@ess', '@serverless'] }, () => {
   let policyId: string;
 
   beforeEach(() => {
-    cy.login(ServerlessRoleName.SOC_MANAGER);
+    login();
     loadAgentPolicy().then((item) => {
       policyId = item.id;
 
@@ -36,6 +36,7 @@ describe('Packs', { tags: ['@ess', '@serverless'] }, () => {
 
   describe('Duplicate policy ids', () => {
     let packId: string;
+
     beforeEach(() => {
       createPack({
         policy_ids: Array(1000).fill(policyId),
@@ -44,6 +45,7 @@ describe('Packs', { tags: ['@ess', '@serverless'] }, () => {
         expect(response.status).to.eq(200);
       });
     });
+
     afterEach(() => {
       cleanupPack(packId);
     });
@@ -59,6 +61,7 @@ describe('Packs', { tags: ['@ess', '@serverless'] }, () => {
 
   describe('Non existent policy id should return bad request error', () => {
     const nonExistentPolicyId = 'non-existent-policy-id';
+
     it('single non-existent policy id', () => {
       createPack({
         policy_ids: [nonExistentPolicyId],
@@ -67,6 +70,7 @@ describe('Packs', { tags: ['@ess', '@serverless'] }, () => {
         expect(response.body.message).to.contain(nonExistentPolicyId);
       });
     });
+
     it('multiple policy ids with one non-existent policy id', () => {
       createPack({
         policy_ids: [...Array(999).fill(policyId), nonExistentPolicyId],

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/roles/alert_test.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/roles/alert_test.cy.ts
@@ -7,9 +7,9 @@
 
 import { waitForAlertsToPopulate } from '@kbn/cypress-test-helper/src/services/alerting_services';
 import { disableNewFeaturesTours } from '../../tasks/navigation';
-import { initializeDataViews } from '../../tasks/login';
+import { login } from '../../tasks/login';
 import { checkResults, clickRuleName, submitQuery } from '../../tasks/live_query';
-import { loadRule, cleanupRule } from '../../tasks/api_fixtures';
+import { cleanupRule, loadRule } from '../../tasks/api_fixtures';
 import { ServerlessRoleName } from '../../support/roles';
 
 describe('Alert Test', { tags: ['@ess'] }, () => {
@@ -17,7 +17,6 @@ describe('Alert Test', { tags: ['@ess'] }, () => {
   let ruleId: string;
 
   before(() => {
-    initializeDataViews();
     loadRule().then((data) => {
       ruleName = data.name;
       ruleId = data.id;
@@ -26,7 +25,7 @@ describe('Alert Test', { tags: ['@ess'] }, () => {
 
   describe('t1_analyst role', () => {
     beforeEach(() => {
-      cy.login(ServerlessRoleName.T1_ANALYST);
+      login(ServerlessRoleName.T1_ANALYST);
 
       cy.visit('/app/security/rules', {
         onBeforeLoad: (win) => disableNewFeaturesTours(win),

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/roles/reader.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/roles/reader.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { login } from '../../tasks/login';
 import {
   activeStateSwitchComponentSelector,
   customActionEditSavedQuerySelector,
@@ -43,7 +44,7 @@ describe('Reader - only READ', { tags: ['@ess'] }, () => {
   });
 
   beforeEach(() => {
-    cy.login(ServerlessRoleName.READER);
+    login(ServerlessRoleName.READER);
   });
 
   after(() => {

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/roles/t1_and_t2_analyst.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/roles/t1_and_t2_analyst.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { login } from '../../tasks/login';
 import { navigateTo } from '../../tasks/navigation';
 import {
   checkActionItemsInResults,
@@ -46,7 +47,7 @@ describe(`T1 and T2 analysts`, { tags: ['@ess', '@serverless', '@skipInServerles
       });
 
       beforeEach(() => {
-        cy.login(role as ServerlessRoleName);
+        login(role as ServerlessRoleName);
       });
 
       after(() => {

--- a/x-pack/platform/plugins/shared/osquery/cypress/tasks/login.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/tasks/login.ts
@@ -5,17 +5,11 @@
  * 2.0.
  */
 
-import { disableNewFeaturesTours } from './navigation';
 import { ServerlessRoleName } from '../support/roles';
 
-// Login as a SOC_MANAGER to properly initialize Security Solution App
-export const initializeDataViews = () => {
-  cy.login(ServerlessRoleName.SOC_MANAGER);
-  cy.visit('/app/security/alerts', {
-    onBeforeLoad: (win) => disableNewFeaturesTours(win),
-  });
-  cy.getBySel('globalLoadingIndicator').should('exist');
-  // In serverless the app sometimes takes a long time to load with this check causing flakiness.
-  cy.getBySel('globalLoadingIndicator', { timeout: 1.5 * 60 * 1000 }).should('not.exist');
-  cy.getBySel('manage-alert-detection-rules').should('exist');
+/**
+ * By default, we log in as a SOC_MANAGER to properly initialize Security Solution App
+ */
+export const login = (role: ServerlessRoleName = ServerlessRoleName.SOC_MANAGER) => {
+  cy.login(role);
 };


### PR DESCRIPTION
## Context

I am in the process of refactoring the alerts page code (and have [this draft PR](https://github.com/elastic/kibana/pull/222457) open) but most of the OSQuery Cypress tests are failing (see [this build](https://buildkite.com/elastic/kibana-pull-request/builds/329886#_) for example).

Looking into where the failure is happening, I realized that the tests are failing pretty much instantly, as there is a infinite loop at the very beginning, when trying to load the alerts page. It seems that the page keeps refreshing...

https://github.com/user-attachments/assets/2a974d8f-4752-4ead-8127-2f2676366ef1

This PR changes the logic in the `initializeDataViews` method used in most of the OSQuery Cypress tests.
The previous implementation was doing something like this:
```typescript
cy.login(ServerlessRoleName.SOC_MANAGER);
cy.visit('/app/security/alerts', {
  onBeforeLoad: (win) => disableNewFeaturesTours(win),
});
cy.getBySel('globalLoadingIndicator').should('exist');
// In serverless the app sometimes takes a long time to load with this check causing flakiness.
cy.getBySel('globalLoadingIndicator', { timeout: 1.5 * 60 * 1000 }).should('not.exist');
cy.getBySel('manage-alert-detection-rules').should('exist');
```

This really confuses me as none of the OSQuery Cypress actually go through the alerts page??? So why navigating to the alerts page in the first place?
The name `initializeDataViews` is also confusing to me.

## Proposition of changes

This PR makes the following changes:
- rename `initializeDataViews` to `login`
- remove all the code in the `login` function that was navigating to the alerts page
- made the `login` function take a role as input, defaulted to `SOC_MANAGER` role as this is what most tests use
- updated tests accordingly, also moving the `login` calls to `beforeEach` instead of `before` (as it is recommended and safer)

### Checklist

- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9154
