### PR TITLE
[8.19] [APM] Fix the exit span analysis (#231432)

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/diagnostic_service_map.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/diagnostic_service_map.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { apm, ApmFields, httpExitSpan, Serializable } from '@kbn/apm-synthtrace-client';
+import { Readable } from 'stream';
+import { Scenario } from '../cli/scenario';
+import { RunOptions } from '../cli/utils/parse_run_cli_flags';
+import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
+import { withClient } from '../lib/utils/with_client';
+
+const ENVIRONMENT = getSynthtraceEnvironment(__filename);
+
+const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
+  return {
+    generate: ({ range, clients: { apmEsClient } }) => {
+      const successfulTimestamps = range.interval('15m').rate(1);
+
+      const web = apm
+        .service({ name: 'web', environment: ENVIRONMENT, agentName: 'rum-js' })
+        .instance('my-instance');
+      const proxy = apm
+        .service({ name: 'frontend-proxy', environment: ENVIRONMENT, agentName: 'nodejs' })
+        .instance('my-instance');
+      const backend = apm
+        .service({ name: 'backend', environment: ENVIRONMENT, agentName: 'go' })
+        .instance('my-instance');
+
+      const payment = apm
+        .service({ name: 'payment-service', environment: ENVIRONMENT, agentName: 'go' })
+        .instance('my-instance');
+
+      const traces = successfulTimestamps.generator((timestamp) => {
+        // web
+        return web
+          .transaction({ transactionName: 'Initial transaction in web' })
+          .duration(400)
+          .timestamp(timestamp)
+          .children(
+            // web -> proxy
+            web
+              .span(
+                httpExitSpan({
+                  spanName: 'Missing span.destination.service.resource',
+                  destinationUrl: 'http://proxy:3000',
+                })
+              )
+              .duration(300)
+              .timestamp(timestamp + 10)
+              .children(
+                // frontend
+                proxy
+                  .transaction({ transactionName: 'Initial transaction in proxy' })
+                  .duration(300)
+                  .timestamp(timestamp + 20)
+              ),
+
+            web
+              .span(
+                httpExitSpan({
+                  spanName: 'GET /backend/api/products/top',
+                  destinationUrl: 'http://backend:3000',
+                })
+              )
+              .duration(300)
+              .timestamp(timestamp + 10)
+              .children(
+                // backend
+                backend
+                  .transaction({ transactionName: 'Initial transaction in backend' })
+                  .duration(300)
+                  .timestamp(timestamp + 20)
+                  .children(
+                    backend
+                      .span(
+                        httpExitSpan({
+                          spanName: 'GET /payment',
+                          destinationUrl: 'http://payment:3000',
+                        })
+                      )
+                      .timestamp(timestamp + 30)
+                      .duration(300)
+                      .children(
+                        // payment
+                        payment
+                          .transaction({ transactionName: 'Initial transaction in payment' })
+                          .timestamp(timestamp + 40)
+                          .duration(200)
+                          .children(
+                            payment
+                              .span({ spanName: 'execute_payment', spanType: 'custom' })
+                              .timestamp(timestamp + 50)
+                              .duration(100)
+                              .success()
+                          )
+                      )
+                  )
+              )
+          );
+      });
+
+      const unserialized = Array.from(traces);
+
+      const serialized = unserialized
+        .flatMap((event) => event.serialize())
+        .filter((event) => event['transaction.name'] !== 'Initial transaction in payment')
+        .map((event) => {
+          if (event['span.destination.service.resource'] === 'proxy:3000') {
+            delete event['span.destination.service.resource'];
+          }
+          return event;
+        });
+
+      const unserializedChanged = serialized.map((event) => ({
+        fields: event,
+        serialize: () => {
+          return [event];
+        },
+      })) as Array<Serializable<ApmFields>>;
+
+      return withClient(apmEsClient, Readable.from([...unserializedChanged]));
+    },
+  };
+};
+
+export default scenario;

--- a/x-pack/solutions/observability/plugins/apm/common/service_map_diagnostic_types.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/service_map_diagnostic_types.ts
@@ -8,16 +8,12 @@
 import type { ESSearchResponse, ESSearchRequest } from '@kbn/es-types';
 
 export interface ExitSpanFields {
-  destinationService?: string;
-  spanSubType?: string;
-  spanId?: string;
-  spanType?: string;
-  transactionId?: string;
-  serviceNodeName?: string;
-  traceId?: string;
-  agentName?: string;
-  docCount?: number;
-  isOtel?: boolean;
+  destinationService: string;
+  spanId: string;
+  transactionId: string;
+  serviceNodeName: string;
+  traceId: string;
+  agentName: string;
 }
 
 export interface ServiceMapDiagnosticResponse {
@@ -25,7 +21,7 @@ export interface ServiceMapDiagnosticResponse {
     exitSpans: {
       found: boolean;
       totalConnections: number;
-      apmExitSpans: ExitSpanFields[];
+      apmExitSpans: ExitSpanFields[] | [];
       hasMatchingDestinationResources: boolean;
     };
     parentRelationships: {
@@ -43,7 +39,7 @@ export interface ServiceMapDiagnosticResponse {
   };
   elasticsearchResponses: {
     exitSpansQuery?: ESSearchResponse<unknown, ESSearchRequest>;
-    sourceSpanIdsQuery?: ESSearchResponse<unknown, ESSearchRequest>;
+    sourceSpansQuery?: ESSearchResponse<unknown, ESSearchRequest>;
     destinationParentIdsQuery?: ESSearchResponse<unknown, ESSearchRequest>;
     traceCorrelationQuery?: ESSearchResponse<unknown, ESSearchRequest>;
   };

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/diagnostic_tool/diagnostic_highlighted_exit_spans_table.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/diagnostic_tool/diagnostic_highlighted_exit_spans_table.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiBasicTable, EuiPanel, EuiBadge } from '@elastic/eui';
+import { EuiBasicTable, EuiPanel } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { ExitSpanFields } from '../../../../../common/service_map_diagnostic_types';
@@ -28,20 +28,7 @@ const columns: Array<EuiBasicTableColumn<ExitSpanFields>> = [
     name: i18n.translate('xpack.apm.serviceMap.diagnosticResults.table.destinationService', {
       defaultMessage: 'Destination Service',
     }),
-    render: (value: string | undefined, item: ExitSpanFields) => (
-      <div>
-        {value || <em>—</em>}
-        {item.isOtel && (
-          <div style={{ marginTop: '4px' }}>
-            <EuiBadge color="accent">
-              {i18n.translate('xpack.apm.serviceMap.diagnosticResults.table.otelBadge', {
-                defaultMessage: 'OTEL (destination.address)',
-              })}
-            </EuiBadge>
-          </div>
-        )}
-      </div>
-    ),
+    render: (value: string | undefined, item: ExitSpanFields) => <div>{value || <em>—</em>}</div>,
   },
   {
     field: 'agentName',
@@ -51,23 +38,9 @@ const columns: Array<EuiBasicTableColumn<ExitSpanFields>> = [
     render: (value: string | undefined) => value || <em>—</em>,
   },
   {
-    field: 'spanSubType',
-    name: i18n.translate('xpack.apm.serviceMap.diagnosticResults.table.subtype', {
-      defaultMessage: 'Subtype',
-    }),
-    render: (value: string | undefined) => value || <em>—</em>,
-  },
-  {
     field: 'spanId',
     name: i18n.translate('xpack.apm.serviceMap.diagnosticResults.table.spanId', {
       defaultMessage: 'Span ID',
-    }),
-    render: (value: string | undefined) => value || <em>—</em>,
-  },
-  {
-    field: 'spanType',
-    name: i18n.translate('xpack.apm.serviceMap.diagnosticResults.table.type', {
-      defaultMessage: 'Type',
     }),
     render: (value: string | undefined) => value || <em>—</em>,
   },

--- a/x-pack/solutions/observability/plugins/apm/server/routes/diagnostics/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/diagnostics/route.ts
@@ -117,7 +117,7 @@ const getServiceMapDiagnosticsRoute = createApmServerRoute({
       end,
     });
 
-    const [sourceSpanIds, traceCorrelation] = await Promise.all([
+    const [sourceSpans, traceCorrelation] = await Promise.all([
       getSourceSpanIds({
         apmEventClient,
         start,
@@ -142,13 +142,13 @@ const getServiceMapDiagnosticsRoute = createApmServerRoute({
         end,
         sourceNode,
         destinationNode,
-        ids: sourceSpanIds.spanIds,
+        parentSpans: sourceSpans.destinationsBySpanId,
       }),
       getDestinationParentIds({
         apmEventClient,
         start,
         end,
-        ids: sourceSpanIds.spanIds,
+        parentSpans: sourceSpans.destinationsBySpanId,
         destinationNode,
       }),
     ]);
@@ -164,7 +164,7 @@ const getServiceMapDiagnosticsRoute = createApmServerRoute({
         parentRelationships: {
           found: destinationParentIds.hasParent,
           documentCount: destinationParentIds.rawResponse?.hits?.hits?.length || 0,
-          sourceSpanIds: [...sourceSpanIds.spanIds],
+          sourceSpanIds: [...sourceSpans.destinationsBySpanId.keys()],
         },
         ...(traceId && {
           traceCorrelation: {
@@ -179,7 +179,7 @@ const getServiceMapDiagnosticsRoute = createApmServerRoute({
       // Include raw Elasticsearch responses for debugging and advanced analysis
       elasticsearchResponses: {
         exitSpansQuery: exitSpans.rawResponse,
-        sourceSpanIdsQuery: sourceSpanIds.sourceSpanIdsRawResponse,
+        sourceSpansQuery: sourceSpans.sourceSpanIdsRawResponse,
         destinationParentIdsQuery: destinationParentIds.rawResponse,
         ...(traceId && {
           traceCorrelationQuery: traceCorrelation?.rawResponse,

--- a/x-pack/solutions/observability/plugins/apm/server/routes/diagnostics/service_map/get_exit_spans_from_samples.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/diagnostics/service_map/get_exit_spans_from_samples.ts
@@ -12,8 +12,6 @@ import type { ESSearchResponse, ESSearchRequest } from '@kbn/es-types';
 import {
   SERVICE_NAME,
   SPAN_ID,
-  SPAN_TYPE,
-  SPAN_SUBTYPE,
   TRACE_ID,
   TRANSACTION_ID,
   SPAN_NAME,
@@ -23,33 +21,37 @@ import {
   SPAN_DESTINATION_SERVICE_RESOURCE,
 } from '@kbn/apm-types';
 import type { APMEventClient } from '@kbn/apm-data-access-plugin/server';
+import type { ExitSpanFields } from '../../../../common/service_map_diagnostic_types';
 import { asMutableArray } from '../../../../common/utils/as_mutable_array';
+
+type DestinationsBySpanId = Map<string, string | undefined>;
 
 export async function getExitSpans({
   apmEventClient,
   start,
   end,
   destinationNode,
-  ids,
+  parentSpans,
 }: {
   apmEventClient: APMEventClient;
   start: number;
   end: number;
   sourceNode: string;
   destinationNode: string;
-  ids: string[];
+  parentSpans: DestinationsBySpanId;
 }) {
   const requiredFields = asMutableArray([
     SERVICE_NAME,
     SPAN_ID,
-    SPAN_TYPE,
-    SPAN_SUBTYPE,
     TRACE_ID,
     TRANSACTION_ID,
     SPAN_NAME,
     SERVICE_NODE_NAME,
     AGENT_NAME,
+    PARENT_ID,
   ] as const);
+
+  const parentSpanIds = Array.from(parentSpans.keys());
 
   const response = await apmEventClient.search('diagnostics_get_exit_spans_from_source_node', {
     apm: {
@@ -60,7 +62,7 @@ export async function getExitSpans({
       size: 0,
       query: {
         bool: {
-          filter: [...rangeQuery(start, end), ...termsQuery(PARENT_ID, ...ids)],
+          filter: [...rangeQuery(start, end), ...termsQuery(PARENT_ID, ...parentSpanIds)],
         },
       },
       aggs: {
@@ -73,20 +75,7 @@ export async function getExitSpans({
           aggs: {
             sample_docs: {
               top_hits: {
-                size: 5,
-              },
-            },
-          },
-        },
-        destination_services: {
-          terms: {
-            field: SERVICE_NAME,
-            size: 50,
-          },
-          aggs: {
-            sample_docs: {
-              top_hits: {
-                size: 5,
+                size: 50,
                 fields: [...requiredFields],
               },
             },
@@ -96,31 +85,30 @@ export async function getExitSpans({
     },
   });
 
-  const apmExitSpans =
-    response?.aggregations?.destination_services?.buckets?.map((item) => {
-      const fields = unflattenKnownApmEventFields(item?.sample_docs?.hits?.hits?.[0]?.fields);
+  const apmExitSpans = (
+    response?.aggregations?.matching_destination_resources?.sample_docs?.hits?.hits.map((doc) => {
+      const fields = unflattenKnownApmEventFields(doc?.fields);
+
+      if (!fields?.parent?.id || !parentSpans.get(fields?.parent?.id)) {
+        return;
+      }
 
       return {
         destinationService: fields?.service?.name,
-        spanSubType: fields?.span?.subtype ?? '',
         spanId: fields?.span?.id ?? '',
-        spanType: fields?.span?.type ?? '',
         transactionId: fields?.transaction?.id ?? '',
         serviceNodeName: fields?.service?.node?.name ?? '',
         traceId: fields?.trace?.id ?? '',
         agentName: fields?.agent?.name ?? '',
-        docCount: item?.doc_count ?? 0,
-        isOtel: false,
       };
-    }) ?? [];
+    }) ?? []
+  ).filter((span): span is ExitSpanFields => !!span);
 
-  const matchingCount =
-    response?.aggregations?.matching_destination_resources?.sample_docs?.hits?.total?.value || 0;
   return {
     apmExitSpans,
     totalConnections: apmExitSpans.length,
     rawResponse: response,
-    hasMatchingDestinationResources: matchingCount > 0,
+    hasMatchingDestinationResources: apmExitSpans.length > 0,
   };
 }
 
@@ -137,37 +125,49 @@ export async function getSourceSpanIds({
   sourceNode: string;
   traceIds: string[];
 }): Promise<{
-  spanIds: string[];
+  destinationsBySpanId: DestinationsBySpanId;
   sourceSpanIdsRawResponse: ESSearchResponse<unknown, ESSearchRequest>;
 }> {
   const requiredFields = asMutableArray([SPAN_ID] as const);
+  const optionalFields = asMutableArray([SPAN_DESTINATION_SERVICE_RESOURCE] as const);
   const response = await apmEventClient.search('diagnostics_get_source_node_span_samples', {
     apm: {
       events: [ProcessorEvent.span],
     },
-    body: {
+    body:{ 
       track_total_hits: false,
       size: 0,
       query: {
         bool: {
-          filter: [
-            ...rangeQuery(start, end),
-            ...termsQuery(SERVICE_NAME, sourceNode),
-            ...termsQuery(TRACE_ID, ...traceIds),
-          ],
+          filter: [...rangeQuery(start, end), ...termsQuery(TRACE_ID, ...traceIds)],
         },
       },
       aggs: {
         sample_docs: {
-          terms: {
-            field: SPAN_NAME,
-            size: 500,
+          composite: {
+            size: 1000,
+            sources: asMutableArray([
+              {
+                serviceName: {
+                  terms: {
+                    field: SERVICE_NAME,
+                  },
+                },
+              },
+              {
+                spanName: {
+                  terms: {
+                    field: SPAN_NAME,
+                  },
+                },
+              },
+            ] as const),
           },
           aggs: {
             top_span_ids: {
               top_hits: {
                 size: 10,
-                fields: [...requiredFields],
+                fields: [...requiredFields, ...optionalFields],
               },
             },
           },
@@ -176,17 +176,19 @@ export async function getSourceSpanIds({
     },
   });
 
+  const destinationsBySpanId: DestinationsBySpanId = new Map();
+
   return {
     sourceSpanIdsRawResponse: response,
-    spanIds:
-      response.aggregations?.sample_docs?.buckets?.flatMap((bucket) => {
+    destinationsBySpanId:
+      response.aggregations?.sample_docs?.buckets?.reduce((acc, bucket) => {
         const event = unflattenKnownApmEventFields(
           bucket.top_span_ids.hits.hits[0].fields,
           requiredFields
         );
-
-        return event.span.id ?? [];
-      }) ?? [],
+        acc.set(event.span.id, event.span?.destination?.service?.resource);
+        return acc;
+      }, destinationsBySpanId) ?? destinationsBySpanId,
   };
 }
 
@@ -194,15 +196,17 @@ export async function getDestinationParentIds({
   apmEventClient,
   start,
   end,
-  ids,
+  parentSpans,
   destinationNode,
 }: {
   apmEventClient: APMEventClient;
   start: number;
   end: number;
-  ids: string[] | undefined;
+  parentSpans: DestinationsBySpanId;
   destinationNode: string;
 }) {
+  const parentSpanIds = Array.from(parentSpans.keys());
+
   const response = await apmEventClient.search('diagnostics_get_destination_node_parent_ids', {
     apm: {
       events: [ProcessorEvent.transaction],
@@ -214,16 +218,16 @@ export async function getDestinationParentIds({
         bool: {
           filter: [
             ...rangeQuery(start, end),
-            ...(ids ? termsQuery(PARENT_ID, ...ids) : []),
+            ...(parentSpanIds ? termsQuery(PARENT_ID, ...parentSpanIds) : []),
             ...termQuery(SERVICE_NAME, destinationNode),
           ],
         },
-      },
-      aggs: {
-        sample_docs: {
-          top_hits: {
-            size: 5,
-            fields: [PARENT_ID, SERVICE_NAME, SPAN_DESTINATION_SERVICE_RESOURCE],
+        aggs: {
+          sample_docs: {
+            top_hits: {
+              size: 5,
+              fields: [PARENT_ID, SERVICE_NAME, SPAN_DESTINATION_SERVICE_RESOURCE],
+            },
           },
         },
       },

--- a/x-pack/solutions/observability/plugins/apm/server/routes/diagnostics/service_map/get_exit_spans_from_samples.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/diagnostics/service_map/get_exit_spans_from_samples.ts
@@ -222,12 +222,12 @@ export async function getDestinationParentIds({
             ...termQuery(SERVICE_NAME, destinationNode),
           ],
         },
-        aggs: {
-          sample_docs: {
-            top_hits: {
-              size: 5,
-              fields: [PARENT_ID, SERVICE_NAME, SPAN_DESTINATION_SERVICE_RESOURCE],
-            },
+      },
+      aggs: {
+        sample_docs: {
+          top_hits: {
+            size: 5,
+            fields: [PARENT_ID, SERVICE_NAME, SPAN_DESTINATION_SERVICE_RESOURCE],
           },
         },
       },

--- a/x-pack/solutions/observability/plugins/apm/server/routes/diagnostics/service_map/get_exit_spans_from_samples.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/diagnostics/service_map/get_exit_spans_from_samples.ts
@@ -134,7 +134,7 @@ export async function getSourceSpanIds({
     apm: {
       events: [ProcessorEvent.span],
     },
-    body:{ 
+    body: {
       track_total_hits: false,
       size: 0,
       query: {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/diagnostics/index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/diagnostics/index.ts
@@ -15,5 +15,6 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./index_templates.spec.ts'));
     loadTestFile(require.resolve('./indices.spec.ts'));
     loadTestFile(require.resolve('./privileges.spec.ts'));
+    loadTestFile(require.resolve('./service_map.spec.ts'));
   });
 }

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/diagnostics/service_map.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/diagnostics/service_map.spec.ts
@@ -1,0 +1,274 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
+import expect from 'expect';
+import { Readable } from 'node:stream';
+import {
+  serviceMap,
+  timerange,
+  apm,
+  ApmFields,
+  httpExitSpan,
+  Serializable,
+} from '@kbn/apm-synthtrace-client';
+import { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const apmApiClient = getService('apmApi');
+  const synthtrace = getService('synthtrace');
+
+  const startNumber = new Date('2025-08-12T00:00:00.000Z').getTime();
+  const endNumber = new Date('2025-08-12T00:01:00.000Z').getTime();
+
+  const start = new Date(startNumber).toISOString();
+  const end = new Date(endNumber).toISOString();
+
+  describe('Diagnostics: Service Map', () => {
+    describe('without data', () => {
+      it('returns empty analysis when no data exists', async () => {
+        const { status, body } = await apmApiClient.readUser({
+          endpoint: 'POST /internal/apm/diagnostics/service-map',
+          params: {
+            body: {
+              start,
+              end,
+              sourceNode: 'service-a',
+              destinationNode: 'service-b',
+              traceId: 'foo',
+            },
+          },
+        });
+
+        expect(status).toBe(200);
+        expect(body.analysis.exitSpans).toEqual({
+          found: false,
+          totalConnections: 0,
+          apmExitSpans: [],
+          hasMatchingDestinationResources: false,
+        });
+        expect(body.analysis.parentRelationships).toEqual({
+          found: false,
+          documentCount: 0,
+          sourceSpanIds: [],
+        });
+        expect(body.analysis.traceCorrelation).toBeDefined();
+        expect(body.elasticsearchResponses.exitSpansQuery).toBeDefined();
+        expect(body.elasticsearchResponses.sourceSpansQuery).toBeDefined();
+        expect(body.elasticsearchResponses.destinationParentIdsQuery).toBeDefined();
+        expect(body.analysis.traceCorrelation).toEqual({
+          found: false,
+          foundInSourceNode: false,
+          foundInDestinationNode: false,
+          sourceNodeDocumentCount: 0,
+          destinationNodeDocumentCount: 0,
+        });
+        expect(body.elasticsearchResponses.traceCorrelationQuery).toBeDefined();
+      });
+    });
+
+    describe('with data', () => {
+      let synthtraceEsClient: ApmSynthtraceEsClient;
+
+      describe('when trace is complete', () => {
+        before(async () => {
+          synthtraceEsClient = await synthtrace.createApmSynthtraceEsClient();
+
+          const events = timerange(start, end)
+            .interval('10s')
+            .rate(3)
+            .generator(
+              serviceMap({
+                services: [
+                  { 'frontend-rum': 'rum-js' },
+                  { 'frontend-node': 'nodejs' },
+                  { advertService: 'java' },
+                ],
+                definePaths([rum, node, adv]) {
+                  return [
+                    [
+                      [rum, 'fetchAd'],
+                      [node, 'GET /nodejs/adTag'],
+                      [adv, 'APIRestController#getAd'],
+                      ['elasticsearch', 'GET ad-*/_search'],
+                    ],
+                  ];
+                },
+              })
+            );
+
+          return synthtraceEsClient.index(Readable.from(Array.from(events)));
+        });
+
+        after(async () => {
+          await synthtraceEsClient.clean();
+        });
+
+        it('returns analysis with exit spans when complete trace exists', async () => {
+          const { status, body } = await apmApiClient.readUser({
+            endpoint: 'POST /internal/apm/diagnostics/service-map',
+            params: {
+              body: {
+                start,
+                end,
+                sourceNode: 'frontend-node',
+                destinationNode: 'advertService',
+              },
+            },
+          });
+
+          expect(status).toBe(200);
+          expect(body.analysis.exitSpans.found).toBe(true);
+          expect(body.analysis.exitSpans.totalConnections).toBe(1);
+          expect(body.analysis.exitSpans.hasMatchingDestinationResources).toBe(true);
+          expect(body.analysis.parentRelationships.found).toBe(true);
+          expect(body.analysis.parentRelationships.documentCount).toBe(1);
+          expect(body.analysis.parentRelationships.sourceSpanIds.length).toBe(4);
+          expect(body.elasticsearchResponses.exitSpansQuery).toBeDefined();
+          expect(body.elasticsearchResponses.sourceSpansQuery).toBeDefined();
+          expect(body.elasticsearchResponses.destinationParentIdsQuery).toBeDefined();
+        });
+      });
+
+      describe('when the exit span does not have a span.destination.service.resource field', () => {
+        let traceId: string | undefined;
+        let response: {
+          status: number;
+          body: APIReturnType<'POST /internal/apm/diagnostics/service-map'>;
+        };
+
+        before(async () => {
+          synthtraceEsClient = await synthtrace.createApmSynthtraceEsClient();
+
+          const web = apm
+            .service({ name: 'web', environment: 'prod', agentName: 'rum-js' })
+            .instance('my-instance');
+          const proxy = apm
+            .service({ name: 'frontend-proxy', environment: 'prod', agentName: 'nodejs' })
+            .instance('my-instance');
+          const backend = apm
+            .service({ name: 'backend', environment: 'prod', agentName: 'go' })
+            .instance('my-instance');
+
+          const range = timerange(start, end).interval('10s').rate(1);
+
+          // Create transactions with exit spans later delete the exit span destination resource
+          const frontendEvents = range.generator((timestamp) =>
+            web
+              .transaction({ transactionName: 'Initial transaction in web' })
+              .duration(400)
+              .timestamp(timestamp)
+              .children(
+                // web -> proxy
+                web
+                  .span(
+                    httpExitSpan({
+                      spanName: 'Missing span.destination.service.resource',
+                      destinationUrl: 'http://proxy:3000',
+                    })
+                  )
+                  .duration(300)
+                  .timestamp(timestamp + 10)
+                  .children(
+                    // procy
+                    proxy
+                      .transaction({ transactionName: 'Initial transaction in proxy' })
+                      .duration(300)
+                      .timestamp(timestamp + 20)
+                  ),
+                // web -> backend
+                web
+                  .span(
+                    httpExitSpan({
+                      spanName: 'GET /backend/api/products/top',
+                      destinationUrl: 'http://backend:3000',
+                    })
+                  )
+                  .duration(300)
+                  .timestamp(timestamp + 10)
+                  .children(
+                    // backend
+                    backend
+                      .transaction({ transactionName: 'Initial transaction in backend' })
+                      .duration(300)
+                      .timestamp(timestamp + 20)
+                  )
+              )
+          );
+
+          const unserialized = Array.from(frontendEvents);
+
+          const serialized = unserialized
+            .flatMap((event) => event.serialize())
+            .map((event) => {
+              if (event['span.destination.service.resource'] === 'proxy:3000') {
+                delete event['span.destination.service.resource'];
+              }
+              return event;
+            });
+
+          traceId = serialized.find(
+            (event) => event['span.name'] === 'Missing span.destination.service.resource'
+          )?.['trace.id'];
+
+          const unserializedChanged = serialized.map((event) => ({
+            fields: event,
+            serialize: () => {
+              return [event];
+            },
+          })) as Array<Serializable<ApmFields>>;
+
+          return synthtraceEsClient.index(Readable.from([...unserializedChanged]));
+        });
+
+        after(async () => {
+          await synthtraceEsClient.clean();
+        });
+
+        describe('no exit span is present', () => {
+          before(async () => {
+            response = await apmApiClient.readUser({
+              endpoint: 'POST /internal/apm/diagnostics/service-map',
+              params: {
+                body: {
+                  start,
+                  end,
+                  sourceNode: 'web',
+                  destinationNode: 'frontend-proxy',
+                  ...(traceId && { traceId }),
+                },
+              },
+            });
+          });
+
+          it('returns that no exit span found', () => {
+            expect(response.status).toBe(200);
+            expect(response.body.analysis.exitSpans.found).toBe(false);
+            expect(response.body.analysis.exitSpans.totalConnections).toBe(0);
+            expect(response.body.analysis.exitSpans.apmExitSpans).toEqual([]);
+            expect(response.body.analysis.exitSpans.hasMatchingDestinationResources).toBe(false);
+          });
+
+          it('detects parent relationship even when exit span is missing', () => {
+            expect(response.body.analysis.parentRelationships.found).toBe(true);
+            expect(response.body.analysis.parentRelationships.documentCount).toBe(1);
+            expect(response.body.analysis.parentRelationships.sourceSpanIds.length).toBe(2);
+          });
+
+          it('detects trace correlation between services even without an exit span', () => {
+            expect(response.body.analysis.traceCorrelation?.found).toBe(true);
+            expect(response.body.analysis?.traceCorrelation?.foundInDestinationNode).toBe(true);
+            expect(response.body.analysis?.traceCorrelation?.foundInSourceNode).toBe(true);
+            expect(response.body.analysis?.traceCorrelation?.sourceNodeDocumentCount).toBe(3);
+            expect(response.body.analysis?.traceCorrelation?.destinationNodeDocumentCount).toBe(1);
+          });
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM] Fix the exit span analysis (#231432)](https://github.com/elastic/kibana/pull/231432)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Katerina","email":"aikaterini.patticha@elastic.co"},"sourceCommit":{"committedDate":"2025-08-13T17:32:39Z","message":"[APM] Fix the exit span analysis (#231432)\n\ncloses https://github.com/elastic/kibana/issues/231428 \n## Summary\n\n- Fix the exit span analysis\n- Add a scenario to test the tool in the ui\n- API tests \n- Remove unused fields in the ui  \n\n### How to test \n\n-  run the scenario\n-  `node scripts/synthtrace diagnostic_service_map  --clean` \n- enable the `observability:enableDiagnosticMode` in advanced settings\n- go to service map and click on a service \n- then click open diagnostic tool","sha":"864089100ae779405f277d279233a0b1f8ca1171","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","Team:obs-ux-infra_services","v9.2.0"],"title":"[APM] Fix the exit span analysis","number":231432,"url":"https://github.com/elastic/kibana/pull/231432","mergeCommit":{"message":"[APM] Fix the exit span analysis (#231432)\n\ncloses https://github.com/elastic/kibana/issues/231428 \n## Summary\n\n- Fix the exit span analysis\n- Add a scenario to test the tool in the ui\n- API tests \n- Remove unused fields in the ui  \n\n### How to test \n\n-  run the scenario\n-  `node scripts/synthtrace diagnostic_service_map  --clean` \n- enable the `observability:enableDiagnosticMode` in advanced settings\n- go to service map and click on a service \n- then click open diagnostic tool","sha":"864089100ae779405f277d279233a0b1f8ca1171"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231432","number":231432,"mergeCommit":{"message":"[APM] Fix the exit span analysis (#231432)\n\ncloses https://github.com/elastic/kibana/issues/231428 \n## Summary\n\n- Fix the exit span analysis\n- Add a scenario to test the tool in the ui\n- API tests \n- Remove unused fields in the ui  \n\n### How to test \n\n-  run the scenario\n-  `node scripts/synthtrace diagnostic_service_map  --clean` \n- enable the `observability:enableDiagnosticMode` in advanced settings\n- go to service map and click on a service \n- then click open diagnostic tool","sha":"864089100ae779405f277d279233a0b1f8ca1171"}},{"url":"https://github.com/elastic/kibana/pull/232050","number":232050,"branch":"9.1","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/232055","number":232055,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->