### PR TITLE
[9.1] [Security solution][Alerts] Disable additional toolbar controls for group children in alerts table (#229638)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -127,6 +127,7 @@ interface DetectionEngineAlertTableProps
   sourcererScope?: SourcererScopeName;
   isLoading?: boolean;
   onRuleChange?: () => void;
+  disableAdditionalToolbarControls?: boolean;
 }
 
 const initialSort: GetSecurityAlertsTableProp<'initialSort'> = [
@@ -145,6 +146,7 @@ const DetectionEngineAlertsTableComponent: FC<Omit<DetectionEngineAlertTableProp
   sourcererScope = SourcererScopeName.detections,
   isLoading,
   onRuleChange,
+  disableAdditionalToolbarControls,
   ...tablePropsOverrides
 }) => {
   const { id } = tablePropsOverrides;
@@ -433,6 +435,14 @@ const DetectionEngineAlertsTableComponent: FC<Omit<DetectionEngineAlertTableProp
     [count, isEventRenderedView]
   );
 
+  /**
+   * We want to hide additional controls (like grouping) if the table is being rendered
+   * in the cases page OR if the user of the table explicitly set `disableAdditionalToolbarControls`
+   * to true
+   */
+  const shouldRenderAdditionalToolbarControls =
+    disableAdditionalToolbarControls || tableType === TableId.alertsOnCasePage;
+
   if (isLoading) {
     return null;
   }
@@ -469,7 +479,7 @@ const DetectionEngineAlertsTableComponent: FC<Omit<DetectionEngineAlertTableProp
               renderCellValue={CellValue}
               renderActionsCell={ActionsCell}
               renderAdditionalToolbarControls={
-                tableType !== TableId.alertsOnCasePage ? AdditionalToolbarControls : undefined
+                shouldRenderAdditionalToolbarControls ? undefined : AdditionalToolbarControls
               }
               actionsColumnWidth={leadingControlColumn.width}
               additionalBulkActions={bulkActions}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.tsx
@@ -332,6 +332,7 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
           tableType={TableId.alertsOnAlertsPage}
           inputFilters={[...alertsTableDefaultFilters, ...groupingFilters]}
           isLoading={isAlertTableLoading}
+          disableAdditionalToolbarControls={!!groupingFilters.length}
         />
       );
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security solution][Alerts] Disable additional toolbar controls for group children in alerts table (#229638)](https://github.com/elastic/kibana/pull/229638)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicholas Peretti","email":"nicholas.peretti@elastic.co"},"sourceCommit":{"committedDate":"2025-08-14T12:12:51Z","message":"[Security solution][Alerts] Disable additional toolbar controls for group children in alerts table (#229638)\n\nFixes #227518\n\n## Summary\n\n### 🛑 Problem overview\n\nAs reported in issue #227518, when grouping alerts in the alerts page\nthe user is able to see grouping controls in the children of the group\n(highlighted in red):\n\n<img width=\"2560\" height=\"1023\" alt=\"Screenshot 2025-07-28 at 14 16 19\"\nsrc=\"https://github.com/user-attachments/assets/8030cf8d-9c49-486b-a434-6309f7f2defb\"\n/>\n\nThis shouldn't happen as the user can already use multiple grouping by\nselecting multiple fields in the top level group controls (highlighted\nin green in the screenshot)\n\n### 💡 Solution\n\nAs this table is re-used a lot around the codebase, I've found the\ncleanest way to address this issue was to add a prop that would tell the\ntable to disable the additional controls in the toolbar, called\n`disableAdditionalToolbarControls`.\n\nWe set this to true when we know we are inside a group child. This can\nbe achieved by checking the length of the `groupingFilters` passed to\nthe `renderAlertTable` function.\n\n### 🧠  Conclusions\n\nThis approach extends the behaviour of the table allowing us to disable\nadditional controls when needed without disrupting other use-cases\naround the codebase","sha":"82c69398f19dc048f83cb6fccdec25b37c499da1","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team: SecuritySolution","backport:version","v8.18.0","v9.1.0","v8.19.0","v9.2.0"],"title":"[Security solution][Alerts] Disable additional toolbar controls for group children in alerts table","number":229638,"url":"https://github.com/elastic/kibana/pull/229638","mergeCommit":{"message":"[Security solution][Alerts] Disable additional toolbar controls for group children in alerts table (#229638)\n\nFixes #227518\n\n## Summary\n\n### 🛑 Problem overview\n\nAs reported in issue #227518, when grouping alerts in the alerts page\nthe user is able to see grouping controls in the children of the group\n(highlighted in red):\n\n<img width=\"2560\" height=\"1023\" alt=\"Screenshot 2025-07-28 at 14 16 19\"\nsrc=\"https://github.com/user-attachments/assets/8030cf8d-9c49-486b-a434-6309f7f2defb\"\n/>\n\nThis shouldn't happen as the user can already use multiple grouping by\nselecting multiple fields in the top level group controls (highlighted\nin green in the screenshot)\n\n### 💡 Solution\n\nAs this table is re-used a lot around the codebase, I've found the\ncleanest way to address this issue was to add a prop that would tell the\ntable to disable the additional controls in the toolbar, called\n`disableAdditionalToolbarControls`.\n\nWe set this to true when we know we are inside a group child. This can\nbe achieved by checking the length of the `groupingFilters` passed to\nthe `renderAlertTable` function.\n\n### 🧠  Conclusions\n\nThis approach extends the behaviour of the table allowing us to disable\nadditional controls when needed without disrupting other use-cases\naround the codebase","sha":"82c69398f19dc048f83cb6fccdec25b37c499da1"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.1","8.19"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229638","number":229638,"mergeCommit":{"message":"[Security solution][Alerts] Disable additional toolbar controls for group children in alerts table (#229638)\n\nFixes #227518\n\n## Summary\n\n### 🛑 Problem overview\n\nAs reported in issue #227518, when grouping alerts in the alerts page\nthe user is able to see grouping controls in the children of the group\n(highlighted in red):\n\n<img width=\"2560\" height=\"1023\" alt=\"Screenshot 2025-07-28 at 14 16 19\"\nsrc=\"https://github.com/user-attachments/assets/8030cf8d-9c49-486b-a434-6309f7f2defb\"\n/>\n\nThis shouldn't happen as the user can already use multiple grouping by\nselecting multiple fields in the top level group controls (highlighted\nin green in the screenshot)\n\n### 💡 Solution\n\nAs this table is re-used a lot around the codebase, I've found the\ncleanest way to address this issue was to add a prop that would tell the\ntable to disable the additional controls in the toolbar, called\n`disableAdditionalToolbarControls`.\n\nWe set this to true when we know we are inside a group child. This can\nbe achieved by checking the length of the `groupingFilters` passed to\nthe `renderAlertTable` function.\n\n### 🧠  Conclusions\n\nThis approach extends the behaviour of the table allowing us to disable\nadditional controls when needed without disrupting other use-cases\naround the codebase","sha":"82c69398f19dc048f83cb6fccdec25b37c499da1"}}]}] BACKPORT-->