### PR TITLE
make error messages more accessible

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/components/section_error.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/section_error.tsx
@@ -6,6 +6,7 @@
  */
 
 import { EuiCallOut, EuiSpacer } from '@elastic/eui';
+import type { AriaAttributes } from 'react';
 import React, { Fragment } from 'react';
 
 export interface Error {
@@ -20,6 +21,10 @@ export interface Error {
 interface Props {
   title: React.ReactNode;
   error: Error;
+  id?: string;
+  role?: string;
+  'aria-live'?: AriaAttributes['aria-live'];
+  'data-test-subj'?: string;
 }
 
 export const SectionError: React.FunctionComponent<Props> = ({ title, error, ...rest }) => {

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/template_form/template_form.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/template_form/template_form.tsx
@@ -155,6 +155,7 @@ export const TemplateForm = ({
   const apiError = saveError ? (
     <>
       <SectionError
+        id="templateCreationError"
         title={
           <FormattedMessage
             id="xpack.idxMgmt.templateForm.saveTemplateError"
@@ -162,6 +163,8 @@ export const TemplateForm = ({
           />
         }
         error={saveError}
+        role="alert"
+        aria-live="assertive"
         data-test-subj="saveTemplateError"
       />
       <EuiSpacer size="m" />

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/edit_data_retention_modal/edit_data_retention_modal.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/edit_data_retention_modal/edit_data_retention_modal.tsx
@@ -203,10 +203,11 @@ export const EditDataRetentionModal: React.FunctionComponent<Props> = ({
       onClose={() => onClose()}
       data-test-subj="editDataRetentionModal"
       css={{ width: 650 }}
+      aria-labelledby="editDataRetentionModalTitle"
     >
       <Form form={form} data-test-subj="editDataRetentionForm">
         <EuiModalHeader>
-          <EuiModalHeaderTitle>
+          <EuiModalHeaderTitle id="editDataRetentionModalTitle">
             {isBulkEdit ? (
               <FormattedMessage
                 id="xpack.idxMgmt.dataStreams.editDataRetentionModal.bulkEdit.modalTitleText"
@@ -353,6 +354,7 @@ export const EditDataRetentionModal: React.FunctionComponent<Props> = ({
 
           {affectedDataStreams.length > 0 && !formData.infiniteRetentionPeriod && (
             <EuiCallOut
+              id="dataRetentionDeletionWarning"
               title={i18n.translate(
                 'xpack.idxMgmt.dataStreams.editDataRetentionModal.affectedDataStreamsCalloutTitle',
                 {
@@ -361,6 +363,8 @@ export const EditDataRetentionModal: React.FunctionComponent<Props> = ({
               )}
               color="danger"
               iconType="warning"
+              role="alert"
+              aria-live="assertive"
               data-test-subj="reducedDataRetentionCallout"
             >
               <p>
@@ -410,6 +414,11 @@ export const EditDataRetentionModal: React.FunctionComponent<Props> = ({
             disabled={disableSubmit}
             data-test-subj="saveButton"
             onClick={onSubmitForm}
+            aria-describedby={
+              affectedDataStreams.length > 0 && !formData.infiniteRetentionPeriod
+                ? 'dataRetentionDeletionWarning'
+                : undefined
+            }
           >
             <FormattedMessage
               id="xpack.idxMgmt.dataStreams.editDataRetentionModal.saveButtonLabel"

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_settings_content.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_settings_content.tsx
@@ -224,6 +224,7 @@ export const DetailsPageSettingsContent: FunctionComponent<Props> = ({
                 isDisabled={!isEditMode || !editableSettings || settingsString === editableSettings}
                 isLoading={isLoading}
                 onClick={updateSettings}
+                aria-describedby={updateError ? 'indexSettingsUpdateError' : undefined}
               >
                 <FormattedMessage
                   id="xpack.idxMgmt.indexDetails.settings.saveButtonLabel"
@@ -249,6 +250,7 @@ export const DetailsPageSettingsContent: FunctionComponent<Props> = ({
             <>
               <EuiSpacer size="m" />
               <EuiCallOut
+                id="indexSettingsUpdateError"
                 title={i18n.translate(
                   'xpack.idxMgmt.indexDetails.settings.saveSettingsErrorMessage',
                   {
@@ -257,6 +259,8 @@ export const DetailsPageSettingsContent: FunctionComponent<Props> = ({
                 )}
                 color="danger"
                 iconType="error"
+                role="alert"
+                aria-live="assertive"
               >
                 {updateError.message && <p>{updateError.message}</p>}
               </EuiCallOut>


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/218646

This PR improves accessibility of error messages for screen readers in Index Management, specifically:
- Edit data retention modal
- Template creation wizard
- Edit index settings 

See GH issue for more details.