### PR TITLE
[9.0] Add `reporting_user` feature for reserved set of privileges (#231533)

### DIFF
--- a/src/platform/packages/private/kbn-reporting/get_csv_panel_actions/panel_actions/get_csv_panel_action.tsx
+++ b/src/platform/packages/private/kbn-reporting/get_csv_panel_actions/panel_actions/get_csv_panel_action.tsx
@@ -160,8 +160,11 @@ export class ReportingCsvPanelAction implements ActionDefinition<EmbeddableApiCo
     const license = await firstValueFrom(licensing.license$);
     const licenseHasCsvReporting = checkLicense(license.check('reporting', 'basic')).showLinks;
 
+    const capabilities = application.capabilities;
     // NOTE: For historical reasons capability identifier is called `downloadCsv. It can not be renamed.
-    const capabilityHasCsvReporting = application.capabilities.dashboard_v2?.downloadCsv === true;
+    const capabilityHasCsvReporting =
+      capabilities.dashboard_v2?.downloadCsv === true ||
+      capabilities.reportingLegacy?.generateReport === true;
     if (!licenseHasCsvReporting || !capabilityHasCsvReporting) {
       return false;
     }

--- a/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_csv_modal_reporting.tsx
+++ b/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_csv_modal_reporting.tsx
@@ -65,7 +65,9 @@ export const reportingCsvShareProvider = ({
     const licenseHasCsvReporting = licenseCheck.showLinks;
     const licenseDisabled = !licenseCheck.enableLinks;
 
-    const capabilityHasCsvReporting = application.capabilities.discover_v2?.generateCsv === true;
+    const capabilityHasCsvReporting =
+      application.capabilities.discover_v2?.generateCsv === true ||
+      application.capabilities.reportingLegacy?.generateReport === true;
 
     const generateReportingJobCSV = ({ intl }: { intl: InjectedIntl }) => {
       const { reportType, decoratedJobParams } = getSearchCsvJobParams({

--- a/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_pdf_png_modal_reporting.tsx
+++ b/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_pdf_png_modal_reporting.tsx
@@ -10,6 +10,7 @@
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { toMountPoint } from '@kbn/react-kibana-mount';
+import type { Capabilities } from '@kbn/core/public';
 import { ShareContext, ShareMenuItemV2, ShareMenuProvider } from '@kbn/share-plugin/public';
 import React from 'react';
 import { firstValueFrom } from 'rxjs';
@@ -39,6 +40,13 @@ const getJobParams = (opts: JobParamsProviderOptions, type: 'pngV2' | 'printable
   return { ...baseParams, locatorParams };
 };
 
+const hasCapabilityByKey = (capabilities: Capabilities, capabilityKey: keyof Capabilities) => {
+  return (
+    capabilities[capabilityKey]?.generateScreenshot === true ||
+    capabilities.reportingLegacy?.generateReport === true
+  );
+};
+
 /**
  * This is used by Dashboard and Visualize apps (sharing modal)
  */
@@ -63,10 +71,14 @@ export const reportingExportModalProvider = ({
     const licenseHasScreenshotReporting = showLinks;
     const licenseDisabled = !enableLinks;
 
-    const capabilityHasDashboardScreenshotReporting =
-      application.capabilities.dashboard_v2?.generateScreenshot === true;
-    const capabilityHasVisualizeScreenshotReporting =
-      application.capabilities.visualize_v2?.generateScreenshot === true;
+    const capabilityHasDashboardReporting = hasCapabilityByKey(
+      application.capabilities,
+      'dashboard_v2'
+    );
+    const capabilityHasVisualizeReporting = hasCapabilityByKey(
+      application.capabilities,
+      'visualize_v2'
+    );
 
     if (!licenseHasScreenshotReporting) {
       return [];
@@ -78,15 +90,11 @@ export const reportingExportModalProvider = ({
       return [];
     }
 
-    if (objectType === 'dashboard' && !capabilityHasDashboardScreenshotReporting) {
+    if (objectType === 'dashboard' && !capabilityHasDashboardReporting) {
       return [];
     }
 
-    if (
-      isSupportedType &&
-      !capabilityHasVisualizeScreenshotReporting &&
-      !capabilityHasDashboardScreenshotReporting
-    ) {
+    if (isSupportedType && !capabilityHasVisualizeReporting && !capabilityHasDashboardReporting) {
       return [];
     }
 

--- a/x-pack/platform/packages/private/security/authorization_core/src/privileges/privileges.ts
+++ b/x-pack/platform/packages/private/security/authorization_core/src/privileges/privileges.ts
@@ -245,6 +245,8 @@ export function privilegesFactory(
           read: [actions.login, ...readActions],
         },
         reserved: features.reduce((acc: Record<string, string[]>, feature: KibanaFeature) => {
+          // Reserved privileges are intentionally not excluded from registration based on their `hidden` attribute.
+          // This is explicitly to support the legacy reporting use case.
           if (feature.reserved) {
             feature.reserved.privileges.forEach((reservedPrivilege) => {
               acc[reservedPrivilege.id] = [

--- a/x-pack/platform/plugins/private/canvas/public/services/kibana_services.ts
+++ b/x-pack/platform/plugins/private/canvas/public/services/kibana_services.ts
@@ -45,13 +45,17 @@ export const setKibanaServices = (
   kibanaVersion = initContext.env.packageInfo.version;
 
   coreServices = kibanaCore;
+  const capabilities = kibanaCore.application.capabilities;
   contentManagementService = deps.contentManagement;
   dataService = deps.data;
   dataViewsService = deps.dataViews;
   embeddableService = deps.embeddable;
   expressionsService = deps.expressions;
   presentationUtilService = deps.presentationUtil;
-  reportingService = Boolean(kibanaCore.application.capabilities.canvas?.generatePdf)
+  reportingService = Boolean(
+    capabilities.canvas?.generatePdf === true ||
+      capabilities.reportingLegacy?.generateReport === true
+  )
     ? deps.reporting
     : undefined;
   spacesService = deps.spaces;

--- a/x-pack/platform/plugins/private/reporting/server/features.ts
+++ b/x-pack/platform/plugins/private/reporting/server/features.ts
@@ -16,9 +16,10 @@ interface FeatureRegistrationOpts {
 }
 
 export function registerFeatures({ isServerless, features }: FeatureRegistrationOpts) {
-  // Register a 'shell' feature specifically for Serverless. If granted, it will automatically provide access to
-  // reporting capabilities in other features, such as Discover, Dashboards, and Visualizations. On its own, this
-  // feature doesn't grant any additional privileges.
+  // Register a 'shell' features for Reporting. On their own, they don't grant specific privileges.
+
+  // Shell feature for Serverless. If granted, it will automatically provide access to
+  // reporting capabilities in other features, such as Discover, Dashboards, and Visualizations.
   if (isServerless) {
     features.registerKibanaFeature({
       id: 'reporting',
@@ -32,6 +33,44 @@ export function registerFeatures({ isServerless, features }: FeatureRegistration
         all: { savedObject: { all: [], read: [] }, ui: [] },
         // No read-only mode currently supported
         read: { disabled: true, savedObject: { all: [], read: [] }, ui: [] },
+      },
+    });
+  } else {
+    // Shell feature for self-managed environments, to be leveraged by a reserved privilege defined
+    // in ES. This grants access to reporting features in a legacy fashion.
+    features.registerKibanaFeature({
+      id: 'reportingLegacy',
+      name: i18n.translate('xpack.reporting.features.reportingLegacyFeatureName', {
+        defaultMessage: 'Reporting Legacy',
+      }),
+      category: DEFAULT_APP_CATEGORIES.management,
+      management: { insightsAndAlerting: ['reporting'] },
+      scope: [KibanaFeatureScope.Spaces, KibanaFeatureScope.Security],
+      hidden: true,
+      app: [],
+      privileges: null,
+      reserved: {
+        description: i18n.translate(
+          'xpack.reporting.features.reportingLegacyFeatureReservedDescription',
+          {
+            defaultMessage:
+              'Reserved for use by the Reporting plugin. This feature is used to grant access to Reporting capabilities in a legacy manner.',
+          }
+        ),
+        privileges: [
+          {
+            id: 'reporting_user',
+            privilege: {
+              excludeFromBasePrivileges: true,
+              app: [],
+              catalogue: [],
+              management: { insightsAndAlerting: ['reporting'] },
+              savedObject: { all: [], read: [] },
+              api: ['generateReport'],
+              ui: ['generateReport'],
+            },
+          },
+        ],
       },
     });
   }

--- a/x-pack/platform/plugins/private/reporting/server/plugin.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/plugin.test.ts
@@ -5,13 +5,8 @@
  * 2.0.
  */
 
-import {
-  CoreSetup,
-  CoreStart,
-  DEFAULT_APP_CATEGORIES,
-  Logger,
-  type PackageInfo,
-} from '@kbn/core/server';
+import type { CoreSetup, CoreStart, Logger } from '@kbn/core/server';
+import { DEFAULT_APP_CATEGORIES, type PackageInfo } from '@kbn/core/server';
 import { coreMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { featuresPluginMock } from '@kbn/features-plugin/server/mocks';
 import { createMockConfigSchema } from '@kbn/reporting-mocks-server';
@@ -25,7 +20,7 @@ import { ReportingPlugin } from './plugin';
 import { createMockPluginSetup, createMockPluginStart } from './test_helpers';
 import type { ReportingSetupDeps } from './types';
 import { ExportTypesRegistry } from '@kbn/reporting-server/export_types_registry';
-import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 
 const sleep = (time: number) => new Promise((r) => setTimeout(r, time));
 

--- a/x-pack/platform/plugins/private/reporting/server/plugin.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/plugin.test.ts
@@ -165,7 +165,7 @@ describe('Reporting Plugin', () => {
   describe('features registration', () => {
     it('does not register Kibana reporting feature in traditional build flavour', async () => {
       plugin.setup(coreSetup, pluginSetup);
-      expect(featuresSetup.registerKibanaFeature).not.toHaveBeenCalled();
+      expect(featuresSetup.registerKibanaFeature).toHaveBeenCalledTimes(1);
       expect(featuresSetup.enableReportingUiCapabilities).toHaveBeenCalledTimes(1);
     });
 

--- a/x-pack/platform/plugins/shared/features/common/kibana_feature.ts
+++ b/x-pack/platform/plugins/shared/features/common/kibana_feature.ts
@@ -159,6 +159,8 @@ export interface KibanaFeatureConfig {
    * Indicates whether the feature is available as a standalone feature. The feature can still be
    * referenced by other features, but it will not be displayed in any feature management UIs. By default, all features
    * are visible.
+   *
+   * @note This flag is designed for use via configuration overrides, and very select use cases. Please consult prior to use.
    */
   hidden?: boolean;
 

--- a/x-pack/platform/plugins/shared/features/server/feature_registry.test.ts
+++ b/x-pack/platform/plugins/shared/features/server/feature_registry.test.ts
@@ -2030,6 +2030,114 @@ describe('FeatureRegistry', () => {
       );
     });
 
+    it('allows reserved features to be hidden', () => {
+      const feature: KibanaFeatureConfig = {
+        id: 'test-feature',
+        name: 'Test Feature',
+        app: [],
+        category: { id: 'foo', label: 'foo' },
+        privileges: null,
+        hidden: true,
+        reserved: {
+          description: 'my reserved privileges',
+          privileges: [
+            {
+              id: 'a_reserved_1',
+              privilege: {
+                savedObject: {
+                  all: [],
+                  read: [],
+                },
+                ui: [],
+                app: [],
+              },
+            },
+          ],
+        },
+      };
+
+      const featureRegistry = new FeatureRegistry();
+      expect(() => featureRegistry.registerKibanaFeature(feature)).not.toThrowError();
+    });
+
+    it('does not allow features with both regular and reserved privileges to be hidden', () => {
+      const feature: KibanaFeatureConfig = {
+        id: 'test-feature',
+        name: 'Test Feature',
+        app: [],
+        category: { id: 'foo', label: 'foo' },
+        privileges: {
+          all: {
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: [],
+          },
+          read: {
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: [],
+          },
+        },
+        hidden: true,
+        reserved: {
+          description: 'my reserved privileges',
+          privileges: [
+            {
+              id: 'a_reserved_1',
+              privilege: {
+                savedObject: {
+                  all: [],
+                  read: [],
+                },
+                ui: [],
+                app: [],
+              },
+            },
+          ],
+        },
+      };
+
+      const featureRegistry = new FeatureRegistry();
+      expect(() =>
+        featureRegistry.registerKibanaFeature(feature)
+      ).toThrowErrorMatchingInlineSnapshot(`"Feature test-feature cannot be hidden."`);
+    });
+
+    it('does not allow features with regular privileges to be hidden', () => {
+      const feature: KibanaFeatureConfig = {
+        id: 'test-feature',
+        name: 'Test Feature',
+        app: [],
+        category: { id: 'foo', label: 'foo' },
+        privileges: {
+          all: {
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: [],
+          },
+          read: {
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: [],
+          },
+        },
+        hidden: true,
+      };
+
+      const featureRegistry = new FeatureRegistry();
+      expect(() =>
+        featureRegistry.registerKibanaFeature(feature)
+      ).toThrowErrorMatchingInlineSnapshot(`"Feature test-feature cannot be hidden."`);
+    });
+
     it('allows independent sub-feature privileges to register a minimumLicense', () => {
       const feature1: KibanaFeatureConfig = {
         id: 'test-feature',

--- a/x-pack/platform/plugins/shared/features/server/feature_schema.ts
+++ b/x-pack/platform/plugins/shared/features/server/feature_schema.ts
@@ -217,7 +217,7 @@ const kibanaSubFeatureSchema = schema.object({
   ),
 });
 
-// NOTE: This schema intentionally omits the `composedOf` and `hidden` properties to discourage consumers from using
+// NOTE: This schema intentionally omits the `composedOf` property to discourage consumers from using
 // them during feature registration. This is because these properties should only be set via configuration overrides.
 const kibanaFeatureSchema = schema.object({
   id: schema.string({
@@ -233,6 +233,9 @@ const kibanaFeatureSchema = schema.object({
   name: schema.string(),
   category: appCategorySchema,
   scope: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
+  // The hidden flag is only supported for explicit configuration for features with reserved privileges.
+  // All other usages are via configuration overrides.
+  hidden: schema.maybe(schema.boolean()),
   description: schema.maybe(schema.string()),
   order: schema.maybe(schema.number()),
   excludeFromBasePrivileges: schema.maybe(schema.boolean()),
@@ -321,6 +324,14 @@ const elasticsearchFeatureSchema = schema.object({
 
 export function validateKibanaFeature(feature: KibanaFeatureConfig) {
   kibanaFeatureSchema.validate(feature);
+
+  // The `hidden` attribute is ONLY permitted for features with reserved privileges, AND without normal privileges.
+  // The original intent of the hidden flag was to support serverless configuration overrides. There is now (>=9.0) an additional,
+  // maybe temporary use case for the legacy reporting authorization mode, which registers as a reserved privilege.
+  const { hidden, privileges, reserved } = feature;
+  if (hidden && (privileges !== null || typeof reserved === 'undefined')) {
+    throw new Error(`Feature ${feature.id} cannot be hidden.`);
+  }
 
   const unknownScopesEntries = difference(feature.scope ?? [], Object.values(KibanaFeatureScope));
 

--- a/x-pack/platform/plugins/shared/spaces/public/management/components/enabled_features/__snapshots__/enabled_features.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/spaces/public/management/components/enabled_features/__snapshots__/enabled_features.test.tsx.snap
@@ -75,6 +75,23 @@ exports[`EnabledFeatures renders as expected 1`] = `
                 "security",
               ],
             },
+            Object {
+              "app": Array [],
+              "category": Object {
+                "euiIconType": "logoKibana",
+                "id": "kibana",
+                "label": "Analytics",
+                "order": 1000,
+              },
+              "hidden": true,
+              "id": "feature-3",
+              "name": "Feature 3 (hidden)",
+              "privileges": null,
+              "scope": Array [
+                "spaces",
+                "security",
+              ],
+            },
           ]
         }
         onChange={[MockFunction]}

--- a/x-pack/platform/plugins/shared/spaces/public/management/components/enabled_features/enabled_features.test.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/management/components/enabled_features/enabled_features.test.tsx
@@ -32,6 +32,15 @@ const features: KibanaFeatureConfig[] = [
     category: DEFAULT_APP_CATEGORIES.kibana,
     privileges: null,
   },
+  {
+    id: 'feature-3',
+    name: 'Feature 3 (hidden)',
+    hidden: true,
+    scope: [KibanaFeatureScope.Spaces, KibanaFeatureScope.Security],
+    app: [],
+    category: DEFAULT_APP_CATEGORIES.kibana,
+    privileges: null,
+  },
 ];
 
 describe('EnabledFeatures', () => {

--- a/x-pack/platform/plugins/shared/spaces/public/management/components/enabled_features/feature_table.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/management/components/enabled_features/feature_table.tsx
@@ -43,6 +43,7 @@ export class FeatureTable extends Component<Props, {}> {
     super(props);
     // features are static for the lifetime of the page, so this is safe to do here in a non-reactive manner
     props.features.forEach((feature) => {
+      if (feature.hidden === true) return;
       if (!this.featureCategories.has(feature.category.id)) {
         this.featureCategories.set(feature.category.id, []);
       }
@@ -185,8 +186,9 @@ export class FeatureTable extends Component<Props, {}> {
 
     accordions.sort((a1, a2) => a1.order - a2.order);
 
-    const featureCount = this.props.features.length;
-    const enabledCount = getEnabledFeatures(this.props.features, this.props.space).length;
+    const visibleFeatures = this.props.features.filter((f) => !f.hidden);
+    const featureCount = visibleFeatures.length;
+    const enabledCount = getEnabledFeatures(visibleFeatures, this.props.space).length;
     const controls = [];
     if (enabledCount < featureCount) {
       controls.push(

--- a/x-pack/test/api_integration/apis/features/features/features.ts
+++ b/x-pack/test/api_integration/apis/features/features/features.ts
@@ -6,9 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import { KibanaFeature } from '@kbn/features-plugin/server';
+import type { KibanaFeature } from '@kbn/features-plugin/server';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
-import { FtrProviderContext } from '../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
@@ -126,6 +126,7 @@ export default function ({ getService }: FtrProviderContext) {
             'inventory',
             'logs',
             'maintenanceWindow',
+            'reportingLegacy',
             'maps_v2',
             'osquery',
             'rulesSettings',
@@ -203,6 +204,7 @@ export default function ({ getService }: FtrProviderContext) {
           'fleet',
           'fleetv2',
           'entityManager',
+          'reportingLegacy',
         ];
 
         const features = body.filter(

--- a/x-pack/test/api_integration/apis/security/privileges.ts
+++ b/x-pack/test/api_integration/apis/security/privileges.ts
@@ -284,7 +284,7 @@ export default function ({ getService }: FtrProviderContext) {
       inventory: ['all', 'read', 'minimal_all', 'minimal_read'],
       entityManager: ['all', 'read', 'minimal_all', 'minimal_read'],
     },
-    reserved: ['fleet-setup', 'ml_user', 'ml_admin', 'ml_apm_user', 'monitoring'],
+    reserved: ['fleet-setup', 'ml_user', 'ml_admin', 'ml_apm_user', 'monitoring', 'reporting_user'],
   };
 
   describe('Privileges', () => {

--- a/x-pack/test/api_integration/apis/security/privileges_basic.ts
+++ b/x-pack/test/api_integration/apis/security/privileges_basic.ts
@@ -82,7 +82,14 @@ export default function ({ getService }: FtrProviderContext) {
           },
           global: ['all', 'read'],
           space: ['all', 'read'],
-          reserved: ['fleet-setup', 'ml_user', 'ml_admin', 'ml_apm_user', 'monitoring'],
+          reserved: [
+            'fleet-setup',
+            'ml_user',
+            'ml_admin',
+            'ml_apm_user',
+            'monitoring',
+            'reporting_user',
+          ],
         };
 
         await supertest
@@ -383,7 +390,14 @@ export default function ({ getService }: FtrProviderContext) {
             inventory: ['all', 'read', 'minimal_all', 'minimal_read'],
             entityManager: ['all', 'read', 'minimal_all', 'minimal_read'],
           },
-          reserved: ['fleet-setup', 'ml_user', 'ml_admin', 'ml_apm_user', 'monitoring'],
+          reserved: [
+            'fleet-setup',
+            'ml_user',
+            'ml_admin',
+            'ml_apm_user',
+            'monitoring',
+            'reporting_user',
+          ],
         };
 
         await supertest

--- a/x-pack/test/reporting_api_integration/reporting_and_security/default_reporting_user_role.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/default_reporting_user_role.ts
@@ -5,44 +5,377 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../ftr_provider_context';
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
-// eslint-disable-next-line import/no-default-export
-export default function ({ getService }: FtrProviderContext) {
+const randomString = (length = 3) => {
+  return Math.random()
+    .toString(36)
+    .substring(2, length + 2);
+};
+
+/**
+ * Test services that are specialized for testing the default user role using
+ * roles, with other specific privileges, across spaces, and sometimes sending
+ * requests that are expected to fail with an authorization error.
+ */
+const defaultUserRoleTestServices = ({ getService }: FtrProviderContext) => {
+  const esArchiver = getService('esArchiver');
   const reportingAPI = getService('reportingAPI');
   const security = getService('security');
+  const kibanaServer = getService('kibanaServer');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
   const log = getService('log');
 
-  const testUserUsername = 'test_reporting_user';
-  const testUserPassword = 'changeme';
+  const DEFAULT_SPACE = 'default';
+  const TEST_CUSTOM_SPACE = 'test_space_' + randomString();
 
-  describe.skip('Default reporting_user role', () => {
-    before(async () => {
-      await reportingAPI.initEcommerce();
+  const ECOMMERCE_DATA_INDEX = 'ecommerce';
+  const LOGS_DATA_INDEX = 'logstash-*';
 
-      log.info('creating test user with reporting_user role');
-      await security.user.create(testUserUsername, {
-        password: testUserPassword,
-        roles: ['data_analyst', 'reporting_user'], // no custom privileges to reporting, uses the built-in role that grants access to all features in all applications and all spaces
-        full_name:
-          'a reporting user which uses the built-in reporting_user role to access reporting features',
+  const DATA_READER_ROLE = 'test_data_reader_role_' + randomString();
+  const SPACE_PRIVILEGES_ROLE = 'test_space_privileges_role_' + randomString();
+
+  const UNPRIVILEGED_USER = 'test_unprivileged_reporting_user_' + randomString();
+  const UNPRIVILEGED_USER_PASSWORD = 'changeme_' + randomString();
+
+  const PRIVILEGED_REPORTING_USER = 'test_privileged_reporting_user_' + randomString();
+  const PRIVILEGED_REPORTING_USER_PASSWORD = 'changeme_' + randomString();
+
+  const archiveRoot = 'x-pack/platform/test/fixtures/es_archives';
+  const ecommerceArchivePath = archiveRoot + '/reporting/ecommerce';
+  const logsArchivePath = archiveRoot + '/logstash_functional';
+
+  const soRoot = 'x-pack/platform/test/functional/fixtures/kbn_archives/reporting';
+  const logsSOPath = soRoot + '/logs';
+  const ecommerceSOPath = soRoot + '/ecommerce';
+
+  /**
+   * Ecommerce data: load SOs into the default space
+   */
+  const initEcommerce = async (spaceId = DEFAULT_SPACE) => {
+    await esArchiver.load(ecommerceArchivePath, {
+      performance: { batchSize: 300, concurrency: 1 },
+    });
+    await kibanaServer.importExport.load(ecommerceSOPath, { space: spaceId });
+  };
+
+  const teardownEcommerce = async (spaceId = DEFAULT_SPACE) => {
+    await esArchiver.unload(ecommerceArchivePath);
+    await kibanaServer.importExport.unload(ecommerceSOPath, { space: spaceId });
+  };
+
+  /**
+   * Logs data: load into a custom space
+   */
+  const initLogs = async (spaceId = TEST_CUSTOM_SPACE) => {
+    log.info(`initializing logs for space: ${spaceId}`);
+    await esArchiver.load(logsArchivePath, {
+      performance: { batchSize: 300, concurrency: 1 },
+    });
+    await kibanaServer.importExport.load(logsSOPath, { space: spaceId });
+  };
+
+  const teardownLogs = async (spaceId = TEST_CUSTOM_SPACE) => {
+    log.info(`tearing down logs for space: ${spaceId}`);
+    await esArchiver.unload(logsArchivePath);
+    await kibanaServer.importExport.unload(logsSOPath, { space: spaceId });
+  };
+
+  const createTestSpace = async (spaceId = TEST_CUSTOM_SPACE) => {
+    log.info(`creating test space: ${spaceId}`);
+    await kibanaServer.spaces.create({
+      id: spaceId,
+      name: `Test Space ${spaceId}`,
+    });
+  };
+
+  const createTestDataReaderRole = async (roleName = DATA_READER_ROLE) => {
+    log.info(`creating test role ${roleName} to access ecommerce data`);
+    await security.role.create(roleName, {
+      elasticsearch: {
+        cluster: [],
+        indices: [
+          {
+            names: [ECOMMERCE_DATA_INDEX, LOGS_DATA_INDEX],
+            privileges: ['read', 'view_index_metadata'],
+            allow_restricted_indices: false,
+          },
+        ],
+        run_as: [],
+      },
+      kibana: [], // No Kibana privileges
+    });
+  };
+
+  const createSpacePrivilegesRole = async (
+    roleName = SPACE_PRIVILEGES_ROLE,
+    spaceId = TEST_CUSTOM_SPACE
+  ) => {
+    log.info(`creating ${roleName} test role to access applications in ${spaceId}`);
+    await security.role.create(roleName, {
+      elasticsearch: {
+        cluster: [],
+        indices: [], // No data access
+        run_as: [],
+      },
+      kibana: [
+        {
+          base: [],
+          feature: {
+            discover: ['minimal_read'],
+            dashboard: ['minimal_read'],
+            canvas: ['minimal_read'],
+            visualize: ['minimal_read'],
+          },
+          spaces: [spaceId],
+        },
+      ],
+    });
+  };
+
+  const createTestUser = async (username: string, password: string, roles: string[]) => {
+    log.info(
+      `creating test user: ${username} with password: ${password} and roles: ${roles.join(', ')}`
+    );
+    await security.user.create(username, { password, roles });
+  };
+
+  const _postJob = async (spaceId: string, apiPath: string, username: string, password: string) => {
+    log.info(`requesting reporting job with user: ${username} in space: ${spaceId}`);
+    const job = await supertestWithoutAuth
+      .post(apiPath)
+      .auth(username, password)
+      .set('kbn-xsrf', 'xxx');
+
+    if (job?.body?.path) {
+      const path = job.body.path;
+      log.info('test report job download path: ', path);
+      await reportingAPI.waitForJobToFinish(path, false, username, password, {
+        checkStatus: false,
       });
+    }
+
+    return job;
+  };
+
+  const postJobDefaultSpace = async (username: string, password: string) => {
+    const apiPath = getCsvGenerationPath(DEFAULT_SPACE);
+    return _postJob(DEFAULT_SPACE, apiPath, username, password);
+  };
+
+  const postJobCustomSpace = async (
+    username: string,
+    password: string,
+    spaceId = TEST_CUSTOM_SPACE
+  ) => {
+    const apiPath = getCsvGenerationPath(spaceId);
+    return _postJob(spaceId, apiPath, username, password);
+  };
+
+  /**
+   * A successful request should generate a CSV report with 32 rows and 8 columns.
+   */
+  const getCsvGenerationPath = (spaceId: string) => {
+    // Export Ecommerce data in the default space
+    const ECOMMERCE_CSV_GENERATION_PATH_DEFAULT_SPACE =
+      '/api/reporting/generate/csv_searchsource?jobParams=%28browserTimezone%3AUTC%2Ccolumns%3A%21%28order_date%2Ccategory%2Ccurrency%2Ccustomer_id%2Corder_id%2Cday_of_week_i%2Cproducts.created_on%2Csku%29%2CobjectType%3Asearch%2CsearchSource%3A%28fields%3A%21%28%28field%3Aorder_date%2Cinclude_unmapped%3A%21t%29%2C%28field%3Acategory%2Cinclude_unmapped%3A%21t%29%2C%28field%3Acurrency%2Cinclude_unmapped%3A%21t%29%2C%28field%3Acustomer_id%2Cinclude_unmapped%3A%21t%29%2C%28field%3Aorder_id%2Cinclude_unmapped%3A%21t%29%2C%28field%3Aday_of_week_i%2Cinclude_unmapped%3A%21t%29%2C%28field%3Aproducts.created_on%2Cinclude_unmapped%3A%21t%29%2C%28field%3Asku%2Cinclude_unmapped%3A%21t%29%29%2Cfilter%3A%21%28%28meta%3A%28field%3Aorder_date%2Cindex%3A%275193f870-d861-11e9-a311-0fa548c5f953%27%2Cparams%3A%28%29%29%2Cquery%3A%28range%3A%28order_date%3A%28format%3Astrict_date_optional_time%2Cgte%3A%272019-07-01T20%3A56%3A00.833Z%27%2Clte%3A%272019-07-02T15%3A09%3A46.563Z%27%29%29%29%29%29%2Cindex%3A%275193f870-d861-11e9-a311-0fa548c5f953%27%2Cquery%3A%28language%3Akuery%2Cquery%3A%27%27%29%2Csort%3A%21%28%28order_date%3A%28format%3Astrict_date_optional_time%2Corder%3Adesc%29%29%2C%28order_id%3Adesc%29%29%2Cversion%3A%21t%29%2Ctitle%3A%27Ecommerce%20Data%27%2Cversion%3A%279.0.0%27%29';
+
+    // Export Logs data in a custom space
+    const LOGS_CSV_GENERATION_PATH_CUSTOM_SPACE =
+      '/s/__SPACE__/api/reporting/generate/csv_searchsource?jobParams=%28browserTimezone%3AUTC%2Ccolumns%3A%21%28%27%40timestamp%27%2C%27%40message%27%2Curl%2C%27%40tags%27%29%2CobjectType%3Asearch%2CsearchSource%3A%28fields%3A%21%28%28field%3A%27%40timestamp%27%2Cinclude_unmapped%3A%21t%29%2C%28field%3A%27%40message%27%2Cinclude_unmapped%3A%21t%29%2C%28field%3Aurl%2Cinclude_unmapped%3A%21t%29%2C%28field%3A%27%40tags%27%2Cinclude_unmapped%3A%21t%29%29%2Cfilter%3A%21%28%28meta%3A%28field%3A%27%40timestamp%27%2Cindex%3A%27logstash-%2A%27%2Cparams%3A%28%29%29%2Cquery%3A%28range%3A%28%27%40timestamp%27%3A%28format%3Astrict_date_optional_time%2Cgte%3A%272015-07-30T15%3A49%3A33.702Z%27%2Clte%3A%272015-11-01T01%3A39%3A01.782Z%27%29%29%29%29%29%2Cindex%3A%27logstash-%2A%27%2Cquery%3A%28language%3Akuery%2Cquery%3A%27host%3Amedia-for-the-masses%27%29%2Csort%3A%21%28%28%27%40timestamp%27%3A%28format%3Astrict_date_optional_time%2Corder%3Adesc%29%29%29%29%2Ctitle%3A%27A%20saved%20search%20with%20the%20time%20stored%20and%20a%20query%27%2Cversion%3A%279.2.0%27%29';
+
+    if (spaceId === DEFAULT_SPACE) {
+      return ECOMMERCE_CSV_GENERATION_PATH_DEFAULT_SPACE;
+    } else {
+      return LOGS_CSV_GENERATION_PATH_CUSTOM_SPACE.replace(
+        /__SPACE__/g,
+        encodeURIComponent(spaceId)
+      );
+    }
+  };
+
+  const getReportInfo = async (downloadPath: string, username: string, password: string) => {
+    // change the downloadPath to the info path
+    const infoPath = downloadPath.replace('/api/', '/internal/').replace('/download/', '/info/');
+    log.info(`getting report info from path: ${infoPath} with user: ${username}`);
+    const response = await supertestWithoutAuth
+      .get(infoPath)
+      .auth(username, password)
+      .set('kbn-xsrf', 'xxx');
+    return response.body;
+  };
+
+  return {
+    DEFAULT_SPACE,
+    TEST_CUSTOM_SPACE,
+    ECOMMERCE_DATA_INDEX,
+    LOGS_DATA_INDEX,
+    DATA_READER_ROLE,
+    SPACE_PRIVILEGES_ROLE,
+    UNPRIVILEGED_USER,
+    UNPRIVILEGED_USER_PASSWORD,
+    PRIVILEGED_REPORTING_USER,
+    PRIVILEGED_REPORTING_USER_PASSWORD,
+
+    initEcommerce,
+    teardownEcommerce,
+    initLogs,
+    teardownLogs,
+    createTestSpace,
+    createTestDataReaderRole,
+    createSpacePrivilegesRole,
+    createTestUser,
+
+    postJobDefaultSpace,
+    postJobCustomSpace,
+
+    getCsvGenerationPath,
+    getReportInfo,
+  };
+};
+
+// eslint-disable-next-line import/no-default-export
+export default function (context: FtrProviderContext) {
+  const security = context.getService('security');
+  const kibanaServer = context.getService('kibanaServer');
+  const reportingAPI = context.getService('reportingAPI');
+
+  const api = defaultUserRoleTestServices(context); // Custom API for this test suite
+
+  describe('Default reporting_user role', () => {
+    before(async () => {
+      const {
+        createTestSpace,
+        createTestDataReaderRole,
+        createSpacePrivilegesRole,
+        createTestUser,
+        initEcommerce,
+        initLogs,
+        UNPRIVILEGED_USER,
+        UNPRIVILEGED_USER_PASSWORD,
+        PRIVILEGED_REPORTING_USER,
+        PRIVILEGED_REPORTING_USER_PASSWORD,
+        DATA_READER_ROLE,
+        SPACE_PRIVILEGES_ROLE,
+      } = api;
+
+      const { REPORTING_ROLE_BUILT_IN } = reportingAPI;
+
+      /**
+       * - Create an unprivileged user account
+       * - Grant the unprivileged user the built-in reporting_user role, and grant access to data. The access should NOT include access to any Kibana applications in any space
+       *
+       * - Create a privileged user account
+       * - Grant the privileged user the built-in reporting_user role, access to data, and access to applications in the custom space ONLY.
+       */
+      await createTestSpace();
+      await createTestDataReaderRole();
+      await createSpacePrivilegesRole();
+
+      await createTestUser(UNPRIVILEGED_USER, UNPRIVILEGED_USER_PASSWORD, [
+        REPORTING_ROLE_BUILT_IN, // Gives access to reporting features using the built-in role, but no access to applications in any space
+        DATA_READER_ROLE, // Gives access to the ecommerce data but no access to applications in any space
+      ]);
+      await createTestUser(PRIVILEGED_REPORTING_USER, PRIVILEGED_REPORTING_USER_PASSWORD, [
+        REPORTING_ROLE_BUILT_IN, // Gives access to reporting features using the built-in role, but no access to applications in any space
+        DATA_READER_ROLE, // Gives access to the ecommerce data but no access to applications in any space
+        SPACE_PRIVILEGES_ROLE, // Grants access to applications in the custom space
+      ]);
+
+      await initEcommerce();
+      await initLogs();
     });
 
     after(async () => {
-      await reportingAPI.teardownEcommerce();
+      const {
+        teardownEcommerce,
+        teardownLogs,
+        UNPRIVILEGED_USER,
+        PRIVILEGED_REPORTING_USER,
+        DATA_READER_ROLE,
+        SPACE_PRIVILEGES_ROLE,
+        TEST_CUSTOM_SPACE,
+      } = api;
+
+      await teardownEcommerce();
+      await teardownLogs();
+      await security.role.delete(DATA_READER_ROLE);
+      await security.role.delete(SPACE_PRIVILEGES_ROLE);
+      await security.user.delete(UNPRIVILEGED_USER);
+      await security.user.delete(PRIVILEGED_REPORTING_USER);
+      await kibanaServer.spaces.delete(TEST_CUSTOM_SPACE);
     });
 
-    it('able to generate CSV report', async () => {
-      log.info('posting test report job with test user account');
-      const reportPath = await reportingAPI.postJob(
-        '/api/reporting/generate/csv_searchsource?jobParams=%28browserTimezone%3AAmerica%2FPhoenix%2Ccolumns%3A%21%28order_date%2Ccategory%2Ccurrency%2Ccustomer_id%2Corder_id%2Cday_of_week_i%2Cproducts.created_on%2Csku%29%2CobjectType%3Asearch%2CsearchSource%3A%28fields%3A%21%28%28field%3Aorder_date%2Cinclude_unmapped%3A%21t%29%2C%28field%3Acategory%2Cinclude_unmapped%3A%21t%29%2C%28field%3Acurrency%2Cinclude_unmapped%3A%21t%29%2C%28field%3Acustomer_id%2Cinclude_unmapped%3A%21t%29%2C%28field%3Aorder_id%2Cinclude_unmapped%3A%21t%29%2C%28field%3Aday_of_week_i%2Cinclude_unmapped%3A%21t%29%2C%28field%3Aproducts.created_on%2Cinclude_unmapped%3A%21t%29%2C%28field%3Asku%2Cinclude_unmapped%3A%21t%29%29%2Cfilter%3A%21%28%28meta%3A%28field%3Aorder_date%2Cindex%3A%275193f870-d861-11e9-a311-0fa548c5f953%27%2Cparams%3A%28%29%29%2Cquery%3A%28range%3A%28order_date%3A%28format%3Astrict_date_optional_time%2Cgte%3A%272019-07-01T20%3A56%3A00.833Z%27%2Clte%3A%272019-07-02T15%3A09%3A46.563Z%27%29%29%29%29%29%2Cindex%3A%275193f870-d861-11e9-a311-0fa548c5f953%27%2Cquery%3A%28language%3Akuery%2Cquery%3A%27%27%29%2Csort%3A%21%28%28order_date%3A%28format%3Astrict_date_optional_time%2Corder%3Adesc%29%29%2C%28order_id%3Adesc%29%29%2Cversion%3A%21t%29%2Ctitle%3A%27Ecommerce%20Data%27%2Cversion%3A%279.0.0%27%29',
-        testUserUsername,
-        testUserPassword
+    it('unprivileged user should not be able to generate report in default space', async () => {
+      // Try to invoke a reporting job in the default space, which should FAIL with an authorization error
+      const jobDefaultSpace = await api.postJobDefaultSpace(
+        api.UNPRIVILEGED_USER,
+        api.UNPRIVILEGED_USER_PASSWORD
       );
-      log.info('test report job download path: ', reportPath);
 
-      await reportingAPI.waitForJobToFinish(reportPath, false, testUserUsername, testUserPassword);
+      // the request should succeed
+      expect(jobDefaultSpace?.statusCode).to.be(200);
+
+      // the job WILL NOT BE generated
+      const result = await api.getReportInfo(
+        jobDefaultSpace?.body?.path,
+        api.UNPRIVILEGED_USER,
+        api.UNPRIVILEGED_USER_PASSWORD
+      );
+
+      expect(result.status).to.be('failed');
+      expect(result.output?.warnings).to.eql([
+        'ReportingError(code: unknown_error) "Unable to bulk_get index-pattern"',
+      ]);
+    });
+
+    it('privileged user is not able to generate a report in the default space', async () => {
+      // Try to invoke a reporting job in the default space, which should FAIL with an authorization error
+      const jobDefaultSpace = await api.postJobDefaultSpace(
+        api.PRIVILEGED_REPORTING_USER,
+        api.PRIVILEGED_REPORTING_USER_PASSWORD
+      );
+
+      // the request should succeed
+      expect(jobDefaultSpace?.statusCode).to.be(200);
+
+      // the job WILL NOT BE generated
+      const result = await api.getReportInfo(
+        jobDefaultSpace?.body?.path,
+        api.PRIVILEGED_REPORTING_USER,
+        api.PRIVILEGED_REPORTING_USER_PASSWORD
+      );
+
+      expect(result.status).to.be('failed');
+      expect(result.output?.warnings).to.eql([
+        'ReportingError(code: unknown_error) "Unable to bulk_get index-pattern"',
+      ]);
+    });
+
+    it('privileged user is able to generate a report in a custom space only', async () => {
+      // Try to invoke a reporting job in the custom space, which should SUCCEED
+      const jobCustomSpace = await api.postJobCustomSpace(
+        api.PRIVILEGED_REPORTING_USER,
+        api.PRIVILEGED_REPORTING_USER_PASSWORD
+      );
+
+      // the request should succeed and the job WILL BE generated
+      expect(jobCustomSpace?.statusCode).to.be(200);
+      const result = await api.getReportInfo(
+        jobCustomSpace?.body?.path,
+        api.PRIVILEGED_REPORTING_USER,
+        api.PRIVILEGED_REPORTING_USER_PASSWORD
+      );
+
+      expect(result.status).to.contain('completed'); // could be 'completed' or 'completed_with_warnings'
+      expect(result.output?.error_code).to.be(undefined);
+      expect(result.output).to.eql({
+        content_type: 'text/csv',
+        size: 5722,
+        csv_contains_formulas: true,
+        max_size_reached: true,
+      });
     });
   });
 }

--- a/x-pack/test/reporting_api_integration/reporting_and_security/default_reporting_user_role.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/default_reporting_user_role.ts
@@ -42,11 +42,11 @@ const defaultUserRoleTestServices = ({ getService }: FtrProviderContext) => {
   const PRIVILEGED_REPORTING_USER = 'test_privileged_reporting_user_' + randomString();
   const PRIVILEGED_REPORTING_USER_PASSWORD = 'changeme_' + randomString();
 
-  const archiveRoot = 'x-pack/platform/test/fixtures/es_archives';
+  const archiveRoot = 'x-pack/test/functional/es_archives';
   const ecommerceArchivePath = archiveRoot + '/reporting/ecommerce';
   const logsArchivePath = archiveRoot + '/logstash_functional';
 
-  const soRoot = 'x-pack/platform/test/functional/fixtures/kbn_archives/reporting';
+  const soRoot = 'x-pack/test/functional/fixtures/kbn_archiver/reporting';
   const logsSOPath = soRoot + '/logs';
   const ecommerceSOPath = soRoot + '/ecommerce';
 

--- a/x-pack/test/reporting_api_integration/services/usage.ts
+++ b/x-pack/test/reporting_api_integration/services/usage.ts
@@ -20,7 +20,8 @@ export function createUsageServices({ getService }: FtrProviderContext) {
       downloadReportPath: string,
       ignoreFailure = false,
       username = 'elastic',
-      password = process.env.TEST_KIBANA_PASS || 'changeme'
+      password = process.env.TEST_KIBANA_PASS || 'changeme',
+      { checkStatus = true } = {}
     ) {
       log.debug(`Waiting for job to finish: ${downloadReportPath}`);
       const JOB_IS_PENDING_CODE = 503;
@@ -54,8 +55,11 @@ export function createUsageServices({ getService }: FtrProviderContext) {
             )
           )
           .auth(username, password);
-        expect(jobInfo.body.output.warnings).to.be(undefined); // expect no failure message to be present in job info
-        expect(statusCode).to.be(200);
+
+        if (checkStatus) {
+          expect(jobInfo.body.output.warnings).to.be(undefined); // expect no failure message to be present in job info
+          expect(statusCode).to.be(200);
+        }
       }
     },
 

--- a/x-pack/test/reporting_functional/reporting_and_security/security_roles_privileges.ts
+++ b/x-pack/test/reporting_functional/reporting_and_security/security_roles_privileges.ts
@@ -61,7 +61,7 @@ export default function ({ getService }: FtrProviderContext) {
       it('does not allow user that does not have reporting privileges', async () => {
         await reportingFunctional.loginDataAnalyst();
         await reportingFunctional.openSavedSearch(SAVEDSEARCH_TITLE);
-        await reportingFunctional.tryDiscoverCsvNotAvailable();
+        await reportingFunctional.tryReportsNotAvailable();
       });
 
       it('does allow user with reporting privileges', async () => {

--- a/x-pack/test/spaces_api_integration/spaces_only/telemetry/telemetry.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/telemetry/telemetry.ts
@@ -75,6 +75,7 @@ export default function ({ getService }: FtrProviderContext) {
         fleetv2: 0,
         fleet: 0,
         osquery: 0,
+        reportingLegacy: 0,
         observabilityCases: 0,
         observabilityCasesV2: 0,
         observabilityCasesV3: 0,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Add `reporting_user` feature for reserved set of privileges (#231533)](https://github.com/elastic/kibana/pull/231533)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tim Sullivan","email":"tsullivan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-20T11:57:52Z","message":"Add `reporting_user` feature for reserved set of privileges (#231533)\n\n## Summary\n\nWe want to switch the reserved `reporting_user` role to use a \"reserved\nprivilege definition\" and uses just that privilege. This PR satisfies\nthe Kibana requirements. There is a corresponding Elasticsearch PR:\nhttps://github.com/elastic/elasticsearch/pull/132766\n\n## Testing\n**NOTE: PNG/PDF reporting requires a Trial, or Gold+ license**\n\n1. Create `test_reporting_user` role\n\n    ```\n    POST /_security/role/test_reporting_user\n    {\n        \"cluster\": [],\n        \"indices\": [],\n        \"application\": [{\n            \"application\": \"kibana-*\",\n            \"privileges\": [\"reserved_reporting_user\"],\n            \"resources\": [\"*\"]\n        }]\n    }\n    ```\n\n2. Create `test_analyst_user` role\n\n    ```\n    POST /_security/role/test_analyst_user\n    {\n        \"cluster\": [],\n        \"indices\": [\n            {\n            \"names\": [\"kibana_sample_*\"],\n            \"privileges\": [\"all\"],\n            \"field_security\": {\n                \"grant\": [\"*\"],\n                \"except\": []\n            },\n            \"allow_restricted_indices\": false\n            }\n        ],\n        \"applications\": [\n            {\n            \"application\": \"kibana-.kibana\",\n            \"privileges\": [\n                \"feature_discover_v2.read\",\n                \"feature_dashboard_v2.read\",\n                \"feature_canvas.read\",\n                \"feature_visualize_v2.read\"\n            ],\n            \"resources\": [\"space:default\"]\n            }\n        ],\n        \"run_as\": [],\n        \"metadata\": {},\n        \"transient_metadata\": {\n            \"enabled\": true\n        }\n    }\n    ```\n\n3. Create a test user with just those two roles. Install sample data.\nLog in using the new test user.\n4. Test cases\n\n    | App | Reporting feature\n    |-|-\n    | Dashboard | PDF, PNG, CSV (from saved search panel action)\n    | Discover | CSV\n    | Canvas | PDF\n    | Lens | PDF, PNG\n| Stack Management | List reports, download reports, view report info,\ndelete reports\n\n6. As admin, create an additional Space which the test user should not\nhave access to. Ensure the test user does not have access to those\nspaces.\n7. Remove the `test_reporting_user` role from the user and ensure they\ndo not see any Reporting controls in the UI, and can not access Stack\nManagement > Reporting.\n\n## Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- ~~[ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- ~~[ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- ~~[ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- ~~[ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- ~~[ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"f9be58be65e59b85dc6c4d8fa74970a4f8c1971e","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.2.0","v9.1.3","v9.0.6"],"title":"Add `reporting_user` feature for reserved set of privileges","number":231533,"url":"https://github.com/elastic/kibana/pull/231533","mergeCommit":{"message":"Add `reporting_user` feature for reserved set of privileges (#231533)\n\n## Summary\n\nWe want to switch the reserved `reporting_user` role to use a \"reserved\nprivilege definition\" and uses just that privilege. This PR satisfies\nthe Kibana requirements. There is a corresponding Elasticsearch PR:\nhttps://github.com/elastic/elasticsearch/pull/132766\n\n## Testing\n**NOTE: PNG/PDF reporting requires a Trial, or Gold+ license**\n\n1. Create `test_reporting_user` role\n\n    ```\n    POST /_security/role/test_reporting_user\n    {\n        \"cluster\": [],\n        \"indices\": [],\n        \"application\": [{\n            \"application\": \"kibana-*\",\n            \"privileges\": [\"reserved_reporting_user\"],\n            \"resources\": [\"*\"]\n        }]\n    }\n    ```\n\n2. Create `test_analyst_user` role\n\n    ```\n    POST /_security/role/test_analyst_user\n    {\n        \"cluster\": [],\n        \"indices\": [\n            {\n            \"names\": [\"kibana_sample_*\"],\n            \"privileges\": [\"all\"],\n            \"field_security\": {\n                \"grant\": [\"*\"],\n                \"except\": []\n            },\n            \"allow_restricted_indices\": false\n            }\n        ],\n        \"applications\": [\n            {\n            \"application\": \"kibana-.kibana\",\n            \"privileges\": [\n                \"feature_discover_v2.read\",\n                \"feature_dashboard_v2.read\",\n                \"feature_canvas.read\",\n                \"feature_visualize_v2.read\"\n            ],\n            \"resources\": [\"space:default\"]\n            }\n        ],\n        \"run_as\": [],\n        \"metadata\": {},\n        \"transient_metadata\": {\n            \"enabled\": true\n        }\n    }\n    ```\n\n3. Create a test user with just those two roles. Install sample data.\nLog in using the new test user.\n4. Test cases\n\n    | App | Reporting feature\n    |-|-\n    | Dashboard | PDF, PNG, CSV (from saved search panel action)\n    | Discover | CSV\n    | Canvas | PDF\n    | Lens | PDF, PNG\n| Stack Management | List reports, download reports, view report info,\ndelete reports\n\n6. As admin, create an additional Space which the test user should not\nhave access to. Ensure the test user does not have access to those\nspaces.\n7. Remove the `test_reporting_user` role from the user and ensure they\ndo not see any Reporting controls in the UI, and can not access Stack\nManagement > Reporting.\n\n## Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- ~~[ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- ~~[ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- ~~[ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- ~~[ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- ~~[ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"f9be58be65e59b85dc6c4d8fa74970a4f8c1971e"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231533","number":231533,"mergeCommit":{"message":"Add `reporting_user` feature for reserved set of privileges (#231533)\n\n## Summary\n\nWe want to switch the reserved `reporting_user` role to use a \"reserved\nprivilege definition\" and uses just that privilege. This PR satisfies\nthe Kibana requirements. There is a corresponding Elasticsearch PR:\nhttps://github.com/elastic/elasticsearch/pull/132766\n\n## Testing\n**NOTE: PNG/PDF reporting requires a Trial, or Gold+ license**\n\n1. Create `test_reporting_user` role\n\n    ```\n    POST /_security/role/test_reporting_user\n    {\n        \"cluster\": [],\n        \"indices\": [],\n        \"application\": [{\n            \"application\": \"kibana-*\",\n            \"privileges\": [\"reserved_reporting_user\"],\n            \"resources\": [\"*\"]\n        }]\n    }\n    ```\n\n2. Create `test_analyst_user` role\n\n    ```\n    POST /_security/role/test_analyst_user\n    {\n        \"cluster\": [],\n        \"indices\": [\n            {\n            \"names\": [\"kibana_sample_*\"],\n            \"privileges\": [\"all\"],\n            \"field_security\": {\n                \"grant\": [\"*\"],\n                \"except\": []\n            },\n            \"allow_restricted_indices\": false\n            }\n        ],\n        \"applications\": [\n            {\n            \"application\": \"kibana-.kibana\",\n            \"privileges\": [\n                \"feature_discover_v2.read\",\n                \"feature_dashboard_v2.read\",\n                \"feature_canvas.read\",\n                \"feature_visualize_v2.read\"\n            ],\n            \"resources\": [\"space:default\"]\n            }\n        ],\n        \"run_as\": [],\n        \"metadata\": {},\n        \"transient_metadata\": {\n            \"enabled\": true\n        }\n    }\n    ```\n\n3. Create a test user with just those two roles. Install sample data.\nLog in using the new test user.\n4. Test cases\n\n    | App | Reporting feature\n    |-|-\n    | Dashboard | PDF, PNG, CSV (from saved search panel action)\n    | Discover | CSV\n    | Canvas | PDF\n    | Lens | PDF, PNG\n| Stack Management | List reports, download reports, view report info,\ndelete reports\n\n6. As admin, create an additional Space which the test user should not\nhave access to. Ensure the test user does not have access to those\nspaces.\n7. Remove the `test_reporting_user` role from the user and ensure they\ndo not see any Reporting controls in the UI, and can not access Stack\nManagement > Reporting.\n\n## Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- ~~[ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- ~~[ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- ~~[ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- ~~[ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- ~~[ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"f9be58be65e59b85dc6c4d8fa74970a4f8c1971e"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->