### PR TITLE
[Query Rules] Render Query Rules plugin only on correct license level

### DIFF
--- a/x-pack/solutions/search/plugins/search_query_rules/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/search_query_rules/kibana.jsonc
@@ -14,6 +14,7 @@
     ],
     "requiredPlugins": [
       "features",
+      "licensing",
     ],
     "optionalPlugins": [
       "cloud",

--- a/x-pack/solutions/search/plugins/search_query_rules/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/types.ts
@@ -11,6 +11,7 @@ import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
 
 export type * from '../common/types';
 export interface AppPluginStartDependencies {
@@ -20,6 +21,7 @@ export interface AppPluginStartDependencies {
   cloud?: CloudStart;
   searchNavigation?: SearchNavigationPluginStart;
   usageCollection?: UsageCollectionStart;
+  licensing: LicensingPluginStart;
 }
 
 export type AppServicesContext = CoreStart & AppPluginStartDependencies;

--- a/x-pack/solutions/search/plugins/search_query_rules/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/server/plugin.ts
@@ -40,6 +40,7 @@ export class SearchQueryRulesPlugin
 
     plugins.features.registerKibanaFeature({
       id: PLUGIN_ID,
+      minimumLicense: 'enterprise',
       name: PLUGIN_TITLE,
       order: 0,
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,

--- a/x-pack/solutions/search/plugins/search_query_rules/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_query_rules/tsconfig.json
@@ -33,6 +33,7 @@
     "@kbn/analytics",
     "@kbn/usage-collection-plugin",
     "@kbn/cloud-plugin",
+    "@kbn/licensing-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary
Query rules require minimum Enterprise license level.
This PR adds checks for the license level and hides the plugin in Hosted deployments same as the other plugins.

Before - Basic license (see sidebar has no other `enterprise` licensed elements
<img width="2308" height="1096" alt="Screenshot 2025-08-18 at 15 29 33" src="https://github.com/user-attachments/assets/0153bda4-c99a-414a-80db-d95bb268677b" />
After - Basic license
<img width="2305" height="1092" alt="Screenshot 2025-08-19 at 12 07 33" src="https://github.com/user-attachments/assets/c1a5de1b-16c9-468a-bab0-cea86415d7b8" />

Trial
<img width="2302" height="1090" alt="Screenshot 2025-08-19 at 12 07 50" src="https://github.com/user-attachments/assets/17427629-f7c8-4d5f-90c1-b54e63848d3f" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release Note

Fixed Query rules UI showing a permission error when license requirements not met. It is now hidden to match behaviour with other plugins.
