### PR TITLE
[ONWEEK] Background search indicator research

### DIFF
--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/fetch/publishes_search_session.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/fetch/publishes_search_session.ts
@@ -11,6 +11,7 @@ import type { PublishingSubject } from '../../publishing_subject';
 
 export interface PublishesSearchSession {
   searchSessionId$: PublishingSubject<string | undefined>;
+  searchSessionIdFromUrl$: PublishingSubject<string | undefined>;
 }
 
 export const apiPublishesSearchSession = (

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -214,7 +214,7 @@ export function getDashboardApi({
     type: DASHBOARD_API_TYPE as 'dashboard',
     uuid: v4(),
     getPassThroughContext: () => creationOptions?.getPassThroughContext?.(),
-  } as Omit<DashboardApi, 'searchSessionId$'>;
+  } as Omit<DashboardApi, 'searchSessionId$' | 'searchSessionIdFromUrl$'>;
 
   const internalApi: DashboardInternalApi = {
     ...layoutManager.internalApi,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/search_sessions/search_session_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/search_sessions/search_session_manager.ts
@@ -16,10 +16,11 @@ import { startDashboardSearchSessionIntegration } from './start_dashboard_search
 export function initializeSearchSessionManager(
   searchSessionSettings: DashboardCreationOptions['searchSessionSettings'],
   incomingEmbeddable: EmbeddablePackageState | undefined,
-  dashboardApi: Omit<DashboardApi, 'searchSessionId$'>,
+  dashboardApi: Omit<DashboardApi, 'searchSessionId$' | 'searchSessionIdFromUrl'>,
   dashboardInternalApi: DashboardInternalApi
 ) {
   const searchSessionId$ = new BehaviorSubject<string | undefined>(undefined);
+  const searchSessionIdFromUrl$ = new BehaviorSubject<string | undefined>(undefined);
 
   let stopSearchSessionIntegration: (() => void) | undefined;
   if (searchSessionSettings) {
@@ -31,6 +32,7 @@ export function initializeSearchSessionManager(
     }
     if (sessionIdToRestore) {
       dataService.search.session.restore(sessionIdToRestore);
+      searchSessionIdFromUrl$.next(sessionIdToRestore);
     }
     const existingSession = dataService.search.session.getSessionId();
 
@@ -54,6 +56,7 @@ export function initializeSearchSessionManager(
   return {
     api: {
       searchSessionId$,
+      searchSessionIdFromUrl$,
     },
     cleanup: () => {
       stopSearchSessionIntegration?.();

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -29,6 +29,7 @@ import type { TopNavMenuBadgeProps, TopNavMenuProps } from '@kbn/navigation-plug
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
 import { LazyLabsFlyout, withSuspense } from '@kbn/presentation-util-plugin/public';
 import { MountPointPortal } from '@kbn/react-kibana-mount';
+import useObservable from 'react-use/lib/useObservable';
 
 import { DASHBOARD_APP_ID, UI_SETTINGS } from '../../common/constants';
 import { useDashboardApi } from '../dashboard_api/use_dashboard_api';
@@ -108,6 +109,8 @@ export function InternalDashboardTopNav({
 
   const [savedQueryId, setSavedQueryId] = useState<string | undefined>();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const searchSessionId = useObservable(dashboardApi.searchSessionId$);
+  const searchSessionIdFromUrl = useObservable(dashboardApi.searchSessionIdFromUrl$);
 
   const dashboardTitle = useMemo(() => {
     return getDashboardTitle(title, viewMode, !lastSavedId);
@@ -357,6 +360,8 @@ export function InternalDashboardTopNav({
           ref={dashboardTitleRef}
         >{`${getDashboardBreadcrumb()} - ${dashboardTitle}`}</h1>
       </EuiScreenReaderOnly>
+      {searchSessionIdFromUrl === searchSessionId &&
+        dataService.search.session.getBackgroundSearchIndicator()}
       <navigationService.ui.TopNavMenu
         {...visibilityProps}
         query={query as Query | undefined}

--- a/src/platform/plugins/shared/data/public/search/session/session_service.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.tsx
@@ -6,7 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-
+import React from 'react';
 import type { PublicContract, SerializableRecord } from '@kbn/utility-types';
 import {
   distinctUntilChanged,
@@ -31,6 +31,7 @@ import type {
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
 import type { ISearchOptions } from '@kbn/search-types';
+import { EuiCallOut } from '@elastic/eui';
 import type { SearchUsageCollector } from '../..';
 import type { ConfigSchema } from '../../../server/config';
 import type {
@@ -702,6 +703,25 @@ export class SessionService {
       isDisabled: () => ({ disabled: false }),
       ...this.searchSessionIndicatorUiConfig,
     };
+  }
+
+  public getBackgroundSearchIndicator() {
+    // const bgSearch = useObservable(this.state$);
+    const bgSearchEnabled = this.featureFlags?.getBooleanValue(
+      BACKGROUND_SEARCH_FEATURE_FLAG_KEY,
+      false
+    );
+
+    if (!bgSearchEnabled) {
+      return null;
+    }
+    // Note that there are more bgSearch states we need to check for
+    return (
+      <EuiCallOut size="s">
+        You are viewing cached data from a specific time range from a background search. Changing
+        the time range or query will re-run the session.
+      </EuiCallOut>
+    );
   }
 
   private async refreshSearchSessionSavedObject() {

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
@@ -425,6 +425,8 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
               defaultMessage: 'Discover - Search not yet saved',
             })}
       </h1>
+      {stateContainer.searchSessionManager.hasSearchSessionIdInURL() &&
+        data.search.session.getBackgroundSearchIndicator()}
       <TopNavMemoized
         savedQuery={savedQuery}
         stateContainer={stateContainer}


### PR DESCRIPTION
POC to indentify rabbit holes of #229740

This pull request introduces a new mechanism for tracking and displaying when a dashboard or Discover view is using a search session ID sourced from the URL, which typically indicates a background search session. The changes add a new observable, `searchSessionIdFromUrl, across relevant APIs and components, and provide a user-facing indicator when cached data from a background search session is being viewed.

**Search session management enhancements:**

* Added `searchSessionIdFromUrl to the `PublishesSearchSession` interface and propagated its usage through the dashboard API and session manager, allowing components to distinguish between regular and URL-restored search sessions. [[1]](diffhunk://#diff-56bd6aab11d5129b93111caea3f76d7bb7b3eb7ae19c073e7020f2708ac24fffR14) [[2]](diffhunk://#diff-b2f48ec02c4890a127e45453b2a5ecad128f27a58af60466eb2e037a2d40b2a6L217-R217) [[3]](diffhunk://#diff-760af05a7fc4083c6fabeb1845fc9c210eeb37a4eed229b4666426d40cdd6e56L19-R23) [[4]](diffhunk://#diff-760af05a7fc4083c6fabeb1845fc9c210eeb37a4eed229b4666426d40cdd6e56R59)
* Updated the search session manager to set `searchSessionIdFromUrl when a session is restored from the URL, ensuring accurate tracking of session origin.

**User interface improvements:**

* Added a background search indicator UI (`EuiCallOut`) to the `SessionService`, which is shown to users when the current session is restored from the URL and background search is enabled.
* Integrated the background search indicator into the dashboard top navigation and Discover layout, displaying it only when the user is viewing data from a session restored via the URL. [[1]](diffhunk://#diff-0b0f8bc95e0b82c1e38583113e86357c4b9df80119719777135be129e8c9f227R363-R364) [[2]](diffhunk://#diff-8cc5e41bb5a1d1898df019faf8e9a7aae646e4a274aeb3781de974fc2dffda4aR428-R429)

**Technical updates:**

* Renamed `session_service.ts` to `session_service.tsx` and added necessary React imports to support rendering the indicator component. [[1]](diffhunk://#diff-d18ae9bd399a31851f23e4d44b6477a29679d3baf38896e00346d08c936c11b7L9-R9) [[2]](diffhunk://#diff-d18ae9bd399a31851f23e4d44b6477a29679d3baf38896e00346d08c936c11b7R34)

These changes collectively improve user awareness of background search sessions and enhance session management throughout the dashboard and Discover experiences.

That's how it looks like for Dashboards in this POC

<img width="1726" height="1148" alt="CleanShot 2025-08-26 at 11 54 24" src="https://github.com/user-attachments/assets/2f43d32c-07c5-4258-b617-b6b33de605c0" />

That's how it looks like for Discover in the POC

![Uploading CleanShot 2025-08-26 at 11.55.07.png…]()






