### PR TITLE
[8.19] [ResponseOps] Allow tasks to indicate they should disable themselves after run (#230998)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -7,6 +7,7 @@
 
 import sinon from 'sinon';
 import { usageCountersServiceMock } from '@kbn/usage-collection-plugin/server/usage_counters/usage_counters_service.mock';
+import type { SavedObject } from '@kbn/core/server';
 import type {
   RuleExecutorOptions,
   RuleTypeParams,
@@ -21,6 +22,7 @@ import {
   RuleExecutionStatusWarningReasons,
   DEFAULT_FLAPPING_SETTINGS,
   DEFAULT_QUERY_DELAY_SETTINGS,
+  type RawRule,
 } from '../types';
 import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import {
@@ -3597,6 +3599,37 @@ describe('Task Runner', () => {
       '5555',
       '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
     ]);
+  });
+
+  test('should return shouldDisableTask when task is enabled but rule is not', async () => {
+    const taskRunner = new TaskRunner({
+      ruleType,
+      internalSavedObjectsRepository,
+      taskInstance: { ...mockedTaskInstance },
+      context: taskRunnerFactoryInitializerParams,
+      inMemoryMetrics,
+    });
+    expect(AlertingEventLogger).toHaveBeenCalled();
+    const mockedRuleTypeSavedObjectDisabled = {
+      ...(mockedRuleTypeSavedObject as Rule),
+      enabled: false,
+    };
+    const mockedRawRuleSODisabled: SavedObject<RawRule> = {
+      ...mockedRawRuleSO,
+    };
+    mockedRawRuleSODisabled.attributes.enabled = false;
+
+    mockGetAlertFromRaw.mockReturnValue(mockedRuleTypeSavedObjectDisabled);
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(mockedRawRuleSO);
+
+    const result = await taskRunner.run();
+
+    expect(ruleType.executor).not.toHaveBeenCalled();
+
+    expect(result.shouldDisableTask).toEqual(true);
+    expect(result.taskRunError?.message).toBe(
+      'Rule failed to execute because rule ran after it was disabled.'
+    );
   });
 
   function testAlertingEventLogCalls({

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/types.ts
@@ -62,6 +62,8 @@ export interface RuleTaskRunResult {
   monitoring: RuleMonitoring | undefined;
   schedule: IntervalSchedule | undefined;
   taskRunError?: DecoratedError;
+  shouldDeleteTask?: boolean;
+  shouldDisableTask?: boolean;
 }
 
 // This is the state of the alerting task after rule execution, which includes run metrics plus the task state

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -77,6 +77,7 @@ export type SuccessfulRunResult = {
   taskRunError?: DecoratedError;
   shouldValidate?: boolean;
   shouldDeleteTask?: boolean;
+  shouldDisableTask?: boolean;
 } & (
   | // ensure a SuccessfulRunResult can either specify a new `runAt` or a new `schedule`, but not both
   {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -665,6 +665,7 @@ export class TaskManagerRunner implements TaskRunner {
     result: Result<SuccessfulRunResult, FailedRunResult>
   ): Promise<TaskRunResult> {
     const hasTaskRunFailed = isOk(result);
+    let shouldTaskBeDisabled = false;
     const fieldUpdates: Partial<ConcreteTaskInstance> & Pick<ConcreteTaskInstance, 'status'> = flow(
       // if running the task has failed ,try to correct by scheduling a retry in the near future
       mapErr(this.rescheduleFailedRun),
@@ -676,10 +677,16 @@ export class TaskManagerRunner implements TaskRunner {
           state,
           attempts = 0,
           shouldDeleteTask,
+          shouldDisableTask,
         }: SuccessfulRunResult & { attempts: number }) => {
           if (shouldDeleteTask) {
             // set the status to failed so task will get deleted
             return asOk({ status: TaskStatus.ShouldDelete });
+          }
+
+          if (shouldDisableTask) {
+            shouldTaskBeDisabled = true;
+            return asOk({ status: TaskStatus.Idle });
           }
 
           const updatedTaskSchedule = reschedule ?? this.instance.task.schedule;
@@ -745,6 +752,14 @@ export class TaskManagerRunner implements TaskRunner {
         }
       } else {
         shouldUpdateTask = true;
+
+        if (shouldTaskBeDisabled) {
+          const label = `${this.taskType}:${this.instance.task.id}`;
+          this.logger.warn(`Disabling task ${label} as it indicated it should disable itself`, {
+            tags: [this.taskType],
+          });
+        }
+
         partialTask = {
           ...partialTask,
           ...fieldUpdates,
@@ -752,6 +767,7 @@ export class TaskManagerRunner implements TaskRunner {
           startedAt: null,
           retryAt: null,
           ownerId: null,
+          ...(shouldTaskBeDisabled ? { enabled: false } : {}),
         };
       }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
@@ -2487,7 +2487,10 @@ describe('TaskStore', () => {
             },
           },
         ],
-        { refresh: false }
+        {
+          overwrite: true,
+          refresh: false,
+        }
       );
 
       expect(result).toEqual([
@@ -2936,7 +2939,10 @@ describe('TaskStore', () => {
             },
           },
         ],
-        { refresh: false }
+        {
+          overwrite: true,
+          refresh: false,
+        }
       );
     });
   });

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -424,6 +424,7 @@ export class TaskStore {
     try {
       savedObjects = await soClient.bulkCreate<SerializedConcreteTaskInstance>(objects, {
         refresh: false,
+        overwrite: true,
       });
       this.adHocTaskCounter.increment(
         taskInstances.filter((task) => {

--- a/x-pack/platform/test/alerting_api_integration/common/lib/task_manager_utils.ts
+++ b/x-pack/platform/test/alerting_api_integration/common/lib/task_manager_utils.ts
@@ -170,4 +170,16 @@ export class TaskManagerUtils {
       }
     });
   }
+
+  async setTaskEnabled(id: string, enabled: boolean) {
+    await this.es.update({
+      id: `task:${id}`,
+      index: '.kibana_task_manager',
+      doc: {
+        task: {
+          enabled,
+        },
+      },
+    });
+  }
 }

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group1/disable.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group1/disable.ts
@@ -7,6 +7,7 @@
 
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
+import type { RawRule } from '@kbn/alerting-plugin/server/types';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { ALERT_STATUS } from '@kbn/rule-data-utils';
 import { Spaces } from '../../../scenarios';
@@ -19,6 +20,7 @@ import {
   getTestRuleData,
   ObjectRemover,
   getEventLog,
+  TaskManagerUtils,
 } from '../../../../common/lib';
 import { validateEvent } from './event_log';
 
@@ -29,6 +31,7 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const retry = getService('retry');
   const supertest = getService('supertest');
+  const taskManagerUtils = new TaskManagerUtils(es, retry);
 
   describe('disable', function () {
     this.tags('skipFIPS');
@@ -53,6 +56,14 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
         index: '.kibana_task_manager',
       });
       return scheduledTask._source!;
+    }
+
+    async function getRule(id: string): Promise<RawRule> {
+      const ruleDoc = await es.get<{ alert: RawRule }>({
+        id: `alert:${id}`,
+        index: '.kibana_alerting_cases',
+      });
+      return ruleDoc._source!.alert;
     }
 
     it('should handle disable rule request appropriately', async () => {
@@ -310,5 +321,45 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
         });
       });
     });
+    it('should disable task if task is run but rule is disabled', async () => {
+      const { body: createdRule } = await supertestWithoutAuth
+        .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule`)
+        .set('kbn-xsrf', 'foo')
+        .send(
+          getTestRuleData({
+            enabled: true,
+            schedule: {
+              interval: '3s',
+            },
+          })
+        )
+        .expect(200);
+      objectRemover.add(Spaces.space1.id, createdRule.id, 'rule', 'alerting');
+
+      // wait for rule to run once
+      await retry.try(async () => {
+        const rule = await getRule(createdRule.id);
+        expect(rule?.monitoring?.run?.last_run?.timestamp).not.to.be(undefined);
+      });
+
+      // disable rule, and implicitly task
+      await ruleUtils.disable(createdRule.id);
+
+      // wait for the task to be disabled
+      await waitForDisabledTask(createdRule.scheduled_task_id);
+
+      // manually enable task
+      await taskManagerUtils.setTaskEnabled(createdRule.scheduled_task_id, true);
+
+      // wait for the task to be disabled
+      await waitForDisabledTask(createdRule.scheduled_task_id);
+    });
+
+    async function waitForDisabledTask(taskId: string) {
+      await retry.try(async () => {
+        const taskDoc = await getScheduledTask(taskId);
+        expect(taskDoc.task.enabled).to.be(false);
+      });
+    }
   });
 }

--- a/x-pack/platform/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
+++ b/x-pack/platform/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
@@ -222,6 +222,21 @@ export class SampleTaskManagerFixturePlugin
           },
         },
       },
+      sampleRecurringTaskDisablesItself: {
+        title: 'Sample Recurring Task that disables itself',
+        description: 'A sample task that disables itself.',
+        maxAttempts: 3,
+        timeout: '60s',
+        createTaskRunner: () => ({
+          async run() {
+            await new Promise((resolve) => setTimeout(resolve, 3000)); // 3 seconds
+            return {
+              shouldDisableTask: true,
+              state: {},
+            };
+          },
+        }),
+      },
       sampleRecurringTaskTimingOut: {
         title: 'Sample Recurring Task that Times Out',
         description: 'A sample task that times out each run.',

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -23,6 +23,7 @@ export default function ({ getService }: FtrProviderContext) {
     'sampleAdHocTaskTimingOut',
     'lowPriorityTask',
     'sampleOneTimeTaskThrowingError',
+    'sampleRecurringTaskDisablesItself',
     'sampleRecurringTaskTimingOut',
     'sampleRecurringTaskWhichHangs',
     'sampleRecurringTaskThatDeletesItself',

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/task_management.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/task_management.ts
@@ -1171,5 +1171,30 @@ export default function ({ getService }: FtrProviderContext) {
         expect(scheduledTask.retryAt).to.be(null);
       });
     });
+
+    it('should disable a task that returns shouldDisableTask: true', async () => {
+      const task = await scheduleTask({
+        taskType: 'sampleRecurringTaskDisablesItself',
+        schedule: { interval: '1d' },
+        params: {},
+      });
+
+      await retry.try(async () => {
+        const [scheduledTask] = (await currentTasks()).docs;
+        expect(scheduledTask.id).to.eql(task.id);
+        expect(scheduledTask.status).to.be('running');
+        expect(scheduledTask.startedAt).not.to.be(null);
+        expect(scheduledTask.retryAt).not.to.be(null);
+      });
+
+      await retry.try(async () => {
+        const currTasks = await currentTasks();
+
+        const [scheduledTask] = currTasks.docs;
+        expect(scheduledTask.id).to.eql(task.id);
+        expect(scheduledTask.status).to.be('idle');
+        expect(scheduledTask.enabled).to.be(false);
+      });
+    });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps] Allow tasks to indicate they should disable themselves after run (#230998)](https://github.com/elastic/kibana/pull/230998)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2025-08-15T21:56:00Z","message":"[ResponseOps] Allow tasks to indicate they should disable themselves after run (#230998)\n\nresolves https://github.com/elastic/kibana/issues/228306\nresolves https://github.com/elastic/kibana/issues/227894\n\nAdds the capability of a task to disable itself after running, by\nreturning an indication in the task response. We then use this with\nalerting to allow a rule's task to disable itself if it ran but found\nthe rule itself was disabled.\n\nSpecifically:\n- A rule throwing an error with a new reason\n`RuleExecutionStatusErrorReasons.Disabled` will cause the alerting task\nrunner to return to task manager with a new flag `shouldDisableTask:\ntrue`.\n- During the post processing of the task, if the task indicated it\nshould disable itself via the new flag, it will log a warning that it's\ngoing to do that, and then update the task with `enabled: false`.\n\nTask store has been updated as well, to use `overwrite: true` when doing\n`bulkSchedule`, as this code currently assumes that - at this point -\nthe task doc does not exist, so the bulk update fails with a conflict if\none does.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cdda7049bd81ec8341d9a1a2c719aa1fe1d5d516","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Feature:Task Manager","Team:ResponseOps","backport:all-open","v9.2.0"],"title":"[ResponseOps] Allow tasks to indicate they should disable themselves after run","number":230998,"url":"https://github.com/elastic/kibana/pull/230998","mergeCommit":{"message":"[ResponseOps] Allow tasks to indicate they should disable themselves after run (#230998)\n\nresolves https://github.com/elastic/kibana/issues/228306\nresolves https://github.com/elastic/kibana/issues/227894\n\nAdds the capability of a task to disable itself after running, by\nreturning an indication in the task response. We then use this with\nalerting to allow a rule's task to disable itself if it ran but found\nthe rule itself was disabled.\n\nSpecifically:\n- A rule throwing an error with a new reason\n`RuleExecutionStatusErrorReasons.Disabled` will cause the alerting task\nrunner to return to task manager with a new flag `shouldDisableTask:\ntrue`.\n- During the post processing of the task, if the task indicated it\nshould disable itself via the new flag, it will log a warning that it's\ngoing to do that, and then update the task with `enabled: false`.\n\nTask store has been updated as well, to use `overwrite: true` when doing\n`bulkSchedule`, as this code currently assumes that - at this point -\nthe task doc does not exist, so the bulk update fails with a conflict if\none does.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cdda7049bd81ec8341d9a1a2c719aa1fe1d5d516"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230998","number":230998,"mergeCommit":{"message":"[ResponseOps] Allow tasks to indicate they should disable themselves after run (#230998)\n\nresolves https://github.com/elastic/kibana/issues/228306\nresolves https://github.com/elastic/kibana/issues/227894\n\nAdds the capability of a task to disable itself after running, by\nreturning an indication in the task response. We then use this with\nalerting to allow a rule's task to disable itself if it ran but found\nthe rule itself was disabled.\n\nSpecifically:\n- A rule throwing an error with a new reason\n`RuleExecutionStatusErrorReasons.Disabled` will cause the alerting task\nrunner to return to task manager with a new flag `shouldDisableTask:\ntrue`.\n- During the post processing of the task, if the task indicated it\nshould disable itself via the new flag, it will log a warning that it's\ngoing to do that, and then update the task with `enabled: false`.\n\nTask store has been updated as well, to use `overwrite: true` when doing\n`bulkSchedule`, as this code currently assumes that - at this point -\nthe task doc does not exist, so the bulk update fails with a conflict if\none does.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cdda7049bd81ec8341d9a1a2c719aa1fe1d5d516"}}]}] BACKPORT-->