### PR TITLE
[9.0] [UII] Supporting input-level `deployment_modes` for integration policies (#226086)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
@@ -14,7 +14,37 @@ import {
 import { PackagePolicyValidationError } from '../errors';
 import type { NewPackagePolicyInput, PackageInfo, RegistryPolicyTemplate } from '../types';
 
-import type { SimplifiedInputs } from './simplified_package_policy_helper';
+export interface RegistryInputForDeploymentMode {
+  type: string;
+  policy_template?: string;
+  deployment_modes?: string[];
+}
+
+/**
+ * Extract registry inputs from package info for deployment mode checking.
+ * Keyed by both input type and policy template name.
+ */
+function extractRegistryInputsForDeploymentMode(
+  packageInfo?: Pick<PackageInfo, 'policy_templates'>
+): RegistryInputForDeploymentMode[] {
+  const inputs: RegistryInputForDeploymentMode[] = [];
+
+  packageInfo?.policy_templates?.forEach((template) => {
+    if ('inputs' in template && template.inputs) {
+      template.inputs.forEach((input) => {
+        if (!inputs.find((i) => i.type === input.type && i.policy_template === template.name)) {
+          inputs.push({
+            type: input.type,
+            policy_template: template.name,
+            deployment_modes: input.deployment_modes,
+          });
+        }
+      });
+    }
+  });
+
+  return inputs;
+}
 
 export const isAgentlessIntegration = (
   packageInfo: Pick<PackageInfo, 'policy_templates'> | undefined
@@ -64,45 +94,59 @@ export const isOnlyAgentlessPolicyTemplate = (policyTemplate: RegistryPolicyTemp
 };
 
 /*
- * Check if the package policy inputs is not allowed in agentless
+ * Check if an input is allowed for a specific deployment mode based on its deployment_modes property.
+ * If deployment_modes is not present, check against the input type blocklist instead.
  */
-export function inputNotAllowedInAgentless(inputType: string, supportsAgentless?: boolean | null) {
-  return supportsAgentless === true && AGENTLESS_DISABLED_INPUTS.includes(inputType);
+export function isInputAllowedForDeploymentMode(
+  input: Pick<NewPackagePolicyInput, 'type' | 'policy_template'>,
+  deploymentMode: 'default' | 'agentless',
+  packageInfo?: PackageInfo
+): boolean {
+  // Always allow system package for monitoring, if this is not excluded it will be blocked
+  // by the following code because it contains `logfile` input which is in the blocklist.
+  if (packageInfo?.name === 'system') {
+    return true;
+  }
+
+  // Find the registry input definition for this input type and policy template
+  const registryInput = extractRegistryInputsForDeploymentMode(packageInfo).find(
+    (rInput) =>
+      rInput.type === input.type &&
+      (input.policy_template ? input.policy_template === rInput.policy_template : true)
+  );
+
+  // If deployment_modes is specified in the registry, use it
+  if (registryInput?.deployment_modes && Array.isArray(registryInput.deployment_modes)) {
+    return registryInput.deployment_modes.includes(deploymentMode);
+  }
+
+  // For backward compatibility, if deployment_modes is not specified:
+  // - For agentless mode, check the blocklist
+  // - For default mode, allow all inputs
+  if (deploymentMode === 'agentless') {
+    return !AGENTLESS_DISABLED_INPUTS.includes(input.type);
+  }
+
+  return true; // Allow all inputs for default mode when deployment_modes is not specified
 }
 
 /*
  * Throw error if trying to enabling an input that is not allowed in agentless
  */
-export function validateAgentlessInputs(
-  packagePolicyInputs: NewPackagePolicyInput[] | SimplifiedInputs,
-  supportsAgentless?: boolean | null
+export function validateDeploymentModesForInputs(
+  inputs: Array<Pick<NewPackagePolicyInput, 'type' | 'enabled' | 'policy_template'>>,
+  deploymentMode: 'default' | 'agentless',
+  packageInfo?: PackageInfo
 ) {
-  if (Array.isArray(packagePolicyInputs)) {
-    packagePolicyInputs.forEach((input) => {
-      throwIfInputNotAllowed(input.type, input.enabled, supportsAgentless);
-    });
-  } else {
-    Object.keys(packagePolicyInputs).forEach((inputName) => {
-      const input = packagePolicyInputs[inputName];
-      const match = inputName.match(/\-(\w*)$/);
-      const inputType = match && match.length > 0 ? match[1] : '';
-      throwIfInputNotAllowed(inputType, input?.enabled ?? false, supportsAgentless);
-    });
-  }
-}
-
-function throwIfInputNotAllowed(
-  inputType: string,
-  inputEnabled: boolean,
-  supportsAgentless?: boolean | null
-) {
-  if (inputNotAllowedInAgentless(inputType, supportsAgentless) && inputEnabled === true) {
-    throw new PackagePolicyValidationError(
-      `Input ${inputType} is not allowed: types '${AGENTLESS_DISABLED_INPUTS.map(
-        (name) => name
-      ).join(', ')}' cannot be enabled for an Agentless integration`
-    );
-  }
+  inputs.forEach((input) => {
+    if (input.enabled && !isInputAllowedForDeploymentMode(input, deploymentMode, packageInfo)) {
+      throw new PackagePolicyValidationError(
+        `Input ${input.type}${
+          packageInfo?.name ? ` in ${packageInfo.name}` : ''
+        } is not allowed for deployment mode '${deploymentMode}'`
+      );
+    }
+  });
 }
 
 /**

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
@@ -15,11 +15,12 @@ import type {
   PackageInfo,
   ExperimentalDataStreamFeature,
 } from '../types';
-import { AGENTLESS_DISABLED_INPUTS, DATASET_VAR_NAME } from '../constants';
+import { DATASET_VAR_NAME } from '../constants';
+
 import { PackagePolicyValidationError } from '../errors';
 
 import { packageToPackagePolicy } from '.';
-import { inputNotAllowedInAgentless } from './agentless_policy_helper';
+import { isInputAllowedForDeploymentMode } from './agentless_policy_helper';
 
 export type SimplifiedVars = Record<string, string | string[] | boolean | number | number[] | null>;
 
@@ -76,18 +77,25 @@ export function generateInputId(input: NewPackagePolicyInput) {
   return `${input.policy_template ? `${input.policy_template}-` : ''}${input.type}`;
 }
 
-export function formatInputs(inputs: NewPackagePolicy['inputs'], supportsAgentless?: boolean) {
+export function formatInputs(
+  inputs: NewPackagePolicy['inputs'],
+  supportsAgentless?: boolean,
+  packageInfo?: PackageInfo
+) {
   return inputs.reduce((acc, input) => {
     const inputId = generateInputId(input);
     if (!acc) {
       acc = {};
     }
-    const enabled =
-      supportsAgentless === true && AGENTLESS_DISABLED_INPUTS.includes(input.type)
-        ? false
-        : input.enabled;
+
     acc[inputId] = {
-      enabled,
+      enabled: isInputAllowedForDeploymentMode(
+        input,
+        supportsAgentless ? 'agentless' : 'default',
+        packageInfo
+      )
+        ? input.enabled
+        : false,
       vars: formatVars(input.vars),
       streams: formatStreams(input.streams),
     };
@@ -197,18 +205,18 @@ export function simplifiedPackagePolicytoNewPackagePolicy(
     const { enabled, streams = {}, vars: inputLevelVars } = val;
 
     const { input: packagePolicyInput, streams: streamsMap } = inputMap.get(inputId) ?? {};
+
     if (!packagePolicyInput || !streamsMap) {
       throw new PackagePolicyValidationError(`Input not found: ${inputId}`);
     }
 
-    if (
-      inputNotAllowedInAgentless(packagePolicyInput.type, packagePolicy?.supports_agentless) ||
-      enabled === false
-    ) {
-      packagePolicyInput.enabled = false;
-    } else {
-      packagePolicyInput.enabled = true;
-    }
+    const isInputAllowed = isInputAllowedForDeploymentMode(
+      packagePolicyInput,
+      packagePolicy?.supports_agentless ? 'agentless' : 'default',
+      packageInfo
+    );
+
+    packagePolicyInput.enabled = !isInputAllowed || enabled === false ? false : true;
 
     if (inputLevelVars) {
       assignVariables(inputLevelVars, packagePolicyInput.vars, `${inputId}`);
@@ -221,10 +229,7 @@ export function simplifiedPackagePolicytoNewPackagePolicy(
         throw new PackagePolicyValidationError(`Stream not found ${inputId}: ${streamId}`);
       }
 
-      if (
-        streamEnabled === false ||
-        inputNotAllowedInAgentless(packagePolicyInput.type, packagePolicy?.supports_agentless)
-      ) {
+      if (streamEnabled === false || isInputAllowed === false) {
         packagePolicyStream.enabled = false;
       } else {
         packagePolicyStream.enabled = true;

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
@@ -282,6 +282,7 @@ export enum RegistryInputKeys {
   input_group = 'input_group',
   required_vars = 'required_vars',
   vars = 'vars',
+  deployment_modes = 'deployment_modes',
 }
 
 export type RegistryInputGroup = 'logs' | 'metrics';
@@ -295,6 +296,7 @@ export interface RegistryInput {
   [RegistryInputKeys.input_group]?: RegistryInputGroup;
   [RegistryInputKeys.required_vars]?: RegistryRequiredVars;
   [RegistryInputKeys.vars]?: RegistryVarsEntry[];
+  [RegistryInputKeys.deployment_modes]?: string[];
 }
 
 export enum RegistryStreamKeys {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
@@ -20,14 +20,13 @@ import {
   isIntegrationPolicyTemplate,
   getRegistryStreamWithDataStreamForInputType,
 } from '../../../../../../../../common/services';
+import { isInputAllowedForDeploymentMode } from '../../../../../../../../common/services/agentless_policy_helper';
 
 import type { PackageInfo, NewPackagePolicy, NewPackagePolicyInput } from '../../../../../types';
 import { Loading } from '../../../../../components';
 import { doesPackageHaveIntegrations } from '../../../../../services';
 
 import type { PackagePolicyValidationResults } from '../../services';
-
-import { AGENTLESS_DISABLED_INPUTS } from '../../../../../../../../common/constants';
 
 import { PackagePolicyInputPanel } from './components';
 
@@ -101,11 +100,15 @@ export const StepConfigurePackagePolicy: React.FunctionComponent<{
                 });
               };
 
-              return packagePolicyInput &&
-                !(
-                  (isAgentlessSelected || packagePolicy.supports_agentless === true) &&
-                  AGENTLESS_DISABLED_INPUTS.includes(packagePolicyInput.type)
-                ) ? (
+              const isInputAvailable =
+                packagePolicyInput &&
+                isInputAllowedForDeploymentMode(
+                  packagePolicyInput,
+                  isAgentlessSelected && packagePolicy.supports_agentless ? 'agentless' : 'default',
+                  packageInfo
+                );
+
+              return isInputAvailable ? (
                 <EuiFlexItem key={packageInput.type}>
                   <PackagePolicyInputPanel
                     packageInput={packageInput}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -37,6 +37,7 @@ import {
   SO_SEARCH_LIMIT,
 } from '../../../../../../../../common';
 import { getMaxPackageName } from '../../../../../../../../common/services';
+import { isInputAllowedForDeploymentMode } from '../../../../../../../../common/services/agentless_policy_helper';
 import { useConfirmForceInstall } from '../../../../../../integrations/hooks';
 import { validatePackagePolicy, validationHasErrors } from '../../services';
 import type { PackagePolicyValidationResults } from '../../services';
@@ -49,8 +50,6 @@ import {
   getCloudFormationPropsFromPackagePolicy,
   getCloudShellUrlFromPackagePolicy,
 } from '../../../../../../../components/cloud_security_posture/services';
-
-import { AGENTLESS_DISABLED_INPUTS } from '../../../../../../../../common/constants';
 
 import { useAgentless, useSetupTechnology } from './setup_technology';
 
@@ -316,12 +315,19 @@ export function useOnSubmit({
 
   const newInputs = useMemo(() => {
     return packagePolicy.inputs.map((input, i) => {
-      if (isAgentlessSelected && AGENTLESS_DISABLED_INPUTS.includes(input.type)) {
+      if (
+        isInputAllowedForDeploymentMode(
+          input,
+          isAgentlessSelected ? 'agentless' : 'default',
+          packageInfo
+        )
+      ) {
+        return input;
+      } else {
         return { ...input, enabled: false };
       }
-      return packagePolicy.inputs[i];
     });
-  }, [packagePolicy.inputs, isAgentlessSelected]);
+  }, [packagePolicy.inputs, isAgentlessSelected, packageInfo]);
 
   useEffect(() => {
     if (prevSetupTechnology !== selectedSetupTechnology) {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
@@ -56,12 +56,7 @@ import {
   packagePolicyToSimplifiedPackagePolicy,
 } from '../../../common/services/simplified_package_policy_helper';
 
-import type {
-  SimplifiedInputs,
-  SimplifiedPackagePolicy,
-} from '../../../common/services/simplified_package_policy_helper';
-
-import { validateAgentlessInputs } from '../../../common/services/agentless_policy_helper';
+import type { SimplifiedPackagePolicy } from '../../../common/services/simplified_package_policy_helper';
 
 import {
   isSimplifiedCreatePackagePolicyRequest,
@@ -366,10 +361,6 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
         pkgInfo,
         { experimental_data_stream_features: pkg.experimental_data_stream_features }
       );
-      validateAgentlessInputs(
-        body?.inputs as SimplifiedInputs,
-        body?.supports_agentless || newData.supports_agentless
-      );
     } else {
       // complete request
       const { overrides, ...restOfBody } = body as TypeOf<
@@ -399,10 +390,7 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
         newData.overrides = overrides;
       }
     }
-    validateAgentlessInputs(
-      newData.inputs,
-      newData.supports_agentless || packagePolicy.supports_agentless
-    );
+
     newData.inputs = alignInputsAndStreams(newData.inputs);
 
     if (

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -214,20 +214,25 @@ jest.mock('./secrets', () => ({
 
 type CombinedExternalCallback = PutPackagePolicyUpdateCallback | PostPackagePolicyCreateCallback;
 
-const mockAgentPolicyGet = (spaceIds: string[] = ['default']) => {
+const mockAgentPolicyGet = (spaceIds: string[] = ['default'], additionalProps?: any) => {
+  const basePolicy = {
+    name: 'Test Agent Policy',
+    namespace: 'test',
+    status: 'active',
+    is_managed: false,
+    updated_at: new Date().toISOString(),
+    updated_by: 'test',
+    revision: 1,
+    is_protected: false,
+    space_ids: spaceIds,
+    ...additionalProps,
+  };
+
   mockAgentPolicyService.get.mockImplementation(
     (_soClient: SavedObjectsClientContract, id: string, _force = false, _errorMessage?: string) => {
       return Promise.resolve({
         id,
-        name: 'Test Agent Policy',
-        namespace: 'test',
-        status: 'active',
-        is_managed: false,
-        updated_at: new Date().toISOString(),
-        updated_by: 'test',
-        revision: 1,
-        is_protected: false,
-        space_ids: spaceIds,
+        ...basePolicy,
       });
     }
   );
@@ -237,15 +242,7 @@ const mockAgentPolicyGet = (spaceIds: string[] = ['default']) => {
       return Promise.resolve(
         ids.map((id) => ({
           id,
-          name: 'Test Agent Policy',
-          namespace: 'test',
-          status: 'active',
-          is_managed: false,
-          updated_at: new Date().toISOString(),
-          updated_by: 'test',
-          revision: 1,
-          is_protected: false,
-          space_ids: spaceIds,
+          ...basePolicy,
         }))
       );
     }
@@ -348,6 +345,48 @@ describe('Package policy service', () => {
       ).rejects.toThrowError(
         /Reusable integration policies cannot be used with agent policies belonging to multiple spaces./
       );
+    });
+
+    it('should throw validation error for agentless deployment mode with disallowed inputs', async () => {
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      const soClient = savedObjectsClientMock.create();
+
+      soClient.create.mockResolvedValueOnce({
+        id: 'test-package-policy',
+        attributes: {},
+        references: [],
+        type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+      });
+
+      // Mock an agentless agent policy
+      mockAgentPolicyGet(undefined, { supports_agentless: true });
+
+      await expect(
+        packagePolicyService.create(
+          soClient,
+          esClient,
+          {
+            name: 'Test Package Policy',
+            namespace: 'test',
+            enabled: true,
+            policy_id: 'test',
+            policy_ids: ['test'],
+            inputs: [
+              {
+                type: 'tcp', // tcp input is in the blocklist for agentless
+                enabled: true,
+                streams: [],
+              },
+            ],
+            package: {
+              name: 'test',
+              title: 'Test',
+              version: '0.0.1',
+            },
+          },
+          { id: 'test-package-policy', skipUniqueNameVerification: true }
+        )
+      ).rejects.toThrowError(/Input tcp is not allowed for deployment mode 'agentless'/);
     });
   });
 
@@ -2036,6 +2075,55 @@ describe('Package policy service', () => {
           expect(call[2]).toContain(`test-agent-policy-${idx + 1}`);
           expect(call[3]).toMatchObject({ removeProtection: false });
         });
+      });
+
+      it('should throw validation error for agentless deployment mode with disallowed inputs', async () => {
+        const savedObjectsClient = savedObjectsClientMock.create();
+        const elasticsearchClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+        // Mock existing package policy
+        savedObjectsClient.bulkGet.mockResolvedValue({
+          saved_objects: [
+            {
+              id: 'test',
+              type: 'abcd',
+              references: [],
+              version: 'test',
+              attributes: createPackagePolicyMock(),
+            },
+          ],
+        });
+
+        // Mock agentless agent policy
+        mockAgentPolicyGet(undefined, { supports_agentless: true });
+
+        await expect(
+          packagePolicyService.update(
+            savedObjectsClient,
+            elasticsearchClient,
+            'the-package-policy-id',
+            {
+              name: 'test-policy',
+              description: '',
+              namespace: 'default',
+              enabled: true,
+              policy_id: 'test',
+              policy_ids: ['test'],
+              inputs: [
+                {
+                  type: 'tcp', // tcp input is in the blocklist for agentless
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+              package: {
+                name: 'test',
+                title: 'Test',
+                version: '0.0.1',
+              },
+            }
+          )
+        ).rejects.toThrowError(/Input tcp is not allowed for deployment mode 'agentless'/);
       });
     });
   });
@@ -5381,67 +5469,6 @@ describe('Package policy service', () => {
                 },
               },
             ],
-          },
-        ],
-        vars: {
-          paths: {
-            value: ['/var/log/apache2/access.log*'],
-            type: 'text',
-          },
-        },
-      });
-    });
-
-    it('should disable inputs if supports_agentless == true if inputs are not allowed', async () => {
-      const newPolicy = {
-        name: 'apache-1',
-        inputs: [
-          { type: 'logfile', enabled: false },
-          { type: 'tcp', enabled: true },
-        ],
-        package: { name: 'apache', version: '0.3.3' },
-        policy_id: '1',
-        policy_ids: ['1'],
-        supports_agentless: true,
-      } as NewPackagePolicy;
-      const result = await packagePolicyService.enrichPolicyWithDefaultsFromPackage(
-        savedObjectsClientMock.create(),
-        newPolicy
-      );
-      expect(result).toEqual({
-        name: 'apache-1',
-        namespace: '',
-        description: '',
-        output_id: undefined,
-        package: {
-          name: 'apache',
-          title: 'Apache',
-          version: '1.0.0',
-          experimental_data_stream_features: undefined,
-        },
-        enabled: true,
-        policy_id: '1',
-        policy_ids: ['1'],
-        supports_agentless: true,
-        inputs: [
-          {
-            enabled: false,
-            type: 'logfile',
-            policy_template: 'log',
-            streams: [
-              {
-                enabled: false,
-                data_stream: {
-                  type: 'logs',
-                  dataset: 'apache.access',
-                },
-              },
-            ],
-          },
-          {
-            enabled: false,
-            type: 'tcp',
-            streams: undefined,
           },
         ],
         vars: {

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/changelog.yml
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/changelog.yml
@@ -1,0 +1,7 @@
+version: 1.0.0
+entries:
+  - version: 1.0.0
+    changes:
+      - description: Initial version
+        type: enhancement
+        link: https://github.com/elastic/kibana/pull/123456

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/docs/README.md
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/docs/README.md
@@ -1,0 +1,22 @@
+# Test Package for Deployment Modes
+
+This is a test package for verifying deployment_modes functionality in Fleet.
+
+## Policy Templates
+
+### mixed_modes
+Template with inputs supporting different deployment modes:
+- logs: supports both default and agentless
+- metrics: default mode only  
+- http_endpoint: agentless only
+- winlog: no deployment_modes specified (fallback to blocklist)
+
+### agentless_only
+Template that only supports agentless deployment:
+- cloudwatch: AWS CloudWatch metrics
+- s3: AWS S3 access logs
+
+### default_only
+Template that only supports default deployment:
+- filestream: File stream input
+- system: System metrics collection

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/fields/fields.yml
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/fields/fields.yml
@@ -1,0 +1,12 @@
+- name: '@timestamp'
+  type: date
+  description: Event timestamp
+- name: message
+  type: keyword
+  description: Log message
+- name: input.type
+  type: keyword
+  description: Type of input
+- name: agent.name
+  type: keyword
+  description: Agent name

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/manifest.yml
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/manifest.yml
@@ -1,0 +1,67 @@
+format_version: 3.0.0
+name: deployment_modes_test
+title: Test Package for Deployment Modes
+description: >-
+  Test package to verify deployment_modes functionality in Fleet
+type: integration
+version: 1.0.0
+license: basic
+categories:
+  - observability
+policy_templates:
+  - name: mixed_modes
+    title: Mixed Deployment Modes
+    description: Template with inputs supporting different deployment modes
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+    inputs:
+      - type: logs
+        title: Log Collection
+        description: Collect logs (supports both default and agentless)
+        deployment_modes: ["default", "agentless"]
+      - type: metrics
+        title: Metrics Collection
+        description: Collect metrics (default mode only)
+        deployment_modes: ["default"]
+      - type: http_endpoint
+        title: HTTP Endpoint
+        description: HTTP endpoint monitoring (agentless only)
+        deployment_modes: ["agentless"]
+      - type: winlog
+        title: Windows Event Logs
+        description: Windows event logs (no deployment_modes specified - should fall back to blocklist)
+  - name: agentless_only
+    title: Agentless Only Template
+    description: Template that only supports agentless deployment
+    deployment_modes:
+      agentless:
+        enabled: true
+    inputs:
+      - type: cloudwatch
+        title: CloudWatch Metrics
+        description: AWS CloudWatch metrics
+        deployment_modes: ["agentless"]
+      - type: s3
+        title: S3 Access Logs
+        description: AWS S3 access logs
+        deployment_modes: ["agentless"]
+  - name: default_only
+    title: Default Only Template
+    description: Template that only supports default deployment
+    deployment_modes:
+      default:
+        enabled: true
+    inputs:
+      - type: filestream
+        title: File Stream
+        description: File stream input
+        deployment_modes: ["default"]
+      - type: system
+        title: System Metrics
+        description: System metrics collection
+        deployment_modes: ["default"]
+owner:
+  github: elastic/fleet

--- a/x-pack/test/fleet_api_integration/apis/package_policy/deployment_modes.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/deployment_modes.ts
@@ -1,0 +1,659 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import * as http from 'http';
+import expect from '@kbn/expect';
+import { v4 as uuidv4 } from 'uuid';
+import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupMockServer } from '../agents/helpers/mock_agentless_api';
+
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const supertest = getService('supertest');
+  const esArchiver = getService('esArchiver');
+  const fleetAndAgents = getService('fleetAndAgents');
+  const mockAgentlessApiService = setupMockServer();
+
+  describe('package policy deployment modes', () => {
+    let mockApiServer: http.Server;
+    skipIfNoDockerRegistry(providerContext);
+
+    before(async () => {
+      mockApiServer = await mockAgentlessApiService.listen(8089); // Start the agentless api mock server on port 8089
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/fleet/empty_fleet_server');
+      await fleetAndAgents.setup();
+
+      // Set up default Fleet Server host, needed during agentless agent creation
+      await supertest
+        .post(`/api/fleet/fleet_server_hosts`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          id: 'fleet-default-fleet-server-host',
+          name: 'Default',
+          is_default: true,
+          host_urls: ['https://test.com:8080', 'https://test.com:8081'],
+        });
+    });
+
+    after(async () => {
+      await supertest
+        .delete(`/api/fleet/fleet_server_hosts/fleet-default-fleet-server-host`)
+        .set('kbn-xsrf', 'xxxx');
+      await esArchiver.unload('x-pack/test/functional/es_archives/fleet/empty_fleet_server');
+      mockApiServer.close();
+    });
+
+    describe('deployment_modes support', () => {
+      let agentPolicyId: string;
+      let agentlessAgentPolicyId: string;
+
+      before(async () => {
+        // Install test package with deployment_modes
+        await supertest
+          .post(`/api/fleet/epm/packages/deployment_modes_test/1.0.0`)
+          .set('kbn-xsrf', 'xxxx')
+          .expect(200);
+
+        // Create regular agent policy
+        const {
+          body: {
+            item: { id: regularPolicyId },
+          },
+        } = await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Test policy ${uuidv4()}`,
+            namespace: 'default',
+            monitoring_enabled: [],
+          })
+          .expect(200);
+        agentPolicyId = regularPolicyId;
+
+        // Create agentless agent policy
+        const {
+          body: {
+            item: { id: agentlessPolicyId },
+          },
+        } = await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Test agentless policy ${uuidv4()}`,
+            namespace: 'default',
+            monitoring_enabled: [],
+            supports_agentless: true,
+          })
+          .expect(200);
+        agentlessAgentPolicyId = agentlessPolicyId;
+      });
+
+      after(async () => {
+        // Clean up agent policies
+        if (agentPolicyId) {
+          await supertest
+            .post(`/api/fleet/agent_policies/delete`)
+            .send({ agentPolicyId })
+            .set('kbn-xsrf', 'xxxx')
+            .expect(200);
+        }
+        if (agentlessAgentPolicyId) {
+          await supertest
+            .post(`/api/fleet/agent_policies/delete`)
+            .send({ agentPolicyId: agentlessAgentPolicyId })
+            .set('kbn-xsrf', 'xxxx')
+            .expect(200);
+        }
+
+        // Uninstall test package
+        await supertest
+          .delete(`/api/fleet/epm/packages/deployment_modes_test/1.0.0`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({ force: true })
+          .expect(200);
+      });
+
+      describe('mixed_modes policy template', () => {
+        it('should allow logs input for both default and agentless deployment modes', async () => {
+          // Test default deployment mode
+          const { body: defaultResponse } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-logs-default-${uuidv4()}`,
+              description: 'Test logs input in default mode',
+              namespace: 'default',
+              policy_id: agentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'logs',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          expect(defaultResponse.item.inputs).to.have.length(1);
+          expect(defaultResponse.item.inputs[0].type).to.be('logs');
+          expect(defaultResponse.item.inputs[0].enabled).to.be(true);
+
+          // Test agentless deployment mode
+          const { body: agentlessResponse } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-logs-agentless-${uuidv4()}`,
+              description: 'Test logs input in agentless mode',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'logs',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          expect(agentlessResponse.item.inputs).to.have.length(1);
+          expect(agentlessResponse.item.inputs[0].type).to.be('logs');
+          expect(agentlessResponse.item.inputs[0].enabled).to.be(true);
+        });
+
+        it('should allow metrics input only for default deployment mode', async () => {
+          // Test default deployment mode (should succeed)
+          const { body: defaultResponse } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-metrics-default-${uuidv4()}`,
+              description: 'Test metrics input in default mode',
+              namespace: 'default',
+              policy_id: agentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'metrics',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          expect(defaultResponse.item.inputs).to.have.length(1);
+          expect(defaultResponse.item.inputs[0].type).to.be('metrics');
+          expect(defaultResponse.item.inputs[0].enabled).to.be(true);
+
+          // Test agentless deployment mode (should fail)
+          await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-metrics-agentless-${uuidv4()}`,
+              description: 'Test metrics input in agentless mode',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'metrics',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(400)
+            .then((response) => {
+              expect(response.body.message).to.contain(
+                "Input metrics in deployment_modes_test is not allowed for deployment mode 'agentless'"
+              );
+            });
+        });
+
+        it('should allow http_endpoint input only for agentless deployment mode', async () => {
+          // Test agentless deployment mode (should succeed)
+          const { body: agentlessResponse } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-http-agentless-${uuidv4()}`,
+              description: 'Test http_endpoint input in agentless mode',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'http_endpoint',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          expect(agentlessResponse.item.inputs).to.have.length(1);
+          expect(agentlessResponse.item.inputs[0].type).to.be('http_endpoint');
+          expect(agentlessResponse.item.inputs[0].enabled).to.be(true);
+
+          // Test default deployment mode (should fail)
+          await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-http-default-${uuidv4()}`,
+              description: 'Test http_endpoint input in default mode',
+              namespace: 'default',
+              policy_id: agentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'http_endpoint',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(400)
+            .then((response) => {
+              expect(response.body.message).to.contain(
+                "Input http_endpoint in deployment_modes_test is not allowed for deployment mode 'default'"
+              );
+            });
+        });
+
+        it('should fall back to blocklist for inputs without deployment_modes', async () => {
+          // Test winlog input for default mode (should succeed - no blocklist for default)
+          const { body: defaultResponse } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-winlog-default-${uuidv4()}`,
+              description: 'Test winlog input in default mode (fallback allows all)',
+              namespace: 'default',
+              policy_id: agentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'winlog',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          expect(defaultResponse.item.inputs).to.have.length(1);
+          expect(defaultResponse.item.inputs[0].type).to.be('winlog');
+          expect(defaultResponse.item.inputs[0].enabled).to.be(true);
+
+          // Test winlog input (blocked by AGENTLESS_DISABLED_INPUTS) for agentless mode
+          const { body: agentlessResponse } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-winlog-agentless-${uuidv4()}`,
+              description: 'Test winlog input in agentless mode (fallback to blocklist)',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'winlog',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(400);
+
+          expect(agentlessResponse.message).to.contain(
+            "Input winlog in deployment_modes_test is not allowed for deployment mode 'agentless'"
+          );
+        });
+      });
+
+      describe('agentless_only policy template', () => {
+        it('should allow agentless inputs only for agentless deployment mode', async () => {
+          // Test agentless deployment mode (should succeed)
+          const { body: agentlessResponse } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-cloudwatch-agentless-${uuidv4()}`,
+              description: 'Test cloudwatch input in agentless mode',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'cloudwatch',
+                  policy_template: 'agentless_only',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          expect(agentlessResponse.item.inputs).to.have.length(1);
+          expect(agentlessResponse.item.inputs[0].type).to.be('cloudwatch');
+
+          // Test default deployment mode (should fail)
+          await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-cloudwatch-default-${uuidv4()}`,
+              description: 'Test cloudwatch input in default mode',
+              namespace: 'default',
+              policy_id: agentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'cloudwatch',
+                  policy_template: 'agentless_only',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(400)
+            .then((response) => {
+              expect(response.body.message).to.contain(
+                "Input cloudwatch in deployment_modes_test is not allowed for deployment mode 'default'"
+              );
+            });
+        });
+      });
+
+      describe('default_only policy template', () => {
+        it('should allow default inputs only for default deployment mode', async () => {
+          // Test default deployment mode (should succeed)
+          const { body: defaultResponse } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-filestream-default-${uuidv4()}`,
+              description: 'Test filestream input in default mode',
+              namespace: 'default',
+              policy_id: agentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'filestream',
+                  policy_template: 'default_only',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          expect(defaultResponse.item.inputs).to.have.length(1);
+          expect(defaultResponse.item.inputs[0].type).to.be('filestream');
+
+          // Test agentless deployment mode (should fail)
+          await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-filestream-agentless-${uuidv4()}`,
+              description: 'Test filestream input in agentless mode',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'filestream',
+                  policy_template: 'default_only',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(400)
+            .then((response) => {
+              expect(response.body.message).to.contain(
+                "Input filestream in deployment_modes_test is not allowed for deployment mode 'agentless'"
+              );
+            });
+        });
+      });
+
+      describe('multiple inputs with mixed deployment modes', () => {
+        it('should validate all inputs and reject if any are incompatible', async () => {
+          // Try to create a package policy with both valid and invalid inputs for agentless
+          await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-mixed-invalid-${uuidv4()}`,
+              description: 'Test mixed inputs with invalid combination',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'logs',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+                {
+                  type: 'metrics', // This should fail for agentless
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(400)
+            .then((response) => {
+              expect(response.body.message).to.contain(
+                "Input metrics in deployment_modes_test is not allowed for deployment mode 'agentless'"
+              );
+            });
+        });
+
+        it('should succeed when all inputs are compatible with deployment mode', async () => {
+          // Create a package policy with only compatible inputs for agentless
+          const { body: response } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-mixed-valid-${uuidv4()}`,
+              description: 'Test mixed inputs with valid combination',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'logs',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+                {
+                  type: 'http_endpoint',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          expect(response.item.inputs).to.have.length(2);
+          expect(response.item.inputs.map((input: any) => input.type)).to.contain('logs');
+          expect(response.item.inputs.map((input: any) => input.type)).to.contain('http_endpoint');
+        });
+      });
+
+      describe('disabled inputs', () => {
+        it('should allow disabled inputs even if they are not compatible with deployment mode', async () => {
+          // Create a package policy with a disabled metrics input for agentless (should succeed)
+          const { body: response } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-disabled-${uuidv4()}`,
+              description: 'Test disabled incompatible input',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'logs',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+                {
+                  type: 'metrics',
+                  policy_template: 'mixed_modes',
+                  enabled: false, // Disabled input should be allowed
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          expect(response.item.inputs).to.have.length(2);
+          const metricsInput = response.item.inputs.find((input: any) => input.type === 'metrics');
+          expect(metricsInput.enabled).to.be(false);
+        });
+      });
+
+      describe('package policy updates', () => {
+        let packagePolicyId: string;
+
+        beforeEach(async () => {
+          // Create a package policy for testing updates
+          const { body: response } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-update-${uuidv4()}`,
+              description: 'Test package policy for updates',
+              namespace: 'default',
+              policy_id: agentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'logs',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          packagePolicyId = response.item.id;
+        });
+
+        it('should validate deployment modes when updating package policy inputs', async () => {
+          // Try to update to add an incompatible input
+          await supertest
+            .put(`/api/fleet/package_policies/${packagePolicyId}`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-update-${uuidv4()}`,
+              description: 'Updated package policy with incompatible input',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId, // Switch to agentless policy
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'logs',
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+                {
+                  type: 'metrics', // This should fail for agentless
+                  policy_template: 'mixed_modes',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(400)
+            .then((response) => {
+              expect(response.body.message).to.contain(
+                "Input metrics in deployment_modes_test is not allowed for deployment mode 'agentless'"
+              );
+            });
+        });
+      });
+    });
+  });
+}

--- a/x-pack/test/fleet_api_integration/apis/package_policy/index.js
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/index.js
@@ -20,5 +20,6 @@ export default function loadTests({ loadTestFile, getService }) {
     loadTestFile(require.resolve('./upgrade'));
     loadTestFile(require.resolve('./input_package_create_upgrade'));
     loadTestFile(require.resolve('./input_package_rollback'));
+    loadTestFile(require.resolve('./deployment_modes'));
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[UII] Supporting input-level `deployment_modes` for integration policies (#226086)](https://github.com/elastic/kibana/pull/226086)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2025-07-17T17:42:19Z","message":"[UII] Supporting input-level `deployment_modes` for integration policies (#226086)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/213841.\n\nThis PR adds support for the package-spec change\n(https://github.com/elastic/package-spec/pull/915) that allows\ninput-level deployment modes to be specified. For example:\n```ts\n\"policy_templates\": [\n  {\n    // this package's policy template supports both deployment modes\n    \"deployment_modes\": {\n      \"default\": { \"enabled\": true },\n      \"agentless\": { \"enabled\": true }\n    },\n    \"inputs\": [\n      {\n        // but this input can only be enabled in the default mode, not agentless\n        \"deployment_modes\": [ \"default\" ],\n        \"type\": \"some-input\",\n        ...\n      }\n    ]\n    ...\n  }\n]\n```\n\nWhen `deployment_modes` is not specified for an input, we will still\nfallback to checking the `type` against the [agentless\nblocklist](https://github.com/elastic/kibana/blob/7b2c6932827f93049509be37365d063567df7c79/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts#L43).\n\nThis enforcement happens at both the UI and API level.\n\n## Testing\n1. To test, upload or spin up a local registry containing this test\npackage:\n\n[microsoft_sentinel-1.2.1.zip](https://github.com/user-attachments/files/21264108/microsoft_sentinel-1.2.1.zip)\n\nThis package has 3 inputs:\n\n* `Collect Microsoft Sentinel logs via API` -> allowed for both\nagent-based and agentless modes\n* `Collect Microsoft Sentinel events via Azure Event Hub` -> allowed\nonly in agent-based mode due to `azure-eventhub` being on blocklist\n* `Input type disallowed in agentless` -> allowed only in agent-based\nmode due to `deployment_modes: ['default']` being specified on the input\n\n2. Observe that the correct inputs are shown when switching between\nagent-based and agentless modes:\n\n<img width=\"1408\" height=\"714\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3816d86c-afc1-4eb4-aad4-f31867bf5269\"\n/>\n\n<img width=\"1405\" height=\"504\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3b34d2e9-7df8-4c27-9a32-b79c55ff1ee6\"\n/>\n\n3. Observe that attempting to enable disallowed inputs via API\n(create/update) returns an error:\n\n<img width=\"1409\" height=\"605\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e6b21154-ba93-4a39-8efa-897fa431a9df\"\n/>\n\n<img width=\"1408\" height=\"629\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bba1cac3-43a9-4bbf-83d7-74bd71cd7101\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"641c1ab963a67ed5d1864a466668ab37fbd51cfa","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:current-major","v9.2.0","v8.19.3","v8.18.6"],"title":"[UII] Supporting input-level `deployment_modes` for integration policies","number":226086,"url":"https://github.com/elastic/kibana/pull/226086","mergeCommit":{"message":"[UII] Supporting input-level `deployment_modes` for integration policies (#226086)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/213841.\n\nThis PR adds support for the package-spec change\n(https://github.com/elastic/package-spec/pull/915) that allows\ninput-level deployment modes to be specified. For example:\n```ts\n\"policy_templates\": [\n  {\n    // this package's policy template supports both deployment modes\n    \"deployment_modes\": {\n      \"default\": { \"enabled\": true },\n      \"agentless\": { \"enabled\": true }\n    },\n    \"inputs\": [\n      {\n        // but this input can only be enabled in the default mode, not agentless\n        \"deployment_modes\": [ \"default\" ],\n        \"type\": \"some-input\",\n        ...\n      }\n    ]\n    ...\n  }\n]\n```\n\nWhen `deployment_modes` is not specified for an input, we will still\nfallback to checking the `type` against the [agentless\nblocklist](https://github.com/elastic/kibana/blob/7b2c6932827f93049509be37365d063567df7c79/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts#L43).\n\nThis enforcement happens at both the UI and API level.\n\n## Testing\n1. To test, upload or spin up a local registry containing this test\npackage:\n\n[microsoft_sentinel-1.2.1.zip](https://github.com/user-attachments/files/21264108/microsoft_sentinel-1.2.1.zip)\n\nThis package has 3 inputs:\n\n* `Collect Microsoft Sentinel logs via API` -> allowed for both\nagent-based and agentless modes\n* `Collect Microsoft Sentinel events via Azure Event Hub` -> allowed\nonly in agent-based mode due to `azure-eventhub` being on blocklist\n* `Input type disallowed in agentless` -> allowed only in agent-based\nmode due to `deployment_modes: ['default']` being specified on the input\n\n2. Observe that the correct inputs are shown when switching between\nagent-based and agentless modes:\n\n<img width=\"1408\" height=\"714\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3816d86c-afc1-4eb4-aad4-f31867bf5269\"\n/>\n\n<img width=\"1405\" height=\"504\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3b34d2e9-7df8-4c27-9a32-b79c55ff1ee6\"\n/>\n\n3. Observe that attempting to enable disallowed inputs via API\n(create/update) returns an error:\n\n<img width=\"1409\" height=\"605\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e6b21154-ba93-4a39-8efa-897fa431a9df\"\n/>\n\n<img width=\"1408\" height=\"629\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bba1cac3-43a9-4bbf-83d7-74bd71cd7101\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"641c1ab963a67ed5d1864a466668ab37fbd51cfa"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226086","number":226086,"mergeCommit":{"message":"[UII] Supporting input-level `deployment_modes` for integration policies (#226086)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/213841.\n\nThis PR adds support for the package-spec change\n(https://github.com/elastic/package-spec/pull/915) that allows\ninput-level deployment modes to be specified. For example:\n```ts\n\"policy_templates\": [\n  {\n    // this package's policy template supports both deployment modes\n    \"deployment_modes\": {\n      \"default\": { \"enabled\": true },\n      \"agentless\": { \"enabled\": true }\n    },\n    \"inputs\": [\n      {\n        // but this input can only be enabled in the default mode, not agentless\n        \"deployment_modes\": [ \"default\" ],\n        \"type\": \"some-input\",\n        ...\n      }\n    ]\n    ...\n  }\n]\n```\n\nWhen `deployment_modes` is not specified for an input, we will still\nfallback to checking the `type` against the [agentless\nblocklist](https://github.com/elastic/kibana/blob/7b2c6932827f93049509be37365d063567df7c79/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts#L43).\n\nThis enforcement happens at both the UI and API level.\n\n## Testing\n1. To test, upload or spin up a local registry containing this test\npackage:\n\n[microsoft_sentinel-1.2.1.zip](https://github.com/user-attachments/files/21264108/microsoft_sentinel-1.2.1.zip)\n\nThis package has 3 inputs:\n\n* `Collect Microsoft Sentinel logs via API` -> allowed for both\nagent-based and agentless modes\n* `Collect Microsoft Sentinel events via Azure Event Hub` -> allowed\nonly in agent-based mode due to `azure-eventhub` being on blocklist\n* `Input type disallowed in agentless` -> allowed only in agent-based\nmode due to `deployment_modes: ['default']` being specified on the input\n\n2. Observe that the correct inputs are shown when switching between\nagent-based and agentless modes:\n\n<img width=\"1408\" height=\"714\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3816d86c-afc1-4eb4-aad4-f31867bf5269\"\n/>\n\n<img width=\"1405\" height=\"504\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3b34d2e9-7df8-4c27-9a32-b79c55ff1ee6\"\n/>\n\n3. Observe that attempting to enable disallowed inputs via API\n(create/update) returns an error:\n\n<img width=\"1409\" height=\"605\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e6b21154-ba93-4a39-8efa-897fa431a9df\"\n/>\n\n<img width=\"1408\" height=\"629\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bba1cac3-43a9-4bbf-83d7-74bd71cd7101\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"641c1ab963a67ed5d1864a466668ab37fbd51cfa"}},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->