### PR TITLE
Fix timeline modal fullscreen

### DIFF
--- a/src/core/packages/chrome/layout/core-chrome-layout-components/header/layout_header.styles.ts
+++ b/src/core/packages/chrome/layout/core-chrome-layout-components/header/layout_header.styles.ts
@@ -15,7 +15,7 @@ const root: EmotionFn = ({ euiTheme }) => css`
   grid-area: header;
   height: var(--kbn-layout--header-height);
   max-width: var(--kbn-layout--header-width);
-  z-index: var(--kbn-layout--aboveFlyoutLevel);
+  z-index: 1; /* has to be just above main application content */
 `;
 
 export const styles = {

--- a/src/core/packages/chrome/layout/core-chrome-layout/layouts/legacy-fixed/legacy_fixed_global_app_style.tsx
+++ b/src/core/packages/chrome/layout/core-chrome-layout/layouts/legacy-fixed/legacy_fixed_global_app_style.tsx
@@ -71,11 +71,20 @@ const globalLayoutStyles = (euiTheme: UseEuiTheme['euiTheme']) => css`
     );
 
     // for forward compatibility with grid layout,
-    --kbn-application--content-height: calc(100vh - var(--kbnAppHeadersOffset, 0px));
-    --kbn-application--content-top: var(--kbnAppHeadersOffset, var(--euiFixedHeadersOffset, 0));
+    // --kbn-layout--application includes everything except chrome's fixed headers
+    // for solution navigation, it also includes the top bar height (action menu)
+    --kbn-layout--application-top: var(--euiFixedHeadersOffset, 0px);
+    --kbn-layout--application-left: 0px;
+    --kbn-layout--application-bottom: 0px;
+    --kbn-layout--application-right: 0px;
+    --kbn-layout--application-height: calc(100vh - var(--kbn-layout--application-top, 0px));
+
+    // --kbn-application--content also excludes the top bar height (action menu)
+    --kbn-application--content-top: var(--kbnAppHeadersOffset, var(--euiFixedHeadersOffset, 0px));
     --kbn-application--content-left: 0px;
     --kbn-application--content-bottom: 0px;
     --kbn-application--content-right: 0px;
+    --kbn-application--content-height: calc(100vh - var(--kbn-application--content-top, 0px));
   }
 
   // Conditionally override :root CSS fixed header variable. Updating \`--euiFixedHeadersOffset\`

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.styles.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.styles.tsx
@@ -23,10 +23,10 @@ export const usePaneStyles = () => {
   return css`
     // euiOverlayMask styles
     position: fixed;
-    top: var(--kbn-application--content-top, 0px);
-    left: var(--kbn-application--content-left, 0px);
-    right: var(--kbn-application--content-right, 0px);
-    bottom: var(--kbn-application--content-bottom, 0px);
+    top: var(--kbn-layout--application-top, 0px);
+    left: var(--kbn-layout--application-left, 0px);
+    right: var(--kbn-layout--application-right, 0px);
+    bottom: var(--kbn-layout--application-bottom, 0px);
     // TODO EUI: add color with transparency
     background: ${transparentize(euiTheme.colors.ink, 0.5)};
     z-index: ${(euiTheme.levels.flyout as number) +
@@ -43,10 +43,10 @@ export const usePaneStyles = () => {
     .timeline-container {
       min-width: 150px;
       position: fixed;
-      top: var(--kbn-application--content-top, 0px);
-      left: var(--kbn-application--content-left, 0px);
-      right: var(--kbn-application--content-right, 0px);
-      bottom: var(--kbn-application--content-bottom, 0px);
+      top: var(--kbn-layout--application-top, 0px);
+      left: var(--kbn-layout--application-left, 0px);
+      right: var(--kbn-layout--application-right, 0px);
+      bottom: var(--kbn-layout--application-bottom, 0px);
       background: ${euiBackgroundColor(EuiTheme, 'plain')};
       ${euiCanAnimate} {
         animation: ${euiAnimSlideInUp(euiTheme.size.xxl)} ${euiTheme.animation.normal}


### PR DESCRIPTION
## Summary

Fix the regression introduced in https://github.com/elastic/kibana/pull/226995/. The timeline modal with solution navigation height isn't covering the top menu bar like it did before.

I tested the fix with all both: 

- classic nav old layout
- solution nav old layout
- classic nav new layout
- solution nav new layout


Issue:

<img width="1040" height="767" alt="9 2 - security - flyout+timeline png" src="https://github.com/user-attachments/assets/9c38f5ae-e9cb-4d80-8931-93efc00ae261" />


Fixed:

<img width="2399" height="1527" alt="Screenshot 2025-08-15 at 12 29 42" src="https://github.com/user-attachments/assets/32298356-76f4-4af9-92be-6f48a8e1aaa4" />


