### PR TITLE
[ES|QL] LOOKUP JOIN - feedback loop

### DIFF
--- a/src/platform/packages/private/kbn-index-editor/src/components/file_drop_zone.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/file_drop_zone.tsx
@@ -52,7 +52,7 @@ export const FileDropzone: FC<PropsWithChildren<{ noResults: boolean }>> = ({
 }) => {
   const { services } = useKibana<KibanaContextExtra>();
   const { indexUpdateService } = services;
-  const { fileUploadManager, filesStatus, uploadStatus } = useFileUploadContext();
+  const { fileUploadManager, filesStatus, uploadStatus, indexName } = useFileUploadContext();
 
   const isSaving = useObservable(indexUpdateService.isSaving$, false);
 
@@ -183,14 +183,18 @@ export const FileDropzone: FC<PropsWithChildren<{ noResults: boolean }>> = ({
 
   const showLoadingOverlay = isUploading || isAnalyzing;
 
-  return (
-    <FileSelectorContext.Provider value={{ onFileSelectorClick }}>
-      <div {...getRootProps({ css: { height: '100%', cursor: 'default' } })}>
-        {isDragActive ? <div css={overlayDraggingFile} /> : null}
-        {showLoadingOverlay ? loadingIndicator : null}
-        <input {...getInputProps()} />
-        {content}
-      </div>
-    </FileSelectorContext.Provider>
-  );
+  if (indexName) {
+    return (
+      <FileSelectorContext.Provider value={{ onFileSelectorClick }}>
+        <div {...getRootProps({ css: { height: '100%', cursor: 'default' } })}>
+          {isDragActive ? <div css={overlayDraggingFile} /> : null}
+          {showLoadingOverlay ? loadingIndicator : null}
+          <input {...getInputProps()} />
+          {content}
+        </div>
+      </FileSelectorContext.Provider>
+    );
+  } else {
+    return null;
+  }
 };

--- a/src/platform/packages/private/kbn-index-editor/src/components/file_preview.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/file_preview.tsx
@@ -267,6 +267,7 @@ const ResultsPreview: FC<ResultsPreviewProps> = ({ filePreview, columnNames }) =
         field: name,
         name,
         dataType: 'auto',
+        truncateText: { lines: 2 },
       };
     });
   }, [columnNames]);
@@ -302,7 +303,14 @@ const ResultsPreview: FC<ResultsPreviewProps> = ({ filePreview, columnNames }) =
           <EuiSpacer size={'s'} />
         </>
       ) : null}
-      {filePreview.sampleDocs?.length ? <EuiBasicTable columns={columns} items={items} /> : null}
+      {filePreview.sampleDocs?.length ? (
+        <EuiBasicTable
+          tableLayout="auto"
+          columns={columns}
+          items={items}
+          css={{ overflow: 'auto' }}
+        />
+      ) : null}
     </>
   );
 };

--- a/src/platform/packages/private/kbn-index-editor/src/components/flyout_footer.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/flyout_footer.tsx
@@ -64,9 +64,7 @@ export const FlyoutFooter: FC<FlyoutFooterProps> = ({ onClose }) => {
     }
   };
 
-  const isSaveButtonVisible =
-    (!isSaving && !canImport && !isIndexCreated) ||
-    (!isSaving && isIndexCreated && hasUnsavedChanges);
+  const isSaveButtonVisible = !isSaving && hasUnsavedChanges;
 
   return (
     <EuiFlyoutFooter>

--- a/src/platform/packages/private/kbn-index-editor/src/components/grid_custom_renderers/value_input_popover.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/grid_custom_renderers/value_input_popover.tsx
@@ -65,12 +65,25 @@ export const getValueInputPopover =
             return;
           }
         }
+        if (event.key === 'Tab') {
+          event.preventDefault();
+
+          if (error) {
+            return;
+          }
+
+          dataTableRef?.current?.closeCellPopover();
+          requestAnimationFrame(() => {
+            // openCellPopover takes care of checking the colIndex is out of bounds
+            dataTableRef?.current?.openCellPopover({ rowIndex, colIndex: colIndex + 1 });
+          });
+        }
         if (event.key === 'Escape') {
           setInputValue(cellValue);
           setError(null);
         }
       },
-      [cellValue, error]
+      [cellValue, colIndex, error, rowIndex]
     );
 
     const saveValue = useCallback(

--- a/src/platform/packages/private/kbn-index-editor/src/components/index_name.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/index_name.tsx
@@ -146,6 +146,10 @@ export const IndexName: FC = () => {
         'data-test-subj': 'indexNameReadMode',
       }}
       onSave={async (value) => {
+        if (error.length) {
+          return false;
+        }
+
         setIsLoading(true);
         const indexExists = await fileUpload.checkIndexExists(value);
         setIsLoading(false);

--- a/src/platform/packages/private/kbn-index-editor/src/components/query_bar.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/query_bar.tsx
@@ -56,8 +56,6 @@ export const QueryBar = () => {
       })
     : null;
 
-  const isDiscoverButtonDisabled = !discoverLink;
-
   if (!dataView) {
     return null;
   }
@@ -90,7 +88,7 @@ export const QueryBar = () => {
         <EuiButton
           size={'s'}
           color={'text'}
-          isDisabled={isDiscoverButtonDisabled}
+          isDisabled={!isIndexCreated}
           href={discoverLink ?? undefined}
           target="_blank"
           iconType={'discoverApp'}

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -478,12 +478,17 @@ export class IndexUpdateService {
       return dataView;
     }
 
-    return await this.data.dataViews.create({
+    const newDataView = await this.data.dataViews.create({
       title: indexName,
       name: indexName,
       // The index might not exist yet
       allowNoIndex: true,
     });
+
+    // If at some point the index existed, the dataView fields are present in the browser cache, we need to force refresh it.
+    await this.data.dataViews.refreshFields(newDataView, false, true);
+
+    return newDataView;
   }
 
   private listenForUpdates() {


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/207330
## Summary
Took care of some points provided in the feedback loop.
* Don't allow to set index name if it has errors.
* Fix old mappings being shown if an index with the same name was created before.
  *  This was due to get fields request being cached in the browser.
* Disable discover link if index is not created yet.
* Support tabbing across cell inputs, (only when inside an input, otherwise it would be difficult for the user to scape the grid).
* Improved file preview of large files.
* Don't allow to drop a file if index name is not provided.
