### PR TITLE
[UII] Add `index.mapping.ignore_malformed: true` to transform index template settings

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/install.ts
@@ -569,10 +569,16 @@ const installTransformsAssets = async (
               componentTemplates,
               indexTemplate: {
                 templateName: destinationIndexTemplate.installationName,
-                // @ts-expect-error data_stream property is not needed here
+                // @ts-expect-error `data_stream` property is not needed/allowed for transform index templates
                 indexTemplate: {
                   template: {
-                    settings: undefined,
+                    settings: {
+                      index: {
+                        mapping: {
+                          ignore_malformed: true,
+                        },
+                      },
+                    },
                     mappings: undefined,
                   },
                   priority: DEFAULT_TRANSFORM_TEMPLATES_PRIORITY,

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/transforms.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/transforms.test.ts
@@ -392,7 +392,16 @@ _meta:
           ],
           index_patterns: ['.metrics-endpoint.metadata_united_default'],
           priority: 250,
-          template: { mappings: undefined, settings: undefined },
+          template: {
+            mappings: undefined,
+            settings: {
+              index: {
+                mapping: {
+                  ignore_malformed: true,
+                },
+              },
+            },
+          },
           ignore_missing_component_templates: [
             'endpoint@custom',
             'logs-endpoint.metadata_current-template@custom',
@@ -681,7 +690,16 @@ _meta:
           ],
           index_patterns: ['.metrics-endpoint.metadata_united_default'],
           priority: 250,
-          template: { mappings: undefined, settings: undefined },
+          template: {
+            mappings: undefined,
+            settings: {
+              index: {
+                mapping: {
+                  ignore_malformed: true,
+                },
+              },
+            },
+          },
           ignore_missing_component_templates: [
             'endpoint@custom',
             'logs-endpoint.metadata_current-template@custom',
@@ -947,7 +965,16 @@ _meta:
           ],
           index_patterns: ['.metrics-endpoint.metadata_united_default'],
           priority: 250,
-          template: { mappings: undefined, settings: undefined },
+          template: {
+            mappings: undefined,
+            settings: {
+              index: {
+                mapping: {
+                  ignore_malformed: true,
+                },
+              },
+            },
+          },
           ignore_missing_component_templates: [
             'endpoint@custom',
             'logs-endpoint.metadata_current-template@custom',


### PR DESCRIPTION
## Summary

Resolves #179445. Does what it says on the tin :)

## Release note
Transform index templates installed by Fleet will now have the `index.mapping.ignore_malformed: true` setting set. This resolves issues where transforms can enter a failed state due to invalid values in the source index.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->