### PR TITLE
[9.1] [Dashboard] fix references lost when returning to unsaved dashboard with by reference panels (#231517)

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -96,8 +96,8 @@ export function getDashboardApi({
     creationOptions
   );
   const unsavedChangesManager = initializeUnsavedChangesManager({
-    viewModeManager,
-    creationOptions,
+    viewMode$: viewModeManager.api.viewMode$,
+    storeUnsavedChanges: creationOptions?.useSessionStorageIntegration,
     controlGroupManager,
     lastSavedState: savedObjectResult?.dashboardInput ?? DEFAULT_DASHBOARD_STATE,
     layoutManager,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/unsaved_changes_manager.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/unsaved_changes_manager.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import { ViewMode } from '@kbn/presentation-publishing';
+import { initializeControlGroupManager } from './control_group_manager';
+import { initializeUnsavedChangesManager } from './unsaved_changes_manager';
+import { DEFAULT_DASHBOARD_STATE } from './default_dashboard_state';
+import { initializeLayoutManager } from './layout_manager';
+import { DashboardChildren } from './layout_manager/types';
+import { DashboardSettings, DashboardState, isDashboardSection } from '../../common';
+import { initializeSettingsManager } from './settings_manager';
+import { initializeUnifiedSearchManager } from './unified_search_manager';
+import type { DashboardPanel } from '../../server';
+
+jest.mock('../services/dashboard_backup_service', () => ({}));
+
+const controlGroupApi = {
+  hasUnsavedChanges$: new BehaviorSubject(false),
+};
+const controlGroupManagerMock = {
+  api: {
+    controlGroupApi$: new BehaviorSubject(controlGroupApi),
+  },
+  internalApi: {
+    serializeControlGroup: () => ({
+      controlGroupInput: {},
+      controlGroupReferences: [],
+    }),
+  },
+} as unknown as ReturnType<typeof initializeControlGroupManager>;
+const layoutUnsavedChanges$ = new BehaviorSubject<{ panels?: DashboardState['panels'] }>({});
+const layoutManagerMock = {
+  api: {
+    children$: new BehaviorSubject<DashboardChildren>({}),
+  },
+  internalApi: {
+    startComparing$: () => layoutUnsavedChanges$,
+    serializeLayout: () => {
+      const panels = layoutUnsavedChanges$.getValue()?.panels ?? [];
+      return {
+        panels,
+        // create one reference per panel
+        references: panels
+          .filter((panel) => !isDashboardSection(panel))
+          .map((panel, index) => ({
+            name: 'savedObjectRef',
+            type: (panel as DashboardPanel).type,
+            id: `savedObject${index + 1}`,
+          })),
+      };
+    },
+  },
+} as unknown as ReturnType<typeof initializeLayoutManager>;
+const settingsManagerMock = {
+  internalApi: {
+    startComparing$: () => new BehaviorSubject<Partial<DashboardSettings>>({}),
+  },
+} as unknown as ReturnType<typeof initializeSettingsManager>;
+const unifiedSearchManagerMock = {
+  internalApi: {
+    startComparing$: () =>
+      new BehaviorSubject<
+        Partial<Pick<DashboardState, 'filters' | 'query' | 'refreshInterval' | 'timeRange'>>
+      >({}),
+  },
+} as unknown as ReturnType<typeof initializeUnifiedSearchManager>;
+const getReferences = () => [];
+const savedObjectId$ = new BehaviorSubject<string | undefined>('dashboard1234');
+const viewMode$ = new BehaviorSubject<ViewMode>('edit');
+
+const setBackupStateMock = jest.fn();
+
+describe('unsavedChangesManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    layoutUnsavedChanges$.next({});
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require('../services/dashboard_backup_service').getDashboardBackupService = () => ({
+      setState: setBackupStateMock,
+    });
+  });
+
+  describe('onUnsavedChanges', () => {
+    describe('session state', () => {
+      test('should backup unsaved panel changes and references when only layout changes', (done) => {
+        initializeUnsavedChangesManager({
+          viewMode$,
+          storeUnsavedChanges: true,
+          controlGroupManager: controlGroupManagerMock,
+          lastSavedState: DEFAULT_DASHBOARD_STATE,
+          layoutManager: layoutManagerMock,
+          savedObjectId$,
+          settingsManager: settingsManagerMock,
+          unifiedSearchManager: unifiedSearchManagerMock,
+          getReferences,
+        });
+
+        setBackupStateMock.mockImplementation((id, backupState) => {
+          expect(id).toBe(savedObjectId$.value);
+          expect(backupState).toMatchInlineSnapshot(`
+            Object {
+              "panels": Array [
+                Object {
+                  "panelConfig": Object {
+                    "title": "New panel",
+                  },
+                  "type": "testType",
+                },
+              ],
+              "references": Array [
+                Object {
+                  "id": "savedObject1",
+                  "name": "savedObjectRef",
+                  "type": "testType",
+                },
+              ],
+              "viewMode": "edit",
+            }
+          `);
+          done();
+        });
+
+        layoutUnsavedChanges$.next({
+          panels: [
+            {
+              type: 'testType',
+              panelConfig: {
+                title: 'New panel',
+              },
+            } as unknown as DashboardPanel,
+          ],
+        });
+      });
+    });
+  });
+});

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/unsaved_changes_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/unsaved_changes_manager.ts
@@ -12,6 +12,7 @@ import { HasLastSavedChildState, childrenUnsavedChanges$ } from '@kbn/presentati
 import {
   PublishesSavedObjectId,
   PublishingSubject,
+  ViewMode,
   apiHasSerializableState,
 } from '@kbn/presentation-publishing';
 import { omit } from 'lodash';
@@ -28,10 +29,8 @@ import {
 import { getDashboardBackupService } from '../services/dashboard_backup_service';
 import { initializeLayoutManager } from './layout_manager';
 import { initializeSettingsManager } from './settings_manager';
-import { DashboardCreationOptions } from './types';
 import { DashboardState } from '../../common';
 import { initializeUnifiedSearchManager } from './unified_search_manager';
-import { initializeViewModeManager } from './view_mode_manager';
 import {
   CONTROL_GROUP_EMBEDDABLE_ID,
   initializeControlGroupManager,
@@ -44,19 +43,19 @@ export function initializeUnsavedChangesManager({
   savedObjectId$,
   lastSavedState,
   settingsManager,
-  viewModeManager,
-  creationOptions,
+  viewMode$,
+  storeUnsavedChanges,
   controlGroupManager,
   getReferences,
   unifiedSearchManager,
 }: {
   lastSavedState: DashboardState;
-  creationOptions?: DashboardCreationOptions;
+  storeUnsavedChanges?: boolean;
   getReferences: (id: string) => Reference[];
   savedObjectId$: PublishesSavedObjectId['savedObjectId$'];
   controlGroupManager: ReturnType<typeof initializeControlGroupManager>;
   layoutManager: ReturnType<typeof initializeLayoutManager>;
-  viewModeManager: ReturnType<typeof initializeViewModeManager>;
+  viewMode$: PublishingSubject<ViewMode>;
   settingsManager: ReturnType<typeof initializeSettingsManager>;
   unifiedSearchManager: ReturnType<typeof initializeUnifiedSearchManager>;
 }): {
@@ -101,7 +100,7 @@ export function initializeUnsavedChangesManager({
   );
 
   const unsavedChangesSubscription = combineLatest([
-    viewModeManager.api.viewMode$,
+    viewMode$,
     dashboardStateChanges$,
     hasPanelChanges$,
     controlGroupManager.api.controlGroupApi$.pipe(
@@ -114,14 +113,14 @@ export function initializeUnsavedChangesManager({
     .pipe(debounceTime(DEBOUNCE_TIME))
     .subscribe(([viewMode, dashboardChanges, hasPanelChanges, hasControlGroupChanges]) => {
       const hasDashboardChanges = Object.keys(dashboardChanges ?? {}).length > 0;
+      const hasLayoutChanges = dashboardChanges.panels;
       const hasUnsavedChanges = hasDashboardChanges || hasPanelChanges || hasControlGroupChanges;
 
       if (hasUnsavedChanges !== hasUnsavedChanges$.value) {
         hasUnsavedChanges$.next(hasUnsavedChanges);
       }
 
-      // backup unsaved changes if configured to do so
-      if (creationOptions?.useSessionStorageIntegration) {
+      if (storeUnsavedChanges) {
         const dashboardStateToBackup: Partial<DashboardState> = omit(dashboardChanges ?? {}, [
           'timeRange',
           'refreshInterval',
@@ -130,7 +129,7 @@ export function initializeUnsavedChangesManager({
         // always back up view mode. This allows us to know which Dashboards were last changed while in edit mode.
         dashboardStateToBackup.viewMode = viewMode;
         // Backup latest state from children that have unsaved changes
-        if (hasPanelChanges || hasControlGroupChanges) {
+        if (hasPanelChanges || hasControlGroupChanges || hasLayoutChanges) {
           const { panels, references } = layoutManager.internalApi.serializeLayout();
           const { controlGroupInput, controlGroupReferences } =
             controlGroupManager.internalApi.serializeControlGroup();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Dashboard] fix references lost when returning to unsaved dashboard with by reference panels (#231517)](https://github.com/elastic/kibana/pull/231517)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2025-08-14T20:53:54Z","message":"[Dashboard] fix references lost when returning to unsaved dashboard with by reference panels (#231517)\n\nCloses https://github.com/elastic/kibana/issues/231430\n\nPR updates session backup logic to ensure references are stored when\nonly layout changes. Even though regression only impacts main branch and\nserverless, backporting to 8.19 to resolve underlying issue exposed by\nregression in all branches.\n\nTest steps\n* install sample web logs\n* Create new dashboard\n* Click \"Add from library\" and add discover session to dashboard\n* without saving, use left nav menu to navigate to discover\n* use left nav menu to navigate back to dashboard. Dashboard should\nprevious dashboard in working state\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"f6b630463c3c898b97bc9acc1cca41d6325d5c98","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","backport:version","v9.2.0","v9.1.3","v8.19.3","v9.0.6"],"title":"[Dashboard] fix references lost when returning to unsaved dashboard with by reference panels","number":231517,"url":"https://github.com/elastic/kibana/pull/231517","mergeCommit":{"message":"[Dashboard] fix references lost when returning to unsaved dashboard with by reference panels (#231517)\n\nCloses https://github.com/elastic/kibana/issues/231430\n\nPR updates session backup logic to ensure references are stored when\nonly layout changes. Even though regression only impacts main branch and\nserverless, backporting to 8.19 to resolve underlying issue exposed by\nregression in all branches.\n\nTest steps\n* install sample web logs\n* Create new dashboard\n* Click \"Add from library\" and add discover session to dashboard\n* without saving, use left nav menu to navigate to discover\n* use left nav menu to navigate back to dashboard. Dashboard should\nprevious dashboard in working state\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"f6b630463c3c898b97bc9acc1cca41d6325d5c98"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231517","number":231517,"mergeCommit":{"message":"[Dashboard] fix references lost when returning to unsaved dashboard with by reference panels (#231517)\n\nCloses https://github.com/elastic/kibana/issues/231430\n\nPR updates session backup logic to ensure references are stored when\nonly layout changes. Even though regression only impacts main branch and\nserverless, backporting to 8.19 to resolve underlying issue exposed by\nregression in all branches.\n\nTest steps\n* install sample web logs\n* Create new dashboard\n* Click \"Add from library\" and add discover session to dashboard\n* without saving, use left nav menu to navigate to discover\n* use left nav menu to navigate back to dashboard. Dashboard should\nprevious dashboard in working state\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"f6b630463c3c898b97bc9acc1cca41d6325d5c98"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->