### PR TITLE
[Search] fix: remove incorrect link on "build" breadcrumb

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
@@ -126,10 +126,7 @@ export const useAnalyticsBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
   ]);
 
 export const useEnterpriseSearchContentBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
-  useSearchBreadcrumbs([
-    { text: ENTERPRISE_SEARCH_DATA_PLUGIN.NAV_TITLE, path: '/' },
-    ...breadcrumbs,
-  ]);
+  useSearchBreadcrumbs([{ text: ENTERPRISE_SEARCH_DATA_PLUGIN.NAV_TITLE }, ...breadcrumbs]);
 
 export const useSearchExperiencesBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
   useSearchBreadcrumbs([{ text: SEARCH_EXPERIENCES_PLUGIN.NAV_TITLE, path: '/' }, ...breadcrumbs]);


### PR DESCRIPTION
## Summary

The "build" breadcrumb on the search indices (enterprise search content) and connector pages was incorrectly linking to the search indices page. This fix removes the link from the breadcrumb.

### Before

<img width="500" height="417" alt="Screenshot 2025-08-21 at 15 44 02" src="https://github.com/user-attachments/assets/95bbb75c-bbbf-4b3e-a7ca-eeb327002891" />
<img width="500" height="416" alt="Screenshot 2025-08-21 at 15 43 46" src="https://github.com/user-attachments/assets/1b455cc4-9cce-424a-b798-5e4f17601942" />

### After

<img width="500" height="424" alt="Screenshot 2025-08-21 at 15 44 39" src="https://github.com/user-attachments/assets/e2cc55b9-662e-4dbe-9d1e-08dcdbc1956b" />
<img width="500" height="423" alt="Screenshot 2025-08-21 at 15 44 22" src="https://github.com/user-attachments/assets/1e6f7cda-64b7-4a1a-b8fc-b5c867b82caf" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release note

Fixes the "Build" breadcrumb showing an incorrect link to the search indices page.




<!--ONMERGE {"backportTargets":["9.0","9.1"]} ONMERGE-->