### PR TITLE
[9.0] [Response Ops][Task Manager] Update task status to `idle` after timeout (#223162)

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
@@ -2041,30 +2041,98 @@ describe('TaskManagerRunner', () => {
         expect(onTaskEvent).toHaveBeenCalledTimes(2);
       });
 
-      test('emits TaskEvent when a task run throws an error and has timed out', async () => {
+      test('emits TaskEvent when a recurring task run throws an error due to timeout', async () => {
         jest.setSystemTime(new Date(2023, 1, 1, 0, 0, 0, 0));
         const id = _.random(1, 20).toString();
-        const error = new Error('Dangit!');
+        const error = new Error('Task was cancelled');
         const onTaskEvent = jest.fn();
+        let wasCancelled = false;
         const { runner, instance } = await readyToRunStageSetup({
           onTaskEvent,
           instance: {
             id,
+            schedule: { interval: '1s' },
           },
           definitions: {
             bar: {
               title: 'Bar!',
-              timeout: `1s`,
+              timeout: `15s`,
               createTaskRunner: () => ({
                 async run() {
-                  throw error;
+                  const promise = new Promise((r) => setTimeout(r, 20000));
+                  jest.advanceTimersByTime(20000);
+                  await promise;
+                  if (wasCancelled) {
+                    throw error;
+                  }
+                },
+                async cancel() {
+                  wasCancelled = true;
                 },
               }),
             },
           },
         });
         jest.setSystemTime(new Date(2023, 1, 1, 0, 10, 0, 0));
-        await runner.run();
+        const promise = runner.run();
+        await Promise.resolve();
+        await runner.cancel();
+        await promise;
+
+        expect(onTaskEvent).toHaveBeenCalledWith(
+          withAnyTiming(
+            asTaskRunEvent(
+              id,
+              asErr({
+                error,
+                task: instance,
+                persistence: TaskPersistence.Recurring,
+                result: TaskRunResult.RetryScheduled,
+                isExpired: true,
+              })
+            )
+          )
+        );
+        expect(onTaskEvent).toHaveBeenCalledWith(
+          asTaskManagerStatEvent('runDelay', asOk(expect.any(Number)))
+        );
+        expect(onTaskEvent).toHaveBeenCalledTimes(2);
+      });
+
+      test('testtest emits TaskEvent when an ad-hoc task run throws an error due to timeout', async () => {
+        jest.setSystemTime(new Date(2023, 1, 1, 0, 0, 0, 0));
+        const id = _.random(1, 20).toString();
+        const error = new Error('Task was cancelled');
+        const onTaskEvent = jest.fn();
+        let wasCancelled = false;
+        const { runner, instance } = await readyToRunStageSetup({
+          onTaskEvent,
+          instance: { id },
+          definitions: {
+            bar: {
+              title: 'Bar!',
+              timeout: `15s`,
+              createTaskRunner: () => ({
+                async run() {
+                  const promise = new Promise((r) => setTimeout(r, 20000));
+                  jest.advanceTimersByTime(20000);
+                  await promise;
+                  if (wasCancelled) {
+                    throw error;
+                  }
+                },
+                async cancel() {
+                  wasCancelled = true;
+                },
+              }),
+            },
+          },
+        });
+        jest.setSystemTime(new Date(2023, 1, 1, 0, 10, 0, 0));
+        const promise = runner.run();
+        await Promise.resolve();
+        await runner.cancel();
+        await promise;
 
         expect(onTaskEvent).toHaveBeenCalledWith(
           withAnyTiming(
@@ -2075,6 +2143,101 @@ describe('TaskManagerRunner', () => {
                 task: instance,
                 persistence: TaskPersistence.NonRecurring,
                 result: TaskRunResult.Failed,
+                isExpired: true,
+              })
+            )
+          )
+        );
+        expect(onTaskEvent).toHaveBeenCalledWith(
+          asTaskManagerStatEvent('runDelay', asOk(expect.any(Number)))
+        );
+        expect(onTaskEvent).toHaveBeenCalledTimes(2);
+      });
+
+      test('emits TaskEvent when a recurring task run times out without throwing error', async () => {
+        jest.setSystemTime(new Date(2023, 1, 1, 0, 0, 0, 0));
+        const id = _.random(1, 20).toString();
+        const onTaskEvent = jest.fn();
+        const { runner, instance } = await readyToRunStageSetup({
+          onTaskEvent,
+          instance: {
+            id,
+            schedule: { interval: '1s' },
+          },
+          definitions: {
+            bar: {
+              title: 'Bar!',
+              timeout: `15s`,
+              createTaskRunner: () => ({
+                async run() {
+                  const promise = new Promise((r) => setTimeout(r, 20000));
+                  jest.advanceTimersByTime(20000);
+                  await promise;
+                },
+              }),
+            },
+          },
+        });
+        jest.setSystemTime(new Date(2023, 1, 1, 0, 10, 0, 0));
+        const promise = runner.run();
+        await Promise.resolve();
+        await runner.cancel();
+        await promise;
+
+        expect(onTaskEvent).toHaveBeenCalledWith(
+          withAnyTiming(
+            asTaskRunEvent(
+              id,
+              asOk({
+                persistence: TaskPersistence.Recurring,
+                task: instance,
+                result: TaskRunResult.Success,
+                isExpired: true,
+              })
+            )
+          )
+        );
+        expect(onTaskEvent).toHaveBeenCalledWith(
+          asTaskManagerStatEvent('runDelay', asOk(expect.any(Number)))
+        );
+        expect(onTaskEvent).toHaveBeenCalledTimes(2);
+      });
+
+      test('emits TaskEvent when an ad-hoc task run times out without throwing error', async () => {
+        jest.setSystemTime(new Date(2023, 1, 1, 0, 0, 0, 0));
+        const id = _.random(1, 20).toString();
+        const onTaskEvent = jest.fn();
+        const { runner, instance } = await readyToRunStageSetup({
+          onTaskEvent,
+          instance: { id },
+          definitions: {
+            bar: {
+              title: 'Bar!',
+              timeout: `15s`,
+              createTaskRunner: () => ({
+                async run() {
+                  const promise = new Promise((r) => setTimeout(r, 20000));
+                  jest.advanceTimersByTime(20000);
+                  await promise;
+                },
+              }),
+            },
+          },
+        });
+        jest.setSystemTime(new Date(2023, 1, 1, 0, 10, 0, 0));
+        const promise = runner.run();
+        await Promise.resolve();
+        await runner.cancel();
+        await promise;
+
+        expect(onTaskEvent).toHaveBeenCalledWith(
+          withAnyTiming(
+            asTaskRunEvent(
+              id,
+              asOk({
+                persistence: TaskPersistence.NonRecurring,
+                task: instance,
+                result: TaskRunResult.Success,
                 isExpired: true,
               })
             )
@@ -2279,30 +2442,35 @@ describe('TaskManagerRunner', () => {
       });
     });
 
-    test('does not update saved object if task expires', async () => {
+    test('does not update saved object if recurring task expires without throwing error and timeout is greater than schedule', async () => {
       const id = _.random(1, 20).toString();
       const onTaskEvent = jest.fn();
-      const error = new Error('Dangit!');
-      const { runner, store, usageCounter, logger } = await readyToRunStageSetup({
+      const { runner, store, usageCounter } = await readyToRunStageSetup({
         onTaskEvent,
         instance: {
           id,
           startedAt: moment().subtract(5, 'm').toDate(),
+          schedule: { interval: '1s' },
         },
         definitions: {
           bar: {
             title: 'Bar!',
-            timeout: '1m',
+            timeout: '15s',
             createTaskRunner: () => ({
               async run() {
-                return { error, state: {}, runAt: moment().add(1, 'm').toDate() };
+                const promise = new Promise((r) => setTimeout(r, 20000));
+                jest.advanceTimersByTime(20000);
+                await promise;
               },
             }),
           },
         },
       });
 
-      await runner.run();
+      const promise = runner.run();
+      await Promise.resolve();
+      await runner.cancel();
+      await promise;
 
       expect(store.partialUpdate).not.toHaveBeenCalled();
       expect(usageCounter.incrementCounter).toHaveBeenCalledWith({
@@ -2310,9 +2478,174 @@ describe('TaskManagerRunner', () => {
         counterType: 'taskManagerTaskRunner',
         incrementBy: 1,
       });
-      expect(logger.warn).toHaveBeenCalledWith(
-        `Skipping reschedule for task bar \"${id}\" due to the task expiring`
+    });
+
+    test('does not update saved object if recurring task throws error due to expiration and timeout is greater than schedule', async () => {
+      const id = _.random(1, 20).toString();
+      const onTaskEvent = jest.fn();
+      let wasCancelled = false;
+      const { runner, store, usageCounter } = await readyToRunStageSetup({
+        onTaskEvent,
+        instance: {
+          id,
+          startedAt: moment().subtract(5, 'm').toDate(),
+          schedule: { interval: '1s' },
+        },
+        definitions: {
+          bar: {
+            title: 'Bar!',
+            timeout: '15s',
+            createTaskRunner: () => ({
+              async run() {
+                const promise = new Promise((r) => setTimeout(r, 20000));
+                jest.advanceTimersByTime(20000);
+                await promise;
+                if (wasCancelled) {
+                  throw new Error('Task was cancelled');
+                }
+              },
+              async cancel() {
+                wasCancelled = true;
+              },
+            }),
+          },
+        },
+      });
+
+      const promise = runner.run();
+      await Promise.resolve();
+      await runner.cancel();
+      await promise;
+
+      expect(store.partialUpdate).not.toHaveBeenCalled();
+      expect(usageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: 'taskManagerUpdateSkippedDueToTaskExpiration',
+        counterType: 'taskManagerTaskRunner',
+        incrementBy: 1,
+      });
+    });
+
+    test('updates saved object if recurring task expires without throwing error and schedule is greater than timeout', async () => {
+      const id = _.random(1, 20).toString();
+      const onTaskEvent = jest.fn();
+      const {
+        instance: taskInstance,
+        runner,
+        store,
+        usageCounter,
+      } = await readyToRunStageSetup({
+        onTaskEvent,
+        instance: {
+          id,
+          startedAt: moment().subtract(5, 'm').toDate(),
+          schedule: { interval: '30s' },
+        },
+        definitions: {
+          bar: {
+            title: 'Bar!',
+            timeout: '15s',
+            createTaskRunner: () => ({
+              async run() {
+                const promise = new Promise((r) => setTimeout(r, 20000));
+                jest.advanceTimersByTime(20000);
+                await promise;
+              },
+            }),
+          },
+        },
+      });
+
+      const promise = runner.run();
+      await Promise.resolve();
+      await runner.cancel();
+      await promise;
+
+      expect(store.partialUpdate).toHaveBeenCalledTimes(1);
+      expect(store.partialUpdate).toHaveBeenCalledWith(
+        {
+          id: expect.any(String),
+          ownerId: null,
+          retryAt: null,
+          runAt: expect.any(Date),
+          startedAt: null,
+          status: 'idle',
+          version: undefined,
+        },
+        {
+          validate: true,
+          doc: taskInstance,
+        }
       );
+      expect(usageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: 'taskManagerUpdateSkippedDueToTaskExpiration',
+        counterType: 'taskManagerTaskRunner',
+        incrementBy: 1,
+      });
+    });
+
+    test('updates saved object if recurring task throws error due to expiration and schedule is greater than timeout', async () => {
+      const id = _.random(1, 20).toString();
+      const onTaskEvent = jest.fn();
+      let wasCancelled = false;
+      const {
+        instance: taskInstance,
+        runner,
+        store,
+        usageCounter,
+      } = await readyToRunStageSetup({
+        onTaskEvent,
+        instance: {
+          id,
+          startedAt: moment().subtract(5, 'm').toDate(),
+          schedule: { interval: '30s' },
+        },
+        definitions: {
+          bar: {
+            title: 'Bar!',
+            timeout: '15s',
+            createTaskRunner: () => ({
+              async run() {
+                const promise = new Promise((r) => setTimeout(r, 20000));
+                jest.advanceTimersByTime(20000);
+                await promise;
+                if (wasCancelled) {
+                  throw new Error('Task was cancelled');
+                }
+              },
+              async cancel() {
+                wasCancelled = true;
+              },
+            }),
+          },
+        },
+      });
+
+      const promise = runner.run();
+      await Promise.resolve();
+      await runner.cancel();
+      await promise;
+
+      expect(store.partialUpdate).toHaveBeenCalledTimes(1);
+      expect(store.partialUpdate).toHaveBeenCalledWith(
+        {
+          id: expect.any(String),
+          ownerId: null,
+          retryAt: null,
+          runAt: expect.any(Date),
+          startedAt: null,
+          status: 'idle',
+          version: undefined,
+        },
+        {
+          validate: true,
+          doc: taskInstance,
+        }
+      );
+      expect(usageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: 'taskManagerUpdateSkippedDueToTaskExpiration',
+        counterType: 'taskManagerTaskRunner',
+        incrementBy: 1,
+      });
     });
 
     test('Prints debug logs on task start/end', async () => {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -40,7 +40,7 @@ import {
   TaskTiming,
   TaskManagerStat,
 } from '../task_events';
-import { intervalFromDate } from '../lib/intervals';
+import { intervalFromDate, parseIntervalAsMillisecond } from '../lib/intervals';
 import { createWrappedLogger } from '../lib/wrapped_logger';
 import {
   CancelFunction,
@@ -49,6 +49,7 @@ import {
   FailedRunResult,
   FailedTaskResult,
   isFailedRunResult,
+  IntervalSchedule,
   PartialConcreteTaskInstance,
   SuccessfulRunResult,
   TaskDefinition,
@@ -594,6 +595,18 @@ export class TaskManagerRunner implements TaskRunner {
     return this.instance.task.attempts < this.getMaxAttempts();
   }
 
+  private shouldUpdateExpiredTask(): boolean {
+    if (!this.instance.task.schedule || !this.instance.task.schedule.interval) {
+      // if the task does not have a schedule interval, we will not update it on timeout
+      return false;
+    }
+
+    const timeoutDuration = parseIntervalAsMillisecond(this.timeout);
+    const scheduleDuration = parseIntervalAsMillisecond(this.instance.task.schedule.interval);
+
+    return scheduleDuration > timeoutDuration;
+  }
+
   private rescheduleFailedRun = (
     failureResult: FailedRunResult
   ): Result<SuccessfulRunResult, FailedTaskResult> => {
@@ -603,19 +616,20 @@ export class TaskManagerRunner implements TaskRunner {
     if (this.shouldTryToScheduleRetry() && !isUnrecoverableError(error)) {
       // if we're retrying, keep the number of attempts
 
-      const reschedule = failureResult.runAt
-        ? { runAt: failureResult.runAt }
-        : failureResult.schedule
-        ? { schedule: failureResult.schedule }
-        : schedule
-        ? { schedule }
-        : // when result.error is truthy, then we're retrying because it failed
-          {
-            runAt: getRetryDate({
-              attempts,
-              error,
-            }),
-          };
+      let reschedule:
+        | { runAt?: Date; schedule?: never }
+        | { schedule?: IntervalSchedule; runAt?: never } = {};
+
+      if (failureResult.runAt) {
+        reschedule = { runAt: failureResult.runAt };
+      } else if (failureResult.schedule) {
+        reschedule = { schedule: failureResult.schedule };
+      } else if (schedule) {
+        reschedule = { schedule };
+      } else {
+        // when result.error is truthy, then we're retrying because it failed
+        reschedule = { runAt: getRetryDate({ attempts, error }) };
+      }
 
       if (reschedule.runAt || reschedule.schedule) {
         return asOk({
@@ -673,13 +687,7 @@ export class TaskManagerRunner implements TaskRunner {
       unwrap
     )(result);
 
-    if (this.isExpired) {
-      this.usageCounter?.incrementCounter({
-        counterName: `taskManagerUpdateSkippedDueToTaskExpiration`,
-        counterType: 'taskManagerTaskRunner',
-        incrementBy: 1,
-      });
-    } else if (
+    if (
       fieldUpdates.status === TaskStatus.Failed ||
       fieldUpdates.status === TaskStatus.ShouldDelete
     ) {
@@ -689,22 +697,54 @@ export class TaskManagerRunner implements TaskRunner {
     } else {
       const { shouldValidate = true } = unwrap(result);
 
-      const partialTask = {
-        ...fieldUpdates,
-        // reset fields that track the lifecycle of the concluded `task run`
-        startedAt: null,
-        retryAt: null,
-        ownerId: null,
+      let shouldUpdateTask: boolean = false;
+      let partialTask: PartialConcreteTaskInstance = {
         id: this.instance.task.id,
         version: this.instance.task.version,
       };
 
-      this.instance = asRan(
-        await this.bufferedTaskStore.partialUpdate(partialTask, {
-          validate: shouldValidate,
-          doc: this.instance.task,
-        })
-      );
+      if (this.isExpired) {
+        this.usageCounter?.incrementCounter({
+          counterName: `taskManagerUpdateSkippedDueToTaskExpiration`,
+          counterType: 'taskManagerTaskRunner',
+          incrementBy: 1,
+        });
+
+        if (this.shouldUpdateExpiredTask()) {
+          shouldUpdateTask = true;
+
+          partialTask = {
+            ...partialTask,
+            // excluding updated task state from the update
+            // because the execution ended in failure due to timeout, we do not update the state
+            status: TaskStatus.Idle,
+            runAt: fieldUpdates.runAt,
+            // reset fields that track the lifecycle of the concluded `task run`
+            startedAt: null,
+            retryAt: null,
+            ownerId: null,
+          };
+        }
+      } else {
+        shouldUpdateTask = true;
+        partialTask = {
+          ...partialTask,
+          ...fieldUpdates,
+          // reset fields that track the lifecycle of the concluded `task run`
+          startedAt: null,
+          retryAt: null,
+          ownerId: null,
+        };
+      }
+
+      if (shouldUpdateTask) {
+        this.instance = asRan(
+          await this.bufferedTaskStore.partialUpdate(partialTask, {
+            validate: shouldValidate,
+            doc: this.instance.task,
+          })
+        );
+      }
     }
 
     return fieldUpdates.status === TaskStatus.Failed
@@ -803,7 +843,7 @@ export class TaskManagerRunner implements TaskRunner {
               task,
               persistence: task.schedule ? TaskPersistence.Recurring : TaskPersistence.NonRecurring,
               result: await this.processResultForRecurringTask(result),
-              isExpired: this.isExpired,
+              isExpired: taskHasExpired,
               error,
             }),
             taskTiming

--- a/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
+++ b/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
@@ -160,7 +160,7 @@ export class SampleTaskManagerFixturePlugin
         timeout: '1s',
         createTaskRunner: () => ({
           async run() {
-            return await new Promise((resolve) => {});
+            return await new Promise((resolve) => setTimeout(resolve, 3000)); // 3 seconds
           },
         }),
       },

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/task_management.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/task_management.ts
@@ -905,56 +905,29 @@ export default function ({ getService }: FtrProviderContext) {
         expect(task.runAt).to.eql(scheduledRunAt);
       });
     });
+
+    it('should set status of recurring task back to idle when schedule interval is greater than timeout', async () => {
+      const task = await scheduleTask({
+        taskType: 'sampleRecurringTaskTimingOut',
+        schedule: { interval: '1d' },
+        params: {},
+      });
+
+      await retry.try(async () => {
+        const [scheduledTask] = (await currentTasks()).docs;
+        expect(scheduledTask.id).to.eql(task.id);
+        expect(scheduledTask.status).to.be('running');
+        expect(scheduledTask.startedAt).not.to.be(null);
+        expect(scheduledTask.retryAt).not.to.be(null);
+      });
+
+      await retry.try(async () => {
+        const [scheduledTask] = (await currentTasks()).docs;
+        expect(scheduledTask.id).to.eql(task.id);
+        expect(scheduledTask.status).to.be('idle');
+        expect(scheduledTask.startedAt).to.be(null);
+        expect(scheduledTask.retryAt).to.be(null);
+      });
+    });
   });
-
-  // TODO: Add this back in with https://github.com/elastic/kibana/issues/106139
-  // function ensureOverlappingTasksDontExceedThreshold(
-  //   executions: Array<{
-  //     result: {
-  //       id: string;
-  //       state: {
-  //         timings: Array<{
-  //           start: number;
-  //           stop: number;
-  //         }>;
-  //       };
-  //     };
-  //   }>,
-  //   threshold: number
-  // ) {
-  //   const executionRanges = executions.map((execution) => ({
-  //     id: execution.result.id,
-  //     range: range(
-  //       // calculate range of milliseconds
-  //       // in which the task was running (that should be good enough)
-  //       execution.result.state.timings[0].start,
-  //       execution.result.state.timings[0].stop
-  //     ),
-  //   }));
-
-  //   const intersections = new Map<string, string[]>();
-  //   for (const currentExecution of executionRanges) {
-  //     for (const executionToComparteTo of executionRanges) {
-  //       if (currentExecution.id !== executionToComparteTo.id) {
-  //         // find all executions that intersect
-  //         if (intersection(currentExecution.range, executionToComparteTo.range).length) {
-  //           intersections.set(currentExecution.id, [
-  //             ...(intersections.get(currentExecution.id) ?? []),
-  //             executionToComparteTo.id,
-  //           ]);
-  //         }
-  //       }
-  //     }
-  //   }
-
-  //   const tooManyIntersectingTasks = [...intersections.entries()].find(
-  //     // make sure each task intersects with, at most, threshold of other task
-  //     ([, intersectingTasks]) => intersectingTasks.length > threshold
-  //   );
-  //   if (tooManyIntersectingTasks) {
-  //     throw new Error(
-  //       `Invalid execution found: ${tooManyIntersectingTasks[0]} overlaps with ${tooManyIntersectingTasks[1]}`
-  //     );
-  //   }
-  // }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Response Ops][Task Manager] Update task status to `idle` after timeout (#223162)](https://github.com/elastic/kibana/pull/223162)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-07-30T15:12:16Z","message":"[Response Ops][Task Manager] Update task status to `idle` after timeout (#223162)\n\nResolves https://github.com/elastic/kibana/issues/218237\n\n## Summary\n\nWhen a recurring task runs, we set the status to `running` calculate the\n`retryAt` as:\n* `retryAt = now + schedule interval` if schedule interval > task\ntimeout\n* `retryAt = now + timeout` if task timeout > schedule interval\n\nIf the execution gets cancelled due to timeout, we currently do not\nperform any updates to the task document. This works fine if the task\ntimeout > schedule interval because the moment the task times out, it\nwill be claimed for the next scheduled execution so we don't want any\nupdates from the outdated task.\n\nFor example, if we have a rule running every `2m` with a `5m` timeout\nthat actually takes 6 minutes to run\n00:00: Run 1 starts, retryAt set to 00:05, status = `running`\n00:05: Run 1 cancelled, Run 2 claimed and starts because the `retryAt`\nhas passed\n00:06: Run 1 actually finishes, we discard any task updates from Run 1\nbecause if Run 2 has finished in the meantime, we don't want to\noverwrite the task with stale data.\n\nHowever, if the schedule interval > task timeout, we run into this\nsituation\n\nIf we have a rule running every `6h` with a `5m` timeout:\n\n00:00: Run 1 starts, retryAt set to 06:00, status = `running`\n00:05: Run 1 cancelled, status stays `running`\n00:05 - 06:00: Status stays as `running`, cannot call `runSoon` on the\nrule because it seems to already be running\n06:00 - Run 2 starts\n\nThis PR updates the task runner to update the task after a run if\nexecution times out so the status is reset to `idle` only if the\nschedule interval > task timeout. It will calculate the next `runAt`\ndate and set that so the expected cadence is maintained. With this\nchange, for the above example, the following would occur:\n\n00:00: Run 1 starts, retryAt set to 06:00, status = `running`\n00:05: Run 1 cancelled, status set to `idle`, runAt set to 06:00\n00:05 - 06:00: Status is `idle` so rule can be manually triggered using\n`runSoon` if desired\n06:00 - Run 2 starts\n\n\n## To Verify\n\n1. Add an await to a rule type executor so it will timeout (default\ntimeout is `5m` but you can set it shorter in your config)\n\n```\n--- a/x-pack/examples/alerting_example/server/rule_types/always_firing.ts\n+++ b/x-pack/examples/alerting_example/server/rule_types/always_firing.ts\n@@ -91,6 +91,8 @@ export const ruleType: RuleType<\n         });\n       });\n+    await new Promise((resolve) => setTimeout(resolve, 360000)); // 6 minutes\n+\n     return {\n       state: {\n```\n2. Create a rule with a schedule interval greater than the timeout, like\n`1d`\n3. When the rule run times out and then finishes running, check the task\ndocument. The status should be set to `idle` and the `runAt` date should\nbe the next schedule interval.\n4. Should be able to manually run the rule by selecting `Run soon` from\nthe UI without getting a \"rule is already running\" response\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0f0767be60938966c01c7c58c2ad7aa9bb687f96","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Task Manager","backport:skip","Team:ResponseOps","v9.2.0"],"title":"[Response Ops][Task Manager] Update task status to `idle` after timeout","number":223162,"url":"https://github.com/elastic/kibana/pull/223162","mergeCommit":{"message":"[Response Ops][Task Manager] Update task status to `idle` after timeout (#223162)\n\nResolves https://github.com/elastic/kibana/issues/218237\n\n## Summary\n\nWhen a recurring task runs, we set the status to `running` calculate the\n`retryAt` as:\n* `retryAt = now + schedule interval` if schedule interval > task\ntimeout\n* `retryAt = now + timeout` if task timeout > schedule interval\n\nIf the execution gets cancelled due to timeout, we currently do not\nperform any updates to the task document. This works fine if the task\ntimeout > schedule interval because the moment the task times out, it\nwill be claimed for the next scheduled execution so we don't want any\nupdates from the outdated task.\n\nFor example, if we have a rule running every `2m` with a `5m` timeout\nthat actually takes 6 minutes to run\n00:00: Run 1 starts, retryAt set to 00:05, status = `running`\n00:05: Run 1 cancelled, Run 2 claimed and starts because the `retryAt`\nhas passed\n00:06: Run 1 actually finishes, we discard any task updates from Run 1\nbecause if Run 2 has finished in the meantime, we don't want to\noverwrite the task with stale data.\n\nHowever, if the schedule interval > task timeout, we run into this\nsituation\n\nIf we have a rule running every `6h` with a `5m` timeout:\n\n00:00: Run 1 starts, retryAt set to 06:00, status = `running`\n00:05: Run 1 cancelled, status stays `running`\n00:05 - 06:00: Status stays as `running`, cannot call `runSoon` on the\nrule because it seems to already be running\n06:00 - Run 2 starts\n\nThis PR updates the task runner to update the task after a run if\nexecution times out so the status is reset to `idle` only if the\nschedule interval > task timeout. It will calculate the next `runAt`\ndate and set that so the expected cadence is maintained. With this\nchange, for the above example, the following would occur:\n\n00:00: Run 1 starts, retryAt set to 06:00, status = `running`\n00:05: Run 1 cancelled, status set to `idle`, runAt set to 06:00\n00:05 - 06:00: Status is `idle` so rule can be manually triggered using\n`runSoon` if desired\n06:00 - Run 2 starts\n\n\n## To Verify\n\n1. Add an await to a rule type executor so it will timeout (default\ntimeout is `5m` but you can set it shorter in your config)\n\n```\n--- a/x-pack/examples/alerting_example/server/rule_types/always_firing.ts\n+++ b/x-pack/examples/alerting_example/server/rule_types/always_firing.ts\n@@ -91,6 +91,8 @@ export const ruleType: RuleType<\n         });\n       });\n+    await new Promise((resolve) => setTimeout(resolve, 360000)); // 6 minutes\n+\n     return {\n       state: {\n```\n2. Create a rule with a schedule interval greater than the timeout, like\n`1d`\n3. When the rule run times out and then finishes running, check the task\ndocument. The status should be set to `idle` and the `runAt` date should\nbe the next schedule interval.\n4. Should be able to manually run the rule by selecting `Run soon` from\nthe UI without getting a \"rule is already running\" response\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0f0767be60938966c01c7c58c2ad7aa9bb687f96"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223162","number":223162,"mergeCommit":{"message":"[Response Ops][Task Manager] Update task status to `idle` after timeout (#223162)\n\nResolves https://github.com/elastic/kibana/issues/218237\n\n## Summary\n\nWhen a recurring task runs, we set the status to `running` calculate the\n`retryAt` as:\n* `retryAt = now + schedule interval` if schedule interval > task\ntimeout\n* `retryAt = now + timeout` if task timeout > schedule interval\n\nIf the execution gets cancelled due to timeout, we currently do not\nperform any updates to the task document. This works fine if the task\ntimeout > schedule interval because the moment the task times out, it\nwill be claimed for the next scheduled execution so we don't want any\nupdates from the outdated task.\n\nFor example, if we have a rule running every `2m` with a `5m` timeout\nthat actually takes 6 minutes to run\n00:00: Run 1 starts, retryAt set to 00:05, status = `running`\n00:05: Run 1 cancelled, Run 2 claimed and starts because the `retryAt`\nhas passed\n00:06: Run 1 actually finishes, we discard any task updates from Run 1\nbecause if Run 2 has finished in the meantime, we don't want to\noverwrite the task with stale data.\n\nHowever, if the schedule interval > task timeout, we run into this\nsituation\n\nIf we have a rule running every `6h` with a `5m` timeout:\n\n00:00: Run 1 starts, retryAt set to 06:00, status = `running`\n00:05: Run 1 cancelled, status stays `running`\n00:05 - 06:00: Status stays as `running`, cannot call `runSoon` on the\nrule because it seems to already be running\n06:00 - Run 2 starts\n\nThis PR updates the task runner to update the task after a run if\nexecution times out so the status is reset to `idle` only if the\nschedule interval > task timeout. It will calculate the next `runAt`\ndate and set that so the expected cadence is maintained. With this\nchange, for the above example, the following would occur:\n\n00:00: Run 1 starts, retryAt set to 06:00, status = `running`\n00:05: Run 1 cancelled, status set to `idle`, runAt set to 06:00\n00:05 - 06:00: Status is `idle` so rule can be manually triggered using\n`runSoon` if desired\n06:00 - Run 2 starts\n\n\n## To Verify\n\n1. Add an await to a rule type executor so it will timeout (default\ntimeout is `5m` but you can set it shorter in your config)\n\n```\n--- a/x-pack/examples/alerting_example/server/rule_types/always_firing.ts\n+++ b/x-pack/examples/alerting_example/server/rule_types/always_firing.ts\n@@ -91,6 +91,8 @@ export const ruleType: RuleType<\n         });\n       });\n+    await new Promise((resolve) => setTimeout(resolve, 360000)); // 6 minutes\n+\n     return {\n       state: {\n```\n2. Create a rule with a schedule interval greater than the timeout, like\n`1d`\n3. When the rule run times out and then finishes running, check the task\ndocument. The status should be set to `idle` and the `runAt` date should\nbe the next schedule interval.\n4. Should be able to manually run the rule by selecting `Run soon` from\nthe UI without getting a \"rule is already running\" response\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0f0767be60938966c01c7c58c2ad7aa9bb687f96"}}]}] BACKPORT-->