### PR TITLE
[Background search] Add app filtering and background search opened handler

### DIFF
--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/get_columns.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/get_columns.test.tsx
@@ -16,7 +16,7 @@ import { SessionsClient } from '../../../../sessions_client';
 import { getUiSessionMock } from '../../../__mocks__';
 import { SearchSessionsMgmtAPI } from '../../../lib/api';
 import type { EuiBasicTableColumn, EuiTableFieldDataColumnType } from '@elastic/eui';
-import type { BackgroundSearchOpenedHandler, UISession } from '../../../types';
+import type { UISession } from '../../../types';
 import { render, screen } from '@testing-library/react';
 import { SearchSessionStatus } from '../../../../../../../common';
 
@@ -32,11 +32,9 @@ const getColumn = (columns: Array<EuiBasicTableColumn<UISession>>, field: string
 const setup = ({
   kibanaVersion = '7.14.0',
   tz = 'UTC',
-  onBackgroundSearchClicked = jest.fn(),
 }: {
   kibanaVersion?: string;
   tz?: string;
-  onBackgroundSearchClicked?: BackgroundSearchOpenedHandler;
 } = {}) => {
   const mockCoreSetup = coreMock.createSetup();
   const mockCoreStart = coreMock.createStart();

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { coreMock } from '@kbn/core/public/mocks';
+import { createSearchUsageCollectorMock } from '../../../../../collectors/mocks';
+import { nameColumn } from './name';
+import { render, screen } from '@testing-library/react';
+import { getUiSessionMock } from '../../../__mocks__';
+import { SearchSessionStatus } from '../../../../../../../common';
+import type { UISession } from '../../../types';
+import userEvent from '@testing-library/user-event';
+
+const setup = ({
+  kibanaVersion = '9.0.0',
+  uiSession = getUiSessionMock(),
+}: {
+  kibanaVersion?: string;
+  uiSession?: UISession;
+} = {}) => {
+  const user = userEvent.setup();
+  const core = coreMock.createStart();
+  const searchUsageCollector = createSearchUsageCollectorMock();
+  const onBackgroundSearchOpened = jest.fn();
+
+  const column = nameColumn({
+    core,
+    searchUsageCollector,
+    kibanaVersion,
+    onBackgroundSearchOpened,
+  });
+
+  if (!('render' in column) || !column.render) throw Error('Column is not valid');
+
+  render(column.render(uiSession.name, uiSession));
+
+  return { core, searchUsageCollector, kibanaVersion, onBackgroundSearchOpened, user };
+};
+
+describe('name column', () => {
+  describe('when the session name is clicked', () => {
+    it('should call onBackgroundSearchOpened', async () => {
+      // Given
+      const mockSession = getUiSessionMock();
+
+      // When
+      const { user, onBackgroundSearchOpened } = setup({ uiSession: mockSession });
+      await user.click(screen.getByText(mockSession.name));
+
+      // Then
+      expect(onBackgroundSearchOpened).toHaveBeenCalledWith({
+        event: expect.any(Object),
+        session: mockSession,
+      });
+    });
+  });
+
+  describe('when the session is from an older version', () => {
+    const kibanaVersion = '7.14.0';
+    const sessionVersion = '7.13.0';
+
+    describe.each([SearchSessionStatus.IN_PROGRESS, SearchSessionStatus.COMPLETE])(
+      'when status is %s',
+      (status) => {
+        it('should render a warning', () => {
+          // Given
+          const mockSession = getUiSessionMock({
+            version: sessionVersion,
+            status,
+          });
+
+          // When
+          setup({ kibanaVersion, uiSession: mockSession });
+
+          // Then
+          expect(screen.getByTestId('versionIncompatibleWarningTestSubj')).toBeVisible();
+        });
+      }
+    );
+
+    describe.each([
+      SearchSessionStatus.CANCELLED,
+      SearchSessionStatus.ERROR,
+      SearchSessionStatus.EXPIRED,
+    ])('when status is %s', (status) => {
+      it('should NOT render a warning', () => {
+        // Given
+        const mockSession = getUiSessionMock({
+          version: sessionVersion,
+          status,
+        });
+
+        // When
+        setup({ uiSession: mockSession, kibanaVersion });
+
+        // Then
+        expect(screen.queryByTestId('versionIncompatibleWarningTestSubj')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('when the session is from the same version', () => {
+    const version = '7.15.0';
+
+    describe.each([
+      SearchSessionStatus.IN_PROGRESS,
+      SearchSessionStatus.COMPLETE,
+      SearchSessionStatus.CANCELLED,
+      SearchSessionStatus.ERROR,
+      SearchSessionStatus.EXPIRED,
+    ])('when status is %s', (status) => {
+      it('should NOT render a warning', () => {
+        // Given
+        const mockSession = getUiSessionMock({
+          version,
+          status,
+        });
+
+        // When
+        setup({ kibanaVersion: version, uiSession: mockSession });
+
+        // Then
+        expect(screen.queryByTestId('versionIncompatibleWarningTestSubj')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
@@ -16,7 +16,7 @@ import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import type { CoreStart } from '@kbn/core/public';
 import { SearchSessionStatus } from '../../../../../../../common';
 import type { SearchUsageCollector } from '../../../../../collectors';
-import type { UISession } from '../../../types';
+import type { BackgroundSearchOpenedHandler, UISession } from '../../../types';
 import { TableText } from '../..';
 
 function isSessionRestorable(status: SearchSessionStatus) {
@@ -27,17 +27,21 @@ export const nameColumn = ({
   core,
   searchUsageCollector,
   kibanaVersion,
+  onBackgroundSearchOpened,
 }: {
   core: CoreStart;
   searchUsageCollector: SearchUsageCollector;
   kibanaVersion: string;
+  onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
 }): EuiBasicTableColumn<UISession> => ({
   field: 'name',
   name: i18n.translate('data.mgmt.searchSessions.table.headerName', {
     defaultMessage: 'Name',
   }),
   sortable: true,
-  render: (name: UISession['name'], { restoreUrl, reloadUrl, status, version }) => {
+  render: (name: UISession['name'], session) => {
+    const { restoreUrl, reloadUrl, status, version } = session;
+
     const isRestorable = isSessionRestorable(status);
     const href = isRestorable ? restoreUrl : reloadUrl;
     const trackAction = isRestorable
@@ -87,7 +91,10 @@ export const nameColumn = ({
         {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
         <EuiLink
           href={href}
-          onClick={() => trackAction?.()}
+          onClick={(event) => {
+            trackAction?.();
+            onBackgroundSearchOpened?.({ session, event });
+          }}
           data-test-subj="sessionManagementNameCol"
         >
           <TableText>

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
@@ -39,7 +39,7 @@ const Component = ({
 }: {
   data?: SearchSessionSavedObject[];
   statuses?: Record<string, SearchSessionStatusResponse>;
-  props?: Partial<typeof SearchSessionsMgmtTable>;
+  props?: Partial<React.ComponentProps<typeof SearchSessionsMgmtTable>>;
 }) => {
   const mockCoreSetup = coreMock.createSetup();
   const mockCoreStart = coreMock.createStart();
@@ -64,11 +64,11 @@ const Component = ({
     application: mockCoreStart.application,
     featureFlags: mockCoreStart.featureFlags,
   });
-  api.fetchTableData = async () => {
+  sessionsClient.find = async () => {
     return {
-      savedObjects: data,
+      saved_objects: data,
       statuses,
-    };
+    } as unknown as ReturnType<typeof sessionsClient.find>;
   };
 
   const mockSearchUsageCollector = createSearchUsageCollectorMock();
@@ -274,6 +274,65 @@ export const NoFiltersAndRefreshButton = {
         hideRefreshButton: true,
         getColumns: ({ core, searchUsageCollector, kibanaVersion }: GetColumnsParams) => [
           columns.nameColumn({ core, searchUsageCollector, kibanaVersion }),
+        ],
+      }}
+    />
+  ),
+};
+
+export const FilteredSessions = {
+  name: 'Filtered sessions',
+  argTypes: {
+    appId: {
+      options: ['discover', 'dashboard'],
+      control: { type: 'select' },
+    },
+  },
+  args: {
+    appId: 'discover',
+  },
+  render: (args: { appId: string }) => (
+    <Component
+      data={getSearchSessionSavedObjectMocks({
+        length: 50,
+        overrides: ({ idx }) => {
+          const mappings = Array.from({ length: idx }, (_, i) => [`index-${i}`, `doc-${i}`]);
+          const idMapping = Object.fromEntries(mappings);
+
+          return {
+            attributes: getPersistedSearchSessionSavedObjectAttributesMock({
+              idMapping,
+              appId: idx % 2 === 0 ? 'discover' : 'dashboard',
+            }),
+            numSearches: idx,
+          };
+        },
+      })}
+      props={{
+        appId: args.appId,
+        getColumns: ({ core, searchUsageCollector, kibanaVersion }: GetColumnsParams) => [
+          columns.nameColumn({ core, searchUsageCollector, kibanaVersion }),
+          columns.appIdColumn,
+        ],
+      }}
+    />
+  ),
+};
+
+export const OnClickHandler = {
+  name: 'On click handler',
+  render: () => (
+    <Component
+      data={getSearchSessionSavedObjectMocks({ length: 10 })}
+      props={{
+        getColumns: ({ core, searchUsageCollector, kibanaVersion }: GetColumnsParams) => [
+          columns.nameColumn({
+            core,
+            searchUsageCollector,
+            kibanaVersion,
+            onBackgroundSearchOpened: ({ session }) =>
+              alert(`You have clicked session ${session.name}`),
+          }),
         ],
       }}
     />

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
@@ -280,8 +280,8 @@ export const NoFiltersAndRefreshButton = {
   ),
 };
 
-export const FilteredSessions = {
-  name: 'Filtered sessions',
+export const PreFilteredSessions = {
+  name: 'PreFiltered sessions',
   argTypes: {
     appId: {
       options: ['discover', 'dashboard'],

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
@@ -19,7 +19,7 @@ import { TableText } from '..';
 import { SEARCH_SESSIONS_TABLE_ID } from '../../../../../../common';
 import type { SearchSessionsMgmtAPI } from '../../lib/api';
 import { getColumns as getDefaultColumns } from './columns/get_columns';
-import type { LocatorsStart, UISession } from '../../types';
+import type { BackgroundSearchOpenedHandler, LocatorsStart, UISession } from '../../types';
 import type { OnActionComplete } from './actions';
 import { getAppFilter } from './utils/get_app_filter';
 import { getStatusFilter } from './utils/get_status_filter';
@@ -36,6 +36,8 @@ interface Props {
   kibanaVersion: string;
   searchUsageCollector: SearchUsageCollector;
   hideRefreshButton?: boolean;
+  appId?: string;
+  onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
   getColumns?: (params: {
     core: CoreStart;
     api: SearchSessionsMgmtAPI;
@@ -44,6 +46,7 @@ interface Props {
     kibanaVersion: string;
     searchUsageCollector: SearchUsageCollector;
     onActionComplete: OnActionComplete;
+    onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
   }) => Array<EuiBasicTableColumn<UISession>>;
 }
 
@@ -59,6 +62,8 @@ export function SearchSessionsMgmtTable({
   searchUsageCollector,
   hideRefreshButton = false,
   getColumns = getDefaultColumns,
+  appId,
+  onBackgroundSearchOpened,
   ...props
 }: Props) {
   const [tableData, setTableData] = useState<UISession[]>([]);
@@ -104,7 +109,7 @@ export function SearchSessionsMgmtTable({
     if (document.visibilityState !== 'hidden') {
       let results: UISession[] = [];
       try {
-        const { savedObjects, statuses } = await api.fetchTableData();
+        const { savedObjects, statuses } = await api.fetchTableData({ appId });
         results = savedObjects.map((savedObject) =>
           mapToUISession({ savedObject, locators, sessionStatuses: statuses })
         );
@@ -120,7 +125,7 @@ export function SearchSessionsMgmtTable({
       if (refreshTimeoutRef.current) clearTimeout(refreshTimeoutRef.current);
       refreshTimeoutRef.current = window.setTimeout(doRefresh, refreshInterval);
     }
-  }, [api, refreshInterval, locators]);
+  }, [api, refreshInterval, locators, appId]);
 
   // initial data load
   useEffect(() => {
@@ -143,6 +148,7 @@ export function SearchSessionsMgmtTable({
     onActionComplete,
     kibanaVersion,
     searchUsageCollector,
+    onBackgroundSearchOpened,
   });
 
   const filters = useMemo(() => {

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
@@ -155,7 +155,7 @@ export function SearchSessionsMgmtTable({
     const _filters = [];
 
     const hasAppColumn = columns.some((column) => 'field' in column && column.field === 'appId');
-    if (hasAppColumn) _filters.push(getAppFilter(tableData));
+    if (hasAppColumn && !appId) _filters.push(getAppFilter(tableData));
 
     const hasStatusColumn = columns.some(
       (column) => 'field' in column && column.field === 'status'
@@ -163,7 +163,7 @@ export function SearchSessionsMgmtTable({
     if (hasStatusColumn) _filters.push(getStatusFilter(tableData));
 
     return _filters;
-  }, [columns, tableData]);
+  }, [columns, tableData, appId]);
 
   // table config: search / filters
   const search: EuiSearchBarProps = {

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
@@ -23,7 +23,7 @@ import type { SearchSessionsConfigSchema } from '../../../../../server/config';
 import type { SearchSessionsMgmtAPI } from '../lib/api';
 import { SearchSessionsMgmtTable } from '../components/table';
 import type { SearchUsageCollector } from '../../../collectors';
-import type { LocatorsStart } from '../types';
+import type { BackgroundSearchOpenedHandler, LocatorsStart } from '../types';
 import { getColumns } from './get_columns';
 
 export const Flyout = ({
@@ -34,6 +34,8 @@ export const Flyout = ({
   config,
   kibanaVersion,
   locators,
+  appId,
+  onBackgroundSearchOpened,
 }: {
   onClose: () => void;
   api: SearchSessionsMgmtAPI;
@@ -42,6 +44,8 @@ export const Flyout = ({
   config: SearchSessionsConfigSchema;
   kibanaVersion: string;
   locators: LocatorsStart;
+  appId?: string;
+  onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
 }) => {
   const flyoutId = useGeneratedHtmlId();
 
@@ -68,6 +72,8 @@ export const Flyout = ({
           locators={locators}
           hideRefreshButton
           getColumns={getColumns}
+          appId={appId}
+          onBackgroundSearchOpened={onBackgroundSearchOpened}
         />
       </EuiFlyoutBody>
       <EuiFlyoutFooter>

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_columns.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_columns.tsx
@@ -20,11 +20,13 @@ export const getColumns: GetColumnsFn = ({
   api,
   timezone,
   onActionComplete,
+  onBackgroundSearchOpened,
 }) => [
   columns.nameColumn({
     core,
     kibanaVersion,
     searchUsageCollector,
+    onBackgroundSearchOpened,
   }),
   columns.statusColumn(timezone),
   columns.actionsColumn({

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
@@ -17,6 +17,7 @@ import { SearchSessionsMgmtAPI } from '../lib/api';
 import type { SearchUsageCollector } from '../../../collectors';
 import type { SearchSessionsConfigSchema } from '../../../../../server/config';
 import { Flyout } from './flyout';
+import type { BackgroundSearchOpenedHandler } from '../types';
 
 export function openSearchSessionsFlyout({
   coreStart,
@@ -33,7 +34,9 @@ export function openSearchSessionsFlyout({
   sessionsClient: ISessionsClient;
   share: SharePluginStart;
 }) {
-  return () => {
+  return (
+    attrs: { appId?: string; onBackgroundSearchOpened?: BackgroundSearchOpenedHandler } = {}
+  ) => {
     const api = new SearchSessionsMgmtAPI(sessionsClient, config, {
       notifications: coreStart.notifications,
       application: coreStart.application,
@@ -48,6 +51,8 @@ export function openSearchSessionsFlyout({
           <KibanaReactContextProvider>
             <Flyout
               onClose={() => flyout.close()}
+              onBackgroundSearchOpened={attrs.onBackgroundSearchOpened}
+              appId={attrs.appId}
               api={api}
               coreStart={coreStart}
               usageCollector={usageCollector}

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/index.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/index.ts
@@ -25,6 +25,7 @@ import type { AsyncSearchIntroDocumentation } from './lib/documentation';
 import type { SearchSessionsConfigSchema } from '../../../../server/config';
 
 export { openSearchSessionsFlyout } from './flyout/get_flyout';
+export type { BackgroundSearchOpenedHandler } from './types';
 
 export interface IManagementSectionsPluginsSetup {
   management: ManagementSetup;

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/api.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/api.test.ts
@@ -83,6 +83,59 @@ describe('Search Sessions Management API', () => {
       expect(statuses['hello-pizza-123']).toEqual({ status: 'complete' });
     });
 
+    test('fetchDataTable returns saved objects for a specific appId', async () => {
+      sessionsClient.find = jest.fn().mockImplementation(async () => {
+        return {
+          saved_objects: [
+            {
+              id: 'hello-pizza-123',
+              attributes: {
+                name: 'Veggie',
+                appId: 'pizza',
+                initialState: {},
+                restoreState: {},
+                idMapping: [],
+              },
+            },
+            {
+              id: 'hello-burguer-123',
+              attributes: {
+                name: 'Cheeseburguer',
+                appId: 'burguer',
+                initialState: {},
+                restoreState: {},
+                idMapping: [],
+              },
+            },
+          ],
+          statuses: {
+            'hello-pizza-123': { status: 'complete' },
+            'hello-burguer-123': { status: 'complete' },
+          },
+        };
+      });
+
+      const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
+        notifications: mockCoreStart.notifications,
+        application: mockCoreStart.application,
+      });
+
+      const { savedObjects: results, statuses } = await api.fetchTableData({ appId: 'burguer' });
+      expect(results).toEqual([
+        {
+          id: 'hello-burguer-123',
+          attributes: {
+            name: 'Cheeseburguer',
+            appId: 'burguer',
+            initialState: {},
+            restoreState: {},
+            idMapping: [],
+          },
+        },
+      ]);
+      expect(statuses['hello-burguer-123']).toEqual({ status: 'complete' });
+    });
+
     test('expired session is showed as expired', async () => {
       sessionsClient.find = jest.fn().mockImplementation(async () => {
         return {

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/api.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/api.test.ts
@@ -118,6 +118,7 @@ describe('Search Sessions Management API', () => {
       const api = new SearchSessionsMgmtAPI(sessionsClient, mockConfig, {
         notifications: mockCoreStart.notifications,
         application: mockCoreStart.application,
+        featureFlags: mockCoreStart.featureFlags,
       });
 
       const { savedObjects: results, statuses } = await api.fetchTableData({ appId: 'burguer' });

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/api.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/api.ts
@@ -38,7 +38,7 @@ export class SearchSessionsMgmtAPI {
     private deps: SearchSessionManagementDeps
   ) {}
 
-  public async fetchTableData(): Promise<FetchReturn> {
+  public async fetchTableData({ appId }: { appId?: string } = {}): Promise<FetchReturn> {
     const mgmtConfig = this.config.management;
 
     const refreshTimeout = moment.duration(mgmtConfig.refreshTimeout);
@@ -80,7 +80,10 @@ export class SearchSessionsMgmtAPI {
       const result = await race(fetch$, timeout$).toPromise();
       if (result && result.saved_objects) {
         return {
-          savedObjects: result.saved_objects as SearchSessionSavedObject[],
+          savedObjects: result.saved_objects.filter((object) => {
+            if (!appId) return true;
+            return object.attributes.appId === appId;
+          }) as SearchSessionSavedObject[],
           statuses: result.statuses,
         };
       }

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/types.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/types.ts
@@ -57,3 +57,8 @@ export interface SearchSessionSavedObject {
   id: string;
   attributes: PersistedSearchSessionSavedObjectAttributes;
 }
+
+export type BackgroundSearchOpenedHandler = (attrs: {
+  session: UISession;
+  event: React.MouseEvent<HTMLAnchorElement>;
+}) => void;

--- a/src/platform/plugins/shared/data/public/search/types.ts
+++ b/src/platform/plugins/shared/data/public/search/types.ts
@@ -17,6 +17,7 @@ import type { ISearchStartSearchSource } from '../../common/search';
 import type { AggsSetup, AggsSetupDependencies, AggsStart, AggsStartDependencies } from './aggs';
 import type { SearchUsageCollector } from './collectors';
 import type { ISessionsClient, ISessionService } from './session';
+import type { BackgroundSearchOpenedHandler } from './session/sessions_mgmt';
 
 export { SEARCH_EVENT_TYPE } from './collectors';
 export type { ISearchStartSearchSource, SearchUsageCollector };
@@ -70,7 +71,10 @@ export interface ISearchStart {
   /**
    * Shows a flyout with a table to manage search sessions.
    */
-  showSearchSessionsFlyout: () => void;
+  showSearchSessionsFlyout: (attrs?: {
+    appId?: string;
+    onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
+  }) => void;
   /**
    * high level search
    * {@link ISearchStartSearchSource}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/231389

This PR adds two main changes to the `showSearchSessionsFlyout` function, mainly in the form of two attributes:
- the `appId` attribute filters the sessions that are rendered in the table
- the `onBackgroundSearchOpened` handler that allows to change the behaviour of what happens when a session link is clicked in the table

### How to run storybook

1. In a terminal run `yarn storybook data`
2. Once it is running go to http://localhost:9001/
3. Open SearchSessionsMgmtTable and there should be some stories for it

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



