### PR TITLE
[Search][FTR] fix index details es3 tests

### DIFF
--- a/x-pack/solutions/search/test/functional_search/tests/search_index_details.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/search_index_details.ts
@@ -193,17 +193,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             );
           });
         });
-        describe('With dense vecotrs', () => {
+        describe('With dense vectors', () => {
           it('should have ai quick stats for index with semantic mappings', async () => {
             await pageObjects.searchNavigation.navigateToIndexDetailPage(indexWithDenseVectorName);
             await pageObjects.searchIndexDetailsPage.expectQuickStatsAIMappingsToHaveVectorFields();
           });
         });
         describe('has index actions enabled', () => {
-          before(async () => {
-            await pageObjects.searchNavigation.navigateToIndexDetailPage(indexWithDenseVectorName);
-          });
-
           beforeEach(async () => {
             await pageObjects.searchNavigation.navigateToIndexDetailPage(indexWithDenseVectorName);
           });

--- a/x-pack/solutions/search/test/serverless/functional/page_objects/svl_search_index_detail_page.ts
+++ b/x-pack/solutions/search/test/serverless/functional/page_objects/svl_search_index_detail_page.ts
@@ -139,6 +139,12 @@ export function SvlSearchIndexDetailPageProvider({ getService }: FtrProviderCont
       ).findByClassName('euiTitle');
       expect(await pageLoadErrorElement.getVisibleText()).to.contain('Not Found');
     },
+    async hasPageReloadButton() {
+      await testSubjects.existOrFail('reloadButton');
+    },
+    async pageReloadButtonIsVisible() {
+      return testSubjects.isDisplayed('reloadButton');
+    },
     async clickPageReload() {
       await retry.tryForTime(60 * 1000, async () => {
         await testSubjects.click('reloadButton', 2000);
@@ -289,6 +295,13 @@ export function SvlSearchIndexDetailPageProvider({ getService }: FtrProviderCont
       await testSubjects.existOrFail('indexDetailsMappingsAddField');
       const isMappingsFieldEnabled = await testSubjects.isEnabled('indexDetailsMappingsAddField');
       expect(isMappingsFieldEnabled).to.be(true);
+    },
+
+    async dismissIngestTourIfShown() {
+      if (await testSubjects.isDisplayed('searchIngestTourCloseButton')) {
+        await testSubjects.click('searchIngestTourCloseButton');
+        await testSubjects.missingOrFail('searchIngestTourCloseButton', { timeout: 2000 });
+      }
     },
   };
 }

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/search_index_detail.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/search_index_detail.ts
@@ -7,6 +7,12 @@
 import type { FtrProviderContext } from '../ftr_provider_context';
 import { testHasEmbeddedConsole } from './embedded_console';
 
+const archivedBooksIndex = 'x-pack/solutions/search/test/functional_search/fixtures/search-books';
+const archiveEmptyIndex =
+  'x-pack/solutions/search/test/functional_search/fixtures/search-empty-index';
+const archiveDenseVectorIndex =
+  'x-pack/solutions/search/test/functional_search/fixtures/search-national-parks';
+
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const pageObjects = getPageObjects([
     'svlCommonPage',
@@ -19,107 +25,77 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   ]);
   const svlSearchNavigation = getService('svlSearchNavigation');
   const es = getService('es');
-  const security = getService('security');
+  const esArchiver = getService('esArchiver');
   const browser = getService('browser');
   const retry = getService('retry');
 
   const esDeleteAllIndices = getService('esDeleteAllIndices');
-  const indexName = 'test-my-index';
 
-  // Failing: See https://github.com/elastic/kibana/issues/203508
-  // Failing: See https://github.com/elastic/kibana/issues/203508
-  describe.skip('index details page - search solution', function () {
+  const indexWithDataName = 'search-books';
+  const indexWithoutDataName = 'search-empty-index';
+  const indexWithDenseVectorName = 'search-national-parks';
+  const indexDoesNotExistName = 'search-not-found';
+
+  const createIndices = async () => {
+    await esArchiver.load(archivedBooksIndex);
+    await esArchiver.load(archiveDenseVectorIndex);
+    await esArchiver.load(archiveEmptyIndex);
+  };
+  const deleteIndices = async () => {
+    await esArchiver.unload(archivedBooksIndex);
+    await esArchiver.unload(archiveDenseVectorIndex);
+    await esArchiver.unload(archiveEmptyIndex);
+    await esDeleteAllIndices([indexDoesNotExistName]);
+  };
+
+  describe('index details page - search solution', function () {
+    before(async () => {
+      await createIndices();
+    });
+
+    after(async () => {
+      await deleteIndices();
+    });
     describe('developer', function () {
       before(async () => {
         await pageObjects.svlCommonPage.loginWithRole('developer');
         await pageObjects.svlApiKeys.deleteAPIKeys();
       });
-      after(async () => {
-        await esDeleteAllIndices(indexName);
-      });
       describe('search index details page', () => {
         before(async () => {
-          await es.indices.create({ index: indexName });
-          await svlSearchNavigation.navigateToIndexDetailPage(indexName);
-        });
-        after(async () => {
-          await esDeleteAllIndices(indexName);
+          await svlSearchNavigation.navigateToIndexDetailPage(indexWithoutDataName);
         });
         it('can load index detail page', async () => {
           await pageObjects.svlSearchIndexDetailPage.expectIndexDetailPageHeader();
           await pageObjects.svlSearchIndexDetailPage.expectSearchIndexDetailsTabsExists();
+          await pageObjects.svlSearchIndexDetailPage.dismissIngestTourIfShown();
           await pageObjects.svlSearchIndexDetailPage.expectAPIReferenceDocLinkExists();
           await pageObjects.svlSearchIndexDetailPage.expectAPIReferenceDocLinkMissingInMoreOptions();
         });
         it('should have embedded dev console', async () => {
           await testHasEmbeddedConsole(pageObjects);
         });
+
+        it('should have breadcrumb navigation', async () => {
+          await pageObjects.svlSearchIndexDetailPage.expectBreadcrumbNavigationWithIndexName(
+            indexWithoutDataName
+          );
+          await pageObjects.svlSearchIndexDetailPage.clickOnIndexManagementBreadcrumb();
+          await pageObjects.indexManagement.expectToBeOnIndexManagement();
+          await svlSearchNavigation.navigateToIndexDetailPage(indexWithoutDataName);
+        });
+
         it('should have connection details', async () => {
           await pageObjects.svlSearchIndexDetailPage.expectConnectionDetails();
         });
 
-        describe('check code example texts', () => {
-          const indexNameCodeExample = 'test-my-index2';
-          before(async () => {
-            await es.indices.create({ index: indexNameCodeExample });
-            await svlSearchNavigation.navigateToIndexDetailPage(indexNameCodeExample);
-          });
-
-          after(async () => {
-            await esDeleteAllIndices(indexNameCodeExample);
-          });
-
-          it('should have basic example texts', async () => {
-            await pageObjects.svlSearchIndexDetailPage.expectHasSampleDocuments();
-          });
-        });
-
-        describe('API key details', () => {
-          // see details: https://github.com/elastic/kibana/issues/208695
-          this.tags(['failsOnMKI']);
-          it('should show api key', async () => {
-            await pageObjects.svlApiKeys.deleteAPIKeys();
-            await svlSearchNavigation.navigateToIndexDetailPage(indexName);
-            // sometimes the API key exists in the cluster and its lost in sessionStorage
-            // if fails we retry to delete the API key and refresh the browser
-            await retry.try(
-              async () => {
-                await pageObjects.svlApiKeys.expectAPIKeyExists();
-              },
-              async () => {
-                await pageObjects.svlApiKeys.deleteAPIKeys();
-                await browser.refresh();
-              }
-            );
-            await pageObjects.svlApiKeys.expectAPIKeyAvailable();
-            const apiKey = await pageObjects.svlApiKeys.getAPIKeyFromUI();
-            await pageObjects.svlSearchIndexDetailPage.expectAPIKeyToBeVisibleInCodeBlock(apiKey);
-          });
+        it('should have basic example texts', async () => {
+          await pageObjects.svlSearchIndexDetailPage.expectHasSampleDocuments();
         });
 
         it('should have quick stats', async () => {
           await pageObjects.svlSearchIndexDetailPage.expectQuickStats();
           await pageObjects.svlSearchIndexDetailPage.expectQuickStatsAIMappings();
-          await es.indices.putMapping({
-            index: indexName,
-            properties: {
-              my_field: {
-                type: 'dense_vector',
-                dims: 3,
-              },
-            },
-          });
-          await svlSearchNavigation.navigateToIndexDetailPage(indexName);
-          await pageObjects.svlSearchIndexDetailPage.expectQuickStatsAIMappingsToHaveVectorFields();
-        });
-
-        it('should have breadcrumb navigation', async () => {
-          await pageObjects.svlSearchIndexDetailPage.expectBreadcrumbNavigationWithIndexName(
-            indexName
-          );
-          await pageObjects.svlSearchIndexDetailPage.clickOnIndexManagementBreadcrumb();
-          await pageObjects.indexManagement.expectToBeOnIndexManagement();
-          await svlSearchNavigation.navigateToIndexDetailPage(indexName);
         });
 
         it('should show code examples for adding documents', async () => {
@@ -142,14 +118,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         describe('With data', () => {
           before(async () => {
-            await es.index({
-              index: indexName,
-              refresh: true,
-              body: {
-                my_field: [1, 0, 1],
-              },
-            });
-            await svlSearchNavigation.navigateToIndexDetailPage(indexName);
+            await svlSearchNavigation.navigateToIndexDetailPage(indexWithDataName);
           });
           it('should have index documents', async () => {
             await pageObjects.svlSearchIndexDetailPage.expectHasIndexDocuments();
@@ -161,8 +130,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             await pageObjects.svlSearchIndexDetailPage.clickMoreOptionsActionsButton();
             await pageObjects.svlSearchIndexDetailPage.expectAPIReferenceDocLinkExistsInMoreOptions();
           });
-          it('should have one document in quick stats', async () => {
-            await pageObjects.svlSearchIndexDetailPage.expectQuickStatsToHaveDocumentCount(1);
+          it('should have documents in quick stats', async () => {
+            await pageObjects.svlSearchIndexDetailPage.expectQuickStatsToHaveDocumentCount(46);
           });
           it('should have with data tabs', async () => {
             await pageObjects.svlSearchIndexDetailPage.expectTabsExists();
@@ -181,23 +150,35 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           it('should be able to delete document', async () => {
             await pageObjects.svlSearchIndexDetailPage.changeTab('dataTab');
             await pageObjects.svlSearchIndexDetailPage.clickFirstDocumentDeleteAction();
-            await pageObjects.svlSearchIndexDetailPage.expectAddDocumentCodeExamples();
-            await pageObjects.svlSearchIndexDetailPage.expectQuickStatsToHaveDocumentCount(0);
+
+            // re-open page to refresh queries for test (these will auto-refresh,
+            // but waiting for that will make this test flakey)
+            await browser.refresh();
+            await retry.tryWithRetries(
+              'Wait for document count to update',
+              async () => {
+                await pageObjects.svlSearchIndexDetailPage.expectQuickStatsToHaveDocumentCount(45);
+              },
+              {
+                retryCount: 5,
+                retryDelay: 1000,
+              },
+              async () => {
+                await browser.refresh();
+              }
+            );
           });
         });
-        describe('has index actions enabled', () => {
-          before(async () => {
-            await es.index({
-              index: indexName,
-              body: {
-                my_field: [1, 0, 1],
-              },
-            });
-            await svlSearchNavigation.navigateToIndexDetailPage(indexName);
+        describe('With dense vectors', () => {
+          it('should have ai quick stats for index with semantic mappings', async () => {
+            await svlSearchNavigation.navigateToIndexDetailPage(indexWithDenseVectorName);
+            await pageObjects.svlSearchIndexDetailPage.expectQuickStatsAIMappingsToHaveVectorFields();
           });
+        });
 
+        describe('has index actions enabled', () => {
           beforeEach(async () => {
-            await svlSearchNavigation.navigateToIndexDetailPage(indexName);
+            await svlSearchNavigation.navigateToIndexDetailPage(indexWithDenseVectorName);
           });
 
           it('delete document button is enabled', async () => {
@@ -222,22 +203,36 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         describe('page loading error', () => {
           before(async () => {
-            await svlSearchNavigation.navigateToIndexDetailPage(indexName);
-            await esDeleteAllIndices(indexName);
+            // manually navigate to index detail page for an index that doesn't exist
+            await pageObjects.common.navigateToApp(
+              `elasticsearch/indices/index_details/${indexDoesNotExistName}`,
+              {
+                shouldLoginIfPrompted: false,
+              }
+            );
           });
           it('has page load error section', async () => {
             await pageObjects.svlSearchIndexDetailPage.expectPageLoadErrorExists();
             await pageObjects.svlSearchIndexDetailPage.expectIndexNotFoundErrorExists();
           });
           it('reload button shows details page again', async () => {
-            await es.indices.create({ index: indexName });
-            await pageObjects.svlSearchIndexDetailPage.clickPageReload();
-            await pageObjects.svlSearchIndexDetailPage.expectIndexDetailPageHeader();
+            await es.indices.create({ index: indexDoesNotExistName });
+            await retry.tryForTime(
+              30 * 1000,
+              async () => {
+                if (await pageObjects.svlSearchIndexDetailPage.pageReloadButtonIsVisible()) {
+                  await pageObjects.svlSearchIndexDetailPage.clickPageReload();
+                }
+                await pageObjects.svlSearchIndexDetailPage.expectIndexDetailPageHeader();
+              },
+              undefined,
+              1000
+            );
           });
         });
         describe('Index more options menu', () => {
           before(async () => {
-            await svlSearchNavigation.navigateToIndexDetailPage(indexName);
+            await svlSearchNavigation.navigateToIndexDetailPage(indexWithDenseVectorName);
           });
           it('shows action menu in actions popover', async () => {
             await pageObjects.svlSearchIndexDetailPage.expectMoreOptionsActionButtonExists();
@@ -252,22 +247,15 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         });
       });
       describe('index management index list page', () => {
-        before(async () => {
-          await es.indices.create({ index: indexName });
-          await security.testUser.setRoles(['index_management_user']);
-        });
         beforeEach(async () => {
           await pageObjects.common.navigateToApp('indexManagement');
           // Navigate to the indices tab
           await pageObjects.indexManagement.changeTabs('indicesTab');
           await pageObjects.header.waitUntilLoadingHasFinished();
         });
-        after(async () => {
-          await esDeleteAllIndices(indexName);
-        });
         describe('manage index action', () => {
           beforeEach(async () => {
-            await pageObjects.indexManagement.manageIndex(indexName);
+            await pageObjects.indexManagement.manageIndex(indexWithoutDataName);
             await pageObjects.indexManagement.manageIndexContextMenuExists();
           });
           it('navigates to overview tab', async () => {
@@ -287,38 +275,16 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             await pageObjects.svlSearchIndexDetailPage.expectUrlShouldChangeTo('mappings');
           });
         });
-        describe('can view search index details', function () {
-          it('renders search index details with no documents', async () => {
-            await pageObjects.svlSearchIndexDetailPage.openIndicesDetailFromIndexManagementIndicesListTable(
-              0
-            );
-            await pageObjects.svlSearchIndexDetailPage.expectIndexDetailPageHeader();
-            await pageObjects.svlSearchIndexDetailPage.expectSearchIndexDetailsTabsExists();
-            await pageObjects.svlSearchIndexDetailPage.expectAPIReferenceDocLinkExists();
-          });
-        });
       });
     });
 
     describe('viewer', function () {
-      before(async () => {
-        await esDeleteAllIndices(indexName);
-        await es.index({
-          index: indexName,
-          body: {
-            my_field: [1, 0, 1],
-          },
-        });
-      });
-      after(async () => {
-        await esDeleteAllIndices(indexName);
-      });
       describe('search index details page', function () {
         before(async () => {
           await pageObjects.svlCommonPage.loginAsViewer();
         });
         beforeEach(async () => {
-          await svlSearchNavigation.navigateToIndexDetailPage(indexName);
+          await svlSearchNavigation.navigateToIndexDetailPage(indexWithDataName);
         });
         it('delete document button is disabled', async () => {
           await pageObjects.svlSearchIndexDetailPage.expectDeleteDocumentActionIsDisabled();


### PR DESCRIPTION
## Summary

Removing the API related tests from index details (they are flakey) 

Aligned ES3 tests with updates stateful tests that pre-creates indices instead of creating and destroying indices during tests. this should allow them to be more reliable.

### Checklist


- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
