### PR TITLE
[Search] [Serverless] Rename Playground to RAG Playground

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/sample_data_action_button.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/sample_data_action_button.tsx
@@ -99,7 +99,7 @@ export const SampleDataActionButton = ({ clickEvent = AnalyticsEvents.installSam
               <EuiContextMenuItem key="playground" onClick={navigateToPlayground} icon="comment">
                 <FormattedMessage
                   id="xpack.searchHomepage.sampleData.linkToPlayground"
-                  defaultMessage="Playground"
+                  defaultMessage="RAG Playground"
                 />
               </EuiContextMenuItem>,
               <EuiContextMenuItem key="index" onClick={navigateToIndexDetails} icon="index">

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page.tsx
@@ -256,7 +256,7 @@ export const SearchIndexDetailsPage = () => {
                       >
                         <FormattedMessage
                           id="xpack.searchIndices.indexAction.useInPlaygroundButtonLabel"
-                          defaultMessage="Search in Playground"
+                          defaultMessage="Search in RAG Playground"
                         />
                       </EuiButton>
                     </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_search_example.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_search_example.tsx
@@ -72,7 +72,7 @@ export const IndexSearchExample = ({
           <h5>
             <FormattedMessage
               id="xpack.searchIndices.indexDetail.searchExample.playground.title"
-              defaultMessage="Playground"
+              defaultMessage="RAG Playground"
             />
           </h5>
         </EuiTitle>
@@ -94,7 +94,7 @@ export const IndexSearchExample = ({
           >
             <FormattedMessage
               id="xpack.searchIndices.indexDetail.searchExample.playground.cta"
-              defaultMessage="Search in Playground"
+              defaultMessage="Search in RAG Playground"
             />
           </EuiButton>
         </div>

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/sample_data_action_button.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/sample_data_action_button.tsx
@@ -95,7 +95,7 @@ export const SampleDataActionButton: React.FC<SampleDataActionButtonProps> = ({
               <EuiContextMenuItem key="playground" onClick={navigateToPlayground} icon="comment">
                 <FormattedMessage
                   id="xpack.searchIndices.shared.createIndex.ingestSampleData.linkToPlayground"
-                  defaultMessage="Playground"
+                  defaultMessage="RAG Playground"
                 />
               </EuiContextMenuItem>,
               <EuiContextMenuItem

--- a/x-pack/solutions/search/plugins/search_playground/common/index.ts
+++ b/x-pack/solutions/search/plugins/search_playground/common/index.ts
@@ -12,7 +12,7 @@ export { SearchPlaygroundQueryKeys, SearchPlaygroundMutationKeys } from './query
 
 export const PLUGIN_ID = 'searchPlayground';
 export const PLUGIN_NAME = i18n.translate('xpack.searchPlayground.plugin.name', {
-  defaultMessage: 'Playground',
+  defaultMessage: 'RAG Playground',
 });
 export const PLUGIN_PATH = '/app/search_playground';
 

--- a/x-pack/solutions/search/plugins/search_playground/public/components/chat_sidebar.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/chat_sidebar.tsx
@@ -24,7 +24,7 @@ export const ChatSidebar: React.FC = () => {
     },
     {
       title: i18n.translate('xpack.searchPlayground.sidebar.contextTitle', {
-        defaultMessage: 'Playground context',
+        defaultMessage: 'RAG Playground context',
       }),
       extraAction: (
         <EuiLink

--- a/x-pack/solutions/search/plugins/search_playground/public/components/header.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/header.tsx
@@ -85,7 +85,7 @@ export const Header: React.FC<HeaderProps> = ({
             <h2>
               <FormattedMessage
                 id="xpack.searchPlayground.unsaved.pageTitle"
-                defaultMessage="Unsaved playground"
+                defaultMessage="Unsaved RAG playground"
               />
             </h2>
           </EuiTitle>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/not_found.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/not_found.tsx
@@ -54,7 +54,7 @@ export const PlaygroundRouteNotFound = () => {
         actions={
           <EuiButton data-test-subj="playgroundRouteNotFoundCTA" onClick={goToPlayground} fill>
             {i18n.translate('xpack.searchPlayground.notFound.action1', {
-              defaultMessage: 'Back to Playground',
+              defaultMessage: 'Back to RAG Playground',
             })}
           </EuiButton>
         }

--- a/x-pack/solutions/search/plugins/search_playground/public/components/playground_header_docs.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/playground_header_docs.tsx
@@ -23,7 +23,7 @@ export const PlaygroundHeaderDocs: React.FC = () => (
     size="s"
   >
     {i18n.translate('xpack.searchPlayground.pageTitle.header.docLink', {
-      defaultMessage: 'Playground Docs',
+      defaultMessage: 'RAG Playground Docs',
     })}
   </EuiButtonEmpty>
 );

--- a/x-pack/solutions/search/plugins/search_playground/public/components/playgrounds_list/empty_state/body.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/playgrounds_list/empty_state/body.tsx
@@ -37,7 +37,7 @@ export const PlaygroundsListEmptyStateBody = ({
           >
             <FormattedMessage
               id="xpack.searchPlayground.playgroundsList.emptyPrompt.cta.text"
-              defaultMessage="New Playground"
+              defaultMessage="New RAG Playground"
             />
           </EuiButton>
         </span>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/playgrounds_list/empty_state/description_list_columns.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/playgrounds_list/empty_state/description_list_columns.tsx
@@ -44,7 +44,10 @@ export const DescriptionListColumns = () => {
         )}
         description={i18n.translate(
           'xpack.searchPlayground.playgroundsList.emptyPrompt.listItems.abTest.description',
-          { defaultMessage: 'Playground allow you to A/B test different LLMs from model providers' }
+          {
+            defaultMessage:
+              'RAG Playground allows you to A/B test different LLMs from model providers',
+          }
         )}
       />
       <DescriptionListColumn
@@ -67,7 +70,7 @@ export const DescriptionListColumns = () => {
         )}
         description={i18n.translate(
           'xpack.searchPlayground.playgroundsList.emptyPrompt.listItems.lowCode.description',
-          { defaultMessage: "Elastic's playground experience is a low-code interface" }
+          { defaultMessage: "Elastic's RAG Playground experience is a low-code interface" }
         )}
       />
     </EuiFlexGrid>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/playgrounds_list/playgrounds_list.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/playgrounds_list/playgrounds_list.tsx
@@ -95,7 +95,7 @@ export const PlaygroundsList = () => {
           >
             <FormattedMessage
               id="xpack.searchPlayground.playgroundsList.page.cta.text"
-              defaultMessage="New Playground"
+              defaultMessage="New RAG Playground"
             />
           </EuiButton>,
         ]}

--- a/x-pack/solutions/search/plugins/search_playground/public/components/playgrounds_list/playgrounds_table.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/playgrounds_list/playgrounds_table.tsx
@@ -58,7 +58,7 @@ export const PlaygroundsTable = ({
     () => [
       {
         name: i18n.translate('xpack.searchPlayground.playgroundsList.table.columns.name.header', {
-          defaultMessage: 'Playground',
+          defaultMessage: 'RAG Playground',
         }),
         render: ({ id, name }: PlaygroundListObject) => (
           <EuiLink
@@ -94,7 +94,7 @@ export const PlaygroundsTable = ({
               i18n.translate(
                 'xpack.searchPlayground.playgroundsList.table.columns.actions.delete.description',
                 {
-                  defaultMessage: 'Delete playground {name}',
+                  defaultMessage: 'Delete RAG playground {name}',
                   values: { name: playground.name },
                 }
               ),

--- a/x-pack/solutions/search/plugins/search_playground/public/components/save_new_playground_button.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/save_new_playground_button.test.tsx
@@ -32,7 +32,7 @@ jest.mock('./saved_playground/save_playground_modal', () => ({
         data-test-subj="modal-save-button"
         onClick={() => onNavigateToNewPlayground('test-playground-id')}
       >
-        Save Playground
+        Save RAG Playground
       </button>
       <button data-test-subj="modal-close-button" onClick={onClose}>
         Close

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/delete_playground_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/delete_playground_modal.tsx
@@ -35,7 +35,7 @@ export const DeletePlaygroundModal = ({
       const errorMessage = getErrorMessage(error);
       notifications.toasts.addError(error instanceof Error ? error : new Error(errorMessage), {
         title: i18n.translate('xpack.searchPlayground.savedPlayground.deleteError.title', {
-          defaultMessage: 'Error deleting playground',
+          defaultMessage: 'Error deleting RAG playground',
         }),
         toastMessage: errorMessage,
       });
@@ -62,7 +62,7 @@ export const DeletePlaygroundModal = ({
       title={i18n.translate(
         'xpack.searchPlayground.savedPlayground.deletePlayground.confirmModal.modalTitle',
         {
-          defaultMessage: 'Delete playground',
+          defaultMessage: 'Delete RAG playground',
         }
       )}
       titleProps={{ id: modalTitleId }}
@@ -79,7 +79,7 @@ export const DeletePlaygroundModal = ({
       confirmButtonText={i18n.translate(
         'xpack.searchPlayground.savedPlayground.deletePlayground.confirmModal.confirmButtonText',
         {
-          defaultMessage: 'Delete playground',
+          defaultMessage: 'Delete RAG playground',
         }
       )}
     >
@@ -88,7 +88,7 @@ export const DeletePlaygroundModal = ({
           <p>
             <FormattedMessage
               id="xpack.searchPlayground.savedPlayground.deletePlayground.deleteDescription"
-              defaultMessage="You are about to delete the {playgroundName} playground"
+              defaultMessage="You are about to delete the {playgroundName} RAG playground"
               values={{
                 playgroundName: <strong>{playgroundName}</strong>,
               }}
@@ -97,7 +97,7 @@ export const DeletePlaygroundModal = ({
           <p>
             <FormattedMessage
               id="xpack.searchPlayground.savedPlayground.deletePlayground.deleteWarningDescription"
-              defaultMessage="You can't recover a deleted playground. Make sure you have appropriate backups."
+              defaultMessage="You can't recover a deleted RAG playground. Make sure you have appropriate backups."
             />
           </p>
         </EuiText>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/edit_name_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/edit_name_modal.tsx
@@ -64,7 +64,7 @@ export const EditPlaygroundNameModal = ({
         <EuiModalHeaderTitle id={modalTitleId}>
           <FormattedMessage
             id="xpack.searchPlayground.savedPlayground.nameEditModal.title"
-            defaultMessage="Edit playground name"
+            defaultMessage="Edit RAG playground name"
           />
         </EuiModalHeaderTitle>
       </EuiModalHeader>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/invalid_state_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/invalid_state_modal.tsx
@@ -57,7 +57,7 @@ export const SavedPlaygroundInvalidStateModal = ({
           errorsTypes.has(InvalidPlaygroundType.MissingModel) ? (
             <FormattedMessage
               id="xpack.searchPlayground.savedPlayground.invalidPlayground.title"
-              defaultMessage="Invalid playground values"
+              defaultMessage="Invalid RAG playground values"
             />
           ) : errorsTypes.has(InvalidPlaygroundType.MissingModel) ? (
             <FormattedMessage
@@ -79,7 +79,7 @@ export const SavedPlaygroundInvalidStateModal = ({
               <p>
                 <FormattedMessage
                   id="xpack.searchPlayground.savedPlayground.invalidDataSources.description"
-                  defaultMessage="Some indices were not found. These indices will be removed from your data source selection for this playground."
+                  defaultMessage="Some indices were not found. These indices will be removed from your data source selection for this RAG playground."
                 />
               </p>
               <ul>
@@ -93,7 +93,7 @@ export const SavedPlaygroundInvalidStateModal = ({
             <p>
               <FormattedMessage
                 id="xpack.searchPlayground.savedPlayground.invalidModelConnector.description"
-                defaultMessage="The selected LLM connector for this playground was not found. Please select a different LLM for use with this playground."
+                defaultMessage="The selected LLM connector for this RAG playground was not found. Please select a different LLM for use with this RAG playground."
               />
             </p>
           )}

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/playground_more_options.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/playground_more_options.tsx
@@ -79,7 +79,7 @@ export const PlaygroundMoreOptionsMenu = ({
       <EuiText size="s" color="danger">
         <FormattedMessage
           id="xpack.searchPlayground.savedPlayground.moreOptions.deletePlayground.label"
-          defaultMessage="Delete playground"
+          defaultMessage="Delete RAG playground"
         />
       </EuiText>
     </EuiContextMenuItem>,

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/playground_name.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/playground_name.tsx
@@ -17,7 +17,7 @@ export interface PlaygroundNameProps {
 
 const EDIT_NAME_LABEL = i18n.translate(
   'xpack.searchPlayground.savedPlayground.editPlaygroundName.ariaLabel',
-  { defaultMessage: 'Edit playground name' }
+  { defaultMessage: 'Edit RAG playground name' }
 );
 
 export const PlaygroundName = ({ playgroundName, onEditName }: PlaygroundNameProps) => {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/save_playground_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/save_playground_modal.tsx
@@ -39,7 +39,7 @@ function makePlaygroundName(name?: string) {
         values: { name },
       })
     : i18n.translate('xpack.searchPlayground.savedPlayground.defaultName', {
-        defaultMessage: 'New Playground',
+        defaultMessage: 'New RAG Playground',
       });
 }
 
@@ -84,7 +84,7 @@ export const SavePlaygroundModal = ({
           reset(newPlayground);
           notifications.toasts.addSuccess({
             title: i18n.translate('xpack.searchPlayground.savedPlayground.saveSuccess.title', {
-              defaultMessage: 'Playground saved',
+              defaultMessage: 'RAG playground saved',
             }),
             text: i18n.translate('xpack.searchPlayground.savedPlayground.saveSuccess.text', {
               defaultMessage: '{name} was saved.',
@@ -99,7 +99,7 @@ export const SavePlaygroundModal = ({
           const errorMessage = getErrorMessage(error);
           notifications.toasts.addError(error instanceof Error ? error : new Error(errorMessage), {
             title: i18n.translate('xpack.searchPlayground.savedPlayground.saveError.title', {
-              defaultMessage: 'Error saving playground',
+              defaultMessage: 'Error saving RAG playground',
             }),
             toastMessage: errorMessage,
           });
@@ -131,12 +131,12 @@ export const SavePlaygroundModal = ({
           {saveAs ? (
             <FormattedMessage
               id="xpack.searchPlayground.savedPlayground.savePlaygroundModal.title"
-              defaultMessage="Save playground as"
+              defaultMessage="Save RAG playground as"
             />
           ) : (
             <FormattedMessage
               id="xpack.searchPlayground.savedPlayground.savePlaygroundModal.title"
-              defaultMessage="Save playground"
+              defaultMessage="Save RAG playground"
             />
           )}
         </EuiModalHeaderTitle>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/saved_playground_fetch_error.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/saved_playground_fetch_error.tsx
@@ -29,7 +29,7 @@ export const SavedPlaygroundFetchError = () => {
       title={
         <h1>
           {i18n.translate('xpack.searchPlayground.savedPlayground.fetchError.title', {
-            defaultMessage: 'Error loading playground',
+            defaultMessage: 'Error loading RAG playground',
           })}
         </h1>
       }

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_playground_breadcrumbs.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_playground_breadcrumbs.ts
@@ -29,7 +29,7 @@ export const usePlaygroundBreadcrumbs = (playgroundName?: string) => {
           ]),
       {
         text: i18n.translate('xpack.searchPlayground.breadcrumbs.playground', {
-          defaultMessage: 'Playground',
+          defaultMessage: 'RAG Playground',
         }),
         href: playgroundName !== undefined ? http.basePath.prepend(PLUGIN_PATH) : undefined,
       },

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/saved_playground.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/saved_playground.test.ts
@@ -418,18 +418,18 @@ describe('saved_playgrounds utils', () => {
     });
 
     it('should return error for empty name', () => {
-      expect(validatePlaygroundName('')).toBe('Playground name is required');
+      expect(validatePlaygroundName('')).toBe('RAG Playground name is required');
     });
 
     it('should return error for names longer than 100 characters', () => {
       const longName = 'a'.repeat(101);
       expect(validatePlaygroundName(longName)).toBe(
-        'Playground name must be less than 100 characters'
+        'RAG Playground name must be less than 100 characters'
       );
     });
 
     it('should handle whitespace-only names as empty', () => {
-      expect(validatePlaygroundName('   ')).toBe('Playground name is required');
+      expect(validatePlaygroundName('   ')).toBe('RAG Playground name is required');
     });
   });
 

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/saved_playgrounds.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/saved_playgrounds.ts
@@ -176,12 +176,12 @@ export function validatePlaygroundName(name: string): string | null {
   const trimmedName = name.trim();
   if (!name || !trimmedName) {
     return i18n.translate('xpack.searchPlayground.savedPlayground.errors.name.required', {
-      defaultMessage: 'Playground name is required',
+      defaultMessage: 'RAG Playground name is required',
     });
   }
   if (name.length > 100) {
     return i18n.translate('xpack.searchPlayground.savedPlayground.errors.name.tooLong', {
-      defaultMessage: 'Playground name must be less than 100 characters',
+      defaultMessage: 'RAG Playground name must be less than 100 characters',
     });
   }
   return null;

--- a/x-pack/solutions/search/plugins/search_playground/server/routes/saved_playgrounds.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/routes/saved_playgrounds.ts
@@ -239,7 +239,7 @@ export const defineSavedPlaygroundRoutes = ({ logger, router }: DefineRoutesOpti
           return response.badRequest({
             body: {
               message: i18n.translate('xpack.searchPlayground.savedPlaygrounds.validationError', {
-                defaultMessage: 'Invalid playground request',
+                defaultMessage: 'Invalid RAG playground request',
               }),
               attributes: {
                 errors: validationErrors,

--- a/x-pack/solutions/search/plugins/search_playground/server/utils/playgrounds.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/utils/playgrounds.test.ts
@@ -56,9 +56,9 @@ describe('Playground utils', () => {
         ...validSearchPlayground,
         name: '',
       };
-      expect(validatePlayground(playground)).toContain('Playground name cannot be empty');
+      expect(validatePlayground(playground)).toContain('RAG Playground name cannot be empty');
       playground.name = ' ';
-      expect(validatePlayground(playground)).toContain('Playground name cannot be empty');
+      expect(validatePlayground(playground)).toContain('RAG Playground name cannot be empty');
     });
     it('should return an error when elasticsearchQuery is invalid JSON', () => {
       const playground: PlaygroundSavedObject = {

--- a/x-pack/solutions/search/plugins/search_playground/server/utils/playgrounds.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/utils/playgrounds.ts
@@ -20,7 +20,7 @@ export function validatePlayground(playground: PlaygroundSavedObject): string[] 
   if (playground.name.trim().length === 0) {
     errors.push(
       i18n.translate('xpack.searchPlayground.playgroundNameError', {
-        defaultMessage: 'Playground name cannot be empty',
+        defaultMessage: 'RAG Playground name cannot be empty',
       })
     );
   }

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -91,7 +91,7 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
               ...isAvailable('searchPlayground', {
                 id: 'searchPlayground',
                 title: i18n.translate('xpack.serverlessSearch.nav.build.searchPlayground', {
-                  defaultMessage: 'Playground',
+                  defaultMessage: 'RAG Playground',
                 }),
                 link: 'searchPlayground' as AppDeepLinkId,
                 breadcrumbStatus: 'hidden' as 'hidden',

--- a/x-pack/solutions/search/test/functional_search/apps/search_playground/saved_playgrounds.ts
+++ b/x-pack/solutions/search/test/functional_search/apps/search_playground/saved_playgrounds.ts
@@ -82,7 +82,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         );
         const { solutionNavigation } = pageObjects;
         await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Build' });
-        await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Playground' });
+        await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'RAG Playground' });
         await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
           text: testPlaygroundName,
         });

--- a/x-pack/solutions/search/test/functional_search/page_objects/search_playground_page.ts
+++ b/x-pack/solutions/search/test/functional_search/page_objects/search_playground_page.ts
@@ -692,7 +692,7 @@ export function SearchPlaygroundPageProvider({ getService }: FtrProviderContext)
       SaveExtendedTimeout: SAVE_PLAYGROUND_EXTENDED_TIMEOUT,
       async expectAndCloseSavedPlaygroundToast() {
         const toastTitle = await toasts.getTitleAndDismiss();
-        expect(toastTitle).to.equal('Playground saved');
+        expect(toastTitle).to.equal('RAG playground saved');
       },
       async getPlaygroundIdFromUrl() {
         const url = await browser.getCurrentUrl();

--- a/x-pack/solutions/search/test/functional_search/tests/classic_navigation.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/classic_navigation.ts
@@ -45,7 +45,7 @@ export default function searchSolutionNavigation({
         { id: 'Home', label: 'Home' },
         { id: 'Build', label: 'Build' },
         { id: 'Indices', label: 'Index Management' },
-        { id: 'Playground', label: 'Playground' },
+        { id: 'Playground', label: 'RAG Playground' },
         { id: 'Connectors', label: 'Connectors' },
         { id: 'SearchApplications', label: 'Search applications' },
         { id: 'Relevance', label: 'Relevance' },
@@ -76,7 +76,7 @@ export default function searchSolutionNavigation({
         },
         {
           navItem: 'Playground',
-          breadcrumbs: ['Build', 'Playground'],
+          breadcrumbs: ['Build', 'RAG Playground'],
           pageTestSubject: 'playgroundsListPage',
         },
         {

--- a/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
@@ -50,7 +50,7 @@ export default function searchSolutionNavigation({
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Discover' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dashboards' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Index Management' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'RAG Playground' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Connectors' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Search applications' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Synonyms' });
@@ -93,7 +93,7 @@ export default function searchSolutionNavigation({
         },
         {
           deepLinkId: 'searchPlayground',
-          breadcrumbs: ['Build', 'Playground'],
+          breadcrumbs: ['Build', 'RAG Playground'],
           pageTestSubject: 'playgroundsListPage',
         },
         {

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/navigation.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/navigation.ts
@@ -76,7 +76,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
         },
         {
           deepLinkId: 'searchPlayground',
-          breadcrumbs: ['Build', 'Playground'],
+          breadcrumbs: ['Build', 'RAG Playground'],
           pageTestSubject: 'playgroundsListPage',
         },
         {
@@ -156,7 +156,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
     it('navigate to playground from side nav', async () => {
       await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'searchPlayground' });
       await header.waitUntilLoadingHasFinished();
-      await svlCommonNavigation.breadcrumbs.expectBreadcrumbTexts(['Build', 'Playground']);
+      await svlCommonNavigation.breadcrumbs.expectBreadcrumbTexts(['Build', 'RAG Playground']);
 
       await svlCommonNavigation.sidenav.expectLinkActive({ deepLinkId: 'searchPlayground' });
       expect(await browser.getCurrentUrl()).contain('/app/search_playground');
@@ -217,7 +217,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dashboards' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Build' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Index Management' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'RAG Playground' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Connectors' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Web crawlers' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Relevance' });

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/search_playground/saved_playgrounds.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/search_playground/saved_playgrounds.ts
@@ -89,7 +89,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         );
         const { solutionNavigation } = pageObjects;
         await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Build' });
-        await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Playground' });
+        await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'RAG Playground' });
         await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
           text: testPlaygroundName,
         });


### PR DESCRIPTION
## Summary

This PR renames `Playground` to `Rag Playground` in the side nav, breadcrumbs and everywhere within the Playground. It also renames the CTA buttons in Index Management and on the home page.

#### RAG Playground

<img width="600" alt="FireShot Capture 023 - RAG Playground - Elastic -  localhost" src="https://github.com/user-attachments/assets/81650c06-e1de-494d-8778-0e2ca8bfa4e4" />
<img width="600" alt="FireShot Capture 024 - RAG Playground - Elastic -  localhost" src="https://github.com/user-attachments/assets/6bb0c8a4-e4b7-4be7-a28b-d501a66992b4" />
<img width="300" alt="Screenshot 2025-08-18 at 17 53 54" src="https://github.com/user-attachments/assets/514d69b3-6fea-4b64-a42c-b82bfb68a9cc" />
<img width="300" alt="Screenshot 2025-08-18 at 17 54 01" src="https://github.com/user-attachments/assets/9a462f6c-32c6-4a92-aef9-731a12e391dd" />

#### Index Management

<img width="600" alt="FireShot Capture 025 - kibana_sample_data_elasticsearch_documentation - Elastic -  localhost" src="https://github.com/user-attachments/assets/db1829f2-3f49-4a89-bdf7-ef5bfd8abba0" />

#### Home page

<img width="600" alt="FireShot Capture 026 - Elastic -  localhost" src="https://github.com/user-attachments/assets/adc55dfb-64a8-430d-9350-6b4ab3b63e24" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~


