### PR TITLE
[9.1] Fix honoring deployment mode restrictions (#231679)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.test.ts
@@ -388,10 +388,7 @@ describe('agentless_policy_helper', () => {
               enabled: true,
             },
           },
-          inputs: [
-            { type: 'logs' },
-            { type: 'metrics' },
-          ],
+          inputs: [{ type: 'logs' }, { type: 'metrics' }],
         },
         {
           name: 'template2',
@@ -402,10 +399,7 @@ describe('agentless_policy_helper', () => {
               enabled: true,
             },
           },
-          inputs: [
-            { type: 'logs' },
-            { type: 'tcp' },
-          ],
+          inputs: [{ type: 'logs' }, { type: 'tcp' }],
         },
       ] as RegistryPolicyTemplate[],
     } as any;
@@ -602,10 +596,7 @@ describe('agentless_policy_helper', () => {
               enabled: true,
             },
           },
-          inputs: [
-            { type: 'logs' },
-            { type: 'metrics' },
-          ],
+          inputs: [{ type: 'logs' }, { type: 'metrics' }],
         },
       ] as RegistryPolicyTemplate[],
     } as any;

--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.test.ts
@@ -12,6 +12,8 @@ import {
   getAgentlessAgentPolicyNameFromPackagePolicyName,
   isOnlyAgentlessIntegration,
   isOnlyAgentlessPolicyTemplate,
+  isInputAllowedForDeploymentMode,
+  validateDeploymentModesForInputs,
 } from './agentless_policy_helper';
 
 describe('agentless_policy_helper', () => {
@@ -103,6 +105,58 @@ describe('agentless_policy_helper', () => {
       const result = isAgentlessIntegration(packageInfo);
 
       expect(result).toBe(false);
+    });
+
+    it('should return true if the specified integration supports agentless', () => {
+      const packageInfo = {
+        policy_templates: [
+          {
+            name: 'template1',
+            deployment_modes: {
+              agentless: { enabled: true },
+              default: { enabled: false },
+            },
+          },
+          {
+            name: 'template2',
+            deployment_modes: {
+              agentless: { enabled: false },
+              default: { enabled: true },
+            },
+          },
+        ] as RegistryPolicyTemplate[],
+      };
+
+      expect(isAgentlessIntegration(packageInfo, 'template1')).toBe(true);
+      expect(isAgentlessIntegration(packageInfo, 'template2')).toBe(false);
+    });
+
+    it('should return false if the specified integration does not exist', () => {
+      const packageInfo = {
+        policy_templates: [
+          {
+            name: 'template1',
+            deployment_modes: {
+              agentless: { enabled: true },
+              default: { enabled: false },
+            },
+          },
+        ] as RegistryPolicyTemplate[],
+      };
+
+      expect(isAgentlessIntegration(packageInfo, 'nonexistent')).toBe(false);
+    });
+
+    it('should return false if the specified integration exists but has no deployment_modes', () => {
+      const packageInfo = {
+        policy_templates: [
+          {
+            name: 'template1',
+          },
+        ] as RegistryPolicyTemplate[],
+      };
+
+      expect(isAgentlessIntegration(packageInfo, 'template1')).toBe(false);
     });
   });
 
@@ -316,6 +370,271 @@ describe('agentless_policy_helper', () => {
       const result = isOnlyAgentlessPolicyTemplate(policyTemplate);
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('isInputAllowedForDeploymentMode', () => {
+    const packageInfoWithDeploymentModes = {
+      name: 'test-package',
+      version: '1.0.0',
+      owner: { github: 'elastic' },
+      policy_templates: [
+        {
+          name: 'template1',
+          title: 'Template 1',
+          description: '',
+          deployment_modes: {
+            agentless: {
+              enabled: true,
+            },
+          },
+          inputs: [
+            { type: 'logs' },
+            { type: 'metrics' },
+          ],
+        },
+        {
+          name: 'template2',
+          title: 'Template 2',
+          description: '',
+          deployment_modes: {
+            agentless: {
+              enabled: true,
+            },
+          },
+          inputs: [
+            { type: 'logs' },
+            { type: 'tcp' },
+          ],
+        },
+      ] as RegistryPolicyTemplate[],
+    } as any;
+
+    it('should return false for input without a policy_template deployment_mode enabled for agentless', () => {
+      const packageInfoWithoutPolicyTemplateDeploymentModes = {
+        name: 'test-package',
+        version: '1.0.0',
+        owner: { github: 'elastic' },
+        policy_templates: [
+          {
+            name: 'template1',
+            title: 'Template 1',
+            description: '',
+            inputs: [{ type: 'metrics' }],
+          },
+        ] as RegistryPolicyTemplate[],
+      } as any;
+      const input = { type: 'metrics', policy_template: 'template1' };
+      expect(
+        isInputAllowedForDeploymentMode(
+          input,
+          'agentless',
+          packageInfoWithoutPolicyTemplateDeploymentModes
+        )
+      ).toBe(false);
+    });
+
+    it("should return false for input with a policy_template deployment mode that doesn't support it", () => {
+      const packageInfoWithPolicyTemplateOverride = {
+        name: 'test-package',
+        version: '1.0.0',
+        owner: { github: 'elastic' },
+        policy_templates: [
+          {
+            name: 'template1',
+            title: 'Template 1',
+            description: '',
+            deployment_modes: {
+              agentless: {
+                enabled: false,
+              },
+              default: {
+                enabled: false,
+              },
+            },
+            inputs: [{ type: 'metrics' }],
+          },
+        ] as RegistryPolicyTemplate[],
+      } as any;
+      const input = { type: 'metrics', policy_template: 'template1' };
+      expect(
+        isInputAllowedForDeploymentMode(input, 'agentless', packageInfoWithPolicyTemplateOverride)
+      ).toBe(false);
+
+      expect(
+        isInputAllowedForDeploymentMode(input, 'default', packageInfoWithPolicyTemplateOverride)
+      ).toBe(false);
+    });
+
+    it('should return true for input with no policy template deployment mode defined when requested mode is default', () => {
+      const packageInfoWithPolicyTemplateOverride = {
+        name: 'test-package',
+        version: '1.0.0',
+        owner: { github: 'elastic' },
+        policy_templates: [
+          {
+            name: 'template1',
+            title: 'Template 1',
+            description: '',
+            inputs: [{ type: 'metrics' }],
+          },
+        ] as RegistryPolicyTemplate[],
+      } as any;
+      const input = { type: 'metrics', policy_template: 'template1' };
+      expect(
+        isInputAllowedForDeploymentMode(input, 'default', packageInfoWithPolicyTemplateOverride)
+      ).toBe(true);
+    });
+
+    it('should handle inputs with different deployment_modes under different policy templates', () => {
+      const input1 = { type: 'logs', policy_template: 'template1' };
+      const input2 = { type: 'logs', policy_template: 'template2' };
+
+      expect(
+        isInputAllowedForDeploymentMode(input1, 'default', packageInfoWithDeploymentModes)
+      ).toBe(true);
+      expect(
+        isInputAllowedForDeploymentMode(input2, 'default', packageInfoWithDeploymentModes)
+      ).toBe(false);
+    });
+
+    it('should fall back to blocklist for agentless mode when deployment_modes not specified', () => {
+      const packageInfoWithoutDeploymentModes = {
+        name: 'test-package',
+        version: '1.0.0',
+        owner: { github: 'elastic' },
+        policy_templates: [
+          {
+            name: 'template1',
+            title: 'Template 1',
+            description: '',
+            deployment_modes: {
+              agentless: {
+                enabled: true,
+              },
+            },
+            inputs: [{ type: 'log' }, { type: 'winlog' }],
+          },
+        ] as RegistryPolicyTemplate[],
+      } as any;
+
+      const logInput = { type: 'log', policy_template: 'template1' };
+      const winlogInput = { type: 'winlog', policy_template: 'template1' };
+
+      // `winlog` is in AGENTLESS_DISABLED_INPUTS and is therefore not allowed in agentless
+      // `log` is not on the blocklist and is allowed in agentless
+      expect(
+        isInputAllowedForDeploymentMode(winlogInput, 'agentless', packageInfoWithoutDeploymentModes)
+      ).toBe(false);
+      expect(
+        isInputAllowedForDeploymentMode(logInput, 'agentless', packageInfoWithoutDeploymentModes)
+      ).toBe(true);
+    });
+
+    it('should return true for default mode when deployment_modes not specified', () => {
+      const packageInfoWithoutDeploymentModes = {
+        name: 'test-package',
+        version: '1.0.0',
+        owner: { github: 'elastic' },
+        policy_templates: [
+          {
+            name: 'template1',
+            title: 'Template 1',
+            description: '',
+            inputs: [{ type: 'logfile' }],
+          },
+        ] as RegistryPolicyTemplate[],
+      } as any;
+
+      const input = { type: 'logfile', policy_template: 'template1' };
+      expect(
+        isInputAllowedForDeploymentMode(input, 'default', packageInfoWithoutDeploymentModes)
+      ).toBe(true);
+    });
+
+    it('should always allow system package inputs regardless of blocklist or deployment_modes', () => {
+      const systemPackageInfo = {
+        name: 'system',
+        version: '1.0.0',
+        owner: { github: 'elastic' },
+        policy_templates: [
+          {
+            name: 'system',
+            title: 'System',
+            description: '',
+            inputs: [
+              { type: 'filelog' }, // This would normally be blocked by agentless blocklist
+              { type: 'system/metrics' },
+            ],
+          },
+        ] as RegistryPolicyTemplate[],
+      } as any;
+
+      const winlogInput = { type: 'winlog', policy_template: 'system' };
+      const metricsInput = { type: 'system/metrics', policy_template: 'system' };
+
+      // System package should always be allowed for any deployment mode
+      expect(isInputAllowedForDeploymentMode(winlogInput, 'agentless', systemPackageInfo)).toBe(
+        true
+      );
+      expect(isInputAllowedForDeploymentMode(winlogInput, 'default', systemPackageInfo)).toBe(true);
+      expect(isInputAllowedForDeploymentMode(metricsInput, 'agentless', systemPackageInfo)).toBe(
+        true
+      );
+      expect(isInputAllowedForDeploymentMode(metricsInput, 'default', systemPackageInfo)).toBe(
+        true
+      );
+    });
+  });
+
+  describe('validateDeploymentModesForInputs', () => {
+    const packageInfo = {
+      name: 'test-package',
+      version: '1.0.0',
+      owner: { github: 'elastic' },
+      policy_templates: [
+        {
+          name: 'template1',
+          title: 'Template 1',
+          description: '',
+          deployment_modes: {
+            agentless: {
+              enabled: true,
+            },
+          },
+          inputs: [
+            { type: 'logs' },
+            { type: 'metrics' },
+          ],
+        },
+      ] as RegistryPolicyTemplate[],
+    } as any;
+
+    it('should not throw for valid inputs', () => {
+      const inputs = [
+        { type: 'logs', enabled: true, policy_template: 'template1' },
+        { type: 'metrics', enabled: false, policy_template: 'template1' },
+      ];
+
+      expect(() =>
+        validateDeploymentModesForInputs(inputs, 'agentless', packageInfo)
+      ).not.toThrow();
+    });
+
+    it('should throw for invalid enabled inputs', () => {
+      const inputs = [{ type: 'metrics', enabled: true, policy_template: 'template1' }];
+
+      expect(() => validateDeploymentModesForInputs(inputs, 'agentless', packageInfo)).toThrow(
+        "Input metrics in test-package is not allowed for deployment mode 'agentless'"
+      );
+    });
+
+    it('should not throw for disabled inputs even if they are not allowed', () => {
+      const inputs = [{ type: 'metrics', enabled: false, policy_template: 'template1' }];
+
+      expect(() =>
+        validateDeploymentModesForInputs(inputs, 'agentless', packageInfo)
+      ).not.toThrow();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
@@ -14,8 +14,6 @@ import {
 import { PackagePolicyValidationError } from '../errors';
 import type { NewPackagePolicyInput, PackageInfo, RegistryPolicyTemplate } from '../types';
 
-import type { SimplifiedInputs } from './simplified_package_policy_helper';
-
 // Checks if a package has a policy template that supports agentless
 // Provide a specific integration policy template name to check if it alone supports agentless
 export const isAgentlessIntegration = (

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
@@ -15,11 +15,11 @@ import type {
   PackageInfo,
   ExperimentalDataStreamFeature,
 } from '../types';
-import { AGENTLESS_DISABLED_INPUTS, DATASET_VAR_NAME } from '../constants';
+import { DATASET_VAR_NAME } from '../constants';
 import { PackagePolicyValidationError } from '../errors';
 
 import { packageToPackagePolicy } from '.';
-import { inputNotAllowedInAgentless } from './agentless_policy_helper';
+import { isInputAllowedForDeploymentMode } from './agentless_policy_helper';
 
 export type SimplifiedVars = Record<string, string | string[] | boolean | number | number[] | null>;
 
@@ -77,18 +77,23 @@ export function generateInputId(input: NewPackagePolicyInput) {
   return `${input.policy_template ? `${input.policy_template}-` : ''}${input.type}`;
 }
 
-export function formatInputs(inputs: NewPackagePolicy['inputs'], supportsAgentless?: boolean) {
+export function formatInputs(
+  inputs: NewPackagePolicy['inputs'],
+  supportsAgentless?: boolean,
+  packageInfo?: PackageInfo
+) {
   return inputs.reduce((acc, input) => {
     const inputId = generateInputId(input);
     if (!acc) {
       acc = {};
     }
-    const enabled =
-      supportsAgentless === true && AGENTLESS_DISABLED_INPUTS.includes(input.type)
-        ? false
-        : input.enabled;
+
     acc[inputId] = {
-      enabled,
+      enabled: isInputAllowedForDeploymentMode(
+        input,
+        supportsAgentless ? 'agentless' : 'default',
+        packageInfo
+      ),
       vars: formatVars(input.vars),
       streams: formatStreams(input.streams),
     };
@@ -206,15 +211,13 @@ export function simplifiedPackagePolicytoNewPackagePolicy(
     if (!packagePolicyInput || !streamsMap) {
       throw new PackagePolicyValidationError(`Input not found: ${inputId}`);
     }
+    const isInputAllowed = isInputAllowedForDeploymentMode(
+      packagePolicyInput,
+      packagePolicy?.supports_agentless ? 'agentless' : 'default',
+      packageInfo
+    );
 
-    if (
-      inputNotAllowedInAgentless(packagePolicyInput.type, packagePolicy?.supports_agentless) ||
-      enabled === false
-    ) {
-      packagePolicyInput.enabled = false;
-    } else {
-      packagePolicyInput.enabled = true;
-    }
+    packagePolicyInput.enabled = !isInputAllowed || enabled === false ? false : true;
 
     if (inputLevelVars) {
       assignVariables(inputLevelVars, packagePolicyInput.vars, `${inputId}`);
@@ -227,10 +230,7 @@ export function simplifiedPackagePolicytoNewPackagePolicy(
         throw new PackagePolicyValidationError(`Stream not found ${inputId}: ${streamId}`);
       }
 
-      if (
-        streamEnabled === false ||
-        inputNotAllowedInAgentless(packagePolicyInput.type, packagePolicy?.supports_agentless)
-      ) {
+      if (streamEnabled === false || isInputAllowed === false) {
         packagePolicyStream.enabled = false;
       } else {
         packagePolicyStream.enabled = true;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
@@ -20,14 +20,12 @@ import {
   isIntegrationPolicyTemplate,
   getRegistryStreamWithDataStreamForInputType,
 } from '../../../../../../../../common/services';
-
+import { isInputAllowedForDeploymentMode } from '../../../../../../../../common/services/agentless_policy_helper';
 import type { PackageInfo, NewPackagePolicy, NewPackagePolicyInput } from '../../../../../types';
 import { Loading } from '../../../../../components';
 import { doesPackageHaveIntegrations } from '../../../../../services';
 
 import type { PackagePolicyValidationResults } from '../../services';
-
-import { AGENTLESS_DISABLED_INPUTS } from '../../../../../../../../common/constants';
 
 import { PackagePolicyInputPanel } from './components';
 
@@ -53,6 +51,10 @@ export const StepConfigurePackagePolicy: React.FunctionComponent<{
   isAgentlessSelected = false,
 }) => {
   const hasIntegrations = useMemo(() => doesPackageHaveIntegrations(packageInfo), [packageInfo]);
+  const deploymentMode =
+    (isEditPage || isAgentlessSelected) && packagePolicy.supports_agentless
+      ? 'agentless'
+      : 'default';
   const packagePolicyTemplates = useMemo(
     () =>
       showOnlyIntegration
@@ -101,11 +103,11 @@ export const StepConfigurePackagePolicy: React.FunctionComponent<{
                 });
               };
 
-              return packagePolicyInput &&
-                !(
-                  (isAgentlessSelected || packagePolicy.supports_agentless === true) &&
-                  AGENTLESS_DISABLED_INPUTS.includes(packagePolicyInput.type)
-                ) ? (
+              const isInputAvailable =
+                packagePolicyInput &&
+                isInputAllowedForDeploymentMode(packagePolicyInput, deploymentMode, packageInfo);
+
+              return isInputAvailable ? (
                 <EuiFlexItem key={packageInput.type}>
                   <PackagePolicyInputPanel
                     packageInput={packageInput}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
@@ -224,4 +224,241 @@ describe('useOnSubmit', () => {
       },
     });
   });
+
+  describe('input deployment mode filtering', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should disable inputs that are not allowed for agentless deployment mode', async () => {
+      // Mock packageInfo with inputs that have deployment_modes
+      const packageInfoWithInputs: PackageInfo = {
+        ...packageInfo,
+        policy_templates: [
+          {
+            name: 'test_template',
+            title: 'Test Template',
+            description: 'Test template',
+            deployment_modes: {
+              default: { enabled: true },
+              agentless: { enabled: true },
+            },
+            inputs: [
+              {
+                type: 'logs',
+                title: 'Logs',
+                description: 'Log collection',
+              },
+              {
+                type: 'metrics',
+                title: 'Metrics',
+                description: 'Metrics collection',
+              },
+              {
+                type: 'http_endpoint',
+                title: 'HTTP Endpoint',
+                description: 'HTTP endpoint',
+              },
+            ],
+          },
+        ],
+      };
+
+      // Mock useConfig to return agentless configuration
+      (useConfig as MockFn).mockReturnValue({
+        agentless: { enabled: true },
+      } as any);
+
+      // Render the hook with a package policy that has inputs including metrics
+      renderResult = testRenderer.renderHook(() =>
+        useOnSubmit({
+          agentCount: 0,
+          packageInfo: packageInfoWithInputs,
+          withSysMonitoring: false,
+          selectedPolicyTab: SelectedPolicyTab.NEW,
+          newAgentPolicy: { name: 'test', namespace: '', supports_agentless: true },
+          queryParamsPolicyId: undefined,
+          hasFleetAddAgentsPrivileges: true,
+          setNewAgentPolicy: jest.fn(),
+          setSelectedPolicyTab: jest.fn(),
+        })
+      );
+
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+      act(() => {
+        // Simulate switching to agentless setup technology
+        renderResult.result.current.handleSetupTechnologyChange('agentless' as any);
+      });
+
+      await waitFor(() => {
+        const { packagePolicy } = renderResult.result.current;
+        const logsInput = packagePolicy.inputs.find((input: any) => input.type === 'logs');
+        const metricsInput = packagePolicy.inputs.find((input: any) => input.type === 'metrics');
+        const httpInput = packagePolicy.inputs.find((input: any) => input.type === 'http_endpoint');
+
+        // Expect logs and metrics to be enabled, and http_endpoint to be disabled
+        expect(logsInput?.enabled).toBe(true);
+        expect(metricsInput?.enabled).toBe(true);
+        expect(httpInput?.enabled).toBe(false);
+      });
+    });
+
+    it('should disable inputs when policy_template deployment mode is not declared when in agentless deployment mode', async () => {
+      // Mock packageInfo with a policy template that doesn't declare agentless deployment mode
+      // But also has a policy template that does so the package is deemed supports_agentless
+      // We will try to install the non-agentless policy template
+
+      const packageInfoWithInputs: PackageInfo = {
+        ...packageInfo,
+        policy_templates: [
+          {
+            name: 'test_template',
+            title: 'Test Template',
+            description: 'Test template',
+            inputs: [
+              {
+                type: 'logs',
+                title: 'Logs',
+                description: 'Log collection',
+              },
+              {
+                type: 'metrics',
+                title: 'Metrics',
+                description: 'Metrics collection',
+              },
+              {
+                type: 'http_endpoint',
+                title: 'HTTP Endpoint',
+                description: 'HTTP endpoint',
+              },
+            ],
+          },
+          {
+            name: 'test_template_2',
+            title: 'Test Template 2',
+            description: 'Test template',
+            deployment_modes: {
+              agentless: { enabled: true },
+              default: { enabled: true },
+            },
+            inputs: [
+              {
+                type: 'logs',
+                title: 'Logs',
+                description: 'Log collection',
+              },
+              {
+                type: 'metrics',
+                title: 'Metrics',
+                description: 'Metrics collection',
+              },
+              {
+                type: 'http_endpoint',
+                title: 'HTTP Endpoint',
+                description: 'HTTP endpoint',
+              },
+            ],
+          },
+        ],
+      };
+
+      // Mock useConfig to return agentless configuration
+      (useConfig as MockFn).mockReturnValue({
+        agentless: { enabled: true },
+      } as any);
+
+      // Render the hook with a package policy that has inputs including metrics
+      renderResult = testRenderer.renderHook(() =>
+        useOnSubmit({
+          agentCount: 0,
+          packageInfo: packageInfoWithInputs,
+          integrationToEnable: 'test_template_1',
+          withSysMonitoring: false,
+          selectedPolicyTab: SelectedPolicyTab.NEW,
+          newAgentPolicy: { name: 'test', namespace: '', supports_agentless: true },
+          queryParamsPolicyId: undefined,
+          hasFleetAddAgentsPrivileges: true,
+          setNewAgentPolicy: jest.fn(),
+          setSelectedPolicyTab: jest.fn(),
+        })
+      );
+
+      act(() => {
+        // Simulate switching to agentless setup technology
+        renderResult.result.current.handleSetupTechnologyChange('agentless' as any);
+      });
+
+      await waitFor(() => {
+        const { packagePolicy } = renderResult.result.current;
+        const logsInput = packagePolicy.inputs.find((input: any) => input.type === 'logs');
+        const metricsInput = packagePolicy.inputs.find((input: any) => input.type === 'metrics');
+        const httpInput = packagePolicy.inputs.find((input: any) => input.type === 'http_endpoint');
+
+        expect(logsInput?.enabled).toBe(false);
+        expect(httpInput?.enabled).toBe(false);
+        expect(metricsInput?.enabled).toBe(false);
+      });
+    });
+
+    it('should enable all inputs for default deployment mode', async () => {
+      // Mock packageInfo with inputs
+      const packageInfoWithInputs: PackageInfo = {
+        ...packageInfo,
+        policy_templates: [
+          {
+            name: 'test_template',
+            title: 'Test Template',
+            description: 'Test template',
+            deployment_modes: {
+              default: { enabled: true },
+              agentless: { enabled: true },
+            },
+            inputs: [
+              {
+                type: 'logs',
+                title: 'Logs',
+                description: 'Log collection',
+              },
+              {
+                type: 'metrics',
+                title: 'Metrics',
+                description: 'Metrics collection',
+              },
+            ],
+          },
+        ],
+      };
+
+      // Mock useConfig to return regular configuration
+      (useConfig as MockFn).mockReturnValue({
+        agentless: undefined,
+      } as any);
+
+      // Render the hook with regular agent policy
+      renderResult = testRenderer.renderHook(() =>
+        useOnSubmit({
+          agentCount: 0,
+          packageInfo: packageInfoWithInputs,
+          withSysMonitoring: false,
+          selectedPolicyTab: SelectedPolicyTab.NEW,
+          newAgentPolicy: { name: 'test', namespace: '' },
+          queryParamsPolicyId: undefined,
+          hasFleetAddAgentsPrivileges: true,
+          setNewAgentPolicy: jest.fn(),
+          setSelectedPolicyTab: jest.fn(),
+        })
+      );
+
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+      await waitFor(() => {
+        const { packagePolicy } = renderResult.result.current;
+        const logsInput = packagePolicy.inputs.find((input: any) => input.type === 'logs');
+        const metricsInput = packagePolicy.inputs.find((input: any) => input.type === 'metrics');
+
+        // Both inputs should remain enabled for default mode
+        expect(logsInput?.enabled).toBe(true);
+        expect(metricsInput?.enabled).toBe(true);
+      });
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -55,7 +55,7 @@ import {
   getCloudFormationPropsFromPackagePolicy,
   getCloudShellUrlFromPackagePolicy,
 } from '../../../../../../../components/cloud_security_posture/services';
-import { AGENTLESS_DISABLED_INPUTS } from '../../../../../../../../common/constants';
+import { isInputAllowedForDeploymentMode } from '../../../../../../../../common/services/agentless_policy_helper';
 import { ensurePackageKibanaAssetsInstalled } from '../../../../../services/ensure_kibana_assets_installed';
 
 import { useAgentless, useSetupTechnology } from './setup_technology';
@@ -405,12 +405,19 @@ export function useOnSubmit({
 
   const newInputs = useMemo(() => {
     return packagePolicy.inputs.map((input, i) => {
-      if (isAgentlessSelected && AGENTLESS_DISABLED_INPUTS.includes(input.type)) {
+      if (
+        isInputAllowedForDeploymentMode(
+          input,
+          isAgentlessSelected ? 'agentless' : 'default',
+          packageInfo
+        )
+      ) {
+        return input;
+      } else {
         return { ...input, enabled: false };
       }
-      return packagePolicy.inputs[i];
     });
-  }, [packagePolicy.inputs, isAgentlessSelected]);
+  }, [packagePolicy.inputs, isAgentlessSelected, packageInfo]);
 
   useEffect(() => {
     if (prevSetupTechnology !== selectedSetupTechnology) {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
@@ -107,9 +107,17 @@ export function useSetupTechnology({
   const [currentAgentPolicy, setCurrentAgentPolicy] = useState(newAgentPolicy);
 
   const allowedSetupTechnologies = useMemo(() => {
-    return isOnlyAgentlessIntegration(packageInfo, integrationToEnable)
-      ? [SetupTechnology.AGENTLESS]
-      : [SetupTechnology.AGENTLESS, SetupTechnology.AGENT_BASED];
+    const setupTechnologies = [];
+
+    if (isAgentlessIntegrationFn(packageInfo, integrationToEnable)) {
+      setupTechnologies.push(SetupTechnology.AGENTLESS);
+    }
+
+    if (!isOnlyAgentlessIntegration(packageInfo, integrationToEnable)) {
+      setupTechnologies.push(SetupTechnology.AGENT_BASED);
+    }
+
+    return setupTechnologies;
   }, [integrationToEnable, packageInfo]);
   const [selectedSetupTechnology, setSelectedSetupTechnology] = useState<SetupTechnology>(
     SetupTechnology.AGENT_BASED

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
@@ -60,12 +60,8 @@ import {
   packagePolicyToSimplifiedPackagePolicy,
 } from '../../../common/services/simplified_package_policy_helper';
 
-import type {
-  SimplifiedInputs,
-  SimplifiedPackagePolicy,
-} from '../../../common/services/simplified_package_policy_helper';
+import type { SimplifiedPackagePolicy } from '../../../common/services/simplified_package_policy_helper';
 import { runWithCache } from '../../services/epm/packages/cache';
-import { validateAgentlessInputs } from '../../../common/services/agentless_policy_helper';
 
 import {
   isSimplifiedCreatePackagePolicyRequest,
@@ -397,10 +393,6 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
         pkgInfo,
         { experimental_data_stream_features: pkg.experimental_data_stream_features }
       );
-      validateAgentlessInputs(
-        body?.inputs as SimplifiedInputs,
-        body?.supports_agentless || newData.supports_agentless
-      );
     } else {
       // complete request
       const { overrides, ...restOfBody } = body as TypeOf<
@@ -430,10 +422,6 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
         newData.overrides = overrides;
       }
     }
-    validateAgentlessInputs(
-      newData.inputs,
-      newData.supports_agentless || packagePolicy.supports_agentless
-    );
     newData.inputs = alignInputsAndStreams(newData.inputs);
 
     if (

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/manifest.yml
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/manifest.yml
@@ -1,0 +1,74 @@
+format_version: 3.0.0
+name: deployment_modes_test
+title: Test Package for Deployment Modes
+description: >-
+  Test package to verify deployment_modes functionality in Fleet
+type: integration
+version: 1.0.0
+license: basic
+categories:
+  - observability
+policy_templates:
+  - name: mixed_modes
+    title: Mixed Deployment Modes
+    description: Template with inputs supporting different deployment modes
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+    inputs:
+      - type: logs
+        title: Log Collection
+        description: Collect logs (supports both default and agentless)
+        deployment_modes: ["default", "agentless"]
+      - type: metrics
+        title: Metrics Collection
+        description: Collect metrics (default mode only)
+        deployment_modes: ["default"]
+      - type: http_endpoint
+        title: HTTP Endpoint
+        description: HTTP endpoint monitoring (agentless only)
+        deployment_modes: ["agentless"]
+      - type: winlog
+        title: Windows Event Logs
+        description: Windows event logs (no deployment_modes specified - should fall back to blocklist)
+  - name: agentless_only
+    title: Agentless Only Template
+    description: Template that only supports agentless deployment
+    deployment_modes:
+      agentless:
+        enabled: true
+    inputs:
+      - type: cloudwatch
+        title: CloudWatch Metrics
+        description: AWS CloudWatch metrics
+        deployment_modes: ["agentless"]
+      - type: s3
+        title: S3 Access Logs
+        description: AWS S3 access logs
+        deployment_modes: ["agentless"]
+  - name: default_only
+    title: Default Only Template
+    description: Template that only supports default deployment
+    deployment_modes:
+      default:
+        enabled: true
+    inputs:
+      - type: filestream
+        title: File Stream
+        description: File stream input
+        deployment_modes: ["default"]
+      - type: system
+        title: System Metrics
+        description: System metrics collection
+        deployment_modes: ["default"]
+  - name: no_deployment_mode_default_only
+    title: No Deployment Mode Default Only Template
+    description: Template that only supports default deployment with no explicit deployment_mode
+    inputs:
+      - type: cloudwatch
+        title: CloudWatch Metrics for only default deployment
+        description: AWS CloudWatch metrics
+owner:
+  github: elastic/fleet

--- a/x-pack/platform/test/fleet_api_integration/apis/package_policy/deployment_modes.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/package_policy/deployment_modes.ts
@@ -656,6 +656,67 @@ export default function (providerContext: FtrProviderContext) {
             });
         });
       });
+      describe('default_only policy template with no deployment mode', () => {
+        it('should allow default inputs only for default deployment mode', async () => {
+          // Test default deployment mode (should succeed)
+          const { body: defaultResponse } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-cloudwatch-default-${uuidv4()}`,
+              description:
+                'Test input in default mode without explicit policy template deployment mode declaration',
+              namespace: 'default',
+              policy_id: agentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'cloudwatch',
+                  policy_template: 'no_deployment_mode_default_only',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          expect(defaultResponse.item.inputs).to.have.length(1);
+          expect(defaultResponse.item.inputs[0].type).to.be('cloudwatch');
+
+          // Test agentless deployment mode (should fail)
+          await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-cloudwatch-agentless-${uuidv4()}`,
+              description:
+                'Test input in agentless mode without explicit policy template deployment mode declaration',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'cloudwatch',
+                  policy_template: 'no_deployment_mode_default_only',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(400)
+            .then((response) => {
+              expect(response.body.message).to.contain(
+                "Input cloudwatch in deployment_modes_test is not allowed for deployment mode 'agentless'"
+              );
+            });
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - Fix honoring deployment mode restrictions (#231679) (99bed97a)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michel Losier","email":"michel.losier@elastic.co"},"sourceCommit":{"committedDate":"2025-08-19T13:37:21Z","message":"Fix honoring deployment mode restrictions (#231679)\n\nResolves: https://github.com/elastic/kibana/issues/231621\n\nThis makes sure that when creating package policies the\n`deployment_modes` definition, if available, on policy templates are\nevaluated as such:\n\n* When agentless mode is selected, inputs of policy templates are only included if the deployment mode\nexplicitly declares agentless enabled\n* When default mode (agent-based) is selected, inputs are included if policy template deployment mode is not\ndeclared, or if declared only if default.enabled is true\n\n## Release note:\n\nFixes the `deployment_modes` evaluation for policy templates when creating a\npackage policy. When deploying in agentless mode this ensures we don't\nallow inputs from policy templates that are not opted into the agentless\nmode at the template level.","sha":"99bed97a5a347ad30ba5f3fe289c4c64f85f01b4"},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->