### PR TITLE
[9.1] [Dataset quality] 🐞 Allow es to ignore closed indices stats (#230943)

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/README.md
+++ b/x-pack/platform/plugins/shared/dataset_quality/README.md
@@ -26,7 +26,7 @@ The deployment-agnostic API tests are located in [`x-pack/solutions/observabilit
 
 ```sh
 # start server
-node scripts/functional_tests_server --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/ion_deployment_agnostic/configs/stateful/oblt.stateful.config.ts
+node scripts/functional_tests_server --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.stateful.config.ts
 
 # run tests
 node scripts/functional_test_runner --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.stateful.config.ts --include ./x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/$

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/index.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/index.ts
@@ -95,7 +95,7 @@ export async function getDataStreamDetails({
     };
   } catch (e) {
     // Respond with empty object if data stream does not exist
-    if (e.statusCode === 404) {
+    if (e.statusCode === 404 || e.body?.error?.type === 'index_closed_exception') {
       return {};
     }
     throw e;
@@ -180,7 +180,7 @@ async function getMeteringAvgDocSizeInBytes(esClient: ElasticsearchClient, index
 }
 
 async function getAvgDocSizeInBytes(esClient: ElasticsearchClient, index: string) {
-  const indexStats = await esClient.indices.stats({ index });
+  const indexStats = await esClient.indices.stats({ index, forbid_closed_indices: false });
   const docCount = indexStats._all.total?.docs?.count ?? 0;
   const sizeInBytes = indexStats._all.total?.store?.size_in_bytes ?? 0;
 
@@ -188,6 +188,10 @@ async function getAvgDocSizeInBytes(esClient: ElasticsearchClient, index: string
 }
 
 function getTermsFromAgg(termAgg: TermAggregation, aggregations: any) {
+  if (!aggregations) {
+    return {};
+  }
+
   return Object.entries(termAgg).reduce((acc, [key, _value]) => {
     const values = aggregations[key]?.buckets.map((bucket: any) => bucket.key) as string[];
     return { ...acc, [key]: values };

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_dataset_aggregated_paginated_results.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_dataset_aggregated_paginated_results.ts
@@ -59,6 +59,7 @@ export async function getAggregatedDatasetPaginatedResults(options: {
       bool,
     },
     aggs: aggs(after),
+    ignore_unavailable: true,
   });
 
   const currResults =

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_non_aggregatable_data_streams/index.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_non_aggregatable_data_streams/index.ts
@@ -29,36 +29,48 @@ export async function getNonAggregatableDataStreams({
 
   const dataStreamTypes = types.map((type) => `${type}-*-*`).join(',');
 
-  const response = await datasetQualityESClient.fieldCaps({
-    index: dataStream ?? dataStreamTypes,
-    fields: [_IGNORED],
-    index_filter: {
-      ...rangeQuery(start, end)[0],
-    },
-  });
+  try {
+    const response = await datasetQualityESClient.fieldCaps({
+      index: dataStream ?? dataStreamTypes,
+      fields: [_IGNORED],
+      index_filter: {
+        ...rangeQuery(start, end)[0],
+      },
+    });
 
-  const indices = response?.indices ?? [];
+    const indices = response?.indices ?? [];
 
-  // if no indices are returned, it means there are no data streams matching the criteria
-  // so we return an empty response - aggregatable is set to true so no error is thrown in the UI
-  if (indices.length === 0) {
+    // if no indices are returned, it means there are no data streams matching the criteria
+    // so we return an empty response - aggregatable is set to true so no error is thrown in the UI
+    if (indices.length === 0) {
+      return {
+        aggregatable: true,
+        datasets: [],
+      };
+    }
+
+    const nonAggregatableIndices =
+      response.fields._ignored?._ignored?.non_aggregatable_indices ?? [];
+
+    const datasets = extractNonAggregatableDatasets(indices, nonAggregatableIndices);
+    // If there are no non_aggregatable_indices, it means that either all indices are either aggregatable or non-aggregatable
+    // so we need to check the aggregatable field to determine
+    const aggregatable = response.fields._ignored?._ignored?.non_aggregatable_indices
+      ? datasets.length === 0
+      : Boolean(response.fields._ignored?._ignored?.aggregatable);
+
     return {
-      aggregatable: true,
-      datasets: [],
+      aggregatable,
+      datasets,
     };
+  } catch (error) {
+    if (error.message.includes('index_closed_exception')) {
+      return {
+        aggregatable: true,
+        datasets: [],
+      };
+    }
+
+    throw error;
   }
-
-  const nonAggregatableIndices = response.fields._ignored?._ignored?.non_aggregatable_indices ?? [];
-
-  const datasets = extractNonAggregatableDatasets(indices, nonAggregatableIndices);
-  // If there are no non_aggregatable_indices, it means that either all indices are either aggregatable or non-aggregatable
-  // so we need to check the aggregatable field to determine
-  const aggregatable = response.fields._ignored?._ignored?.non_aggregatable_indices
-    ? datasets.length === 0
-    : Boolean(response.fields._ignored?._ignored?.aggregatable);
-
-  return {
-    aggregatable,
-    datasets,
-  };
 }

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/routes.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/routes.ts
@@ -324,11 +324,21 @@ const degradedFieldsRoute = createDatasetQualityServerRoute({
 
     const esClient = coreContext.elasticsearch.client.asCurrentUser;
 
-    return await getDegradedFields({
-      esClient,
-      dataStream,
-      ...params.query,
-    });
+    try {
+      return await getDegradedFields({
+        esClient,
+        dataStream,
+        ...params.query,
+      });
+    } catch (e) {
+      if (e.body?.error?.type === 'index_closed_exception') {
+        return {
+          degradedFields: [],
+        };
+      }
+
+      throw e;
+    }
   },
 });
 

--- a/x-pack/platform/plugins/shared/dataset_quality/server/services/data_telemetry/helpers.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/services/data_telemetry/helpers.ts
@@ -242,6 +242,7 @@ export function getIndexBasicStats({
           index: indexChunk,
           metric: ['docs', 'store'],
           filter_path: ['indices.*.primaries.docs', 'indices.*.primaries.store.size_in_bytes'],
+          forbid_closed_indices: false,
         })
       )
     )
@@ -361,6 +362,7 @@ async function getIndicesInfoForPattern({
         index: indexChunk,
         features: ['mappings'],
         filter_path: ['*.mappings', '*._meta'],
+        ignore_unavailable: true,
       })
     )
   );

--- a/x-pack/platform/plugins/shared/dataset_quality/server/services/index_stats.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/services/index_stats.ts
@@ -21,7 +21,11 @@ class IndexStatsService {
   ): Promise<IndexStatsResponse> {
     try {
       const { indices } = await processAsyncInChunks(dataStreams, (indexChunk) =>
-        esClient.indices.stats({ index: indexChunk, metric: ['docs'] })
+        esClient.indices.stats({
+          index: indexChunk,
+          metric: ['docs'],
+          forbid_closed_indices: false,
+        })
       );
 
       const docsCountPerDataStream = chain(indices || {})

--- a/x-pack/platform/plugins/shared/dataset_quality/server/utils/create_dataset_quality_es_client.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/utils/create_dataset_quality_es_client.ts
@@ -33,7 +33,9 @@ export function createDatasetQualityESClient(esClient: ElasticsearchClient) {
     search<TDocument, TParams extends DatasetQualityESSearchParams>(
       searchParams: TParams
     ): Promise<InferSearchResponseOf<TDocument, TParams>> {
-      return esClient.search<TDocument>(searchParams) as Promise<any>;
+      return esClient.search<TDocument>({
+        ...searchParams,
+      }) as Promise<any>;
     },
     msearch<TDocument, TParams extends DatasetQualityESSearchParams>(
       index = {} as { index?: Indices },
@@ -46,7 +48,7 @@ export function createDatasetQualityESClient(esClient: ElasticsearchClient) {
       }) as Promise<any>;
     },
     fieldCaps(params: FieldCapsRequest): Promise<FieldCapsResponse> {
-      return esClient.fieldCaps(params);
+      return esClient.fieldCaps({ ...params });
     },
     mappings(params: { index: string }): Promise<IndicesGetMappingResponse> {
       return esClient.indices.getMapping(params);

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/data_stream_total_docs.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/data_stream_total_docs.ts
@@ -10,9 +10,9 @@ import expect from '@kbn/expect';
 
 import { APIClientRequestParamsOf } from '@kbn/dataset-quality-plugin/common/rest';
 import { LogsSynthtraceEsClient } from '@kbn/apm-synthtrace';
+import { DataStreamDocsStat } from '@kbn/dataset-quality-plugin/common/api_types';
 import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { RoleCredentials, SupertestWithRoleScopeType } from '../../services';
-import { DataStreamDocsStat } from '@kbn/dataset-quality-plugin/common/api_types';
 import { closeDataStream, rolloverDataStream } from './utils';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/data_stream_total_docs.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/data_stream_total_docs.ts
@@ -12,8 +12,11 @@ import { APIClientRequestParamsOf } from '@kbn/dataset-quality-plugin/common/res
 import { LogsSynthtraceEsClient } from '@kbn/apm-synthtrace';
 import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { RoleCredentials, SupertestWithRoleScopeType } from '../../services';
+import { DataStreamDocsStat } from '@kbn/dataset-quality-plugin/common/api_types';
+import { closeDataStream, rolloverDataStream } from './utils';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const esClient = getService('es');
   const samlAuth = getService('samlAuth');
   const roleScopedSupertest = getService('roleScopedSupertest');
   const synthtrace = getService('synthtrace');
@@ -66,71 +69,212 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           withInternalHeaders: true,
         }
       );
-
-      await synthtraceLogsEsClient.index([
-        timerange(from, to)
-          .interval('1m')
-          .rate(1)
-          .generator((timestamp) => [
-            log
-              .create()
-              .message('This is a log message')
-              .timestamp(timestamp)
-              .dataset(dataset)
-              .namespace(namespace)
-              .defaults({
-                'log.file.path': '/my-service.log',
-                'service.name': serviceName,
-                'host.name': hostName,
-              }),
-            log
-              .create()
-              .message('This is a log message')
-              .timestamp(timestamp)
-              .dataset(syntheticsDataset)
-              .namespace(namespace)
-              .defaults({
-                'log.file.path': '/my-service.log',
-                'service.name': serviceName,
-                'host.name': hostName,
-              }),
-          ]),
-      ]);
     });
 
     after(async () => {
-      await synthtraceLogsEsClient.clean();
       await samlAuth.invalidateM2mApiKeyWithRoleScope(adminRoleAuthc);
     });
 
-    it('returns number of documents per DataStream', async () => {
-      const resp = await callApiAs({
-        roleScopedSupertestWithCookieCredentials: supertestAdminWithCookieCredentials,
-        apiParams: {
-          type: dataStreamType,
-          start: from,
-          end: to,
-        },
+    describe('when all data streams are open', () => {
+      before(async () => {
+        await synthtraceLogsEsClient.index([
+          timerange(from, to)
+            .interval('1m')
+            .rate(1)
+            .generator((timestamp) => [
+              log
+                .create()
+                .message('This is a log message')
+                .timestamp(timestamp)
+                .dataset(dataset)
+                .namespace(namespace)
+                .defaults({
+                  'log.file.path': '/my-service.log',
+                  'service.name': serviceName,
+                  'host.name': hostName,
+                }),
+              log
+                .create()
+                .message('This is a log message')
+                .timestamp(timestamp)
+                .dataset(syntheticsDataset)
+                .namespace(namespace)
+                .defaults({
+                  'log.file.path': '/my-service.log',
+                  'service.name': serviceName,
+                  'host.name': hostName,
+                }),
+            ]),
+        ]);
       });
 
-      expect(resp.body.totalDocs.length).to.be(2);
-      expect(resp.body.totalDocs[0].dataset).to.be(dataStreamName);
-      expect(resp.body.totalDocs[0].count).to.be(1);
-      expect(resp.body.totalDocs[1].dataset).to.be(syntheticsDataStreamName);
-      expect(resp.body.totalDocs[1].count).to.be(1);
+      after(async () => {
+        await synthtraceLogsEsClient.clean();
+      });
+
+      it('returns number of documents per DataStream', async () => {
+        const resp = await callApiAs({
+          roleScopedSupertestWithCookieCredentials: supertestAdminWithCookieCredentials,
+          apiParams: {
+            type: dataStreamType,
+            start: from,
+            end: to,
+          },
+        });
+
+        expect(resp.body.totalDocs.length).to.be(2);
+        expect(resp.body.totalDocs[0].dataset).to.be(dataStreamName);
+        expect(resp.body.totalDocs[0].count).to.be(1);
+        expect(resp.body.totalDocs[1].dataset).to.be(syntheticsDataStreamName);
+        expect(resp.body.totalDocs[1].count).to.be(1);
+      });
+
+      it('returns empty when all documents are outside timeRange', async () => {
+        const resp = await callApiAs({
+          roleScopedSupertestWithCookieCredentials: supertestAdminWithCookieCredentials,
+          apiParams: {
+            type: dataStreamType,
+            start: '2024-09-21T11:00:00.000Z',
+            end: '2024-09-21T11:01:00.000Z',
+          },
+        });
+
+        expect(resp.body.totalDocs.length).to.be(0);
+      });
     });
 
-    it('returns empty when all documents are outside timeRange', async () => {
-      const resp = await callApiAs({
-        roleScopedSupertestWithCookieCredentials: supertestAdminWithCookieCredentials,
-        apiParams: {
-          type: dataStreamType,
-          start: '2024-09-21T11:00:00.000Z',
-          end: '2024-09-21T11:01:00.000Z',
-        },
+    describe('when there are data streams closed', () => {
+      before(async () => {
+        await synthtraceLogsEsClient.index([
+          timerange(from, to)
+            .interval('1m')
+            .rate(1)
+            .generator((timestamp) =>
+              log
+                .create()
+                .message('This is a log message')
+                .timestamp(timestamp)
+                .dataset('synth.open')
+                .defaults({
+                  'log.file.path': '/my-service.log',
+                })
+            ),
+          timerange(from, to)
+            .interval('1m')
+            .rate(1)
+            .generator((timestamp) =>
+              log
+                .create()
+                .message('This is a log message')
+                .timestamp(timestamp)
+                .dataset('synth.closed')
+                .defaults({
+                  'log.file.path': '/my-service.log',
+                })
+            ),
+        ]);
+
+        await closeDataStream(esClient, 'logs-synth.closed-default');
       });
 
-      expect(resp.body.totalDocs.length).to.be(0);
+      after(async () => {
+        await synthtraceLogsEsClient.clean();
+      });
+
+      it('returns stats correctly', async () => {
+        const stats = await callApiAs({
+          roleScopedSupertestWithCookieCredentials: supertestAdminWithCookieCredentials,
+          apiParams: {
+            type: dataStreamType,
+            start: from,
+            end: to,
+          },
+        });
+
+        expect(stats.body.totalDocs.length).to.be(1);
+
+        const docsStats = stats.body.totalDocs.reduce(
+          (acc: Record<string, { count: number }>, curr: DataStreamDocsStat) => ({
+            ...acc,
+            [curr.dataset]: {
+              count: curr.count,
+            },
+          }),
+          {}
+        );
+
+        expect(docsStats['logs-synth.open-default']).to.eql({
+          count: 1,
+        });
+      });
+
+      describe('when new backing indices are open', () => {
+        before(async () => {
+          await rolloverDataStream(esClient, 'logs-synth.closed-default');
+
+          await synthtraceLogsEsClient.index([
+            timerange(from, to)
+              .interval('1m')
+              .rate(1)
+              .generator((timestamp) =>
+                log
+                  .create()
+                  .message('This is a log message')
+                  .timestamp(timestamp)
+                  .dataset('synth.open')
+                  .defaults({
+                    'log.file.path': '/my-service.log',
+                  })
+              ),
+            timerange(from, to)
+              .interval('1m')
+              .rate(1)
+              .generator((timestamp) =>
+                log
+                  .create()
+                  .message('This is a log message')
+                  .timestamp(timestamp)
+                  .dataset('synth.closed')
+                  .defaults({
+                    'log.file.path': '/my-service.log',
+                  })
+              ),
+          ]);
+        });
+
+        after(async () => {
+          await synthtraceLogsEsClient.clean();
+        });
+
+        it('returns stats correctly when some of the backing indices are closed and others are open', async () => {
+          const stats = await callApiAs({
+            roleScopedSupertestWithCookieCredentials: supertestAdminWithCookieCredentials,
+            apiParams: {
+              type: dataStreamType,
+              start: from,
+              end: to,
+            },
+          });
+          expect(stats.body.totalDocs.length).to.be(2);
+
+          const docsStats = stats.body.totalDocs.reduce(
+            (acc: Record<string, { count: number }>, curr: DataStreamDocsStat) => ({
+              ...acc,
+              [curr.dataset]: {
+                count: curr.count,
+              },
+            }),
+            {}
+          );
+
+          expect(docsStats['logs-synth.open-default']).to.eql({
+            count: 2,
+          });
+          expect(docsStats['logs-synth.closed-default']).to.eql({
+            count: 1,
+          });
+        });
+      });
     });
   });
 }

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/degraded_docs.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/degraded_docs.ts
@@ -12,8 +12,10 @@ import { log, timerange } from '@kbn/apm-synthtrace-client';
 import { DataStreamDocsStat } from '@kbn/dataset-quality-plugin/common/api_types';
 import { SupertestWithRoleScopeType } from '../../services';
 import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+import { closeDataStream, rolloverDataStream } from './utils';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const esClient = getService('es');
   const roleScopedSupertest = getService('roleScopedSupertest');
   const synthtrace = getService('synthtrace');
   const start = '2023-12-11T18:00:00.000Z';
@@ -202,6 +204,129 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
         after(async () => {
           await synthtraceLogsEsClient.clean();
+        });
+      });
+
+      describe('when there are data streams closed', () => {
+        before(async () => {
+          await synthtraceLogsEsClient.index([
+            timerange(start, end)
+              .interval('1m')
+              .rate(1)
+              .generator((timestamp) =>
+                log
+                  .create()
+                  .message('This is a log message')
+                  .timestamp(timestamp)
+                  .dataset('synth.open')
+                  .logLevel(MORE_THAN_1024_CHARS)
+                  .defaults({
+                    'log.file.path': '/my-service.log',
+                  })
+              ),
+            timerange(start, end)
+              .interval('1m')
+              .rate(1)
+              .generator((timestamp) =>
+                log
+                  .create()
+                  .message('This is a log message')
+                  .timestamp(timestamp)
+                  .dataset('synth.closed')
+                  .logLevel(MORE_THAN_1024_CHARS)
+                  .defaults({
+                    'log.file.path': '/my-service.log',
+                  })
+              ),
+          ]);
+
+          await closeDataStream(esClient, 'logs-synth.closed-default');
+        });
+
+        after(async () => {
+          await synthtraceLogsEsClient.clean();
+        });
+
+        it('returns stats correctly', async () => {
+          const stats = await callApiAs(supertestViewerWithCookieCredentials);
+          expect(stats.body.degradedDocs.length).to.be(1);
+
+          const degradedDocsStats = stats.body.degradedDocs.reduce(
+            (acc: Record<string, { count: number }>, curr: DataStreamDocsStat) => ({
+              ...acc,
+              [curr.dataset]: {
+                count: curr.count,
+              },
+            }),
+            {}
+          );
+
+          expect(degradedDocsStats['logs-synth.open-default']).to.eql({
+            count: 1,
+          });
+        });
+
+        describe('when new backing indices are open', () => {
+          before(async () => {
+            await rolloverDataStream(esClient, 'logs-synth.closed-default');
+
+            await synthtraceLogsEsClient.index([
+              timerange(start, end)
+                .interval('1m')
+                .rate(1)
+                .generator((timestamp) =>
+                  log
+                    .create()
+                    .message('This is a log message')
+                    .timestamp(timestamp)
+                    .dataset('synth.open')
+                    .logLevel(MORE_THAN_1024_CHARS)
+                    .defaults({
+                      'log.file.path': '/my-service.log',
+                    })
+                ),
+              timerange(start, end)
+                .interval('1m')
+                .rate(1)
+                .generator((timestamp) =>
+                  log
+                    .create()
+                    .message('This is a log message')
+                    .timestamp(timestamp)
+                    .dataset('synth.closed')
+                    .logLevel(MORE_THAN_1024_CHARS)
+                    .defaults({
+                      'log.file.path': '/my-service.log',
+                    })
+                ),
+            ]);
+          });
+
+          after(async () => {
+            await synthtraceLogsEsClient.clean();
+          });
+
+          it('returns stats correctly when some of the backing indices are closed and others are open', async () => {
+            const stats = await callApiAs(supertestViewerWithCookieCredentials);
+            expect(stats.body.degradedDocs.length).to.be(2);
+
+            const degradedDocsStats = stats.body.degradedDocs.reduce(
+              (acc: Record<string, { count: number }>, curr: DataStreamDocsStat) => ({
+                ...acc,
+                [curr.dataset]: {
+                  count: curr.count,
+                },
+              }),
+              {}
+            );
+
+            expect(degradedDocsStats['logs-synth.open-default']).to.eql({
+              count: 2,
+            });
+            expect(degradedDocsStats['logs-synth.closed-default']).to.eql({
+              count: 1,
+            });
+          });
         });
       });
     });

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/failed_docs.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/failed_docs.ts
@@ -13,6 +13,7 @@ import { DataStreamDocsStat } from '@kbn/dataset-quality-plugin/common/api_types
 import { SupertestWithRoleScopeType } from '../../services';
 import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { processors } from './processors';
+import { closeDataStream, rolloverDataStream } from './utils';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const roleScopedSupertest = getService('roleScopedSupertest');
@@ -131,6 +132,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           await synthtraceLogsEsClient.refresh();
         });
 
+        after(async () => {
+          await synthtraceLogsEsClient.clean();
+        });
+
         it('returns stats correctly', async () => {
           await retry.tryForTime(180 * 1000, async () => {
             const stats = await callApiAs(supertestViewerWithCookieCredentials);
@@ -151,10 +156,6 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             });
           });
         });
-
-        after(async () => {
-          await synthtraceLogsEsClient.clean();
-        });
       });
 
       describe('and there are not log documents', () => {
@@ -162,6 +163,113 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           const stats = await callApiAs(supertestViewerWithCookieCredentials);
 
           expect(stats.body.failedDocs.length).to.be(0);
+        });
+      });
+
+      describe('when there are data streams closed', () => {
+        before(async () => {
+          await synthtraceLogsEsClient.index([
+            timerange(start, end)
+              .interval('1m')
+              .rate(1)
+              .generator((timestamp) =>
+                log
+                  .create()
+                  .message('This is a log message')
+                  .timestamp(timestamp)
+                  .dataset('synth.1')
+                  .defaults({
+                    'log.file.path': '/my-service.log',
+                  })
+              ),
+            timerange(start, end)
+              .interval('1m')
+              .rate(1)
+              .generator((timestamp) =>
+                log
+                  .create()
+                  .message('This is a log message')
+                  .timestamp(timestamp)
+                  .dataset('synth.2')
+                  .logLevel('5')
+                  .defaults({
+                    'log.file.path': '/my-service.log',
+                  })
+              ),
+          ]);
+
+          await closeDataStream(esClient, 'logs-synth.2-default::failures');
+        });
+
+        after(async () => {
+          await synthtraceLogsEsClient.clean();
+        });
+
+        it('returns stats correctly', async () => {
+          const stats = await callApiAs(supertestViewerWithCookieCredentials);
+
+          expect(stats.body.failedDocs.length).to.be(0);
+        });
+
+        describe('when new backing indices are open', () => {
+          before(async () => {
+            await rolloverDataStream(esClient, 'logs-synth.2-default::failures');
+
+            await synthtraceLogsEsClient.index([
+              timerange(start, end)
+                .interval('1m')
+                .rate(1)
+                .generator((timestamp) =>
+                  log
+                    .create()
+                    .message('This is a log message')
+                    .timestamp(timestamp)
+                    .dataset('synth.1')
+                    .defaults({
+                      'log.file.path': '/my-service.log',
+                    })
+                ),
+              timerange(start, end)
+                .interval('1m')
+                .rate(1)
+                .generator((timestamp) =>
+                  log
+                    .create()
+                    .message('This is a log message')
+                    .timestamp(timestamp)
+                    .dataset('synth.2')
+                    .logLevel('5')
+                    .defaults({
+                      'log.file.path': '/my-service.log',
+                    })
+                ),
+            ]);
+          });
+
+          after(async () => {
+            await synthtraceLogsEsClient.clean();
+          });
+
+          it('returns stats correctly when some of the backing indices are closed and others are open', async () => {
+            await retry.tryForTime(180 * 1000, async () => {
+              const stats = await callApiAs(supertestViewerWithCookieCredentials);
+              expect(stats.body.failedDocs.length).to.be(1);
+
+              const failedDocsStats = stats.body.failedDocs.reduce(
+                (acc: Record<string, { count: number }>, curr: DataStreamDocsStat) => ({
+                  ...acc,
+                  [curr.dataset]: {
+                    count: curr.count,
+                  },
+                }),
+                {}
+              );
+
+              expect(failedDocsStats['logs-synth.2-default']).to.eql({
+                count: 1,
+              });
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Dataset quality] 🐞 Allow es to ignore closed indices stats (#230943)](https://github.com/elastic/kibana/pull/230943)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Yngrid Coello","email":"yngrid.coello@elastic.co"},"sourceCommit":{"committedDate":"2025-08-21T16:05:26Z","message":"[Dataset quality] 🐞 Allow es to ignore closed indices stats (#230943)\n\nCloses https://github.com/elastic/kibana/issues/220840.\n\nThe usage of `expand_wildcards=open` and `forbid_closed_indices=true`,\nas suggsted in the issue, was not suitable for this case: es will still\nthrow `index_closed_exception` if any of the indices(in this case\ndataStreams) actually points to a closed index. For example:\n\n```\nmy-data-stream will be resolved internally to .ds-my-data-stream-000001.\n\n.ds-my-data-stream-000001 is closed, this will raise the error.\n```\n\nIn particular:\n\n`expand_wildcards=open` only controls wildcard expansion, it doesn’t\nfilter out closed concrete index names you explicitly pass.\n\n`forbid_closed_indices=true` just forces es to error instead of silently\nskipping closed ones.\n\n\n### 🎥  Demo\n\n#### Before the changes\n\n\nhttps://github.com/user-attachments/assets/9130df3c-3519-4f32-998d-dd7ba26ced04\n\n\n#### After the changes\n\n\nhttps://github.com/user-attachments/assets/5f604c2e-6d6c-44d3-8a6c-b5b9dfcb08ff","sha":"6244557c49cca7e250cc70f23e81885385161721","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.2.0","v9.1.3","v8.19.3"],"title":"[Dataset quality] 🐞 Allow es to ignore closed indices stats","number":230943,"url":"https://github.com/elastic/kibana/pull/230943","mergeCommit":{"message":"[Dataset quality] 🐞 Allow es to ignore closed indices stats (#230943)\n\nCloses https://github.com/elastic/kibana/issues/220840.\n\nThe usage of `expand_wildcards=open` and `forbid_closed_indices=true`,\nas suggsted in the issue, was not suitable for this case: es will still\nthrow `index_closed_exception` if any of the indices(in this case\ndataStreams) actually points to a closed index. For example:\n\n```\nmy-data-stream will be resolved internally to .ds-my-data-stream-000001.\n\n.ds-my-data-stream-000001 is closed, this will raise the error.\n```\n\nIn particular:\n\n`expand_wildcards=open` only controls wildcard expansion, it doesn’t\nfilter out closed concrete index names you explicitly pass.\n\n`forbid_closed_indices=true` just forces es to error instead of silently\nskipping closed ones.\n\n\n### 🎥  Demo\n\n#### Before the changes\n\n\nhttps://github.com/user-attachments/assets/9130df3c-3519-4f32-998d-dd7ba26ced04\n\n\n#### After the changes\n\n\nhttps://github.com/user-attachments/assets/5f604c2e-6d6c-44d3-8a6c-b5b9dfcb08ff","sha":"6244557c49cca7e250cc70f23e81885385161721"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230943","number":230943,"mergeCommit":{"message":"[Dataset quality] 🐞 Allow es to ignore closed indices stats (#230943)\n\nCloses https://github.com/elastic/kibana/issues/220840.\n\nThe usage of `expand_wildcards=open` and `forbid_closed_indices=true`,\nas suggsted in the issue, was not suitable for this case: es will still\nthrow `index_closed_exception` if any of the indices(in this case\ndataStreams) actually points to a closed index. For example:\n\n```\nmy-data-stream will be resolved internally to .ds-my-data-stream-000001.\n\n.ds-my-data-stream-000001 is closed, this will raise the error.\n```\n\nIn particular:\n\n`expand_wildcards=open` only controls wildcard expansion, it doesn’t\nfilter out closed concrete index names you explicitly pass.\n\n`forbid_closed_indices=true` just forces es to error instead of silently\nskipping closed ones.\n\n\n### 🎥  Demo\n\n#### Before the changes\n\n\nhttps://github.com/user-attachments/assets/9130df3c-3519-4f32-998d-dd7ba26ced04\n\n\n#### After the changes\n\n\nhttps://github.com/user-attachments/assets/5f604c2e-6d6c-44d3-8a6c-b5b9dfcb08ff","sha":"6244557c49cca7e250cc70f23e81885385161721"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->