### PR TITLE
[onechat] fix empty tool results throwing errors

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/messages.test.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/messages.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ToolMessage } from '@langchain/core/messages';
+
+import { extractToolReturn } from './messages';
+
+const createMessage = (artifact: unknown): ToolMessage => {
+  return {
+    artifact,
+  } as ToolMessage;
+};
+
+describe('extractToolReturn', () => {
+  it('should return the artifact as RunToolReturn when it contains valid results', () => {
+    const message = createMessage({
+      results: [{ key: 'value' }],
+    });
+
+    const result = extractToolReturn(message);
+    expect(result).toEqual(message.artifact);
+  });
+
+  it('should throw an error if the message does not contain an artifact', () => {
+    const mockMessage = createMessage(undefined);
+
+    expect(() => extractToolReturn(mockMessage)).toThrowError(
+      'No artifact attached to tool message'
+    );
+  });
+
+  it('should throw an error if the artifact does not have an array of results', () => {
+    const mockMessage = createMessage({
+      results: 'not-an-array',
+    });
+
+    expect(() => extractToolReturn(mockMessage)).toThrowError(
+      'Artifact is not a structured tool artifact. Received artifact={"results":"not-an-array"}'
+    );
+  });
+
+  it('should handle an empty results array correctly', () => {
+    const mockMessage = createMessage({
+      results: [],
+    });
+
+    const result = extractToolReturn(mockMessage);
+    expect(result).toEqual(mockMessage.artifact);
+  });
+});

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/messages.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/messages.ts
@@ -8,7 +8,7 @@
 import type { BaseMessage, ToolMessage, MessageContentComplex } from '@langchain/core/messages';
 import { isAIMessage } from '@langchain/core/messages';
 import type { RunToolReturn } from '@kbn/onechat-server';
-import { isArray, isEmpty } from 'lodash';
+import { isArray } from 'lodash';
 
 /**
  * Extract the text content from a langchain message or chunk.
@@ -63,7 +63,7 @@ export const extractToolReturn = (message: ToolMessage): RunToolReturn => {
   if (!message.artifact) {
     throw new Error('No artifact attached to tool message');
   }
-  if (!isArray(message.artifact.results) || isEmpty(message.artifact.results)) {
+  if (!isArray(message.artifact.results)) {
     throw new Error(
       `Artifact is not a structured tool artifact. Received artifact=${JSON.stringify(
         message.artifact


### PR DESCRIPTION
## Summary

Fix unwanted behavior of empty tool results throwing an error during artifact extraction
