### PR TITLE
[9.0] [Security Solution] Unskip Cypress tests for prebuilt rules (#232021)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_error_handling.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_error_handling.cy.ts
@@ -45,7 +45,6 @@ import {
 } from '../../../../../tasks/prebuilt_rules';
 import { visitRulesManagementTable } from '../../../../../tasks/rules_management';
 
-// https://github.com/elastic/kibana/issues/179970
 describe(
   'Detection rules, Prebuilt Rules Installation - Error handling',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_notifications.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_notifications.cy.ts
@@ -50,7 +50,6 @@ describe(
         cy.get(ADD_ELASTIC_RULES_BTN).should('have.text', 'Add Elastic rules');
       });
 
-      // https://github.com/elastic/kibana/issues/179967
       it(
         'does NOT display install notifications when latest rules are installed',
         { tags: ['@skipInServerlessMKI'] },
@@ -72,7 +71,6 @@ describe(
       );
     });
 
-    // https://github.com/elastic/kibana/issues/179968
     describe('Notifications', () => {
       const PREBUILT_RULE = createRuleAssetSavedObject({
         name: 'Test prebuilt rule 1',

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/management/management.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/management/management.cy.ts
@@ -49,7 +49,6 @@ const PREBUILT_RULE_ASSETS = Array.from(Array(5)).map((_, i) =>
   })
 );
 
-// https://github.com/elastic/kibana/issues/179973
 describe('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
   before(() => {
     installMockPrebuiltRulesPackage();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Security Solution] Unskip Cypress tests for prebuilt rules (#232021) (3eb7745f)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgii Gorbachev","email":"georgii.gorbachev@elastic.co"},"sourceCommit":{"committedDate":"2025-08-18T13:17:54Z","message":"[Security Solution] Unskip Cypress tests for prebuilt rules (#232021)\n\n**Partially addresses: https://github.com/elastic/kibana/issues/229688**\n\n**Resolves: https://github.com/elastic/kibana/issues/182682**\n**Resolves: https://github.com/elastic/kibana/issues/182439**\n**Resolves: https://github.com/elastic/kibana/issues/182440**\n**Resolves: https://github.com/elastic/kibana/issues/182441**\n**Resolves: https://github.com/elastic/kibana/issues/182442**\n**Resolves: https://github.com/elastic/kibana/issues/182483**\n**Resolves: https://github.com/elastic/kibana/issues/182484**\n**Resolves: https://github.com/elastic/kibana/issues/182485**\n**Resolves: https://github.com/elastic/kibana/issues/182486**\n\n**Resolves: https://github.com/elastic/kibana/issues/228945**\n\n## Summary\n\nThis PR fixes and unskips the following tests:\n\n-\n`x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_update_authorization.cy.ts`\n-\n`x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_via_fleet.cy.ts`\n\n## Flaky test runs\n\n- [50x ESS + 50x\nServerless](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9163)\n🟢\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3eb7745f5f3c51196330a0936f20fb1afd508fbb"},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->