### PR TITLE
[8.19] [Security Solution] Unskip Cypress tests for related integrations (#232022)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/related_integrations/related_integrations.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/related_integrations/related_integrations.cy.ts
@@ -47,8 +47,6 @@ import {
   waitForPageToBeLoaded,
 } from '../../../../tasks/rule_details';
 
-// https://github.com/elastic/kibana/issues/179943
-
 describe('Related integrations', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
   const DATA_STREAM_NAME = 'logs-related-integrations-test';
   const PREBUILT_RULE_NAME = 'Prebuilt rule with related integrations';
@@ -74,6 +72,7 @@ describe('Related integrations', { tags: ['@ess', '@serverless', '@skipInServerl
     },
     { package: 'system', version: '1.17.0' },
   ];
+
   const PREBUILT_RULE = createRuleAssetSavedObject({
     name: PREBUILT_RULE_NAME,
     index: [DATA_STREAM_NAME],
@@ -81,6 +80,7 @@ describe('Related integrations', { tags: ['@ess', '@serverless', '@skipInServerl
     rule_id: 'rule_1',
     related_integrations: RELATED_INTEGRATIONS,
   });
+
   const EXPECTED_RELATED_INTEGRATIONS: ExpectedRelatedIntegration[] = [
     {
       title: 'Auditd Logs',
@@ -102,6 +102,7 @@ describe('Related integrations', { tags: ['@ess', '@serverless', '@skipInServerl
       status: 'Enabled',
     },
   ];
+
   const EXPECTED_KNOWN_RELATED_INTEGRATIONS = EXPECTED_RELATED_INTEGRATIONS.filter((x) =>
     Boolean(x.status)
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Unskip Cypress tests for related integrations (#232022)](https://github.com/elastic/kibana/pull/232022)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgii Gorbachev","email":"georgii.gorbachev@elastic.co"},"sourceCommit":{"committedDate":"2025-08-18T13:26:56Z","message":"[Security Solution] Unskip Cypress tests for related integrations (#232022)\n\n**Partially addresses: https://github.com/elastic/kibana/issues/229688**\n**Resolves: https://github.com/elastic/kibana/issues/176027**\n\n## Summary\n\nThis PR unskips the following tests:\n\n-\n`x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/related_integrations/related_integrations.cy.ts`\n\nNo additional fixes have been made. The idea is that flakiness in these\ntests has been already fixed by all the prior efforts already done\nwithin the [parent\nepic](https://github.com/elastic/kibana/issues/229688).\n\n## Flaky test runs\n\n- [100x ESS + 100x\nServerless](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9161)\n🟢\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4379c31117d0cff37b5d278e14ed97b13ef78b7f","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Related Integrations","backport:version","v9.2.0","v9.1.3","v8.19.3"],"title":"[Security Solution] Unskip Cypress tests for related integrations","number":232022,"url":"https://github.com/elastic/kibana/pull/232022","mergeCommit":{"message":"[Security Solution] Unskip Cypress tests for related integrations (#232022)\n\n**Partially addresses: https://github.com/elastic/kibana/issues/229688**\n**Resolves: https://github.com/elastic/kibana/issues/176027**\n\n## Summary\n\nThis PR unskips the following tests:\n\n-\n`x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/related_integrations/related_integrations.cy.ts`\n\nNo additional fixes have been made. The idea is that flakiness in these\ntests has been already fixed by all the prior efforts already done\nwithin the [parent\nepic](https://github.com/elastic/kibana/issues/229688).\n\n## Flaky test runs\n\n- [100x ESS + 100x\nServerless](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9161)\n🟢\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4379c31117d0cff37b5d278e14ed97b13ef78b7f"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232022","number":232022,"mergeCommit":{"message":"[Security Solution] Unskip Cypress tests for related integrations (#232022)\n\n**Partially addresses: https://github.com/elastic/kibana/issues/229688**\n**Resolves: https://github.com/elastic/kibana/issues/176027**\n\n## Summary\n\nThis PR unskips the following tests:\n\n-\n`x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/related_integrations/related_integrations.cy.ts`\n\nNo additional fixes have been made. The idea is that flakiness in these\ntests has been already fixed by all the prior efforts already done\nwithin the [parent\nepic](https://github.com/elastic/kibana/issues/229688).\n\n## Flaky test runs\n\n- [100x ESS + 100x\nServerless](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9161)\n🟢\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4379c31117d0cff37b5d278e14ed97b13ef78b7f"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232084","number":232084,"state":"OPEN"},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->