### PR TITLE
[onechat] fix previous tool calls causing errors during next round

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/to_langchain_messages.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/to_langchain_messages.test.ts
@@ -93,12 +93,14 @@ describe('conversationLangchainMessages', () => {
     // ToolMessage type guard is not imported, so just check property
     expect((toolCallToolMessage as ToolMessage).tool_call_id).toBe('call-1');
     expect(toolCallToolMessage.content).toEqual(
-      JSON.stringify([
-        {
-          type: ToolResultType.other,
-          data: 'result!',
-        },
-      ])
+      JSON.stringify({
+        results: [
+          {
+            type: ToolResultType.other,
+            data: 'result!',
+          },
+        ],
+      })
     );
     expect(isAIMessage(assistantMessage)).toBe(true);
     expect(assistantMessage.content).toBe('done!');
@@ -149,7 +151,7 @@ describe('conversationLangchainMessages', () => {
     expect((toolCallAIMessage as AIMessage).tool_calls![0].id).toBe('call-2');
     expect((toolCallToolMessage as ToolMessage).tool_call_id).toBe('call-2');
     expect(toolCallToolMessage.content).toEqual(
-      JSON.stringify([{ type: ToolResultType.other, data: 'found!' }])
+      JSON.stringify({ results: [{ type: ToolResultType.other, data: 'found!' }] })
     );
     expect(isAIMessage(secondAssistantMessage)).toBe(true);
     expect(secondAssistantMessage.content).toBe('done with bar');

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/to_langchain_messages.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/to_langchain_messages.ts
@@ -83,7 +83,7 @@ export const createToolCallMessages = (toolCall: ToolCallWithResult): [AIMessage
 
   const toolResultMessage = new ToolMessage({
     tool_call_id: toolCall.tool_call_id,
-    content: JSON.stringify(toolCall.results),
+    content: JSON.stringify({ results: toolCall.results }),
   });
 
   return [toolCallMessage, toolResultMessage];


### PR DESCRIPTION
## Summary

Some models (hello Claude, hello Gemini) only accept json objects (and not arrays) as tool results, which was causing errors when continuing the conversation.

This PR fixes it, by returning a `{ results: [] }` structure instead of the result array.



