### PR TITLE
[9.1] Fix honoring deployment mode restrictions (#231679)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.test.ts
@@ -106,6 +106,58 @@ describe('agentless_policy_helper', () => {
 
       expect(result).toBe(false);
     });
+
+    it('should return true if the specified integration supports agentless', () => {
+      const packageInfo = {
+        policy_templates: [
+          {
+            name: 'template1',
+            deployment_modes: {
+              agentless: { enabled: true },
+              default: { enabled: false },
+            },
+          },
+          {
+            name: 'template2',
+            deployment_modes: {
+              agentless: { enabled: false },
+              default: { enabled: true },
+            },
+          },
+        ] as RegistryPolicyTemplate[],
+      };
+
+      expect(isAgentlessIntegration(packageInfo, 'template1')).toBe(true);
+      expect(isAgentlessIntegration(packageInfo, 'template2')).toBe(false);
+    });
+
+    it('should return false if the specified integration does not exist', () => {
+      const packageInfo = {
+        policy_templates: [
+          {
+            name: 'template1',
+            deployment_modes: {
+              agentless: { enabled: true },
+              default: { enabled: false },
+            },
+          },
+        ] as RegistryPolicyTemplate[],
+      };
+
+      expect(isAgentlessIntegration(packageInfo, 'nonexistent')).toBe(false);
+    });
+
+    it('should return false if the specified integration exists but has no deployment_modes', () => {
+      const packageInfo = {
+        policy_templates: [
+          {
+            name: 'template1',
+          },
+        ] as RegistryPolicyTemplate[],
+      };
+
+      expect(isAgentlessIntegration(packageInfo, 'template1')).toBe(false);
+    });
   });
 
   describe('getAgentlessAgentPolicyNameFromPackagePolicyName', () => {
@@ -331,6 +383,11 @@ describe('agentless_policy_helper', () => {
           name: 'template1',
           title: 'Template 1',
           description: '',
+          deployment_modes: {
+            agentless: {
+              enabled: true,
+            },
+          },
           inputs: [
             { type: 'logs', deployment_modes: ['default', 'agentless'] },
             { type: 'metrics', deployment_modes: ['default'] },
@@ -340,6 +397,11 @@ describe('agentless_policy_helper', () => {
           name: 'template2',
           title: 'Template 2',
           description: '',
+          deployment_modes: {
+            agentless: {
+              enabled: true,
+            },
+          },
           inputs: [
             { type: 'logs', deployment_modes: ['agentless'] },
             { type: 'tcp', deployment_modes: ['default'] },
@@ -368,6 +430,82 @@ describe('agentless_policy_helper', () => {
       ).toBe(true);
     });
 
+    it('should return false for input without a policy_template deployment_mode enabled for agentless when the requested mode is agentless', () => {
+      const packageInfoWithoutPolicyTemplateDeploymentModes = {
+        name: 'test-package',
+        version: '1.0.0',
+        owner: { github: 'elastic' },
+        policy_templates: [
+          {
+            name: 'template1',
+            title: 'Template 1',
+            description: '',
+            inputs: [{ type: 'metrics', deployment_modes: ['agentless', 'default'] }],
+          },
+        ] as RegistryPolicyTemplate[],
+      } as any;
+      const input = { type: 'metrics', policy_template: 'template1' };
+      expect(
+        isInputAllowedForDeploymentMode(
+          input,
+          'agentless',
+          packageInfoWithoutPolicyTemplateDeploymentModes
+        )
+      ).toBe(false);
+    });
+
+    it('should return false for input with a policy_template deployment mode that overrides the requested mode', () => {
+      const packageInfoWithPolicyTemplateOverride = {
+        name: 'test-package',
+        version: '1.0.0',
+        owner: { github: 'elastic' },
+        policy_templates: [
+          {
+            name: 'template1',
+            title: 'Template 1',
+            description: '',
+            deployment_modes: {
+              agentless: {
+                enabled: false,
+              },
+              default: {
+                enabled: false,
+              },
+            },
+            inputs: [{ type: 'metrics', deployment_modes: ['agentless', 'default'] }],
+          },
+        ] as RegistryPolicyTemplate[],
+      } as any;
+      const input = { type: 'metrics', policy_template: 'template1' };
+      expect(
+        isInputAllowedForDeploymentMode(input, 'agentless', packageInfoWithPolicyTemplateOverride)
+      ).toBe(false);
+
+      expect(
+        isInputAllowedForDeploymentMode(input, 'default', packageInfoWithPolicyTemplateOverride)
+      ).toBe(false);
+    });
+
+    it('should return true for input with no policy template or input deployment mode defined when requested mode is default ', () => {
+      const packageInfoWithPolicyTemplateOverride = {
+        name: 'test-package',
+        version: '1.0.0',
+        owner: { github: 'elastic' },
+        policy_templates: [
+          {
+            name: 'template1',
+            title: 'Template 1',
+            description: '',
+            inputs: [{ type: 'metrics' }],
+          },
+        ] as RegistryPolicyTemplate[],
+      } as any;
+      const input = { type: 'metrics', policy_template: 'template1' };
+      expect(
+        isInputAllowedForDeploymentMode(input, 'default', packageInfoWithPolicyTemplateOverride)
+      ).toBe(true);
+    });
+
     it('should handle inputs with different deployment_modes under different policy templates', () => {
       const input1 = { type: 'logs', policy_template: 'template1' };
       const input2 = { type: 'logs', policy_template: 'template2' };
@@ -390,6 +528,11 @@ describe('agentless_policy_helper', () => {
             name: 'template1',
             title: 'Template 1',
             description: '',
+            deployment_modes: {
+              agentless: {
+                enabled: true,
+              },
+            },
             inputs: [{ type: 'log' }, { type: 'winlog' }],
           },
         ] as RegistryPolicyTemplate[],
@@ -502,6 +645,11 @@ describe('agentless_policy_helper', () => {
           name: 'template1',
           title: 'Template 1',
           description: '',
+          deployment_modes: {
+            agentless: {
+              enabled: true,
+            },
+          },
           inputs: [
             { type: 'logs', deployment_modes: ['default', 'agentless'] },
             { type: 'metrics', deployment_modes: ['default'] },

--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
@@ -46,19 +46,24 @@ function extractRegistryInputsForDeploymentMode(
   return inputs;
 }
 
+// Checks if a package has a policy template that supports agentless
+// Provide a specific integration policy template name to check if it alone supports agentless
 export const isAgentlessIntegration = (
-  packageInfo: Pick<PackageInfo, 'policy_templates'> | undefined
+  packageInfo: Pick<PackageInfo, 'policy_templates'> | undefined,
+  integrationToEnable?: string
 ) => {
-  if (
-    packageInfo?.policy_templates &&
-    packageInfo?.policy_templates.length > 0 &&
-    !!packageInfo?.policy_templates.find(
-      (policyTemplate) => policyTemplate?.deployment_modes?.agentless.enabled === true
-    )
-  ) {
-    return true;
+  if (integrationToEnable) {
+    return Boolean(
+      packageInfo?.policy_templates?.find(({ name }) => name === integrationToEnable)
+        ?.deployment_modes?.agentless?.enabled === true
+    );
   }
-  return false;
+
+  return Boolean(
+    packageInfo?.policy_templates?.some(
+      (policyTemplate) => policyTemplate?.deployment_modes?.agentless?.enabled === true
+    )
+  );
 };
 
 export const getAgentlessAgentPolicyNameFromPackagePolicyName = (packagePolicyName: string) => {
@@ -108,6 +113,15 @@ export function isInputAllowedForDeploymentMode(
     return true;
   }
 
+  // Check first if policy_template for input supports the deployment type
+  if (
+    packageInfo &&
+    input.policy_template &&
+    !integrationSupportsDeploymentMode(deploymentMode, packageInfo, input.policy_template)
+  ) {
+    return false;
+  }
+
   // Find the registry input definition for this input type and policy template
   const registryInput = extractRegistryInputsForDeploymentMode(packageInfo).find(
     (rInput) =>
@@ -129,6 +143,24 @@ export function isInputAllowedForDeploymentMode(
 
   return true; // Allow all inputs for default mode when deployment_modes is not specified
 }
+
+const integrationSupportsDeploymentMode = (
+  deploymentMode: string,
+  packageInfo: PackageInfo,
+  integrationName: string
+) => {
+  if (deploymentMode === 'agentless') {
+    return isAgentlessIntegration(packageInfo, integrationName);
+  }
+
+  const integration = packageInfo.policy_templates?.find(({ name }) => name === integrationName);
+
+  if (integration?.deployment_modes?.default) {
+    return integration.deployment_modes?.default.enabled;
+  }
+
+  return true;
+};
 
 /*
  * Throw error if trying to enabling an input that is not allowed in agentless

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
@@ -52,6 +52,10 @@ export const StepConfigurePackagePolicy: React.FunctionComponent<{
   isAgentlessSelected = false,
 }) => {
   const hasIntegrations = useMemo(() => doesPackageHaveIntegrations(packageInfo), [packageInfo]);
+  const deploymentMode =
+    (isEditPage || isAgentlessSelected) && packagePolicy.supports_agentless
+      ? 'agentless'
+      : 'default';
   const packagePolicyTemplates = useMemo(
     () =>
       showOnlyIntegration
@@ -102,11 +106,7 @@ export const StepConfigurePackagePolicy: React.FunctionComponent<{
 
               const isInputAvailable =
                 packagePolicyInput &&
-                isInputAllowedForDeploymentMode(
-                  packagePolicyInput,
-                  isAgentlessSelected && packagePolicy.supports_agentless ? 'agentless' : 'default',
-                  packageInfo
-                );
+                isInputAllowedForDeploymentMode(packagePolicyInput, deploymentMode, packageInfo);
 
               return isInputAvailable ? (
                 <EuiFlexItem key={packageInput.type}>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
@@ -306,6 +306,109 @@ describe('useOnSubmit', () => {
       });
     });
 
+    it('should disable inputs when policy_template deployment mode is not declared when in agentless deployment mode', async () => {
+      // Mock packageInfo with a policy template that doesn't declare agentless deployment mode
+      // But also has a policy template that does so the package is deemed supports_agentless
+      // We will try to install the non-agentless policy template
+
+      const packageInfoWithInputs: PackageInfo = {
+        ...packageInfo,
+        policy_templates: [
+          {
+            name: 'test_template',
+            title: 'Test Template',
+            description: 'Test template',
+            inputs: [
+              {
+                type: 'logs',
+                title: 'Logs',
+                description: 'Log collection',
+                deployment_modes: ['default', 'agentless'],
+              },
+              {
+                type: 'metrics',
+                title: 'Metrics',
+                description: 'Metrics collection',
+                deployment_modes: ['default'],
+              },
+              {
+                type: 'http_endpoint',
+                title: 'HTTP Endpoint',
+                description: 'HTTP endpoint',
+                deployment_modes: ['agentless'],
+              },
+            ],
+          },
+          {
+            name: 'test_template_2',
+            title: 'Test Template 2',
+            description: 'Test template',
+            deployment_modes: {
+              agentless: { enabled: true },
+              default: { enabled: true },
+            },
+            inputs: [
+              {
+                type: 'logs',
+                title: 'Logs',
+                description: 'Log collection',
+                deployment_modes: ['default', 'agentless'],
+              },
+              {
+                type: 'metrics',
+                title: 'Metrics',
+                description: 'Metrics collection',
+                deployment_modes: ['default'],
+              },
+              {
+                type: 'http_endpoint',
+                title: 'HTTP Endpoint',
+                description: 'HTTP endpoint',
+                deployment_modes: ['agentless'],
+              },
+            ],
+          },
+        ],
+      };
+
+      // Mock useConfig to return agentless configuration
+      (useConfig as MockFn).mockReturnValue({
+        agentless: { enabled: true },
+      } as any);
+
+      // Render the hook with a package policy that has inputs including metrics
+      renderResult = testRenderer.renderHook(() =>
+        useOnSubmit({
+          agentCount: 0,
+          packageInfo: packageInfoWithInputs,
+          integrationToEnable: 'test_template_1',
+          withSysMonitoring: false,
+          selectedPolicyTab: SelectedPolicyTab.NEW,
+          newAgentPolicy: { name: 'test', namespace: '', supports_agentless: true },
+          queryParamsPolicyId: undefined,
+          hasFleetAddAgentsPrivileges: true,
+          setNewAgentPolicy: jest.fn(),
+          setSelectedPolicyTab: jest.fn(),
+        })
+      );
+
+      act(() => {
+        // Simulate switching to agentless setup technology
+        renderResult.result.current.handleSetupTechnologyChange('agentless' as any);
+      });
+
+      await waitFor(() => {
+        const { packagePolicy } = renderResult.result.current;
+        const logsInput = packagePolicy.inputs.find((input: any) => input.type === 'logs');
+        const metricsInput = packagePolicy.inputs.find((input: any) => input.type === 'metrics');
+        const httpInput = packagePolicy.inputs.find((input: any) => input.type === 'http_endpoint');
+
+        expect(logsInput?.enabled).toBe(false);
+        expect(httpInput?.enabled).toBe(false);
+        expect(metricsInput?.enabled).toBe(false);
+      });
+    });
+
     it('should enable all inputs for default deployment mode', async () => {
       // Mock packageInfo with inputs
       const packageInfoWithInputs: PackageInfo = {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
@@ -107,9 +107,17 @@ export function useSetupTechnology({
   const [currentAgentPolicy, setCurrentAgentPolicy] = useState(newAgentPolicy);
 
   const allowedSetupTechnologies = useMemo(() => {
-    return isOnlyAgentlessIntegration(packageInfo, integrationToEnable)
-      ? [SetupTechnology.AGENTLESS]
-      : [SetupTechnology.AGENTLESS, SetupTechnology.AGENT_BASED];
+    const setupTechnologies = [];
+
+    if (isAgentlessIntegrationFn(packageInfo, integrationToEnable)) {
+      setupTechnologies.push(SetupTechnology.AGENTLESS);
+    }
+
+    if (!isOnlyAgentlessIntegration(packageInfo, integrationToEnable)) {
+      setupTechnologies.push(SetupTechnology.AGENT_BASED);
+    }
+
+    return setupTechnologies;
   }, [integrationToEnable, packageInfo]);
   const [selectedSetupTechnology, setSelectedSetupTechnology] = useState<SetupTechnology>(
     SetupTechnology.AGENT_BASED

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/manifest.yml
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/deployment_modes_test/1.0.0/manifest.yml
@@ -63,5 +63,12 @@ policy_templates:
         title: System Metrics
         description: System metrics collection
         deployment_modes: ["default"]
+  - name: no_deployment_mode_default_only
+    title: No Deployment Mode Default Only Template
+    description: Template that only supports default deployment with no explicit deployment_mode
+    inputs:
+      - type: cloudwatch
+        title: CloudWatch Metrics for only default deployment
+        description: AWS CloudWatch metrics
 owner:
   github: elastic/fleet

--- a/x-pack/platform/test/fleet_api_integration/apis/package_policy/deployment_modes.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/package_policy/deployment_modes.ts
@@ -656,6 +656,67 @@ export default function (providerContext: FtrProviderContext) {
             });
         });
       });
+      describe('default_only policy template with no deployment mode', () => {
+        it('should allow default inputs only for default deployment mode', async () => {
+          // Test default deployment mode (should succeed)
+          const { body: defaultResponse } = await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-cloudwatch-default-${uuidv4()}`,
+              description:
+                'Test input in default mode without explicit policy template deployment mode declaration',
+              namespace: 'default',
+              policy_id: agentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'cloudwatch',
+                  policy_template: 'no_deployment_mode_default_only',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(200);
+
+          expect(defaultResponse.item.inputs).to.have.length(1);
+          expect(defaultResponse.item.inputs[0].type).to.be('cloudwatch');
+
+          // Test agentless deployment mode (should fail)
+          await supertest
+            .post(`/api/fleet/package_policies`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `deployment-test-cloudwatch-agentless-${uuidv4()}`,
+              description:
+                'Test input in agentless mode without explicit policy template deployment mode declaration',
+              namespace: 'default',
+              policy_id: agentlessAgentPolicyId,
+              package: {
+                name: 'deployment_modes_test',
+                version: '1.0.0',
+              },
+              inputs: [
+                {
+                  type: 'cloudwatch',
+                  policy_template: 'no_deployment_mode_default_only',
+                  enabled: true,
+                  streams: [],
+                },
+              ],
+            })
+            .expect(400)
+            .then((response) => {
+              expect(response.body.message).to.contain(
+                "Input cloudwatch in deployment_modes_test is not allowed for deployment mode 'agentless'"
+              );
+            });
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix honoring deployment mode restrictions (#231679)](https://github.com/elastic/kibana/pull/231679)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michel Losier","email":"michel.losier@elastic.co"},"sourceCommit":{"committedDate":"2025-08-19T13:37:21Z","message":"Fix honoring deployment mode restrictions (#231679)\n\nResolves: https://github.com/elastic/kibana/issues/231621\n\nThis makes sure that when creating package policies the\n`deployment_modes` definition, if available, on policy templates are\nevaluated as such:\n\n* When agentless mode is selected, inputs of policy templates are only included if the deployment mode\nexplicitly declares agentless enabled\n* When default mode (agent-based) is selected, inputs are included if policy template deployment mode is not\ndeclared, or if declared only if default.enabled is true\n\n## Release note:\n\nFixes the `deployment_modes` evaluation for policy templates when creating a\npackage policy. When deploying in agentless mode this ensures we don't\nallow inputs from policy templates that are not opted into the agentless\nmode at the template level.","sha":"99bed97a5a347ad30ba5f3fe289c4c64f85f01b4","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:current-major","v9.2.0"],"title":"Fix honoring deployment mode restrictions","number":231679,"url":"https://github.com/elastic/kibana/pull/231679","mergeCommit":{"message":"Fix honoring deployment mode restrictions (#231679)\n\nResolves: https://github.com/elastic/kibana/issues/231621\n\nThis makes sure that when creating package policies the\n`deployment_modes` definition, if available, on policy templates are\nevaluated as such:\n\n* When agentless mode is selected, inputs of policy templates are only included if the deployment mode\nexplicitly declares agentless enabled\n* When default mode (agent-based) is selected, inputs are included if policy template deployment mode is not\ndeclared, or if declared only if default.enabled is true\n\n## Release note:\n\nFixes the `deployment_modes` evaluation for policy templates when creating a\npackage policy. When deploying in agentless mode this ensures we don't\nallow inputs from policy templates that are not opted into the agentless\nmode at the template level.","sha":"99bed97a5a347ad30ba5f3fe289c4c64f85f01b4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231679","number":231679,"mergeCommit":{"message":"Fix honoring deployment mode restrictions (#231679)\n\nResolves: https://github.com/elastic/kibana/issues/231621\n\nThis makes sure that when creating package policies the\n`deployment_modes` definition, if available, on policy templates are\nevaluated as such:\n\n* When agentless mode is selected, inputs of policy templates are only included if the deployment mode\nexplicitly declares agentless enabled\n* When default mode (agent-based) is selected, inputs are included if policy template deployment mode is not\ndeclared, or if declared only if default.enabled is true\n\n## Release note:\n\nFixes the `deployment_modes` evaluation for policy templates when creating a\npackage policy. When deploying in agentless mode this ensures we don't\nallow inputs from policy templates that are not opted into the agentless\nmode at the template level.","sha":"99bed97a5a347ad30ba5f3fe289c4c64f85f01b4"}}]}] BACKPORT-->