### PR TITLE
[8.17] [Cases] Fix case activity stats (#231948)

### DIFF
--- a/x-pack/plugins/cases/common/types/api/user_action/v1.test.ts
+++ b/x-pack/plugins/cases/common/types/api/user_action/v1.test.ts
@@ -8,6 +8,7 @@
 import { AttachmentType } from '../../domain/attachment/v1';
 import { UserActionTypes } from '../../domain/user_action/action/v1';
 import {
+  type CaseUserActionStatsResponse,
   CaseUserActionStatsResponseRt,
   CaseUserActionStatsRt,
   UserActionFindRequestRt,
@@ -115,10 +116,13 @@ describe('User actions APIs', () => {
 
   describe('User actions stats API', () => {
     describe('CaseUserActionStatsResponseRt', () => {
-      const defaultRequest = {
+      const defaultRequest: CaseUserActionStatsResponse = {
         total: 15,
+        total_deletions: 0,
         total_comments: 10,
+        total_comment_deletions: 0,
         total_other_actions: 5,
+        total_other_action_deletions: 0,
       };
 
       it('has expected attributes in request', () => {
@@ -141,10 +145,13 @@ describe('User actions APIs', () => {
     });
 
     describe('CaseUserActionStatsRt', () => {
-      const defaultRequest = {
+      const defaultRequest: CaseUserActionStatsResponse = {
         total: 100,
+        total_deletions: 0,
         total_comments: 60,
+        total_comment_deletions: 0,
         total_other_actions: 40,
+        total_other_action_deletions: 0,
       };
 
       it('has expected attributes in request', () => {

--- a/x-pack/plugins/cases/common/types/api/user_action/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/user_action/v1.ts
@@ -25,8 +25,11 @@ export type UserActionWithResponse<T> = T & { id: string; version: string } & rt
  */
 export const CaseUserActionStatsRt = rt.strict({
   total: rt.number,
+  total_deletions: rt.number,
   total_comments: rt.number,
+  total_comment_deletions: rt.number,
   total_other_actions: rt.number,
+  total_other_action_deletions: rt.number,
 });
 
 export type CaseUserActionStatsResponse = rt.TypeOf<typeof CaseUserActionStatsRt>;

--- a/x-pack/plugins/cases/public/components/user_actions/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/index.test.tsx
@@ -24,13 +24,17 @@ import { defaultUseFindCaseUserActions } from '../case_view/mocks';
 import { waitForComponentToUpdate } from '../../common/test_utils';
 import { useInfiniteFindCaseUserActions } from '../../containers/use_infinite_find_case_user_actions';
 import { getMockBuilderArgs } from './mock';
+import type { CaseUserActionsStats } from '../../containers/types';
 
 const onUpdateField = jest.fn();
 
-const userActionsStats = {
+const userActionsStats: CaseUserActionsStats = {
   total: 25,
+  totalDeletions: 0,
   totalComments: 9,
+  totalCommentDeletions: 0,
   totalOtherActions: 16,
+  totalOtherActionDeletions: 0,
 };
 
 const userActivityQueryParams: UserActivityParams = {

--- a/x-pack/plugins/cases/public/components/user_actions/use_last_page.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/use_last_page.test.tsx
@@ -9,6 +9,7 @@ import { renderHook } from '@testing-library/react-hooks';
 
 import { useLastPage } from './use_last_page';
 import type { UserActivityParams } from '../user_actions_activity_bar/types';
+import type { CaseUserActionsStats } from '../../containers/types';
 
 const userActivityQueryParams: UserActivityParams = {
   type: 'all',
@@ -17,10 +18,13 @@ const userActivityQueryParams: UserActivityParams = {
   perPage: 10,
 };
 
-const userActionsStats = {
+const userActionsStats: CaseUserActionsStats = {
   total: 5,
+  totalDeletions: 0,
   totalComments: 2,
+  totalCommentDeletions: 0,
   totalOtherActions: 3,
+  totalOtherActionDeletions: 0,
 };
 
 jest.mock('../../common/lib/kibana');
@@ -46,7 +50,14 @@ describe('useLastPage', () => {
   it('returns 1 when actions stats are 0', async () => {
     const { result } = renderHook(() =>
       useLastPage({
-        userActionsStats: { total: 0, totalComments: 0, totalOtherActions: 0 },
+        userActionsStats: {
+          total: 0,
+          totalDeletions: 0,
+          totalComments: 0,
+          totalCommentDeletions: 0,
+          totalOtherActions: 0,
+          totalOtherActionDeletions: 0,
+        },
         userActivityQueryParams,
       })
     );
@@ -59,7 +70,14 @@ describe('useLastPage', () => {
   it('returns correct last page when filter type is all', async () => {
     const { result } = renderHook(() =>
       useLastPage({
-        userActionsStats: { total: 38, totalComments: 17, totalOtherActions: 21 },
+        userActionsStats: {
+          total: 38,
+          totalDeletions: 0,
+          totalComments: 17,
+          totalCommentDeletions: 0,
+          totalOtherActions: 21,
+          totalOtherActionDeletions: 0,
+        },
         userActivityQueryParams,
       })
     );
@@ -72,7 +90,14 @@ describe('useLastPage', () => {
   it('returns correct last page when filter type is user', async () => {
     const { result } = renderHook(() =>
       useLastPage({
-        userActionsStats: { total: 38, totalComments: 17, totalOtherActions: 21 },
+        userActionsStats: {
+          total: 38,
+          totalDeletions: 0,
+          totalComments: 17,
+          totalCommentDeletions: 0,
+          totalOtherActions: 21,
+          totalOtherActionDeletions: 0,
+        },
         userActivityQueryParams: {
           ...userActivityQueryParams,
           type: 'user',
@@ -88,7 +113,14 @@ describe('useLastPage', () => {
   it('returns correct last page when filter type is action', async () => {
     const { result } = renderHook(() =>
       useLastPage({
-        userActionsStats: { total: 38, totalComments: 17, totalOtherActions: 21 },
+        userActionsStats: {
+          total: 38,
+          totalDeletions: 0,
+          totalComments: 17,
+          totalCommentDeletions: 0,
+          totalOtherActions: 21,
+          totalOtherActionDeletions: 0,
+        },
         userActivityQueryParams: {
           ...userActivityQueryParams,
           type: 'action',

--- a/x-pack/plugins/cases/public/components/user_actions_activity_bar/filter_activity.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions_activity_bar/filter_activity.test.tsx
@@ -19,8 +19,20 @@ describe('FilterActivity ', () => {
   let appMockRender: AppMockRenderer;
   const userActionsStats: CaseUserActionsStats = {
     total: 20,
+    totalDeletions: 0,
     totalComments: 11,
+    totalCommentDeletions: 0,
     totalOtherActions: 9,
+    totalOtherActionDeletions: 0,
+  };
+
+  const userActionsStatsWithDeletions: CaseUserActionsStats = {
+    total: 20,
+    totalDeletions: 2,
+    totalComments: 11,
+    totalCommentDeletions: 3,
+    totalOtherActions: 9,
+    totalOtherActionDeletions: 4,
   };
 
   beforeEach(() => {
@@ -34,6 +46,24 @@ describe('FilterActivity ', () => {
     expect(screen.getByTestId('user-actions-filter-activity-button-all')).toBeInTheDocument();
     expect(screen.getByTestId('user-actions-filter-activity-button-comments')).toBeInTheDocument();
     expect(screen.getByTestId('user-actions-filter-activity-button-history')).toBeInTheDocument();
+  });
+
+  it('renders filters correctly with deletions', () => {
+    renderWithTestingProviders(
+      <FilterActivity
+        type="all"
+        onFilterChange={onFilterActivityChange}
+        userActionsStats={userActionsStatsWithDeletions}
+      />
+    );
+
+    expect(screen.getByTestId('user-actions-filter-activity-button-all')).toHaveTextContent('18');
+    expect(screen.getByTestId('user-actions-filter-activity-button-comments')).toHaveTextContent(
+      '8'
+    );
+    expect(screen.getByTestId('user-actions-filter-activity-button-history')).toHaveTextContent(
+      '5'
+    );
   });
 
   it('renders loading state correctly', () => {

--- a/x-pack/plugins/cases/public/components/user_actions_activity_bar/filter_activity.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions_activity_bar/filter_activity.test.tsx
@@ -49,7 +49,7 @@ describe('FilterActivity ', () => {
   });
 
   it('renders filters correctly with deletions', () => {
-    renderWithTestingProviders(
+    appMockRender.render(
       <FilterActivity
         type="all"
         onFilterChange={onFilterActivityChange}

--- a/x-pack/plugins/cases/public/components/user_actions_activity_bar/filter_activity.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions_activity_bar/filter_activity.tsx
@@ -51,7 +51,11 @@ export const FilterActivity = React.memo<FilterActivityProps>(
           grow={false}
           onClick={() => handleFilterChange('all')}
           hasActiveFilters={type === 'all'}
-          numFilters={userActionsStats && userActionsStats.total > 0 ? userActionsStats.total : 0}
+          numFilters={
+            userActionsStats && userActionsStats.total > 0
+              ? userActionsStats.total - userActionsStats.totalDeletions
+              : 0
+          }
           isLoading={isLoading}
           isDisabled={isLoading}
           data-test-subj="user-actions-filter-activity-button-all"
@@ -65,7 +69,7 @@ export const FilterActivity = React.memo<FilterActivityProps>(
           hasActiveFilters={type === 'user'}
           numFilters={
             userActionsStats && userActionsStats.totalComments > 0
-              ? userActionsStats.totalComments
+              ? userActionsStats.totalComments - userActionsStats.totalCommentDeletions
               : 0
           }
           isLoading={isLoading}
@@ -79,7 +83,7 @@ export const FilterActivity = React.memo<FilterActivityProps>(
           hasActiveFilters={type === 'action'}
           numFilters={
             userActionsStats && userActionsStats.totalOtherActions > 0
-              ? userActionsStats.totalOtherActions
+              ? userActionsStats.totalOtherActions - userActionsStats.totalOtherActionDeletions
               : 0
           }
           onClick={() => handleFilterChange('action')}

--- a/x-pack/plugins/cases/public/containers/api.test.tsx
+++ b/x-pack/plugins/cases/public/containers/api.test.tsx
@@ -74,6 +74,7 @@ import { getCaseConnectorsMockResponse } from '../common/mock/connectors';
 import { set } from '@kbn/safer-lodash-set';
 import { cloneDeep, omit } from 'lodash';
 import type { CaseUserActionTypeWithAll } from './types';
+import type { CaseUserActionStatsResponse } from '../../common/types/api';
 import {
   CaseSeverity,
   CaseStatuses,
@@ -643,10 +644,13 @@ describe('Cases API', () => {
   });
 
   describe('getCaseUserActionsStats', () => {
-    const getCaseUserActionsStatsSnake = {
+    const getCaseUserActionsStatsSnake: CaseUserActionStatsResponse = {
       total: 20,
+      total_deletions: 0,
       total_comments: 10,
+      total_comment_deletions: 0,
       total_other_actions: 10,
+      total_other_action_deletions: 0,
     };
 
     beforeEach(() => {

--- a/x-pack/plugins/cases/public/containers/mock.ts
+++ b/x-pack/plugins/cases/public/containers/mock.ts
@@ -964,8 +964,11 @@ export const findCaseUserActionsResponse: FindCaseUserActions = {
 
 export const getCaseUserActionsStatsResponse: CaseUserActionsStats = {
   total: 20,
+  totalDeletions: 0,
   totalComments: 10,
+  totalCommentDeletions: 0,
   totalOtherActions: 10,
+  totalOtherActionDeletions: 0,
 };
 
 // components tests

--- a/x-pack/plugins/cases/public/containers/use_get_case_user_actions_stats.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_case_user_actions_stats.test.tsx
@@ -43,8 +43,11 @@ describe('useGetCaseUserActionsStats', () => {
         ...initialData,
         data: {
           total: 20,
+          totalDeletions: 0,
           totalComments: 10,
+          totalCommentDeletions: 0,
           totalOtherActions: 10,
+          totalOtherActionDeletions: 0,
         },
         isError: false,
         isLoading: false,

--- a/x-pack/plugins/cases/server/services/user_actions/index.ts
+++ b/x-pack/plugins/cases/server/services/user_actions/index.ts
@@ -14,7 +14,7 @@ import type {
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { KueryNode } from '@kbn/es-query';
 import type { CaseUserActionDeprecatedResponse } from '../../../common/types/api';
-import { UserActionTypes } from '../../../common/types/domain';
+import { UserActionActions, UserActionTypes } from '../../../common/types/domain';
 import { decodeOrThrow } from '../../common/runtime_types';
 import {
   CASE_SAVED_OBJECT,
@@ -723,9 +723,12 @@ export class CaseUserActionService {
     });
 
     const result = {
-      total: response.total,
+      total: response.total ?? 0,
+      total_deletions: response.aggregations?.deletions?.doc_count ?? 0,
       total_comments: 0,
+      total_comment_deletions: 0,
       total_other_actions: 0,
+      total_other_action_deletions: 0,
     };
 
     response.aggregations?.totals.buckets.forEach(({ key, doc_count: docCount }) => {
@@ -734,7 +737,14 @@ export class CaseUserActionService {
       }
     });
 
+    response.aggregations?.deletions.deletions.buckets.forEach(({ key, doc_count: docCount }) => {
+      if (key === 'user') {
+        result.total_comment_deletions = docCount;
+      }
+    });
+
     result.total_other_actions = result.total - result.total_comments;
+    result.total_other_action_deletions = result.total_deletions - result.total_comment_deletions;
 
     return result;
   }
@@ -748,6 +758,21 @@ export class CaseUserActionService {
         terms: {
           field: `${CASE_USER_ACTION_SAVED_OBJECT}.attributes.payload.comment.type`,
           size: 100,
+        },
+      },
+      deletions: {
+        filter: {
+          term: {
+            [`${CASE_USER_ACTION_SAVED_OBJECT}.attributes.action`]: UserActionActions.delete,
+          },
+        },
+        aggs: {
+          deletions: {
+            terms: {
+              field: `${CASE_USER_ACTION_SAVED_OBJECT}.attributes.payload.comment.type`,
+              size: 100,
+            },
+          },
         },
       },
     };

--- a/x-pack/plugins/cases/server/services/user_actions/types.ts
+++ b/x-pack/plugins/cases/server/services/user_actions/types.ts
@@ -237,6 +237,15 @@ export interface UserActionsStatsAggsResult {
       doc_count: number;
     }>;
   };
+  deletions: {
+    doc_count: number;
+    deletions: {
+      buckets: Array<{
+        key: string;
+        doc_count: number;
+      }>;
+    };
+  };
 }
 
 export interface MultipleCasesUserActionsTotalAggsResult {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Cases] Fix case activity stats (#231948)](https://github.com/elastic/kibana/pull/231948)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jan Monschke","email":"jan.monschke@elastic.co"},"sourceCommit":{"committedDate":"2025-08-20T06:59:06Z","message":"[Cases] Fix case activity stats (#231948)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/173164\n\n<img width=\"390\" height=\"263\" alt=\"Screenshot 2025-08-18 at 16 01 14\"\nsrc=\"https://github.com/user-attachments/assets/60bbbc88-2d8d-441c-9b64-0c543bc6a33c\"\n/>\n\nThe reason the for the \"incorrect\" count is that we don't show both\n`create/add` activities in case they were `deleted`. We only show the\n`delete` activity in the list. This PR adds new deletion stats to the\nendpoint and calculates the correct count in the frontend.\n\nThe count in the backend remains unchanged because the endpoint is a\ngeneric `stats` endpoint so it should not account for filters that are\nonly applied in the frontend.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9c121adc446c502b7d0dffa772e15fd19ddc173f","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","Team:Cases","v9.2.0"],"title":"[Cases] Fix case activity stats","number":231948,"url":"https://github.com/elastic/kibana/pull/231948","mergeCommit":{"message":"[Cases] Fix case activity stats (#231948)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/173164\n\n<img width=\"390\" height=\"263\" alt=\"Screenshot 2025-08-18 at 16 01 14\"\nsrc=\"https://github.com/user-attachments/assets/60bbbc88-2d8d-441c-9b64-0c543bc6a33c\"\n/>\n\nThe reason the for the \"incorrect\" count is that we don't show both\n`create/add` activities in case they were `deleted`. We only show the\n`delete` activity in the list. This PR adds new deletion stats to the\nendpoint and calculates the correct count in the frontend.\n\nThe count in the backend remains unchanged because the endpoint is a\ngeneric `stats` endpoint so it should not account for filters that are\nonly applied in the frontend.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9c121adc446c502b7d0dffa772e15fd19ddc173f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231948","number":231948,"mergeCommit":{"message":"[Cases] Fix case activity stats (#231948)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/173164\n\n<img width=\"390\" height=\"263\" alt=\"Screenshot 2025-08-18 at 16 01 14\"\nsrc=\"https://github.com/user-attachments/assets/60bbbc88-2d8d-441c-9b64-0c543bc6a33c\"\n/>\n\nThe reason the for the \"incorrect\" count is that we don't show both\n`create/add` activities in case they were `deleted`. We only show the\n`delete` activity in the list. This PR adds new deletion stats to the\nendpoint and calculates the correct count in the frontend.\n\nThe count in the backend remains unchanged because the endpoint is a\ngeneric `stats` endpoint so it should not account for filters that are\nonly applied in the frontend.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9c121adc446c502b7d0dffa772e15fd19ddc173f"}},{"url":"https://github.com/elastic/kibana/pull/232328","number":232328,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/232329","number":232329,"branch":"8.19","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/232330","number":232330,"branch":"9.0","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/232331","number":232331,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->