### PR TITLE
Skip reporting_user test

### DIFF
--- a/x-pack/platform/test/reporting_api_integration/reporting_and_security/default_reporting_user_role.ts
+++ b/x-pack/platform/test/reporting_api_integration/reporting_and_security/default_reporting_user_role.ts
@@ -15,7 +15,7 @@ export default function ({ getService }: FtrProviderContext) {
   const testUserUsername = 'test_reporting_user';
   const testUserPassword = 'changeme';
 
-  describe('Default reporting_user role', () => {
+  describe.skip('Default reporting_user role', () => {
     before(async () => {
       await reportingAPI.initEcommerce();
 


### PR DESCRIPTION
## Summary

Temporarily skips reporting tests to unblock the ES promotion

<!--ONMERGE {"backportTargets":["9.0","9.1"]} ONMERGE-->