### PR TITLE
[Security Solution] Unskip Cypress tests for rule execution log

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/execution_log.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/execution_log.cy.ts
@@ -23,8 +23,7 @@ import { getNewRule } from '../../../../objects/rule';
 import { EXECUTION_SHOWING } from '../../../../screens/rule_details';
 import { manualRuleRun } from '../../../../tasks/api_calls/backfill';
 
-// FLAKY: https://github.com/elastic/kibana/issues/184360
-describe.skip(
+describe(
   'Event log',
   {
     tags: ['@ess', '@serverless'],

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/api_calls/backfill.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/api_calls/backfill.ts
@@ -27,8 +27,7 @@ export const manualRuleRun = ({
     body: [
       {
         rule_id: ruleId,
-        start,
-        end,
+        ranges: [{ start, end }],
       },
     ],
   });


### PR DESCRIPTION
**Partially addresses: https://github.com/elastic/kibana/issues/229688**
**Resolves: https://github.com/elastic/kibana/issues/184360**

## Summary

This PR fixes and unskips the following tests:

- `x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/execution_log.cy.ts`

## Flaky test runs

- [100x ESS + 100x Serverless](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9162) 🟢  

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->