### PR TITLE
Skip upgrade assistant flaky test

### DIFF
--- a/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
+++ b/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
@@ -207,7 +207,7 @@ export default function ({ getService }: FtrProviderContext) {
         );
       });
     });
-    it('GET /api/upgrade_assistant/status does not return { readyForUpgrade: false } if there are only critical API deprecations', async () => {
+    it.skip('GET /api/upgrade_assistant/status does not return { readyForUpgrade: false } if there are only critical API deprecations', async () => {
       /** Throw in another critical deprecation... */
       await supertest.get(`/api/routing_example/d/removed_route`).expect(200);
       // sleep a little until the usage counter is synced into ES


### PR DESCRIPTION
Only skipping on the 9.0 branch, as this is the only branch that is flaky. 

Flaky test issue: https://github.com/elastic/kibana/issues/227432