### PR TITLE
[9.1] [Security Solution][Entity Analytics][PrivMon] FTR tests privmon for `/disable` API endpoint (#229247)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine.ts
@@ -7,6 +7,7 @@
 
 import expect from 'expect';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
+import { dataViewRouteHelpersFactory } from '../../utils/data_view';
 import { disablePrivmonSetting, enablePrivmonSetting } from '../../utils';
 import { PrivMonUtils } from './privileged_users/utils';
 
@@ -17,6 +18,9 @@ export default ({ getService }: FtrProviderContext) => {
   const log = getService('log');
   const es = getService('es');
   const retry = getService('retry');
+  const spaces = getService('spaces');
+  const customSpace = 'privmontestspace';
+  const supertest = getService('supertest');
 
   const createUserIndex = async (indexName: string) =>
     es.indices.create({
@@ -47,12 +51,33 @@ export default ({ getService }: FtrProviderContext) => {
       return res.body.length >= length; // wait until we have at least one user
     });
 
+  async function getPrivMonSoStatus(space: string = 'default') {
+    return kibanaServer.savedObjects.find({
+      type: 'privilege-monitoring-status',
+      space,
+    });
+  }
+
   describe('@ess Entity Privilege Monitoring APIs', () => {
+    const dataView = dataViewRouteHelpersFactory(supertest);
+    const dataViewWithNamespace = dataViewRouteHelpersFactory(supertest, customSpace);
+
+    // Global setup and teardown
     before(async () => {
+      await dataView.create('security-solution');
+      await spaces.create({
+        id: customSpace,
+        name: customSpace,
+        disabledFeatures: [],
+      });
+      await dataViewWithNamespace.create('security-solution');
       await enablePrivmonSetting(kibanaServer);
     });
 
     after(async () => {
+      await dataView.delete('security-solution');
+      await dataViewWithNamespace.delete('security-solution');
+      await spaces.delete(customSpace);
       await disablePrivmonSetting(kibanaServer);
     });
 
@@ -60,12 +85,22 @@ export default ({ getService }: FtrProviderContext) => {
       await api.deleteMonitoringEngine({ query: { data: true } });
     });
 
+    // Health check tests
     describe('health', () => {
+      before(async () => {
+        await enablePrivmonSetting(kibanaServer);
+      });
+
+      after(async () => {
+        await disablePrivmonSetting(kibanaServer);
+      });
+
       it('should be healthy', async () => {
+        log.info('Checking health of privilege monitoring');
         const res = await api.privMonHealth();
 
         if (res.status !== 200) {
-          log.error(`Health check failed`);
+          log.error('Health check failed');
           log.error(JSON.stringify(res.body));
         }
 
@@ -73,7 +108,205 @@ export default ({ getService }: FtrProviderContext) => {
       });
     });
 
+    // Disable functionality tests
+    describe('privMon disable engine', () => {
+      before(async () => {
+        // Initialize engines for both default and custom spaces
+        await enablePrivmonSetting(kibanaServer);
+        await enablePrivmonSetting(kibanaServer, customSpace);
+        await api.initMonitoringEngine();
+        await api.initMonitoringEngine(customSpace);
+      });
+
+      after(async () => {
+        // Clean up engines and settings
+        await disablePrivmonSetting(kibanaServer);
+        await disablePrivmonSetting(kibanaServer, customSpace);
+        await api.deleteMonitoringEngine({ query: { data: true } });
+        await api.deleteMonitoringEngine({ query: { data: true } }, customSpace);
+      });
+
+      it('should disable the privilege monitoring engine in default space', async () => {
+        log.info('Disabling privilege monitoring engine');
+        const res = await api.disableMonitoringEngine();
+
+        if (res.status !== 200) {
+          log.error('Disable failed');
+          log.error(JSON.stringify(res.body));
+        }
+
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe('disabled');
+      });
+
+      it('should disable the privilege monitoring engine in custom space', async () => {
+        log.info('Disabling privilege monitoring engine in custom space');
+
+        // Re-initialize for this test since previous test disabled it
+        await api.initMonitoringEngine(customSpace);
+        const res = await api.disableMonitoringEngine(customSpace);
+
+        if (res.status !== 200) {
+          log.error('Disable failed in custom space');
+          log.error(JSON.stringify(res.body));
+        }
+
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe('disabled');
+      });
+
+      it('should not disable when setting is disabled in default space', async () => {
+        log.info('Testing disable with setting disabled');
+        await disablePrivmonSetting(kibanaServer);
+
+        const res = await api.disableMonitoringEngine();
+        expect(res.status).toBe(500);
+      });
+
+      it('should not disable when setting is disabled in custom space', async () => {
+        log.info('Testing disable with setting disabled in custom space');
+        await disablePrivmonSetting(kibanaServer, customSpace);
+
+        const res = await api.disableMonitoringEngine(customSpace);
+        expect(res.status).toBe(500);
+      });
+    });
+
+    // Initialize and disable workflow tests
+    describe('privMon init and disable engine workflow', () => {
+      beforeEach(async () => {
+        await enablePrivmonSetting(kibanaServer);
+      });
+
+      afterEach(async () => {
+        log.info('Cleaning up after test');
+        try {
+          await api.deleteMonitoringEngine({ query: { data: true } });
+        } catch (err) {
+          log.warning(`Failed to clean up in afterEach: ${err.message}`);
+        }
+        await disablePrivmonSetting(kibanaServer);
+      });
+
+      it('should handle complete init-disable-reinit cycle', async () => {
+        // Initialize engine
+        log.info('Initializing privilege monitoring engine');
+        const initRes = await api.initMonitoringEngine();
+        expect(initRes.status).toBe(200);
+        expect(initRes.body.status).toBe('started');
+
+        const soStatus = await getPrivMonSoStatus();
+        expect(soStatus.saved_objects[0].attributes.status).toBe('started');
+
+        // Disable engine
+        log.info('Disabling privilege monitoring engine');
+        const disableRes = await api.disableMonitoringEngine();
+        expect(disableRes.status).toBe(200);
+        expect(disableRes.body.status).toBe('disabled');
+
+        const soStatusAfterDisable = await getPrivMonSoStatus();
+        expect(soStatusAfterDisable.saved_objects[0].attributes.status).toBe('disabled');
+
+        // Test re-disabling (should be idempotent)
+        log.info('Re-disabling privilege monitoring engine');
+        const reDisableRes = await api.disableMonitoringEngine();
+        expect(reDisableRes.status).toBe(200);
+        expect(reDisableRes.body.status).toBe('disabled');
+
+        const soStatusAfterReDisable = await getPrivMonSoStatus();
+        expect(soStatusAfterReDisable.saved_objects[0].attributes.status).toBe('disabled');
+
+        // Re-initialize after disable
+        log.info('Initializing privilege monitoring engine after disable');
+        const initResAfterDisable = await api.initMonitoringEngine();
+        expect(initResAfterDisable.status).toBe(200);
+        expect(initResAfterDisable.body.status).toBe('started');
+
+        const soStatusOnInitAfterDisable = await getPrivMonSoStatus();
+        expect(soStatusOnInitAfterDisable.saved_objects[0].attributes.status).toBe('started');
+
+        // Test re-initializing (should be idempotent)
+        log.info('Re-initializing privilege monitoring engine after disable');
+        const reInitRes = await api.initMonitoringEngine();
+        expect(reInitRes.status).toBe(200);
+        expect(reInitRes.body.status).toBe('started');
+
+        const soStatusAfterReInit = await getPrivMonSoStatus();
+        expect(soStatusAfterReInit.saved_objects[0].attributes.status).toBe('started');
+      });
+    });
+
+    // Custom space init and disable engine workflow tests
+    describe('privMon init and disable engine workflow in custom space', () => {
+      beforeEach(async () => {
+        await enablePrivmonSetting(kibanaServer, customSpace);
+      });
+
+      afterEach(async () => {
+        log.info('Cleaning up after test in custom space');
+        try {
+          await api.deleteMonitoringEngine({ query: { data: true } }, customSpace);
+        } catch (err) {
+          log.warning(`Failed to clean up in afterEach for custom space: ${err.message}`);
+        }
+        await disablePrivmonSetting(kibanaServer, customSpace);
+      });
+
+      it('should handle complete init-disable-reinit cycle in custom space', async () => {
+        // Initialize engine in custom space
+        log.info('Initializing privilege monitoring engine in custom space');
+        const initRes = await api.initMonitoringEngine(customSpace);
+        expect(initRes.status).toBe(200);
+        expect(initRes.body.status).toBe('started');
+
+        const soStatus = await getPrivMonSoStatus(customSpace);
+        expect(soStatus.saved_objects[0].attributes.status).toBe('started');
+
+        // Disable engine in custom space
+        log.info('Disabling privilege monitoring engine in custom space');
+        const disableRes = await api.disableMonitoringEngine(customSpace);
+        expect(disableRes.status).toBe(200);
+        expect(disableRes.body.status).toBe('disabled');
+
+        const soStatusAfterDisable = await getPrivMonSoStatus(customSpace);
+        expect(soStatusAfterDisable.saved_objects[0].attributes.status).toBe('disabled');
+
+        // Test re-disabling (should be idempotent)
+        log.info('Re-disabling privilege monitoring engine in custom space');
+        const reDisableRes = await api.disableMonitoringEngine(customSpace);
+        expect(reDisableRes.status).toBe(200);
+        expect(reDisableRes.body.status).toBe('disabled');
+
+        const soStatusAfterReDisable = await getPrivMonSoStatus(customSpace);
+        expect(soStatusAfterReDisable.saved_objects[0].attributes.status).toBe('disabled');
+
+        // Re-initialize after disable
+        log.info('Initializing privilege monitoring engine after disable in custom space');
+        const initResAfterDisable = await api.initMonitoringEngine(customSpace);
+        expect(initResAfterDisable.status).toBe(200);
+        expect(initResAfterDisable.body.status).toBe('started');
+
+        const soStatusOnInitAfterDisable = await getPrivMonSoStatus(customSpace);
+        expect(soStatusOnInitAfterDisable.saved_objects[0].attributes.status).toBe('started');
+
+        // Test re-initializing (should be idempotent)
+        log.info('Re-initializing privilege monitoring engine after disable in custom space');
+        const reInitRes = await api.initMonitoringEngine(customSpace);
+        expect(reInitRes.status).toBe(200);
+        expect(reInitRes.body.status).toBe('started');
+
+        const soStatusAfterReInit = await getPrivMonSoStatus(customSpace);
+        expect(soStatusAfterReInit.saved_objects[0].attributes.status).toBe('started');
+      });
+    });
+
     describe('init', () => {
+      beforeEach(async () => {
+        await enablePrivmonSetting(kibanaServer);
+      });
+      afterEach(async () => {
+        await disablePrivmonSetting(kibanaServer);
+      });
       it('should be able to be called multiple times', async () => {
         log.info(`Initializing Privilege Monitoring engine`);
         const res1 = await api.initMonitoringEngine();
@@ -115,6 +348,7 @@ export default ({ getService }: FtrProviderContext) => {
 
       beforeEach(async () => {
         await createUserIndex(indexName);
+        await enablePrivmonSetting(kibanaServer);
       });
 
       afterEach(async () => {
@@ -123,6 +357,7 @@ export default ({ getService }: FtrProviderContext) => {
         } catch (err) {
           log.warning(`Failed to clean up in afterEach: ${err.message}`);
         }
+        await disablePrivmonSetting(kibanaServer);
       });
 
       it('should sync plain index', async () => {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/utils/privmon_advanced_settings.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/utils/privmon_advanced_settings.ts
@@ -8,14 +8,20 @@
 import { ENABLE_PRIVILEGED_USER_MONITORING_SETTING } from '@kbn/security-solution-plugin/common/constants';
 import { KbnClient } from '@kbn/test';
 
-export const enablePrivmonSetting = async (kibanaServer: KbnClient) => {
-  await kibanaServer.uiSettings.update({
-    [ENABLE_PRIVILEGED_USER_MONITORING_SETTING]: true,
-  });
+export const enablePrivmonSetting = async (kibanaServer: KbnClient, space: string = 'default') => {
+  await kibanaServer.uiSettings.update(
+    {
+      [ENABLE_PRIVILEGED_USER_MONITORING_SETTING]: true,
+    },
+    { space }
+  );
 };
 
-export const disablePrivmonSetting = async (kibanaServer: KbnClient) => {
-  await kibanaServer.uiSettings.update({
-    [ENABLE_PRIVILEGED_USER_MONITORING_SETTING]: false,
-  });
+export const disablePrivmonSetting = async (kibanaServer: KbnClient, space: string = 'default') => {
+  await kibanaServer.uiSettings.update(
+    {
+      [ENABLE_PRIVILEGED_USER_MONITORING_SETTING]: false,
+    },
+    { space }
+  );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution][Entity Analytics][PrivMon] FTR tests privmon for `/disable` API endpoint (#229247)](https://github.com/elastic/kibana/pull/229247)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Abhishek Bhatia","email":"117628830+abhishekbhatia1710@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-14T14:47:00Z","message":"[Security Solution][Entity Analytics][PrivMon] FTR tests privmon for `/disable` API endpoint (#229247)\n\n## Summary\n\nThis PR includes changes for the FTR tests for privMon `/disable`\nendpoint.\n\nIt adds FTR tests for :\n- `disable` endpoint individually\n- `init` and `disable` endpoint in various combination.\n\nIt checks for the SO status after `init` and `disable` to make sure that\nthe required SO is updated with the right status.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Mark Hopkin <mark.hopkin@elastic.co>","sha":"d6489ef2cb731980161f655bb322cd85e6fa474f","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Entity Analytics","backport:version","v9.1.0","v9.2.0"],"title":"[Security Solution][Entity Analytics][PrivMon] FTR tests privmon for `/disable` API endpoint","number":229247,"url":"https://github.com/elastic/kibana/pull/229247","mergeCommit":{"message":"[Security Solution][Entity Analytics][PrivMon] FTR tests privmon for `/disable` API endpoint (#229247)\n\n## Summary\n\nThis PR includes changes for the FTR tests for privMon `/disable`\nendpoint.\n\nIt adds FTR tests for :\n- `disable` endpoint individually\n- `init` and `disable` endpoint in various combination.\n\nIt checks for the SO status after `init` and `disable` to make sure that\nthe required SO is updated with the right status.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Mark Hopkin <mark.hopkin@elastic.co>","sha":"d6489ef2cb731980161f655bb322cd85e6fa474f"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229247","number":229247,"mergeCommit":{"message":"[Security Solution][Entity Analytics][PrivMon] FTR tests privmon for `/disable` API endpoint (#229247)\n\n## Summary\n\nThis PR includes changes for the FTR tests for privMon `/disable`\nendpoint.\n\nIt adds FTR tests for :\n- `disable` endpoint individually\n- `init` and `disable` endpoint in various combination.\n\nIt checks for the SO status after `init` and `disable` to make sure that\nthe required SO is updated with the right status.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Mark Hopkin <mark.hopkin@elastic.co>","sha":"d6489ef2cb731980161f655bb322cd85e6fa474f"}}]}] BACKPORT-->