### PR TITLE
[Dataset quality] include failed docs when redirecting to discover

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/table/columns.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/table/columns.tsx
@@ -480,7 +480,7 @@ const RedirectLink = ({
 }) => {
   const { sendTelemetry } = useDatasetRedirectLinkTelemetry({ rawName: dataStreamStat.rawName });
   const redirectLinkProps = useRedirectLink({
-    dataStreamStat,
+    dataStreamStat: `${dataStreamStat.rawName},${dataStreamStat.rawName}${FAILURE_STORE_SELECTOR}`,
     sendTelemetry,
     timeRangeConfig: timeRange,
   });

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/header.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/header.tsx
@@ -17,6 +17,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React from 'react';
+import { FAILURE_STORE_SELECTOR } from '../../../common/constants';
 import { openInDiscoverText } from '../../../common/translations';
 import { AlertFlyout } from '../../alerts/alert_flyout';
 import {
@@ -46,7 +47,7 @@ export function Header({
     navigationSource: navigationSources.Header,
   });
   const redirectLinkProps = useRedirectLink({
-    dataStreamStat: datasetDetails,
+    dataStreamStat: `${datasetDetails.rawName},${datasetDetails.rawName}${FAILURE_STORE_SELECTOR}`,
     timeRangeConfig: timeRange,
     sendTelemetry,
   });

--- a/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_redirect_link.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_redirect_link.ts
@@ -7,7 +7,7 @@
 
 import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
 import { DISCOVER_APP_LOCATOR } from '@kbn/discover-plugin/common';
-import type { AggregateQuery, Query } from '@kbn/es-query';
+import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import { buildPhraseFilter } from '@kbn/es-query';
 import { getRouterLinkProps } from '@kbn/router-utils';
 import type { RouterLinkProps } from '@kbn/router-utils/src/get_router_link_props';
@@ -17,7 +17,7 @@ import type { BasicDataStream, DataStreamSelector, TimeRangeConfig } from '../..
 import { useKibanaContextForPlugin } from '../utils';
 import type { SendTelemetryFn } from './use_redirect_link_telemetry';
 
-export const useRedirectLink = <T extends BasicDataStream>({
+export const useRedirectLink = <T extends BasicDataStream | string>({
   dataStreamStat,
   query,
   timeRangeConfig,
@@ -85,7 +85,7 @@ export const useRedirectLink = <T extends BasicDataStream>({
   ]);
 };
 
-const buildDiscoverConfig = <T extends BasicDataStream>({
+const buildDiscoverConfig = <T extends BasicDataStream | string>({
   locatorClient,
   dataStreamStat,
   query,
@@ -105,28 +105,17 @@ const buildDiscoverConfig = <T extends BasicDataStream>({
   navigate: () => void;
   routerLinkProps: RouterLinkProps;
 } => {
-  const dataViewNamespace = `${selector ? dataStreamStat.namespace : '*'}`;
-  const dataViewSelector = selector ? `${selector}` : '';
-  const dataViewId = `${dataStreamStat.type}-${dataStreamStat.name}-${dataViewNamespace}${dataViewSelector}`;
-  const dataViewTitle = dataStreamStat.integration
-    ? `[${dataStreamStat.integration.title}] ${dataStreamStat.name}-${dataViewNamespace}${dataViewSelector}`
-    : `${dataViewId}`;
+  const { dataViewId, dataViewTitle } = getDataView({
+    dataStreamStat,
+    selector,
+  });
 
-  const filters = selector
-    ? []
-    : [
-        buildPhraseFilter(
-          {
-            name: 'data_stream.namespace',
-            type: 'string',
-          },
-          dataStreamStat.namespace,
-          {
-            id: dataViewId,
-            title: dataViewTitle,
-          }
-        ),
-      ];
+  const filters = getFilters({
+    dataStreamStat,
+    dataViewId,
+    dataViewTitle,
+    selector,
+  });
 
   const params: DiscoverAppLocatorParams = {
     timeRange: {
@@ -165,4 +154,59 @@ const buildDiscoverConfig = <T extends BasicDataStream>({
   });
 
   return { routerLinkProps: discoverLinkProps, navigate: navigateToDiscover };
+};
+
+const getDataView = <T extends BasicDataStream | string>({
+  dataStreamStat,
+  selector,
+}: {
+  dataStreamStat: T;
+  selector?: DataStreamSelector;
+}): { dataViewId: string; dataViewTitle: string } => {
+  if (dataStreamStat && typeof dataStreamStat === 'string') {
+    return { dataViewId: dataStreamStat, dataViewTitle: dataStreamStat };
+  }
+
+  const { name, namespace, type, integration } = dataStreamStat as BasicDataStream;
+
+  const dataViewNamespace = `${namespace || '*'}`;
+  const dataViewSelector = selector ? `${selector}` : '';
+  const dataViewId = `${type}-${name}-${dataViewNamespace}${dataViewSelector}`;
+  const dataViewTitle = integration
+    ? `[${integration.title}] ${name}-${dataViewNamespace}${dataViewSelector}`
+    : `${dataViewId}`;
+
+  return { dataViewId, dataViewTitle };
+};
+
+const getFilters = <T extends BasicDataStream | string>({
+  dataStreamStat,
+  dataViewId,
+  dataViewTitle,
+  selector,
+}: {
+  dataStreamStat: T;
+  dataViewId: string;
+  dataViewTitle: string;
+  selector?: DataStreamSelector;
+}): Filter[] => {
+  if (dataStreamStat && typeof dataStreamStat === 'string') {
+    return [];
+  }
+
+  return selector
+    ? []
+    : [
+        buildPhraseFilter(
+          {
+            name: 'data_stream.namespace',
+            type: 'string',
+          },
+          (dataStreamStat as BasicDataStream).namespace,
+          {
+            id: dataViewId,
+            title: dataViewTitle,
+          }
+        ),
+      ];
 };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/231565

### 🎥  Demo

#### Before

https://github.com/user-attachments/assets/19db12b3-091e-4bd5-a3a8-52cde53425bc

#### After

https://github.com/user-attachments/assets/2595fa1b-49fb-417b-89e5-4a681e60cc0d

### How to test?
1. Run synthtrace scenario `failed_logs`
2. Navigate to `Data set quality` page
3. Click on `Open` within Actions column
4. You will be redirected to discover and the dataView will include failed docs index


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->