### PR TITLE
[Background search] Rename remaining places when bgs is enabled

### DIFF
--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
@@ -27,6 +27,10 @@ import type { SearchServiceStartDependencies } from '../search_service';
 import type { Start as InspectorStart } from '@kbn/inspector-plugin/public';
 import { SearchTimeoutError, TimeoutErrorMode } from './timeout_error';
 
+import { SearchSessionIncompleteWarning } from './search_session_incomplete_warning';
+import { getMockSearchConfig } from '../../../config.mock';
+import { BACKGROUND_SEARCH_FEATURE_FLAG_KEY } from '../session/constants';
+
 jest.mock('./create_request_hash', () => {
   const originalModule = jest.requireActual('./create_request_hash');
   return {
@@ -40,9 +44,7 @@ jest.mock('./create_request_hash', () => {
 jest.mock('./search_session_incomplete_warning', () => ({
   SearchSessionIncompleteWarning: jest.fn(),
 }));
-
-import { SearchSessionIncompleteWarning } from './search_session_incomplete_warning';
-import { getMockSearchConfig } from '../../../config.mock';
+const SearchSessionIncompleteWarningMock = jest.mocked(SearchSessionIncompleteWarning);
 
 let searchInterceptor: SearchInterceptor;
 
@@ -147,6 +149,7 @@ describe('SearchInterceptor', () => {
     error.mockClear();
     complete.mockClear();
     jest.clearAllTimers();
+    jest.clearAllMocks();
 
     const inspectorServiceMock = {
       open: () => {},
@@ -850,7 +853,7 @@ describe('SearchInterceptor', () => {
 
         await timeTravel(10);
 
-        expect(SearchSessionIncompleteWarning).toBeCalledTimes(0);
+        expect(SearchSessionIncompleteWarningMock).toBeCalledTimes(0);
       });
 
       test('should not show warning if a search outside of session is running', async () => {
@@ -885,57 +888,130 @@ describe('SearchInterceptor', () => {
 
         await timeTravel(10);
 
-        expect(SearchSessionIncompleteWarning).toBeCalledTimes(0);
+        expect(SearchSessionIncompleteWarningMock).toBeCalledTimes(0);
       });
 
-      test('should show warning once if a search is not available during restore', async () => {
-        setup({
-          isRestore: true,
-          isStored: true,
-          sessionId: '123',
-        });
+      describe('when background search is disabled', () => {
+        test('should show warning once if a search is not available during restore', async () => {
+          mockCoreStart.featureFlags.getBooleanValue.mockReturnValue(false);
 
-        const responses = [
-          {
-            time: 10,
-            value: getMockSearchResponse({
-              isPartial: false,
-              isRunning: false,
-              isRestored: false,
-              id: '1',
-              rawResponse: {
-                took: 1,
-              },
+          setup({
+            isRestore: true,
+            isStored: true,
+            sessionId: '123',
+          });
+
+          const responses = [
+            {
+              time: 10,
+              value: getMockSearchResponse({
+                isPartial: false,
+                isRunning: false,
+                isRestored: false,
+                id: '1',
+                rawResponse: {
+                  took: 1,
+                },
+              }),
+            },
+          ];
+          mockCoreSetup.http.post.mockImplementation(getHttpMock(responses));
+
+          searchInterceptor
+            .search(
+              {},
+              {
+                sessionId: '123',
+              }
+            )
+            .subscribe({ next, error, complete });
+
+          await timeTravel(10);
+
+          expect(SearchSessionIncompleteWarningMock).toHaveBeenCalledTimes(1);
+          expect(mockCoreSetup.notifications.toasts.addWarning).toHaveBeenCalledWith(
+            expect.objectContaining({
+              title: 'Your search session is still running',
             }),
-          },
-        ];
-        mockCoreSetup.http.post.mockImplementation(getHttpMock(responses));
+            expect.anything()
+          );
 
-        searchInterceptor
-          .search(
-            {},
+          searchInterceptor
+            .search(
+              {},
+              {
+                sessionId: '123',
+              }
+            )
+            .subscribe({ next, error, complete });
+
+          await timeTravel(10);
+
+          expect(SearchSessionIncompleteWarningMock).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('when background search is enabled', () => {
+        test('should show warning once if a search is not available during restore', async () => {
+          mockCoreStart.featureFlags.getBooleanValue.mockImplementation((featureFlag) => {
+            if (featureFlag === BACKGROUND_SEARCH_FEATURE_FLAG_KEY) return true;
+            return false;
+          });
+
+          setup({
+            isRestore: true,
+            isStored: true,
+            sessionId: '123',
+          });
+
+          const responses = [
             {
-              sessionId: '123',
-            }
-          )
-          .subscribe({ next, error, complete });
+              time: 10,
+              value: getMockSearchResponse({
+                isPartial: false,
+                isRunning: false,
+                isRestored: false,
+                id: '1',
+                rawResponse: {
+                  took: 1,
+                },
+              }),
+            },
+          ];
+          mockCoreSetup.http.post.mockImplementation(getHttpMock(responses));
 
-        await timeTravel(10);
+          searchInterceptor
+            .search(
+              {},
+              {
+                sessionId: '123',
+              }
+            )
+            .subscribe({ next, error, complete });
 
-        expect(SearchSessionIncompleteWarning).toBeCalledTimes(1);
+          await timeTravel(10);
 
-        searchInterceptor
-          .search(
-            {},
-            {
-              sessionId: '123',
-            }
-          )
-          .subscribe({ next, error, complete });
+          expect(SearchSessionIncompleteWarningMock).toHaveBeenCalledTimes(1);
+          expect(mockCoreSetup.notifications.toasts.addWarning).toHaveBeenCalledWith(
+            expect.objectContaining({
+              title: 'Your background search is still running',
+            }),
+            expect.anything()
+          );
 
-        await timeTravel(10);
+          searchInterceptor
+            .search(
+              {},
+              {
+                sessionId: '123',
+              }
+            )
+            .subscribe({ next, error, complete });
 
-        expect(SearchSessionIncompleteWarning).toBeCalledTimes(1);
+          await timeTravel(10);
+
+          expect(SearchSessionIncompleteWarningMock).toHaveBeenCalledTimes(1);
+        });
       });
     });
 

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -40,6 +40,7 @@ import type {
   CoreStart,
   DocLinksStart,
   ExecutionContextSetup,
+  FeatureFlagsStart,
   I18nStart,
   IUiSettingsClient,
   ThemeServiceStart,
@@ -84,6 +85,7 @@ import { SearchAbortController } from './search_abort_controller';
 import type { SearchConfigSchema } from '../../../server/config';
 import type { SearchServiceStartDependencies } from '../search_service';
 import { createRequestHash } from './create_request_hash';
+import { BACKGROUND_SEARCH_FEATURE_FLAG_KEY } from '../session/constants';
 
 export interface SearchInterceptorDeps {
   http: HttpSetup;
@@ -119,6 +121,7 @@ export class SearchInterceptor {
   private application!: ApplicationStart;
   private docLinks!: DocLinksStart;
   private inspector!: InspectorStart;
+  private featureFlags!: FeatureFlagsStart;
 
   /*
    * Services for toMountPoint
@@ -143,6 +146,7 @@ export class SearchInterceptor {
       this.docLinks = docLinks;
       this.startRenderServices = startRenderServices;
       this.inspector = (depsStart as SearchServiceStartDependencies).inspector;
+      this.featureFlags = coreStart.featureFlags;
     });
 
     this.searchTimeout = deps.uiSettings.get(UI_SETTINGS.SEARCH_TIMEOUT);
@@ -645,10 +649,21 @@ export class SearchInterceptor {
     }
   );
 
-  private showRestoreWarningToast = (_sessionId?: string) => {
+  private showRestoreWarningToast = async (_sessionId?: string) => {
+    const isBackgroundSearchEnabled = await this.featureFlags.getBooleanValue(
+      BACKGROUND_SEARCH_FEATURE_FLAG_KEY,
+      false
+    );
+
     this.deps.toasts.addWarning(
       {
-        title: 'Your search session is still running',
+        title: isBackgroundSearchEnabled
+          ? i18n.translate('data.searchService.backgroundSearchRestoreWarning', {
+              defaultMessage: 'Your background search is still running',
+            })
+          : i18n.translate('data.searchService.restoreWarning', {
+              defaultMessage: 'Your search session is still running',
+            }),
         text: toMountPoint(SearchSessionIncompleteWarning(this.docLinks), this.startRenderServices),
       },
       {

--- a/src/platform/plugins/shared/data/public/search/search_service.ts
+++ b/src/platform/plugins/shared/data/public/search/search_service.ts
@@ -305,6 +305,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
               storage: new Storage(window.localStorage),
               usageCollector: this.usageCollector,
               tourDisabled: screenshotMode.isScreenshotMode(),
+              featureFlags: coreStart.featureFlags,
             })
           ),
           startServices

--- a/src/platform/plugins/shared/data/public/search/session/session_indicator/connected_search_session_indicator/connected_search_session_indicator.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/session_indicator/connected_search_session_indicator/connected_search_session_indicator.test.tsx
@@ -28,6 +28,7 @@ import { createSearchUsageCollectorMock } from '../../../collectors/mocks';
 const coreStart = coreMock.createStart();
 const application = coreStart.application;
 const basePath = coreStart.http.basePath;
+const featureFlags = coreStart.featureFlags;
 const dataStart = dataPluginMock.createStartContract();
 const sessionService = dataStart.search.session as jest.Mocked<ISessionService>;
 let storage: Storage;
@@ -64,6 +65,7 @@ test("shouldn't show indicator in case no active search session", async () => {
     usageCollector,
     basePath,
     tourDisabled,
+    featureFlags,
   });
   const { getByTestId, container } = render(
     <Container>
@@ -93,6 +95,7 @@ test("shouldn't show indicator in case app hasn't opt-in", async () => {
     usageCollector,
     basePath,
     tourDisabled,
+    featureFlags,
   });
   const { getByTestId, container } = render(
     <Container>
@@ -124,6 +127,7 @@ test('should show indicator in case there is an active search session', async ()
     usageCollector,
     basePath,
     tourDisabled,
+    featureFlags,
   });
   const { getByTestId } = render(
     <Container>
@@ -149,6 +153,7 @@ test('should be disabled in case uiConfig says so ', async () => {
     usageCollector,
     basePath,
     tourDisabled,
+    featureFlags,
   });
 
   render(
@@ -172,6 +177,7 @@ test('should be disabled in case not enough permissions', async () => {
     storage,
     basePath,
     tourDisabled,
+    featureFlags,
   });
 
   render(
@@ -201,6 +207,7 @@ describe('Completed inactivity', () => {
       usageCollector,
       basePath,
       tourDisabled,
+      featureFlags,
     });
 
     render(
@@ -242,6 +249,7 @@ describe('tour steps', () => {
         usageCollector,
         basePath,
         tourDisabled,
+        featureFlags,
       });
       const rendered = render(
         <Container>
@@ -283,6 +291,7 @@ describe('tour steps', () => {
         usageCollector,
         basePath,
         tourDisabled,
+        featureFlags,
       });
       const rendered = render(
         <Container>
@@ -317,6 +326,7 @@ describe('tour steps', () => {
         usageCollector,
         basePath,
         tourDisabled: true,
+        featureFlags,
       });
       const rendered = render(
         <Container>
@@ -362,6 +372,7 @@ describe('tour steps', () => {
       usageCollector,
       basePath,
       tourDisabled,
+      featureFlags,
     });
     const rendered = render(
       <Container>
@@ -389,6 +400,7 @@ describe('tour steps', () => {
       usageCollector,
       basePath,
       tourDisabled,
+      featureFlags,
     });
     const rendered = render(
       <Container>

--- a/src/platform/plugins/shared/data/public/search/session/session_indicator/connected_search_session_indicator/connected_search_session_indicator.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/session_indicator/connected_search_session_indicator/connected_search_session_indicator.tsx
@@ -14,13 +14,14 @@ import useObservable from 'react-use/lib/useObservable';
 import { i18n } from '@kbn/i18n';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
-import type { ApplicationStart, IBasePath } from '@kbn/core/public';
+import type { ApplicationStart, FeatureFlagsStart, IBasePath } from '@kbn/core/public';
 import type { SearchSessionIndicatorRef } from '../search_session_indicator';
 import { SearchSessionIndicator } from '../search_session_indicator';
 import { useSearchSessionTour } from './search_session_tour';
 import type { SearchUsageCollector } from '../../../collectors';
 import type { ISessionService } from '../../session_service';
 import { SearchSessionState } from '../../search_session_state';
+import { BACKGROUND_SEARCH_FEATURE_FLAG_KEY } from '../../constants';
 
 export interface SearchSessionIndicatorDeps {
   sessionService: ISessionService;
@@ -29,6 +30,7 @@ export interface SearchSessionIndicatorDeps {
   storage: IStorageWrapper;
   tourDisabled: boolean;
   usageCollector?: SearchUsageCollector;
+  featureFlags: FeatureFlagsStart;
 }
 
 export const createConnectedSearchSessionIndicator = ({
@@ -38,7 +40,13 @@ export const createConnectedSearchSessionIndicator = ({
   usageCollector,
   basePath,
   tourDisabled,
+  featureFlags,
 }: SearchSessionIndicatorDeps): React.FC => {
+  const hasBackgroundSearchEnabled = featureFlags.getBooleanValue(
+    BACKGROUND_SEARCH_FEATURE_FLAG_KEY,
+    false
+  );
+
   const searchSessionsManagementUrl = basePath.prepend('/app/management/kibana/search_sessions');
 
   const debouncedSessionServiceState$ = sessionService.state$.pipe(
@@ -69,12 +77,16 @@ export const createConnectedSearchSessionIndicator = ({
 
     if (disableSaveAfterSearchesExpire) {
       saveDisabled = true;
-      saveDisabledReasonText = i18n.translate(
-        'data.searchSessionIndicator.disabledDueToTimeoutMessage',
-        {
-          defaultMessage: 'Search session results expired.',
-        }
-      );
+      saveDisabledReasonText = hasBackgroundSearchEnabled
+        ? i18n.translate(
+            'data.searchSessionIndicator.backgroundSearchDisabledDueToTimeoutMessage',
+            {
+              defaultMessage: 'Background search results expired.',
+            }
+          )
+        : i18n.translate('data.searchSessionIndicator.disabledDueToTimeoutMessage', {
+            defaultMessage: 'Search session results expired.',
+          });
     }
 
     if (isSaveDisabledByApp.disabled) {
@@ -86,12 +98,16 @@ export const createConnectedSearchSessionIndicator = ({
     // this happens in case there is no app that allows current user to use search session
     if (!sessionService.hasAccess()) {
       managementDisabled = saveDisabled = true;
-      managementDisabledReasonText = saveDisabledReasonText = i18n.translate(
-        'data.searchSessionIndicator.disabledDueToDisabledGloballyMessage',
-        {
-          defaultMessage: "You don't have permissions to manage search sessions",
-        }
-      );
+      managementDisabledReasonText = saveDisabledReasonText = hasBackgroundSearchEnabled
+        ? i18n.translate(
+            'data.searchSessionIndicator.backgroundSearchDisabledDueToDisabledGloballyMessage',
+            {
+              defaultMessage: "You don't have permissions to manage background searches",
+            }
+          )
+        : i18n.translate('data.searchSessionIndicator.disabledDueToDisabledGloballyMessage', {
+            defaultMessage: "You don't have permissions to manage search sessions",
+          });
     }
 
     const { markOpenedDone, markRestoredDone } = useSearchSessionTour(
@@ -175,6 +191,7 @@ export const createConnectedSearchSessionIndicator = ({
           startedTime={startTime}
           completedTime={completedTime}
           canceledTime={canceledTime}
+          hasBackgroundSearchEnabled={hasBackgroundSearchEnabled}
         />
       </RedirectAppLinks>
     );

--- a/src/platform/plugins/shared/data/public/search/session/session_indicator/search_session_indicator/components/search_session_name/search_session_name.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/session_indicator/search_session_indicator/components/search_session_name/search_session_name.tsx
@@ -14,10 +14,15 @@ import { i18n } from '@kbn/i18n';
 
 export interface SearchSessionNameProps {
   name: string;
+  hasBackgroundSearchEnabled: boolean;
   editName: (newName: string) => Promise<unknown>;
 }
 
-export const SearchSessionName: React.FC<SearchSessionNameProps> = ({ name, editName }) => {
+export const SearchSessionName: React.FC<SearchSessionNameProps> = ({
+  name,
+  editName,
+  hasBackgroundSearchEnabled,
+}) => {
   const [isEditing, setIsEditing] = React.useState(false);
   const [newName, setNewName] = React.useState(name);
 
@@ -47,9 +52,15 @@ export const SearchSessionName: React.FC<SearchSessionNameProps> = ({ name, edit
         autoFocus={true}
         iconType={'pencil'}
         color={'text'}
-        aria-label={i18n.translate('data.searchSessionName.editAriaLabelText', {
-          defaultMessage: 'Edit search session name',
-        })}
+        aria-label={
+          hasBackgroundSearchEnabled
+            ? i18n.translate('data.searchSessionName.backgroundSearchEditAriaLabelText', {
+                defaultMessage: 'Edit background search name',
+              })
+            : i18n.translate('data.searchSessionName.editAriaLabelText', {
+                defaultMessage: 'Edit search session name',
+              })
+        }
         data-test-subj={'searchSessionNameEdit'}
         onClick={() => setIsEditing(true)}
       />
@@ -58,16 +69,28 @@ export const SearchSessionName: React.FC<SearchSessionNameProps> = ({ name, edit
     <EuiFieldText
       autoFocus={true}
       compressed={true}
-      placeholder={i18n.translate('data.searchSessionName.placeholderText', {
-        defaultMessage: 'Enter a name for the search session',
-      })}
+      placeholder={
+        hasBackgroundSearchEnabled
+          ? i18n.translate('data.searchSessionName.backgroundSearchPlaceholderText', {
+              defaultMessage: 'Enter a name for the background search',
+            })
+          : i18n.translate('data.searchSessionName.placeholderText', {
+              defaultMessage: 'Enter a name for the search session',
+            })
+      }
       value={newName}
       onChange={(e) => {
         setNewName(e.target.value);
       }}
-      aria-label={i18n.translate('data.searchSessionName.ariaLabelText', {
-        defaultMessage: 'Search session name',
-      })}
+      aria-label={
+        hasBackgroundSearchEnabled
+          ? i18n.translate('data.searchSessionName.backgroundSearchAriaLabelText', {
+              defaultMessage: 'Background search name',
+            })
+          : i18n.translate('data.searchSessionName.ariaLabelText', {
+              defaultMessage: 'Search session name',
+            })
+      }
       data-test-subj={'searchSessionNameInput'}
       append={
         <EuiButtonEmpty

--- a/src/platform/plugins/shared/data/public/search/session/session_indicator/search_session_indicator/search_session_indicator.stories.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/session_indicator/search_session_indicator/search_session_indicator.stories.tsx
@@ -29,10 +29,15 @@ const DefaultComponent = () => {
   return (
     <>
       <div>
-        <SearchSessionIndicator state={SearchSessionState.Loading} startedTime={new Date()} />
+        <SearchSessionIndicator
+          hasBackgroundSearchEnabled={false}
+          state={SearchSessionState.Loading}
+          startedTime={new Date()}
+        />
       </div>
       <div>
         <SearchSessionIndicator
+          hasBackgroundSearchEnabled={false}
           state={SearchSessionState.Completed}
           startedTime={new Date()}
           completedTime={new Date()}
@@ -40,6 +45,7 @@ const DefaultComponent = () => {
       </div>
       <div>
         <SearchSessionIndicator
+          hasBackgroundSearchEnabled={false}
           state={SearchSessionState.BackgroundLoading}
           searchSessionName={searchSessionName}
           saveSearchSessionNameFn={saveSearchSessionNameFn}
@@ -48,6 +54,7 @@ const DefaultComponent = () => {
       </div>
       <div>
         <SearchSessionIndicator
+          hasBackgroundSearchEnabled={false}
           state={SearchSessionState.BackgroundCompleted}
           searchSessionName={searchSessionName}
           saveSearchSessionNameFn={saveSearchSessionNameFn}
@@ -57,6 +64,7 @@ const DefaultComponent = () => {
       </div>
       <div>
         <SearchSessionIndicator
+          hasBackgroundSearchEnabled={false}
           state={SearchSessionState.Restored}
           searchSessionName={searchSessionName}
           saveSearchSessionNameFn={saveSearchSessionNameFn}
@@ -66,6 +74,7 @@ const DefaultComponent = () => {
       </div>
       <div>
         <SearchSessionIndicator
+          hasBackgroundSearchEnabled={false}
           state={SearchSessionState.Canceled}
           startedTime={new Date()}
           canceledTime={new Date()}
@@ -73,6 +82,7 @@ const DefaultComponent = () => {
       </div>
       <div>
         <SearchSessionIndicator
+          hasBackgroundSearchEnabled={false}
           state={SearchSessionState.Completed}
           saveDisabled={true}
           startedTime={new Date()}

--- a/src/platform/plugins/shared/data/public/search/session/session_indicator/search_session_indicator/search_session_indicator.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/session_indicator/search_session_indicator/search_session_indicator.tsx
@@ -51,6 +51,8 @@ export interface SearchSessionIndicatorProps {
   startedTime?: Date;
   completedTime?: Date;
   canceledTime?: Date;
+
+  hasBackgroundSearchEnabled: boolean;
 }
 
 type ActionButtonProps = SearchSessionIndicatorProps & { buttonProps: EuiButtonEmptyProps };
@@ -135,210 +137,301 @@ const SaveButton = ({
   </EuiToolTip>
 );
 
-const searchSessionIndicatorViewStateToProps: {
-  [state in SearchSessionState]: {
-    button: Pick<EuiButtonIconProps, 'color' | 'iconType' | 'aria-label'> & {
-      tooltipText: string;
-    };
-    popover: {
-      title: string;
-      description: string;
-      whenText: (props: SearchSessionIndicatorProps) => string;
-      primaryAction?: React.ComponentType<ActionButtonProps>;
-      secondaryAction?: React.ComponentType<ActionButtonProps>;
-    };
-  } | null;
-} = {
-  [SearchSessionState.None]: null,
-  [SearchSessionState.Loading]: {
-    button: {
-      color: 'text',
-      iconType: PartialClock,
-      'aria-label': i18n.translate('data.searchSessionIndicator.loadingResultsIconAriaLabel', {
-        defaultMessage: 'Search session loading',
-      }),
-      tooltipText: i18n.translate('data.searchSessionIndicator.loadingResultsIconTooltipText', {
-        defaultMessage: 'Search session loading',
-      }),
-    },
-    popover: {
-      title: i18n.translate('data.searchSessionIndicator.loadingResultsTitle', {
-        defaultMessage: 'Your search is taking a while...',
-      }),
-      description: i18n.translate('data.searchSessionIndicator.loadingResultsDescription', {
-        defaultMessage: 'Save your session, continue your work, and return to completed results',
-      }),
-      whenText: (props: SearchSessionIndicatorProps) =>
-        i18n.translate('data.searchSessionIndicator.loadingResultsWhenText', {
-          defaultMessage: 'Started {when}',
-          values: {
-            when: props.startedTime ? moment(props.startedTime).format(`L @ LTS`) : '',
-          },
+const searchSessionIndicatorViewStateToProps = ({
+  hasBackgroundSearchEnabled,
+  state,
+}: {
+  hasBackgroundSearchEnabled: boolean;
+  state: SearchSessionState;
+}) => {
+  const stateProps: {
+    [state in SearchSessionState]: {
+      button: Pick<EuiButtonIconProps, 'color' | 'iconType' | 'aria-label'> & {
+        tooltipText: string;
+      };
+      popover: {
+        title: string;
+        description: string;
+        whenText: (props: SearchSessionIndicatorProps) => string;
+        primaryAction?: React.ComponentType<ActionButtonProps>;
+        secondaryAction?: React.ComponentType<ActionButtonProps>;
+      };
+    } | null;
+  } = {
+    [SearchSessionState.None]: null,
+    [SearchSessionState.Loading]: {
+      button: {
+        color: 'text',
+        iconType: PartialClock,
+        'aria-label': hasBackgroundSearchEnabled
+          ? i18n.translate(
+              'data.searchSessionIndicator.backgroundSearchLoadingResultsIconAriaLabel',
+              {
+                defaultMessage: 'Background search loading',
+              }
+            )
+          : i18n.translate('data.searchSessionIndicator.loadingResultsIconAriaLabel', {
+              defaultMessage: 'Search session loading',
+            }),
+        tooltipText: hasBackgroundSearchEnabled
+          ? i18n.translate(
+              'data.backgroundSearchIndicator.backgroundSearchLoadingResultsIconTooltipText',
+              {
+                defaultMessage: 'Background search loading',
+              }
+            )
+          : i18n.translate('data.searchSessionIndicator.loadingResultsIconTooltipText', {
+              defaultMessage: 'Search session loading',
+            }),
+      },
+      popover: {
+        title: i18n.translate('data.searchSessionIndicator.loadingResultsTitle', {
+          defaultMessage: 'Your search is taking a while...',
         }),
-      primaryAction: CancelButton,
-      secondaryAction: ContinueInBackgroundButton,
-    },
-  },
-  [SearchSessionState.Completed]: {
-    button: {
-      color: 'text',
-      iconType: 'check',
-      'aria-label': i18n.translate('data.searchSessionIndicator.resultsLoadedIconAriaLabel', {
-        defaultMessage: 'Search session complete',
-      }),
-      tooltipText: i18n.translate('data.searchSessionIndicator.resultsLoadedIconTooltipText', {
-        defaultMessage: 'Search session complete',
-      }),
-    },
-    popover: {
-      title: i18n.translate('data.searchSessionIndicator.resultsLoadedText', {
-        defaultMessage: 'Search session complete',
-      }),
-      description: i18n.translate('data.searchSessionIndicator.resultsLoadedDescriptionText', {
-        defaultMessage: 'Save your session and return to it later',
-      }),
-      whenText: (props: SearchSessionIndicatorProps) =>
-        i18n.translate('data.searchSessionIndicator.resultsLoadedWhenText', {
-          defaultMessage: 'Completed {when}',
-          values: {
-            when: props.completedTime ? moment(props.completedTime).format(`L @ LTS`) : '',
-          },
+        description: i18n.translate('data.searchSessionIndicator.loadingResultsDescription', {
+          defaultMessage: 'Save your session, continue your work, and return to completed results',
         }),
-      primaryAction: SaveButton,
-      secondaryAction: ViewAllSearchSessionsButton,
+        whenText: (props: SearchSessionIndicatorProps) =>
+          i18n.translate('data.searchSessionIndicator.loadingResultsWhenText', {
+            defaultMessage: 'Started {when}',
+            values: {
+              when: props.startedTime ? moment(props.startedTime).format(`L @ LTS`) : '',
+            },
+          }),
+        primaryAction: CancelButton,
+        secondaryAction: ContinueInBackgroundButton,
+      },
     },
-  },
-  [SearchSessionState.BackgroundLoading]: {
-    button: {
-      iconType: EuiLoadingSpinner,
-      'aria-label': i18n.translate(
-        'data.searchSessionIndicator.loadingInTheBackgroundIconAriaLabel',
-        {
+    [SearchSessionState.Completed]: {
+      button: {
+        color: 'text',
+        iconType: 'check',
+        'aria-label': hasBackgroundSearchEnabled
+          ? i18n.translate(
+              'data.searchSessionIndicator.backgroundSearchResultsLoadedIconAriaLabel',
+              {
+                defaultMessage: 'Background search complete',
+              }
+            )
+          : i18n.translate('data.searchSessionIndicator.resultsLoadedIconAriaLabel', {
+              defaultMessage: 'Search session complete',
+            }),
+        tooltipText: hasBackgroundSearchEnabled
+          ? i18n.translate(
+              'data.searchSessionIndicator.backgroundSearchResultsLoadedIconTooltipText',
+              {
+                defaultMessage: 'Background search complete',
+              }
+            )
+          : i18n.translate('data.searchSessionIndicator.resultsLoadedIconTooltipText', {
+              defaultMessage: 'Search session complete',
+            }),
+      },
+      popover: {
+        title: hasBackgroundSearchEnabled
+          ? i18n.translate('data.searchSessionIndicator.backgroundSearchResultsLoadedText', {
+              defaultMessage: 'Background search complete',
+            })
+          : i18n.translate('data.searchSessionIndicator.resultsLoadedText', {
+              defaultMessage: 'Search session complete',
+            }),
+        description: i18n.translate('data.searchSessionIndicator.resultsLoadedDescriptionText', {
+          defaultMessage: 'Save your session and return to it later',
+        }),
+        whenText: (props: SearchSessionIndicatorProps) =>
+          i18n.translate('data.searchSessionIndicator.resultsLoadedWhenText', {
+            defaultMessage: 'Completed {when}',
+            values: {
+              when: props.completedTime ? moment(props.completedTime).format(`L @ LTS`) : '',
+            },
+          }),
+        primaryAction: SaveButton,
+        secondaryAction: ViewAllSearchSessionsButton,
+      },
+    },
+    [SearchSessionState.BackgroundLoading]: {
+      button: {
+        iconType: EuiLoadingSpinner,
+        'aria-label': hasBackgroundSearchEnabled
+          ? i18n.translate(
+              'data.searchSessionIndicator.backgroundSearchLoadingInTheBackgroundIconAriaLabel',
+              {
+                defaultMessage: 'Saved background search in progress',
+              }
+            )
+          : i18n.translate('data.searchSessionIndicator.loadingInTheBackgroundIconAriaLabel', {
+              defaultMessage: 'Saved session in progress',
+            }),
+        tooltipText: hasBackgroundSearchEnabled
+          ? i18n.translate(
+              'data.searchSessionIndicator.backgroundSearchLoadingInTheBackgroundIconTooltipText',
+              {
+                defaultMessage: 'Saved background search in progress',
+              }
+            )
+          : i18n.translate('data.searchSessionIndicator.loadingInTheBackgroundIconTooltipText', {
+              defaultMessage: 'Saved session in progress',
+            }),
+      },
+      popover: {
+        title: i18n.translate('data.searchSessionIndicator.loadingInTheBackgroundTitleText', {
           defaultMessage: 'Saved session in progress',
-        }
-      ),
-      tooltipText: i18n.translate(
-        'data.searchSessionIndicator.loadingInTheBackgroundIconTooltipText',
-        {
-          defaultMessage: 'Saved session in progress',
-        }
-      ),
-    },
-    popover: {
-      title: i18n.translate('data.searchSessionIndicator.loadingInTheBackgroundTitleText', {
-        defaultMessage: 'Saved session in progress',
-      }),
-      description: i18n.translate(
-        'data.searchSessionIndicator.loadingInTheBackgroundDescriptionText',
-        {
-          defaultMessage: 'You can return to completed results from Management',
-        }
-      ),
-      whenText: (props: SearchSessionIndicatorProps) =>
-        i18n.translate('data.searchSessionIndicator.loadingInTheBackgroundWhenText', {
-          defaultMessage: 'Started {when}',
-          values: {
-            when: props.startedTime ? moment(props.startedTime).format(`L @ LTS`) : '',
-          },
         }),
-      primaryAction: CancelButton,
-      secondaryAction: ViewAllSearchSessionsButton,
+        description: i18n.translate(
+          'data.searchSessionIndicator.loadingInTheBackgroundDescriptionText',
+          {
+            defaultMessage: 'You can return to completed results from Management',
+          }
+        ),
+        whenText: (props: SearchSessionIndicatorProps) =>
+          i18n.translate('data.searchSessionIndicator.loadingInTheBackgroundWhenText', {
+            defaultMessage: 'Started {when}',
+            values: {
+              when: props.startedTime ? moment(props.startedTime).format(`L @ LTS`) : '',
+            },
+          }),
+        primaryAction: CancelButton,
+        secondaryAction: ViewAllSearchSessionsButton,
+      },
     },
-  },
-  [SearchSessionState.BackgroundCompleted]: {
-    button: {
-      color: 'success',
-      iconType: 'checkInCircleFilled',
-      'aria-label': i18n.translate(
-        'data.searchSessionIndicator.resultLoadedInTheBackgroundIconAriaLabel',
-        {
-          defaultMessage: 'Saved session complete',
-        }
-      ),
-      tooltipText: i18n.translate(
-        'data.searchSessionIndicator.resultLoadedInTheBackgroundIconTooltipText',
-        {
-          defaultMessage: 'Saved session complete',
-        }
-      ),
+    [SearchSessionState.BackgroundCompleted]: {
+      button: {
+        color: 'success',
+        iconType: 'checkInCircleFilled',
+        'aria-label': i18n.translate(
+          'data.searchSessionIndicator.resultLoadedInTheBackgroundIconAriaLabel',
+          {
+            defaultMessage: 'Saved session complete',
+          }
+        ),
+        tooltipText: i18n.translate(
+          'data.searchSessionIndicator.resultLoadedInTheBackgroundIconTooltipText',
+          {
+            defaultMessage: 'Saved session complete',
+          }
+        ),
+      },
+      popover: {
+        title: hasBackgroundSearchEnabled
+          ? i18n.translate(
+              'data.searchSessionIndicator.backgroundSearchResultLoadedInTheBackgroundTitleText',
+              {
+                defaultMessage: 'Background search saved',
+              }
+            )
+          : i18n.translate('data.searchSessionIndicator.resultLoadedInTheBackgroundTitleText', {
+              defaultMessage: 'Search session saved',
+            }),
+        description: i18n.translate(
+          'data.searchSessionIndicator.resultLoadedInTheBackgroundDescriptionText',
+          {
+            defaultMessage: 'You can return to these results from Management',
+          }
+        ),
+        whenText: (props: SearchSessionIndicatorProps) =>
+          i18n.translate('data.searchSessionIndicator.resultLoadedInTheBackgroundWhenText', {
+            defaultMessage: 'Completed {when}',
+            values: {
+              when: props.completedTime ? moment(props.completedTime).format(`L @ LTS`) : '',
+            },
+          }),
+        secondaryAction: ViewAllSearchSessionsButton,
+      },
     },
-    popover: {
-      title: i18n.translate('data.searchSessionIndicator.resultLoadedInTheBackgroundTitleText', {
-        defaultMessage: 'Search session saved',
-      }),
-      description: i18n.translate(
-        'data.searchSessionIndicator.resultLoadedInTheBackgroundDescriptionText',
-        {
-          defaultMessage: 'You can return to these results from Management',
-        }
-      ),
-      whenText: (props: SearchSessionIndicatorProps) =>
-        i18n.translate('data.searchSessionIndicator.resultLoadedInTheBackgroundWhenText', {
-          defaultMessage: 'Completed {when}',
-          values: {
-            when: props.completedTime ? moment(props.completedTime).format(`L @ LTS`) : '',
-          },
+    [SearchSessionState.Restored]: {
+      button: {
+        color: 'success',
+        iconType: CheckInEmptyCircle,
+        'aria-label': hasBackgroundSearchEnabled
+          ? i18n.translate(
+              'data.searchSessionIndicator.backgroundSearchRestoredResultsIconAriaLabel',
+              {
+                defaultMessage: 'Saved background search restored',
+              }
+            )
+          : i18n.translate('data.searchSessionIndicator.restoredResultsIconAriaLabel', {
+              defaultMessage: 'Saved session restored',
+            }),
+        tooltipText: hasBackgroundSearchEnabled
+          ? i18n.translate(
+              'data.searchSessionIndicator.backgroundSearchRestoredResultsTooltipText',
+              {
+                defaultMessage: 'Background search restored',
+              }
+            )
+          : i18n.translate('data.searchSessionIndicator.restoredResultsTooltipText', {
+              defaultMessage: 'Search session restored',
+            }),
+      },
+      popover: {
+        title: hasBackgroundSearchEnabled
+          ? i18n.translate('data.searchSessionIndicator.backgroundSearchRestoredTitleText', {
+              defaultMessage: 'Background search restored',
+            })
+          : i18n.translate('data.searchSessionIndicator.restoredTitleText', {
+              defaultMessage: 'Search session restored',
+            }),
+        description: i18n.translate('data.searchSessionIndicator.restoredDescriptionText', {
+          defaultMessage:
+            'You are viewing cached data from a specific time range. Changing the time range or filters will re-run the session',
         }),
-      secondaryAction: ViewAllSearchSessionsButton,
+        whenText: (props: SearchSessionIndicatorProps) =>
+          i18n.translate('data.searchSessionIndicator.restoredWhenText', {
+            defaultMessage: 'Completed {when}',
+            values: {
+              when: props.completedTime ? moment(props.completedTime).format(`L @ LTS`) : '',
+            },
+          }),
+        secondaryAction: ViewAllSearchSessionsButton,
+      },
     },
-  },
-  [SearchSessionState.Restored]: {
-    button: {
-      color: 'success',
-      iconType: CheckInEmptyCircle,
-      'aria-label': i18n.translate('data.searchSessionIndicator.restoredResultsIconAriaLabel', {
-        defaultMessage: 'Saved session restored',
-      }),
-      tooltipText: i18n.translate('data.searchSessionIndicator.restoredResultsTooltipText', {
-        defaultMessage: 'Search session restored',
-      }),
+    [SearchSessionState.Canceled]: {
+      button: {
+        color: 'danger',
+        iconType: 'error',
+        'aria-label': hasBackgroundSearchEnabled
+          ? i18n.translate('data.searchSessionIndicator.backgroundSearchCanceledIconAriaLabel', {
+              defaultMessage: 'Background search stopped',
+            })
+          : i18n.translate('data.searchSessionIndicator.canceledIconAriaLabel', {
+              defaultMessage: 'Search session stopped',
+            }),
+        tooltipText: hasBackgroundSearchEnabled
+          ? i18n.translate('data.searchSessionIndicator.backgroundSearchCanceledTooltipText', {
+              defaultMessage: 'Background search stopped',
+            })
+          : i18n.translate('data.searchSessionIndicator.canceledTooltipText', {
+              defaultMessage: 'Search session stopped',
+            }),
+      },
+      popover: {
+        title: hasBackgroundSearchEnabled
+          ? i18n.translate('data.searchSessionIndicator.backgroundSearchCanceledTitleText', {
+              defaultMessage: 'Background search stopped',
+            })
+          : i18n.translate('data.searchSessionIndicator.canceledTitleText', {
+              defaultMessage: 'Search session stopped',
+            }),
+        description: hasBackgroundSearchEnabled
+          ? i18n.translate('data.searchSessionIndicator.backgroundSearchCanceledDescriptionText', {
+              defaultMessage: 'You are viewing incomplete data',
+            })
+          : i18n.translate('data.searchSessionIndicator.canceledDescriptionText', {
+              defaultMessage: 'You are viewing incomplete data',
+            }),
+        whenText: (props: SearchSessionIndicatorProps) =>
+          i18n.translate('data.searchSessionIndicator.canceledWhenText', {
+            defaultMessage: 'Stopped {when}',
+            values: {
+              when: props.canceledTime ? moment(props.canceledTime).format(`L @ LTS`) : '',
+            },
+          }),
+        secondaryAction: ViewAllSearchSessionsButton,
+      },
     },
-    popover: {
-      title: i18n.translate('data.searchSessionIndicator.restoredTitleText', {
-        defaultMessage: 'Search session restored',
-      }),
-      description: i18n.translate('data.searchSessionIndicator.restoredDescriptionText', {
-        defaultMessage:
-          'You are viewing cached data from a specific time range. Changing the time range or filters will re-run the session',
-      }),
-      whenText: (props: SearchSessionIndicatorProps) =>
-        i18n.translate('data.searchSessionIndicator.restoredWhenText', {
-          defaultMessage: 'Completed {when}',
-          values: {
-            when: props.completedTime ? moment(props.completedTime).format(`L @ LTS`) : '',
-          },
-        }),
-      secondaryAction: ViewAllSearchSessionsButton,
-    },
-  },
-  [SearchSessionState.Canceled]: {
-    button: {
-      color: 'danger',
-      iconType: 'error',
-      'aria-label': i18n.translate('data.searchSessionIndicator.canceledIconAriaLabel', {
-        defaultMessage: 'Search session stopped',
-      }),
-      tooltipText: i18n.translate('data.searchSessionIndicator.canceledTooltipText', {
-        defaultMessage: 'Search session stopped',
-      }),
-    },
-    popover: {
-      title: i18n.translate('data.searchSessionIndicator.canceledTitleText', {
-        defaultMessage: 'Search session stopped',
-      }),
-      description: i18n.translate('data.searchSessionIndicator.canceledDescriptionText', {
-        defaultMessage: 'You are viewing incomplete data',
-      }),
-      whenText: (props: SearchSessionIndicatorProps) =>
-        i18n.translate('data.searchSessionIndicator.canceledWhenText', {
-          defaultMessage: 'Stopped {when}',
-          values: {
-            when: props.canceledTime ? moment(props.canceledTime).format(`L @ LTS`) : '',
-          },
-        }),
-      secondaryAction: ViewAllSearchSessionsButton,
-    },
-  },
+  };
+
+  return stateProps[state];
 };
 
 export interface SearchSessionIndicatorRef {
@@ -379,9 +472,14 @@ export const SearchSessionIndicator = React.forwardRef<
     [openPopover, closePopover]
   );
 
-  if (!searchSessionIndicatorViewStateToProps[props.state]) return null;
+  const stateProps = searchSessionIndicatorViewStateToProps({
+    hasBackgroundSearchEnabled: props.hasBackgroundSearchEnabled,
+    state: props.state,
+  });
 
-  const { button, popover } = searchSessionIndicatorViewStateToProps[props.state]!;
+  if (!stateProps) return null;
+
+  const { button, popover } = stateProps;
 
   return (
     <EuiPopover
@@ -417,6 +515,7 @@ export const SearchSessionIndicator = React.forwardRef<
           <SearchSessionName
             name={props.searchSessionName}
             editName={props.saveSearchSessionNameFn}
+            hasBackgroundSearchEnabled={props.hasBackgroundSearchEnabled}
           />
         ) : (
           <EuiText size={'s'}>

--- a/src/platform/plugins/shared/data/public/search/session/session_indicator/search_session_indicator/search_session_indicator.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/session_indicator/search_session_indicator/search_session_indicator.tsx
@@ -412,13 +412,9 @@ const searchSessionIndicatorViewStateToProps = ({
           : i18n.translate('data.searchSessionIndicator.canceledTitleText', {
               defaultMessage: 'Search session stopped',
             }),
-        description: hasBackgroundSearchEnabled
-          ? i18n.translate('data.searchSessionIndicator.backgroundSearchCanceledDescriptionText', {
-              defaultMessage: 'You are viewing incomplete data',
-            })
-          : i18n.translate('data.searchSessionIndicator.canceledDescriptionText', {
-              defaultMessage: 'You are viewing incomplete data',
-            }),
+        description: i18n.translate('data.searchSessionIndicator.canceledDescriptionText', {
+          defaultMessage: 'You are viewing incomplete data',
+        }),
         whenText: (props: SearchSessionIndicatorProps) =>
           i18n.translate('data.searchSessionIndicator.canceledWhenText', {
             defaultMessage: 'Stopped {when}',

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -23,6 +23,7 @@ import {
 import type { Observable } from 'rxjs';
 import { BehaviorSubject, combineLatest, EMPTY, from, merge, of, Subscription, timer } from 'rxjs';
 import type {
+  FeatureFlagsStart,
   PluginInitializerContext,
   StartServicesAccessor,
   ToastsStart as ToastService,
@@ -44,7 +45,7 @@ import {
 } from './search_session_state';
 import type { ISessionsClient } from './sessions_client';
 import type { NowProviderInternalContract } from '../../now_provider';
-import { SEARCH_SESSIONS_MANAGEMENT_ID } from './constants';
+import { BACKGROUND_SEARCH_FEATURE_FLAG_KEY, SEARCH_SESSIONS_MANAGEMENT_ID } from './constants';
 import { formatSessionName } from './lib/session_name_formatter';
 
 /**
@@ -183,6 +184,7 @@ export class SessionService {
   private subscription = new Subscription();
   private currentApp?: string;
   private hasAccessToSearchSessions: boolean = false;
+  private featureFlags?: FeatureFlagsStart;
 
   private toastService?: ToastService;
 
@@ -255,6 +257,8 @@ export class SessionService {
     );
 
     getStartServices().then(([coreStart]) => {
+      this.featureFlags = coreStart.featureFlags;
+
       // using management?.kibana? we infer if any of the apps allows current user to store sessions
       this.hasAccessToSearchSessions =
         coreStart.application.capabilities.management?.kibana?.[SEARCH_SESSIONS_MANAGEMENT_ID];
@@ -608,10 +612,19 @@ export class SessionService {
         await this.sessionsClient.rename(sessionId, newName);
         renamed = true;
       } catch (e) {
+        const hasBackgroundSearchEnabled = this.featureFlags?.getBooleanValue(
+          BACKGROUND_SEARCH_FEATURE_FLAG_KEY,
+          false
+        );
+
         this.toastService?.addError(e, {
-          title: i18n.translate('data.searchSessions.sessionService.sessionEditNameError', {
-            defaultMessage: 'Failed to edit name of the search session',
-          }),
+          title: hasBackgroundSearchEnabled
+            ? i18n.translate('data.searchSessions.sessionService.backgroundSearchEditNameError', {
+                defaultMessage: 'Failed to edit name of the background search',
+              })
+            : i18n.translate('data.searchSessions.sessionService.sessionEditNameError', {
+                defaultMessage: 'Failed to edit name of the search session',
+              }),
         });
       }
 
@@ -701,10 +714,22 @@ export class SessionService {
           this.state.transitions.setSearchSessionSavedObject(savedObject);
         }
       } catch (e) {
+        const hasBackgroundSearchEnabled = this.featureFlags?.getBooleanValue(
+          BACKGROUND_SEARCH_FEATURE_FLAG_KEY,
+          false
+        );
+
         this.toastService?.addError(e, {
-          title: i18n.translate('data.searchSessions.sessionService.sessionObjectFetchError', {
-            defaultMessage: 'Failed to fetch search session info',
-          }),
+          title: hasBackgroundSearchEnabled
+            ? i18n.translate(
+                'data.searchSessions.sessionService.backgroundSearchObjectFetchError',
+                {
+                  defaultMessage: 'Failed to fetch background search info',
+                }
+              )
+            : i18n.translate('data.searchSessions.sessionService.sessionObjectFetchError', {
+                defaultMessage: 'Failed to fetch search session info',
+              }),
         });
       }
     }

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/application/index.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/application/index.tsx
@@ -56,6 +56,7 @@ export class SearchSessionsMgmtApp {
       notifications,
       application,
       usageCollector: setupDeps.searchUsageCollector,
+      featureFlags: coreStart.featureFlags,
     });
 
     const documentation = new AsyncSearchIntroDocumentation(docLinks);

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/main.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/main.test.tsx
@@ -50,6 +50,7 @@ const setup = async ({ backgroundSearchEnabled }: { backgroundSearchEnabled: boo
   const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
     notifications: mockCoreStart.notifications,
     application: mockCoreStart.application,
+    featureFlags: mockCoreStart.featureFlags,
   });
 
   const docLinks: DocLinksStart = {

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/inspect_button.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/inspect_button.tsx
@@ -15,15 +15,20 @@ import type { CoreStart } from '@kbn/core/public';
 import { createKibanaReactContext } from '@kbn/kibana-react-plugin/public';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { CodeEditor } from '@kbn/code-editor';
-import type { IClickActionDescriptor } from './types';
 import type { UISession } from '../../../types';
+import type { IClickActionDescriptor } from './types';
 import type { SearchSessionsMgmtAPI } from '../../../lib/api';
+import { BACKGROUND_SEARCH_FEATURE_FLAG_KEY } from '../../../../constants';
 
 interface InspectFlyoutProps {
   searchSession: UISession;
+  hasBackgroundSearchEnabled: boolean;
 }
 
-const InspectFlyout: React.FC<InspectFlyoutProps> = ({ searchSession }) => {
+const InspectFlyout: React.FC<InspectFlyoutProps> = ({
+  searchSession,
+  hasBackgroundSearchEnabled,
+}) => {
   const renderInfo = () => {
     return (
       <Fragment>
@@ -52,10 +57,17 @@ const InspectFlyout: React.FC<InspectFlyoutProps> = ({ searchSession }) => {
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">
           <h2 id="flyoutTitle">
-            <FormattedMessage
-              id="data.sessions.management.flyoutTitle"
-              defaultMessage="Inspect search session"
-            />
+            {hasBackgroundSearchEnabled ? (
+              <FormattedMessage
+                id="data.sessions.management.backgroundSearchFlyoutTitle"
+                defaultMessage="Inspect background search"
+              />
+            ) : (
+              <FormattedMessage
+                id="data.sessions.management.flyoutTitle"
+                defaultMessage="Inspect search session"
+              />
+            )}
           </h2>
         </EuiTitle>
       </EuiFlyoutHeader>
@@ -63,10 +75,17 @@ const InspectFlyout: React.FC<InspectFlyoutProps> = ({ searchSession }) => {
         <EuiText>
           <EuiText size="xs">
             <p>
-              <FormattedMessage
-                id="data.sessions.management.flyoutText"
-                defaultMessage="Configuration for this search session"
-              />
+              {hasBackgroundSearchEnabled ? (
+                <FormattedMessage
+                  id="data.sessions.management.backgroundSearchFlyoutText"
+                  defaultMessage="Configuration for this background search"
+                />
+              ) : (
+                <FormattedMessage
+                  id="data.sessions.management.flyoutText"
+                  defaultMessage="Configuration for this search session"
+                />
+              )}
             </p>
           </EuiText>
           <EuiSpacer />
@@ -82,6 +101,7 @@ interface InspectFlyoutWrapperProps {
   uiSettings: CoreStart['uiSettings'];
   settings: CoreStart['settings'];
   theme: CoreStart['theme'];
+  hasBackgroundSearchEnabled: boolean;
 }
 
 const InspectFlyoutWrapper: React.FC<InspectFlyoutWrapperProps> = ({
@@ -89,6 +109,7 @@ const InspectFlyoutWrapper: React.FC<InspectFlyoutWrapperProps> = ({
   uiSettings,
   settings,
   theme,
+  hasBackgroundSearchEnabled,
 }) => {
   const { Provider: KibanaReactContextProvider } = createKibanaReactContext({
     uiSettings,
@@ -98,7 +119,10 @@ const InspectFlyoutWrapper: React.FC<InspectFlyoutWrapperProps> = ({
 
   return (
     <KibanaReactContextProvider>
-      <InspectFlyout searchSession={searchSession} />
+      <InspectFlyout
+        searchSession={searchSession}
+        hasBackgroundSearchEnabled={hasBackgroundSearchEnabled}
+      />
     </KibanaReactContextProvider>
   );
 };
@@ -119,6 +143,10 @@ export const createInspectActionDescriptor = (
   onClick: async () => {
     const flyoutWrapper = (
       <InspectFlyoutWrapper
+        hasBackgroundSearchEnabled={core.featureFlags.getBooleanValue(
+          BACKGROUND_SEARCH_FEATURE_FLAG_KEY,
+          false
+        )}
         uiSettings={core.uiSettings}
         settings={core.settings}
         theme={core.theme}

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/rename_button.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/rename_button.tsx
@@ -29,17 +29,19 @@ import type { SearchSessionsMgmtAPI } from '../../../lib/api';
 import type { IClickActionDescriptor } from './types';
 import type { OnActionDismiss } from './types';
 import type { UISession } from '../../../types';
+import { BACKGROUND_SEARCH_FEATURE_FLAG_KEY } from '../../../../constants';
 
 interface RenameButtonProps {
   searchSession: UISession;
   api: SearchSessionsMgmtAPI;
+  hasBackgroundSearchEnabled: boolean;
 }
 
 const RenameDialog = ({
   onActionDismiss,
   ...props
 }: RenameButtonProps & { onActionDismiss: OnActionDismiss }) => {
-  const { api, searchSession } = props;
+  const { api, searchSession, hasBackgroundSearchEnabled } = props;
   const { id, name: originalName } = searchSession;
   const [isLoading, setIsLoading] = useState(false);
   const [newName, setNewName] = useState(originalName);
@@ -49,6 +51,10 @@ const RenameDialog = ({
   const title = i18n.translate('data.mgmt.searchSessions.renameModal.title', {
     defaultMessage: 'Edit search session name',
   });
+  const bgsTitle = i18n.translate('data.mgmt.searchSessions.renameModal.backgroundSearchTitle', {
+    defaultMessage: 'Edit background search name',
+  });
+
   const confirm = i18n.translate('data.mgmt.searchSessions.renameModal.renameButton', {
     defaultMessage: 'Save',
   });
@@ -59,6 +65,12 @@ const RenameDialog = ({
   const label = i18n.translate('data.mgmt.searchSessions.renameModal.searchSessionNameInputLabel', {
     defaultMessage: 'Search session name',
   });
+  const bgsLabel = i18n.translate(
+    'data.mgmt.searchSessions.renameModal.backgroundSearchNameInputLabel',
+    {
+      defaultMessage: 'Background search name',
+    }
+  );
 
   const isNewNameValid = newName && originalName !== newName;
 
@@ -69,12 +81,14 @@ const RenameDialog = ({
       initialFocus="[name=newName]"
     >
       <EuiModalHeader>
-        <EuiModalHeaderTitle id={modalTitleId}>{title}</EuiModalHeaderTitle>
+        <EuiModalHeaderTitle id={modalTitleId}>
+          {hasBackgroundSearchEnabled ? bgsTitle : title}
+        </EuiModalHeaderTitle>
       </EuiModalHeader>
 
       <EuiModalBody>
         <EuiForm>
-          <EuiFormRow label={label}>
+          <EuiFormRow label={hasBackgroundSearchEnabled ? bgsLabel : label}>
             <EuiFieldText
               name="newName"
               placeholder={originalName}
@@ -119,7 +133,15 @@ export const createRenameActionDescriptor = (
   onClick: async () => {
     const ref = core.overlays.openModal(
       toMountPoint(
-        <RenameDialog onActionDismiss={() => ref?.close()} api={api} searchSession={uiSession} />,
+        <RenameDialog
+          hasBackgroundSearchEnabled={core.featureFlags.getBooleanValue(
+            BACKGROUND_SEARCH_FEATURE_FLAG_KEY,
+            false
+          )}
+          onActionDismiss={() => ref?.close()}
+          api={api}
+          searchSession={uiSession}
+        />,
         core
       )
     );

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/get_columns.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/get_columns.test.tsx
@@ -50,6 +50,7 @@ const setup = ({
   const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
     notifications: mockCoreStart.notifications,
     application: mockCoreStart.application,
+    featureFlags: mockCoreStart.featureFlags,
   });
 
   const handleAction = jest.fn();

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
@@ -62,6 +62,7 @@ const Component = ({
   const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
     notifications: mockCoreStart.notifications,
     application: mockCoreStart.application,
+    featureFlags: mockCoreStart.featureFlags,
   });
   api.fetchTableData = async () => {
     return {

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.test.tsx
@@ -61,6 +61,7 @@ const setup = async ({
   const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
     notifications: mockCoreStart.notifications,
     application: mockCoreStart.application,
+    featureFlags: mockCoreStart.featureFlags,
   });
 
   let renderResult: RenderResult;

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.test.tsx
@@ -42,6 +42,7 @@ const setup = () => {
   const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
     notifications: mockCoreStart.notifications,
     application: mockCoreStart.application,
+    featureFlags: mockCoreStart.featureFlags,
   });
 
   const onClose = jest.fn();

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
@@ -38,6 +38,7 @@ export function openSearchSessionsFlyout({
       notifications: coreStart.notifications,
       application: coreStart.application,
       usageCollector,
+      featureFlags: coreStart.featureFlags,
     });
     const { Provider: KibanaReactContextProvider } = createKibanaReactContext(coreStart);
 

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/api.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/api.test.ts
@@ -64,6 +64,7 @@ describe('Search Sessions Management API', () => {
       const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
         notifications: mockCoreStart.notifications,
         application: mockCoreStart.application,
+        featureFlags: mockCoreStart.featureFlags,
       });
 
       const { savedObjects: results, statuses } = await api.fetchTableData();
@@ -107,6 +108,7 @@ describe('Search Sessions Management API', () => {
       const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
         notifications: mockCoreStart.notifications,
         application: mockCoreStart.application,
+        featureFlags: mockCoreStart.featureFlags,
       });
 
       const { savedObjects: res, statuses } = await api.fetchTableData();
@@ -119,6 +121,7 @@ describe('Search Sessions Management API', () => {
       const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
         notifications: mockCoreStart.notifications,
         application: mockCoreStart.application,
+        featureFlags: mockCoreStart.featureFlags,
       });
       await api.fetchTableData();
 
@@ -147,6 +150,7 @@ describe('Search Sessions Management API', () => {
       const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
         notifications: mockCoreStart.notifications,
         application: mockCoreStart.application,
+        featureFlags: mockCoreStart.featureFlags,
       });
       await api.fetchTableData();
 
@@ -174,6 +178,7 @@ describe('Search Sessions Management API', () => {
       const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
         notifications: mockCoreStart.notifications,
         application: mockCoreStart.application,
+        featureFlags: mockCoreStart.featureFlags,
       });
       await api.sendDelete('abc-123-cool-session-ID');
 
@@ -188,6 +193,7 @@ describe('Search Sessions Management API', () => {
       const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
         notifications: mockCoreStart.notifications,
         application: mockCoreStart.application,
+        featureFlags: mockCoreStart.featureFlags,
       });
       await api.sendDelete('abc-123-cool-session-ID');
 
@@ -216,6 +222,7 @@ describe('Search Sessions Management API', () => {
       const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
         notifications: mockCoreStart.notifications,
         application: mockCoreStart.application,
+        featureFlags: mockCoreStart.featureFlags,
       });
       await api.sendExtend('my-id', '5d');
 
@@ -228,6 +235,7 @@ describe('Search Sessions Management API', () => {
       const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
         notifications: mockCoreStart.notifications,
         application: mockCoreStart.application,
+        featureFlags: mockCoreStart.featureFlags,
       });
       await api.sendExtend('my-id', '5d');
 

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/api.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/api.ts
@@ -8,7 +8,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { ApplicationStart, NotificationsStart } from '@kbn/core/public';
+import type { ApplicationStart, FeatureFlagsStart, NotificationsStart } from '@kbn/core/public';
 import moment from 'moment';
 import { from, race, timer } from 'rxjs';
 import { mapTo, tap } from 'rxjs';
@@ -17,11 +17,13 @@ import type { SearchSessionSavedObject } from '../types';
 import type { ISessionsClient } from '../../sessions_client';
 import type { SearchUsageCollector } from '../../../collectors';
 import type { SearchSessionsConfigSchema } from '../../../../../server/config';
+import { BACKGROUND_SEARCH_FEATURE_FLAG_KEY } from '../../constants';
 
 interface SearchSessionManagementDeps {
   notifications: NotificationsStart;
   application: ApplicationStart;
   usageCollector?: SearchUsageCollector;
+  featureFlags: FeatureFlagsStart;
 }
 
 interface FetchReturn {
@@ -51,11 +53,23 @@ export class SearchSessionsMgmtAPI {
     );
     const timeout$ = timer(refreshTimeout.asMilliseconds()).pipe(
       tap(() => {
+        const hasBackgroundSearchEnabled = this.deps.featureFlags.getBooleanValue(
+          BACKGROUND_SEARCH_FEATURE_FLAG_KEY,
+          false
+        );
+
         this.deps.notifications.toasts.addDanger(
-          i18n.translate('data.mgmt.searchSessions.api.fetchTimeout', {
-            defaultMessage: 'Fetching the Search Session info timed out after {timeout} seconds',
-            values: { timeout: refreshTimeout.asSeconds() },
-          })
+          hasBackgroundSearchEnabled
+            ? i18n.translate('data.mgmt.searchSessions.api.backgroundSearchFetchTimeout', {
+                defaultMessage:
+                  'Fetching the Background Search info timed out after {timeout} seconds',
+                values: { timeout: refreshTimeout.asSeconds() },
+              })
+            : i18n.translate('data.mgmt.searchSessions.api.fetchTimeout', {
+                defaultMessage:
+                  'Fetching the Search Session info timed out after {timeout} seconds',
+                values: { timeout: refreshTimeout.asSeconds() },
+              })
         );
       }),
       mapTo(null)
@@ -92,59 +106,98 @@ export class SearchSessionsMgmtAPI {
 
   // Delete and expire
   public async sendDelete(id: string): Promise<void> {
+    const hasBackgroundSearchEnabled = this.deps.featureFlags.getBooleanValue(
+      BACKGROUND_SEARCH_FEATURE_FLAG_KEY,
+      false
+    );
+
     this.deps.usageCollector?.trackSessionDeleted();
     try {
       await this.sessionsClient.delete(id);
 
       this.deps.notifications.toasts.addSuccess({
-        title: i18n.translate('data.mgmt.searchSessions.api.deleted', {
-          defaultMessage: 'The search session was deleted.',
-        }),
+        title: hasBackgroundSearchEnabled
+          ? i18n.translate('data.mgmt.searchSessions.api.backgroundSearchDeleted', {
+              defaultMessage: 'The background search was deleted.',
+            })
+          : i18n.translate('data.mgmt.searchSessions.api.deleted', {
+              defaultMessage: 'The search session was deleted.',
+            }),
       });
     } catch (err) {
       this.deps.notifications.toasts.addError(err, {
-        title: i18n.translate('data.mgmt.searchSessions.api.deletedError', {
-          defaultMessage: 'Failed to delete the search session!',
-        }),
+        title: hasBackgroundSearchEnabled
+          ? i18n.translate('data.mgmt.searchSessions.api.backgroundSearchDeletedError', {
+              defaultMessage: 'Failed to delete the background search!',
+            })
+          : i18n.translate('data.mgmt.searchSessions.api.deletedError', {
+              defaultMessage: 'Failed to delete the search session!',
+            }),
       });
     }
   }
 
   // Extend
   public async sendExtend(id: string, expires: string): Promise<void> {
+    const hasBackgroundSearchEnabled = this.deps.featureFlags.getBooleanValue(
+      BACKGROUND_SEARCH_FEATURE_FLAG_KEY,
+      false
+    );
+
     this.deps.usageCollector?.trackSessionExtended();
     try {
       await this.sessionsClient.extend(id, expires);
 
       this.deps.notifications.toasts.addSuccess({
-        title: i18n.translate('data.mgmt.searchSessions.api.extended', {
-          defaultMessage: 'The search session was extended.',
-        }),
+        title: hasBackgroundSearchEnabled
+          ? i18n.translate('data.mgmt.searchSessions.api.backgroundSearchExtended', {
+              defaultMessage: 'The background search was extended.',
+            })
+          : i18n.translate('data.mgmt.searchSessions.api.extended', {
+              defaultMessage: 'The search session was extended.',
+            }),
       });
     } catch (err) {
       this.deps.notifications.toasts.addError(err, {
-        title: i18n.translate('data.mgmt.searchSessions.api.extendError', {
-          defaultMessage: 'Failed to extend the search session!',
-        }),
+        title: hasBackgroundSearchEnabled
+          ? i18n.translate('data.mgmt.searchSessions.api.backgroundSearchExtendError', {
+              defaultMessage: 'Failed to extend the background search!',
+            })
+          : i18n.translate('data.mgmt.searchSessions.api.extendError', {
+              defaultMessage: 'Failed to extend the search session!',
+            }),
       });
     }
   }
 
   // Change the user-facing name of a search session
   public async sendRename(id: string, newName: string): Promise<void> {
+    const hasBackgroundSearchEnabled = this.deps.featureFlags.getBooleanValue(
+      BACKGROUND_SEARCH_FEATURE_FLAG_KEY,
+      false
+    );
+
     try {
       await this.sessionsClient.rename(id, newName);
 
       this.deps.notifications.toasts.addSuccess({
-        title: i18n.translate('data.mgmt.searchSessions.api.rename', {
-          defaultMessage: 'The search session was renamed',
-        }),
+        title: hasBackgroundSearchEnabled
+          ? i18n.translate('data.mgmt.searchSessions.api.backgroundSearchRename', {
+              defaultMessage: 'The background search was renamed',
+            })
+          : i18n.translate('data.mgmt.searchSessions.api.rename', {
+              defaultMessage: 'The search session was renamed',
+            }),
       });
     } catch (err) {
       this.deps.notifications.toasts.addError(err, {
-        title: i18n.translate('data.mgmt.searchSessions.api.renameError', {
-          defaultMessage: 'Failed to rename the search session',
-        }),
+        title: hasBackgroundSearchEnabled
+          ? i18n.translate('data.mgmt.searchSessions.api.backgroundSearchRenameError', {
+              defaultMessage: 'Failed to rename the background search',
+            })
+          : i18n.translate('data.mgmt.searchSessions.api.renameError', {
+              defaultMessage: 'Failed to rename the search session',
+            }),
       });
     }
   }


### PR DESCRIPTION
## Summary

Renames from "Search session" to "Background search" in the remaining places when the feature flag for it is active.

To enable the feature flag add this to kibana.yml:
```
feature_flags.overrides.search.backgroundSearchEnabled: false
```

There's still the prerequesite of having this too in kibana.yml:
```
data.search.sessions.enabled: true
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



