### PR TITLE
[Synthetics] Disable default alerts toggles for readonly user !!

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/alerting_defaults/alert_defaults_form.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/alerting_defaults/alert_defaults_form.tsx
@@ -110,6 +110,7 @@ export const AlertDefaultsForm = () => {
               defaultStatusRuleEnabled: !(formFields.defaultStatusRuleEnabled ?? true),
             });
           }}
+          disabled={isDisabled}
         />
         <EuiSpacer size="m" />
         <EuiSwitch
@@ -123,6 +124,7 @@ export const AlertDefaultsForm = () => {
               defaultTLSRuleEnabled: !(formFields.defaultTLSRuleEnabled ?? true),
             });
           }}
+          disabled={isDisabled}
         />
       </EuiDescribedFormGroup>
       <EuiSpacer size="m" />


### PR DESCRIPTION
## Summary

Disable default alerts toggles for readonly user !!


<img width="1728" height="892" alt="image" src="https://github.com/user-attachments/assets/7af35bd5-9924-446a-b98b-47154f445505" />


<!--ONMERGE {"backportTargets":["8.18","8.19","9.1"]} ONMERGE-->