### PR TITLE
[Fleet] Remove usage  of Browser SO client

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/.storybook/context/stubs.tsx
+++ b/x-pack/platform/plugins/shared/fleet/.storybook/context/stubs.tsx
@@ -7,20 +7,7 @@
 
 import type { FleetStartServices } from '../../public/plugin';
 
-type Stubs =
-  | 'licensing'
-  | 'storage'
-  | 'data'
-  | 'dataViews'
-  | 'unifiedSearch'
-  | 'deprecations'
-  | 'fatalErrors'
-  | 'navigation'
-  | 'overlays';
-
-type StubbedStartServices = Pick<FleetStartServices, Stubs>;
-
-export const stubbedStartServices: StubbedStartServices = {
+export const stubbedStartServices = {
   licensing: {} as FleetStartServices['licensing'],
   storage: {} as FleetStartServices['storage'],
   data: {} as FleetStartServices['data'],
@@ -30,4 +17,4 @@ export const stubbedStartServices: StubbedStartServices = {
   fatalErrors: {} as FleetStartServices['fatalErrors'],
   navigation: {} as FleetStartServices['navigation'],
   overlays: {} as FleetStartServices['overlays'],
-};
+} as FleetStartServices;

--- a/x-pack/platform/plugins/shared/fleet/.storybook/context/stubs.tsx
+++ b/x-pack/platform/plugins/shared/fleet/.storybook/context/stubs.tsx
@@ -16,8 +16,7 @@ type Stubs =
   | 'deprecations'
   | 'fatalErrors'
   | 'navigation'
-  | 'overlays'
-  | 'savedObjects';
+  | 'overlays';
 
 type StubbedStartServices = Pick<FleetStartServices, Stubs>;
 
@@ -31,5 +30,4 @@ export const stubbedStartServices: StubbedStartServices = {
   fatalErrors: {} as FleetStartServices['fatalErrors'],
   navigation: {} as FleetStartServices['navigation'],
   overlays: {} as FleetStartServices['overlays'],
-  savedObjects: {} as FleetStartServices['savedObjects'],
 };


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana-team/issues/1795 

Remove browser saved object client from our stubs it was not used, and seems not used anywhere in our public codebase.




