### PR TITLE
[8.19] [Ingest Pipelines] Fix API integration tests (#229659)

### DIFF
--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/management/ingest_pipelines.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/management/ingest_pipelines.ts
@@ -191,11 +191,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           // To not be dependent on these, we only confirm the pipeline we created as part of the test exists
           const testPipeline = body.find(({ name }: { name: string }) => name === pipelineName);
 
-          expect(testPipeline).to.eql({
-            ...pipeline,
-            isManaged: false,
-            name: pipelineName,
-          });
+          expect(testPipeline.name).to.eql(pipelineName);
+          expect(testPipeline.isManaged).to.eql(false);
+          expect(testPipeline.processors).to.eql(pipeline.processors);
         });
       });
 
@@ -204,11 +202,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           const uri = `${ingestPipelines.fixtures.apiBasePath}/${pipelineName}`;
           const { body } = await supertestWithAdminScope.get(uri).expect(200);
 
-          expect(body).to.eql({
-            ...pipeline,
-            isManaged: false,
-            name: pipelineName,
-          });
+          expect(body.name).to.eql(pipelineName);
+          expect(body.isManaged).to.eql(false);
+          expect(body.processors).to.eql(pipeline.processors);
         });
       });
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Ingest Pipelines] Fix API integration tests (#229659)](https://github.com/elastic/kibana/pull/229659)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Stoeva","email":"59341489+ElenaStoeva@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-28T17:52:01Z","message":"[Ingest Pipelines] Fix API integration tests (#229659)\n\nFixes https://github.com/elastic/kibana/issues/229526\n\n## Summary\n\nThe Get ingest pipeline API response now includes `created_date_millis`\nand `modified_date_millis` fields, which breaks the API integration\ntests, so this PR fixes them.","sha":"81446d87e0994a5ce64e98ee154b38b7234559a5","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport:skip","Feature:Ingest Node Pipelines","backport:version","v9.2.0","v8.19.3"],"title":"[Ingest Pipelines] Fix API integration tests","number":229659,"url":"https://github.com/elastic/kibana/pull/229659","mergeCommit":{"message":"[Ingest Pipelines] Fix API integration tests (#229659)\n\nFixes https://github.com/elastic/kibana/issues/229526\n\n## Summary\n\nThe Get ingest pipeline API response now includes `created_date_millis`\nand `modified_date_millis` fields, which breaks the API integration\ntests, so this PR fixes them.","sha":"81446d87e0994a5ce64e98ee154b38b7234559a5"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229659","number":229659,"mergeCommit":{"message":"[Ingest Pipelines] Fix API integration tests (#229659)\n\nFixes https://github.com/elastic/kibana/issues/229526\n\n## Summary\n\nThe Get ingest pipeline API response now includes `created_date_millis`\nand `modified_date_millis` fields, which breaks the API integration\ntests, so this PR fixes them.","sha":"81446d87e0994a5ce64e98ee154b38b7234559a5"}},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->