### PR TITLE
[9.1] [UII] Supporting input-level `deployment_modes` for integration policies (#226086)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
@@ -14,7 +14,37 @@ import {
 import { PackagePolicyValidationError } from '../errors';
 import type { NewPackagePolicyInput, PackageInfo, RegistryPolicyTemplate } from '../types';
 
-import type { SimplifiedInputs } from './simplified_package_policy_helper';
+export interface RegistryInputForDeploymentMode {
+  type: string;
+  policy_template?: string;
+  deployment_modes?: string[];
+}
+
+/**
+ * Extract registry inputs from package info for deployment mode checking.
+ * Keyed by both input type and policy template name.
+ */
+function extractRegistryInputsForDeploymentMode(
+  packageInfo?: Pick<PackageInfo, 'policy_templates'>
+): RegistryInputForDeploymentMode[] {
+  const inputs: RegistryInputForDeploymentMode[] = [];
+
+  packageInfo?.policy_templates?.forEach((template) => {
+    if ('inputs' in template && template.inputs) {
+      template.inputs.forEach((input) => {
+        if (!inputs.find((i) => i.type === input.type && i.policy_template === template.name)) {
+          inputs.push({
+            type: input.type,
+            policy_template: template.name,
+            deployment_modes: input.deployment_modes,
+          });
+        }
+      });
+    }
+  });
+
+  return inputs;
+}
 
 export const isAgentlessIntegration = (
   packageInfo: Pick<PackageInfo, 'policy_templates'> | undefined
@@ -64,45 +94,59 @@ export const isOnlyAgentlessPolicyTemplate = (policyTemplate: RegistryPolicyTemp
 };
 
 /*
- * Check if the package policy inputs is not allowed in agentless
+ * Check if an input is allowed for a specific deployment mode based on its deployment_modes property.
+ * If deployment_modes is not present, check against the input type blocklist instead.
  */
-export function inputNotAllowedInAgentless(inputType: string, supportsAgentless?: boolean | null) {
-  return supportsAgentless === true && AGENTLESS_DISABLED_INPUTS.includes(inputType);
+export function isInputAllowedForDeploymentMode(
+  input: Pick<NewPackagePolicyInput, 'type' | 'policy_template'>,
+  deploymentMode: 'default' | 'agentless',
+  packageInfo?: PackageInfo
+): boolean {
+  // Always allow system package for monitoring, if this is not excluded it will be blocked
+  // by the following code because it contains `logfile` input which is in the blocklist.
+  if (packageInfo?.name === 'system') {
+    return true;
+  }
+
+  // Find the registry input definition for this input type and policy template
+  const registryInput = extractRegistryInputsForDeploymentMode(packageInfo).find(
+    (rInput) =>
+      rInput.type === input.type &&
+      (input.policy_template ? input.policy_template === rInput.policy_template : true)
+  );
+
+  // If deployment_modes is specified in the registry, use it
+  if (registryInput?.deployment_modes && Array.isArray(registryInput.deployment_modes)) {
+    return registryInput.deployment_modes.includes(deploymentMode);
+  }
+
+  // For backward compatibility, if deployment_modes is not specified:
+  // - For agentless mode, check the blocklist
+  // - For default mode, allow all inputs
+  if (deploymentMode === 'agentless') {
+    return !AGENTLESS_DISABLED_INPUTS.includes(input.type);
+  }
+
+  return true; // Allow all inputs for default mode when deployment_modes is not specified
 }
 
 /*
  * Throw error if trying to enabling an input that is not allowed in agentless
  */
-export function validateAgentlessInputs(
-  packagePolicyInputs: NewPackagePolicyInput[] | SimplifiedInputs,
-  supportsAgentless?: boolean | null
+export function validateDeploymentModesForInputs(
+  inputs: Array<Pick<NewPackagePolicyInput, 'type' | 'enabled' | 'policy_template'>>,
+  deploymentMode: 'default' | 'agentless',
+  packageInfo?: PackageInfo
 ) {
-  if (Array.isArray(packagePolicyInputs)) {
-    packagePolicyInputs.forEach((input) => {
-      throwIfInputNotAllowed(input.type, input.enabled, supportsAgentless);
-    });
-  } else {
-    Object.keys(packagePolicyInputs).forEach((inputName) => {
-      const input = packagePolicyInputs[inputName];
-      const match = inputName.match(/\-(\w*)$/);
-      const inputType = match && match.length > 0 ? match[1] : '';
-      throwIfInputNotAllowed(inputType, input?.enabled ?? false, supportsAgentless);
-    });
-  }
-}
-
-function throwIfInputNotAllowed(
-  inputType: string,
-  inputEnabled: boolean,
-  supportsAgentless?: boolean | null
-) {
-  if (inputNotAllowedInAgentless(inputType, supportsAgentless) && inputEnabled === true) {
-    throw new PackagePolicyValidationError(
-      `Input ${inputType} is not allowed: types '${AGENTLESS_DISABLED_INPUTS.map(
-        (name) => name
-      ).join(', ')}' cannot be enabled for an Agentless integration`
-    );
-  }
+  inputs.forEach((input) => {
+    if (input.enabled && !isInputAllowedForDeploymentMode(input, deploymentMode, packageInfo)) {
+      throw new PackagePolicyValidationError(
+        `Input ${input.type}${
+          packageInfo?.name ? ` in ${packageInfo.name}` : ''
+        } is not allowed for deployment mode '${deploymentMode}'`
+      );
+    }
+  });
 }
 
 /**

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
@@ -283,6 +283,7 @@ export enum RegistryInputKeys {
   input_group = 'input_group',
   required_vars = 'required_vars',
   vars = 'vars',
+  deployment_modes = 'deployment_modes',
 }
 
 export type RegistryInputGroup = 'logs' | 'metrics';
@@ -296,6 +297,7 @@ export interface RegistryInput {
   [RegistryInputKeys.input_group]?: RegistryInputGroup;
   [RegistryInputKeys.required_vars]?: RegistryRequiredVars;
   [RegistryInputKeys.vars]?: RegistryVarsEntry[];
+  [RegistryInputKeys.deployment_modes]?: string[];
 }
 
 export enum RegistryStreamKeys {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
@@ -20,14 +20,13 @@ import {
   isIntegrationPolicyTemplate,
   getRegistryStreamWithDataStreamForInputType,
 } from '../../../../../../../../common/services';
+import { isInputAllowedForDeploymentMode } from '../../../../../../../../common/services/agentless_policy_helper';
 
 import type { PackageInfo, NewPackagePolicy, NewPackagePolicyInput } from '../../../../../types';
 import { Loading } from '../../../../../components';
 import { doesPackageHaveIntegrations } from '../../../../../services';
 
 import type { PackagePolicyValidationResults } from '../../services';
-
-import { AGENTLESS_DISABLED_INPUTS } from '../../../../../../../../common/constants';
 
 import { PackagePolicyInputPanel } from './components';
 
@@ -101,11 +100,15 @@ export const StepConfigurePackagePolicy: React.FunctionComponent<{
                 });
               };
 
-              return packagePolicyInput &&
-                !(
-                  (isAgentlessSelected || packagePolicy.supports_agentless === true) &&
-                  AGENTLESS_DISABLED_INPUTS.includes(packagePolicyInput.type)
-                ) ? (
+              const isInputAvailable =
+                packagePolicyInput &&
+                isInputAllowedForDeploymentMode(
+                  packagePolicyInput,
+                  isAgentlessSelected && packagePolicy.supports_agentless ? 'agentless' : 'default',
+                  packageInfo
+                );
+
+              return isInputAvailable ? (
                 <EuiFlexItem key={packageInput.type}>
                   <PackagePolicyInputPanel
                     packageInput={packageInput}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -43,6 +43,7 @@ import {
   SO_SEARCH_LIMIT,
 } from '../../../../../../../../common';
 import { getMaxPackageName } from '../../../../../../../../common/services';
+import { isInputAllowedForDeploymentMode } from '../../../../../../../../common/services/agentless_policy_helper';
 import { useConfirmForceInstall } from '../../../../../../integrations/hooks';
 import { validatePackagePolicy, validationHasErrors } from '../../services';
 import type { PackagePolicyValidationResults } from '../../services';
@@ -55,7 +56,6 @@ import {
   getCloudFormationPropsFromPackagePolicy,
   getCloudShellUrlFromPackagePolicy,
 } from '../../../../../../../components/cloud_security_posture/services';
-import { AGENTLESS_DISABLED_INPUTS } from '../../../../../../../../common/constants';
 import { ensurePackageKibanaAssetsInstalled } from '../../../../../services/ensure_kibana_assets_installed';
 
 import { useAgentless, useSetupTechnology } from './setup_technology';
@@ -405,12 +405,19 @@ export function useOnSubmit({
 
   const newInputs = useMemo(() => {
     return packagePolicy.inputs.map((input, i) => {
-      if (isAgentlessSelected && AGENTLESS_DISABLED_INPUTS.includes(input.type)) {
+      if (
+        isInputAllowedForDeploymentMode(
+          input,
+          isAgentlessSelected ? 'agentless' : 'default',
+          packageInfo
+        )
+      ) {
+        return input;
+      } else {
         return { ...input, enabled: false };
       }
-      return packagePolicy.inputs[i];
     });
-  }, [packagePolicy.inputs, isAgentlessSelected]);
+  }, [packagePolicy.inputs, isAgentlessSelected, packageInfo]);
 
   useEffect(() => {
     if (prevSetupTechnology !== selectedSetupTechnology) {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
@@ -60,12 +60,8 @@ import {
   packagePolicyToSimplifiedPackagePolicy,
 } from '../../../common/services/simplified_package_policy_helper';
 
-import type {
-  SimplifiedInputs,
-  SimplifiedPackagePolicy,
-} from '../../../common/services/simplified_package_policy_helper';
+import type { SimplifiedPackagePolicy } from '../../../common/services/simplified_package_policy_helper';
 import { runWithCache } from '../../services/epm/packages/cache';
-import { validateAgentlessInputs } from '../../../common/services/agentless_policy_helper';
 
 import {
   isSimplifiedCreatePackagePolicyRequest,
@@ -397,10 +393,6 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
         pkgInfo,
         { experimental_data_stream_features: pkg.experimental_data_stream_features }
       );
-      validateAgentlessInputs(
-        body?.inputs as SimplifiedInputs,
-        body?.supports_agentless || newData.supports_agentless
-      );
     } else {
       // complete request
       const { overrides, ...restOfBody } = body as TypeOf<
@@ -430,10 +422,7 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
         newData.overrides = overrides;
       }
     }
-    validateAgentlessInputs(
-      newData.inputs,
-      newData.supports_agentless || packagePolicy.supports_agentless
-    );
+
     newData.inputs = alignInputsAndStreams(newData.inputs);
 
     if (

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/utils.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/utils.test.ts
@@ -14,7 +14,7 @@ import { licenseService } from '../license';
 import { outputService } from '../output';
 
 import {
-  canDeployAsAgentlessOrThrow,
+  canDeployCustomPackageAsAgentlessOrThrow,
   mapPackagePolicySavedObjectToPackagePolicy,
   preflightCheckPackagePolicy,
 } from './utils';
@@ -200,7 +200,7 @@ describe('canDeployAsAgentlessOrThrow', () => {
     jest.spyOn(appContextService, 'getConfig').mockReturnValue(getMockConfig());
     let error = null;
     try {
-      canDeployAsAgentlessOrThrow(
+      canDeployCustomPackageAsAgentlessOrThrow(
         getTestPolicy(),
         createPackageInfoMock({ installSource: 'custom' })
       );
@@ -215,7 +215,7 @@ describe('canDeployAsAgentlessOrThrow', () => {
     jest.spyOn(appContextService, 'getConfig').mockReturnValue(getMockConfig());
     let error = null;
     try {
-      canDeployAsAgentlessOrThrow(getTestPolicy(), createPackageInfoMock());
+      canDeployCustomPackageAsAgentlessOrThrow(getTestPolicy(), createPackageInfoMock());
     } catch (e) {
       error = e;
     }
@@ -227,7 +227,7 @@ describe('canDeployAsAgentlessOrThrow', () => {
     jest.spyOn(appContextService, 'getConfig').mockReturnValue(getMockConfig());
     let error = null;
     try {
-      canDeployAsAgentlessOrThrow(
+      canDeployCustomPackageAsAgentlessOrThrow(
         getTestPolicy(false),
         createPackageInfoMock({ installSource: 'upload' })
       );
@@ -242,7 +242,7 @@ describe('canDeployAsAgentlessOrThrow', () => {
     jest.spyOn(appContextService, 'getConfig').mockReturnValue(getMockConfig(true));
     let error = null;
     try {
-      canDeployAsAgentlessOrThrow(
+      canDeployCustomPackageAsAgentlessOrThrow(
         getTestPolicy(),
         createPackageInfoMock({ installSource: 'custom' })
       );

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/utils.ts
@@ -128,7 +128,7 @@ export async function canUseOutputForIntegration(
   };
 }
 
-export function canDeployAsAgentlessOrThrow(
+export function canDeployCustomPackageAsAgentlessOrThrow(
   packagePolicy: NewPackagePolicy,
   packageInfo: PackageInfo
 ) {

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/list.ts
@@ -321,7 +321,7 @@ export default function ({ getService }: FtrProviderContext) {
         .post(`/api/fleet/fleet_server_hosts`)
         .set('kbn-xsrf', 'xxxx')
         .send({
-          id: 'default-agentless-fleet-server-host',
+          id: 'fleet-default-fleet-server-host',
           name: 'Default',
           is_default: true,
           host_urls: ['https://test.com:8080', 'https://test.com:8081'],

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/changelog.yml
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/changelog.yml
@@ -1,0 +1,7 @@
+version: 1.0.0
+entries:
+  - version: 1.0.0
+    changes:
+      - description: Initial version
+        type: enhancement
+        link: https://github.com/elastic/kibana/pull/123456

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/docs/README.md
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/docs/README.md
@@ -1,0 +1,22 @@
+# Test Package for Deployment Modes
+
+This is a test package for verifying deployment_modes functionality in Fleet.
+
+## Policy Templates
+
+### mixed_modes
+Template with inputs supporting different deployment modes:
+- logs: supports both default and agentless
+- metrics: default mode only  
+- http_endpoint: agentless only
+- winlog: no deployment_modes specified (fallback to blocklist)
+
+### agentless_only
+Template that only supports agentless deployment:
+- cloudwatch: AWS CloudWatch metrics
+- s3: AWS S3 access logs
+
+### default_only
+Template that only supports default deployment:
+- filestream: File stream input
+- system: System metrics collection

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/fields/fields.yml
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/fields/fields.yml
@@ -1,0 +1,12 @@
+- name: '@timestamp'
+  type: date
+  description: Event timestamp
+- name: message
+  type: keyword
+  description: Log message
+- name: input.type
+  type: keyword
+  description: Type of input
+- name: agent.name
+  type: keyword
+  description: Agent name

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/manifest.yml
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/manifest.yml
@@ -1,0 +1,67 @@
+format_version: 3.0.0
+name: deployment_modes_test
+title: Test Package for Deployment Modes
+description: >-
+  Test package to verify deployment_modes functionality in Fleet
+type: integration
+version: 1.0.0
+license: basic
+categories:
+  - observability
+policy_templates:
+  - name: mixed_modes
+    title: Mixed Deployment Modes
+    description: Template with inputs supporting different deployment modes
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+    inputs:
+      - type: logs
+        title: Log Collection
+        description: Collect logs (supports both default and agentless)
+        deployment_modes: ["default", "agentless"]
+      - type: metrics
+        title: Metrics Collection
+        description: Collect metrics (default mode only)
+        deployment_modes: ["default"]
+      - type: http_endpoint
+        title: HTTP Endpoint
+        description: HTTP endpoint monitoring (agentless only)
+        deployment_modes: ["agentless"]
+      - type: winlog
+        title: Windows Event Logs
+        description: Windows event logs (no deployment_modes specified - should fall back to blocklist)
+  - name: agentless_only
+    title: Agentless Only Template
+    description: Template that only supports agentless deployment
+    deployment_modes:
+      agentless:
+        enabled: true
+    inputs:
+      - type: cloudwatch
+        title: CloudWatch Metrics
+        description: AWS CloudWatch metrics
+        deployment_modes: ["agentless"]
+      - type: s3
+        title: S3 Access Logs
+        description: AWS S3 access logs
+        deployment_modes: ["agentless"]
+  - name: default_only
+    title: Default Only Template
+    description: Template that only supports default deployment
+    deployment_modes:
+      default:
+        enabled: true
+    inputs:
+      - type: filestream
+        title: File Stream
+        description: File stream input
+        deployment_modes: ["default"]
+      - type: system
+        title: System Metrics
+        description: System metrics collection
+        deployment_modes: ["default"]
+owner:
+  github: elastic/fleet

--- a/x-pack/platform/test/fleet_api_integration/apis/package_policy/deployment_modes.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/package_policy/deployment_modes.ts
@@ -45,7 +45,11 @@ export default function (providerContext: FtrProviderContext) {
       await supertest
         .delete(`/api/fleet/fleet_server_hosts/fleet-default-fleet-server-host`)
         .set('kbn-xsrf', 'xxxx');
+<<<<<<< HEAD
       await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+=======
+      await esArchiver.unload('x-pack/test/functional/es_archives/fleet/empty_fleet_server');
+>>>>>>> 641c1ab963a6 ([UII] Supporting input-level `deployment_modes` for integration policies (#226086))
       mockApiServer.close();
     });
 

--- a/x-pack/platform/test/fleet_api_integration/apis/package_policy/deployment_modes.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/package_policy/deployment_modes.ts
@@ -45,11 +45,7 @@ export default function (providerContext: FtrProviderContext) {
       await supertest
         .delete(`/api/fleet/fleet_server_hosts/fleet-default-fleet-server-host`)
         .set('kbn-xsrf', 'xxxx');
-<<<<<<< HEAD
       await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
-=======
-      await esArchiver.unload('x-pack/test/functional/es_archives/fleet/empty_fleet_server');
->>>>>>> 641c1ab963a6 ([UII] Supporting input-level `deployment_modes` for integration policies (#226086))
       mockApiServer.close();
     });
 

--- a/x-pack/platform/test/fleet_api_integration/apis/package_policy/index.js
+++ b/x-pack/platform/test/fleet_api_integration/apis/package_policy/index.js
@@ -20,5 +20,6 @@ export default function loadTests({ loadTestFile, getService }) {
     loadTestFile(require.resolve('./upgrade'));
     loadTestFile(require.resolve('./input_package_create_upgrade'));
     loadTestFile(require.resolve('./input_package_rollback'));
+    loadTestFile(require.resolve('./deployment_modes'));
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[UII] Supporting input-level `deployment_modes` for integration policies (#226086)](https://github.com/elastic/kibana/pull/226086)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2025-07-17T17:42:19Z","message":"[UII] Supporting input-level `deployment_modes` for integration policies (#226086)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/213841.\n\nThis PR adds support for the package-spec change\n(https://github.com/elastic/package-spec/pull/915) that allows\ninput-level deployment modes to be specified. For example:\n```ts\n\"policy_templates\": [\n  {\n    // this package's policy template supports both deployment modes\n    \"deployment_modes\": {\n      \"default\": { \"enabled\": true },\n      \"agentless\": { \"enabled\": true }\n    },\n    \"inputs\": [\n      {\n        // but this input can only be enabled in the default mode, not agentless\n        \"deployment_modes\": [ \"default\" ],\n        \"type\": \"some-input\",\n        ...\n      }\n    ]\n    ...\n  }\n]\n```\n\nWhen `deployment_modes` is not specified for an input, we will still\nfallback to checking the `type` against the [agentless\nblocklist](https://github.com/elastic/kibana/blob/7b2c6932827f93049509be37365d063567df7c79/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts#L43).\n\nThis enforcement happens at both the UI and API level.\n\n## Testing\n1. To test, upload or spin up a local registry containing this test\npackage:\n\n[microsoft_sentinel-1.2.1.zip](https://github.com/user-attachments/files/21264108/microsoft_sentinel-1.2.1.zip)\n\nThis package has 3 inputs:\n\n* `Collect Microsoft Sentinel logs via API` -> allowed for both\nagent-based and agentless modes\n* `Collect Microsoft Sentinel events via Azure Event Hub` -> allowed\nonly in agent-based mode due to `azure-eventhub` being on blocklist\n* `Input type disallowed in agentless` -> allowed only in agent-based\nmode due to `deployment_modes: ['default']` being specified on the input\n\n2. Observe that the correct inputs are shown when switching between\nagent-based and agentless modes:\n\n<img width=\"1408\" height=\"714\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3816d86c-afc1-4eb4-aad4-f31867bf5269\"\n/>\n\n<img width=\"1405\" height=\"504\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3b34d2e9-7df8-4c27-9a32-b79c55ff1ee6\"\n/>\n\n3. Observe that attempting to enable disallowed inputs via API\n(create/update) returns an error:\n\n<img width=\"1409\" height=\"605\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e6b21154-ba93-4a39-8efa-897fa431a9df\"\n/>\n\n<img width=\"1408\" height=\"629\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bba1cac3-43a9-4bbf-83d7-74bd71cd7101\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"641c1ab963a67ed5d1864a466668ab37fbd51cfa","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:current-major","v9.2.0","v8.19.3","v8.18.6"],"title":"[UII] Supporting input-level `deployment_modes` for integration policies","number":226086,"url":"https://github.com/elastic/kibana/pull/226086","mergeCommit":{"message":"[UII] Supporting input-level `deployment_modes` for integration policies (#226086)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/213841.\n\nThis PR adds support for the package-spec change\n(https://github.com/elastic/package-spec/pull/915) that allows\ninput-level deployment modes to be specified. For example:\n```ts\n\"policy_templates\": [\n  {\n    // this package's policy template supports both deployment modes\n    \"deployment_modes\": {\n      \"default\": { \"enabled\": true },\n      \"agentless\": { \"enabled\": true }\n    },\n    \"inputs\": [\n      {\n        // but this input can only be enabled in the default mode, not agentless\n        \"deployment_modes\": [ \"default\" ],\n        \"type\": \"some-input\",\n        ...\n      }\n    ]\n    ...\n  }\n]\n```\n\nWhen `deployment_modes` is not specified for an input, we will still\nfallback to checking the `type` against the [agentless\nblocklist](https://github.com/elastic/kibana/blob/7b2c6932827f93049509be37365d063567df7c79/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts#L43).\n\nThis enforcement happens at both the UI and API level.\n\n## Testing\n1. To test, upload or spin up a local registry containing this test\npackage:\n\n[microsoft_sentinel-1.2.1.zip](https://github.com/user-attachments/files/21264108/microsoft_sentinel-1.2.1.zip)\n\nThis package has 3 inputs:\n\n* `Collect Microsoft Sentinel logs via API` -> allowed for both\nagent-based and agentless modes\n* `Collect Microsoft Sentinel events via Azure Event Hub` -> allowed\nonly in agent-based mode due to `azure-eventhub` being on blocklist\n* `Input type disallowed in agentless` -> allowed only in agent-based\nmode due to `deployment_modes: ['default']` being specified on the input\n\n2. Observe that the correct inputs are shown when switching between\nagent-based and agentless modes:\n\n<img width=\"1408\" height=\"714\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3816d86c-afc1-4eb4-aad4-f31867bf5269\"\n/>\n\n<img width=\"1405\" height=\"504\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3b34d2e9-7df8-4c27-9a32-b79c55ff1ee6\"\n/>\n\n3. Observe that attempting to enable disallowed inputs via API\n(create/update) returns an error:\n\n<img width=\"1409\" height=\"605\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e6b21154-ba93-4a39-8efa-897fa431a9df\"\n/>\n\n<img width=\"1408\" height=\"629\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bba1cac3-43a9-4bbf-83d7-74bd71cd7101\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"641c1ab963a67ed5d1864a466668ab37fbd51cfa"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226086","number":226086,"mergeCommit":{"message":"[UII] Supporting input-level `deployment_modes` for integration policies (#226086)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/213841.\n\nThis PR adds support for the package-spec change\n(https://github.com/elastic/package-spec/pull/915) that allows\ninput-level deployment modes to be specified. For example:\n```ts\n\"policy_templates\": [\n  {\n    // this package's policy template supports both deployment modes\n    \"deployment_modes\": {\n      \"default\": { \"enabled\": true },\n      \"agentless\": { \"enabled\": true }\n    },\n    \"inputs\": [\n      {\n        // but this input can only be enabled in the default mode, not agentless\n        \"deployment_modes\": [ \"default\" ],\n        \"type\": \"some-input\",\n        ...\n      }\n    ]\n    ...\n  }\n]\n```\n\nWhen `deployment_modes` is not specified for an input, we will still\nfallback to checking the `type` against the [agentless\nblocklist](https://github.com/elastic/kibana/blob/7b2c6932827f93049509be37365d063567df7c79/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts#L43).\n\nThis enforcement happens at both the UI and API level.\n\n## Testing\n1. To test, upload or spin up a local registry containing this test\npackage:\n\n[microsoft_sentinel-1.2.1.zip](https://github.com/user-attachments/files/21264108/microsoft_sentinel-1.2.1.zip)\n\nThis package has 3 inputs:\n\n* `Collect Microsoft Sentinel logs via API` -> allowed for both\nagent-based and agentless modes\n* `Collect Microsoft Sentinel events via Azure Event Hub` -> allowed\nonly in agent-based mode due to `azure-eventhub` being on blocklist\n* `Input type disallowed in agentless` -> allowed only in agent-based\nmode due to `deployment_modes: ['default']` being specified on the input\n\n2. Observe that the correct inputs are shown when switching between\nagent-based and agentless modes:\n\n<img width=\"1408\" height=\"714\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3816d86c-afc1-4eb4-aad4-f31867bf5269\"\n/>\n\n<img width=\"1405\" height=\"504\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3b34d2e9-7df8-4c27-9a32-b79c55ff1ee6\"\n/>\n\n3. Observe that attempting to enable disallowed inputs via API\n(create/update) returns an error:\n\n<img width=\"1409\" height=\"605\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e6b21154-ba93-4a39-8efa-897fa431a9df\"\n/>\n\n<img width=\"1408\" height=\"629\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bba1cac3-43a9-4bbf-83d7-74bd71cd7101\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"641c1ab963a67ed5d1864a466668ab37fbd51cfa"}},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->