### PR TITLE
[DRAFT] POC for demo cases + inverted alerts table DO NOT MERGE

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_alerts.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_alerts.tsx
@@ -86,6 +86,7 @@ export const CaseViewAlerts = ({
             ? SECURITY_SOLUTION_RULE_TYPE_IDS
             : alertData?.ruleTypeIds ?? []
         }
+        caseId={caseData.id}
         consumers={alertData?.featureIds}
         query={alertIdsQuery}
         showAlertStatusWithFlapping={caseData.owner !== SECURITY_SOLUTION_OWNER}

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/types.ts
@@ -47,4 +47,5 @@ export type CaseViewAlertsTableProps = Pick<
   'id' | 'ruleTypeIds' | 'consumers' | 'query' | 'showAlertStatusWithFlapping' | 'onLoaded'
 > & {
   services?: AlertsTableProps['services'];
+  caseId: CaseUI['id'];
 };

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_actions/inverted_alert_actions.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_actions/inverted_alert_actions.tsx
@@ -1,0 +1,280 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiButtonIcon,
+  EuiFlexItem,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiPopover,
+  EuiToolTip,
+} from '@elastic/eui';
+
+import React, { useMemo, useState, useCallback, useEffect } from 'react';
+import { i18n } from '@kbn/i18n';
+import { useRouteMatch } from 'react-router-dom';
+import { SLO_ALERTS_TABLE_ID } from '@kbn/observability-shared-plugin/common';
+import { DefaultAlertActions } from '@kbn/response-ops-alerts-table/components/default_alert_actions';
+import { ALERT_UUID } from '@kbn/rule-data-utils';
+import { useCaseActions } from './use_case_actions';
+import { RULE_DETAILS_PAGE_ID } from '../../pages/rule_details/constants';
+import { paths, SLO_DETAIL_PATH } from '../../../common/locators/paths';
+import { parseAlert } from '../../pages/alerts/helpers/parse_alert';
+import {
+  GetObservabilityAlertsTableProp,
+  ObservabilityAlertsTableContext,
+  observabilityFeatureId,
+} from '../..';
+import { ALERT_DETAILS_PAGE_ID } from '../../pages/alert_details/alert_details';
+import { AlertRowAction } from '../alerts_table/types';
+
+// type AlertActionsType = GetObservabilityAlertsTableProp<'renderActionsCell'>;
+type AlertActionsProps = React.ComponentProps<Extract<GetObservabilityAlertsTableProp<'renderActionsCell'>, React.ComponentType<any>>>;
+
+export function getAlertActions({ extraRowActions = [] }: { extraRowActions?: AlertRowAction[] }) {
+  const AlertActions = ({
+    observabilityRuleTypeRegistry,
+    alert,
+    tableId,
+    refresh,
+    openAlertInFlyout,
+    parentAlert,
+    services,
+    ...rest
+  }: AlertActionsProps) => {
+    const {
+      http: {
+        basePath: { prepend },
+      },
+      cases,
+    } = services;
+    const isSLODetailsPage = useRouteMatch(SLO_DETAIL_PATH);
+
+    const isInApp = Boolean(tableId === SLO_ALERTS_TABLE_ID && isSLODetailsPage);
+
+    const userCasesPermissions = cases?.helpers.canUseCases([observabilityFeatureId]);
+    const [viewInAppUrl, setViewInAppUrl] = useState<string>();
+
+    const parseObservabilityAlert = useMemo(
+      () => parseAlert(observabilityRuleTypeRegistry),
+      [observabilityRuleTypeRegistry]
+    );
+
+    const observabilityAlert = parseObservabilityAlert(alert);
+
+    useEffect(() => {
+      const alertLink = observabilityAlert.link;
+      if (!observabilityAlert.hasBasePath && prepend) {
+        setViewInAppUrl(prepend(alertLink ?? ''));
+      } else {
+        setViewInAppUrl(alertLink);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const handleViewInAppUrl = useCallback(() => {
+      const alertLink = observabilityAlert.link as unknown as string;
+      if (!observabilityAlert.hasBasePath) {
+        setViewInAppUrl(prepend(alertLink ?? ''));
+      } else {
+        setViewInAppUrl(alertLink);
+      }
+    }, [observabilityAlert.link, observabilityAlert.hasBasePath, prepend]);
+
+    const { isPopoverOpen, setIsPopoverOpen, handleAddToExistingCaseClick, handleAddToNewCaseClick } =
+      useCaseActions({
+        refresh,
+        alerts: [alert],
+        services: {
+          cases,
+        },
+      });
+
+    const closeActionsPopover = useCallback(() => {
+      setIsPopoverOpen(false);
+    }, [setIsPopoverOpen]);
+
+    const toggleActionsPopover = () => {
+      setIsPopoverOpen(!isPopoverOpen);
+    };
+
+    const actionsMenuItems = [
+      ...(userCasesPermissions?.createComment && userCasesPermissions?.read
+        ? [
+            <EuiContextMenuItem
+              data-test-subj="add-to-existing-case-action"
+              key="addToExistingCase"
+              onClick={handleAddToExistingCaseClick}
+              size="s"
+            >
+              {i18n.translate('xpack.observability.alerts.actions.addToCase', {
+                defaultMessage: 'Add to existing case',
+              })}
+            </EuiContextMenuItem>,
+            <EuiContextMenuItem
+              data-test-subj="add-to-new-case-action"
+              key="addToNewCase"
+              onClick={handleAddToNewCaseClick}
+              size="s"
+            >
+              {i18n.translate('xpack.observability.alerts.actions.addToNewCase', {
+                defaultMessage: 'Add to new case',
+              })}
+            </EuiContextMenuItem>,
+          ]
+        : []),
+      useMemo(
+        () => (
+          <DefaultAlertActions<ObservabilityAlertsTableContext>
+            observabilityRuleTypeRegistry={observabilityRuleTypeRegistry}
+            key="defaultRowActions"
+            onActionExecuted={closeActionsPopover}
+            isAlertDetailsEnabled={true}
+            resolveRulePagePath={(ruleId, currentPageId) =>
+              currentPageId !== RULE_DETAILS_PAGE_ID ? paths.observability.ruleDetails(ruleId) : null
+            }
+            resolveAlertPagePath={(alertId, currentPageId) =>
+              currentPageId !== ALERT_DETAILS_PAGE_ID
+                ? paths.observability.alertDetails(alertId)
+                : null
+            }
+            tableId={tableId}
+            refresh={refresh}
+            alert={alert}
+            openAlertInFlyout={openAlertInFlyout}
+            services={services}
+            {...rest}
+          />
+        ),
+        [
+          alert,
+          closeActionsPopover,
+          observabilityRuleTypeRegistry,
+          openAlertInFlyout,
+          refresh,
+          services,
+          rest,
+          tableId,
+        ]
+      ),
+      ...extraRowActions.map((action) => (
+        <EuiContextMenuItem
+          data-test-subj={action.dataTestSubj}
+          key={action.key}
+          onClick={() => action.callback({ alert })}
+          size="s"
+        >
+          {action.label}
+        </EuiContextMenuItem>
+      ))
+    ];
+
+    const actionsToolTip =
+      actionsMenuItems.length <= 0
+        ? i18n.translate('xpack.observability.alertsTable.notEnoughPermissions', {
+            defaultMessage: 'Additional privileges required',
+          })
+        : i18n.translate('xpack.observability.alertsTable.moreActionsTextLabel', {
+            defaultMessage: 'More actions',
+          });
+
+    const onExpandEvent = () => {
+      const parsedAlert = parseAlert(observabilityRuleTypeRegistry)(alert);
+      openAlertInFlyout?.(parsedAlert.fields[ALERT_UUID]);
+    };
+
+    const hideViewInApp = isInApp || viewInAppUrl === '' || parentAlert;
+
+    return (
+      <>
+        {!parentAlert && (
+          <EuiFlexItem>
+            <EuiToolTip data-test-subj="expand-event-tool-tip" content={VIEW_DETAILS}>
+              <EuiButtonIcon
+                aria-label="Expand this alert"
+                data-test-subj="expand-event"
+                iconType="expand"
+                onClick={onExpandEvent}
+                size="s"
+                color="text"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+        )}
+        {!hideViewInApp && (
+          <EuiFlexItem>
+            <EuiToolTip
+              content={i18n.translate('xpack.observability.alertsTable.viewInAppTextLabel', {
+                defaultMessage: 'View in app',
+              })}
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                data-test-subj="o11yAlertActionsButton"
+                aria-label={i18n.translate('xpack.observability.alertsTable.viewInAppTextLabel', {
+                  defaultMessage: 'View in app',
+                })}
+                color="text"
+                onMouseOver={handleViewInAppUrl}
+                onClick={() => window.open(viewInAppUrl)}
+                iconType="eye"
+                size="s"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+        )}
+
+        <EuiFlexItem
+          css={{
+            textAlign: 'center',
+          }}
+          grow={parentAlert ? false : undefined}
+        >
+          <EuiPopover
+            anchorPosition="downLeft"
+            button={
+              <EuiToolTip content={actionsToolTip} disableScreenReaderOutput>
+                <EuiButtonIcon
+                  aria-label={actionsToolTip}
+                  color="text"
+                  data-test-subj="alertsTableRowActionMore"
+                  display="empty"
+                  iconType="boxesHorizontal"
+                  onClick={toggleActionsPopover}
+                  size="s"
+                />
+              </EuiToolTip>
+            }
+            closePopover={closeActionsPopover}
+            isOpen={isPopoverOpen}
+            panelPaddingSize="none"
+          >
+            <EuiContextMenuPanel
+              size="s"
+              items={actionsMenuItems}
+              data-test-subj="alertsTableActionsMenu"
+            />
+          </EuiPopover>
+        </EuiFlexItem>
+      </>
+    );
+  };
+
+  return AlertActions;
+}
+
+
+
+// Default export used for lazy loading
+// eslint-disable-next-line import/no-default-export
+export default getAlertActions;
+
+const VIEW_DETAILS = i18n.translate('xpack.observability.alertsTable.viewDetailsTextLabel', {
+  defaultMessage: 'Alert details',
+});
+
+export type AlertActions = ReturnType<typeof getAlertActions>;

--- a/x-pack/solutions/observability/plugins/observability/public/components/alerts_table/alerts_table.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alerts_table/alerts_table.tsx
@@ -10,7 +10,7 @@ import { ALERT_START } from '@kbn/rule-data-utils';
 import { SortOrder } from '@elastic/elasticsearch/lib/api/types';
 import { AlertsTable } from '@kbn/response-ops-alerts-table';
 import { ObservabilityPublicStart } from '../..';
-import AlertActions from '../alert_actions/alert_actions';
+import getAlertActions from '../alert_actions/inverted_alert_actions';
 import { useKibana } from '../../utils/kibana_react';
 import { casesFeatureId, observabilityFeatureId } from '../../../common';
 import {
@@ -44,6 +44,8 @@ export function ObservabilityAlertsTable(props: ObservabilityAlertsTableProps) {
   const { observability } = useKibana<{ observability?: ObservabilityPublicStart }>().services;
   const { observabilityRuleTypeRegistry, config } = usePluginContext();
 
+  const AlertActions = getAlertActions({ extraRowActions: props.additionalContext?.extraRowActions });
+
   return (
     <AlertsTable<ObservabilityAlertsTableContext>
       columns={columns}
@@ -54,6 +56,7 @@ export function ObservabilityAlertsTable(props: ObservabilityAlertsTableProps) {
         observabilityRuleTypeRegistry:
           observabilityRuleTypeRegistry ?? observability?.observabilityRuleTypeRegistry,
         config,
+        // extraRowActions: props.additionalContext?.extraRowActions ?? []
       }}
       renderCellValue={AlertsTableCellValue}
       renderActionsCell={AlertActions}

--- a/x-pack/solutions/observability/plugins/observability/public/components/alerts_table/types.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alerts_table/types.ts
@@ -8,11 +8,20 @@
 import { SetOptional } from 'type-fest';
 import type { AlertsTablePropsWithRef } from '@kbn/response-ops-alerts-table/types';
 import type { ConfigSchema, ObservabilityRuleTypeRegistry, TopAlert } from '../..';
+import { Alert } from '@kbn/alerting-types';
 
 export interface ObservabilityAlertsTableContext {
-  observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry;
-  config: ConfigSchema;
+  observabilityRuleTypeRegistry?: ObservabilityRuleTypeRegistry;
+  config?: ConfigSchema;
   parentAlert?: TopAlert;
+  extraRowActions?: AlertRowAction[];
+}
+
+export interface AlertRowAction {
+  label: string;
+  key: string;
+  dataTestSubj?: string;
+  callback: ({ alert }: { alert: Alert }) => void;
 }
 
 export type ObservabilityAlertsTableProps = SetOptional<

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alerts/helpers/parse_alert.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alerts/helpers/parse_alert.ts
@@ -22,7 +22,7 @@ import { ObservabilityRuleTypeRegistry } from '../../../rules/create_observabili
 import type { TopAlert } from '../../../typings/alerts';
 
 export const parseAlert =
-  (observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry) =>
+  (observabilityRuleTypeRegistry?: ObservabilityRuleTypeRegistry) =>
   (alert: Record<string, unknown>): TopAlert => {
     const experimentalFields = Object.keys(legacyExperimentalFieldMap);
     const alertWithExperimentalFields = experimentalFields.reduce((acc, key) => {
@@ -37,7 +37,7 @@ export const parseAlert =
       ...parseExperimentalFields(alertWithExperimentalFields, true),
     };
 
-    const formatter = observabilityRuleTypeRegistry.getFormatter(parsedFields[ALERT_RULE_TYPE_ID]!);
+    const formatter = observabilityRuleTypeRegistry?.getFormatter(parsedFields[ALERT_RULE_TYPE_ID]!);
     let formattedFields = {};
     try {
       formattedFields =


### PR DESCRIPTION
I'm showing the work that was required to invert the alert table so we can pass in extra alert row actions in context and take advantage of the variables that are already in scope in our app without having to pass everything down into the alerts table somehow. We shouldn't merge this but it took me several hours just to get this working the way I would've expected it to work right from the start, so I'm committing the code just to demo it.

I've added a bunch of comments to the PR to explain a few things, so we can talk about this later if we want to try to talk to the Cases team or Response Ops about making any of this a bit simpler or easier to extend per instantiation. 

To see this in action, add an alert to a case, then go to the case detail view and go to the alerts tab, click on the three dots context menu for that alert row, choose "Remove from case", confirm in the modal, and see the alert ID and case ID appear in the console.

<img width="1263" height="604" alt="Screenshot 2025-08-16 at 7 25 09 PM" src="https://github.com/user-attachments/assets/a7912510-8dea-4e02-982e-9427f14a38fd" />

<img width="1260" height="540" alt="Screenshot 2025-08-16 at 7 25 21 PM" src="https://github.com/user-attachments/assets/7242da3b-2ea7-4ee0-a4e7-4d24e2f7fb1a" />

<img width="1121" height="178" alt="Screenshot 2025-08-16 at 7 25 41 PM" src="https://github.com/user-attachments/assets/4c2de049-987f-4c7b-aa95-7049ecd29249" />


