### PR TITLE
[DO NOT REVIEW] [Incident Management] Add GenericSuggestionPayload

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.ts
@@ -24,7 +24,14 @@ export type SuggestionContext = z.infer<typeof suggestionContextRt>;
 
 export type SuggestionOwner = z.infer<typeof suggestionOwnerSchema>;
 export type SuggestionOwners = SuggestionOwner[];
-export interface AttachmentItem<TPayload extends {} = {}> {
+export interface GenericSuggestionPayload {
+  id: string;
+  [key: PropertyKey]: unknown;
+}
+
+export interface AttachmentItem<
+  TPayload extends GenericSuggestionPayload = GenericSuggestionPayload
+> {
   /* The payload associated with the attachment. Used primarily to support
    * custom UI rendering */
   payload: TPayload;
@@ -39,7 +46,7 @@ export interface AttachmentItem<TPayload extends {} = {}> {
  * For every suggestion code authors want to include as a completely separate suggestion box,
  * they should return a separate SuggestionItem. */
 export interface SuggestionItem<
-  TPayload extends {} = {} // Generic type for the payload, defaults to an empty object
+  TPayload extends GenericSuggestionPayload = GenericSuggestionPayload
 > {
   id: string; // Unique identifier for suggestion
   /* Optional plaintext description of the entire suggestion payload.
@@ -49,6 +56,8 @@ export interface SuggestionItem<
   data: Array<AttachmentItem<TPayload>>; // The main data of the context, containing 1 or more context items
 }
 
-export interface SuggestionResponse<TPayload extends {} = {}> {
+export interface SuggestionResponse<
+  TPayload extends GenericSuggestionPayload = GenericSuggestionPayload
+> {
   suggestions: SuggestionItem<TPayload>[]; // Array of suggestions
 }

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.ts
@@ -24,10 +24,7 @@ export type SuggestionContext = z.infer<typeof suggestionContextRt>;
 
 export type SuggestionOwner = z.infer<typeof suggestionOwnerSchema>;
 export type SuggestionOwners = SuggestionOwner[];
-export interface GenericSuggestionPayload {
-  id: string;
-  [key: PropertyKey]: unknown;
-}
+export type GenericSuggestionPayload = object;
 
 export interface AttachmentItem<
   TPayload extends GenericSuggestionPayload = GenericSuggestionPayload

--- a/x-pack/platform/plugins/shared/cases/public/application.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/application.tsx
@@ -18,6 +18,7 @@ import type { PersistableStateAttachmentTypeRegistry } from './client/attachment
 import type { RenderAppProps } from './types';
 
 import { CasesApp } from './components/app';
+import type { AttachmentSuggestionRegistry } from './client/attachment_framework/suggestion_registry';
 
 export const renderApp = (deps: RenderAppProps) => {
   const { mountParams } = deps;
@@ -33,6 +34,7 @@ export const renderApp = (deps: RenderAppProps) => {
 interface CasesAppWithContextProps {
   externalReferenceAttachmentTypeRegistry: ExternalReferenceAttachmentTypeRegistry;
   persistableStateAttachmentTypeRegistry: PersistableStateAttachmentTypeRegistry;
+  attachmentSuggestionRegistry: AttachmentSuggestionRegistry;
   getFilesClient: (scope: string) => ScopedFilesClient;
 }
 
@@ -40,12 +42,14 @@ const CasesAppWithContext: React.FC<CasesAppWithContextProps> = React.memo(
   ({
     externalReferenceAttachmentTypeRegistry,
     persistableStateAttachmentTypeRegistry,
+    attachmentSuggestionRegistry,
     getFilesClient,
   }) => {
     return (
       <CasesApp
         externalReferenceAttachmentTypeRegistry={externalReferenceAttachmentTypeRegistry}
         persistableStateAttachmentTypeRegistry={persistableStateAttachmentTypeRegistry}
+        attachmentSuggestionRegistry={attachmentSuggestionRegistry}
         getFilesClient={getFilesClient}
       />
     );
@@ -73,6 +77,7 @@ export const App: React.FC<{ deps: RenderAppProps }> = ({ deps }) => {
             externalReferenceAttachmentTypeRegistry={deps.externalReferenceAttachmentTypeRegistry}
             persistableStateAttachmentTypeRegistry={deps.persistableStateAttachmentTypeRegistry}
             getFilesClient={pluginsStart.files.filesClientFactory.asScoped}
+            attachmentSuggestionRegistry={deps.attachmentSuggestionRegistry}
           />
         </Router>
       </KibanaContextProvider>

--- a/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/types.ts
@@ -12,6 +12,8 @@ import type {
   PersistableStateAttachmentPayload,
   SuggestionOwner,
   SuggestionItem,
+  GenericSuggestionPayload,
+  AttachmentItem,
 } from '../../../common/types/domain';
 import type { CaseUI } from '../../containers/types';
 
@@ -80,12 +82,16 @@ interface BaseSuggestionType {
   owner: SuggestionOwner;
 }
 
-export type SuggestionType<TPayload extends {} = {}> = BaseSuggestionType & {
-  children: React.LazyExoticComponent<React.FC<SuggestionChildrenProps<TPayload>>>;
-};
+export type SuggestionType<TPayload extends GenericSuggestionPayload = GenericSuggestionPayload> =
+  BaseSuggestionType & {
+    children: React.LazyExoticComponent<React.FC<SuggestionChildrenProps<TPayload>>>;
+  };
 
-export interface SuggestionChildrenProps<TPayload extends {} = {}> {
+export interface SuggestionChildrenProps<
+  TPayload extends GenericSuggestionPayload = GenericSuggestionPayload
+> {
   suggestion: SuggestionItem<TPayload>;
+  attachment: AttachmentItem<TPayload>;
 }
 
 export interface AttachmentFramework {
@@ -95,5 +101,7 @@ export interface AttachmentFramework {
   registerPersistableState: (
     persistableStateAttachmentType: PersistableStateAttachmentType
   ) => void;
-  registerSuggestion: <TPayload extends {} = {}>(suggestionType: SuggestionType<TPayload>) => void;
+  registerSuggestion: <TPayload extends GenericSuggestionPayload = GenericSuggestionPayload>(
+    suggestionType: SuggestionType<TPayload>
+  ) => void;
 }

--- a/x-pack/platform/plugins/shared/cases/public/client/ui/get_all_cases_selector_modal.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/client/ui/get_all_cases_selector_modal.tsx
@@ -16,6 +16,7 @@ export type GetAllCasesSelectorModalProps = Omit<
   GetAllCasesSelectorModalPropsInternal,
   | 'externalReferenceAttachmentTypeRegistry'
   | 'persistableStateAttachmentTypeRegistry'
+  | 'attachmentSuggestionRegistry'
   | 'getFilesClient'
 >;
 
@@ -25,6 +26,7 @@ const AllCasesSelectorModalLazy: React.FC<AllCasesSelectorModalProps> = lazy(
 export const getAllCasesSelectorModalLazy = ({
   externalReferenceAttachmentTypeRegistry,
   persistableStateAttachmentTypeRegistry,
+  attachmentSuggestionRegistry,
   getFilesClient,
   owner,
   permissions,
@@ -36,6 +38,7 @@ export const getAllCasesSelectorModalLazy = ({
     value={{
       externalReferenceAttachmentTypeRegistry,
       persistableStateAttachmentTypeRegistry,
+      attachmentSuggestionRegistry,
       getFilesClient,
       owner,
       permissions,

--- a/x-pack/platform/plugins/shared/cases/public/client/ui/get_cases.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/client/ui/get_cases.tsx
@@ -17,6 +17,7 @@ export type GetCasesProps = Omit<
   | 'externalReferenceAttachmentTypeRegistry'
   | 'persistableStateAttachmentTypeRegistry'
   | 'getFilesClient'
+  | 'attachmentSuggestionRegistry'
 >;
 
 const CasesRoutesLazy: React.FC<CasesProps> = lazy(() => import('../../components/app/routes'));
@@ -38,6 +39,7 @@ export const getCasesLazy = ({
   features,
   releasePhase,
   renderAlertsTable,
+  attachmentSuggestionRegistry,
 }: GetCasesPropsInternal) => (
   <CasesProvider
     value={{
@@ -49,6 +51,7 @@ export const getCasesLazy = ({
       basePath,
       features,
       releasePhase,
+      attachmentSuggestionRegistry,
     }}
   >
     <Suspense fallback={<EuiLoadingSpinner />}>

--- a/x-pack/platform/plugins/shared/cases/public/client/ui/get_cases_context.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/client/ui/get_cases_context.tsx
@@ -15,6 +15,7 @@ export type GetCasesContextProps = Omit<
   CasesContextProps,
   | 'externalReferenceAttachmentTypeRegistry'
   | 'persistableStateAttachmentTypeRegistry'
+  | 'attachmentSuggestionRegistry'
   | 'getFilesClient'
 >;
 
@@ -26,6 +27,7 @@ const CasesProviderLazy: React.FC<{
 const CasesProviderLazyWrapper = ({
   externalReferenceAttachmentTypeRegistry,
   persistableStateAttachmentTypeRegistry,
+  attachmentSuggestionRegistry,
   owner,
   permissions,
   features,
@@ -38,6 +40,7 @@ const CasesProviderLazyWrapper = ({
       value={{
         externalReferenceAttachmentTypeRegistry,
         persistableStateAttachmentTypeRegistry,
+        attachmentSuggestionRegistry,
         owner,
         permissions,
         features,
@@ -55,11 +58,13 @@ CasesProviderLazyWrapper.displayName = 'CasesProviderLazyWrapper';
 export const getCasesContextLazy = ({
   externalReferenceAttachmentTypeRegistry,
   persistableStateAttachmentTypeRegistry,
+  attachmentSuggestionRegistry,
   getFilesClient,
 }: Pick<
   GetCasesContextPropsInternal,
   | 'externalReferenceAttachmentTypeRegistry'
   | 'persistableStateAttachmentTypeRegistry'
+  | 'attachmentSuggestionRegistry'
   | 'getFilesClient'
 >): (() => React.FC<PropsWithChildren<GetCasesContextProps>>) => {
   const CasesProviderLazyWrapperWithRegistry: React.FC<PropsWithChildren<GetCasesContextProps>> = ({
@@ -70,6 +75,7 @@ export const getCasesContextLazy = ({
       {...props}
       externalReferenceAttachmentTypeRegistry={externalReferenceAttachmentTypeRegistry}
       persistableStateAttachmentTypeRegistry={persistableStateAttachmentTypeRegistry}
+      attachmentSuggestionRegistry={attachmentSuggestionRegistry}
       getFilesClient={getFilesClient}
     >
       {children}

--- a/x-pack/platform/plugins/shared/cases/public/client/ui/get_create_case_flyout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/client/ui/get_create_case_flyout.tsx
@@ -16,6 +16,7 @@ export type GetCreateCaseFlyoutProps = Omit<
   GetCreateCaseFlyoutPropsInternal,
   | 'externalReferenceAttachmentTypeRegistry'
   | 'persistableStateAttachmentTypeRegistry'
+  | 'attachmentSuggestionRegistry'
   | 'getFilesClient'
 >;
 
@@ -25,6 +26,7 @@ export const CreateCaseFlyoutLazy: React.FC<CreateCaseFlyoutProps> = lazy(
 export const getCreateCaseFlyoutLazy = ({
   externalReferenceAttachmentTypeRegistry,
   persistableStateAttachmentTypeRegistry,
+  attachmentSuggestionRegistry,
   getFilesClient,
   owner,
   permissions,
@@ -38,6 +40,7 @@ export const getCreateCaseFlyoutLazy = ({
     value={{
       externalReferenceAttachmentTypeRegistry,
       persistableStateAttachmentTypeRegistry,
+      attachmentSuggestionRegistry,
       getFilesClient,
       owner,
       permissions,

--- a/x-pack/platform/plugins/shared/cases/public/client/ui/get_recent_cases.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/client/ui/get_recent_cases.tsx
@@ -16,6 +16,7 @@ export type GetRecentCasesProps = Omit<
   GetRecentCasesPropsInternal,
   | 'externalReferenceAttachmentTypeRegistry'
   | 'persistableStateAttachmentTypeRegistry'
+  | 'attachmentSuggestionRegistry'
   | 'getFilesClient'
 >;
 
@@ -25,6 +26,7 @@ const RecentCasesLazy: React.FC<RecentCasesProps> = lazy(
 export const getRecentCasesLazy = ({
   externalReferenceAttachmentTypeRegistry,
   persistableStateAttachmentTypeRegistry,
+  attachmentSuggestionRegistry,
   getFilesClient,
   owner,
   permissions,
@@ -34,6 +36,7 @@ export const getRecentCasesLazy = ({
     value={{
       externalReferenceAttachmentTypeRegistry,
       persistableStateAttachmentTypeRegistry,
+      attachmentSuggestionRegistry,
       getFilesClient,
       owner,
       permissions,

--- a/x-pack/platform/plugins/shared/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/common/mock/test_providers.tsx
@@ -33,6 +33,7 @@ import { ExternalReferenceAttachmentTypeRegistry } from '../../client/attachment
 import { PersistableStateAttachmentTypeRegistry } from '../../client/attachment_framework/persistable_state_registry';
 import { allCasesPermissions } from './permissions';
 import type { CasesPublicStartDependencies } from '../../types';
+import { AttachmentSuggestionRegistry } from '../../client/attachment_framework/suggestion_registry';
 
 interface TestProviderProps {
   children: React.ReactNode;
@@ -42,6 +43,7 @@ interface TestProviderProps {
   releasePhase?: ReleasePhase;
   externalReferenceAttachmentTypeRegistry?: ExternalReferenceAttachmentTypeRegistry;
   persistableStateAttachmentTypeRegistry?: PersistableStateAttachmentTypeRegistry;
+  attachmentSuggestionRegistry?: AttachmentSuggestionRegistry;
   license?: ILicense;
   services?: CasesPublicStartDependencies;
   queryClient?: QueryClient;
@@ -87,6 +89,7 @@ const TestProvidersComponent: React.FC<TestProviderProps> = ({
   releasePhase,
   externalReferenceAttachmentTypeRegistry,
   persistableStateAttachmentTypeRegistry,
+  attachmentSuggestionRegistry,
   license,
   coreStart,
   services,
@@ -127,12 +130,16 @@ const TestProvidersComponent: React.FC<TestProviderProps> = ({
     []
   );
 
+  const defaultAttachmentSuggestionRegistry = useMemo(() => new AttachmentSuggestionRegistry(), []);
+
   const casesProviderValue: CasesContextProps = useMemo(
     () => ({
       externalReferenceAttachmentTypeRegistry:
         externalReferenceAttachmentTypeRegistry ?? defaultExternalReferenceAttachmentTypeRegistry,
       persistableStateAttachmentTypeRegistry:
         persistableStateAttachmentTypeRegistry ?? defaultPersistableStateAttachmentTypeRegistry,
+      attachmentSuggestionRegistry:
+        attachmentSuggestionRegistry ?? defaultAttachmentSuggestionRegistry,
       features,
       owner: owner ?? mockedTestProvidersOwner,
       permissions: permissions ?? defaultPermissions,
@@ -150,6 +157,8 @@ const TestProvidersComponent: React.FC<TestProviderProps> = ({
       permissions,
       persistableStateAttachmentTypeRegistry,
       releasePhase,
+      attachmentSuggestionRegistry,
+      defaultAttachmentSuggestionRegistry,
     ]
   );
 

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
@@ -22,6 +22,7 @@ import { ExternalReferenceAttachmentTypeRegistry } from '../../../client/attachm
 import type { AddToExistingCaseModalProps } from './use_cases_add_to_existing_case_modal';
 import { useCasesAddToExistingCaseModal } from './use_cases_add_to_existing_case_modal';
 import { PersistableStateAttachmentTypeRegistry } from '../../../client/attachment_framework/persistable_state_registry';
+import { AttachmentSuggestionRegistry } from '../../../client/attachment_framework/suggestion_registry';
 
 jest.mock('../../../common/use_cases_toast');
 jest.mock('../../../common/lib/kibana/use_application');
@@ -55,6 +56,7 @@ const useCreateAttachmentsMock = useCreateAttachments as jest.Mock;
 
 const externalReferenceAttachmentTypeRegistry = new ExternalReferenceAttachmentTypeRegistry();
 const persistableStateAttachmentTypeRegistry = new PersistableStateAttachmentTypeRegistry();
+const attachmentSuggestionRegistry = new AttachmentSuggestionRegistry();
 
 describe('use cases add to existing case modal hook', () => {
   useCreateAttachmentsMock.mockReturnValue({
@@ -69,6 +71,7 @@ describe('use cases add to existing case modal hook', () => {
         value={{
           externalReferenceAttachmentTypeRegistry,
           persistableStateAttachmentTypeRegistry,
+          attachmentSuggestionRegistry,
           owner: ['test'],
           permissions: allCasesPermissions(),
           basePath: '/jest',

--- a/x-pack/platform/plugins/shared/cases/public/components/app/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/app/index.tsx
@@ -15,6 +15,7 @@ import { APP_OWNER } from '../../../common/constants';
 import { getCasesLazy } from '../../client/ui/get_cases';
 import { useApplicationCapabilities } from '../../common/lib/kibana';
 import type { CasesRoutesProps } from './types';
+import type { AttachmentSuggestionRegistry } from '../../client/attachment_framework/suggestion_registry';
 
 export type CasesProps = CasesRoutesProps;
 
@@ -22,11 +23,13 @@ interface CasesAppProps {
   externalReferenceAttachmentTypeRegistry: ExternalReferenceAttachmentTypeRegistry;
   persistableStateAttachmentTypeRegistry: PersistableStateAttachmentTypeRegistry;
   getFilesClient: (scope: string) => ScopedFilesClient;
+  attachmentSuggestionRegistry: AttachmentSuggestionRegistry;
 }
 
 const CasesAppComponent: React.FC<CasesAppProps> = ({
   externalReferenceAttachmentTypeRegistry,
   persistableStateAttachmentTypeRegistry,
+  attachmentSuggestionRegistry,
   getFilesClient,
 }) => {
   const userCapabilities = useApplicationCapabilities();
@@ -36,6 +39,7 @@ const CasesAppComponent: React.FC<CasesAppProps> = ({
       {getCasesLazy({
         externalReferenceAttachmentTypeRegistry,
         persistableStateAttachmentTypeRegistry,
+        attachmentSuggestionRegistry,
         getFilesClient,
         owner: [APP_OWNER],
         useFetchAlertData: () => [false, {}],

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_context/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_context/index.tsx
@@ -33,12 +33,14 @@ import { casesContextReducer, getInitialCasesContextState } from './state/cases_
 import { CasesStateContext } from './state/cases_state_context';
 import { isRegisteredOwner } from '../../files';
 import { casesQueryClient } from './query_client';
+import type { AttachmentSuggestionRegistry } from '../../client/attachment_framework/suggestion_registry';
 
 type CasesContextValueDispatch = Dispatch<CasesContextStoreAction>;
 
 export interface CasesContextValue {
   externalReferenceAttachmentTypeRegistry: ExternalReferenceAttachmentTypeRegistry;
   persistableStateAttachmentTypeRegistry: PersistableStateAttachmentTypeRegistry;
+  attachmentSuggestionRegistry: AttachmentSuggestionRegistry;
   owner: string[];
   permissions: CasesPermissions;
   basePath: string;
@@ -54,6 +56,7 @@ export interface CasesContextProps
     | 'permissions'
     | 'externalReferenceAttachmentTypeRegistry'
     | 'persistableStateAttachmentTypeRegistry'
+    | 'attachmentSuggestionRegistry'
   > {
   basePath?: string;
   features?: CasesFeatures;
@@ -73,6 +76,7 @@ export const CasesProvider: FC<
   value: {
     externalReferenceAttachmentTypeRegistry,
     persistableStateAttachmentTypeRegistry,
+    attachmentSuggestionRegistry,
     owner,
     permissions,
     basePath = DEFAULT_BASE_PATH,
@@ -88,6 +92,7 @@ export const CasesProvider: FC<
     () => ({
       externalReferenceAttachmentTypeRegistry,
       persistableStateAttachmentTypeRegistry,
+      attachmentSuggestionRegistry,
       owner,
       permissions: {
         all: permissions.all,

--- a/x-pack/platform/plugins/shared/cases/public/components/create/flyout/use_cases_add_to_new_case_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/flyout/use_cases_add_to_new_case_flyout.test.tsx
@@ -15,11 +15,13 @@ import { useCasesAddToNewCaseFlyout } from './use_cases_add_to_new_case_flyout';
 import { allCasesPermissions } from '../../../common/mock';
 import { ExternalReferenceAttachmentTypeRegistry } from '../../../client/attachment_framework/external_reference_registry';
 import { PersistableStateAttachmentTypeRegistry } from '../../../client/attachment_framework/persistable_state_registry';
+import { AttachmentSuggestionRegistry } from '../../../client/attachment_framework/suggestion_registry';
 
 jest.mock('../../../common/use_cases_toast');
 
 const externalReferenceAttachmentTypeRegistry = new ExternalReferenceAttachmentTypeRegistry();
 const persistableStateAttachmentTypeRegistry = new PersistableStateAttachmentTypeRegistry();
+const attachmentSuggestionRegistry = new AttachmentSuggestionRegistry();
 
 describe('use cases add to new case flyout hook', () => {
   const dispatch = jest.fn();
@@ -32,6 +34,7 @@ describe('use cases add to new case flyout hook', () => {
           value={{
             externalReferenceAttachmentTypeRegistry,
             persistableStateAttachmentTypeRegistry,
+            attachmentSuggestionRegistry,
             owner: ['test'],
             permissions: allCasesPermissions(),
             basePath: '/jest',

--- a/x-pack/platform/plugins/shared/cases/public/components/visualizations/actions/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/visualizations/actions/types.ts
@@ -16,6 +16,7 @@ export type CasesActionContextProps = Pick<
   CasesContextProps,
   | 'externalReferenceAttachmentTypeRegistry'
   | 'persistableStateAttachmentTypeRegistry'
+  | 'attachmentSuggestionRegistry'
   | 'getFilesClient'
 >;
 

--- a/x-pack/platform/plugins/shared/cases/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/public/plugin.ts
@@ -73,6 +73,7 @@ export class CasesUiPlugin
     const storage = this.storage;
     const externalReferenceAttachmentTypeRegistry = this.externalReferenceAttachmentTypeRegistry;
     const persistableStateAttachmentTypeRegistry = this.persistableStateAttachmentTypeRegistry;
+    const attachmentSuggestionRegistry = this.attachmentSuggestionRegistry;
 
     registerInternalAttachments(
       externalReferenceAttachmentTypeRegistry,
@@ -115,6 +116,7 @@ export class CasesUiPlugin
             kibanaVersion,
             externalReferenceAttachmentTypeRegistry,
             persistableStateAttachmentTypeRegistry,
+            attachmentSuggestionRegistry,
           });
         },
       });
@@ -156,6 +158,7 @@ export class CasesUiPlugin
     const getCasesContext = getCasesContextLazy({
       externalReferenceAttachmentTypeRegistry: this.externalReferenceAttachmentTypeRegistry,
       persistableStateAttachmentTypeRegistry: this.persistableStateAttachmentTypeRegistry,
+      attachmentSuggestionRegistry: this.attachmentSuggestionRegistry,
       getFilesClient: plugins.files.filesClientFactory.asScoped,
     });
 
@@ -163,6 +166,7 @@ export class CasesUiPlugin
       {
         externalReferenceAttachmentTypeRegistry: this.externalReferenceAttachmentTypeRegistry,
         persistableStateAttachmentTypeRegistry: this.persistableStateAttachmentTypeRegistry,
+        attachmentSuggestionRegistry: this.attachmentSuggestionRegistry,
         getFilesClient: plugins.files.filesClientFactory.asScoped,
       },
       {
@@ -182,6 +186,7 @@ export class CasesUiPlugin
             externalReferenceAttachmentTypeRegistry: this.externalReferenceAttachmentTypeRegistry,
             persistableStateAttachmentTypeRegistry: this.persistableStateAttachmentTypeRegistry,
             getFilesClient: plugins.files.filesClientFactory.asScoped,
+            attachmentSuggestionRegistry: this.attachmentSuggestionRegistry,
           }),
         getCasesContext,
         getRecentCases: (props) =>
@@ -190,6 +195,7 @@ export class CasesUiPlugin
             externalReferenceAttachmentTypeRegistry: this.externalReferenceAttachmentTypeRegistry,
             persistableStateAttachmentTypeRegistry: this.persistableStateAttachmentTypeRegistry,
             getFilesClient: plugins.files.filesClientFactory.asScoped,
+            attachmentSuggestionRegistry: this.attachmentSuggestionRegistry,
           }),
         // @deprecated Please use the hook useCasesAddToExistingCaseModal
         getAllCasesSelectorModal: (props) =>
@@ -198,6 +204,7 @@ export class CasesUiPlugin
             externalReferenceAttachmentTypeRegistry: this.externalReferenceAttachmentTypeRegistry,
             persistableStateAttachmentTypeRegistry: this.persistableStateAttachmentTypeRegistry,
             getFilesClient: plugins.files.filesClientFactory.asScoped,
+            attachmentSuggestionRegistry: this.attachmentSuggestionRegistry,
           }),
       },
       hooks: {

--- a/x-pack/platform/plugins/shared/cases/public/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/types.ts
@@ -56,6 +56,7 @@ import type {
 } from '../common/types/api';
 
 import type { SupportedCaseAttachment } from '../common/types/domain';
+import type { AttachmentSuggestionRegistry } from './client/attachment_framework/suggestion_registry';
 
 export type {
   SupportedCaseAttachment,
@@ -112,6 +113,7 @@ export interface RenderAppProps {
   kibanaVersion: string;
   externalReferenceAttachmentTypeRegistry: ExternalReferenceAttachmentTypeRegistry;
   persistableStateAttachmentTypeRegistry: PersistableStateAttachmentTypeRegistry;
+  attachmentSuggestionRegistry: AttachmentSuggestionRegistry;
 }
 
 export interface CasesPublicSetup {

--- a/x-pack/platform/plugins/shared/cases/server/attachment_framework/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/attachment_framework/types.ts
@@ -13,6 +13,7 @@ import type {
   SuggestionOwner,
   SuggestionContext,
   SuggestionResponse,
+  GenericSuggestionPayload,
 } from '../../common/types/domain';
 
 export type PersistableStateAttachmentState = Pick<
@@ -39,7 +40,9 @@ export interface ExternalReferenceAttachmentType {
   schemaValidator?: (data: unknown) => void;
 }
 
-export interface SuggestionType<TPayload extends {} = {}> {
+export interface SuggestionType<
+  TPayload extends GenericSuggestionPayload = GenericSuggestionPayload
+> {
   /* Unique identifier for the suggestion type */
   id: string;
   /* Unique identifier for the type of attachment the suggestion is for */
@@ -56,9 +59,9 @@ export interface SuggestionType<TPayload extends {} = {}> {
   >;
 }
 
-export type SuggestionHandler<TPayload extends {} = {}> = (
-  params: SuggestionHandlerParams
-) => Promise<SuggestionResponse<TPayload>>;
+export type SuggestionHandler<
+  TPayload extends GenericSuggestionPayload = GenericSuggestionPayload
+> = (params: SuggestionHandlerParams) => Promise<SuggestionResponse<TPayload>>;
 
 export interface SuggestionHandlerParams {
   request: KibanaRequest;
@@ -72,7 +75,7 @@ export interface AttachmentFramework {
   registerPersistableState: (
     persistableStateAttachmentType: PersistableStateAttachmentTypeSetup
   ) => void;
-  registerSuggestion: <TPayload extends {} = {}>(
+  registerSuggestion: <TPayload extends GenericSuggestionPayload = GenericSuggestionPayload>(
     attachmentSuggestion: SuggestionType<TPayload>
   ) => void;
 }


### PR DESCRIPTION
✨ Experimental ✨

This PR improves the generic type of AttachmentItem replacing `{}` (that in TS represents any non nullish value) with a `GenericSuggestionPayload` interface. It also adds the `attachmentSuggestionRegistry` to case context.

Before:
<img width="289" height="39" alt="Screenshot 2025-08-21 at 15 30 50" src="https://github.com/user-attachments/assets/312e4cb6-624c-4694-907c-1c9998bc4a51" />

After:
<img width="760" height="149" alt="Screenshot 2025-08-21 at 15 30 28" src="https://github.com/user-attachments/assets/ce1c7ed3-7cb5-468b-9d08-a9679c0dff61" />
