### PR TITLE
[Onboarding ingest][Bug] Call bulk requests one by one to avoid queue in es

### DIFF
--- a/x-pack/platform/plugins/shared/sample_data_ingest/server/services/index_manager/utils/populate_index.ts
+++ b/x-pack/platform/plugins/shared/sample_data_ingest/server/services/index_manager/utils/populate_index.ts
@@ -32,19 +32,18 @@ export const populateIndex = async ({
   try {
     const contentEntries = archive.getEntryPaths().filter(isArtifactContentFilePath);
 
-    await Promise.all(
-      contentEntries.map(async (entryPath) => {
-        log.debug(`Indexing content for entry ${entryPath}`);
-        const contentBuffer = await archive.getEntryContent(entryPath);
-        await indexContentFile({
-          indexName,
-          esClient,
-          contentBuffer,
-          legacySemanticText,
-          elserInferenceId,
-        });
-      })
-    );
+    for (const entryPath of contentEntries) {
+      log.debug(`Indexing content for entry ${entryPath}`);
+
+      const contentBuffer = await archive.getEntryContent(entryPath);
+      await indexContentFile({
+        indexName,
+        esClient,
+        contentBuffer,
+        legacySemanticText,
+        elserInferenceId,
+      });
+    }
 
     await esClient.indices.refresh({ index: indexName });
 


### PR DESCRIPTION
## Summary
Populating data make ES queue filled up, but we continued sending bulk requests even after received 409 status code. As a solution we want to send bulk request one by one and wait.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


