### PR TITLE
[Discover][APM] Add text to trace fullscreen button

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
@@ -138,7 +138,7 @@ export const FullScreenWaterfall = ({
                   ariaLabel={i18n.translate(
                     'unifiedDocViewer.observability.traces.fullScreenWaterfall.exitFullScreen.button',
                     {
-                      defaultMessage: 'Exit full screen waterfall',
+                      defaultMessage: 'Exit expanded trace timeline',
                     }
                   )}
                 />

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace.tsx
@@ -9,7 +9,7 @@
 
 import React, { useCallback, useState } from 'react';
 import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle, EuiButtonIcon } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle, EuiButtonEmpty } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
 import type { DataViewField } from '@kbn/data-views-plugin/common';
@@ -48,6 +48,13 @@ export const Trace = ({
   const [showFullScreenWaterfall, setShowFullScreenWaterfall] = useState(false);
 
   const { from: rangeFrom, to: rangeTo } = data.query.timefilter.timefilter.getAbsoluteTime();
+
+  const fullScreenButtonLabel = i18n.translate(
+    'unifiedDocViewer.observability.traces.trace.fullScreen.button',
+    {
+      defaultMessage: 'Expand trace timeline',
+    }
+  );
 
   const getParentApi = useCallback(
     () => ({
@@ -110,21 +117,17 @@ export const Trace = ({
         </EuiFlexItem>
         {showWaterfall && (
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
+            <EuiButtonEmpty
               data-test-subj="unifiedDocViewerObservabilityTracesTraceFullScreenButton"
-              iconSize="m"
+              size="xs"
               iconType="fullScreen"
-              color="text"
-              aria-label={i18n.translate(
-                'unifiedDocViewer.observability.traces.trace.fullScreen.button',
-                {
-                  defaultMessage: 'Open full screen waterfall',
-                }
-              )}
               onClick={() => {
                 setShowFullScreenWaterfall(true);
               }}
-            />
+              aria-label={fullScreenButtonLabel}
+            >
+              {fullScreenButtonLabel}
+            </EuiButtonEmpty>
           </EuiFlexItem>
         )}
       </EuiFlexGroup>

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/span_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/span_overview.tsx
@@ -156,6 +156,7 @@ export function SpanOverview({
                 </EuiFlexItem>
               )}
               <EuiFlexItem>
+                <EuiSpacer size="m" />
                 <Trace
                   fields={fieldConfigurations}
                   fieldMappings={dataViewFields}

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/transaction_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/transaction_overview.tsx
@@ -146,17 +146,20 @@ export function TransactionOverview({
             )}
             <EuiFlexItem>
               {traceId && transactionId && (
-                <Trace
-                  fields={fieldConfigurations}
-                  fieldMappings={dataViewFields}
-                  traceId={traceId}
-                  docId={transactionId}
-                  displayType="transaction"
-                  dataView={dataView}
-                  tracesIndexPattern={indexes.apm.traces}
-                  showWaterfall={showWaterfall}
-                  showActions={showActions}
-                />
+                <>
+                  <EuiSpacer size="m" />
+                  <Trace
+                    fields={fieldConfigurations}
+                    fieldMappings={dataViewFields}
+                    traceId={traceId}
+                    docId={transactionId}
+                    displayType="transaction"
+                    dataView={dataView}
+                    tracesIndexPattern={indexes.apm.traces}
+                    showWaterfall={showWaterfall}
+                    showActions={showActions}
+                  />
+                </>
               )}
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_item_row.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_item_row.tsx
@@ -74,8 +74,11 @@ export function TraceItemRow({ item, childrenCount, state, onToggle }: Props) {
           }
           padding: 6px 0;
           ${isHighlighted ? `background-color: ${euiTheme.colors.lightestShade};` : undefined}
-          &:hover {
+          ${
+            !highlightedTraceId &&
+            ` &:hover {
             background-color: ${euiTheme.colors.lightestShade};
+          }`
           }
         `}
         >


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/232085

After some feedback and user interactions observed through telemetry and FullStory highlighted the low discoverability of the full screen button, we added text to the button so the action is more visible.

|Before|After|
|-|-|
|<img width="1445" height="964" alt="Screenshot 2025-08-18 at 15 33 30" src="https://github.com/user-attachments/assets/bc5a6d1a-9cf4-44be-b16b-c869b0fe7c75" />|![Screen Recording 2025-08-18 at 15 03 49](https://github.com/user-attachments/assets/19cabac8-ff19-4245-a79d-ae28c5ec6106)|

We also removed the hover style change in the focused waterfall since there’s no action available there, and from a UX perspective it could be confusing for users.

|Before|After|
|-|-|
|![Screen Recording 2025-08-18 at 15 33 10](https://github.com/user-attachments/assets/ae4f9323-80d4-42c4-9db2-ee2fa41c0be1)|![Screen Recording 2025-08-18 at 15 31 45](https://github.com/user-attachments/assets/d063aa6e-b4dd-400e-9056-b7b242608cb1)|
