### PR TITLE
[8.19] [ResponseOps] Change field params type in find rules api (#230788)

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -5512,15 +5512,22 @@
             }
           },
           {
+            "description": "The fields to return in the `attributes` key of the response.",
             "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
-              "items": {
-                "description": "The fields to return in the `attributes` key of the response.",
-                "type": "string"
-              },
-              "type": "array"
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           {

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -5049,15 +5049,22 @@
             }
           },
           {
+            "description": "The fields to return in the `attributes` key of the response.",
             "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
-              "items": {
-                "description": "The fields to return in the `attributes` key of the response.",
-                "type": "string"
-              },
-              "type": "array"
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           {

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -4780,14 +4780,16 @@ paths:
             required:
               - type
               - id
-        - in: query
+        - description: The fields to return in the `attributes` key of the response.
+          in: query
           name: fields
           required: false
           schema:
-            items:
-              description: The fields to return in the `attributes` key of the response.
-              type: string
-            type: array
+            anyOf:
+              - items:
+                  type: string
+                type: array
+              - type: string
         - description: 'A KQL string that you filter with an attribute from your saved object. It should look like `savedObjectType.attributes.title: "myTitle"`. However, if you used a direct attribute of a saved object, such as `updatedAt`, you must define your filter, for example, `savedObjectType.updatedAt > 2018-12-22`.'
           in: query
           name: filter

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -4760,14 +4760,16 @@ paths:
             required:
               - type
               - id
-        - in: query
+        - description: The fields to return in the `attributes` key of the response.
+          in: query
           name: fields
           required: false
           schema:
-            items:
-              description: The fields to return in the `attributes` key of the response.
-              type: string
-            type: array
+            anyOf:
+              - items:
+                  type: string
+                type: array
+              - type: string
         - description: 'A KQL string that you filter with an attribute from your saved object. It should look like `savedObjectType.attributes.title: "myTitle"`. However, if you used a direct attribute of a saved object, such as `updatedAt`, you must define your filter, for example, `savedObjectType.updatedAt > 2018-12-22`.'
           in: query
           name: filter

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/find/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/find/schemas/v1.ts
@@ -4,8 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import { schema } from '@kbn/config-schema';
+import { stringOrStringArraySchema } from '../../../../../schemas';
 
 export const findRulesRequestQuerySchema = schema.object({
   per_page: schema.number({
@@ -37,7 +37,7 @@ export const findRulesRequestQuerySchema = schema.object({
     },
   }),
   search_fields: schema.maybe(
-    schema.oneOf([schema.arrayOf(schema.string()), schema.string()], {
+    stringOrStringArraySchema({
       meta: {
         description: 'The fields to perform the simple_query_string parsed query against.',
       },
@@ -77,13 +77,11 @@ export const findRulesRequestQuerySchema = schema.object({
     )
   ),
   fields: schema.maybe(
-    schema.arrayOf(
-      schema.string({
-        meta: {
-          description: 'The fields to return in the `attributes` key of the response.',
-        },
-      })
-    )
+    stringOrStringArraySchema({
+      meta: {
+        description: 'The fields to return in the `attributes` key of the response.',
+      },
+    })
   ),
   filter: schema.maybe(
     schema.string({
@@ -117,7 +115,7 @@ export const findRulesInternalRequestBodySchema = schema.object({
   default_search_operator: schema.oneOf([schema.literal('OR'), schema.literal('AND')], {
     defaultValue: 'OR',
   }),
-  search_fields: schema.maybe(schema.oneOf([schema.arrayOf(schema.string()), schema.string()])),
+  search_fields: schema.maybe(stringOrStringArraySchema()),
   sort_field: schema.maybe(schema.string()),
   sort_order: schema.maybe(schema.oneOf([schema.literal('asc'), schema.literal('desc')])),
   has_reference: schema.maybe(

--- a/x-pack/platform/plugins/shared/alerting/common/schemas.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/schemas.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { UnionTypeOptions } from '@kbn/config-schema/src/types';
+
+export const stringOrStringArraySchema = (options?: UnionTypeOptions<string | string[]>) =>
+  schema.oneOf([schema.arrayOf(schema.string()), schema.string()], options);

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/find/find_internal_rules_route.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/find/find_internal_rules_route.ts
@@ -51,7 +51,6 @@ export const findInternalRulesRoute = (
         const options = transformFindRulesInternalBodyV1({
           ...body,
           has_reference: body.has_reference || undefined,
-          search_fields: searchFieldsAsArray(body.search_fields),
         });
 
         if (req.body.fields) {
@@ -78,10 +77,3 @@ export const findInternalRulesRoute = (
     )
   );
 };
-
-function searchFieldsAsArray(searchFields: string | string[] | undefined): string[] | undefined {
-  if (!searchFields) {
-    return;
-  }
-  return Array.isArray(searchFields) ? searchFields : [searchFields];
-}

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/find/find_rules_route.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/find/find_rules_route.test.ts
@@ -515,6 +515,146 @@ describe('findRulesRoute', () => {
     });
   });
 
+  it('should support fields param as string', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    findRulesRoute(router, licenseState);
+
+    const [config, handler] = router.get.mock.calls[0];
+
+    expect(config.path).toMatchInlineSnapshot(`"/api/alerting/rules/_find"`);
+
+    const findResult = {
+      page: 1,
+      perPage: 1,
+      total: 0,
+      data: [],
+    };
+    rulesClient.find.mockResolvedValueOnce(findResult);
+
+    const [context, req, res] = mockHandlerArguments(
+      { rulesClient },
+      {
+        query: {
+          per_page: 1,
+          page: 1,
+          default_search_operator: 'OR',
+          fields: 'foobar',
+        },
+      },
+      ['ok']
+    );
+
+    expect(await handler(context, req, res)).toMatchInlineSnapshot(`
+            Object {
+              "body": Object {
+                "data": Array [],
+                "page": 1,
+                "per_page": 1,
+                "total": 0,
+              },
+            }
+        `);
+
+    expect(rulesClient.find).toHaveBeenCalledTimes(1);
+    expect(rulesClient.find.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "excludeFromPublicApi": true,
+          "includeSnoozeData": true,
+          "options": Object {
+            "defaultSearchOperator": "OR",
+            "fields": Array [
+              "foobar",
+            ],
+            "page": 1,
+            "perPage": 1,
+          },
+        },
+      ]
+    `);
+
+    expect(res.ok).toHaveBeenCalledWith({
+      body: {
+        page: 1,
+        per_page: 1,
+        total: 0,
+        data: [],
+      },
+    });
+  });
+
+  it('should support search_fields param as string', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    findRulesRoute(router, licenseState);
+
+    const [config, handler] = router.get.mock.calls[0];
+
+    expect(config.path).toMatchInlineSnapshot(`"/api/alerting/rules/_find"`);
+
+    const findResult = {
+      page: 1,
+      perPage: 1,
+      total: 0,
+      data: [],
+    };
+    rulesClient.find.mockResolvedValueOnce(findResult);
+
+    const [context, req, res] = mockHandlerArguments(
+      { rulesClient },
+      {
+        query: {
+          per_page: 1,
+          page: 1,
+          default_search_operator: 'OR',
+          search_fields: 'foobar',
+        },
+      },
+      ['ok']
+    );
+
+    expect(await handler(context, req, res)).toMatchInlineSnapshot(`
+            Object {
+              "body": Object {
+                "data": Array [],
+                "page": 1,
+                "per_page": 1,
+                "total": 0,
+              },
+            }
+        `);
+
+    expect(rulesClient.find).toHaveBeenCalledTimes(1);
+    expect(rulesClient.find.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "excludeFromPublicApi": true,
+          "includeSnoozeData": true,
+          "options": Object {
+            "defaultSearchOperator": "OR",
+            "page": 1,
+            "perPage": 1,
+            "searchFields": Array [
+              "foobar",
+            ],
+          },
+        },
+      ]
+    `);
+
+    expect(res.ok).toHaveBeenCalledWith({
+      body: {
+        page: 1,
+        per_page: 1,
+        total: 0,
+        data: [],
+      },
+    });
+  });
+
   it('should not support consumers', async () => {
     const licenseState = licenseStateMock.create();
     const router = httpServiceMock.createRouter();

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/find/find_rules_route.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/find/find_rules_route.ts
@@ -68,7 +68,6 @@ export const findRulesRoute = (
         const options = transformFindRulesBodyV1({
           ...query,
           has_reference: query.has_reference || undefined,
-          search_fields: searchFieldsAsArray(query.search_fields),
         });
 
         if (req.query.fields) {
@@ -95,10 +94,3 @@ export const findRulesRoute = (
     )
   );
 };
-
-function searchFieldsAsArray(searchFields: string | string[] | undefined): string[] | undefined {
-  if (!searchFields) {
-    return;
-  }
-  return Array.isArray(searchFields) ? searchFields : [searchFields];
-}

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/find/transforms/transform_find_rules_body/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/find/transforms/transform_find_rules_body/v1.ts
@@ -28,7 +28,7 @@ export const transformFindRulesBody = (params: FindRulesRequestQueryV1): FindRul
   return {
     ...(page ? { page } : {}),
     ...(search ? { search } : {}),
-    ...(fields ? { fields } : {}),
+    ...(fields ? { fields: Array.isArray(fields) ? fields : [fields] } : {}),
     ...(filter ? { filter } : {}),
     ...(defaultSearchOperator ? { defaultSearchOperator } : {}),
     ...(perPage ? { perPage } : {}),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps] Change field params type in find rules api (#230788)](https://github.com/elastic/kibana/pull/230788)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Antonio","email":"antonio.coelho@elastic.co"},"sourceCommit":{"committedDate":"2025-08-11T10:07:01Z","message":"[ResponseOps] Change field params type in find rules api (#230788)\n\nCloses #154554\n\n## Summary\n\nThis PR changes the type accepted for the fields query parameter in the\nfind rules public API.\n\nIn some of our APIs, we accept an array of items in the query params.\nThe schema is usually defined as `schema.arrayOf(schema.string())`. If\nthe user submits only one parameter, in this case `_find?fields=id`, the\nschema validation throws an error, such as `[request query.fields]:\ncould not parse array value from JSON input`.\n\nChanging the accepted type to\n`schema.oneOf([schema.arrayOf(schema.string()), schema.string()])`, and\nhandling the `string` possibility, fixes this problem.\n\nI also removed a couple of occurrences of `searchFieldsAsArray` since\nthat logic is duplicated and already handled in\n`transformFindRules*Body`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3af89ec325e51a0e7dba0fbed82d0b821be2469b","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport missing","backport:version","v9.2.0"],"title":"[ResponseOps] Change field params type in find rules api","number":230788,"url":"https://github.com/elastic/kibana/pull/230788","mergeCommit":{"message":"[ResponseOps] Change field params type in find rules api (#230788)\n\nCloses #154554\n\n## Summary\n\nThis PR changes the type accepted for the fields query parameter in the\nfind rules public API.\n\nIn some of our APIs, we accept an array of items in the query params.\nThe schema is usually defined as `schema.arrayOf(schema.string())`. If\nthe user submits only one parameter, in this case `_find?fields=id`, the\nschema validation throws an error, such as `[request query.fields]:\ncould not parse array value from JSON input`.\n\nChanging the accepted type to\n`schema.oneOf([schema.arrayOf(schema.string()), schema.string()])`, and\nhandling the `string` possibility, fixes this problem.\n\nI also removed a couple of occurrences of `searchFieldsAsArray` since\nthat logic is duplicated and already handled in\n`transformFindRules*Body`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3af89ec325e51a0e7dba0fbed82d0b821be2469b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230788","number":230788,"mergeCommit":{"message":"[ResponseOps] Change field params type in find rules api (#230788)\n\nCloses #154554\n\n## Summary\n\nThis PR changes the type accepted for the fields query parameter in the\nfind rules public API.\n\nIn some of our APIs, we accept an array of items in the query params.\nThe schema is usually defined as `schema.arrayOf(schema.string())`. If\nthe user submits only one parameter, in this case `_find?fields=id`, the\nschema validation throws an error, such as `[request query.fields]:\ncould not parse array value from JSON input`.\n\nChanging the accepted type to\n`schema.oneOf([schema.arrayOf(schema.string()), schema.string()])`, and\nhandling the `string` possibility, fixes this problem.\n\nI also removed a couple of occurrences of `searchFieldsAsArray` since\nthat logic is duplicated and already handled in\n`transformFindRules*Body`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3af89ec325e51a0e7dba0fbed82d0b821be2469b"}}]}] BACKPORT-->