### PR TITLE
[Search][Playground] show tour for elastic llm costs transparency

### DIFF
--- a/x-pack/solutions/search/packages/shared-ui/src/constants.ts
+++ b/x-pack/solutions/search/packages/shared-ui/src/constants.ts
@@ -7,6 +7,7 @@
 
 export const WORKFLOW_LOCALSTORAGE_KEY = 'search_onboarding_workflow';
 export const GLOBAL_EMPTY_STATE_SKIP_KEY = 'search_onboarding_global_empty_state_skip';
+export const ELASTIC_LLM_COST_TOUR_SKIP_KEY = 'search_elastic_llm_cost_info_skip';
 
 // Feature Flags
 export const SEARCH_HOMEPAGE_INGESTION_CTA_FEATURE_FLAG = 'searchSolution.homepage.ingestionCTA';

--- a/x-pack/solutions/search/plugins/search_playground/common/doc_links.ts
+++ b/x-pack/solutions/search/plugins/search_playground/common/doc_links.ts
@@ -13,6 +13,8 @@ class PlaygroundDocLinks {
   public retrieval: string = '';
   public context: string = '';
   public hiddenFields: string = '';
+  public elasticLLMCosts: string = '';
+  public elasticLLM: string = '';
 
   constructor() {}
 
@@ -22,6 +24,8 @@ class PlaygroundDocLinks {
     this.retrieval = newDocLinks.playground.retrieval;
     this.context = newDocLinks.playground.context;
     this.hiddenFields = newDocLinks.playground.hiddenFields;
+    this.elasticLLMCosts = newDocLinks.observability.elasticManagedLlmUsageCost;
+    this.elasticLLM = newDocLinks.observability.elasticManagedLlm;
   }
 }
 

--- a/x-pack/solutions/search/plugins/search_playground/public/analytics/constants.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/analytics/constants.ts
@@ -34,4 +34,6 @@ export enum AnalyticsEvents {
   setupSearchPageLoaded = 'search_setup_page_loaded',
   viewCodeFlyoutOpened = 'view_code_flyout_opened',
   viewCodeLanguageChange = 'view_code_language_change',
+  viewCostTransparencyTour = 'view_cost_transparency_tour',
+  closedCostTransparencyTour = 'closed_cost_transparency_tour',
 }

--- a/x-pack/solutions/search/plugins/search_playground/public/components/elastic_llm_cost_tour.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/elastic_llm_cost_tour.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiButtonEmpty, EuiLink, EuiText, EuiTourStep, type EuiTourStepProps } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { docLinks } from '../../common/doc_links';
+import { useShowManagedLLMCostTour } from '../hooks/use_show_managed_llm_cost_tour';
+
+export interface ElasticLLMCostTourProps {
+  connectorName: string;
+  anchorPosition?: EuiTourStepProps['anchorPosition'];
+  children: React.ReactElement;
+}
+
+export const ElasticLLMCostTour = ({
+  anchorPosition = 'downCenter',
+  connectorName,
+  children,
+}: ElasticLLMCostTourProps) => {
+  const { isTourVisible, onSkipTour } = useShowManagedLLMCostTour();
+
+  return (
+    <EuiTourStep
+      title={
+        <FormattedMessage
+          id="xpack.searchPlayground.elasticLLM.costsTour.title"
+          defaultMessage="{connectorName} connector"
+          values={{
+            connectorName,
+          }}
+        />
+      }
+      subtitle={
+        <FormattedMessage
+          id="xpack.searchPlayground.elasticLLM.costsTour.subTitle"
+          defaultMessage="New AI feature!"
+        />
+      }
+      maxWidth="500px"
+      content={
+        <EuiText>
+          <p>
+            <FormattedMessage
+              id="xpack.searchPlayground.elasticLLM.costsTour.description"
+              defaultMessage="{connectorName} is our new default, pre-configured LLM connector. It will incur {additionalCostsLink} You can continue to use other LLM connectors as normal. {learnMoreLink}"
+              values={{
+                connectorName,
+                additionalCostsLink: (
+                  <EuiLink
+                    data-test-subj="elasticLLMAdditionalCostsLink"
+                    target="_blank"
+                    href={docLinks.elasticLLMCosts}
+                  >
+                    <FormattedMessage
+                      id="xpack.searchPlayground.elasticLLM.costsTour.additionalCostsLink"
+                      defaultMessage="additional costs."
+                    />
+                  </EuiLink>
+                ),
+                learnMoreLink: (
+                  <EuiLink
+                    data-test-subj="elasticLLMLearnMoreLink"
+                    target="_blank"
+                    href={docLinks.elasticLLM}
+                  >
+                    <FormattedMessage
+                      id="xpack.searchPlayground.elasticLLM.costsTour.learnModeLink"
+                      defaultMessage="Learn more"
+                    />
+                  </EuiLink>
+                ),
+              }}
+            />
+          </p>
+        </EuiText>
+      }
+      isStepOpen={isTourVisible}
+      anchorPosition={anchorPosition}
+      step={1}
+      stepsTotal={1}
+      onFinish={onSkipTour}
+      footerAction={
+        <EuiButtonEmpty data-test-subj="elasticLLMCostsTourCloseBtn" onClick={onSkipTour}>
+          <FormattedMessage
+            id="xpack.searchPlayground.elasticLLM.costsTour.closeButton"
+            defaultMessage="Ok"
+          />
+        </EuiButtonEmpty>
+      }
+    >
+      {children}
+    </EuiTourStep>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/connect_llm_button.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/connect_llm_button.tsx
@@ -21,7 +21,8 @@ import { useKibana } from '../../hooks/use_kibana';
 import { useLoadConnectors } from '../../hooks/use_load_connectors';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
 import { AnalyticsEvents } from '../../analytics/constants';
-import { LLMs } from '../../../common/types';
+import { isElasticConnector } from '../../utils/playground_connectors';
+import { ElasticManagedConnector } from './elastic_connector_connected';
 
 export const ConnectLLMButton: React.FC = () => {
   const [connectorFlyoutOpen, setConnectorFlyoutOpen] = useState(false);
@@ -54,34 +55,29 @@ export const ConnectLLMButton: React.FC = () => {
       usageTracker?.load(AnalyticsEvents.genAiConnectorSetup);
     }
   }, [connectors?.length, showCallout, usageTracker]);
+  const hasConnectors = connectors?.length;
+  const elasticConnector = hasConnectors ? connectors.find(isElasticConnector) : undefined;
+  const hasElasticConnector = elasticConnector !== undefined;
 
   return (
     <>
-      {connectors?.length ? (
+      {hasConnectors ? (
         <EuiFlexGroup alignItems="center" gutterSize="s" data-test-subj="successConnectLLMText">
           <EuiFlexItem grow={false}>
             <EuiIcon type="checkInCircleFilled" color="success" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiText color="success">
-              {connectors.some((connector) => connector.type === LLMs.inference) ? (
-                <FormattedMessage
-                  id="xpack.searchPlayground.setupPage.elasticManagedLlmConnectedButtonLabel"
-                  defaultMessage="{connectorName} connected"
-                  values={{
-                    connectorName:
-                      connectors.filter((connector) => connector.type === LLMs.inference)[0]
-                        ?.name || 'Elastic Managed LLM',
-                  }}
-                />
-              ) : (
+            {hasElasticConnector ? (
+              <ElasticManagedConnector name={elasticConnector.name} />
+            ) : (
+              <EuiText color="success">
                 <FormattedMessage
                   id="xpack.searchPlayground.setupPage.llmConnectedButtonLabel"
                   defaultMessage="{connectorName} connected"
                   values={{ connectorName: connectors[0]?.name || 'LLM' }}
                 />
-              )}
-            </EuiText>
+              </EuiText>
+            )}
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/elastic_connector_connected.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/elastic_connector_connected.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiText } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { ElasticLLMCostTour } from '../elastic_llm_cost_tour';
+
+export const ElasticManagedConnector = ({ name }: { name: string }) => {
+  return (
+    <ElasticLLMCostTour connectorName={name}>
+      <EuiText color="success">
+        <FormattedMessage
+          id="xpack.searchPlayground.setupPage.elasticManagedLlmConnectedButtonLabel"
+          defaultMessage="{connectorName} connected"
+          values={{
+            connectorName: name || 'Elastic Managed LLM',
+          }}
+        />
+      </EuiText>
+    </ElasticLLMCostTour>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/summarization_model.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/summarization_model.tsx
@@ -24,6 +24,7 @@ import { AnalyticsEvents } from '../../analytics/constants';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
 import type { LLMModel } from '../../types';
 import { useManagementLink } from '../../hooks/use_management_link';
+import { ElasticLLMCostTour } from '../elastic_llm_cost_tour';
 
 interface SummarizationModelProps {
   selectedModel?: LLMModel;
@@ -94,6 +95,14 @@ export const SummarizationModel: React.FC<SummarizationModelProps> = ({
       })),
     [models]
   );
+  const currentModel = useMemo(
+    () =>
+      // find the model from the list to ensure all values present vs. what is saved in the form and loaded in local storage.
+      selectedModel !== undefined
+        ? models.find((model) => model.id === selectedModel.id)
+        : undefined,
+    [selectedModel, models]
+  );
 
   useEffect(() => {
     usageTracker?.click(
@@ -119,13 +128,25 @@ export const SummarizationModel: React.FC<SummarizationModelProps> = ({
     >
       <EuiFlexGroup direction="row" gutterSize="m">
         <EuiFlexItem>
-          <EuiSuperSelect
-            data-test-subj="summarizationModelSelect"
-            options={modelsOption}
-            valueOfSelected={selectedModel && getOptionValue(selectedModel)}
-            onChange={onChange}
-            fullWidth
-          />
+          {currentModel && currentModel.isElasticConnector ? (
+            <ElasticLLMCostTour connectorName={currentModel.connectorName}>
+              <EuiSuperSelect
+                data-test-subj="summarizationModelSelect"
+                options={modelsOption}
+                valueOfSelected={selectedModel && getOptionValue(selectedModel)}
+                onChange={onChange}
+                fullWidth
+              />
+            </ElasticLLMCostTour>
+          ) : (
+            <EuiSuperSelect
+              data-test-subj="summarizationModelSelect"
+              options={modelsOption}
+              valueOfSelected={selectedModel && getOptionValue(selectedModel)}
+              onChange={onChange}
+              fullWidth
+            />
+          )}
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButtonEmpty

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_llms_models.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_llms_models.test.tsx
@@ -12,6 +12,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { LoadConnectorsQuery } from './use_load_connectors';
 import { useLLMsModels } from './use_llms_models';
 import { LLMs } from '../types';
+import { elasticModelIds } from '@kbn/inference-common';
 
 jest.mock('./use_load_connectors', () => ({
   useLoadConnectors: jest.fn(),
@@ -35,6 +36,18 @@ jest.mock('./use_kibana', () => ({
 const mockedLoadConnectorsQuery = jest.fn();
 
 const mockConnectors = [
+  {
+    id: 'connectorId0',
+    name: 'Elastic Managed LLM',
+    actionTypeId: '.inference',
+    type: LLMs.inference,
+    isPreconfigured: true,
+    config: {
+      taskType: 'chat_completion',
+      provider: 'elastic',
+      providerConfig: { model_id: elasticModelIds.RainbowSprinkles },
+    },
+  },
   { id: 'connectorId1', name: 'OpenAI Connector', type: LLMs.openai },
   { id: 'connectorId2', name: 'OpenAI Azure Connector', type: LLMs.openai_azure },
   { id: 'connectorId2', name: 'Bedrock Connector', type: LLMs.bedrock },
@@ -70,12 +83,26 @@ describe('useLLMsModels Query Hook', () => {
     await waitFor(() =>
       expect(result.current).toStrictEqual([
         {
+          connectorId: 'connectorId0',
+          connectorName: 'Elastic Managed LLM',
+          connectorType: LLMs.inference,
+          disabled: false,
+          icon: expect.any(String),
+          id: 'connectorId0Elastic Managed LLM',
+          isElasticConnector: true,
+          name: 'Elastic Managed LLM',
+          showConnectorName: true,
+          value: 'rainbow-sprinkles',
+          promptTokenLimit: 200000,
+        },
+        {
           connectorId: 'connectorId1',
           connectorName: 'OpenAI Connector',
           connectorType: LLMs.openai,
           disabled: false,
           icon: expect.any(String),
           id: 'connectorId1OpenAI GPT-4o ',
+          isElasticConnector: false,
           name: 'OpenAI GPT-4o ',
           showConnectorName: false,
           value: 'gpt-4o',
@@ -88,6 +115,7 @@ describe('useLLMsModels Query Hook', () => {
           disabled: false,
           icon: expect.any(String),
           id: 'connectorId1OpenAI GPT-4 Turbo ',
+          isElasticConnector: false,
           name: 'OpenAI GPT-4 Turbo ',
           showConnectorName: false,
           value: 'gpt-4-turbo',
@@ -100,6 +128,7 @@ describe('useLLMsModels Query Hook', () => {
           disabled: false,
           icon: expect.any(String),
           id: 'connectorId1OpenAI GPT-3.5 Turbo ',
+          isElasticConnector: false,
           name: 'OpenAI GPT-3.5 Turbo ',
           showConnectorName: false,
           value: 'gpt-3.5-turbo',
@@ -112,6 +141,7 @@ describe('useLLMsModels Query Hook', () => {
           disabled: false,
           icon: expect.any(String),
           id: 'connectorId2OpenAI Azure Connector (Azure OpenAI)',
+          isElasticConnector: false,
           name: 'OpenAI Azure Connector (Azure OpenAI)',
           showConnectorName: false,
           value: undefined,
@@ -124,6 +154,7 @@ describe('useLLMsModels Query Hook', () => {
           disabled: false,
           icon: expect.any(String),
           id: 'connectorId2Anthropic Claude 3 Haiku',
+          isElasticConnector: false,
           name: 'Anthropic Claude 3 Haiku',
           showConnectorName: false,
           value: 'anthropic.claude-3-haiku-20240307-v1:0',
@@ -136,6 +167,7 @@ describe('useLLMsModels Query Hook', () => {
           disabled: false,
           icon: expect.any(String),
           id: 'connectorId2Anthropic Claude 3.5 Sonnet',
+          isElasticConnector: false,
           name: 'Anthropic Claude 3.5 Sonnet',
           showConnectorName: false,
           value: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
@@ -148,6 +180,7 @@ describe('useLLMsModels Query Hook', () => {
           disabled: false,
           icon: expect.any(String),
           id: 'connectorId2Anthropic Claude 3.7 Sonnet',
+          isElasticConnector: false,
           name: 'Anthropic Claude 3.7 Sonnet',
           showConnectorName: false,
           value: 'anthropic.claude-3-7-sonnet-20250219-v1:0',
@@ -160,6 +193,7 @@ describe('useLLMsModels Query Hook', () => {
           disabled: false,
           icon: expect.any(String),
           id: 'connectorId3OpenAI OSS Model Connector (OpenAI Compatible Service)',
+          isElasticConnector: false,
           name: 'OpenAI OSS Model Connector (OpenAI Compatible Service)',
           showConnectorName: false,
           value: undefined,
@@ -172,8 +206,9 @@ describe('useLLMsModels Query Hook', () => {
           disabled: false,
           icon: expect.any(String),
           id: 'connectorId4EIS Connector',
+          isElasticConnector: false,
           name: 'EIS Connector',
-          showConnectorName: false,
+          showConnectorName: true,
           value: undefined,
           promptTokenLimit: undefined,
         },

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_llms_models.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_llms_models.ts
@@ -15,6 +15,7 @@ import { SearchPlaygroundQueryKeys } from '../../common';
 import { LLMs } from '../../common/types';
 import type { LLMModel } from '../types';
 import { MODELS } from '../../common/models';
+import { isElasticConnector } from '../utils/playground_connectors';
 import { useKibana } from './use_kibana';
 import { LoadConnectorsQuery } from './use_load_connectors';
 
@@ -145,6 +146,7 @@ export const LLMsQuery =
           disabled: !connector,
           connectorId: connector.id,
           promptTokenLimit,
+          isElasticConnector: isElasticConnector(connector),
         }))
         .forEach((model) => result.push(model));
 

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_show_managed_llm_cost_tour.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_show_managed_llm_cost_tour.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { ELASTIC_LLM_COST_TOUR_SKIP_KEY } from '@kbn/search-shared-ui';
+import { useKibana } from './use_kibana';
+import { useUsageTracker } from './use_usage_tracker';
+import { AnalyticsEvents } from '../analytics/constants';
+
+export const useShowManagedLLMCostTour = () => {
+  const usageTracker = useUsageTracker();
+  const { cloud } = useKibana().services;
+  const [isTourVisible, setIsTourVisible] = useState<boolean>(false);
+  const onSkipTour = useCallback(() => {
+    localStorage.setItem(ELASTIC_LLM_COST_TOUR_SKIP_KEY, 'true');
+    setIsTourVisible(false);
+    usageTracker?.click(AnalyticsEvents.closedCostTransparencyTour);
+  }, [usageTracker]);
+
+  useEffect(() => {
+    const isTourSkipped = localStorage.getItem(ELASTIC_LLM_COST_TOUR_SKIP_KEY) === 'true';
+    const isCloud = cloud?.isCloudEnabled ?? false;
+
+    if (!isTourSkipped && isCloud && !isTourVisible) {
+      setIsTourVisible(true);
+      usageTracker?.click(AnalyticsEvents.viewCostTransparencyTour);
+    }
+  }, [cloud, isTourVisible, usageTracker]);
+
+  return { isTourVisible, onSkipTour };
+};

--- a/x-pack/solutions/search/plugins/search_playground/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/types.ts
@@ -244,6 +244,7 @@ export interface LLMModel {
   icon: string;
   disabled: boolean;
   promptTokenLimit?: number;
+  isElasticConnector?: boolean;
 }
 
 export type { ActionConnector, UserConfiguredActionConnector };

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/playground_connectors.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/playground_connectors.ts
@@ -144,3 +144,11 @@ export async function parsePlaygroundConnectors(
   }
   return playgroundConnectors;
 }
+
+export function isElasticConnector(connector: PlaygroundConnector): boolean {
+  return (
+    isInferenceActionConnector(connector) &&
+    connector.isPreconfigured &&
+    connector.config.provider === 'elastic'
+  );
+}

--- a/x-pack/solutions/search/plugins/search_playground/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_playground/tsconfig.json
@@ -58,7 +58,8 @@
     "@kbn/core-http-router-server-mocks",
     "@kbn/core-saved-objects-server",
     "@kbn/search-queries",
-    "@kbn/monaco"
+    "@kbn/monaco",
+    "@kbn/search-shared-ui"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Adds a tour for costs transparency when using the Elastic Managed LLM in the search playground.

### Screenshots
<img width="1656" height="1249" alt="image" src="https://github.com/user-attachments/assets/499c3aee-7732-43df-8748-891af1c6598b" />

<img width="710" height="981" alt="image" src="https://github.com/user-attachments/assets/5a30e15e-3c81-4afe-bef2-e133bc19498b" />

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.