### PR TITLE
POC: workflow internal actions PoC - Elasticsearch request steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,13 @@ x-pack/solutions/security/test/security_solution_playwright/.env
 .dependency-graph-log.json
 
 .moon/cache
+
+# Gettext translation files
+*.po
+**/po/**
+
+# PoC notes and local artifacts
+/poc_notes/
+
+# Local Copilot instructions
+.github/copilot-instructions.md

--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -15,7 +15,7 @@
 # from requests it receives, and to prevent a deprecation warning at startup.
 # This setting cannot end in a slash.
 #server.basePath: ""
-
+server.host: 0.0.0.0
 # Specifies whether Kibana should rewrite requests that are prefixed with
 # `server.basePath` or require that they are rewritten by your reverse proxy.
 # Defaults to `false`.

--- a/src/platform/packages/shared/kbn-workflows/spec/api_steps.schema.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/api_steps.schema.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  generateYamlSchemaFromConnectors,
+  getJsonSchemaFromYamlSchema,
+} from './lib/generate_yaml_schema';
+
+describe('API step schemas', () => {
+  const strictSchema = generateYamlSchemaFromConnectors([], false);
+  const looseSchema = generateYamlSchemaFromConnectors([], true);
+
+  test('validates elasticsearch.request step (strict)', () => {
+    const workflow = {
+      name: 'wf',
+      triggers: [{ type: 'triggers.elastic.manual', enabled: true }],
+      steps: [
+        {
+          type: 'elasticsearch.request',
+          name: 'es',
+          request: { method: 'GET', path: '/_cluster/health' },
+        },
+      ],
+    };
+    const result = strictSchema.safeParse(workflow);
+    expect(result.success).toBe(true);
+  });
+
+  test('validates kibana.request step (strict)', () => {
+    const workflow = {
+      name: 'wf',
+      triggers: [{ type: 'triggers.elastic.manual', enabled: true }],
+      steps: [
+        {
+          type: 'kibana.request',
+          name: 'kbn',
+          request: { method: 'GET', path: '/api/status' },
+        },
+      ],
+    };
+    const result = strictSchema.safeParse(workflow);
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects elasticsearch.request with invalid path (no leading /)', () => {
+    const workflow = {
+      name: 'wf',
+      triggers: [{ type: 'triggers.elastic.manual', enabled: true }],
+      steps: [
+        {
+          type: 'elasticsearch.request',
+          name: 'es',
+          request: { method: 'GET', path: 'cluster/health' },
+        },
+      ],
+    };
+    const result = strictSchema.safeParse(workflow);
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects kibana.request with non-/api path', () => {
+    const workflow = {
+      name: 'wf',
+      triggers: [{ type: 'triggers.elastic.manual', enabled: true }],
+      steps: [
+        {
+          type: 'kibana.request',
+          name: 'kbn',
+          request: { method: 'GET', path: '/status' },
+        },
+      ],
+    } as any;
+    const result = strictSchema.safeParse(workflow);
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects kibana.request with HEAD method', () => {
+    const workflow = {
+      name: 'wf',
+      triggers: [{ type: 'triggers.elastic.manual', enabled: true }],
+      steps: [
+        {
+          type: 'kibana.request',
+          name: 'kbn',
+          request: { method: 'HEAD', path: '/api/status' },
+        },
+      ],
+    } as any; // let zod validate
+    const result = strictSchema.safeParse(workflow);
+    expect(result.success).toBe(false);
+  });
+
+  test('JSON schema includes api step types', () => {
+    const json = getJsonSchemaFromYamlSchema(strictSchema);
+    const jsonStr = JSON.stringify(json);
+    expect(jsonStr).toContain('elasticsearch.request');
+    expect(jsonStr).toContain('kibana.request');
+  });
+
+  test('loose schema accepts partial step stubs with type only', () => {
+    const workflow = {
+      // name missing on purpose
+      triggers: [{ type: 'triggers.elastic.manual' }],
+      steps: [
+        {
+          type: 'elasticsearch.request',
+          // other fields omitted on purpose
+        },
+      ],
+    } as any;
+    const result = looseSchema.safeParse(workflow);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/platform/packages/shared/kbn-workflows/spec/lib/generate_yaml_schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/generate_yaml_schema.ts
@@ -16,6 +16,8 @@ import {
   getMergeStepSchema,
   getParallelStepSchema,
   WorkflowSchema,
+  getEsApiRequestStepSchema,
+  getKbnApiRequestStepSchema,
 } from '../schema';
 
 export interface ConnectorContract {
@@ -65,6 +67,8 @@ function createRecursiveStepSchema(
     const ifSchema = getIfStepSchema(stepSchema, loose);
     const parallelSchema = getParallelStepSchema(stepSchema, loose);
     const mergeSchema = getMergeStepSchema(stepSchema, loose);
+    const esApiSchema = getEsApiRequestStepSchema(loose);
+    const kbnApiSchema = getKbnApiRequestStepSchema(loose);
 
     // Return discriminated union with all step types
     return z.discriminatedUnion('type', [
@@ -72,6 +76,8 @@ function createRecursiveStepSchema(
       ifSchema,
       parallelSchema,
       mergeSchema,
+      esApiSchema,
+      kbnApiSchema,
       ...connectorSchemas,
     ]);
   });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/service_adapters/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/service_adapters/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v 3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export interface CasesServiceAdapter {
+  createCase(params: Record<string, any>): Promise<any>;
+  addComment(caseId: string, params: Record<string, any>): Promise<any>;
+}
+
+export interface KibanaServiceAdapters {
+  cases?: CasesServiceAdapter;
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/es_api_step.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/es_api_step.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v 3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EsApiStepImpl } from './es_api_step';
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { WorkflowExecutionRuntimeManager } from '../workflow_context_manager/workflow_execution_runtime_manager';
+import { WorkflowContextManager } from '../workflow_context_manager/workflow_context_manager';
+import { graphlib } from '@dagrejs/dagre';
+
+const createMockEsClient = () => {
+  return {
+    transport: {
+      request: jest.fn(),
+    },
+  } as unknown as ElasticsearchClient;
+};
+
+const createRuntime = () => {
+  const g = new graphlib.Graph();
+  g.setNode('s1', { id: 's1', type: 'atomic', configuration: {} });
+  const workflowExecution = {
+    id: 'run-1',
+    workflowId: 'wf-1',
+    status: 'running',
+  } as any;
+  const workflowExecutionRepository = {
+    updateWorkflowExecution: jest.fn(),
+  } as any;
+  const stepExecutionRepository = {
+    createStepExecution: jest.fn(),
+    updateStepExecution: jest.fn(),
+    updateStepExecutions: jest.fn(),
+  } as any;
+  const workflowLogger = { logInfo: jest.fn(), logDebug: jest.fn() } as any;
+
+  const mgr = new WorkflowExecutionRuntimeManager({
+    workflowExecution,
+    workflowExecutionRepository,
+    stepExecutionRepository,
+    workflowExecutionGraph: g,
+    workflowLogger,
+  });
+
+  // Spy on methods used by StepBase with correct signatures
+  jest.spyOn(mgr as any, 'startStep').mockImplementation(async (_stepId: string) => {});
+  jest
+    .spyOn(mgr as any, 'setStepResult')
+    .mockImplementation(async (_stepId: string, _result: any) => {});
+  jest.spyOn(mgr as any, 'finishStep').mockImplementation(async (_stepId: string) => {});
+  jest.spyOn(mgr as any, 'getCurrentStep').mockReturnValue({ id: 's1' });
+  jest.spyOn(mgr as any, 'getStepResult').mockReturnValue(undefined);
+  jest.spyOn(mgr as any, 'getStepState').mockReturnValue(undefined);
+
+  return mgr;
+};
+
+const createContextManager = (runtime: WorkflowExecutionRuntimeManager) =>
+  new WorkflowContextManager({
+    workflowRunId: 'run-1',
+    workflow: {
+      version: '1',
+      name: 'wf',
+      enabled: true,
+      triggers: [{ type: 'triggers.elastic.manual', enabled: true }],
+      steps: [],
+    } as any,
+    event: { type: 'manual' },
+    workflowExecutionGraph: (runtime as any).workflowExecutionGraph,
+    workflowExecutionRuntime: runtime,
+  });
+
+describe('EsApiStepImpl', () => {
+  test('calls transport.request with rendered inputs and stores result', async () => {
+    const runtime = createRuntime();
+    const ctxMgr = createContextManager(runtime);
+    const es = createMockEsClient();
+    (es.transport.request as jest.Mock).mockResolvedValue({ ok: true, statusCode: 200, hits: 1 });
+
+    const step = new EsApiStepImpl(
+      {
+        type: 'elasticsearch.request',
+        name: 'es',
+        request: {
+          method: 'GET',
+          path: '/_cluster/health',
+          query: { level: 'cluster' },
+          headers: { 'x-test': '1' },
+        },
+      } as any,
+      es,
+      ctxMgr,
+      runtime
+    );
+
+    await step.run();
+
+    expect(es.transport.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'GET',
+        path: '/_cluster/health',
+        querystring: { level: 'cluster' },
+      }),
+      expect.objectContaining({ headers: { 'x-test': '1' } })
+    );
+    expect((runtime as any).setStepResult).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ output: expect.any(Object), error: undefined })
+    );
+  });
+
+  test('stores error on failure', async () => {
+    const runtime = createRuntime();
+    const ctxMgr = createContextManager(runtime);
+    const es = createMockEsClient();
+    (es.transport.request as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    const step = new EsApiStepImpl(
+      {
+        type: 'elasticsearch.request',
+        name: 'es',
+        request: { method: 'GET', path: '/_x' },
+      } as any,
+      es,
+      ctxMgr,
+      runtime
+    );
+
+    await step.run();
+
+    expect((runtime as any).setStepResult).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ output: undefined, error: 'boom' })
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/es_api_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/es_api_step.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v 3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { EsApiRequestStep } from '@kbn/workflows';
+import { WorkflowContextManager } from '../workflow_context_manager/workflow_context_manager';
+import { WorkflowExecutionRuntimeManager } from '../workflow_context_manager/workflow_execution_runtime_manager';
+import { StepBase, RunStepResult } from './step_base';
+import { IWorkflowEventLogger } from '../workflow_event_logger/workflow_event_logger';
+
+export interface EsApiStepConfig extends EsApiRequestStep {
+  type: 'elasticsearch.request';
+  // Accept PoC YAML shape that uses `with` instead of `request`
+  with?: {
+    method?: string;
+    path?: string;
+    query?: Record<string, any>;
+    headers?: Record<string, string>;
+    body?: any;
+  };
+}
+
+export class EsApiStepImpl extends StepBase<EsApiStepConfig> {
+  constructor(
+    step: EsApiStepConfig,
+    private esClientAsUser: ElasticsearchClient,
+    contextManager: WorkflowContextManager,
+    workflowExecutionRuntime: WorkflowExecutionRuntimeManager,
+    private workflowLogger?: IWorkflowEventLogger
+  ) {
+    super(step, contextManager, undefined, workflowExecutionRuntime);
+  }
+
+  protected async _run(): Promise<RunStepResult> {
+    // Evaluate optional 'if' condition
+    const shouldRun = await this.evaluateCondition(this.step.if);
+    if (!shouldRun) {
+      return { output: undefined, error: undefined };
+    }
+
+    const ctx = this.contextManager.getContext();
+
+    // Render request pieces (allow templating in strings)
+    const render = (v: any) => (typeof v === 'string' ? this.templatingEngine.render(v, ctx) : v);
+
+    // Normalize request block: prefer explicit `request`, fallback to PoC `with`
+    // If both are present, merge them with `request` taking precedence.
+    const requestBlock = (this.step as any).request ?? {};
+    const withBlock = (this.step as any).with ?? {};
+    const req: any = { ...(withBlock || {}), ...(requestBlock || {}) };
+
+    // Normalize and validate method/path (render strings, coerce non-strings)
+    const methodRaw = req.method;
+    let method: string | undefined;
+    if (typeof methodRaw === 'string') {
+      method = render(methodRaw);
+    } else if (methodRaw != null) {
+      method = String(methodRaw);
+    }
+
+    const pathRaw = req.path;
+    let path: string | undefined;
+    if (typeof pathRaw === 'string') {
+      path = render(pathRaw);
+    } else if (pathRaw != null) {
+      path = String(pathRaw);
+    }
+
+    // Default to GET when method is omitted but path provided (developer-friendly PoC behavior)
+    if (!method && path) {
+      method = 'GET';
+    }
+    // Uppercase method for ES transport
+    if (method) method = method.toUpperCase();
+
+    if (!method || typeof method !== 'string') {
+      return { output: undefined, error: "Elasticsearch API step requires 'with.method' (string)" };
+    }
+    if (!path || typeof path !== 'string') {
+      return { output: undefined, error: "Elasticsearch API step requires 'with.path' (string)" };
+    }
+
+    const query = Object.fromEntries(
+      Object.entries(req.query ?? {}).map(([k, v]) => [k, render(v)])
+    );
+    const headers = Object.fromEntries(
+      Object.entries(req.headers ?? {}).map(([k, v]) => [k, render(v as any)])
+    );
+    const body = render(req.body);
+
+    const timingEvent = {
+      message: `Elasticsearch request ${method} ${path}`,
+      event: { action: 'es-request', category: ['workflow'], type: ['request'] },
+      tags: ['elasticsearch', 'request'],
+    };
+
+    try {
+      this.workflowLogger?.startTiming(timingEvent);
+      this.workflowLogger?.logDebug('Executing Elasticsearch request', {
+        event: { action: 'es-request' },
+        request: { method, path, query, headers: Object.keys(headers) },
+      });
+
+      const resp = await this.esClientAsUser.transport.request(
+        {
+          method: method as any,
+          path,
+          querystring: query as any,
+          body,
+        },
+        { headers }
+      );
+
+      this.workflowLogger?.logDebug('Elasticsearch request completed', {
+        event: { action: 'es-response', outcome: 'success' },
+        response: { statusCode: (resp as any)?.statusCode },
+      });
+      this.workflowLogger?.stopTiming({
+        ...timingEvent,
+        event: { ...timingEvent.event, outcome: 'success' },
+      });
+
+      return {
+        output: {
+          statusCode: (resp as any)?.statusCode ?? undefined,
+          body: resp,
+        },
+        error: undefined,
+      };
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      this.workflowLogger?.logError('Elasticsearch request failed', err as any, {
+        event: { action: 'es-response', outcome: 'failure' },
+        error: { message: errorMessage },
+      });
+      this.workflowLogger?.stopTiming({
+        ...timingEvent,
+        event: { ...timingEvent.event, outcome: 'failure' },
+      });
+
+      return {
+        output: undefined,
+        error: errorMessage,
+      };
+    }
+  }
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/kbn_api_step.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/kbn_api_step.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v 3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { KbnApiStepImpl } from './kbn_api_step';
+import { WorkflowExecutionRuntimeManager } from '../workflow_context_manager/workflow_execution_runtime_manager';
+import { WorkflowContextManager } from '../workflow_context_manager/workflow_context_manager';
+import { graphlib } from '@dagrejs/dagre';
+
+const createRuntime = () => {
+  const g = new graphlib.Graph();
+  g.setNode('s1', { id: 's1', type: 'atomic', configuration: {} });
+  const workflowExecution = {
+    id: 'run-1',
+    workflowId: 'wf-1',
+    status: 'running',
+  } as any;
+  const workflowExecutionRepository = {
+    updateWorkflowExecution: jest.fn(),
+  } as any;
+  const stepExecutionRepository = {
+    createStepExecution: jest.fn(),
+    updateStepExecution: jest.fn(),
+    updateStepExecutions: jest.fn(),
+  } as any;
+  const workflowLogger = { logInfo: jest.fn(), logDebug: jest.fn() } as any;
+
+  const mgr = new WorkflowExecutionRuntimeManager({
+    workflowExecution,
+    workflowExecutionRepository,
+    stepExecutionRepository,
+    workflowExecutionGraph: g,
+    workflowLogger,
+  });
+
+  // Assign fns to avoid type issues with spyOn signatures
+  (mgr as any).startStep = jest.fn(async (_stepId: string) => {});
+  (mgr as any).setStepResult = jest.fn(async (_stepId: string, _result: any) => {});
+  (mgr as any).finishStep = jest.fn(async (_stepId: string) => {});
+  (mgr as any).getCurrentStep = jest.fn().mockReturnValue({ id: 's1' });
+  (mgr as any).getStepResult = jest.fn().mockReturnValue(undefined);
+  (mgr as any).getStepState = jest.fn().mockReturnValue(undefined);
+
+  return mgr;
+};
+
+const createContextManager = (runtime: WorkflowExecutionRuntimeManager) =>
+  new WorkflowContextManager({
+    workflowRunId: 'run-1',
+    workflow: {
+      version: '1',
+      name: 'wf',
+      enabled: true,
+      triggers: [{ type: 'triggers.elastic.manual', enabled: true }],
+      steps: [],
+    } as any,
+    event: { type: 'manual' },
+    workflowExecutionGraph: (runtime as any).workflowExecutionGraph,
+    workflowExecutionRuntime: runtime,
+  });
+
+describe('KbnApiStepImpl', () => {
+  test('returns no-op when with.api is not provided', async () => {
+    const runtime = createRuntime();
+    const ctxMgr = createContextManager(runtime);
+    const services = {} as any;
+
+    const step = new KbnApiStepImpl(
+      {
+        type: 'kibana.request',
+        name: 'kbn',
+        request: { method: 'POST', path: '/api/cases' },
+      } as any,
+      services,
+      ctxMgr,
+      runtime
+    );
+
+    await step.run();
+
+    expect((runtime as any).setStepResult).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ output: undefined, error: undefined })
+    );
+  });
+
+  test('calls cases adapter for cases.create', async () => {
+    const runtime = createRuntime();
+    const ctxMgr = createContextManager(runtime);
+    const services = { cases: { createCase: jest.fn().mockResolvedValue({ id: '1' }) } } as any;
+
+    const step = new KbnApiStepImpl(
+      {
+        type: 'kibana.request',
+        name: 'kbn',
+        request: { method: 'POST', path: '/api/cases' },
+        with: { api: 'cases.create', title: 'T', description: 'D' },
+      } as any,
+      services,
+      ctxMgr,
+      runtime
+    );
+
+    await step.run();
+
+    expect(services.cases.createCase).toHaveBeenCalledWith({ title: 'T', description: 'D' });
+    expect((runtime as any).setStepResult).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ output: { id: '1' }, error: undefined })
+    );
+  });
+
+  test('calls cases adapter for cases.addComment', async () => {
+    const runtime = createRuntime();
+    const ctxMgr = createContextManager(runtime);
+    const services = {
+      cases: { addComment: jest.fn().mockResolvedValue({ id: '1', comment: 'c' }) },
+    } as any;
+
+    const step = new KbnApiStepImpl(
+      {
+        type: 'kibana.request',
+        name: 'kbn',
+        request: { method: 'POST', path: '/api/cases/1/comments' },
+        with: { api: 'cases.addComment', caseId: '1', comment: 'hi' },
+      } as any,
+      services,
+      ctxMgr,
+      runtime
+    );
+
+    await step.run();
+
+    expect(services.cases.addComment).toHaveBeenCalledWith('1', { comment: 'hi' });
+    expect((runtime as any).setStepResult).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ output: { id: '1', comment: 'c' }, error: undefined })
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/kbn_api_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/kbn_api_step.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v 3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { KbnApiRequestStep } from '@kbn/workflows';
+import { WorkflowContextManager } from '../workflow_context_manager/workflow_context_manager';
+import { WorkflowExecutionRuntimeManager } from '../workflow_context_manager/workflow_execution_runtime_manager';
+import { StepBase, RunStepResult } from './step_base';
+import { IWorkflowEventLogger } from '../workflow_event_logger/workflow_event_logger';
+import type { KibanaServiceAdapters } from '../service_adapters/types';
+
+export interface KbnApiStepConfig extends KbnApiRequestStep {
+  type: 'kibana.request';
+  with?: { api?: 'cases.create' | 'cases.addComment' } & Record<string, any>;
+}
+
+export class KbnApiStepImpl extends StepBase<KbnApiStepConfig> {
+  constructor(
+    step: KbnApiStepConfig,
+    private services: KibanaServiceAdapters,
+    contextManager: WorkflowContextManager,
+    workflowExecutionRuntime: WorkflowExecutionRuntimeManager,
+    private workflowLogger?: IWorkflowEventLogger
+  ) {
+    super(step, contextManager, undefined, workflowExecutionRuntime);
+  }
+
+  protected async _run(): Promise<RunStepResult> {
+    const shouldRun = await this.evaluateCondition(this.step.if);
+    if (!shouldRun) {
+      return { output: undefined, error: undefined };
+    }
+
+    const ctx = this.contextManager.getContext();
+    const render = (v: any) => (typeof v === 'string' ? this.templatingEngine.render(v, ctx) : v);
+
+    const api = this.step.with?.api;
+    if (!api) {
+      // Manual-only PoC: do nothing but log
+      this.workflowLogger?.logInfo('kibana.request is manual-only in this PoC');
+      return { output: undefined, error: undefined };
+    }
+
+    try {
+      switch (api) {
+        case 'cases.create': {
+          if (!this.services.cases) throw new Error('Cases service unavailable');
+          const params = { ...(this.step.with || {}) };
+          delete (params as any).api;
+          const rendered = Object.fromEntries(
+            Object.entries(params).map(([k, v]) => [k, render(v)])
+          );
+          this.workflowLogger?.logDebug('Creating case via adapter', {
+            event: { action: api },
+          });
+          const resp = await this.services.cases.createCase(rendered);
+          return { output: resp, error: undefined };
+        }
+        case 'cases.addComment': {
+          if (!this.services.cases) throw new Error('Cases service unavailable');
+          const { caseId, ...rest } = (this.step.with || {}) as any;
+          if (!caseId) throw new Error('with.caseId is required');
+          const renderedCaseId = render(caseId);
+          const rendered = Object.fromEntries(Object.entries(rest).map(([k, v]) => [k, render(v)]));
+          this.workflowLogger?.logDebug('Adding case comment via adapter', {
+            event: { action: api },
+          });
+          const resp = await this.services.cases.addComment(renderedCaseId, rendered);
+          return { output: resp, error: undefined };
+        }
+        default:
+          throw new Error(`Unsupported api: ${api}`);
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      this.workflowLogger?.logError('Kibana request failed', err as any, {
+        event: { action: 'kbn-response', outcome: 'failure' },
+        error: { message: errorMessage },
+      });
+      return { output: undefined, error: errorMessage };
+    }
+  }
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
@@ -29,6 +29,7 @@ export class WorkflowContextManager {
   private context: Record<string, any>; // Make it strongly typed
   private workflowExecutionGraph: graphlib.Graph;
   private workflowExecutionRuntime: WorkflowExecutionRuntimeManager;
+  private esClient?: ElasticsearchClient;
 
   constructor(init: ContextManagerInit) {
     this.context = {
@@ -39,6 +40,7 @@ export class WorkflowContextManager {
 
     this.workflowExecutionGraph = init.workflowExecutionGraph;
     this.workflowExecutionRuntime = init.workflowExecutionRuntime;
+    this.esClient = init.esClient;
   }
 
   public getContext(): Record<string, any> {
@@ -77,5 +79,9 @@ export class WorkflowContextManager {
 
   public getContextKey(key: string): any {
     return this.context[key];
+  }
+
+  public getEsClientAsUser(): ElasticsearchClient | undefined {
+    return this.esClient;
   }
 }

--- a/src/platform/plugins/shared/workflows_management/common/schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/schema.ts
@@ -4,10 +4,15 @@
  * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
  * Public License v 1"; you may not use this file except in compliance with, at
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * License v 3.0 only", or the "Server Side Public License, v 1".
  */
 
 import { generateYamlSchemaFromConnectors } from '@kbn/workflows';
+
+// NOTE:
+// The generated workflow schema now includes built-in API request steps
+// (elasticsearch.request and kibana.request) via generate_yaml_schema wiring.
+// The local connector contracts remain for connector-backed steps.
 
 // TODO: replace with dynamically fetching connectors actions and subactions via ActionsClient or other service once we decide on that.
 

--- a/src/platform/plugins/shared/workflows_management/kibana.jsonc
+++ b/src/platform/plugins/shared/workflows_management/kibana.jsonc
@@ -23,7 +23,8 @@
       "embeddable"
     ],
     "optionalPlugins": [
-      "alerting"
+      "alerting",
+      "console"
     ]
   }
 }

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/yaml_editor/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/yaml_editor/index.tsx
@@ -12,9 +12,20 @@ import { CodeEditor, CodeEditorProps } from '@kbn/code-editor';
 import { configureMonacoYamlSchema } from '@kbn/monaco';
 import { MonacoYamlOptions } from 'monaco-yaml';
 
-interface YamlEditorProps extends Omit<CodeEditorProps, 'languageId'> {
-  schemas: MonacoYamlOptions['schemas'] | null;
+type BaseEditorProps = Omit<CodeEditorProps, 'languageId' | 'value' | 'original' | 'modified'>;
+
+interface YamlEditorSingleProps extends BaseEditorProps {
+  value: string;
 }
+
+interface YamlEditorDiffProps extends BaseEditorProps {
+  original: string;
+  modified: string;
+}
+
+export type YamlEditorProps = (YamlEditorSingleProps | YamlEditorDiffProps) & {
+  schemas: MonacoYamlOptions['schemas'] | null;
+};
 
 export function YamlEditor(props: YamlEditorProps) {
   useEffect(() => {
@@ -23,5 +34,6 @@ export function YamlEditor(props: YamlEditorProps) {
     }
   }, [props.schemas]);
 
-  return <CodeEditor languageId="yaml" {...props} />;
+  const { schemas, ...rest } = props as any;
+  return <CodeEditor languageId="yaml" {...(rest as Omit<CodeEditorProps, 'languageId'>)} />;
 }

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/console_specs/fetcher.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/console_specs/fetcher.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { HttpSetup } from '@kbn/core/public';
+
+// Minimal shape we rely on, taken from Console's /api/console/api_server
+export interface ConsoleSpecDefinitionsResponse {
+  es: {
+    name: string;
+    globals: Record<string, unknown>;
+    endpoints: Record<string, any>;
+  };
+}
+
+let cache: ConsoleSpecDefinitionsResponse | null = null;
+let inflight: Promise<ConsoleSpecDefinitionsResponse> | null = null;
+
+export async function getConsoleSpecs(
+  http?: HttpSetup
+): Promise<ConsoleSpecDefinitionsResponse | null> {
+  if (!http) return null;
+  if (cache) return cache;
+  if (inflight) return inflight;
+
+  inflight = http
+    .get<ConsoleSpecDefinitionsResponse>('/api/console/api_server')
+    .then((resp) => {
+      cache = resp;
+      return resp;
+    })
+    .catch((e) => {
+      // eslint-disable-next-line no-console
+      console.debug('Console specs fetch failed, will fallback to heuristics', e);
+      return null as unknown as ConsoleSpecDefinitionsResponse;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+
+  const result = await inflight;
+  return result ?? null;
+}
+
+export function getCachedConsoleSpecs(): ConsoleSpecDefinitionsResponse | null {
+  return cache;
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/console_specs/indexer.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/console_specs/indexer.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { buildEndpointIndex, findEndpointByMethodAndPath, type EndpointIndex } from './indexer';
+
+describe('console_specs/indexer', () => {
+  const specs = {
+    es: {
+      endpoints: {
+        search: {
+          methods: ['GET', 'POST'],
+          patterns: ['_search', '{index}/_search'],
+          url_params: { q: '' },
+        },
+        cat_indices: {
+          methods: ['GET'],
+          patterns: ['_cat/indices'],
+        },
+      },
+    },
+  } as any;
+
+  it('buildEndpointIndex normalizes and maps endpoints', () => {
+    const idx = buildEndpointIndex(specs);
+    expect(idx.size).toBe(2);
+    const search = idx.get('search');
+    expect(search).toBeDefined();
+    expect(search!.methods).toEqual(['GET', 'POST']);
+    // patterns are normalized to start with '/'
+    expect(search!.patterns).toEqual(['/_search', '/{index}/_search']);
+  });
+
+  it('findEndpointByMethodAndPath matches literal pattern', () => {
+    const idx = buildEndpointIndex(specs);
+    const res = findEndpointByMethodAndPath(idx, 'GET', '/_cat/indices');
+    expect(res.matched).toBe(true);
+    expect(res.endpointName).toBe('cat_indices');
+  });
+
+  it('findEndpointByMethodAndPath matches placeholder pattern', () => {
+    const idx = buildEndpointIndex(specs);
+    const res = findEndpointByMethodAndPath(idx, 'POST', '/myindex/_search');
+    expect(res.matched).toBe(true);
+    expect(res.endpointName).toBe('search');
+  });
+
+  it('findEndpointByMethodAndPath respects method filter', () => {
+    const idx = buildEndpointIndex(specs);
+    const res = findEndpointByMethodAndPath(idx, 'POST', '/_cat/indices');
+    expect(res.matched).toBe(false);
+  });
+
+  it('returns matched=false for unknown endpoint', () => {
+    const idx: EndpointIndex = new Map();
+    const res = findEndpointByMethodAndPath(idx, 'GET', '/_unknown');
+    expect(res.matched).toBe(false);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/console_specs/indexer.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/console_specs/indexer.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v 3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { HttpSetup } from '@kbn/core/public';
+import { getCachedConsoleSpecs, getConsoleSpecs } from './fetcher';
+import type { ConsoleSpecDefinitionsResponse } from './fetcher';
+
+export interface EndpointIndexEntry {
+  methods: string[];
+  patterns: string[]; // e.g. ["_search", "{index}/_search"]
+  url_params?: Record<string, any>;
+}
+
+export type EndpointIndex = Map<string, EndpointIndexEntry>;
+
+function normalizePattern(p: string): string {
+  // Ensure patterns start with '/'
+  return p.startsWith('/') ? p : `/${p}`;
+}
+
+export function buildEndpointIndex(specs: ConsoleSpecDefinitionsResponse | null): EndpointIndex {
+  const index: EndpointIndex = new Map();
+  if (!specs) return index;
+
+  const endpoints = specs.es.endpoints || {};
+  for (const [name, def] of Object.entries<any>(endpoints)) {
+    const methods: string[] = def.methods || [];
+    const patterns: string[] = Array.isArray(def.patterns)
+      ? def.patterns
+      : def.patterns
+      ? [def.patterns]
+      : [];
+    const urlParams = def.url_params;
+
+    const entry: EndpointIndexEntry = {
+      methods,
+      patterns: patterns.map(normalizePattern),
+      url_params: urlParams,
+    };
+
+    index.set(name, entry);
+  }
+
+  return index;
+}
+
+let endpointIndexCache: EndpointIndex | null = null;
+let endpointIndexInflight: Promise<EndpointIndex> | null = null;
+
+export async function getOrBuildEndpointIndex(http?: HttpSetup): Promise<EndpointIndex> {
+  if (endpointIndexCache) return endpointIndexCache;
+  if (endpointIndexInflight) return endpointIndexInflight;
+
+  endpointIndexInflight = (async () => {
+    const cached = getCachedConsoleSpecs();
+    const specs = cached ?? (await getConsoleSpecs(http));
+    const idx = buildEndpointIndex(specs);
+    endpointIndexCache = idx;
+    endpointIndexInflight = null;
+    return idx;
+  })();
+
+  return endpointIndexInflight;
+}
+
+export interface MatchResult {
+  matched: boolean;
+  endpointName?: string;
+  methods?: string[];
+  url_params?: Record<string, any>;
+}
+
+export function findEndpointByMethodAndPath(
+  index: EndpointIndex,
+  method: string,
+  path: string
+): MatchResult {
+  const normPath = normalizePattern(path);
+  // naive: check if the path matches any pattern literally or with simple placeholder replacement
+  for (const [name, entry] of index.entries()) {
+    if (entry.methods.length && !entry.methods.includes(method.toUpperCase())) continue;
+
+    const matches = entry.patterns.some((pat) => {
+      // Convert placeholders like {index} to a wildcard segment matcher
+      const re = new RegExp(
+        '^' + pat.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\{[^}]+\\\}/g, '[^/]+') + '$'
+      );
+      return re.test(normPath);
+    });
+
+    if (matches) {
+      return {
+        matched: true,
+        endpointName: name,
+        methods: entry.methods,
+        url_params: entry.url_params,
+      };
+    }
+  }
+
+  return { matched: false };
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_api_manual_only_markers.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_api_manual_only_markers.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v 3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { monaco } from '@kbn/monaco';
+import { getApiManualOnlyMarkers } from './use_yaml_validation';
+
+describe('getApiManualOnlyMarkers', () => {
+  const dummyModel = {
+    getPositionAt: (offset: number) => ({ lineNumber: 1, column: offset + 1 }),
+  } as unknown as Pick<monaco.editor.ITextModel, 'getPositionAt'>;
+
+  it('returns marker when non-manual trigger and elasticsearch.request step present', () => {
+    const workflow = {
+      triggers: [{ type: 'triggers.elastic.schedule' }],
+      steps: [{ name: 'es', type: 'elasticsearch.request' }],
+    };
+    const text = 'name: es';
+    const markers = getApiManualOnlyMarkers(workflow, text, dummyModel);
+    expect(markers.some((m) => m.source === 'api-steps-manual-only')).toBe(true);
+  });
+
+  it('returns no marker when only manual trigger is present', () => {
+    const workflow = {
+      triggers: [{ type: 'triggers.elastic.manual' }],
+      steps: [{ name: 'es', type: 'elasticsearch.request' }],
+    };
+    const text = 'name: es';
+    const markers = getApiManualOnlyMarkers(workflow, text, dummyModel);
+    expect(markers.some((m) => m.source === 'api-steps-manual-only')).toBe(false);
+  });
+
+  it('returns marker for kibana.request step with non-manual trigger', () => {
+    const workflow = {
+      triggers: [{ type: 'triggers.elastic.schedule' }],
+      steps: [{ name: 'kbn', type: 'kibana.request' }],
+    };
+    const text = 'name: kbn';
+    const markers = getApiManualOnlyMarkers(workflow, text, dummyModel);
+    expect(markers.some((m) => m.source === 'api-steps-manual-only')).toBe(true);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_completion_item_provider.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_completion_item_provider.test.ts
@@ -65,7 +65,7 @@ describe('getCompletionItemProvider', () => {
   const completionProvider = getCompletionItemProvider(workflowSchema);
 
   describe('Integration tests', () => {
-    it('should provide basic completions', () => {
+    it('should provide basic completions', async () => {
       const yamlContent = `
 version: "1"
 name: "test"
@@ -94,7 +94,11 @@ steps:
       );
 
       // Handle both sync and async returns
-      const completionList = result as monaco.languages.CompletionList;
+      const resolved =
+        result && typeof (result as any).then === 'function'
+          ? await (result as Promise<monaco.languages.CompletionList>)
+          : (result as monaco.languages.CompletionList);
+      const completionList = resolved as monaco.languages.CompletionList;
       expect(completionList?.suggestions).toBeDefined();
       expect(completionList?.suggestions.length).toBeGreaterThan(0);
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_completion_item_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_completion_item_provider.ts
@@ -4,17 +4,19 @@
  * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
  * Public License v 1"; you may not use this file except in compliance with, at
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * License v 3.0 only", or the "Server Side Public License, v 1".
  */
 
 import { YAMLParseError, parseDocument } from 'yaml';
 import { monaco } from '@kbn/monaco';
 import { z } from '@kbn/zod';
+import type { HttpSetup } from '@kbn/core/public';
 import _ from 'lodash';
 import { getWorkflowGraph } from '../../../entities/workflows/lib/get_workflow_graph';
 import { getCurrentPath, parseWorkflowYamlToJSON } from '../../../../common/lib/yaml_utils';
 import { getContextForPath } from '../../../features/workflow_context/lib/get_context_for_path';
 import { MUSTACHE_REGEX_GLOBAL, UNFINISHED_MUSTACHE_REGEX_GLOBAL } from './regex';
+import { getOrBuildEndpointIndex } from './console_specs/indexer';
 
 export interface LineParseResult {
   fullKey: string;
@@ -119,12 +121,61 @@ export function getSuggestion(
   };
 }
 
+function isWithinEsApiStep(textBeforeCursor: string): boolean {
+  // Look back for a nearby elasticsearch.request type within the current step block
+  const lines = textBeforeCursor.split('\n').reverse();
+  let indentOfType: number | null = null;
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    const trimmed = line.trimStart();
+    if (!trimmed) continue;
+    const indent = line.length - trimmed.length;
+    if (/^type:\s*["']?elasticsearch\.request["']?\s*$/.test(trimmed)) {
+      indentOfType = indent;
+      return true;
+    }
+    // If we reached a less-indented list item start, we likely left this step
+    if (/^-\s+name:/.test(trimmed) && indentOfType !== null && indent <= indentOfType) {
+      return false;
+    }
+  }
+  return false;
+}
+
+function isKeyOnCurrentLine(lineUpToCursor: string, key: 'method' | 'path'): boolean {
+  const re = new RegExp(`\\b${key}\\s*:\\s*`);
+  return re.test(lineUpToCursor);
+}
+
+function getEsMethodSuggestions(range: monaco.IRange): monaco.languages.CompletionItem[] {
+  const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD'];
+  return methods.map((m) => ({
+    label: m,
+    kind: monaco.languages.CompletionItemKind.Keyword,
+    range,
+    insertText: m,
+    detail: 'HTTP method',
+  }));
+}
+
+function getEsPathSuggestions(range: monaco.IRange): monaco.languages.CompletionItem[] {
+  const paths = ['/_cluster/health', '/_search', '/_cat/indices', '/_cat/health', '/_stats'];
+  return paths.map((p) => ({
+    label: p,
+    kind: monaco.languages.CompletionItemKind.Value,
+    range,
+    insertText: p,
+    detail: 'Elasticsearch endpoint',
+  }));
+}
+
 export function getCompletionItemProvider(
-  workflowYamlSchema: z.ZodSchema
+  workflowYamlSchema: z.ZodSchema,
+  http?: HttpSetup
 ): monaco.languages.CompletionItemProvider {
   return {
-    triggerCharacters: ['@', '.', '{'],
-    provideCompletionItems: (model, position, completionContext) => {
+    triggerCharacters: ['@', '.', '{', '/', '_'],
+    provideCompletionItems: async (model, position, completionContext) => {
       try {
         const { lineNumber } = position;
         const line = model.getLineContent(lineNumber);
@@ -137,29 +188,122 @@ export function getCompletionItemProvider(
           startColumn,
           endColumn,
         };
-        const absolutePosition = model.getOffsetAt(position);
-        const suggestions: monaco.languages.CompletionItem[] = [];
-        const value = model.getValue();
-        const yamlDocument = parseDocument(value);
-        const result = parseWorkflowYamlToJSON(value, workflowYamlSchema);
-        if (result.error) {
-          // Failed to parse YAML into valid definition, skip suggestions
-          return {
-            suggestions: [],
-          };
-        }
-        const workflowGraph = getWorkflowGraph(result.data);
-        const path = getCurrentPath(yamlDocument, absolutePosition);
-        let context = getContextForPath(result.data, workflowGraph, path);
-
         const lineUpToCursor = line.substring(0, position.column - 1);
-        const parseResult = parseLineForCompletion(lineUpToCursor);
-        let scopedContext = context;
 
+        // Parse per-line signals first to avoid heavy work on focus/click
+        const parseResult = parseLineForCompletion(lineUpToCursor);
+
+        // Cheap slice of text before cursor (avoid full getValue unless necessary)
+        const textBeforeCursor = model.getValueInRange({
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: position.lineNumber,
+          endColumn: position.column,
+        });
+
+        // Heuristic ES API suggestions when inside an elasticsearch.request step
+        if (isWithinEsApiStep(textBeforeCursor)) {
+          // Try spec-driven suggestions first if available
+          let usedSpec = false;
+          try {
+            const endpointIndex = await getOrBuildEndpointIndex(http);
+            if (endpointIndex.size > 0) {
+              usedSpec = true;
+              if (isKeyOnCurrentLine(lineUpToCursor, 'method')) {
+                return { suggestions: getEsMethodSuggestions(range) };
+              }
+              if (isKeyOnCurrentLine(lineUpToCursor, 'path')) {
+                const uniquePaths = new Set<string>();
+                for (const entry of endpointIndex.values()) {
+                  for (const p of entry.patterns) uniquePaths.add(p);
+                }
+                const suggestions = [...uniquePaths].slice(0, 200).map((p) => ({
+                  label: p,
+                  kind: monaco.languages.CompletionItemKind.Value,
+                  range,
+                  insertText: p,
+                  detail: 'Elasticsearch endpoint',
+                }));
+                return { suggestions };
+              }
+            }
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.debug('Spec-driven completion failed; falling back to heuristics', e);
+          }
+
+          // Fallback heuristics
+          if (!usedSpec) {
+            if (isKeyOnCurrentLine(lineUpToCursor, 'method')) {
+              return { suggestions: getEsMethodSuggestions(range) };
+            }
+            if (isKeyOnCurrentLine(lineUpToCursor, 'path')) {
+              return { suggestions: getEsPathSuggestions(range) };
+            }
+          }
+        }
+
+        // If there is no relevant trigger/match, bail out early with no suggestions
+        const isTriggeredByChar = completionContext.triggerCharacter != null;
+        if (!isTriggeredByChar && parseResult.matchType === null) {
+          return { suggestions: [] };
+        }
+
+        // Heavy parsing for @/mustache context-aware suggestions
+        const value = model.getValue();
+        const absolutePosition = model.getOffsetAt(position);
+        let yamlDocument: any = null;
+        try {
+          yamlDocument = parseDocument(value);
+        } catch {
+          yamlDocument = null;
+        }
+
+        // Try schema-backed parsing; on failure, fall back to minimal suggestions
+        let workflowData: any | null = null;
+        try {
+          const result = parseWorkflowYamlToJSON(value, workflowYamlSchema);
+          workflowData = result.success ? result.data : null;
+        } catch {
+          workflowData = null;
+        }
+
+        // Minimal context when schema parse fails
+        if (!workflowData) {
+          const suggestions: monaco.languages.CompletionItem[] = [];
+          // Provide top-level roots for @-trigger scenarios
+          ['steps', 'consts', 'inputs', 'event', 'workflow'].forEach((key) => {
+            suggestions.push(getSuggestion(parseResult.fullKey, key, completionContext, range));
+          });
+          return { suggestions };
+        }
+
+        const workflowGraph = getWorkflowGraph(workflowData);
+        const path = yamlDocument ? getCurrentPath(yamlDocument, absolutePosition) : [];
+        let context = getContextForPath(workflowData, workflowGraph, path);
+
+        const suggestions: monaco.languages.CompletionItem[] = [];
+
+        // If context is not an object (e.g., editing inside a scalar), fall back to default roots
+        const provideDefaultRootSuggestions = () => {
+          ['steps', 'consts', 'inputs', 'event', 'workflow'].forEach((key) => {
+            suggestions.push(getSuggestion(parseResult.fullKey, key, completionContext, range));
+          });
+        };
+
+        if (typeof context !== 'object' || context === null) {
+          provideDefaultRootSuggestions();
+          return { suggestions };
+        }
+
+        let scopedContext = context;
         if (parseResult.fullKey) {
           scopedContext = _.get(context, parseResult.fullKey);
           if (typeof scopedContext === 'object' && scopedContext !== null) {
             context = scopedContext;
+          } else {
+            provideDefaultRootSuggestions();
+            return { suggestions };
           }
         }
 
@@ -167,17 +311,14 @@ export function getCompletionItemProvider(
           suggestions.push(getSuggestion(parseResult.fullKey, key, completionContext, range));
         });
 
-        return {
-          suggestions,
-        };
+        return { suggestions };
       } catch (error) {
         if (error instanceof YAMLParseError) {
-          // Failed to parse YAML, skip suggestions
-          return {
-            suggestions: [],
-          };
+          return { suggestions: [] };
         }
-        throw error;
+        // eslint-disable-next-line no-console
+        console.debug('Completion provider error', error);
+        return { suggestions: [] };
       }
     },
   };

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/use_yaml_validation.presence.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/use_yaml_validation.presence.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getEsMethodPathPresenceMarkers } from './use_yaml_validation';
+
+describe('getEsMethodPathPresenceMarkers', () => {
+  const model = {
+    getPositionAt: (offset: number) => ({ lineNumber: 1, column: 1 }),
+  } as any;
+
+  it("warns when 'with.method' is missing", () => {
+    const wf = {
+      steps: [{ name: 'es', type: 'elasticsearch.request', with: { path: '/_search' } }],
+    } as any;
+    const markers = getEsMethodPathPresenceMarkers(wf, 'name: es', model);
+    expect(markers.some((m) => m.message.includes("missing 'with.method'"))).toBe(true);
+  });
+
+  it("warns when 'with.path' is missing", () => {
+    const wf = {
+      steps: [{ name: 'es', type: 'elasticsearch.request', with: { method: 'GET' } }],
+    } as any;
+    const markers = getEsMethodPathPresenceMarkers(wf, 'name: es', model);
+    expect(markers.some((m) => m.message.includes("missing 'with.path'"))).toBe(true);
+  });
+
+  it('skips presence validation when method/path contain mustache', () => {
+    const wf = {
+      steps: [
+        { name: 'es1', type: 'elasticsearch.request', with: { method: '{{ m }}', path: '/_x' } },
+        { name: 'es2', type: 'elasticsearch.request', with: { method: 'GET', path: '{{ p }}' } },
+      ],
+    } as any;
+    const markers = getEsMethodPathPresenceMarkers(wf, 'name: es1\nname: es2', model);
+    expect(markers.length).toBe(0);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/use_yaml_validation.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/use_yaml_validation.test.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useEffect } from 'react';
+import { render, act, waitFor } from '@testing-library/react';
+import { monaco } from '@kbn/monaco';
+import { WORKFLOW_ZOD_SCHEMA_LOOSE } from '../../../../common/schema';
+import { useYamlValidation } from './use_yaml_validation';
+
+let mockCurrentData: any = {};
+
+jest.mock('../../../../common/lib/yaml_utils', () => ({
+  parseWorkflowYamlToJSON: jest.fn((text: string) => ({ success: true, data: mockCurrentData })),
+  getCurrentPath: jest.fn(() => []),
+}));
+
+jest.mock('../../../entities/workflows/lib/get_workflow_graph', () => ({
+  getWorkflowGraph: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../features/workflow_context/lib/get_context_for_path', () => ({
+  getContextForPath: jest.fn(() => ({})),
+}));
+
+function ensureMonacoMocks() {
+  // Ensure monaco.editor object exists
+  (monaco as any).editor = (monaco as any).editor || ({} as any);
+
+  if (!(monaco as any).Range) {
+    (monaco as any).Range = function Range(
+      startLineNumber: number,
+      startColumn: number,
+      endLineNumber: number,
+      endColumn: number
+    ) {
+      return { startLineNumber, startColumn, endLineNumber, endColumn } as any;
+    } as any;
+  }
+  if (!(monaco.editor as any).TrackedRangeStickiness) {
+    (monaco.editor as any).TrackedRangeStickiness = {
+      NeverGrowsWhenTypingAtEdges: 3,
+    } as any;
+  }
+  if (typeof (monaco.editor as any).setModelMarkers !== 'function') {
+    (monaco.editor as any).setModelMarkers = () => undefined;
+  }
+}
+
+function createMockEditor(text: string) {
+  const model = {
+    getValue: () => text,
+    getPositionAt: (offset: number) => {
+      const upTo = text.slice(0, offset);
+      const lines = upTo.split('\n');
+      const lineNumber = lines.length;
+      const column = (lines[lines.length - 1]?.length ?? 0) + 1;
+      return { lineNumber, column };
+    },
+    uri: { path: '/test' },
+  } as any;
+
+  const editor = {
+    getModel: () => model,
+    createDecorationsCollection: () => ({ clear: () => {} }),
+  } as any;
+
+  return editor;
+}
+
+function Harness({ text }: { text: string }) {
+  const { validateVariables } = useYamlValidation({
+    workflowYamlSchema: WORKFLOW_ZOD_SCHEMA_LOOSE,
+  });
+
+  useEffect(() => {
+    ensureMonacoMocks();
+    const editor = createMockEditor(text);
+    // Fire and forget; tests will wait for setModelMarkers to be called
+    void validateVariables(editor);
+  }, [text, validateVariables]);
+
+  return null;
+}
+
+describe('useYamlValidation manual-only API step warning', () => {
+  let setModelMarkersSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    ensureMonacoMocks();
+    setModelMarkersSpy = jest
+      .spyOn(monaco.editor, 'setModelMarkers')
+      .mockImplementation(() => undefined as any);
+  });
+
+  afterEach(() => {
+    setModelMarkersSpy.mockRestore();
+  });
+
+  it('adds a warning marker when non-manual trigger is present with elasticsearch.request step', async () => {
+    mockCurrentData = {
+      version: '1',
+      name: 't',
+      triggers: [{ type: 'triggers.elastic.schedule', cron: '* * * * *' }],
+      steps: [
+        {
+          name: 'es',
+          type: 'elasticsearch.request',
+          with: { method: 'GET', path: '/_cluster/health' },
+        },
+      ],
+    };
+
+    await act(async () => {
+      render(<Harness text={'dummy'} />);
+    });
+
+    await waitFor(() => {
+      expect(setModelMarkersSpy).toHaveBeenCalled();
+    });
+    const lastCall = setModelMarkersSpy.mock.calls[setModelMarkersSpy.mock.calls.length - 1];
+    const markers = lastCall?.[2] as Array<{ message: string; source?: string }>;
+    expect(markers?.some((m) => m.source === 'api-steps-manual-only')).toBe(true);
+    expect(markers?.some((m) => m.message.includes('API steps are manual-only'))).toBe(true);
+  });
+
+  it('does not add the warning when only manual trigger is present', async () => {
+    mockCurrentData = {
+      version: '1',
+      name: 't',
+      triggers: [{ type: 'triggers.elastic.manual' }],
+      steps: [
+        {
+          name: 'es',
+          type: 'elasticsearch.request',
+          with: { method: 'GET', path: '/_cluster/health' },
+        },
+      ],
+    };
+
+    await act(async () => {
+      render(<Harness text={'dummy'} />);
+    });
+
+    await waitFor(() => {
+      expect(setModelMarkersSpy).toHaveBeenCalled();
+    });
+    const lastCall = setModelMarkersSpy.mock.calls[setModelMarkersSpy.mock.calls.length - 1];
+    const markers = lastCall?.[2] as Array<{ source?: string }>;
+    expect(markers?.some((m) => m.source === 'api-steps-manual-only')).toBe(false);
+  });
+
+  it('adds a warning marker for kibana.request step with non-manual trigger', async () => {
+    mockCurrentData = {
+      version: '1',
+      name: 't',
+      triggers: [{ type: 'triggers.elastic.schedule', cron: '* * * * *' }],
+      steps: [
+        {
+          name: 'kbn',
+          type: 'kibana.request',
+          with: { method: 'POST', path: '/api/cases/_find' },
+        },
+      ],
+    };
+
+    await act(async () => {
+      render(<Harness text={'dummy'} />);
+    });
+
+    await waitFor(() => {
+      expect(setModelMarkersSpy).toHaveBeenCalled();
+    });
+    const lastCall = setModelMarkersSpy.mock.calls[setModelMarkersSpy.mock.calls.length - 1];
+    const markers = lastCall?.[2] as Array<{ source?: string; message: string }>;
+    expect(markers?.some((m) => m.source === 'api-steps-manual-only')).toBe(true);
+    expect(markers?.some((m) => m.message.includes('API steps are manual-only'))).toBe(true);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/use_yaml_validation.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/use_yaml_validation.ts
@@ -12,16 +12,19 @@ import { z } from '@kbn/zod';
 import { useCallback, useRef, useState } from 'react';
 import { parseDocument } from 'yaml';
 import _ from 'lodash';
+import type { HttpSetup } from '@kbn/core/public';
 import { getCurrentPath, parseWorkflowYamlToJSON } from '../../../../common/lib/yaml_utils';
 import { YamlValidationError, YamlValidationErrorSeverity } from '../model/types';
 import { MUSTACHE_REGEX_GLOBAL } from './regex';
 import { MarkerSeverity, getSeverityString } from './utils';
 import { getWorkflowGraph } from '../../../entities/workflows/lib/get_workflow_graph';
 import { getContextForPath } from '../../../features/workflow_context/lib/get_context_for_path';
+import { findEndpointByMethodAndPath, getOrBuildEndpointIndex } from './console_specs/indexer';
 
 interface UseYamlValidationProps {
   workflowYamlSchema: z.ZodSchema;
   onValidationErrors?: React.Dispatch<React.SetStateAction<YamlValidationError[]>>;
+  http?: HttpSetup;
 }
 
 const SEVERITY_MAP = {
@@ -30,11 +33,165 @@ const SEVERITY_MAP = {
   info: MarkerSeverity.Hint,
 };
 
+export function getApiManualOnlyMarkers(
+  workflow: any,
+  text: string,
+  model: Pick<monaco.editor.ITextModel, 'getPositionAt'>
+): monaco.editor.IMarkerData[] {
+  const markers: monaco.editor.IMarkerData[] = [];
+  const hasNonManualTrigger = (workflow.triggers ?? []).some(
+    (t: any) => t?.type !== 'triggers.elastic.manual' && t?.enabled !== false
+  );
+  if (!hasNonManualTrigger) return markers;
+
+  const steps: any[] = workflow.steps ?? [];
+  steps.forEach((step: any, index: number) => {
+    if (step?.type === 'elasticsearch.request' || step?.type === 'kibana.request') {
+      const stepName = step?.name ?? `step ${index + 1}`;
+      const search = `name: ${stepName}`;
+      const nameIdx = text.indexOf(search);
+      const startPos = nameIdx >= 0 ? model.getPositionAt(nameIdx) : { lineNumber: 1, column: 1 };
+      const endPos =
+        nameIdx >= 0 ? model.getPositionAt(nameIdx + search.length) : { lineNumber: 1, column: 1 };
+      const message =
+        'API steps are manual-only in this PoC. Remove non-manual triggers or remove API steps.';
+      markers.push({
+        severity: SEVERITY_MAP.warning,
+        message,
+        startLineNumber: (startPos as any).lineNumber,
+        startColumn: (startPos as any).column,
+        endLineNumber: (endPos as any).lineNumber,
+        endColumn: (endPos as any).column,
+        source: 'api-steps-manual-only',
+      });
+    }
+  });
+  return markers;
+}
+
+// Phase 1: Method/path presence validation for elasticsearch.request steps
+export function getEsMethodPathPresenceMarkers(
+  workflow: any,
+  text: string,
+  model: Pick<monaco.editor.ITextModel, 'getPositionAt'>
+): monaco.editor.IMarkerData[] {
+  const markers: monaco.editor.IMarkerData[] = [];
+  const steps: any[] = workflow.steps ?? [];
+
+  const hasMustache = (val: unknown) => {
+    if (typeof val !== 'string') return false;
+    // Reset lastIndex for global regex safety
+    MUSTACHE_REGEX_GLOBAL.lastIndex = 0;
+    return MUSTACHE_REGEX_GLOBAL.test(val);
+  };
+
+  const findAnchorForStep = (step: any, index: number) => {
+    const tryFind = (needle: string) => {
+      const idx = text.indexOf(needle);
+      return idx >= 0 ? model.getPositionAt(idx) : { lineNumber: 1, column: 1 };
+    };
+    if (step?.name) {
+      const search = `name: ${step.name}`;
+      return tryFind(search);
+    }
+    return tryFind('elasticsearch.request');
+  };
+
+  steps.forEach((step: any, index: number) => {
+    if (step?.type !== 'elasticsearch.request') return;
+    const method = step?.with?.method;
+    const path = step?.with?.path;
+
+    const anchor = findAnchorForStep(step, index);
+
+    if (!method || (typeof method === 'string' && method.trim() === '') || hasMustache(method)) {
+      // If method has mustache, skip presence validation
+      if (!hasMustache(method)) {
+        markers.push({
+          severity: SEVERITY_MAP.warning,
+          message: "Elasticsearch API step is missing 'with.method'.",
+          startLineNumber: (anchor as any).lineNumber,
+          startColumn: (anchor as any).column,
+          endLineNumber: (anchor as any).lineNumber,
+          endColumn: (anchor as any).column + 1,
+          source: 'es-api-presence',
+        });
+      }
+    }
+
+    if (!path || (typeof path === 'string' && path.trim() === '') || hasMustache(path)) {
+      // If path has mustache, skip presence validation
+      if (!hasMustache(path)) {
+        markers.push({
+          severity: SEVERITY_MAP.warning,
+          message: "Elasticsearch API step is missing 'with.path'.",
+          startLineNumber: (anchor as any).lineNumber,
+          startColumn: (anchor as any).column,
+          endLineNumber: (anchor as any).lineNumber,
+          endColumn: (anchor as any).column + 1,
+          source: 'es-api-presence',
+        });
+      }
+    }
+  });
+
+  return markers;
+}
+
+async function getEsUnknownEndpointMarkers(
+  workflow: any,
+  text: string,
+  model: Pick<monaco.editor.ITextModel, 'getPositionAt'>,
+  http?: HttpSetup
+): Promise<monaco.editor.IMarkerData[]> {
+  const markers: monaco.editor.IMarkerData[] = [];
+  if (!http) return markers; // console optional; graceful fallback
+
+  const index = await getOrBuildEndpointIndex(http);
+  if (!index || index.size === 0) return markers;
+
+  const hasMustache = (val: unknown) => {
+    if (typeof val !== 'string') return false;
+    MUSTACHE_REGEX_GLOBAL.lastIndex = 0;
+    return MUSTACHE_REGEX_GLOBAL.test(val);
+  };
+
+  const steps: any[] = workflow.steps ?? [];
+  steps.forEach((step: any, i: number) => {
+    if (step?.type !== 'elasticsearch.request') return;
+    const method: string | undefined = step?.with?.method;
+    const path: string | undefined = step?.with?.path;
+
+    if (!method || !path) return;
+    if (hasMustache(method) || hasMustache(path)) return;
+
+    const result = findEndpointByMethodAndPath(index, method, path);
+    if (!result.matched) {
+      const search = step?.name ? `name: ${step.name}` : 'elasticsearch.request';
+      const idx = text.indexOf(search);
+      const startPos = idx >= 0 ? model.getPositionAt(idx) : { lineNumber: 1, column: 1 };
+      const endPos =
+        idx >= 0 ? model.getPositionAt(idx + search.length) : { lineNumber: 1, column: 1 };
+      markers.push({
+        severity: SEVERITY_MAP.warning,
+        message: 'Unknown Elasticsearch endpoint for the selected method + path.',
+        startLineNumber: (startPos as any).lineNumber,
+        startColumn: (startPos as any).column,
+        endLineNumber: (endPos as any).lineNumber,
+        endColumn: (endPos as any).column,
+        source: 'es-api-unknown-endpoint',
+      });
+    }
+  });
+
+  return markers;
+}
+
 export interface UseYamlValidationResult {
   validationErrors: YamlValidationError[] | null;
   validateVariables: (
     editor: monaco.editor.IStandaloneCodeEditor | monaco.editor.IDiffEditor
-  ) => void;
+  ) => Promise<void>;
   handleMarkersChanged: (
     editor: monaco.editor.IStandaloneCodeEditor,
     modelUri: monaco.Uri,
@@ -46,13 +203,14 @@ export interface UseYamlValidationResult {
 export function useYamlValidation({
   workflowYamlSchema,
   onValidationErrors,
+  http,
 }: UseYamlValidationProps): UseYamlValidationResult {
   const [validationErrors, setValidationErrors] = useState<YamlValidationError[] | null>(null);
   const decorationsCollection = useRef<monaco.editor.IEditorDecorationsCollection | null>(null);
 
   // Function to validate mustache expressions and apply decorations
   const validateVariables = useCallback(
-    (editor: monaco.editor.IStandaloneCodeEditor | monaco.editor.IDiffEditor) => {
+    async (editor: monaco.editor.IStandaloneCodeEditor | monaco.editor.IDiffEditor) => {
       const model = editor.getModel();
       if (!model) {
         return;
@@ -65,99 +223,142 @@ export function useYamlValidation({
 
       editor = editor as monaco.editor.IStandaloneCodeEditor;
 
-      const decorations: monaco.editor.IModelDeltaDecoration[] = [];
+      // Always ensure we clear and set markers, even on failures, to avoid stuck UI state
+      const applyMarkers = (markers: monaco.editor.IMarkerData[]) => {
+        try {
+          monaco.editor.setModelMarkers(model, 'mustache-validation', markers);
+        } catch (e) {
+          // noop
+        }
+      };
 
       try {
         const text = model.getValue();
 
-        // Parse the YAML to JSON to get the workflow definition
+        // Parse the YAML to JSON to get the workflow definition (loose schema)
         const result = parseWorkflowYamlToJSON(text, workflowYamlSchema);
-        if (!result.success) {
-          throw new Error('Failed to parse YAML');
-        }
         const yamlDocument = parseDocument(text);
-        const workflowGraph = getWorkflowGraph(result.data);
 
-        // Collect markers to add to the model
+        // Collect markers to add to the model (do this synchronously first)
         const markers: monaco.editor.IMarkerData[] = [];
 
-        const matches = [...text.matchAll(MUSTACHE_REGEX_GLOBAL)];
-        // TODO: check if the variable is inside quouted string or yaml | or > string section
-        for (const match of matches) {
-          const matchStart = match.index ?? 0;
-          const matchEnd = matchStart + match[0].length; // match[0] is the entire {{...}} expression
-
-          // Get the position (line, column) for the match
-          const startPos = model.getPositionAt(matchStart);
-          const endPos = model.getPositionAt(matchEnd);
-
-          let errorMessage: string | null = null;
-          const severity: YamlValidationErrorSeverity = 'warning';
-
-          const path = getCurrentPath(yamlDocument, matchStart);
-          const context = getContextForPath(result.data, workflowGraph, path);
-
-          if (match.groups?.key) {
-            if (!_.get(context, match.groups.key)) {
-              errorMessage = `Variable ${match.groups?.key} is not defined`;
-            }
-          } else {
-            errorMessage = `Variable is not defined`;
-          }
-
-          // Add marker for validation issues
-          if (errorMessage) {
-            markers.push({
-              severity: SEVERITY_MAP[severity],
-              message: errorMessage,
-              startLineNumber: startPos.lineNumber,
-              startColumn: startPos.column,
-              endLineNumber: endPos.lineNumber,
-              endColumn: endPos.column,
-              source: 'mustache-validation',
-            });
-
-            decorations.push({
-              range: new monaco.Range(
-                startPos.lineNumber,
-                startPos.column,
-                endPos.lineNumber,
-                endPos.column
-              ),
-              options: {
-                inlineClassName: 'template-variable-error',
-                stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-              },
-            });
-          } else {
-            decorations.push({
-              range: new monaco.Range(
-                startPos.lineNumber,
-                startPos.column,
-                endPos.lineNumber,
-                endPos.column
-              ),
-              options: {
-                inlineClassName: 'template-variable-valid',
-                stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-              },
-            });
-          }
-        }
-
+        // Clear previous decorations eagerly
         if (decorationsCollection.current) {
           decorationsCollection.current.clear();
+          decorationsCollection.current = null;
         }
-        decorationsCollection.current = editor.createDecorationsCollection(decorations);
 
-        // Set markers on the model for the problems panel
-        monaco.editor.setModelMarkers(model, 'mustache-validation', markers);
+        if (result.success) {
+          const workflowGraph = getWorkflowGraph(result.data);
+
+          // 1) Manual-only API steps warning
+          markers.push(...getApiManualOnlyMarkers(result.data, text, model));
+
+          // 2) ES method/path presence validation (non-blocking)
+          markers.push(...getEsMethodPathPresenceMarkers(result.data, text, model));
+
+          // Compute mustache decorations and variable existence checks
+          const matches = [...text.matchAll(MUSTACHE_REGEX_GLOBAL)];
+          const decorations: monaco.editor.IModelDeltaDecoration[] = [];
+
+          for (const match of matches) {
+            const matchStart = match.index ?? 0;
+            const matchEnd = matchStart + match[0].length; // match[0] is the entire {{...}} expression
+
+            // Get the position (line, column) for the match
+            const startPos = model.getPositionAt(matchStart);
+            const endPos = model.getPositionAt(matchEnd);
+
+            let errorMessage: string | null = null;
+            const severity: YamlValidationErrorSeverity = 'warning';
+
+            const path = getCurrentPath(yamlDocument, matchStart);
+            const context = getContextForPath(result.data, workflowGraph, path);
+
+            if (match.groups?.key) {
+              if (!_.get(context, match.groups.key)) {
+                errorMessage = `Variable ${match.groups?.key} is not defined`;
+              }
+            } else {
+              errorMessage = `Variable is not defined`;
+            }
+
+            // Add marker for validation issues
+            if (errorMessage) {
+              markers.push({
+                severity: SEVERITY_MAP[severity],
+                message: errorMessage,
+                startLineNumber: startPos.lineNumber,
+                startColumn: startPos.column,
+                endLineNumber: endPos.lineNumber,
+                endColumn: endPos.column,
+                source: 'mustache-validation',
+              });
+
+              decorations.push({
+                range: new monaco.Range(
+                  startPos.lineNumber,
+                  startPos.column,
+                  endPos.lineNumber,
+                  endPos.column
+                ),
+                options: {
+                  inlineClassName: 'template-variable-error',
+                  stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+                },
+              });
+            } else {
+              decorations.push({
+                range: new monaco.Range(
+                  startPos.lineNumber,
+                  startPos.column,
+                  endPos.lineNumber,
+                  endPos.column
+                ),
+                options: {
+                  inlineClassName: 'template-variable-valid',
+                  stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+                },
+              });
+            }
+          }
+
+          // Apply decorations
+          if (decorations.length > 0) {
+            decorationsCollection.current = editor.createDecorationsCollection(decorations);
+          }
+
+          // Apply initial markers immediately so UI updates without waiting for async work
+          applyMarkers(markers);
+
+          // 3) ES unknown endpoint validation (non-blocking, spec-driven) — run after initial markers
+          (async () => {
+            try {
+              const unknownEndpointMarkers = await getEsUnknownEndpointMarkers(
+                result.data,
+                text,
+                model,
+                http
+              );
+              if (unknownEndpointMarkers.length > 0) {
+                applyMarkers([...markers, ...unknownEndpointMarkers]);
+              }
+            } catch {
+              // ignore
+            }
+          })();
+        } else {
+          // Schema parse failed: still clear decorations and set empty markers
+          applyMarkers([]);
+        }
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error(error);
+        // Ensure we surface an empty marker set so the footer leaves the initializing state
+        applyMarkers([]);
       }
     },
-    [workflowYamlSchema]
+    [workflowYamlSchema, http]
   );
 
   const handleMarkersChanged = useCallback(
@@ -168,7 +369,7 @@ export function useYamlValidation({
       owner: string
     ) => {
       const editorUri = editor.getModel()?.uri;
-      if (modelUri.path !== editorUri?.path) {
+      if (!editorUri || modelUri.toString() !== editorUri.toString()) {
         return;
       }
 
@@ -176,7 +377,7 @@ export function useYamlValidation({
       for (const marker of markers) {
         errors.push({
           message: marker.message,
-          severity: getSeverityString(marker.severity as MarkerSeverity),
+          severity: getSeverityString((marker.severity as MarkerSeverity) ?? MarkerSeverity.Info),
           lineNumber: marker.startLineNumber,
           column: marker.startColumn,
           owner,

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/use_yaml_validation.unknown_endpoint.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/use_yaml_validation.unknown_endpoint.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useEffect } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { monaco } from '@kbn/monaco';
+import { WORKFLOW_ZOD_SCHEMA_LOOSE } from '../../../../common/schema';
+import { useYamlValidation } from './use_yaml_validation';
+
+jest.mock('../../../../common/lib/yaml_utils', () => ({
+  parseWorkflowYamlToJSON: jest.fn((text: string) => {
+    const hasUnknown = text.includes('/_unknown');
+    const hasMustache = /path:\s*\{\{/.test(text);
+    // crude extraction of method
+    const methodMatch = text.match(/method:\s*(GET|POST|PUT|DELETE|PATCH|HEAD)/);
+    const method = methodMatch ? methodMatch[1] : 'GET';
+    const data = {
+      version: '1',
+      name: 't',
+      triggers: [{ type: 'triggers.elastic.manual' }],
+      steps: [
+        {
+          name: hasUnknown ? 'bad' : 'templ',
+          type: 'elasticsearch.request',
+          with: {
+            method,
+            path: hasMustache ? '{{ some.var }}' : hasUnknown ? '/_unknown' : '/_search',
+          },
+        },
+      ],
+    } as any;
+    return { success: true, data };
+  }),
+  getCurrentPath: jest.fn(() => []),
+}));
+
+jest.mock('../../../entities/workflows/lib/get_workflow_graph', () => ({
+  getWorkflowGraph: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../features/workflow_context/lib/get_context_for_path', () => ({
+  getContextForPath: jest.fn(() => ({})),
+}));
+
+jest.mock('./console_specs/indexer', () => ({
+  getOrBuildEndpointIndex: jest.fn(async () => {
+    const idx = new Map();
+    idx.set('search', { methods: ['GET', 'POST'], patterns: ['/_search', '/{index}/_search'] });
+    return idx;
+  }),
+  findEndpointByMethodAndPath:
+    jest.requireActual('./console_specs/indexer').findEndpointByMethodAndPath,
+}));
+
+function ensureMonacoMocks() {
+  if (!(monaco as any).Range) {
+    (monaco as any).Range = function Range(
+      startLineNumber: number,
+      startColumn: number,
+      endLineNumber: number,
+      endColumn: number
+    ) {
+      return { startLineNumber, startColumn, endLineNumber, endColumn } as any;
+    } as any;
+  }
+  if (!(monaco.editor as any).TrackedRangeStickiness) {
+    (monaco.editor as any).TrackedRangeStickiness = {
+      NeverGrowsWhenTypingAtEdges: 3,
+    } as any;
+  }
+}
+
+function createMockEditor(text: string) {
+  const model = {
+    getValue: () => text,
+    getPositionAt: (offset: number) => {
+      const upTo = text.slice(0, offset);
+      const lines = upTo.split('\n');
+      const lineNumber = lines.length;
+      const column = (lines[lines.length - 1]?.length ?? 0) + 1;
+      return { lineNumber, column };
+    },
+    uri: { path: '/test' },
+  } as any;
+
+  const editor = {
+    getModel: () => model,
+    createDecorationsCollection: () => ({ clear: () => {} }),
+  } as any;
+
+  return editor;
+}
+
+function Harness({ text, http }: { text: string; http: any }) {
+  const { validateVariables } = useYamlValidation({
+    workflowYamlSchema: WORKFLOW_ZOD_SCHEMA_LOOSE,
+    http,
+  });
+
+  useEffect(() => {
+    ensureMonacoMocks();
+    const editor = createMockEditor(text);
+    (async () => {
+      await validateVariables(editor);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text]);
+
+  return null;
+}
+
+describe('unknown endpoint validation', () => {
+  let setModelMarkersSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    ensureMonacoMocks();
+    setModelMarkersSpy = jest
+      .spyOn(monaco.editor, 'setModelMarkers')
+      .mockImplementation(() => undefined as any);
+  });
+
+  afterEach(() => {
+    setModelMarkersSpy.mockRestore();
+  });
+
+  it('adds a non-blocking warning when method+path do not match known endpoints', async () => {
+    const text = `
+version: '1'
+name: t
+triggers:
+  - type: triggers.elastic.manual
+steps:
+  - name: bad
+    type: elasticsearch.request
+    with:
+      method: GET
+      path: /_unknown
+`;
+
+    render(<Harness text={text} http={{}} />);
+
+    await waitFor(() => expect(setModelMarkersSpy).toHaveBeenCalled());
+
+    const lastCall = (setModelMarkersSpy as any).mock.calls[
+      (setModelMarkersSpy as any).mock.calls.length - 1
+    ];
+    const markers = lastCall?.[2] as Array<{ source?: string; message: string }>;
+    expect(markers.some((m) => m.source === 'es-api-unknown-endpoint')).toBe(true);
+    expect(markers.some((m) => m.message.includes('Unknown Elasticsearch endpoint'))).toBe(true);
+  });
+
+  it('skips unknown-endpoint warning when path contains mustache', async () => {
+    const text = `
+version: '1'
+name: t
+triggers:
+  - type: triggers.elastic.manual
+steps:
+  - name: templ
+    type: elasticsearch.request
+    with:
+      method: GET
+      path: {{ some.var }}
+`;
+
+    render(<Harness text={text} http={{}} />);
+
+    await waitFor(() => expect(setModelMarkersSpy).toHaveBeenCalled());
+
+    const lastCall = (setModelMarkersSpy as any).mock.calls[
+      (setModelMarkersSpy as any).mock.calls.length - 1
+    ];
+    const markers = lastCall?.[2] as Array<{ source?: string; message: string }>;
+    expect(markers.some((m) => m.source === 'es-api-unknown-endpoint')).toBe(false);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/index.tsx
@@ -4,16 +4,19 @@
  * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
  * Public License v 1"; you may not use this file except in compliance with, at
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * License v 3.0 only", or the "Server Side Public License, v 1".
  */
 
 import { EuiFlexGroup, EuiFlexItem, UseEuiTheme } from '@elastic/eui';
 import { monaco } from '@kbn/monaco';
-import { getJsonSchemaFromYamlSchema } from '@kbn/workflows';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
-import { WORKFLOW_ZOD_SCHEMA, WORKFLOW_ZOD_SCHEMA_LOOSE } from '../../../../common/schema';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { MonacoYamlOptions } from 'monaco-yaml';
+import type { JSONSchema7 } from 'json-schema';
+import { getJsonSchemaFromYamlSchema } from '@kbn/workflows';
+import { WORKFLOW_ZOD_SCHEMA_LOOSE } from '../../../../common/schema';
 import { YamlEditor } from '../../../shared/ui/yaml_editor';
 import { useYamlValidation } from '../lib/use_yaml_validation';
 import { navigateToErrorPosition } from '../lib/utils';
@@ -21,13 +24,7 @@ import { WorkflowYAMLEditorProps } from '../model/types';
 import { WorkflowYAMLValidationErrors } from './workflow_yaml_validation_errors';
 import { getCompletionItemProvider } from '../lib/get_completion_item_provider';
 
-const WorkflowSchemaUri = 'file:///workflow-schema.json';
-
-const jsonSchema = getJsonSchemaFromYamlSchema(WORKFLOW_ZOD_SCHEMA);
-
-const useWorkflowJsonSchema = () => {
-  return jsonSchema;
-};
+// Note: schema URI and memoized JSON schema unused here; validation uses Zod and monaco schemas elsewhere.
 
 const editorStyles = {
   container: ({ euiTheme }: UseEuiTheme) =>
@@ -58,24 +55,37 @@ export const WorkflowYAMLEditor = ({
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | monaco.editor.IDiffEditor | null>(
     null
   );
+  const completionDisposableRef = useRef<monaco.IDisposable | null>(null);
+  const originalSetModelMarkersRef = useRef<typeof monaco.editor.setModelMarkers | null>(null);
 
-  const workflowJsonSchema = useWorkflowJsonSchema();
-  const schemas = useMemo(() => {
-    return [
-      {
-        fileMatch: ['*'],
-        schema: workflowJsonSchema,
-        uri: WorkflowSchemaUri,
-      },
-    ];
-  }, [workflowJsonSchema]);
+  const { services } = useKibana();
 
   const { validationErrors, validateVariables, handleMarkersChanged } = useYamlValidation({
     workflowYamlSchema: WORKFLOW_ZOD_SCHEMA_LOOSE,
     onValidationErrors,
+    http: services.http,
   });
 
   const [isEditorMounted, setIsEditorMounted] = useState(false);
+
+  // Build JSON schema once and feed it to monaco-yaml to restore original init behavior
+  const yamlSchemas: MonacoYamlOptions['schemas'] = useMemo(() => {
+    try {
+      const jsonSchema = getJsonSchemaFromYamlSchema(
+        WORKFLOW_ZOD_SCHEMA_LOOSE
+      ) as unknown as JSONSchema7;
+      const schemas: MonacoYamlOptions['schemas'] = [
+        {
+          uri: 'kibana://schemas/workflows',
+          fileMatch: ['*'],
+          schema: jsonSchema as unknown as any,
+        },
+      ];
+      return schemas;
+    } catch (e) {
+      return [];
+    }
+  }, []);
 
   const validateMustacheExpressionsEverywhere = useCallback(() => {
     if (editorRef.current) {
@@ -109,17 +119,32 @@ export const WorkflowYAMLEditor = ({
     // Monkey patching to set the initial markers
     // https://github.com/suren-atoyan/monaco-react/issues/70#issuecomment-760389748
     const setModelMarkers = monaco.editor.setModelMarkers;
+    originalSetModelMarkersRef.current = setModelMarkers;
     monaco.editor.setModelMarkers = function (model, owner, markers) {
       setModelMarkers.call(monaco.editor, model, owner, markers);
       handleMarkersChanged(editor, model.uri, markers, owner);
     };
 
-    monaco.languages.registerCompletionItemProvider(
+    // Register completion provider and keep a disposable to clean up later
+    completionDisposableRef.current = monaco.languages.registerCompletionItemProvider(
       'yaml',
-      getCompletionItemProvider(WORKFLOW_ZOD_SCHEMA_LOOSE)
+      getCompletionItemProvider(WORKFLOW_ZOD_SCHEMA_LOOSE, services.http)
     );
 
+    // Proactively set empty markers so footer leaves the initializing state
+    const model = editor.getModel();
+    if (model) {
+      monaco.editor.setModelMarkers(model, 'mustache-validation', []);
+    }
+
     setIsEditorMounted(true);
+
+    // Trigger initial validation immediately after mount
+    try {
+      validateMustacheExpressionsEverywhere();
+    } catch (e) {
+      // noop
+    }
   };
 
   useEffect(() => {
@@ -127,6 +152,21 @@ export const WorkflowYAMLEditor = ({
     if (isEditorMounted && editorRef.current) {
       validateMustacheExpressionsEverywhere();
     }
+
+    return () => {
+      // Cleanup on unmount: dispose completion provider and restore setModelMarkers
+      try {
+        completionDisposableRef.current?.dispose();
+      } catch (e) {
+        // noop
+      }
+      completionDisposableRef.current = null;
+
+      if (originalSetModelMarkersRef.current) {
+        monaco.editor.setModelMarkers = originalSetModelMarkersRef.current;
+        originalSetModelMarkersRef.current = null;
+      }
+    };
   }, [validateMustacheExpressionsEverywhere, isEditorMounted]);
 
   const editorOptions = useMemo<monaco.editor.IStandaloneEditorConstructionOptions>(
@@ -165,8 +205,7 @@ export const WorkflowYAMLEditor = ({
           editorDidMount={handleEditorDidMount}
           onChange={handleChange}
           options={editorOptions}
-          // @ts-expect-error - TODO: fix this
-          schemas={schemas}
+          schemas={yamlSchemas}
           {...props}
         />
       </EuiFlexItem>


### PR DESCRIPTION
This PoC implements elasticsearch.request step type for workflows, enabling Elasticsearch API calls with proper user context and validation.

Key Features:
- elasticsearch.request step with method/path/body/query/headers support
- Integration with Console API specs for validation and autocomplete
- YAML editor enhancements with Monaco schema integration
- Template engine support for dynamic values using Nunjucks
- Real-time validation with async markers for unknown endpoints
- Manual-only execution with proper user permission scoping

Architecture:
- EsApiStepImpl: Executes ES requests using scoped client (asCurrentUser)
- Enhanced YAML editor with spec-driven autocomplete and validation
- Extended Zod schemas in @kbn/workflows for new step types
- Comprehensive unit and integration tests

Testing:
- Unit tests for all step implementations and validation logic
- E2E test plan with sample workflows and data setup
- Editor behavior tests for autocomplete and validation

## Summary

This PoC implements **internal actions** for workflows, enabling workflows to execute Elasticsearch API calls with proper user context and validation. 

## What's Implemented as part of this POC

### 1. Elasticsearch Request Steps (`elasticsearch.request`)
- **Full ES API Access**: Method/path/body/query/headers support for any ES endpoint
- **Console Integration**: Leverages existing Console API specs for validation & autocomplete  
- **Secure Execution**: All requests use `asCurrentUser` context

## 📝 Example Workflows

### create an index, bulk index some docs, search the docs, and console log the result 
```yaml
version: '1'
name: 'e2e: create, bulk, search, log'
settings:
  templating:
    engine: nunjucks
triggers:
  - type: 'triggers.elastic.manual'
    enabled: true
steps:
  - name: createIndex
    type: 'elasticsearch.request'
    request:
      method: PUT
      path: /workflows_e2e_articles2
      body:
        settings:
          number_of_shards: 1
          number_of_replicas: 0
        mappings:
          properties:
            title: { type: text }
            category: { type: keyword }
            created_at: { type: date }
            content: { type: text }

  - name: bulkIndexDocs
    type: 'elasticsearch.request'
    request:
      method: POST
      path: /_bulk
      query:
        refresh: true
      headers:
        Content-Type: application/x-ndjson
      body: |
        {"index":{"_index":"workflows_e2e_articles2","_id":"1"}}
        {"title":"First news","category":"news","created_at":"2025-08-12T10:00:00Z","content":"First content"}
        {"index":{"_index":"workflows_e2e_articles2","_id":"2"}}
        {"title":"Second news","category":"news","created_at":"2025-08-12T11:00:00Z","content":"Second content"}
        {"index":{"_index":"workflows_e2e_articles2","_id":"3"}}
        {"title":"Tech update","category":"tech","created_at":"2025-08-12T12:00:00Z","content":"Tech content"}

  - name: searchNews
    type: 'elasticsearch.request'
    request:
      method: GET
      path: /workflows_e2e_articles2/_search
      body:
        size: 5
        sort:
          - created_at: desc
        query:
          term:
            category: news

  - name: logResults
    type: 'console'
    with:
      message: |
        Found {{ steps.searchNews.body.hits.total.value }} docs in "news".
        Top hits (sources): {{ steps.searchNews.body.hits.hits }}
```

## Files Changed

**Core Engine:**
- `workflows_execution_engine/server/step/es_api_step.ts` - ES request execution
- `workflows_execution_engine/server/step/step_factory.ts` - Step type routing

**Schema & Validation:**  
- `kbn-workflows/spec/schema.ts` - Extended Zod schemas for new step types
- `kbn-workflows/spec/lib/generate_yaml_schema.ts` - JSON Schema generation
