### PR TITLE
[Canvas] Fix progress element

### DIFF
--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/progress/components/progress_drawer.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/progress/components/progress_drawer.tsx
@@ -11,10 +11,10 @@ import type {
   ShapeRef,
   ShapeDrawerComponentProps,
 } from '../../../../public/components/shape_drawer';
-import { ShapeDrawer, getShape } from '../../../../public/components/shape_drawer';
+import { ShapeDrawer, getProgressShape } from '../../../../public/components/shape_drawer';
 
 export const ProgressDrawerComponent = React.forwardRef(
   (props: React.PropsWithChildren<ShapeDrawerComponentProps>, ref: Ref<ShapeRef>) => (
-    <ShapeDrawer {...props} ref={ref} getShape={getShape} />
+    <ShapeDrawer {...props} ref={ref} getShape={getProgressShape} />
   )
 );


### PR DESCRIPTION
Closes #231491.

## Summary

Fixes a bug where progress elements in Canvas were causing an "Unable to load page" error. 

This bug was introduced in this refactor https://github.com/elastic/kibana/pull/214993. The incorrect shape function was used to draw the progress elements. This uses the correct `getProgressShape` function to retrieve progress shapes.

<img width="1220" height="767" alt="Screenshot 2025-08-20 at 11 17 36 AM" src="https://github.com/user-attachments/assets/c80489ce-9cd8-40fa-9f44-c2d14182507a" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->