### PR TITLE
[9.0] [UII] Fix input package component template test (#231505)

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/package_policy/input_package_create_upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/input_package_create_upgrade.ts
@@ -208,37 +208,40 @@ export default function (providerContext: FtrProviderContext) {
 
       // now check the package component template was created correctly
       const packageComponentTemplate = await getComponentTemplate('logs-dataset1@package');
-      expect(packageComponentTemplate).eql({
-        name: 'logs-dataset1@package',
-        component_template: {
-          template: {
-            settings: {
-              index: {
-                lifecycle: { name: 'logs' },
-                default_pipeline: 'logs-dataset1-1.0.0',
-                mapping: {
-                  total_fields: { limit: '1000' },
-                },
+      const {
+        created_date_millis: createdDateMillis,
+        modified_date_millis: modifiedDateMillis,
+        ...definitionWithouTimestamps
+      } = packageComponentTemplate!.component_template as any;
+      expect(packageComponentTemplate!.name).eql('logs-dataset1@package');
+      expect(definitionWithouTimestamps).eql({
+        template: {
+          settings: {
+            index: {
+              lifecycle: { name: 'logs' },
+              default_pipeline: 'logs-dataset1-1.0.0',
+              mapping: {
+                total_fields: { limit: '1000' },
               },
             },
-            mappings: {
-              properties: {
-                input: {
-                  properties: {
-                    name: {
-                      type: 'constant_keyword',
-                      value: 'logs',
-                    },
+          },
+          mappings: {
+            properties: {
+              input: {
+                properties: {
+                  name: {
+                    type: 'constant_keyword',
+                    value: 'logs',
                   },
                 },
               },
             },
           },
-          _meta: {
-            package: { name: 'input_package_upgrade' },
-            managed_by: 'fleet',
-            managed: true,
-          },
+        },
+        _meta: {
+          package: { name: 'input_package_upgrade' },
+          managed_by: 'fleet',
+          managed: true,
         },
       });
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[UII] Fix input package component template test (#231505)](https://github.com/elastic/kibana/pull/231505)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2025-08-12T20:50:27Z","message":"[UII] Fix input package component template test (#231505)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/229901. Fixes ES\npromotion of this test by excluding component template timestamps from\nthe assertion (timestamps were introduced in\nhttps://github.com/elastic/elasticsearch/pull/131536).","sha":"834e2851016889b912229a01f65a0d2c27a213db","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.2.0","v9.1.3","v8.19.3","v9.0.6"],"title":"[UII] Fix input package component template test","number":231505,"url":"https://github.com/elastic/kibana/pull/231505","mergeCommit":{"message":"[UII] Fix input package component template test (#231505)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/229901. Fixes ES\npromotion of this test by excluding component template timestamps from\nthe assertion (timestamps were introduced in\nhttps://github.com/elastic/elasticsearch/pull/131536).","sha":"834e2851016889b912229a01f65a0d2c27a213db"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231505","number":231505,"mergeCommit":{"message":"[UII] Fix input package component template test (#231505)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/229901. Fixes ES\npromotion of this test by excluding component template timestamps from\nthe assertion (timestamps were introduced in\nhttps://github.com/elastic/elasticsearch/pull/131536).","sha":"834e2851016889b912229a01f65a0d2c27a213db"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232157","number":232157,"state":"OPEN"},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232156","number":232156,"state":"OPEN"},{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->