### PR TITLE
remove redundant apm service subheader

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
@@ -102,7 +102,6 @@ function createNavTree({ streamsAvailable }: { streamsAvailable?: boolean }) {
             children: [
               {
                 id: 'apm',
-                link: 'apm:services',
                 children: [
                   {
                     link: 'apm:service-map',

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -111,7 +111,6 @@ export const createNavigationTree = ({
             children: [
               {
                 id: 'apm',
-                link: 'apm:services',
                 children: [
                   {
                     link: 'apm:services',


### PR DESCRIPTION
## Summary

Followup to #227833 to remove redundant subheader for apm nav links

| CURRENT | OLD/PROPOSED |
| ------------- | ------------- |
| <img width="540" height="706" alt="image" src="https://github.com/user-attachments/assets/aae953cc-e885-4805-a64c-07b938374913" />  | <img width="497" height="515" alt="Screenshot 2025-08-19 at 11 08 31 AM" src="https://github.com/user-attachments/assets/7f99aac1-a9c2-448e-bc0e-2bb609cabf00" /> |



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->