### PR TITLE
Changing one-chat default agent system prompt and tool descriptions for nl_search and relevance_search tools

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/chat/prompts.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/chat/prompts.ts
@@ -18,20 +18,42 @@ export const getActPrompt = ({
   return [
     [
       'system',
-      `You are an helpful chat assistant from the Elasticsearch company.
+      `You are an expert enterprise assistant developed by Elastic.
+      
+      ### Core mission
+      1. Deliver accurate, organization‑grounded answers by effectively using your available tools.
+      2. Do not rely on internal/general knowledge for factual content.
 
-       You have a set of tools at your disposal that can be used to help you answering questions.
-       In particular, you have tools to access the Elasticsearch cluster on behalf of the user, to search and retrieve documents
-       they have access to.
+      ### **Golden rules** (non‑negotiable)
+      1. Tool‑first is mandatory (IMPORTANT): For informational, procedural, troubleshooting, or policy questions, make at least one tool call before answering. Use internal knowledge only to choose tools, craft queries, and reason about results—never to assert facts.
+      2. Ground every claim: The final answer must only contain information supported by tool outputs. If you can’t ground it, omit it.
+      3. Strict scope and concision: Answer only what the user asked, in 3–6 sentences or a short bullet list. Do not add background, alternatives, or advice unless present in sources or explicitly requested.
+      4. Clarify only if essential: Ask a targeted question before using tools only when a missing detail would materially change tool choice or query. Otherwise, run a broad search and refine.
+      5. Iterate reasonably: If initial results are insufficient, refine the query or try another relevant tool up to 2–3 attempts before asking for clarification or stating that nothing relevant was found.
+      6. No capability disclaimers or speculation: Do not deflect, over‑explain limitations, guess, or fabricate links/data.
+      7. Hide chain‑of‑thought: Do not reveal internal reasoning or tool traces. Provide only the final answer and brief citations.
+      
+      ### Operating protocol
+      1. Analyze: Identify intent, entities, and constraints. Decide if a clarification is essential; if not, proceed to search.
+      2. Plan: Select the most relevant tool(s); prefer enterprise sources over public. Draft initial queries/filters.
+      3. Act: Call the tool(s). If results are weak or off‑target, refine or switch tools (total 2–3 attempts). If tools error or are unavailable, state this and offer to retry.
+      4. Synthesize: Build the answer strictly from retrieved content; keep it minimal and directly responsive to the question.
+      5. If unsuccessful: Either ask a targeted clarification to unlock a better search, or state that no relevant information was found and request specific details.
+      
+      ### When you may respond without tools
+      1. To ask a necessary, targeted clarification.
+      2. To acknowledge/confirm receipt.
+      3. When the user explicitly instructs you not to use tools.
+      4. When tools are unavailable or erroring (state this and offer to retry). Otherwise, you must make at least one tool call.
+      
+      ### Formatting
+      Use light markdown (short headings or bullets). Keep answers concise. Avoid unsolicited extras.
 
-       - When the user ask a question, assume it refers to information that can be retrieved from Elasticsearch.
-         For example if the user asks "What are my latest alerts", assume you need to search the cluster for alert documents.
+      ${customInstructionsBlock(customInstructions)}
 
-       ${customInstructionsBlock(customInstructions)}
-
-       ### Additional info
-       - The current date is: ${formatDate()}
-       - You can use markdown format to structure your response`,
+      ### Additional info
+      Current date: ${formatDate()}
+      `,
     ],
     ...messages,
   ];

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/builtin/definitions/nl_search.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/builtin/definitions/nl_search.ts
@@ -29,7 +29,17 @@ export const naturalLanguageSearchTool = (): BuiltinToolDefinition<typeof search
   return {
     id: builtinToolIds.naturalLanguageSearch,
     description:
-      'Given a natural language query, run a DSL search query on one index and return matching documents.',
+      `
+      Analyzes natural language questions to automatically find relevant indices, generate appropriate ES|QL queries, and execute them to answer analytical questions. This tool handles the complete workflow from question to answer, including index discovery, query generation, and execution. 
+      Ideal for:
+      - Statistical analysis and aggregations (counts, sums, averages, percentiles)
+      - Time-based analysis and trending (changes over time, comparisons between periods)
+      - Filtering and grouping data by specific criteria
+      - Calculating metrics and KPIs from structured data
+      - Finding patterns, anomalies, or outliers in datasets
+      - Comparing values across different dimensions or categories
+      The tool automatically determines the most appropriate index to query based on the question context, constructs optimized ES|QL queries for the analytical task, and returns processed results ready for interpretation.
+        `,
     schema: searchDslSchema,
     handler: async ({ query: nlQuery, index, context }, { esClient, modelProvider }) => {
       const model = await modelProvider.getDefaultModel();

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/builtin/definitions/relevance_search.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/builtin/definitions/relevance_search.ts
@@ -46,7 +46,7 @@ export interface SearchFulltextResponse {
 export const relevanceSearchTool = (): BuiltinToolDefinition<typeof relevanceSearchSchema> => {
   return {
     id: builtinToolIds.relevanceSearch,
-    description: `Find relevant documents in an index based on a simple fulltext search.
+    description: `Performs a semantic or keyword-based or hybrid search to find relevant documents or information within unstructured text. This is the primary tool for answering questions that require finding explanations, descriptions, factual information or procedural guidance from a knowledge base.
 
     - The 'index' parameter can be used to specify which index to search against. If not provided, the tool will use the index explorer to find the best index to use.
     - The 'fields' parameter can be used to specify which fields to search on. If not provided, the tool will use all searchable fields.


### PR DESCRIPTION
## **DS EXPERIMENT DON'T MERGE**

## If Reviewing look at this [PR](https://github.com/elastic/kibana/pull/232039) which contains all the changes from this PR too

## Problem Statement

While testing the Default Agent in OneChat these problems issues were noticed:
1.  **Ignoring Tools & Defaulting to General Knowledge:** The agent frequently failed to use its available tools (like searching an Elasticsearch index). Instead, when it recognized a topic from its general training data (e.g., "password reset"), it would provide a generic, unhelpful answer without even checking for specific information in its enterprise data sources.

2.  **Being Overly Verbose and Unfocused:** The agent's responses were too conversational, including unnecessary filler ("I understand you want to..."), apologies ("As an enterprise assistant, I can't..."), and unsolicited suggestions. This cluttered the response and increased the risk of providing hallucinated information not backed by a tool's output.

3. **Selecting the wrong tool:** The agent was often confused between the `relevance_search` and `nl_search` tools; and wasted many tools calls on `nl_search` tools for queries that were not meant to use the `relevance_search` tool.

### Summary of the Changes

The prompt was rewritten to be more forceful, direct, and explicit, transforming it from a set of guidelines into a strict operational protocol.

1.  **To Force Tool Usage (Fixing Problem 1):**
    * Created a set of rules for the agent to abide and one of them being defaulting to tools; especially for factual queries
2.  **To Enforce Conciseness (Fixing Problem 2):**
    * In the rule-set specifically instructed the agent for strict scope and concision
3.  **To improve tool selection (Fixing Problem 3):**
    * Changed the tool descriptions of the `relevance_search` and `nl_search` tools; providing more insights on how the tool works; what can it do; and when to use it.
    
    
### Results:
1. Tool selection accuracy in this case improved from 11% to 36% (a 25% increase) for text retrieval queries. Tool selection accuracy was measured as the number of times the correct tool (relevance_search for text retrieval) was selected for text retrieval queries over nl_search
2. Percentage of cases where the model defaults to internal knowledge drop from 17% to 3%.
3. Factual correctness as measure using this [prompt](https://35-187-109-62.sslip.io/prompts/UHJvbXB0OjQ=) went up by  at least 8% from ~18% to ~30%