### PR TITLE
[ES|QL] LOOKUP JOIN - Recalculate placeholders after importing file

### DIFF
--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -423,7 +423,6 @@ export class IndexUpdateService {
   public readonly dataTableColumns$: Observable<DatatableColumn[]> = combineLatest([
     this.dataView$,
     this.pendingColumnsToBeSaved$.pipe(startWith([])),
-    this._refreshSubject$,
   ]).pipe(
     map(([dataView, pendingColumnsToBeSaved]) => {
       const unsavedFields = pendingColumnsToBeSaved
@@ -698,9 +697,9 @@ export class IndexUpdateService {
 
     // Subscribe to pendingColumnsToBeSaved$ and update _pendingColumnsToBeSaved$
     this._subscription.add(
-      this.dataView$
+      combineLatest([this.dataView$, this._refreshSubject$])
         .pipe(
-          switchMap((dataView) => {
+          switchMap(([dataView]) => {
             let placeholderIndex = 0;
             const columnsCount = dataView.fields.filter(
               // @ts-ignore


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/207330
## Summary

After importing a file placeholders that were not filled were still shown. recalculate them after a file upload.