### PR TITLE
[9.1] [Dataset quality] Disabling fs for all and enabling on demand (#230374)

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/logs/custom_logsdb_index_templates.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/logs/custom_logsdb_index_templates.ts
@@ -13,6 +13,7 @@ export enum IndexTemplateName {
   LogsDb = 'logsdb',
   Synht2 = 'synth.2',
   SomeFailureStore = 'synth.fs',
+  NoFailureStore = 'synth.no-fs',
 }
 
 export const indexTemplates: {
@@ -49,9 +50,33 @@ export const indexTemplates: {
         default_pipeline: 'synth.2@pipeline',
       },
     },
-    priority: 500,
+    priority: 501,
     index_patterns: ['logs-synth.2-*'],
     composed_of: ['logs@mappings', 'logs@settings', 'ecs@mappings', 'synth.2@custom'],
+    allow_auto_create: true,
+    data_stream: {
+      hidden: false,
+    },
+  },
+  [IndexTemplateName.NoFailureStore]: {
+    name: IndexTemplateName.NoFailureStore,
+    _meta: {
+      managed: false,
+      description: 'custom index template created by synthtrace tool',
+    },
+    template: {
+      settings: {
+        default_pipeline: 'logs@default-pipeline',
+        data_stream_options: {
+          failure_store: {
+            enabled: false,
+          },
+        },
+      },
+    },
+    priority: 500,
+    index_patterns: ['logs-*'],
+    composed_of: ['logs@mappings', 'logs@settings', 'ecs@mappings'],
     allow_auto_create: true,
     data_stream: {
       hidden: false,

--- a/x-pack/solutions/observability/test/functional/apps/dataset_quality/dataset_quality_table.ts
+++ b/x-pack/solutions/observability/test/functional/apps/dataset_quality/dataset_quality_table.ts
@@ -50,6 +50,10 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       // Install Integration and ingest logs for it
       await PageObjects.observabilityLogsExplorer.installPackage(pkg);
 
+      // Disable failure store for logs-*
+      await synthtrace.createIndexTemplate(IndexTemplateName.NoFailureStore);
+
+      // Enable failure store only for logs-synth.2-*
       await synthtrace.createCustomPipeline(processors, 'synth.2@pipeline');
       await synthtrace.createComponentTemplate({
         name: 'synth.2@custom',
@@ -97,6 +101,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
     after(async () => {
       await synthtrace.clean();
       await PageObjects.observabilityLogsExplorer.uninstallPackage(pkg);
+      await synthtrace.deleteIndexTemplate(IndexTemplateName.NoFailureStore);
       await synthtrace.deleteIndexTemplate(IndexTemplateName.Synht2);
       await synthtrace.deleteComponentTemplate('synth.2@custom');
       await synthtrace.deleteCustomPipeline('synth.2@pipeline');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Dataset quality] Disabling fs for all and enabling on demand (#230374)](https://github.com/elastic/kibana/pull/230374)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Yngrid Coello","email":"yngrid.coello@elastic.co"},"sourceCommit":{"committedDate":"2025-08-04T12:04:08Z","message":"[Dataset quality] Disabling fs for all and enabling on demand (#230374)\n\nCloses https://github.com/elastic/kibana/issues/230154.","sha":"733e1e5f51cc9eac626316bae884f781d36fdab2","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Dataset quality] Disabling fs for all and enabling on demand","number":230374,"url":"https://github.com/elastic/kibana/pull/230374","mergeCommit":{"message":"[Dataset quality] Disabling fs for all and enabling on demand (#230374)\n\nCloses https://github.com/elastic/kibana/issues/230154.","sha":"733e1e5f51cc9eac626316bae884f781d36fdab2"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232124","number":232124,"state":"OPEN"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230374","number":230374,"mergeCommit":{"message":"[Dataset quality] Disabling fs for all and enabling on demand (#230374)\n\nCloses https://github.com/elastic/kibana/issues/230154.","sha":"733e1e5f51cc9eac626316bae884f781d36fdab2"}}]}] BACKPORT-->