### PR TITLE
[9.1] Fix violations of the @elastic/eui/no-unnamed-radio-group ESLint rule (#230068)

### DIFF
--- a/src/platform/plugins/private/links/public/components/editor/link_editor.tsx
+++ b/src/platform/plugins/private/links/public/components/editor/link_editor.tsx
@@ -122,6 +122,7 @@ export const LinkEditor = ({
                 }
                 setSelectedLinkType(id as LinkType);
               }}
+              name="linkType"
             />
           </EuiFormRow>
           <LinkDestination

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_editor_options.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_editor_options.tsx
@@ -139,6 +139,7 @@ export const OptionsListEditorOptions = ({
             setSingleSelect(newSingleSelect);
             updateState({ singleSelect: newSingleSelect });
           }}
+          name="selectionType"
         />
       </EuiFormRow>
       {allowExpensiveQueries && compatibleSearchTechniques.length > 1 && (
@@ -155,6 +156,7 @@ export const OptionsListEditorOptions = ({
               setSearchTechnique(newSearchTechnique);
               updateState({ searchTechnique: newSearchTechnique });
             }}
+            name="searchTechnique"
           />
         </EuiFormRow>
       )}

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/components/fields/radio_group_field.tsx
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/components/fields/radio_group_field.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import { EuiFormRow, EuiRadioGroup } from '@elastic/eui';
+import camelCase from 'lodash/camelCase';
 
 import { FieldHook, getFieldValidityAndErrorMessage } from '../../hook_form_lib';
 
@@ -16,11 +17,13 @@ interface Props {
   field: FieldHook;
   euiFieldProps?: Record<string, any>;
   idAria?: string;
+  name?: string;
   [key: string]: any;
 }
 
-export const RadioGroupField = ({ field, euiFieldProps = {}, idAria, ...rest }: Props) => {
+export const RadioGroupField = ({ field, euiFieldProps = {}, idAria, name, ...rest }: Props) => {
   const { isInvalid, errorMessage } = getFieldValidityAndErrorMessage(field);
+  const radioGroupName = name || camelCase(field.label || 'optionsGroup');
 
   return (
     <EuiFormRow
@@ -37,6 +40,7 @@ export const RadioGroupField = ({ field, euiFieldProps = {}, idAria, ...rest }: 
         options={[]}
         onChange={field.setValue}
         data-test-subj="input"
+        name={radioGroupName}
         {...euiFieldProps}
       />
     </EuiFormRow>

--- a/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/import_mode_control.tsx
+++ b/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/import_mode_control.tsx
@@ -117,6 +117,7 @@ export const ImportModeControl = ({ initialValues, updateSelection }: ImportMode
         onChange={() => onChange({ createNewCopies: false })}
       >
         <EuiRadioGroup
+          name="importModeOverwrite"
           options={[overwriteEnabled, overwriteDisabled]}
           idSelected={overwrite ? overwriteEnabled.id : overwriteDisabled.id}
           onChange={(id: string) => onChange({ overwrite: id === overwriteEnabled.id })}

--- a/src/platform/plugins/shared/share/public/components/url_panel_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/url_panel_content.tsx
@@ -498,6 +498,7 @@ class UrlPanelContentComponent extends Component<UrlPanelContentProps, State, Wi
     return (
       <EuiFormRow helpText={generateLinkAsHelp}>
         <EuiRadioGroup
+          name="exportUrlAs"
           options={this.renderExportUrlAsOptions()}
           idSelected={this.state.exportUrlAs}
           onChange={this.handleExportUrlAs}

--- a/x-pack/platform/packages/private/ml/date_picker/src/components/full_time_range_selector.tsx
+++ b/x-pack/platform/packages/private/ml/date_picker/src/components/full_time_range_selector.tsx
@@ -190,6 +190,7 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
           idSelected={frozenDataPreference}
           onChange={setPreference}
           compressed
+          name="frozenDataPreference"
         />
       </EuiPanel>
     ),

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/shared_fields/shrink_field.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/shared_fields/shrink_field.tsx
@@ -60,6 +60,7 @@ export const ShrinkField: FunctionComponent<Props> = ({ phase }) => {
       {isUsingShardSize === undefined ? null : (
         <>
           <EuiRadioGroup
+            name={`${phase}ShrinkMethod`}
             options={[
               {
                 id: `${phase}-configureShardCount`,

--- a/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/flyout/cel_configuration/steps/confirm_settings_step/endpoint_selection.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/flyout/cel_configuration/steps/confirm_settings_step/endpoint_selection.tsx
@@ -81,6 +81,7 @@ export const EndpointSelection = React.memo<EndpointSelectionProps>(
             <EuiSpacer size="m" />
             <EuiFlexItem>
               <EuiRadioGroup
+                name="endpointPathSelection"
                 options={options}
                 idSelected={selectedPath}
                 disabled={isGenerating}

--- a/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/steps/connector_step/connector_selector.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/steps/connector_step/connector_selector.tsx
@@ -75,6 +75,7 @@ export const ConnectorSelector = React.memo<ConnectorSelectorProps>(
                 <EuiFlexGroup direction="row" alignItems="center" justifyContent="spaceBetween">
                   <EuiFlexItem>
                     <EuiRadio
+                      name="connectorSelector"
                       label={connector.name}
                       id={connector.id}
                       value={connector.id}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/steps/set_deployment_mode.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/steps/set_deployment_mode.tsx
@@ -110,7 +110,7 @@ const DeploymentModeStepContent = ({
         ]}
         idSelected={`${deploymentMode}_${radioSuffix}`}
         onChange={onChangeCallback}
-        name={`radio group ${radioSuffix}`}
+        name={`deploymentMode${radioSuffix}`}
       />
     </>
   );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
@@ -835,7 +835,7 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
                 agent_features: id === 'hostname' ? [] : [{ name: 'fqdn', enabled: true }],
               });
             }}
-            name="radio group"
+            name="hostNameFormat"
           />
         </EuiFormRow>
       </EuiDescribedFormGroup>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -406,6 +406,7 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                                   },
                                 });
                               }}
+                              name="dataStreamType"
                             />
                           </EuiFormRow>
                         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_authentication.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_authentication.tsx
@@ -160,6 +160,7 @@ export const OutputFormKafkaAuthentication: React.FunctionComponent<{
             }
           >
             <EuiRadioGroup
+              name="kafkaConnectionType"
               style={{ display: 'flex', gap: 30 }}
               data-test-subj={'settingsOutputsFlyout.kafkaConnectionTypeRadioInput'}
               options={kafkaConnectionTypeOptions}
@@ -322,6 +323,7 @@ export const OutputFormKafkaAuthentication: React.FunctionComponent<{
               }
             >
               <EuiRadioGroup
+                name="kafkaSaslMechanism"
                 style={{ display: 'flex', gap: 30 }}
                 data-test-subj={'settingsOutputsFlyout.kafkaSaslInput'}
                 options={kafkaSaslOptions}
@@ -405,6 +407,7 @@ export const OutputFormKafkaAuthentication: React.FunctionComponent<{
         <EuiSpacer size="m" />
         <EuiFormRow fullWidth>
           <EuiRadioGroup
+            name="kafkaAuthMethod"
             style={{ display: 'flex', gap: 30 }}
             data-test-subj={'settingsOutputsFlyout.kafkaAuthenticationRadioInput'}
             options={kafkaAuthenticationsOptions}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_partitioning.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_partitioning.tsx
@@ -144,6 +144,7 @@ export const OutputFormKafkaPartitioning: React.FunctionComponent<{
           data-test-subj={'settingsOutputsFlyout.kafkaPartitioningRadioInput'}
           options={kafkaPartitioningOptions}
           compressed
+          name="kafkaPartitioningStrategy"
           {...inputs.kafkaPartitionTypeInput.props}
         />
       </EuiFormRow>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_topics.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_topics.tsx
@@ -142,6 +142,7 @@ export const OutputFormKafkaTopics: React.FunctionComponent<{ inputs: OutputForm
           data-test-subj={'editOutputFlyout.kafkaTopicsRadioInput'}
           options={kafkaTopicsOptions}
           compressed
+          name="kafkaTopics"
           {...inputs.kafkaTopicsInput.props}
         />
       </EuiFormRow>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/ssl_form_section.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/ssl_form_section.tsx
@@ -292,6 +292,7 @@ export const SSLFormSection: React.FunctionComponent<Props> = (props) => {
               data-test-subj={'fleetServerHosts.clientAuthenticationRadioInput'}
               options={clientAuthenticationsOptions}
               compressed
+              name="clientAuth"
               {...inputs.sslClientAuthInput.props}
             />
           </EuiFormRow>

--- a/x-pack/platform/plugins/shared/fleet/public/components/agent_enrollment_flyout/steps/installation_mode_selection_step.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agent_enrollment_flyout/steps/installation_mode_selection_step.tsx
@@ -111,7 +111,7 @@ export const InstallationModeSelectionStep = ({
         ]}
         idSelected={`${mode}_${radioSuffix}`}
         onChange={onChangeCallback}
-        name={`radio group ${radioSuffix}`}
+        name={`installationMode${radioSuffix}`}
       />
     ) : (
       <React.Fragment />

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_create_from_csv/pipelines_csv_uploader.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_create_from_csv/pipelines_csv_uploader.tsx
@@ -102,6 +102,7 @@ export const PipelinesCsvUploader: FC<Props> = ({
           options={options}
           idSelected={action}
           onChange={(id) => setAction(id as FieldCopyAction)}
+          name="defaultAction"
         />
       </EuiFormRow>
 

--- a/x-pack/platform/plugins/shared/maps/public/classes/layers/wizards/choropleth_layer_wizard/__snapshots__/layer_template.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/classes/layers/wizards/choropleth_layer_wizard/__snapshots__/layer_template.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`should render EMS UI when left source is BOUNDARIES_SOURCE.EMS 1`] = `
     <EuiFormRow>
       <EuiRadioGroup
         idSelected="EMS"
+        name="boundariesSource"
         onChange={[Function]}
         options={
           Array [
@@ -64,6 +65,7 @@ exports[`should render elasticsearch UI when left source is BOUNDARIES_SOURCE.EL
     <EuiFormRow>
       <EuiRadioGroup
         idSelected="ELASTICSEARCH"
+        name="boundariesSource"
         onChange={[Function]}
         options={
           Array [

--- a/x-pack/platform/plugins/shared/maps/public/classes/layers/wizards/choropleth_layer_wizard/layer_template.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/layers/wizards/choropleth_layer_wizard/layer_template.tsx
@@ -377,6 +377,7 @@ export class LayerTemplate extends Component<RenderWizardArguments, State> {
 
         <EuiFormRow>
           <EuiRadioGroup
+            name="boundariesSource"
             options={BOUNDARIES_OPTIONS}
             idSelected={this.state.leftSource}
             onChange={this._onLeftSourceChange}

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/es_search_source/util/__snapshots__/scaling_form.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/es_search_source/util/__snapshots__/scaling_form.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`scaling form should disable clusters option when clustering is not supp
         checked={false}
         id="MVT"
         label="Use vector tiles"
+        name="scalingType"
         onChange={[Function]}
       />
       <EuiToolTip
@@ -42,6 +43,7 @@ exports[`scaling form should disable clusters option when clustering is not supp
           disabled={true}
           id="CLUSTERS"
           label="Show clusters when results exceed 10,000"
+          name="scalingType"
           onChange={[Function]}
         />
       </EuiToolTip>
@@ -49,6 +51,7 @@ exports[`scaling form should disable clusters option when clustering is not supp
         checked={true}
         id="LIMIT"
         label="Limit results to 10,000"
+        name="scalingType"
         onChange={[Function]}
       />
     </div>
@@ -92,6 +95,7 @@ exports[`scaling form should render 1`] = `
         checked={false}
         id="MVT"
         label="Use vector tiles"
+        name="scalingType"
         onChange={[Function]}
       />
       <EuiRadio
@@ -99,12 +103,14 @@ exports[`scaling form should render 1`] = `
         disabled={false}
         id="CLUSTERS"
         label="Show clusters when results exceed 10,000"
+        name="scalingType"
         onChange={[Function]}
       />
       <EuiRadio
         checked={true}
         id="LIMIT"
         label="Limit results to 10,000"
+        name="scalingType"
         onChange={[Function]}
       />
     </div>

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/es_search_source/util/scaling_form.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/es_search_source/util/scaling_form.tsx
@@ -221,6 +221,7 @@ export class ScalingForm extends Component<Props, State> {
     const clusteringRadio = (
       <EuiRadio
         id={SCALING_TYPES.CLUSTERS}
+        name="scalingType"
         label={this._getClustersOptionLabel()}
         checked={this.props.scalingType === SCALING_TYPES.CLUSTERS}
         onChange={() => this._onScalingTypeSelect(SCALING_TYPES.CLUSTERS)}
@@ -275,6 +276,7 @@ export class ScalingForm extends Component<Props, State> {
           <div>
             <EuiRadio
               id={SCALING_TYPES.MVT}
+              name="scalingType"
               label={this._getMvtOptionLabel()}
               checked={this.props.scalingType === SCALING_TYPES.MVT}
               onChange={() => this._onScalingTypeSelect(SCALING_TYPES.MVT)}
@@ -282,6 +284,7 @@ export class ScalingForm extends Component<Props, State> {
             {this._renderClusteringRadio()}
             <EuiRadio
               id={SCALING_TYPES.LIMIT}
+              name="scalingType"
               label={this._getLimitOptionLabel()}
               checked={this.props.scalingType === SCALING_TYPES.LIMIT}
               onChange={() => this._onScalingTypeSelect(SCALING_TYPES.LIMIT)}

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/map_settings_panel/__snapshots__/navigation_panel.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/map_settings_panel/__snapshots__/navigation_panel.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`should render 1`] = `
   >
     <EuiRadioGroup
       idSelected="LAST_SAVED_LOCATION"
+      name="initialMapLocation"
       onChange={[Function]}
       options={
         Array [
@@ -134,6 +135,7 @@ exports[`should render browser location form when initialLocation is BROWSER_LOC
   >
     <EuiRadioGroup
       idSelected="BROWSER_LOCATION"
+      name="initialMapLocation"
       onChange={[Function]}
       options={
         Array [
@@ -229,6 +231,7 @@ exports[`should render fixed location form when initialLocation is FIXED_LOCATIO
   >
     <EuiRadioGroup
       idSelected="FIXED_LOCATION"
+      name="initialMapLocation"
       onChange={[Function]}
       options={
         Array [

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/map_settings_panel/navigation_panel.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/map_settings_panel/navigation_panel.tsx
@@ -262,6 +262,7 @@ export function NavigationPanel({ center, settings, updateMapSetting, zoom }: Pr
           options={initialLocationOptions}
           idSelected={settings.initialLocation}
           onChange={onInitialLocationChange}
+          name="initialMapLocation"
         />
       </EuiFormRow>
       {renderInitialLocationInputs()}

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/set_view_control/set_view_form.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/set_view_control/set_view_form.tsx
@@ -99,6 +99,7 @@ export const SetViewForm = React.memo<SetViewFormProps>(({ settings, zoom, cente
         `}
       >
         <EuiRadioGroup
+          name="coordinateSystem"
           options={COORDINATE_SYSTEM_OPTIONS}
           idSelected={coordinateSystem}
           onChange={onCoordinateSystemChange}

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_selection_table/custom_selection_table.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_selection_table/custom_selection_table.js
@@ -291,6 +291,7 @@ export function CustomSelectionTable({
               )}
               {singleSelection && (
                 <EuiRadio
+                  name="jobSelection"
                   id={item[tableItemId]}
                   data-test-subj={`${item[tableItemId]}-radio-button`}
                   checked={isItemSelected(item[tableItemId])}

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/editor.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/editor.tsx
@@ -316,6 +316,7 @@ export const CustomUrlEditor: FC<CustomUrlEditorProps> = ({
           display="rowCompressed"
         >
           <EuiRadioGroup
+            name="linkToType"
             options={getLinkToOptions()}
             idSelected={type}
             onChange={onTypeChange}

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/entity_control/entity_config.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/entity_control/entity_config.tsx
@@ -112,6 +112,7 @@ export const EntityConfig: FC<EntityConfigProps> = ({
           }
         >
           <EuiRadioGroup
+            name="entitySortBy"
             options={sortOptions}
             idSelected={forceSortByName ? 'name' : config?.sort?.by}
             onChange={(id) => {
@@ -132,6 +133,7 @@ export const EntityConfig: FC<EntityConfigProps> = ({
           }
         >
           <EuiRadioGroup
+            name="entitySortOrder"
             options={orderOptions}
             idSelected={config?.sort?.order}
             onChange={(id) => {

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/shards/pack_type_selectable.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/shards/pack_type_selectable.tsx
@@ -84,6 +84,7 @@ const PackTypeSelectableComponent = ({
               title={
                 <EuiRadio
                   id={'osquery_pack_type_policy'}
+                  name="packType"
                   label={i18n.translate('xpack.osquery.pack.form.policyLabel', {
                     defaultMessage: 'Policy',
                   })}
@@ -107,6 +108,7 @@ const PackTypeSelectableComponent = ({
               title={
                 <EuiRadio
                   id={'osquery_pack_type_global'}
+                  name="packType"
                   label={i18n.translate('xpack.osquery.pack.form.globalLabel', {
                     defaultMessage: 'Global',
                   })}

--- a/x-pack/platform/plugins/shared/spaces/public/copy_saved_objects_to_space/components/copy_mode_control.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/copy_saved_objects_to_space/components/copy_mode_control.tsx
@@ -149,6 +149,7 @@ export const CopyModeControl = ({ initialValues, updateSelection }: CopyModeCont
             onChange={(id: string) => onChange({ overwrite: id === overwriteEnabled.id })}
             disabled={createNewCopies}
             data-test-subj={'cts-copyModeControl-overwriteRadioGroup'}
+            name="overwriteOption"
           />
         </EuiCheckableCard>
       </EuiFormFieldset>

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/esql_query_expression.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/esql_query_expression.tsx
@@ -308,6 +308,7 @@ export const EsqlQueryExpression: React.FC<
             setRadioIdSelected(optionId);
             setParam('groupBy', optionId);
           }}
+          name="alertGroup"
         />
       </EuiFormRow>
       <EuiSpacer />

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/chart_options.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/chart_options.tsx
@@ -142,6 +142,7 @@ export const MetricsExplorerChartOptions = ({ chartOptions, onChange }: Props) =
             options={typeRadios}
             idSelected={chartOptions.type}
             onChange={handleTypeChange}
+            name="chartStyle"
           />
         </EuiFormRow>
         <EuiFormRow
@@ -170,6 +171,7 @@ export const MetricsExplorerChartOptions = ({ chartOptions, onChange }: Props) =
             options={yAxisRadios}
             idSelected={chartOptions.yAxisMode}
             onChange={handleYAxisChange}
+            name="yAxisDomain"
           />
         </EuiFormRow>
       </EuiForm>

--- a/x-pack/solutions/observability/plugins/slo/public/components/slo/purge_confirmation_modal/purge_confirmation_modal.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/slo/purge_confirmation_modal/purge_confirmation_modal.tsx
@@ -98,7 +98,7 @@ export function SloPurgeConfirmationModal({
           onChange={(val: string) => {
             setPurgeType(val);
           }}
-          name="radio group"
+          name="purgeType"
         />
       </EuiFormRow>
       {purgeType === 'fixed_age' ? (
@@ -127,6 +127,7 @@ export function SloPurgeConfirmationModal({
             ]}
             idSelected={age}
             onChange={setAge}
+            name="purgeAge"
           />
         </EuiFormRow>
       ) : (

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form.tsx
@@ -263,6 +263,7 @@ export const AwsCredentialsForm = ({
         onChange={(idSelected: SetupFormat) =>
           idSelected !== setupFormat && onSetupFormatChange(idSelected)
         }
+        name="setupFormat"
       />
       <EuiSpacer size="l" />
       {setupFormat === AWS_SETUP_FORMAT.CLOUD_FORMATION && (

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
@@ -441,6 +441,7 @@ export const AzureCredentialsForm = ({
         onChange={(idSelected: SetupFormat) =>
           idSelected !== setupFormat && onSetupFormatChange(idSelected)
         }
+        name="setupFormat"
       />
       <EuiSpacer size="l" />
       {setupFormat === AZURE_SETUP_FORMAT.ARM_TEMPLATE && (

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/csp_boxed_radio_group.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/csp_boxed_radio_group.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { useEuiTheme, EuiButton, EuiRadio, EuiToolTip, EuiBetaBadge } from '@elastic/eui';
 import { css } from '@emotion/react';
+import camelCase from 'lodash/camelCase';
 
 export interface CspRadioGroupProps {
   disabled?: boolean;
@@ -15,6 +16,7 @@ export interface CspRadioGroupProps {
   onChange(id: string): void;
   idSelected: string;
   size?: 's' | 'm';
+  name?: string;
 }
 
 export interface CspRadioOption {
@@ -33,6 +35,7 @@ export const RadioGroup = ({
   options,
   disabled,
   onChange,
+  name,
 }: CspRadioGroupProps) => {
   const { euiTheme } = useEuiTheme();
   return (
@@ -90,6 +93,7 @@ export const RadioGroup = ({
               `}
             >
               <EuiRadio
+                name={name || camelCase(option.label || 'optionsGroup')}
                 data-test-subj={option.testId}
                 label={option.label}
                 id={option.id}

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/eks_credentials_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/eks_credentials_form.tsx
@@ -293,5 +293,6 @@ const AwsCredentialTypeSelector = ({
     options={[...AWS_CREDENTIALS_OPTIONS]}
     idSelected={type}
     onChange={(id) => onChange(id as AwsCredentialsType)}
+    name="awsCredentialType"
   />
 );

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
@@ -522,6 +522,7 @@ export const GcpCredentialsForm = ({
         onChange={(idSelected: SetupFormatGCP) =>
           idSelected !== setupFormat && onSetupFormatChange(idSelected)
         }
+        name="setupFormat"
       />
       <EuiSpacer size="l" />
       {setupFormat === GCP_SETUP_ACCESS.CLOUD_SHELL ? (

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -265,6 +265,7 @@ const AwsAccountTypeSelect = ({
           );
         }}
         size="m"
+        name="awsAccountType"
       />
       {getAwsAccountType(input) === AWS_ORGANIZATION_ACCOUNT && (
         <>
@@ -404,6 +405,7 @@ const GcpAccountTypeSelect = ({
           accountType !== getGcpAccountType(input) && onSetupFormatChange(accountType)
         }
         size="m"
+        name="accountType"
       />
       {getGcpAccountType(input) === GCP_ORGANIZATION_ACCOUNT && (
         <>
@@ -503,6 +505,7 @@ const AzureAccountTypeSelect = ({
           );
         }}
         size="m"
+        name="azureAccountType"
       />
       {getAzureAccountType(input) === AZURE_ORGANIZATION_ACCOUNT && (
         <>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_selectors.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_selectors.tsx
@@ -65,6 +65,7 @@ export const PolicyTemplateSelector = ({
         idSelected={selectedTemplate}
         onChange={(id: CloudSecurityPolicyTemplate) => setPolicyTemplate(id)}
         disabled={disabled}
+        name="policyTemplate"
       />
     </div>
   );

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_selectors.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_selectors.tsx
@@ -206,6 +206,7 @@ export const PolicyTemplateInputSelector = ({ input, disabled, setInput }: Props
       options={options}
       onChange={(inputType) => setInput(inputType as PostureInput)}
       size="m"
+      name="inputType"
     />
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/asset_boxed_radio_group.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/asset_boxed_radio_group.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import camelCase from 'lodash/camelCase';
 import { useEuiTheme, EuiButton, EuiRadio, EuiToolTip, EuiBetaBadge } from '@elastic/eui';
 import { css } from '@emotion/react';
 
@@ -15,6 +16,7 @@ export interface AssetRadioGroupProps {
   onChange(id: string): void;
   idSelected: string;
   size?: 's' | 'm';
+  name?: string;
 }
 
 export interface AssetRadioOption {
@@ -33,6 +35,7 @@ export const RadioGroup = ({
   options,
   disabled,
   onChange,
+  name,
 }: AssetRadioGroupProps) => {
   const { euiTheme } = useEuiTheme();
   return (
@@ -91,6 +94,7 @@ export const RadioGroup = ({
             >
               <EuiRadio
                 data-test-subj={option.testId}
+                name={name || camelCase(option.label || 'optionsGroup')}
                 label={option.label}
                 id={option.id}
                 checked={isChecked}

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/aws_credentials_form/aws_account_type_select.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/aws_credentials_form/aws_account_type_select.tsx
@@ -97,6 +97,7 @@ export const AwsAccountTypeSelect = ({
           );
         }}
         size="m"
+        name="awsAccountType"
       />
       {getAwsAccountType(input) === AWS_ORGANIZATION_ACCOUNT && (
         <>

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/aws_credentials_form/aws_credentials_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/aws_credentials_form/aws_credentials_form.tsx
@@ -263,6 +263,7 @@ export const AwsCredentialsForm = ({
         onChange={(selectedSetupFormat: AwsSetupFormat) =>
           selectedSetupFormat !== setupFormat && onSetupFormatChange(selectedSetupFormat)
         }
+        name="setupFormat"
       />
       <EuiSpacer size="l" />
       {setupFormat === AWS_SETUP_FORMAT.CLOUD_FORMATION && (

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/azure_credentials_form/azure_account_type_select.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/azure_credentials_form/azure_account_type_select.tsx
@@ -106,6 +106,7 @@ export const AzureAccountTypeSelect = ({
           );
         }}
         size="m"
+        name="azureAccountType"
       />
       {getAzureAccountType(input) === AZURE_ORGANIZATION_ACCOUNT && (
         <>

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
@@ -302,6 +302,7 @@ export const AzureCredentialsForm = ({
         onChange={(idSelected: AzureSetupFormat) =>
           idSelected !== setupFormat && onSetupFormatChange(idSelected)
         }
+        name="setupFormat"
       />
       <EuiSpacer size="l" />
       {setupFormat === AZURE_SETUP_FORMAT.ARM_TEMPLATE && <ArmTemplateSetup />}

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/gcp_credentials_form/gcp_account_type_select.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/gcp_credentials_form/gcp_account_type_select.tsx
@@ -130,6 +130,7 @@ export const GcpAccountTypeSelect = ({
           accountType !== getGcpAccountType(input) && onSetupFormatChange(accountType)
         }
         size="m"
+        name="gcpAccountType"
       />
       {getGcpAccountType(input) === GCP_ORGANIZATION_ACCOUNT && (
         <>

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
@@ -490,6 +490,7 @@ export const GcpCredentialsForm = ({
         onChange={(idSelected: SetupFormatGCP) =>
           idSelected !== setupFormat && onSetupFormatChange(idSelected)
         }
+        name="setupFormat"
       />
       <EuiSpacer size="l" />
       {setupFormat === GCP_SETUP_ACCESS.CLOUD_SHELL ? (

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/policy_template_selectors.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/policy_template_selectors.tsx
@@ -151,6 +151,7 @@ export const PolicyTemplateInputSelector = ({
       options={options}
       onChange={(inputType) => setInput(inputType as AssetInput)}
       size="m"
+      name="policyTemplateInput"
     />
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_duration_selector.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_duration_selector.tsx
@@ -94,6 +94,7 @@ const SuppressionDurationSelectorFields = memo(function SuppressionDurationSelec
   return (
     <>
       <EuiRadioGroup
+        name="alertSuppressionDurationType"
         disabled={disabled}
         idSelected={suppressionDurationSelectorField.value}
         options={[

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_lists_options/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_lists_options/index.tsx
@@ -44,6 +44,7 @@ const ExceptionsAddToListsOptionsComponent: React.FC<ExceptionsAddToListsOptions
   return (
     <>
       <EuiRadio
+        name="addToListsOption"
         id="add_to_lists"
         label={
           <EuiFlexGroup

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_options/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_options/index.tsx
@@ -108,7 +108,7 @@ const ExceptionsAddToRulesOptionsComponent: React.FC<ExceptionsAddToRulesOptions
 
   return (
     <>
-      <EuiRadio {...ruleRadioOptionProps} />
+      <EuiRadio name="addToRulesOption" {...ruleRadioOptionProps} />
       {selectedRadioOption === 'select_rules_to_add_to' && (
         <ExceptionsAddToRulesTable
           onRuleSelectionChange={onRuleSelectionChange}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_duplicate_exceptions_confirmation.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_duplicate_exceptions_confirmation.tsx
@@ -61,6 +61,7 @@ const BulkActionDuplicateExceptionsConfirmationComponent = ({
 
       <EuiSpacer />
       <EuiRadioGroup
+        name="duplicateExceptionOption"
         options={[
           {
             id: DuplicateOptions.withExceptions,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_policy_create_extension/components/endpoint_event_collection_preset.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_policy_create_extension/components/endpoint_event_collection_preset.tsx
@@ -84,6 +84,7 @@ export const EndpointEventCollectionPreset = memo<EndpointEventCollectionPresetP
           <EuiFlexGroup gutterSize="s">
             <EuiFlexItem grow={false}>
               <EuiRadio
+                name="endpointDataCollection"
                 id="endpoint_data_collection_only_preset"
                 onChange={NOOP}
                 disabled

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/detect_prevent_protection_level.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/detect_prevent_protection_level.tsx
@@ -87,6 +87,7 @@ export const DetectPreventProtectionLevel = memo<DetectPreventProtectionLevelPro
               return (
                 <EuiFlexItem grow={flexGrow} key={id}>
                   <ProtectionRadio
+                    name="protectionLevel"
                     policy={policy}
                     onChange={onChange}
                     mode={mode}
@@ -114,6 +115,7 @@ interface ProtectionRadioProps extends PolicyFormComponentCommonProps {
   protectionMode: ProtectionModes;
   osList: ImmutableArray<Partial<keyof UIPolicyConfig>>;
   label: string;
+  name: string;
 }
 
 const ProtectionRadio = React.memo(
@@ -125,6 +127,7 @@ const ProtectionRadio = React.memo(
     onChange,
     policy,
     mode,
+    name,
     'data-test-subj': dataTestSubj,
   }: ProtectionRadioProps) => {
     const selected = policy.windows[protection].mode;
@@ -174,6 +177,7 @@ const ProtectionRadio = React.memo(
 
     return (
       <EuiRadio
+        name={name}
         label={label}
         id={radioId}
         checked={selected === protectionMode}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix violations of the @elastic/eui/no-unnamed-radio-group ESLint rule (#230068)](https://github.com/elastic/kibana/pull/230068)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2025-08-12T20:31:35Z","message":"Fix violations of the @elastic/eui/no-unnamed-radio-group ESLint rule (#230068)\n\nCloses: https://github.com/elastic/kibana/issues/212887\n\n## Summary\n\nThis PR applies the auto-fix for the newly introduced\n`@elastic/eui/no-unnamed-radio-group`\nhttps://github.com/elastic/eui/pull/8929 rule. This rule ensures that\nall radio input components have a name attribute. The name attribute is\nrequired for radio inputs to be grouped correctly, allowing users to\nselect only one option from a set. Without it, radios may not behave as\nexpected and can cause accessibility issues for assistive technologies.\n\n## Changes Made\n\n1. Set the `name` attribute for all radio components. Similar changes\nhave been applied across the entire `Kibana` codebase.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Ash <1849116+ashokaditya@users.noreply.github.com>","sha":"3b1354fc8b4e2cb9e274e813773bb705d026c24c","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","Team:Fleet","backport:prev-minor","Team:obs-ux-management","v9.2.0"],"title":"Fix violations of the @elastic/eui/no-unnamed-radio-group ESLint rule","number":230068,"url":"https://github.com/elastic/kibana/pull/230068","mergeCommit":{"message":"Fix violations of the @elastic/eui/no-unnamed-radio-group ESLint rule (#230068)\n\nCloses: https://github.com/elastic/kibana/issues/212887\n\n## Summary\n\nThis PR applies the auto-fix for the newly introduced\n`@elastic/eui/no-unnamed-radio-group`\nhttps://github.com/elastic/eui/pull/8929 rule. This rule ensures that\nall radio input components have a name attribute. The name attribute is\nrequired for radio inputs to be grouped correctly, allowing users to\nselect only one option from a set. Without it, radios may not behave as\nexpected and can cause accessibility issues for assistive technologies.\n\n## Changes Made\n\n1. Set the `name` attribute for all radio components. Similar changes\nhave been applied across the entire `Kibana` codebase.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Ash <1849116+ashokaditya@users.noreply.github.com>","sha":"3b1354fc8b4e2cb9e274e813773bb705d026c24c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230068","number":230068,"mergeCommit":{"message":"Fix violations of the @elastic/eui/no-unnamed-radio-group ESLint rule (#230068)\n\nCloses: https://github.com/elastic/kibana/issues/212887\n\n## Summary\n\nThis PR applies the auto-fix for the newly introduced\n`@elastic/eui/no-unnamed-radio-group`\nhttps://github.com/elastic/eui/pull/8929 rule. This rule ensures that\nall radio input components have a name attribute. The name attribute is\nrequired for radio inputs to be grouped correctly, allowing users to\nselect only one option from a set. Without it, radios may not behave as\nexpected and can cause accessibility issues for assistive technologies.\n\n## Changes Made\n\n1. Set the `name` attribute for all radio components. Similar changes\nhave been applied across the entire `Kibana` codebase.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Ash <1849116+ashokaditya@users.noreply.github.com>","sha":"3b1354fc8b4e2cb9e274e813773bb705d026c24c"}}]}] BACKPORT-->