### PR TITLE
[Security Solution] Unskip perform bulk action tests

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/rules/get_gaps_by_rule_id.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/rules/get_gaps_by_rule_id.ts
@@ -18,6 +18,7 @@ export const getGapsByRuleId = async (
   const response = (await supertest
     .post(routeWithNamespace(`/internal/alerting/rules/gaps/_find`, namespace))
     .set('kbn-xsrf', 'foo')
+    .set('x-elastic-internal-origin', 'kibana')
     .send({
       rule_id: ruleId,
       start,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action.ts
@@ -92,8 +92,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const createWebHookConnector = () => createConnector(getWebHookAction());
   const createSlackConnector = () => createConnector(getSlackAction());
 
-  // Failing: See https://github.com/elastic/kibana/issues/224615
-  describe.skip('@ess @serverless @skipInServerless perform_bulk_action', () => {
+  describe('@ess @serverless perform_bulk_action', () => {
     beforeEach(async () => {
       await deleteAllRules(supertest, log);
       await esArchiver.load('x-pack/platform/test/fixtures/es_archives/auditbeat/hosts');


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/224615
The flaky test runner was run for both ESS and Serverless.

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->