### PR TITLE
[9.1] Add event based telemetry for detected gaps (#231287)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -48,6 +48,7 @@ import { TIMESTAMP_RUNTIME_FIELD } from './constants';
 import { buildTimestampRuntimeMapping } from './utils/build_timestamp_runtime_mapping';
 import { alertsFieldMap, rulesFieldMap } from '../../../../common/field_maps';
 import { sendAlertSuppressionTelemetryEvent } from './utils/telemetry/send_alert_suppression_telemetry_event';
+import { sendGapDetectedTelemetryEvent } from './utils/telemetry/send_gap_detected_telemetry_event';
 import type { RuleParams } from '../rule_schema';
 import {
   SECURITY_FROM,
@@ -380,6 +381,8 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             remainingGap,
             warningStatusMessage: rangeTuplesWarningMessage,
             gap,
+            originalFrom,
+            originalTo,
           } = await getRuleRangeTuples({
             startedAt,
             previousStartedAt,
@@ -399,6 +402,16 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
           if (remainingGap.asMilliseconds() > 0) {
             const gapDuration = `${remainingGap.humanize()} (${remainingGap.asMilliseconds()}ms)`;
             const gapErrorMessage = `${gapDuration} were not queried between this rule execution and the last execution, so signals may have been missed. Consider increasing your look behind time or adding more Kibana instances`;
+            if (analytics) {
+              sendGapDetectedTelemetryEvent({
+                analytics,
+                interval,
+                gapDuration: remainingGap,
+                originalFrom,
+                originalTo,
+                ruleParams: params,
+              });
+            }
             wrapperErrors.push(gapErrorMessage);
             await ruleExecutionLogger.logStatusChange({
               newStatus: RuleExecutionStatusEnum.failed,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/telemetry/send_gap_detected_telemetry_event.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/telemetry/send_gap_detected_telemetry_event.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { coreMock } from '@kbn/core/server/mocks';
+import type { AnalyticsServiceSetup } from '@kbn/core-analytics-server';
+import moment from 'moment';
+import { GAP_DETECTED_EVENT } from '../../../../telemetry/event_based/events';
+
+import { sendGapDetectedTelemetryEvent } from './send_gap_detected_telemetry_event';
+import type { RuleParams } from '../../../rule_schema';
+
+describe('sendGapDetectedTelemetryEvent', () => {
+  let mockAnalytics: jest.Mocked<AnalyticsServiceSetup>;
+  let mockCore: ReturnType<typeof coreMock.createSetup>;
+
+  beforeEach(() => {
+    mockCore = coreMock.createSetup();
+    mockAnalytics = mockCore.analytics;
+  });
+
+  it('should report correct event data with valid parameters', () => {
+    const interval = '5m';
+    const gapDuration = moment.duration(10, 'minutes');
+    const originalFrom = moment('2023-01-01T00:00:00Z');
+    const originalTo = moment('2023-01-01T01:00:00Z');
+    const ruleParams = {
+      type: 'query',
+      ruleSource: { type: 'external', isCustomized: true },
+    } as unknown as RuleParams;
+
+    sendGapDetectedTelemetryEvent({
+      analytics: mockAnalytics,
+      interval,
+      gapDuration,
+      originalFrom,
+      originalTo,
+      ruleParams,
+    });
+
+    expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(GAP_DETECTED_EVENT.eventType, {
+      gapDuration: 600000, // 10 minutes in milliseconds
+      intervalDuration: 300000, // 5 minutes in milliseconds
+      intervalAndLookbackDuration: 3600000, // 1 hour in milliseconds
+      ruleType: 'query',
+      ruleSource: 'external',
+      isCustomized: true,
+    });
+  });
+
+  it('should not report event when interval parsing fails', () => {
+    const invalidInterval = 'invalid-interval';
+    const gapDuration = moment.duration(10, 'minutes');
+    const originalFrom = moment('2023-01-01T00:00:00Z');
+    const originalTo = moment('2023-01-01T01:00:00Z');
+    const ruleParams = { type: 'query' } as unknown as RuleParams;
+
+    sendGapDetectedTelemetryEvent({
+      analytics: mockAnalytics,
+      interval: invalidInterval,
+      gapDuration,
+      originalFrom,
+      originalTo,
+      ruleParams,
+    });
+
+    expect(mockAnalytics.reportEvent).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/telemetry/send_gap_detected_telemetry_event.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/telemetry/send_gap_detected_telemetry_event.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { AnalyticsServiceSetup } from '@kbn/core-analytics-server';
+import moment from 'moment';
+import { GAP_DETECTED_EVENT } from '../../../../telemetry/event_based/events';
+import { parseInterval } from '../utils';
+import type { RuleParams } from '../../../rule_schema';
+
+export const sendGapDetectedTelemetryEvent = ({
+  analytics,
+  interval,
+  gapDuration,
+  originalFrom,
+  originalTo,
+  ruleParams,
+}: {
+  analytics: AnalyticsServiceSetup;
+  interval: string;
+  gapDuration: moment.Duration;
+  originalFrom: moment.Moment;
+  originalTo: moment.Moment;
+  ruleParams: RuleParams;
+}) => {
+  const intervalDuration = parseInterval(interval);
+
+  if (!intervalDuration) {
+    return;
+  }
+
+  const ruleType = ruleParams.type;
+  const ruleSource = ruleParams.ruleSource;
+  const isCustomized = ruleSource?.type === 'external' ? ruleSource.isCustomized : false;
+
+  analytics.reportEvent(GAP_DETECTED_EVENT.eventType, {
+    gapDuration: gapDuration.asMilliseconds(),
+    intervalDuration: intervalDuration.asMilliseconds(),
+    intervalAndLookbackDuration: moment.duration(originalTo.diff(originalFrom)).asMilliseconds(),
+    ruleType,
+    ruleSource: ruleSource?.type,
+    isCustomized,
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
@@ -351,6 +351,23 @@ describe('utils', () => {
       expect(tuples.length).toEqual(1);
       expect(warningStatusMessage).toEqual(undefined);
     });
+
+    test('should return originalFrom and originalTo in response', async () => {
+      const { originalFrom, originalTo } = await getRuleRangeTuples({
+        previousStartedAt: moment().subtract(30, 's').toDate(),
+        startedAt: moment().toDate(),
+        interval: '30s',
+        from: 'now-30s',
+        to: 'now',
+        maxSignals: 20,
+        ruleExecutionLogger,
+        alerting,
+      });
+
+      expect(originalFrom).toBeDefined();
+      expect(originalTo).toBeDefined();
+      expect(moment.duration(originalTo.diff(originalFrom)).asSeconds()).toEqual(30);
+    });
   });
 
   describe('calculateFromValue', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
@@ -427,7 +427,13 @@ export const getRuleRangeTuples = async ({
         interval
       )}"`
     );
-    return { tuples, remainingGap: moment.duration(0), warningStatusMessage };
+    return {
+      tuples,
+      remainingGap: moment.duration(0),
+      warningStatusMessage,
+      originalFrom,
+      originalTo,
+    };
   }
 
   const gap = getGapBetweenRuns({
@@ -469,6 +475,8 @@ export const getRuleRangeTuples = async ({
     remainingGap: moment.duration(remainingGapMilliseconds),
     warningStatusMessage,
     gap: gapRange,
+    originalFrom,
+    originalTo,
   };
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -1567,6 +1567,55 @@ export const ENDPOINT_WORKFLOW_INSIGHTS_REMEDIATED_EVENT: EventTypeOpts<{
   },
 };
 
+export const GAP_DETECTED_EVENT: EventTypeOpts<{
+  gapDuration: number;
+  intervalDuration: number;
+  intervalAndLookbackDuration: number;
+  ruleType: string;
+  ruleSource: string;
+  isCustomized: boolean;
+}> = {
+  eventType: 'gap_detected_event',
+  schema: {
+    gapDuration: {
+      type: 'long',
+      _meta: {
+        description: 'The duration of the gap',
+      },
+    },
+    intervalDuration: {
+      type: 'long',
+      _meta: {
+        description: 'The duration of the interval',
+      },
+    },
+    intervalAndLookbackDuration: {
+      type: 'long',
+      _meta: {
+        description: 'The duration of the interval and lookback',
+      },
+    },
+    ruleType: {
+      type: 'keyword',
+      _meta: {
+        description: 'The type of the rule',
+      },
+    },
+    ruleSource: {
+      type: 'keyword',
+      _meta: {
+        description: 'The source of the rule',
+      },
+    },
+    isCustomized: {
+      type: 'boolean',
+      _meta: {
+        description: 'Whether the prebuilt rule is customized',
+      },
+    },
+  },
+};
+
 export const events = [
   RISK_SCORE_EXECUTION_SUCCESS_EVENT,
   RISK_SCORE_EXECUTION_ERROR_EVENT,
@@ -1600,4 +1649,5 @@ export const events = [
   SIEM_MIGRATIONS_RULE_TRANSLATION_FAILURE,
   SIEM_MIGRATIONS_PREBUILT_RULES_MATCH,
   SIEM_MIGRATIONS_INTEGRATIONS_MATCH,
+  GAP_DETECTED_EVENT,
 ];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Add event based telemetry for detected gaps (#231287)](https://github.com/elastic/kibana/pull/231287)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Khristinin Nikita","email":"nikita.khristinin@elastic.co"},"sourceCommit":{"committedDate":"2025-08-19T14:32:19Z","message":"Add event based telemetry for detected gaps (#231287)\n\n## Summary\n\nAdd a telemetry event for each detected gap.\n\nWe report:\n\n* **gapDuration** — duration of the gap, stored in the event log (after\nremediation).\n* **intervalDuration** — duration of the interval in milliseconds.\n* **intervalAndLookbackDuration** — duration of the interval plus\nlookback, in milliseconds (taken from a field in the rule object).\n\n### How to test\n\nIn `kibana.dev.yaml`, add:\n\n```yaml\ntelemetry.optIn: true\n```\n\n1. Create a rule with a small interval and a lookback time of `1m + 1s`.\n2. Enable the rule, wait for execution, then disable the rule.\n3. Wait 5 minutes, then re-enable the rule.\n4. Observe that the rule fails with a gap error message.\n\nAfter that, the telemetry event should appear in\n[staging](https://telemetry-v2-staging.elastic.dev/s/securitysolution/app/discover/app/discover#/view/77cacf50-36b3-11ee-adde-d5df298171dd?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now%2Fd,to:now%2Fd))&_a=(breakdownField:event_type,columns:!(),dataSource:(dataViewId:security-solution-ebt-kibana-server,type:dataView),filters:!(),grid:(),hideChart:!f,interval:auto,query:(language:kuery,query:'event_type:%20%22gap_detected_event%22'),sort:!(!(timestamp,desc))))\nafter some time (in my experience, anywhere from 5 minutes to a couple\nof hours).\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7263f300d1933fd2fcbb83fff4797062cfb67fb7","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.2.0"],"title":"Add event based telemetry for detected gaps","number":231287,"url":"https://github.com/elastic/kibana/pull/231287","mergeCommit":{"message":"Add event based telemetry for detected gaps (#231287)\n\n## Summary\n\nAdd a telemetry event for each detected gap.\n\nWe report:\n\n* **gapDuration** — duration of the gap, stored in the event log (after\nremediation).\n* **intervalDuration** — duration of the interval in milliseconds.\n* **intervalAndLookbackDuration** — duration of the interval plus\nlookback, in milliseconds (taken from a field in the rule object).\n\n### How to test\n\nIn `kibana.dev.yaml`, add:\n\n```yaml\ntelemetry.optIn: true\n```\n\n1. Create a rule with a small interval and a lookback time of `1m + 1s`.\n2. Enable the rule, wait for execution, then disable the rule.\n3. Wait 5 minutes, then re-enable the rule.\n4. Observe that the rule fails with a gap error message.\n\nAfter that, the telemetry event should appear in\n[staging](https://telemetry-v2-staging.elastic.dev/s/securitysolution/app/discover/app/discover#/view/77cacf50-36b3-11ee-adde-d5df298171dd?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now%2Fd,to:now%2Fd))&_a=(breakdownField:event_type,columns:!(),dataSource:(dataViewId:security-solution-ebt-kibana-server,type:dataView),filters:!(),grid:(),hideChart:!f,interval:auto,query:(language:kuery,query:'event_type:%20%22gap_detected_event%22'),sort:!(!(timestamp,desc))))\nafter some time (in my experience, anywhere from 5 minutes to a couple\nof hours).\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7263f300d1933fd2fcbb83fff4797062cfb67fb7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231287","number":231287,"mergeCommit":{"message":"Add event based telemetry for detected gaps (#231287)\n\n## Summary\n\nAdd a telemetry event for each detected gap.\n\nWe report:\n\n* **gapDuration** — duration of the gap, stored in the event log (after\nremediation).\n* **intervalDuration** — duration of the interval in milliseconds.\n* **intervalAndLookbackDuration** — duration of the interval plus\nlookback, in milliseconds (taken from a field in the rule object).\n\n### How to test\n\nIn `kibana.dev.yaml`, add:\n\n```yaml\ntelemetry.optIn: true\n```\n\n1. Create a rule with a small interval and a lookback time of `1m + 1s`.\n2. Enable the rule, wait for execution, then disable the rule.\n3. Wait 5 minutes, then re-enable the rule.\n4. Observe that the rule fails with a gap error message.\n\nAfter that, the telemetry event should appear in\n[staging](https://telemetry-v2-staging.elastic.dev/s/securitysolution/app/discover/app/discover#/view/77cacf50-36b3-11ee-adde-d5df298171dd?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now%2Fd,to:now%2Fd))&_a=(breakdownField:event_type,columns:!(),dataSource:(dataViewId:security-solution-ebt-kibana-server,type:dataView),filters:!(),grid:(),hideChart:!f,interval:auto,query:(language:kuery,query:'event_type:%20%22gap_detected_event%22'),sort:!(!(timestamp,desc))))\nafter some time (in my experience, anywhere from 5 minutes to a couple\nof hours).\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7263f300d1933fd2fcbb83fff4797062cfb67fb7"}}]}] BACKPORT-->