### PR TITLE
[Obs AI Assistant] Skip KB setup test in serverless

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/knowledge_base/knowledge_base_setup.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/knowledge_base/knowledge_base_setup.spec.ts
@@ -35,6 +35,8 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const loggerMock = getLoggerMock(log);
 
   describe('Knowledge base: POST /internal/observability_ai_assistant/kb/setup', function () {
+    this.tags(['skipServerless']);
+
     before(async () => {
       await restoreIndexAssets(getService);
     });


### PR DESCRIPTION
## Summary

The KB setup takes a while to complete because the model needs to be deployed to an ML node. Once the deployment is complete, the API will return a 200 response.

In Serverless (MKI) environments, this test fails often because the API call times out due to it taking a long time to complete. The test passes in the local Serverless environment.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


