### PR TITLE
Skip Oblt AI assistant knowledge base setup test suite for MKI

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/knowledge_base/knowledge_base_setup.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/knowledge_base/knowledge_base_setup.spec.ts
@@ -35,6 +35,9 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const loggerMock = getLoggerMock(log);
 
   describe('Knowledge base: POST /internal/observability_ai_assistant/kb/setup', function () {
+    // fails/flaky on MKI, see https://github.com/elastic/kibana/issues/232600
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       await restoreIndexAssets(getService);
     });


### PR DESCRIPTION
## Summary

This PR skips the Observability AI assistant knowledge base setup test suite for MKI runs.
More details about the failures/flakiness in #232600.