### PR TITLE
[Observability Onboarding] Add note about the supported helm versions in the K8s OTel flow

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -141,7 +141,7 @@ helm upgrade --install opentelemetry-kube-stack open-telemetry/opentelemetry-kub
                 <p>
                   <FormattedMessage
                     id="xpack.observability_onboarding.otelKubernetesPanel.injectAutoinstrumentationLibrariesForLabel"
-                    defaultMessage="Install the OpenTelemetry Operator using the kube-stack Helm chart and the provided values file. For automatic certificate renewal, we recommend installing the {link}, and customize the values.yaml file before the installation as described {doc}."
+                    defaultMessage="Install the OpenTelemetry Operator using the kube-stack Helm chart and the provided values file. Compatible with Helm up to version 8.14. For automatic certificate renewal, we recommend installing the {link}, and customize the values.yaml file before the installation as described {doc}."
                     values={{
                       link: (
                         <EuiLink


### PR DESCRIPTION
## 📓 Summary
The onboarding flow doesn't work for helm versions `3.18.5` and `3.18.6` (See https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1805 and https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1809).

Until https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1809 and an update in Elastic Agent is merged, this PR adds a note about the supported helm versions.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->