### PR TITLE
Skip Oblt AI assistant recall test suite for MKI

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/complete/functions/recall.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/complete/functions/recall.spec.ts
@@ -26,6 +26,9 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const es = getService('es');
 
   describe('tool: recall', function () {
+    // fails/flaky on MKI, see https://github.com/elastic/kibana/issues/232588
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       await deployTinyElserAndSetupKb(getService);
       await addSampleDocsToInternalKb(getService, technicalSampleDocs);


### PR DESCRIPTION
## Summary

This PR skips the Observability AI assistant recall test suite for MKI runs.
More details about the failures/flakiness in #232588.