### PR TITLE
[SecuritySolution] PrivMon UI changes (low-hanging fruit)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_access_detection/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_access_detection/index.tsx
@@ -136,7 +136,7 @@ export const PrivilegedAccessDetectionsPanel: React.FC<{ spaceId: string }> = ({
                   <PrivilegedAccessInfoPopover />
                 </>
               }
-              titleSize="s"
+              titleSize="m"
               outerDirection="column"
               hideSubtitle
             >

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/constants.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/constants.tsx
@@ -12,7 +12,7 @@ export const PRIVILEGED_USER_ACTIVITY_QUERY_ID = 'privileged-user-activity-query
 export const PAGE_SIZE = 10;
 
 const privilegedUserOption = {
-  text: (
+  inputDisplay: (
     <FormattedMessage
       id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.userActivity.stackBy.privilegedUser"
       defaultMessage="Privileged user"
@@ -22,7 +22,7 @@ const privilegedUserOption = {
 };
 
 const sourceIpOption = {
-  text: (
+  inputDisplay: (
     <FormattedMessage
       id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.userActivity.stackBy.sourceIp"
       defaultMessage="Source IP"
@@ -34,7 +34,7 @@ const sourceIpOption = {
 export const GRANTED_RIGHTS_STACK_BY = [
   privilegedUserOption,
   {
-    text: (
+    inputDisplay: (
       <FormattedMessage
         id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.userActivity.stackBy.targetUser"
         defaultMessage="Target user"
@@ -43,7 +43,7 @@ export const GRANTED_RIGHTS_STACK_BY = [
     value: 'target_user',
   },
   {
-    text: (
+    inputDisplay: (
       <FormattedMessage
         id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.userActivity.stackBy.grantedRight"
         defaultMessage="Granted right"
@@ -57,7 +57,7 @@ export const GRANTED_RIGHTS_STACK_BY = [
 export const ACCOUNT_SWITCH_STACK_BY = [
   privilegedUserOption,
   {
-    text: (
+    inputDisplay: (
       <FormattedMessage
         id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.userActivity.stackBy.targetAccount"
         defaultMessage="Target account"
@@ -66,7 +66,7 @@ export const ACCOUNT_SWITCH_STACK_BY = [
     value: 'target_user',
   },
   {
-    text: (
+    inputDisplay: (
       <FormattedMessage
         id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.userActivity.stackBy.targetAdminGroup"
         defaultMessage="Target admin group"
@@ -80,7 +80,7 @@ export const ACCOUNT_SWITCH_STACK_BY = [
 export const AUTHENTICATIONS_STACK_BY = [
   privilegedUserOption,
   {
-    text: (
+    inputDisplay: (
       <FormattedMessage
         id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.userActivity.stackBy.source"
         defaultMessage="Source"
@@ -89,7 +89,7 @@ export const AUTHENTICATIONS_STACK_BY = [
     value: 'source',
   },
   {
-    text: (
+    inputDisplay: (
       <FormattedMessage
         id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.userActivity.stackBy.type"
         defaultMessage="Type"

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.test.tsx
@@ -6,9 +6,10 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { UserActivityPrivilegedUsersPanel } from '.';
 import { TestProviders } from '../../../../../common/mock';
+import { act } from 'react-dom/test-utils';
 
 jest.mock('../../../../../common/containers/use_global_time', () => ({
   useGlobalTime: () => ({
@@ -63,7 +64,14 @@ describe('UserActivityPrivilegedUsersPanel', () => {
     render(<UserActivityPrivilegedUsersPanel sourcererDataView={mockedSourcererDataView} />, {
       wrapper: TestProviders,
     });
+
     expect(screen.getByText('Stack by')).toBeInTheDocument();
+    const privUserButton = screen.getByText('Privileged user');
+
+    act(() => {
+      privUserButton.click();
+    });
+
     expect(screen.getByRole('option', { name: 'Privileged user' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Target user' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Granted right' })).toBeInTheDocument();
@@ -81,9 +89,17 @@ describe('UserActivityPrivilegedUsersPanel', () => {
     render(<UserActivityPrivilegedUsersPanel sourcererDataView={mockedSourcererDataView} />, {
       wrapper: TestProviders,
     });
-    const select = screen.getByRole('combobox');
-    fireEvent.change(select, { target: { value: 'group_name' } });
-    expect((select as HTMLSelectElement).value).toBe('group_name');
+    expect(screen.getByDisplayValue('privileged_user')).toBeInTheDocument(); // Assert that input value before change
+
+    act(() => {
+      screen.getByText('Privileged user').click(); // click to open the select
+    });
+
+    act(() => {
+      screen.getByRole('option', { name: 'Target user' }).click(); // select "Target user"
+    });
+
+    expect(screen.getByDisplayValue('target_user')).toBeInTheDocument(); // Assert that input value after change
   });
 
   it('renders the "View all events by privileged users" link', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.tsx
@@ -10,7 +10,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
-  EuiSelect,
   EuiSpacer,
   EuiSuperSelect,
 } from '@elastic/eui';

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiPanel,
   EuiSelect,
   EuiSpacer,
+  EuiSuperSelect,
 } from '@elastic/eui';
 import React, { useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
@@ -58,15 +59,14 @@ export const UserActivityPrivilegedUsersPanel: React.FC<{
     usePrivilegedUserActivityParams(selectedToggleOption, sourcererDataView);
   const stackByOptions = useStackByOptions(selectedToggleOption);
   const setSelectedChartOptionCallback = useCallback(
-    (event: React.ChangeEvent<HTMLSelectElement>) => {
-      setSelectedStackByOption(
-        stackByOptions.find((co) => co.value === event.target.value) ?? stackByOptions[0]
-      );
+    (value: string) => {
+      setSelectedStackByOption(value ?? stackByOptions[0].value);
     },
     [stackByOptions]
   );
+
   const defaultStackByOption = stackByOptions[0];
-  const [selectedStackByOption, setSelectedStackByOption] = useState(defaultStackByOption);
+  const [selectedStackByOption, setSelectedStackByOption] = useState(defaultStackByOption.value);
   const toggleOptions = useToggleOptions();
 
   const tableQuery = generateTableQuery('@timestamp', 'DESC', 100);
@@ -108,20 +108,22 @@ export const UserActivityPrivilegedUsersPanel: React.FC<{
                 idSelected={selectedToggleOption}
                 onChange={(id) => {
                   setToggleOption(id as VisualizationToggleOptions);
-                  setSelectedStackByOption(defaultStackByOption);
+                  setSelectedStackByOption(defaultStackByOption.value);
                 }}
                 legend={PICK_VISUALIZATION_LEGEND}
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               {stackByOptions.length > 1 && (
-                <EuiSelect
+                <EuiSuperSelect
                   onChange={setSelectedChartOptionCallback}
                   options={stackByOptions}
                   prepend={i18n.translate('xpack.securitySolution.genericDashboard.stackBy.label', {
                     defaultMessage: 'Stack by',
                   })}
-                  value={selectedStackByOption?.value}
+                  valueOfSelected={selectedStackByOption}
+                  hasDividers={true}
+                  itemLayoutAlign="top"
                 />
               )}
             </EuiFlexItem>
@@ -130,7 +132,7 @@ export const UserActivityPrivilegedUsersPanel: React.FC<{
 
           <EsqlDashboardPanel<TableItemType>
             title={TITLE}
-            stackByField={selectedStackByOption.value}
+            stackByField={selectedStackByOption}
             timerange={{ from, to }}
             getLensAttributes={getLensAttributes}
             generateVisualizationQuery={generateVisualizationQuery}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.tsx
@@ -81,7 +81,7 @@ export const UserActivityPrivilegedUsersPanel: React.FC<{
         id={PRIVILEGED_USER_ACTIVITY_QUERY_ID}
         showInspectButton={false}
         title={TITLE}
-        titleSize="s"
+        titleSize="m"
         outerDirection="column"
         hideSubtitle
       >

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/index.tsx
@@ -90,7 +90,7 @@ export const PrivilegedUsersTable: React.FC<{ spaceId: string }> = ({ spaceId })
           toggleQuery={setToggleStatus}
           id={PRIVILEGED_USERS_TABLE_QUERY_ID}
           title={TITLE}
-          titleSize="s"
+          titleSize="m"
           outerDirection="column"
           hideSubtitle
         />

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/risk_level_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/risk_level_panel/index.test.tsx
@@ -47,7 +47,7 @@ describe('RiskLevelsPrivilegedUsersPanel', () => {
   it('renders the panel with the correct title', () => {
     render(<RiskLevelsPrivilegedUsersPanel spaceId={'default'} />, { wrapper: TestProviders });
 
-    expect(screen.getByText('Risk levels of privileged users')).toBeInTheDocument();
+    expect(screen.getByText('Privileged user risk levels')).toBeInTheDocument();
   });
 
   it('renders the error callout when there is an error', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/risk_level_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/risk_level_panel/index.tsx
@@ -26,7 +26,7 @@ import { EnableRiskScore } from '../../../enable_risk_score';
 
 const TITLE = i18n.translate(
   'xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.riskLevels.title',
-  { defaultMessage: 'Risk levels of privileged users' }
+  { defaultMessage: 'Privileged user risk levels' }
 );
 
 export const DONUT_CHART_HEIGHT = 160;
@@ -92,7 +92,7 @@ export const RiskLevelsPrivilegedUsersPanel: React.FC<{ spaceId: string }> = ({ 
           id={RISK_LEVELS_PRIVILEGED_USERS_QUERY_ID}
           inspectTitle={TITLE}
           title={TITLE}
-          titleSize="s"
+          titleSize="m"
           outerDirection={'column'}
         />
         {toggleStatus &&

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.tsx
@@ -32,11 +32,6 @@ import type { EsqlQueryOrInvalidFields } from '../../../privileged_user_monitori
 
 export const DEFAULT_PAGE_SIZE = 10;
 
-export interface VisualizationStackByOption {
-  text: string;
-  value: string;
-}
-
 export const EsqlDashboardPanel = <TableItemType extends Record<string, string>>({
   stackByField,
   generateVisualizationQuery,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/constants.ts
@@ -72,7 +72,7 @@ export const GRANTED_RIGHTS_DATA: UserRowData[] = [
   },
 ];
 
-export const GRANTED_RIGHTS_STACK_BY_OPTIONS: EuiSuperSelectOption<string>[] = [
+export const GRANTED_RIGHTS_STACK_BY_OPTIONS: EuiSuperSelectOption<VisualizationStackByOption>[] = [
   {
     inputDisplay: 'Privileged User',
     value: 'privileged_user',

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/constants.ts
@@ -6,9 +6,7 @@
  */
 
 import moment from 'moment';
-import type { EuiSuperSelectOption } from '@elastic/eui';
 import type { UserRowData } from './types';
-import type { VisualizationStackByOption } from '../esql_dashboard_panel/esql_dashboard_panel';
 
 export const PAGE_SIZE = 10;
 export const CURRENT_TIME = moment();
@@ -72,7 +70,7 @@ export const GRANTED_RIGHTS_DATA: UserRowData[] = [
   },
 ];
 
-export const GRANTED_RIGHTS_STACK_BY_OPTIONS: EuiSuperSelectOption<VisualizationStackByOption>[] = [
+export const GRANTED_RIGHTS_STACK_BY_OPTIONS = [
   {
     inputDisplay: 'Privileged User',
     value: 'privileged_user',

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/constants.ts
@@ -6,6 +6,7 @@
  */
 
 import moment from 'moment';
+import type { EuiSuperSelectOption } from '@elastic/eui';
 import type { UserRowData } from './types';
 import type { VisualizationStackByOption } from '../esql_dashboard_panel/esql_dashboard_panel';
 
@@ -71,21 +72,21 @@ export const GRANTED_RIGHTS_DATA: UserRowData[] = [
   },
 ];
 
-export const GRANTED_RIGHTS_STACK_BY_OPTIONS: VisualizationStackByOption[] = [
+export const GRANTED_RIGHTS_STACK_BY_OPTIONS: EuiSuperSelectOption<string>[] = [
   {
-    text: 'Privileged User',
+    inputDisplay: 'Privileged User',
     value: 'privileged_user',
   },
   {
-    text: 'Target user',
+    inputDisplay: 'Target user',
     value: 'target_user',
   },
   {
-    text: 'Granted right',
+    inputDisplay: 'Granted right',
     value: 'right',
   },
   {
-    text: 'Source IP',
+    inputDisplay: 'Source IP',
     value: 'ip',
   },
 ];

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/constants.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/constants.tsx
@@ -6,8 +6,9 @@
  */
 
 import moment from 'moment';
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import type { UserRowData } from './types';
-
 export const PAGE_SIZE = 10;
 export const CURRENT_TIME = moment();
 
@@ -72,19 +73,39 @@ export const GRANTED_RIGHTS_DATA: UserRowData[] = [
 
 export const GRANTED_RIGHTS_STACK_BY_OPTIONS = [
   {
-    inputDisplay: 'Privileged User',
+    inputDisplay: (
+      <FormattedMessage
+        id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.sampleDashBoard.stackBy.privilegedUser"
+        defaultMessage="Privileged user"
+      />
+    ),
     value: 'privileged_user',
   },
   {
-    inputDisplay: 'Target user',
+    inputDisplay: (
+      <FormattedMessage
+        id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.sampleDashBoard.stackBy.targetUser"
+        defaultMessage="Target user"
+      />
+    ),
     value: 'target_user',
   },
   {
-    inputDisplay: 'Granted right',
+    inputDisplay: (
+      <FormattedMessage
+        id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.sampleDashBoard.stackBy.grantedRight"
+        defaultMessage="Granted right"
+      />
+    ),
     value: 'right',
   },
   {
-    inputDisplay: 'Source IP',
+    inputDisplay: (
+      <FormattedMessage
+        id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.sampleDashBoard.stackBy.sourceIp"
+        defaultMessage="Source IP"
+      />
+    ),
     value: 'ip',
   },
 ];

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/sample_dashboard.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/sample_dashboard.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { PrivilegedUserMonitoringSampleDashboard } from './sample_dashboard';
 import { TestProviders } from '../../../../../common/mock';
 
@@ -27,23 +27,28 @@ describe('PrivilegedUserMonitoringSampleDashboard', () => {
     expect(screen.getByTestId('esql-dashboard-panel')).toBeInTheDocument();
   });
 
-  it('renders the EuiSelect with stack by options', () => {
+  it('renders the EuiSuperSelect with selected option', () => {
     render(<PrivilegedUserMonitoringSampleDashboard />, { wrapper: TestProviders });
-    expect(screen.getByText('Stack by')).toBeInTheDocument();
-    expect(screen.getAllByRole('option').length).toBeGreaterThan(0);
+    expect(screen.getByText('Privileged user')).toBeInTheDocument();
   });
 
   it('calls setSelectedStackByOption when EuiSelect changes', () => {
     render(<PrivilegedUserMonitoringSampleDashboard />, { wrapper: TestProviders });
-    const select = screen.getByRole<HTMLInputElement>('combobox');
-    const options = screen.getAllByRole('option');
+
+    // Asset the initial state
+    expect(screen.getByDisplayValue('privileged_user')).toBeInTheDocument();
+
+    // Open the select dropdown
+    act(() => {
+      screen.getByText('Privileged user').click(); // click to open the select
+    });
 
     // Simulate changing the select value to the second option
-    const secondOption = options[1];
-    fireEvent.change(select, { target: { value: secondOption.getAttribute('value') } });
+    act(() => {
+      screen.getByRole('option', { name: 'Target user' }).click();
+    });
+
     // The component should re-render with the new stackByField
-    expect(screen.getByRole<HTMLInputElement>('combobox').value).toBe(
-      options[1].getAttribute('value')
-    );
+    expect(screen.getByDisplayValue('target_user')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/sample_dashboard.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/sample_dashboard.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiPanel, EuiSelect, EuiSuperSelect } from '@elastic/eui';
+import { EuiPanel, EuiSuperSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { HeaderSection } from '../../../../../common/components/header_section';
 import { getLensAttributes } from './get_lens_attributes';

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/sample_dashboard.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/sample_dashboard.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiPanel, EuiSelect } from '@elastic/eui';
+import { EuiPanel, EuiSelect, EuiSuperSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { HeaderSection } from '../../../../../common/components/header_section';
 import { getLensAttributes } from './get_lens_attributes';
@@ -19,7 +19,7 @@ import {
   generateVisualizationESQLQuery,
   getBucketTimeRange,
 } from './esql_data_generation';
-import type { VisualizationStackByOption } from '../esql_dashboard_panel/esql_dashboard_panel';
+
 import { EsqlDashboardPanel } from '../esql_dashboard_panel/esql_dashboard_panel';
 import type { TableItemType } from './types';
 
@@ -36,17 +36,16 @@ const PrivilegedUserMonitoringSampleDashboardComponent = () => {
   const stackByOptions = GRANTED_RIGHTS_STACK_BY_OPTIONS;
 
   const setSelectedChartOptionCallback = useCallback(
-    (event: React.ChangeEvent<HTMLSelectElement>) => {
-      setSelectedStackByOption(
-        stackByOptions.find((co) => co.value === event.target.value) ?? stackByOptions[0]
-      );
+    (value: string) => {
+      setSelectedStackByOption(value ?? stackByOptions[0].value);
     },
     [stackByOptions]
   );
 
   const defaultStackByOption = stackByOptions[0];
-  const [selectedStackByOption, setSelectedStackByOption] =
-    useState<VisualizationStackByOption>(defaultStackByOption);
+  const [selectedStackByOption, setSelectedStackByOption] = useState<string>(
+    defaultStackByOption.value
+  );
 
   const title = (
     <FormattedMessage
@@ -58,20 +57,22 @@ const PrivilegedUserMonitoringSampleDashboardComponent = () => {
   return (
     <EuiPanel hasBorder hasShadow={false} data-test-subj="privMonSampleDashboard">
       <HeaderSection title={title} titleSize="s" outerDirection={'column'}>
-        <EuiSelect
+        <EuiSuperSelect
           onChange={setSelectedChartOptionCallback}
           options={GRANTED_RIGHTS_STACK_BY_OPTIONS}
           prepend={i18n.translate('xpack.securitySolution.genericDashboard.stackBy.label', {
             defaultMessage: 'Stack by',
           })}
-          value={selectedStackByOption?.value}
+          valueOfSelected={selectedStackByOption}
+          hasDividers={true}
+          itemLayoutAlign="top"
         />
       </HeaderSection>
 
       <EsqlDashboardPanel<TableItemType>
         title={title}
         timerange={bucketTimerange}
-        stackByField={selectedStackByOption.value}
+        stackByField={selectedStackByOption}
         getLensAttributes={getLensAttributes}
         generateVisualizationQuery={generateVisualizationQuery}
         generateTableQuery={generateTableQuery}


### PR DESCRIPTION
## Summary

* Update "Privileged user risk levels" title
* Update title font size
* Add superselect to "Privileged user activity"

<img width="2944" height="1410" alt="Screenshot 2025-08-18 at 09 04 10" src="https://github.com/user-attachments/assets/cbdb270b-3bde-47b6-85fb-5a818dc23de3" />
<img width="2944" height="1000" alt="Screenshot 2025-08-18 at 09 03 30" src="https://github.com/user-attachments/assets/3490fca5-8ea2-4b03-82fe-4104af597a05" />

