### PR TITLE
[Security Solution][Entity Analytics][PrivMon] User limit in indexSync

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/config.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/config.mock.ts
@@ -55,6 +55,7 @@ export const createMockConfig = (): ConfigType => {
       monitoring: {
         privileges: {
           users: {
+            maxPrivilegedUsersAllowed: 10000,
             csvUpload: {
               errorRetries: 3,
               maxBulkRequestBodySizeBytes: 10_485_760,

--- a/x-pack/solutions/security/plugins/security_solution/server/config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/config.ts
@@ -185,6 +185,7 @@ export const configSchema = schema.object({
     monitoring: schema.object({
       privileges: schema.object({
         users: schema.object({
+          maxPrivilegedUsersAllowed: schema.number({ defaultValue: 10000 }),
           csvUpload: schema.object({
             errorRetries: schema.number({ defaultValue: 1 }),
             maxBulkRequestBodySizeBytes: schema.number({ defaultValue: 100_000 }), // 100KB

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/data_sources/data_sources_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/data_sources/data_sources_service.ts
@@ -10,7 +10,10 @@ import type { PrivilegeMonitoringDataClient } from '../engine/data_client';
 import { PRIVILEGED_MONITOR_IMPORT_USERS_INDEX_MAPPING } from '../engine/elasticsearch/mappings';
 import { createIndexSyncService } from './sync/index_sync';
 
-export const createDataSourcesService = (dataClient: PrivilegeMonitoringDataClient) => {
+export const createDataSourcesService = (
+  dataClient: PrivilegeMonitoringDataClient,
+  maxUsersAllowed?: number
+) => {
   const esClient = dataClient.deps.clusterClient.asCurrentUser;
 
   /**
@@ -56,6 +59,6 @@ export const createDataSourcesService = (dataClient: PrivilegeMonitoringDataClie
   return {
     createImportIndex,
     searchPrivilegesIndices,
-    ...createIndexSyncService(dataClient),
+    ...createIndexSyncService(dataClient, maxUsersAllowed),
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/data_sources/sync/index_sync.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/data_sources/sync/index_sync.test.ts
@@ -107,6 +107,363 @@ describe('Privileged User Monitoring: Index Sync Service', () => {
       );
     });
 
+    it('should respect user limits and skip sync but maintain stale user detection', async () => {
+      // Create a service with user limit
+      const indexSyncServiceWithLimit = createIndexSyncService(dataClient, 100);
+
+      // Mock current user count to be at limit
+      esClientMock.count.mockResolvedValue({
+        count: 100,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      });
+
+      const mockMonitoringSOSources = [{ name: 'source1', indexPattern: 'index1', id: 'source-1' }];
+      mockFindByIndex.mockResolvedValue(mockMonitoringSOSources);
+
+      // Mock current users in the monitoring source
+      mockSearchUsernamesInIndex.mockResolvedValue({
+        hits: {
+          hits: [
+            { _source: { user: { name: 'current_user_1' } } },
+            { _source: { user: { name: 'current_user_2' } } },
+          ],
+        },
+      });
+
+      // Mock stale user detection - simulate finding 1 stale user
+      const mockStaleUsers = [
+        { username: 'stale_user_1', existingUserId: 'stale-id-1', sourceId: 'source-1' },
+      ];
+      mockFindStaleUsersForIndex.mockResolvedValue(mockStaleUsers);
+
+      await indexSyncServiceWithLimit.plainIndexSync(mockSavedObjectClient);
+
+      // Should search for current users in the source for stale detection
+      expect(mockSearchUsernamesInIndex).toHaveBeenCalledWith(
+        expect.objectContaining({
+          indexName: 'index1',
+          batchSize: 1000,
+        })
+      );
+
+      // Should perform stale user detection with current users from source
+      expect(mockFindStaleUsersForIndex).toHaveBeenCalledWith('source-1', [
+        'current_user_1',
+        'current_user_2',
+      ]);
+
+      // Should log appropriate messages
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'User limit reached (100/100). Skipping user sync but continuing with maintenance tasks.'
+        )
+      );
+      expect(deps.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Skipping user sync for index1 due to user limit')
+      );
+      expect(deps.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Found 2 current users in source index1, identified 1 stale users')
+      );
+    });
+
+    it('should proceed with sync when under user limit', async () => {
+      // Create a service with user limit
+      const indexSyncServiceWithLimit = createIndexSyncService(dataClient, 100);
+
+      // Mock current user count to be under limit
+      esClientMock.count.mockResolvedValue({
+        count: 50,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      });
+
+      const mockMonitoringSOSources = [{ name: 'source1', indexPattern: 'index1' }];
+      mockFindByIndex.mockResolvedValue(mockMonitoringSOSources);
+      mockFindStaleUsersForIndex.mockResolvedValue([]);
+
+      await indexSyncServiceWithLimit.plainIndexSync(mockSavedObjectClient);
+
+      // Should proceed with sync operations
+      expect(mockSearchUsernamesInIndex).toHaveBeenCalledTimes(1);
+      expect(deps.logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Starting index sync. Current users: 50/100')
+      );
+    });
+
+    it('should proceed normally when no user limit is set', async () => {
+      // Use default service without limit
+      const mockMonitoringSOSources = [{ name: 'source1', indexPattern: 'index1' }];
+      mockFindByIndex.mockResolvedValue(mockMonitoringSOSources);
+      mockFindStaleUsersForIndex.mockResolvedValue([]);
+
+      await indexSyncService.plainIndexSync(mockSavedObjectClient);
+
+      // Should not check user count when no limit is set
+      expect(esClientMock.count).not.toHaveBeenCalled();
+      expect(mockSearchUsernamesInIndex).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle mixed sources: some under limit, some at limit', async () => {
+      // Create a service with user limit
+      const indexSyncServiceWithLimit = createIndexSyncService(dataClient, 100);
+
+      // Mock current user count at limit
+      esClientMock.count.mockResolvedValue({
+        count: 100,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      });
+
+      const mockMonitoringSOSources = [
+        { name: 'source1', indexPattern: 'index1', id: 'source-1' },
+        { name: 'source2', indexPattern: 'index2', id: 'source-2' },
+      ];
+      mockFindByIndex.mockResolvedValue(mockMonitoringSOSources);
+
+      // Mock responses for both sources
+      mockSearchUsernamesInIndex
+        .mockResolvedValueOnce({
+          hits: { hits: [{ _source: { user: { name: 'user1' } } }] },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [{ _source: { user: { name: 'user2' } } }] },
+        });
+
+      mockFindStaleUsersForIndex
+        .mockResolvedValueOnce([
+          { username: 'stale1', existingUserId: 'id1', sourceId: 'source-1' },
+        ])
+        .mockResolvedValueOnce([]);
+
+      await indexSyncServiceWithLimit.plainIndexSync(mockSavedObjectClient);
+
+      // Both sources should be processed for stale detection
+      expect(mockSearchUsernamesInIndex).toHaveBeenCalledTimes(2);
+      expect(mockFindStaleUsersForIndex).toHaveBeenCalledTimes(2);
+      expect(mockFindStaleUsersForIndex).toHaveBeenNthCalledWith(1, 'source-1', ['user1']);
+      expect(mockFindStaleUsersForIndex).toHaveBeenNthCalledWith(2, 'source-2', ['user2']);
+    });
+
+    it('should handle empty monitoring sources when at limit', async () => {
+      const indexSyncServiceWithLimit = createIndexSyncService(dataClient, 100);
+
+      esClientMock.count.mockResolvedValue({
+        count: 100,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      });
+
+      const mockMonitoringSOSources = [
+        { name: 'empty_source', indexPattern: 'empty-index', id: 'empty-source' },
+      ];
+      mockFindByIndex.mockResolvedValue(mockMonitoringSOSources);
+
+      // Mock empty response from monitoring source
+      mockSearchUsernamesInIndex.mockResolvedValue({
+        hits: { hits: [] },
+      });
+
+      // All previously synced users should be detected as stale
+      const mockStaleUsers = [
+        { username: 'old_user_1', existingUserId: 'old-1', sourceId: 'empty-source' },
+        { username: 'old_user_2', existingUserId: 'old-2', sourceId: 'empty-source' },
+      ];
+      mockFindStaleUsersForIndex.mockResolvedValue(mockStaleUsers);
+
+      await indexSyncServiceWithLimit.plainIndexSync(mockSavedObjectClient);
+
+      expect(mockFindStaleUsersForIndex).toHaveBeenCalledWith('empty-source', []);
+      expect(deps.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Found 0 current users in source empty-index, identified 2 stale users'
+        )
+      );
+    });
+
+    it('should handle source with KQL filter when at limit', async () => {
+      const indexSyncServiceWithLimit = createIndexSyncService(dataClient, 100);
+
+      esClientMock.count.mockResolvedValue({
+        count: 100,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      });
+
+      const mockMonitoringSOSources = [
+        {
+          name: 'filtered_source',
+          indexPattern: 'filtered-index',
+          id: 'filtered-source',
+          filter: { kuery: 'event.action: "login"' },
+        },
+      ];
+      mockFindByIndex.mockResolvedValue(mockMonitoringSOSources);
+
+      mockSearchUsernamesInIndex.mockResolvedValue({
+        hits: { hits: [{ _source: { user: { name: 'filtered_user' } } }] },
+      });
+      mockFindStaleUsersForIndex.mockResolvedValue([]);
+
+      await indexSyncServiceWithLimit.plainIndexSync(mockSavedObjectClient);
+
+      // Should call with the KQL filter converted to Elasticsearch query
+      expect(mockSearchUsernamesInIndex).toHaveBeenCalledWith(
+        expect.objectContaining({
+          indexName: 'filtered-index',
+          query: expect.any(Object), // Should be the converted KQL query
+        })
+      );
+    });
+
+    it('should handle index not found errors when at limit', async () => {
+      const indexSyncServiceWithLimit = createIndexSyncService(dataClient, 100);
+
+      esClientMock.count.mockResolvedValue({
+        count: 100,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      });
+
+      const mockMonitoringSOSources = [
+        { name: 'missing_source', indexPattern: 'missing-index', id: 'missing-source' },
+      ];
+      mockFindByIndex.mockResolvedValue(mockMonitoringSOSources);
+
+      // Mock index not found error
+      const indexNotFoundError = {
+        meta: { body: { error: { type: 'index_not_found_exception' } } },
+        message: 'index_not_found_exception',
+      };
+      mockSearchUsernamesInIndex.mockRejectedValue(indexNotFoundError);
+
+      await indexSyncServiceWithLimit.plainIndexSync(mockSavedObjectClient);
+
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Index "missing-index" not found — skipping.')
+      );
+      expect(mockFindStaleUsersForIndex).not.toHaveBeenCalled();
+    });
+
+    it('should perform stale user cleanup when at limit', async () => {
+      const indexSyncServiceWithLimit = createIndexSyncService(dataClient, 100);
+
+      esClientMock.count.mockResolvedValue({
+        count: 100,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      });
+
+      const mockMonitoringSOSources = [{ name: 'source1', indexPattern: 'index1', id: 'source-1' }];
+      mockFindByIndex.mockResolvedValue(mockMonitoringSOSources);
+
+      mockSearchUsernamesInIndex.mockResolvedValue({
+        hits: { hits: [{ _source: { user: { name: 'current_user' } } }] },
+      });
+
+      // Mock stale users found
+      const mockStaleUsers = [
+        { username: 'stale_user_1', existingUserId: 'stale-1', sourceId: 'source-1' },
+        { username: 'stale_user_2', existingUserId: 'stale-2', sourceId: 'source-1' },
+      ];
+      mockFindStaleUsersForIndex.mockResolvedValue(mockStaleUsers);
+
+      // Mock bulk utils service
+      const mockBulkSoftDeleteOperations = jest
+        .fn()
+        .mockReturnValue([
+          { update: { _id: 'stale-1', body: { doc: { 'user.is_privileged': false } } } },
+          { update: { _id: 'stale-2', body: { doc: { 'user.is_privileged': false } } } },
+        ]);
+
+      // Mock successful bulk response
+      esClientMock.bulk.mockResolvedValue({
+        took: 1,
+        errors: false,
+        items: [
+          { update: { _id: 'stale-1', _index: 'test-index', status: 200, result: 'updated' } },
+          { update: { _id: 'stale-2', _index: 'test-index', status: 200, result: 'updated' } },
+        ],
+      });
+
+      // We need to mock the bulk utils service
+      const mockBulkUtilsService = {
+        bulkSoftDeleteOperations: mockBulkSoftDeleteOperations,
+      };
+
+      // Mock the service creation
+      jest.doMock('../bulk', () => ({
+        createBulkUtilsService: () => mockBulkUtilsService,
+      }));
+
+      await indexSyncServiceWithLimit.plainIndexSync(mockSavedObjectClient);
+
+      // Verify stale user cleanup was attempted
+      expect(deps.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Found 2 stale users across all index sources.')
+      );
+    });
+
+    it('should behave differently when under vs at limit', async () => {
+      const mockMonitoringSOSources = [{ name: 'source1', indexPattern: 'index1', id: 'source-1' }];
+
+      // Test 1: Under limit - should perform full sync
+      mockFindByIndex.mockResolvedValue(mockMonitoringSOSources);
+      const indexSyncServiceWithLimit1 = createIndexSyncService(dataClient, 100);
+      esClientMock.count.mockResolvedValueOnce({
+        count: 50,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      });
+
+      mockFindStaleUsersForIndex.mockResolvedValueOnce([]);
+
+      await indexSyncServiceWithLimit1.plainIndexSync(mockSavedObjectClient);
+
+      // When under limit, should log info about starting sync
+      expect(deps.logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Starting index sync. Current users: 50/100')
+      );
+
+      // Should NOT have warning about skipping sync
+      expect(deps.logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('User limit reached')
+      );
+
+      // Reset mocks
+      jest.clearAllMocks();
+      mockFindByIndex.mockResolvedValue(mockMonitoringSOSources);
+
+      // Test 2: At limit - should skip sync but do stale detection
+      const indexSyncServiceWithLimit2 = createIndexSyncService(dataClient, 100);
+      esClientMock.count.mockResolvedValueOnce({
+        count: 100,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      });
+
+      mockSearchUsernamesInIndex.mockResolvedValue({
+        hits: { hits: [{ _source: { user: { name: 'user1' } } }] },
+      });
+      mockFindStaleUsersForIndex.mockResolvedValueOnce([]);
+
+      await indexSyncServiceWithLimit2.plainIndexSync(mockSavedObjectClient);
+
+      // When at limit, should log warning about skipping sync
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'User limit reached (100/100). Skipping user sync but continuing with maintenance tasks.'
+        )
+      );
+
+      // Should perform search for stale detection
+      expect(mockSearchUsernamesInIndex).toHaveBeenCalledWith(
+        expect.objectContaining({
+          indexName: 'index1',
+          batchSize: 1000,
+        })
+      );
+
+      // Should perform stale user detection
+      expect(mockFindStaleUsersForIndex).toHaveBeenCalledWith('source-1', ['user1']);
+
+      // Should log debug about skipping sync but doing stale detection
+      expect(deps.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Skipping user sync for index1 due to user limit')
+      );
+    });
+
     it('logs and returns if no index sources', async () => {
       mockFindByIndex.mockResolvedValue([]);
       await indexSyncService.plainIndexSync(mockSavedObjectClient);

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -294,6 +294,7 @@ export class Plugin implements ISecuritySolutionPlugin {
       telemetry: core.analytics,
       kibanaVersion: pluginContext.env.packageInfo.version,
       experimentalFeatures,
+      config: this.config,
     });
 
     const requestContextFactory = new RequestContextFactory({


### PR DESCRIPTION
## Summary

This PR enhances the Index Sync Service in Kibana's Security Solution to intelligently handle user capacity limits while maintaining soft deletes and updates.

### Flowchart

```
    A[Index Sync Triggered] --> B{User Limit Configured?}
    
    B -->|No| C[Proceed with Normal Sync]
    B -->|Yes| D[Count Current Privileged Users]
    
    D --> E{Current Count >= Limit?}
    
    E -->|No - Under Limit| F[Log: Starting sync X/Y users]
    E -->|Yes - At/Over Limit| G[Log: User limit reached, skipping sync]
    
    F --> H[For Each Monitoring Source]
    G --> I[For Each Monitoring Source]
    
    H --> J[Execute Full Sync]
    I --> K[Skip User Sync]
    
    J --> L[Add/Update Users from Source]
    K --> M[Collect Current Users from Source]
    
    L --> N[Get All Users from Source]
    M --> N
    
    N --> O[Find Stale Users]
    O --> P[Soft Delete Stale Users]
    
    C --> H
```

### Example Output 
Under Limit (Normal Operation)
```
INFO: Starting index sync. Current users: 850/1000
DEBUG: Processing source: security-logs-* (142 users found)
DEBUG: Added 15 new users, updated 127 existing users
DEBUG: Found 3 stale users across all index sources
```

At limit

```
WARN: User limit reached (1000/1000). Skipping user sync but continuing with maintenance tasks.
DEBUG: Skipping user sync for security-logs-* due to user limit, but checking for stale users
DEBUG: Found 142 current users in source security-logs-*, identified 3 stale users (sync skipped due to limit)
DEBUG: Found 3 stale users across all index sources
```



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

