### PR TITLE
[Onboarding] Make the managed OTLP endpoint the default option for OTel APM onboarding

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/instructions/otel_agent.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/instructions/otel_agent.tsx
@@ -159,27 +159,15 @@ function ConfigureSDKInstructions({
   apmServerUrl: string;
   apiKeyDetails?: AgentApiDetails;
 }) {
-  const [selectedOptionId, setSelectedOptionId] = useState<SDKInstructionsOptionID>('apm');
+  const [selectedOptionId, setSelectedOptionId] = useState<SDKInstructionsOptionID>('otlp');
 
   return (
     <>
       <EuiButtonGroup
         legend="Default single select button group"
         options={[
+          { id: 'otlp', label: 'Managed OTLP Endpoint' },
           { id: 'apm', label: 'Classic APM Endpoint' },
-          {
-            id: 'otlp',
-            label: 'Managed OTLP Endpoint',
-            iconType: 'beaker',
-            iconSide: 'right',
-            toolTipContent: (
-              <FormattedMessage
-                id="xpack.apm.onboarding.otel.managedOtlpEndpointTooltip"
-                defaultMessage="This functionality is in Tech Preview."
-              />
-            ),
-            toolTipProps: { position: 'right' },
-          },
         ]}
         idSelected={selectedOptionId}
         onChange={(id) => setSelectedOptionId(id as SDKInstructionsOptionID)}


### PR DESCRIPTION
## 📓 Summary
Since the Managed OTLP Endpoint is GA, this PR removed the tech preview badge from the tab and makes it the default option for APM onboarding using OpenTelemetry.

Closes https://github.com/elastic/kibana/issues/232070

### Before
<img width="1410" height="536" alt="image" src="https://github.com/user-attachments/assets/c1970643-a777-4d3d-b2aa-cb009b0eb034" />


### After
<img width="1391" height="439" alt="image" src="https://github.com/user-attachments/assets/eb6b9d1a-fffa-4f2f-8a0f-5f1284413391" />
