### PR TITLE
[Cloud Security] Fix Fleet extension overriding valid form state update

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -327,13 +327,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       setIsFleetExtensionLoaded(isExtensionLoaded);
 
       if (isValid !== undefined) {
-        // override the form state
-        setFormState((prevState) => {
-          if (prevState === 'VALID' && !isValid) {
-            return 'INVALID';
-          }
-          return prevState;
-        });
+        setFormState(isValid ? 'VALID' : 'INVALID');
       }
     },
     [updatePackagePolicy, setFormState]

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -325,12 +325,16 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     ({ isValid, updatedPolicy, isExtensionLoaded }) => {
       updatePackagePolicy(updatedPolicy);
       setIsFleetExtensionLoaded(isExtensionLoaded);
-      setFormState((prevState) => {
-        if (prevState === 'VALID' && !isValid) {
-          return 'INVALID';
-        }
-        return prevState;
-      });
+
+      if (isValid !== undefined) {
+        // override the form state
+        setFormState((prevState) => {
+          if (prevState === 'VALID' && !isValid) {
+            return 'INVALID';
+          }
+          return prevState;
+        });
+      }
     },
     [updatePackagePolicy, setFormState]
   );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -234,12 +234,9 @@ export const EditPackagePolicyForm = memo<{
   >(
     ({ isValid, updatedPolicy }) => {
       updatePackagePolicy(updatedPolicy);
-      setFormState((prevState) => {
-        if (prevState === 'VALID' && !isValid) {
-          return 'INVALID';
-        }
-        return prevState;
-      });
+      if (isValid !== undefined) {
+        setFormState(isValid ? 'VALID' : 'INVALID');
+      }
     },
     [updatePackagePolicy, setFormState]
   );

--- a/x-pack/platform/plugins/shared/fleet/public/types/ui_extensions.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/types/ui_extensions.ts
@@ -72,7 +72,7 @@ export interface PackagePolicyEditExtensionComponentProps {
    */
   onChange: (opts: {
     /** is current form state is valid */
-    isValid: boolean;
+    isValid?: boolean;
     /** The updated Integration Policy to be merged back and included in the API call */
     updatedPolicy: Partial<NewPackagePolicy>;
     isExtensionLoaded?: boolean;
@@ -168,7 +168,7 @@ export interface PackagePolicyCreateExtensionComponentProps {
    */
   onChange: (opts: {
     /** is current form state is valid */
-    isValid: boolean;
+    isValid?: boolean;
     /** The updated Integration Policy to be merged back and included in the API call */
     updatedPolicy: NewPackagePolicy;
   }) => void;

--- a/x-pack/solutions/observability/plugins/apm/public/components/fleet_integration/apm_policy_form/edit_apm_policy_form.stories.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/fleet_integration/apm_policy_form/edit_apm_policy_form.stories.tsx
@@ -60,7 +60,9 @@ export const EditAPMPolicy: StoryFn = () => {
         policy={{} as PackagePolicy}
         newPolicy={newPolicy}
         onChange={(value) => {
-          setIsPolicyValid(value.isValid);
+          if (value.isValid !== undefined) {
+            setIsPolicyValid(value.isValid);
+          }
           const updatedVars = value.updatedPolicy.inputs?.[0].vars;
           setNewPolicy((state) => ({
             ...state,

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/azure_credentials_form/azure_hooks.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/azure_credentials_form/azure_hooks.ts
@@ -128,9 +128,9 @@ export const useAzureCredentialsForm = ({
   const lastManualCredentialsType = useRef<string | undefined>(undefined);
 
   useEffect(() => {
-    const isValidArmTemplateSelection =
-      setupFormat === AZURE_SETUP_FORMAT.ARM_TEMPLATE && hasArmTemplateUrl;
-    if (!isValidArmTemplateSelection && isValid) {
+    const isInvalidArmTemplateSelection =
+      setupFormat === AZURE_SETUP_FORMAT.ARM_TEMPLATE && !hasArmTemplateUrl;
+    if (isInvalidArmTemplateSelection && isValid) {
       updatePolicy({
         isValid: false,
         updatedPolicy: newPolicy,

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/azure_credentials_form/azure_hooks.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/azure_credentials_form/azure_hooks.ts
@@ -129,7 +129,7 @@ export const useAzureCredentialsForm = ({
 
   useEffect(() => {
     const isInvalid = setupFormat === AZURE_SETUP_FORMAT.ARM_TEMPLATE && !hasArmTemplateUrl;
-    if (isInvalid !== isValid) {
+    if (isInvalid && isValid) {
       updatePolicy({
         isValid: !isInvalid,
         updatedPolicy: newPolicy,

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/azure_credentials_form/azure_hooks.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/azure_credentials_form/azure_hooks.ts
@@ -128,10 +128,11 @@ export const useAzureCredentialsForm = ({
   const lastManualCredentialsType = useRef<string | undefined>(undefined);
 
   useEffect(() => {
-    const isInvalid = setupFormat === AZURE_SETUP_FORMAT.ARM_TEMPLATE && !hasArmTemplateUrl;
-    if (isInvalid && isValid) {
+    const isValidArmTemplateSelection =
+      setupFormat === AZURE_SETUP_FORMAT.ARM_TEMPLATE && hasArmTemplateUrl;
+    if (!isValidArmTemplateSelection && isValid) {
       updatePolicy({
-        isValid: !isInvalid,
+        isValid: false,
         updatedPolicy: newPolicy,
       });
     }

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
@@ -247,7 +247,7 @@ describe('<CspPolicyTemplateForm />', () => {
     // It should ensure the initial state is valid.
     expect(onChange).toHaveBeenNthCalledWith(1, {
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...policy,
         namespace: 'default',
@@ -267,7 +267,7 @@ describe('<CspPolicyTemplateForm />', () => {
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: { ...policy, name: `${policy.name}1` },
       });
     });
@@ -284,7 +284,7 @@ describe('<CspPolicyTemplateForm />', () => {
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: { ...policy, description: `${policy.description}1` },
       });
     });
@@ -314,7 +314,7 @@ describe('<CspPolicyTemplateForm />', () => {
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: eksPolicy,
       });
     });
@@ -414,7 +414,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
     onChange({
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyK8s(),
         inputs: policy.inputs.map((input) => ({
@@ -428,7 +428,7 @@ describe('<CspPolicyTemplateForm />', () => {
     // 1st call happens on mount and selects the default policy template enabled input
     expect(onChange).toHaveBeenCalledWith({
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyK8s(),
         name: 'cloud_security_posture-1',
@@ -438,7 +438,7 @@ describe('<CspPolicyTemplateForm />', () => {
     // 2nd call happens on mount and increments kspm template enabled input
     expect(onChange).toHaveBeenCalledWith({
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyK8s(),
         inputs: policy.inputs.map((input) => ({
@@ -495,7 +495,7 @@ describe('<CspPolicyTemplateForm />', () => {
     // 1st call happens on mount and selects the default policy template enabled input
     expect(onChange).nthCalledWith(1, {
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyK8s(),
         name: 'cloud_security_posture-1',
@@ -505,7 +505,7 @@ describe('<CspPolicyTemplateForm />', () => {
     // 2nd call happens on mount and increments kspm template enabled input
     expect(onChange).nthCalledWith(2, {
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyK8s(),
         inputs: policy.inputs.map((input) => ({
@@ -522,7 +522,7 @@ describe('<CspPolicyTemplateForm />', () => {
     */
     expect(onChange).nthCalledWith(3, {
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyK8s(),
         inputs: policy.inputs.map((input) => ({
@@ -577,7 +577,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
     onChange({
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyVulnMgmtAWS(),
         inputs: policy.inputs.map((input) => ({
@@ -591,7 +591,7 @@ describe('<CspPolicyTemplateForm />', () => {
     // 1st call happens on mount and selects the default policy template enabled input
     expect(onChange).toHaveBeenCalledWith({
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyVulnMgmtAWS(),
         name: 'vuln_mgmt-2',
@@ -601,7 +601,7 @@ describe('<CspPolicyTemplateForm />', () => {
     // 2nd call happens on mount and increments vuln_mgmt template enabled input
     expect(onChange).toHaveBeenCalledWith({
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyVulnMgmtAWS(),
         inputs: policy.inputs.map((input) => ({
@@ -660,7 +660,7 @@ describe('<CspPolicyTemplateForm />', () => {
     // 1st call happens on mount and selects the CloudFormation template
     expect(onChange).toHaveBeenCalledWith({
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyAWS(),
         name: 'cloud_security_posture-1',
@@ -679,7 +679,7 @@ describe('<CspPolicyTemplateForm />', () => {
     // 2nd call happens on mount and increments cspm template enabled input
     expect(onChange).toHaveBeenCalledWith({
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyAWS(),
         inputs: policy.inputs.map((input) => {
@@ -698,7 +698,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
     onChange({
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyAWS(),
         inputs: policy.inputs.map((input) => ({
@@ -711,7 +711,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
     expect(onChange).toHaveBeenCalledWith({
       isExtensionLoaded: true,
-      isValid: true,
+
       updatedPolicy: {
         ...getMockPolicyAWS(),
         inputs: policy.inputs.map((input) => ({
@@ -780,7 +780,7 @@ describe('<CspPolicyTemplateForm />', () => {
       // Ignore 1st call triggered on mount to ensure initial state is valid
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
     });
@@ -818,7 +818,7 @@ describe('<CspPolicyTemplateForm />', () => {
       // Ignore 1st call triggered on mount to ensure initial state is valid
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
 
@@ -831,7 +831,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
     });
@@ -870,7 +870,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
 
@@ -883,7 +883,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
 
@@ -896,7 +896,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
     });
@@ -932,7 +932,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
 
@@ -945,7 +945,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
     });
@@ -1083,7 +1083,7 @@ describe('<CspPolicyTemplateForm />', () => {
       // Ignore 1st call triggered on mount to ensure initial state is valid
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
     });
@@ -1123,7 +1123,7 @@ describe('<CspPolicyTemplateForm />', () => {
       // Ignore 1st call triggered on mount to ensure initial state is valid
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
 
@@ -1136,7 +1136,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
     });
@@ -1173,13 +1173,13 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
 
@@ -1192,7 +1192,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
 
@@ -1205,7 +1205,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
     });
@@ -1242,7 +1242,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
 
@@ -1255,7 +1255,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
     });
@@ -1294,7 +1294,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: expectedUpdatedPolicy,
       });
     });
@@ -1385,7 +1385,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
     });
@@ -1472,7 +1472,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
     });
@@ -1517,7 +1517,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: { ...policy, name: 'cspm-1' },
       });
 
@@ -1537,7 +1537,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: { ...policy, name: 'cspm-1' },
       });
     });
@@ -1578,7 +1578,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
 
@@ -1593,7 +1593,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
 
@@ -1608,7 +1608,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         isExtensionLoaded: true,
-        isValid: true,
+
         updatedPolicy: policy,
       });
     });
@@ -2220,7 +2220,6 @@ describe('<CspPolicyTemplateForm />', () => {
 
     expect(onChange).toHaveBeenCalledWith({
       isExtensionLoaded: true,
-      isValid: true,
       updatedPolicy: policy,
     });
 
@@ -2235,7 +2234,6 @@ describe('<CspPolicyTemplateForm />', () => {
 
     expect(onChange).toHaveBeenCalledWith({
       isExtensionLoaded: true,
-      isValid: true,
       updatedPolicy: policy,
     });
 
@@ -2250,7 +2248,6 @@ describe('<CspPolicyTemplateForm />', () => {
 
     expect(onChange).toHaveBeenCalledWith({
       isExtensionLoaded: true,
-      isValid: true,
       updatedPolicy: policy,
     });
 
@@ -2265,7 +2262,6 @@ describe('<CspPolicyTemplateForm />', () => {
 
     expect(onChange).toHaveBeenCalledWith({
       isExtensionLoaded: true,
-      isValid: true,
       updatedPolicy: policy,
     });
   });
@@ -2329,7 +2325,6 @@ describe('<CspPolicyTemplateForm />', () => {
     });
 
     expect(onChange).toHaveBeenCalledWith({
-      isValid: true,
       updatedPolicy: policy,
     });
 
@@ -2343,7 +2338,6 @@ describe('<CspPolicyTemplateForm />', () => {
     });
 
     expect(onChange).toHaveBeenCalledWith({
-      isValid: true,
       updatedPolicy: policy,
     });
 
@@ -2357,7 +2351,6 @@ describe('<CspPolicyTemplateForm />', () => {
     });
 
     expect(onChange).toHaveBeenCalledWith({
-      isValid: true,
       updatedPolicy: policy,
     });
 
@@ -2371,7 +2364,6 @@ describe('<CspPolicyTemplateForm />', () => {
     });
 
     expect(onChange).toHaveBeenCalledWith({
-      isValid: true,
       updatedPolicy: policy,
     });
   });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/use_load_fleet_extension.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/use_load_fleet_extension.ts
@@ -233,6 +233,7 @@ export const useLoadFleetExtension = ({
           posture: { value: getPostureType(selectedInput.type) },
         }),
       };
+
       onChange({
         isValid,
         updatedPolicy: newUpdatedPolicy,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/use_load_fleet_extension.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/use_load_fleet_extension.ts
@@ -233,14 +233,6 @@ export const useLoadFleetExtension = ({
           posture: { value: getPostureType(selectedInput.type) },
         }),
       };
-      // Update the policy with the new
-      if (isValid !== undefined) {
-        console.log('isValid changed:', isValid);
-        const error = new Error();
-        // Show in the console the function that called this
-        const callerFunction = error.stack?.split('\n')[2]?.trim();
-        console.log('Called by:', callerFunction);
-      }
       onChange({
         isValid,
         updatedPolicy: newUpdatedPolicy,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/use_load_fleet_extension.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/use_load_fleet_extension.ts
@@ -158,7 +158,7 @@ const useCloudFormationTemplate = ({
 interface UseLoadFleetExtensionProps {
   newPolicy: NewPackagePolicy;
   onChange: (args: {
-    isValid: boolean;
+    isValid?: boolean;
     updatedPolicy: NewPackagePolicy;
     isExtensionLoaded?: boolean;
   }) => void;
@@ -234,13 +234,20 @@ export const useLoadFleetExtension = ({
         }),
       };
       // Update the policy with the new
+      if (isValid !== undefined) {
+        console.log('isValid changed:', isValid);
+        const error = new Error();
+        // Show in the console the function that called this
+        const callerFunction = error.stack?.split('\n')[2]?.trim();
+        console.log('Called by:', callerFunction);
+      }
       onChange({
-        isValid: isValid !== undefined ? isValid : isValidFormState,
+        isValid,
         updatedPolicy: newUpdatedPolicy,
         isExtensionLoaded: isExtensionLoaded !== undefined ? isExtensionLoaded : !isLoading,
       });
     },
-    [isValidFormState, input.policy_template, onChange, isLoading]
+    [input.policy_template, onChange, isLoading]
   );
 
   const setEnabledPolicyInput = useCallback(


### PR DESCRIPTION
## Summary

When Fleet extensions update the policy,  it requires that we have an isValid attribute to override the Fleet form state if it needs to disable the save and continue button.  For example, if a feature is selected but not available, the form state should be invalid.

When entering input, the form state from the Fleet extension is `invalid`,  but after [updating and passing the validation](https://github.com/elastic/kibana/pull/232266/files#diff-d9be644b73b861cc75236af40bbbcda6430a433e89e6c70d2fd5a04ae6c87133R326) results, it is `valid`,  then we are [overriding](https://github.com/elastic/kibana/pull/232266/files#diff-d9be644b73b861cc75236af40bbbcda6430a433e89e6c70d2fd5a04ae6c87133L329) the `valid` state.

This change makes the isValid optional and only overrides the validity if isValid is not `undefined`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common



