### PR TITLE
[APM] Fix service_map scout test

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/sevice_map/service_map.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/sevice_map/service_map.spec.ts
@@ -24,7 +24,9 @@ test.describe('Service map', { tag: ['@ess', '@svlOblt'] }, () => {
     expect(page.url()).toContain('/app/apm/service-map');
     await serviceMapPage.waitForServiceMapToLoad();
     await serviceMapPage.zoomInBtn.click();
+    await serviceMapPage.serviceMap.focus();
     await serviceMapPage.centerServiceMapBtn.click();
+    await serviceMapPage.serviceMap.focus();
     await serviceMapPage.waitForServiceMapToLoad();
   });
 
@@ -36,8 +38,11 @@ test.describe('Service map', { tag: ['@ess', '@svlOblt'] }, () => {
     expect(page.url()).toContain('/services/opbeans-java/service-map');
     await serviceMapPage.waitForServiceMapToLoad();
     await serviceMapPage.zoomOutBtn.click();
+    await serviceMapPage.serviceMap.focus();
     await serviceMapPage.centerServiceMapBtn.click();
+    await serviceMapPage.serviceMap.focus();
     await serviceMapPage.zoomInBtn.click();
+    await serviceMapPage.serviceMap.focus();
     await serviceMapPage.waitForServiceMapToLoad();
   });
 


### PR DESCRIPTION
## Summary

The test is failing sometimes, when we click the zoom/center button, the tooltip is kept displayed.

This forces the browser to focus on the main canvas frame after each click, to get a clear view without any tooltips stuck.



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->