### PR TITLE
[8.18] [Security Solution] Fix endpoint-meta-telemetry flaky integration test (#231963)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/integration_tests/lib/telemetry_helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/integration_tests/lib/telemetry_helpers.ts
@@ -17,15 +17,15 @@ import type {
 } from '@kbn/securitysolution-io-ts-list-types';
 import { asyncForEach } from '@kbn/std';
 
+import { ToolingLog } from '@kbn/tooling-log';
 import {
   createExceptionList,
   createExceptionListItem,
   deleteExceptionList,
   deleteExceptionListItem,
 } from '@kbn/lists-plugin/server/services/exception_lists';
-import { LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common/constants';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
-
+import { getAgentPolicySavedObjectType } from '@kbn/fleet-plugin/server/services/agent_policy';
 import { packagePolicyService } from '@kbn/fleet-plugin/server/services';
 
 import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
@@ -54,6 +54,11 @@ const endpointMetricsIndex = '.ds-metrics-endpoint.metrics-1';
 const endpointMetricsMetadataIndex = '.ds-metrics-endpoint.metadata-1';
 const endpointMetricsPolicyIndex = '.ds-metrics-endpoint.policy-1';
 const prebuiltRulesIndex = '.alerts-security.alerts';
+
+const logger = new ToolingLog({
+  level: 'info',
+  writeTo: process.stdout,
+});
 
 export function getTelemetryTasks(
   spy: jest.SpyInstance<
@@ -260,7 +265,7 @@ export async function createAgentPolicy(
     enabled: true,
     policy_id: 'policy-elastic-agent-on-cloud',
     policy_ids: ['policy-elastic-agent-on-cloud'],
-    package: { name: 'endpoint', title: 'Elastic Endpoint', version: '8.11.1' },
+    package: { name: 'endpoint', title: 'Elastic Endpoint', version: '8.15.1' },
     inputs: [
       {
         config: {
@@ -283,14 +288,38 @@ export async function createAgentPolicy(
     ],
   };
 
-  await soClient.create<unknown>(LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE, {}, { id }).catch(() => {});
-  await packagePolicyService
-    .create(soClient, esClient, packagePolicy, {
-      id,
-      spaceId: 'default',
-      bumpRevision: false,
-    })
-    .catch(() => {});
+  const agentPolicyType = await getAgentPolicySavedObjectType();
+  await soClient.get<unknown>(agentPolicyType, id).catch(async (e) => {
+    try {
+      return await soClient.create<unknown>(agentPolicyType, {}, { id });
+    } catch {
+      logger.error(`>> Error searching for agent: ${e}`);
+      throw Error(`>> Error searching for agent: ${e}`);
+    }
+  });
+  // sometimes we can get an error from epr, e.g.
+  // 503 Service Temporarily Unavailable' error response from package registry at https://epr.elastic.co/package/endpoint/8.15.1/
+  // in case of error, retry up to 1 min, waiting 10 secs between attempts
+  // more info: https://github.com/elastic/kibana/issues/231535
+  await eventually(
+    async () => {
+      await packagePolicyService.get(soClient, id).catch(async () => {
+        try {
+          return await packagePolicyService.create(soClient, esClient, packagePolicy, {
+            id,
+            spaceId: 'default',
+            bumpRevision: false,
+            force: true,
+          });
+        } catch (e) {
+          logger.error(`>> Error creating package policy: ${e}`);
+          throw Error(`>> Error creating package policy: ${e}`);
+        }
+      });
+    },
+    60000,
+    10000
+  );
 }
 
 export async function createMockedExceptionList(so: SavedObjectsServiceStart) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Security Solution] Fix endpoint-meta-telemetry flaky integration test (#231963)](https://github.com/elastic/kibana/pull/231963)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sebastián Zaffarano","email":"sebastian.zaffarano@elastic.co"},"sourceCommit":{"committedDate":"2025-08-15T17:49:24Z","message":"[Security Solution] Fix endpoint-meta-telemetry flaky integration test (#231963)\n\n## Summary\n\nAs part of this [endpoint metadata integration\ntest](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/integration_tests/telemetry.test.ts#L329),\nwe create a package policy, and sometimes https://epr.elastic.co returns\n503.\n\nThis PR adds a retry logic for those cases, waiting a few seconds\nbetween retries.\n\nfixes https://github.com/elastic/kibana/issues/231544\nfixes https://github.com/elastic/kibana/issues/231543\nfixes https://github.com/elastic/kibana/issues/231542\nfixes https://github.com/elastic/kibana/issues/231540\nfixes https://github.com/elastic/kibana/issues/231541\nfixes https://github.com/elastic/kibana/issues/231539\nfixes https://github.com/elastic/kibana/issues/231537\nfixes https://github.com/elastic/kibana/issues/231538\nfixes https://github.com/elastic/kibana/issues/231536\nfixes https://github.com/elastic/kibana/issues/231535","sha":"b58fc4fb6b33691fd5a7669e78c003c6dd256be8","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","backport:prev-major","backport:current-major","v9.2.0","v9.1.3","v9.0.6"],"title":"[Security Solution] Fix endpoint-meta-telemetry flaky integration test","number":231963,"url":"https://github.com/elastic/kibana/pull/231963","mergeCommit":{"message":"[Security Solution] Fix endpoint-meta-telemetry flaky integration test (#231963)\n\n## Summary\n\nAs part of this [endpoint metadata integration\ntest](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/integration_tests/telemetry.test.ts#L329),\nwe create a package policy, and sometimes https://epr.elastic.co returns\n503.\n\nThis PR adds a retry logic for those cases, waiting a few seconds\nbetween retries.\n\nfixes https://github.com/elastic/kibana/issues/231544\nfixes https://github.com/elastic/kibana/issues/231543\nfixes https://github.com/elastic/kibana/issues/231542\nfixes https://github.com/elastic/kibana/issues/231540\nfixes https://github.com/elastic/kibana/issues/231541\nfixes https://github.com/elastic/kibana/issues/231539\nfixes https://github.com/elastic/kibana/issues/231537\nfixes https://github.com/elastic/kibana/issues/231538\nfixes https://github.com/elastic/kibana/issues/231536\nfixes https://github.com/elastic/kibana/issues/231535","sha":"b58fc4fb6b33691fd5a7669e78c003c6dd256be8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231963","number":231963,"mergeCommit":{"message":"[Security Solution] Fix endpoint-meta-telemetry flaky integration test (#231963)\n\n## Summary\n\nAs part of this [endpoint metadata integration\ntest](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/integration_tests/telemetry.test.ts#L329),\nwe create a package policy, and sometimes https://epr.elastic.co returns\n503.\n\nThis PR adds a retry logic for those cases, waiting a few seconds\nbetween retries.\n\nfixes https://github.com/elastic/kibana/issues/231544\nfixes https://github.com/elastic/kibana/issues/231543\nfixes https://github.com/elastic/kibana/issues/231542\nfixes https://github.com/elastic/kibana/issues/231540\nfixes https://github.com/elastic/kibana/issues/231541\nfixes https://github.com/elastic/kibana/issues/231539\nfixes https://github.com/elastic/kibana/issues/231537\nfixes https://github.com/elastic/kibana/issues/231538\nfixes https://github.com/elastic/kibana/issues/231536\nfixes https://github.com/elastic/kibana/issues/231535","sha":"b58fc4fb6b33691fd5a7669e78c003c6dd256be8"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/231978","number":231978,"state":"MERGED","mergeCommit":{"sha":"3da0e87e297ed09610d86188f5a988198448f733","message":"[9.1] [Security Solution] Fix endpoint-meta-telemetry flaky integration test (#231963) (#231978)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution] Fix endpoint-meta-telemetry flaky integration\ntest (#231963)](https://github.com/elastic/kibana/pull/231963)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"}},{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/231977","number":231977,"state":"MERGED","mergeCommit":{"sha":"2e10dcc7fdb3239ba8b2f99ca52aa765559df279","message":"[9.0] [Security Solution] Fix endpoint-meta-telemetry flaky integration test (#231963) (#231977)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Security Solution] Fix endpoint-meta-telemetry flaky integration\ntest (#231963)](https://github.com/elastic/kibana/pull/231963)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"}},{"url":"https://github.com/elastic/kibana/pull/232110","number":232110,"branch":"8.19","state":"OPEN"}]}] BACKPORT-->