### PR TITLE
have index_explorer tool use index meta descriptions from mapping

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.test.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.test.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
+import type { ListIndexInfo } from './steps/list_indices';
+import type { MappingField } from './utils/mappings';
+import { createIndexSelectorPrompt } from './index_explorer';
+
+const TEST_INDEX_NAMES = {
+  LOGS: 'logs-apache-001',
+  METRICS: 'metrics-system-001',
+  TRACES: 'traces-apm-001',
+} as const;
+
+const mockIndices = [
+  { index: TEST_INDEX_NAMES.LOGS },
+  { index: TEST_INDEX_NAMES.METRICS },
+  { index: TEST_INDEX_NAMES.TRACES },
+] as ListIndexInfo[];
+
+const mockFields: Record<string, MappingField[]> = {
+  [TEST_INDEX_NAMES.LOGS]: [
+    { path: '@timestamp', type: 'date' },
+    { path: 'message', type: 'text' },
+    { path: 'host.name', type: 'keyword' },
+    { path: 'http.response.status_code', type: 'long' },
+  ],
+  [TEST_INDEX_NAMES.METRICS]: [
+    { path: '@timestamp', type: 'date' },
+    { path: 'system.cpu.total.pct', type: 'float' },
+    { path: 'system.memory.used.pct', type: 'float' },
+    { path: 'host.name', type: 'keyword' },
+  ],
+  [TEST_INDEX_NAMES.TRACES]: [
+    { path: '@timestamp', type: 'date' },
+    { path: 'trace.id', type: 'keyword' },
+    { path: 'span.duration.us', type: 'long' },
+    { path: 'service.name', type: 'keyword' },
+  ],
+};
+
+const TEST_QUERY = 'Test query';
+
+const TEST_DESCRIPTIONS = {
+  APACHE_LOGS: 'Apache web server access and error logs with HTTP request details',
+  SYSTEM_METRICS: 'System performance metrics including CPU, memory, and disk usage',
+  APM_TRACES: 'APM trace data for distributed request tracking',
+} as const;
+
+const EXPECTED_PROMPT_CONTENT = {
+  ASSISTANT_INTRO: 'You are an AI assistant for the Elasticsearch company',
+  FIELD_PREFIX: 'Fields:',
+} as const;
+
+const EXPECTED_FIELD_LISTS = {
+  LOGS: '@timestamp ,message ,host.name ,http.response.status_code',
+  METRICS: '@timestamp ,system.cpu.total.pct ,system.memory.used.pct ,host.name',
+  TRACES: '@timestamp ,trace.id ,span.duration.us ,service.name',
+} as const;
+
+describe('createIndexSelectorPrompt', () => {
+  describe('when indices have meta descriptions', () => {
+    it('should use meta descriptions in the prompt', () => {
+      const mappingsWithMeta: Record<string, MappingTypeMapping> = {
+        [TEST_INDEX_NAMES.LOGS]: {
+          _meta: { description: TEST_DESCRIPTIONS.APACHE_LOGS },
+          properties: {},
+        },
+        [TEST_INDEX_NAMES.METRICS]: {
+          _meta: { description: TEST_DESCRIPTIONS.SYSTEM_METRICS },
+          properties: {},
+        },
+        [TEST_INDEX_NAMES.TRACES]: {
+          _meta: { description: TEST_DESCRIPTIONS.APM_TRACES },
+          properties: {},
+        },
+      };
+
+      const promptContent = createIndexSelectorPrompt({
+        indices: mockIndices,
+        mappings: mappingsWithMeta,
+        fields: mockFields,
+        nlQuery: TEST_QUERY,
+        limit: 2,
+      });
+
+      expect(promptContent).toContain('up to 2 most relevant indices');
+      expect(promptContent).toContain(TEST_QUERY);
+      expect(promptContent).toContain(
+        `- ${TEST_INDEX_NAMES.LOGS}: ${TEST_DESCRIPTIONS.APACHE_LOGS}`
+      );
+      expect(promptContent).toContain(
+        `- ${TEST_INDEX_NAMES.METRICS}: ${TEST_DESCRIPTIONS.SYSTEM_METRICS}`
+      );
+      expect(promptContent).toContain(
+        `- ${TEST_INDEX_NAMES.TRACES}: ${TEST_DESCRIPTIONS.APM_TRACES}`
+      );
+      expect(promptContent).toContain('select at maximum 2 indices');
+    });
+  });
+
+  describe('when indices do not have meta descriptions', () => {
+    it('should use field lists as descriptions in the prompt', () => {
+      const mappingsWithoutMeta: Record<string, MappingTypeMapping> = {
+        [TEST_INDEX_NAMES.LOGS]: { properties: {} },
+        [TEST_INDEX_NAMES.METRICS]: { properties: {} },
+        [TEST_INDEX_NAMES.TRACES]: { properties: {} },
+      };
+
+      const promptContent = createIndexSelectorPrompt({
+        indices: mockIndices,
+        mappings: mappingsWithoutMeta,
+        fields: mockFields,
+        nlQuery: TEST_QUERY,
+        limit: 1,
+      });
+
+      expect(promptContent).toContain('up to 1 most relevant indices');
+      expect(promptContent).toContain(TEST_QUERY);
+      expect(promptContent).toContain(
+        `- ${TEST_INDEX_NAMES.LOGS}: ${EXPECTED_PROMPT_CONTENT.FIELD_PREFIX} ${EXPECTED_FIELD_LISTS.LOGS}`
+      );
+      expect(promptContent).toContain(
+        `- ${TEST_INDEX_NAMES.METRICS}: ${EXPECTED_PROMPT_CONTENT.FIELD_PREFIX} ${EXPECTED_FIELD_LISTS.METRICS}`
+      );
+      expect(promptContent).toContain(
+        `- ${TEST_INDEX_NAMES.TRACES}: ${EXPECTED_PROMPT_CONTENT.FIELD_PREFIX} ${EXPECTED_FIELD_LISTS.TRACES}`
+      );
+      expect(promptContent).toContain('select at maximum 1 indices');
+    });
+  });
+
+  describe('when indices have mixed meta descriptions', () => {
+    it('should use meta descriptions where available and field lists where not', () => {
+      const mixedMappings: Record<string, MappingTypeMapping> = {
+        [TEST_INDEX_NAMES.LOGS]: {
+          _meta: { description: TEST_DESCRIPTIONS.APACHE_LOGS },
+          properties: {},
+        },
+        [TEST_INDEX_NAMES.METRICS]: { properties: {} },
+        [TEST_INDEX_NAMES.TRACES]: {
+          _meta: { description: TEST_DESCRIPTIONS.APM_TRACES },
+          properties: {},
+        },
+      };
+
+      const promptContent = createIndexSelectorPrompt({
+        indices: mockIndices,
+        mappings: mixedMappings,
+        fields: mockFields,
+        nlQuery: TEST_QUERY,
+        limit: 3,
+      });
+
+      expect(promptContent).toContain(
+        `- ${TEST_INDEX_NAMES.LOGS}: ${TEST_DESCRIPTIONS.APACHE_LOGS}`
+      );
+      expect(promptContent).toContain(
+        `- ${TEST_INDEX_NAMES.METRICS}: ${EXPECTED_PROMPT_CONTENT.FIELD_PREFIX} ${EXPECTED_FIELD_LISTS.METRICS}`
+      );
+      expect(promptContent).toContain(
+        `- ${TEST_INDEX_NAMES.TRACES}: ${TEST_DESCRIPTIONS.APM_TRACES}`
+      );
+    });
+  });
+
+  describe('default limit behavior', () => {
+    it('should default to limit of 1 when not specified', () => {
+      const mappings: Record<string, MappingTypeMapping> = {
+        [TEST_INDEX_NAMES.LOGS]: { properties: {} },
+      };
+
+      const promptContent = createIndexSelectorPrompt({
+        indices: [mockIndices[0]],
+        mappings,
+        fields: { [TEST_INDEX_NAMES.LOGS]: mockFields[TEST_INDEX_NAMES.LOGS] },
+        nlQuery: TEST_QUERY,
+      });
+
+      expect(promptContent).toContain('up to 1 most relevant indices');
+      expect(promptContent).toContain('select at maximum 1 indices');
+    });
+  });
+
+  describe('prompt structure', () => {
+    it('should return string', () => {
+      const mappings: Record<string, MappingTypeMapping> = {
+        [TEST_INDEX_NAMES.LOGS]: { properties: {} },
+      };
+
+      const promptContent = createIndexSelectorPrompt({
+        indices: [mockIndices[0]],
+        mappings,
+        fields: { [TEST_INDEX_NAMES.LOGS]: mockFields[TEST_INDEX_NAMES.LOGS] },
+        nlQuery: TEST_QUERY,
+      });
+
+      expect(typeof promptContent).toBe('string');
+      expect(promptContent).toContain(EXPECTED_PROMPT_CONTENT.ASSISTANT_INTRO);
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.test.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.test.ts
@@ -6,7 +6,7 @@
  */
 
 import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
-import type { ListIndexInfo } from './steps/list_indices';
+import type { ListIndexBasicInfo } from './steps/list_indices';
 import type { MappingField } from './utils/mappings';
 import { createIndexSelectorPrompt } from './index_explorer';
 
@@ -20,7 +20,7 @@ const mockIndices = [
   { index: TEST_INDEX_NAMES.LOGS },
   { index: TEST_INDEX_NAMES.METRICS },
   { index: TEST_INDEX_NAMES.TRACES },
-] as ListIndexInfo[];
+] as ListIndexBasicInfo[];
 
 const mockFields: Record<string, MappingField[]> = {
   [TEST_INDEX_NAMES.LOGS]: [

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.test.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.test.ts
@@ -57,9 +57,9 @@ const EXPECTED_PROMPT_CONTENT = {
 } as const;
 
 const EXPECTED_FIELD_LISTS = {
-  LOGS: '@timestamp ,message ,host.name ,http.response.status_code',
-  METRICS: '@timestamp ,system.cpu.total.pct ,system.memory.used.pct ,host.name',
-  TRACES: '@timestamp ,trace.id ,span.duration.us ,service.name',
+  LOGS: '@timestamp, message, host.name, http.response.status_code',
+  METRICS: '@timestamp, system.cpu.total.pct, system.memory.used.pct, host.name',
+  TRACES: '@timestamp, trace.id, span.duration.us, service.name',
 } as const;
 
 describe('createIndexSelectorPrompt', () => {

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { BaseMessageLike } from '@langchain/core/messages';
 import { z } from '@kbn/zod';
 import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
 import type { ScopedModel } from '@kbn/onechat-server';
@@ -13,6 +12,8 @@ import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { ListIndexBasicInfo } from './steps/list_indices';
 import { listIndices } from './steps/list_indices';
 import { getIndexMappings } from './steps/get_mappings';
+import type { MappingField } from './utils/mappings';
+import { cleanupMapping, flattenMappings } from './utils/mappings';
 
 export interface RelevantIndex {
   indexName: string;
@@ -43,16 +44,28 @@ export const indexExplorer = async ({
     esClient,
   });
 
+  const allMappings = await getIndexMappings({
+    indices: allIndices.map((index) => index.index),
+    esClient,
+  });
+
+  const cleanedMappings: Record<string, MappingTypeMapping> = {};
+  for (const [indexName, mapping] of Object.entries(allMappings)) {
+    cleanedMappings[indexName] = cleanupMapping(mapping.mappings);
+  }
+
+  const flattenedMappings: Record<string, MappingField[]> = {};
+  for (const [indexName, mapping] of Object.entries(allMappings)) {
+    flattenedMappings[indexName] = flattenMappings({ mappings: mapping.mappings });
+  }
+
   const selectedIndices = await selectIndices({
     indices: allIndices,
+    mappings: cleanedMappings,
+    fields: flattenedMappings,
     nlQuery,
     model,
     limit,
-  });
-
-  const mappings = await getIndexMappings({
-    indices: selectedIndices.map((index) => index.indexName),
-    esClient,
   });
 
   const relevantIndices: RelevantIndex[] = selectedIndices.map<RelevantIndex>(
@@ -60,7 +73,7 @@ export const indexExplorer = async ({
       return {
         indexName,
         reason,
-        mappings: mappings[indexName].mappings,
+        mappings: cleanedMappings[indexName],
       };
     }
   );
@@ -73,13 +86,53 @@ export interface SelectedIndex {
   reason: string;
 }
 
+export const createIndexSelectorPrompt = ({
+  indices,
+  mappings,
+  fields,
+  nlQuery,
+  limit = 1,
+}: {
+  indices: ListIndexBasicInfo[];
+  mappings: Record<string, MappingTypeMapping>;
+  fields: Record<string, MappingField[]>;
+  nlQuery: string;
+  limit?: number;
+}): string => {
+  return `You are an AI assistant for the Elasticsearch company.
+       based on a natural language query from the user, your task is to select up to ${limit} most relevant indices from a list of indices.
+
+       *The natural language query is:* ${nlQuery}
+
+       *List of indices with their descriptions:*
+       ${indices
+         .map((index) => {
+           const indexMapping = mappings[index.index];
+           const fieldPaths: string[] = fields[index.index].map((mappingField) => {
+             return mappingField.path;
+           });
+           const description =
+             indexMapping?._meta?.description || `Fields: ${fieldPaths.join(' ,')}`;
+           return `- ${index.index}: ${description}`;
+         })
+         .join('\n\n')}
+
+       Based on the natural language query and the index descriptions, please return the most relevant indices with your reasoning.
+       Remember, you should select at maximum ${limit} indices.
+       `;
+};
+
 const selectIndices = async ({
   indices,
+  mappings,
+  fields,
   nlQuery,
   model,
   limit = 1,
 }: {
   indices: ListIndexBasicInfo[];
+  mappings: Record<string, MappingTypeMapping>;
+  fields: Record<string, MappingField[]>;
   nlQuery: string;
   model: ScopedModel;
   limit?: number;
@@ -96,24 +149,15 @@ const selectIndices = async ({
     })
   );
 
-  const indexSelectorPrompt: BaseMessageLike[] = [
-    [
-      'user',
-      `You are an AI assistant for the Elasticsearch company.
-       based on a natural language query from the user, your task is to select up to ${limit} most relevant indices from a list of indices.
+  const promptContent = createIndexSelectorPrompt({
+    indices,
+    mappings,
+    fields,
+    nlQuery,
+    limit,
+  });
 
-       *The natural language query is:* ${nlQuery}
-
-       *List of indices:*
-       ${indices.map((index) => `- ${index.index}`).join('\n')}
-
-       Based on those information, please return most relevant indices with your reasoning.
-       Remember, you should select at maximum ${limit} indices.
-       `,
-    ],
-  ];
-
-  const { indices: selectedIndices } = await indexSelectorModel.invoke(indexSelectorPrompt);
+  const { indices: selectedIndices } = await indexSelectorModel.invoke(promptContent);
 
   return selectedIndices;
 };


### PR DESCRIPTION
## Summary

After recent discussions on the sub-optimal performance of the `.index_explorer` tool, I did some experimenting to see if I could increase the accuracy of its responses. Building off of an evaluation harness and test dataset that @abhi-elastic had previously pioneered (20 indices, 70 prompts-expectedIndex pairs, 24 easy, 30 medium, 16 hard), I tried several things:

- establishing a baseline - using only index name for index selection
  - baseline accuracy was 77.14% ( easy: 91.67%, medium: 66.67% , hard: 75.00%)
- sending the full index mappings
  - this is a non-starter, as it explodes the context size, and EIS would complain that the message was too large for the Elastic LLM
- sending "cleaned" index mappings in
  - still resulted in too-large of a prompt.
- adding small `_meta.description` values in the the mappings, and only including those in the prompt
  - this boosted accuracy significantly: 87.14% (easy: 95.83% , medium: 80.00% , hard: 87.50% )
- adding large `_meta.description` (briefings) values in the mappings, only including those in the prompt
  -  even more significant boost: 92.86% (easy: 95.83% , medium: 90.00% , hard: 93.75% )
- adding a flat listing of each index's fields to the prompt
  - similar to small descriptions: 87.14% ( easy: 95.83% , medium: 76.67% , hard: 93.75%)
- adding both field lists AND a large `_meta.description` to the prompt
  - same as large description alone: 92.86% (easy: 95.83%, medium: 90.00%, hard: 93.75% )

The conclusion to me here is that we aught to use a provided `_meta.description` if one is available, but if not, fall back to just listing the flat fields on the index.

This PR does just that. It also adds a unit test.



### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



