### PR TITLE
[8.18] [UII] Add `index.mapping.ignore_malformed: true` to transform index template settings (#232439)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/install.ts
@@ -532,10 +532,16 @@ const installTransformsAssets = async (
               componentTemplates,
               indexTemplate: {
                 templateName: destinationIndexTemplate.installationName,
-                // @ts-expect-error data_stream property is not needed here
+                // @ts-expect-error `data_stream` property is not needed/allowed for transform index templates
                 indexTemplate: {
                   template: {
-                    settings: undefined,
+                    settings: {
+                      index: {
+                        mapping: {
+                          ignore_malformed: true,
+                        },
+                      },
+                    },
                     mappings: undefined,
                   },
                   priority: DEFAULT_TRANSFORM_TEMPLATES_PRIORITY,

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/transforms.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/transforms.test.ts
@@ -392,13 +392,13 @@ _meta:
             priority: 250,
             template: {
               mappings: undefined,
-                settings: {
-                  index: {
-                    mapping: {
-                      ignore_malformed: true,
-                    },
+              settings: {
+                index: {
+                  mapping: {
+                    ignore_malformed: true,
                   },
                 },
+              },
             },
             ignore_missing_component_templates: ['logs-endpoint.metadata_current-template@custom'],
           },
@@ -685,13 +685,13 @@ _meta:
             priority: 250,
             template: {
               mappings: undefined,
-                settings: {
-                  index: {
-                    mapping: {
-                      ignore_malformed: true,
-                    },
+              settings: {
+                index: {
+                  mapping: {
+                    ignore_malformed: true,
                   },
                 },
+              },
             },
             ignore_missing_component_templates: ['logs-endpoint.metadata_current-template@custom'],
           },
@@ -955,13 +955,13 @@ _meta:
             priority: 250,
             template: {
               mappings: undefined,
-                settings: {
-                  index: {
-                    mapping: {
-                      ignore_malformed: true,
-                    },
+              settings: {
+                index: {
+                  mapping: {
+                    ignore_malformed: true,
                   },
                 },
+              },
             },
             ignore_missing_component_templates: ['logs-endpoint.metadata_current-template@custom'],
           },

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/transforms.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/transforms.test.ts
@@ -390,7 +390,16 @@ _meta:
             ],
             index_patterns: ['.metrics-endpoint.metadata_united_default'],
             priority: 250,
-            template: { mappings: undefined, settings: undefined },
+            template: {
+              mappings: undefined,
+                settings: {
+                  index: {
+                    mapping: {
+                      ignore_malformed: true,
+                    },
+                  },
+                },
+            },
             ignore_missing_component_templates: ['logs-endpoint.metadata_current-template@custom'],
           },
           name: 'logs-endpoint.metadata_current-template',
@@ -674,7 +683,16 @@ _meta:
             ],
             index_patterns: ['.metrics-endpoint.metadata_united_default'],
             priority: 250,
-            template: { mappings: undefined, settings: undefined },
+            template: {
+              mappings: undefined,
+                settings: {
+                  index: {
+                    mapping: {
+                      ignore_malformed: true,
+                    },
+                  },
+                },
+            },
             ignore_missing_component_templates: ['logs-endpoint.metadata_current-template@custom'],
           },
           name: 'logs-endpoint.metadata_current-template',
@@ -935,7 +953,16 @@ _meta:
             ],
             index_patterns: ['.metrics-endpoint.metadata_united_default'],
             priority: 250,
-            template: { mappings: undefined, settings: undefined },
+            template: {
+              mappings: undefined,
+                settings: {
+                  index: {
+                    mapping: {
+                      ignore_malformed: true,
+                    },
+                  },
+                },
+            },
             ignore_missing_component_templates: ['logs-endpoint.metadata_current-template@custom'],
           },
           name: 'logs-endpoint.metadata_current-template',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[UII] Add `index.mapping.ignore_malformed: true` to transform index template settings (#232439)](https://github.com/elastic/kibana/pull/232439)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2025-08-21T09:15:25Z","message":"[UII] Add `index.mapping.ignore_malformed: true` to transform index template settings (#232439)\n\n## Summary\n\nResolves #179445. Does what it says on the tin :)\n\n## Release note\nTransform index templates installed by Fleet will now have the\n`index.mapping.ignore_malformed: true` setting set. This resolves issues\nwhere transforms can enter a failed state due to invalid values in the\nsource index.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"908e4d8ccb42a3b2ae8203f0c8072d56a4471862","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:all-open","v9.2.0","v9.1.3"],"title":"[UII] Add `index.mapping.ignore_malformed: true` to transform index template settings","number":232439,"url":"https://github.com/elastic/kibana/pull/232439","mergeCommit":{"message":"[UII] Add `index.mapping.ignore_malformed: true` to transform index template settings (#232439)\n\n## Summary\n\nResolves #179445. Does what it says on the tin :)\n\n## Release note\nTransform index templates installed by Fleet will now have the\n`index.mapping.ignore_malformed: true` setting set. This resolves issues\nwhere transforms can enter a failed state due to invalid values in the\nsource index.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"908e4d8ccb42a3b2ae8203f0c8072d56a4471862"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232439","number":232439,"mergeCommit":{"message":"[UII] Add `index.mapping.ignore_malformed: true` to transform index template settings (#232439)\n\n## Summary\n\nResolves #179445. Does what it says on the tin :)\n\n## Release note\nTransform index templates installed by Fleet will now have the\n`index.mapping.ignore_malformed: true` setting set. This resolves issues\nwhere transforms can enter a failed state due to invalid values in the\nsource index.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"908e4d8ccb42a3b2ae8203f0c8072d56a4471862"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232453","number":232453,"state":"MERGED","mergeCommit":{"sha":"fd3254e52650ea987cab7b99d7608863eb32c2a0","message":"[9.1] [UII] Add `index.mapping.ignore_malformed: true` to transform index template settings (#232439) (#232453)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[UII] Add `index.mapping.ignore_malformed: true` to transform index\ntemplate settings\n(#232439)](https://github.com/elastic/kibana/pull/232439)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jen Huang <its.jenetic@gmail.com>"}}]}] BACKPORT-->