### PR TITLE
[8.19][DOCS] Update repo branch in API docs intro

### DIFF
--- a/oas_docs/kibana.info.yaml
+++ b/oas_docs/kibana.info.yaml
@@ -29,7 +29,7 @@ info:
 
     ## Documentation source and versions
 
-    This documentation is derived from the `8.x` branch of the [kibana](https://github.com/elastic/kibana) repository.
+    This documentation is derived from the `8.19` branch of the [kibana](https://github.com/elastic/kibana) repository.
     It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
 
     This documentation contains work-in-progress information for future Elastic Stack releases.

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -30,7 +30,7 @@ info:
 
     ## Documentation source and versions
 
-    This documentation is derived from the `8.x` branch of the [kibana](https://github.com/elastic/kibana) repository.
+    This documentation is derived from the `8.19` branch of the [kibana](https://github.com/elastic/kibana) repository.
     It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
 
     This documentation contains work-in-progress information for future Elastic Stack releases.


### PR DESCRIPTION
## Summary

This PR fixes the [detail in the Kibana API docs](https://www.elastic.co/docs/api/doc/kibana/v8/#topic-documentation-source-and-versions) that indicates which branch it's derived from. It incorrectly indicates that the branch used for the v8 API docs is `8.x` but it is in fact `8.19`.