### PR TITLE
[9.1] [Security Assistant] Breakout Security Solution AI Assistant docLinks (#231725)

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -482,9 +482,10 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
         mlAnomalyDetection: `${ELASTIC_DOCS}explore-analyze/machine-learning/anomaly-detection`,
       },
       detectionEngineOverview: `${ELASTIC_DOCS}solutions/security/detect-and-alert`,
-      // TODO: Follow-up PR for creating an aiAssistant category adding all relevant doc links
-      aiAssistant: `${ELASTIC_DOCS}solutions/security/ai/ai-assistant`,
-      aiAssistantKnowledgeBaseIndexEntries: `${ELASTIC_DOCS}solutions/security/ai/ai-assistant-knowledge-base#knowledge-base-add-knowledge-index`,
+      aiAssistant: {
+        home: `${ELASTIC_DOCS}solutions/security/ai/ai-assistant`,
+        knowledgeBaseIndexEntries: `${ELASTIC_DOCS}solutions/security/ai/ai-assistant-knowledge-base#knowledge-base-add-knowledge-index`,
+      },
       signalsMigrationApi: isServerless
         ? `${KIBANA_APIS}group/endpoint-security-detections-api`
         : `${KIBANA_SERVERLESS_APIS}group/endpoint-security-detections-api`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -300,8 +300,10 @@ export interface DocLinks {
     readonly enableDeprecationHttpDebugLogs: string;
   };
   readonly securitySolution: {
-    readonly aiAssistant: string;
-    readonly aiAssistantKnowledgeBaseIndexEntries: string;
+    readonly aiAssistant: {
+      home: string;
+      knowledgeBaseIndexEntries: string;
+    };
     readonly cloudSecurityPosture: string;
     readonly installElasticDefend: string;
     readonly artifactControl: string;

--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/routes/components/ai_assistant_selection_page.tsx
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/routes/components/ai_assistant_selection_page.tsx
@@ -39,7 +39,7 @@ export function AiAssistantSelectionPage() {
   const observabilityAIAssistantEnabled = capabilities.observabilityAIAssistant?.show;
 
   const observabilityDoc = getDocLinks({ buildFlavor, kibanaBranch }).observability.aiAssistant;
-  const securityDoc = getDocLinks({ buildFlavor, kibanaBranch }).securitySolution.aiAssistant;
+  const securityDoc = getDocLinks({ buildFlavor, kibanaBranch }).securitySolution.aiAssistant.home;
   const isSecurityAIAssistantEnabled = securityAIAssistantEnabled && aiAssistantManagementSelection;
 
   useEffect(() => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/index.tsx
@@ -443,7 +443,7 @@ export const KnowledgeBaseSettingsManagement: React.FC<Params> = React.memo(({ d
                 setSelectedEntry as React.Dispatch<React.SetStateAction<Partial<IndexEntry>>>
               }
               hasManageGlobalKnowledgeBase={hasManageGlobalKnowledgeBase}
-              docLink={docLinks.links.securitySolution.aiAssistantKnowledgeBaseIndexEntries}
+              docLink={docLinks.links.securitySolution.aiAssistant.knowledgeBaseIndexEntries}
             />
           )}
         </>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Assistant] Breakout Security Solution AI Assistant docLinks (#231725)](https://github.com/elastic/kibana/pull/231725)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Garrett Spong","email":"spong@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-15T10:38:18Z","message":"[Security Assistant] Breakout Security Solution AI Assistant docLinks (#231725)\n\n## Summary\n\nThis is a follow-up to https://github.com/elastic/kibana/pull/231376\nwhere I added new `docLinks` for the Security Solution AI Assistant.\nThis PR removes the `TODO` added in that PR and creates a new\n`securitySolution.aiAssistant` grouping so we can more easily add\ndocLinks as needed.\n\nReviewers Note: Sorry for the extra noise here -- I thought there were\nmore references so decided to do in another PR. Turns out there were\nnot, so this is a quick one!","sha":"90470cffa3bdf41045c9c7cb06a97ce38070fe67","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","docs","ci:project-deploy-observability","Team:Security Generative AI","backport:version","v9.2.0","v9.1.3"],"title":"[Security Assistant] Breakout Security Solution AI Assistant docLinks","number":231725,"url":"https://github.com/elastic/kibana/pull/231725","mergeCommit":{"message":"[Security Assistant] Breakout Security Solution AI Assistant docLinks (#231725)\n\n## Summary\n\nThis is a follow-up to https://github.com/elastic/kibana/pull/231376\nwhere I added new `docLinks` for the Security Solution AI Assistant.\nThis PR removes the `TODO` added in that PR and creates a new\n`securitySolution.aiAssistant` grouping so we can more easily add\ndocLinks as needed.\n\nReviewers Note: Sorry for the extra noise here -- I thought there were\nmore references so decided to do in another PR. Turns out there were\nnot, so this is a quick one!","sha":"90470cffa3bdf41045c9c7cb06a97ce38070fe67"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231725","number":231725,"mergeCommit":{"message":"[Security Assistant] Breakout Security Solution AI Assistant docLinks (#231725)\n\n## Summary\n\nThis is a follow-up to https://github.com/elastic/kibana/pull/231376\nwhere I added new `docLinks` for the Security Solution AI Assistant.\nThis PR removes the `TODO` added in that PR and creates a new\n`securitySolution.aiAssistant` grouping so we can more easily add\ndocLinks as needed.\n\nReviewers Note: Sorry for the extra noise here -- I thought there were\nmore references so decided to do in another PR. Turns out there were\nnot, so this is a quick one!","sha":"90470cffa3bdf41045c9c7cb06a97ce38070fe67"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->