### PR TITLE
[9.0] [Search] fix: remove incorrect link on "build" breadcrumb (#232504)

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
@@ -143,10 +143,7 @@ export const useElasticsearchBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
   ]);
 
 export const useEnterpriseSearchContentBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
-  useSearchBreadcrumbs([
-    { text: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAV_TITLE, path: '/' },
-    ...breadcrumbs,
-  ]);
+  useSearchBreadcrumbs([{ text: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAV_TITLE }, ...breadcrumbs]);
 
 export const useSearchExperiencesBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
   useSearchBreadcrumbs([{ text: SEARCH_EXPERIENCES_PLUGIN.NAV_TITLE, path: '/' }, ...breadcrumbs]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Search] fix: remove incorrect link on "build" breadcrumb (#232504)](https://github.com/elastic/kibana/pull/232504)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brittany","email":"seialkali@gmail.com"},"sourceCommit":{"committedDate":"2025-08-22T06:55:00Z","message":"[Search] fix: remove incorrect link on \"build\" breadcrumb (#232504)\n\n## Summary\n\nThe \"build\" breadcrumb on the search indices (enterprise search content)\nand connector pages was incorrectly linking to the search indices page.\nThis fix removes the link from the breadcrumb.\n\n### Before\n\n<img width=\"500\" height=\"417\" alt=\"Screenshot 2025-08-21 at 15 44 02\"\nsrc=\"https://github.com/user-attachments/assets/95bbb75c-bbbf-4b3e-a7ca-eeb327002891\"\n/>\n<img width=\"500\" height=\"416\" alt=\"Screenshot 2025-08-21 at 15 43 46\"\nsrc=\"https://github.com/user-attachments/assets/1b455cc4-9cce-424a-b798-5e4f17601942\"\n/>\n\n### After\n\n<img width=\"500\" height=\"424\" alt=\"Screenshot 2025-08-21 at 15 44 39\"\nsrc=\"https://github.com/user-attachments/assets/e2cc55b9-662e-4dbe-9d1e-08dcdbc1956b\"\n/>\n<img width=\"500\" height=\"423\" alt=\"Screenshot 2025-08-21 at 15 44 22\"\nsrc=\"https://github.com/user-attachments/assets/1e6f7cda-64b7-4a1a-b8fc-b5c867b82caf\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes the \"Build\" breadcrumb showing an incorrect link to the search\nindices page.","sha":"9a885e63046ec6b2794d4b57f4faf27265d8b5da","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Search","backport:version","v9.2.0","v9.1.3","v9.0.6"],"title":"[Search] fix: remove incorrect link on \"build\" breadcrumb","number":232504,"url":"https://github.com/elastic/kibana/pull/232504","mergeCommit":{"message":"[Search] fix: remove incorrect link on \"build\" breadcrumb (#232504)\n\n## Summary\n\nThe \"build\" breadcrumb on the search indices (enterprise search content)\nand connector pages was incorrectly linking to the search indices page.\nThis fix removes the link from the breadcrumb.\n\n### Before\n\n<img width=\"500\" height=\"417\" alt=\"Screenshot 2025-08-21 at 15 44 02\"\nsrc=\"https://github.com/user-attachments/assets/95bbb75c-bbbf-4b3e-a7ca-eeb327002891\"\n/>\n<img width=\"500\" height=\"416\" alt=\"Screenshot 2025-08-21 at 15 43 46\"\nsrc=\"https://github.com/user-attachments/assets/1b455cc4-9cce-424a-b798-5e4f17601942\"\n/>\n\n### After\n\n<img width=\"500\" height=\"424\" alt=\"Screenshot 2025-08-21 at 15 44 39\"\nsrc=\"https://github.com/user-attachments/assets/e2cc55b9-662e-4dbe-9d1e-08dcdbc1956b\"\n/>\n<img width=\"500\" height=\"423\" alt=\"Screenshot 2025-08-21 at 15 44 22\"\nsrc=\"https://github.com/user-attachments/assets/1e6f7cda-64b7-4a1a-b8fc-b5c867b82caf\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes the \"Build\" breadcrumb showing an incorrect link to the search\nindices page.","sha":"9a885e63046ec6b2794d4b57f4faf27265d8b5da"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232504","number":232504,"mergeCommit":{"message":"[Search] fix: remove incorrect link on \"build\" breadcrumb (#232504)\n\n## Summary\n\nThe \"build\" breadcrumb on the search indices (enterprise search content)\nand connector pages was incorrectly linking to the search indices page.\nThis fix removes the link from the breadcrumb.\n\n### Before\n\n<img width=\"500\" height=\"417\" alt=\"Screenshot 2025-08-21 at 15 44 02\"\nsrc=\"https://github.com/user-attachments/assets/95bbb75c-bbbf-4b3e-a7ca-eeb327002891\"\n/>\n<img width=\"500\" height=\"416\" alt=\"Screenshot 2025-08-21 at 15 43 46\"\nsrc=\"https://github.com/user-attachments/assets/1b455cc4-9cce-424a-b798-5e4f17601942\"\n/>\n\n### After\n\n<img width=\"500\" height=\"424\" alt=\"Screenshot 2025-08-21 at 15 44 39\"\nsrc=\"https://github.com/user-attachments/assets/e2cc55b9-662e-4dbe-9d1e-08dcdbc1956b\"\n/>\n<img width=\"500\" height=\"423\" alt=\"Screenshot 2025-08-21 at 15 44 22\"\nsrc=\"https://github.com/user-attachments/assets/1e6f7cda-64b7-4a1a-b8fc-b5c867b82caf\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes the \"Build\" breadcrumb showing an incorrect link to the search\nindices page.","sha":"9a885e63046ec6b2794d4b57f4faf27265d8b5da"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232571","number":232571,"state":"OPEN"},{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->