### PR TITLE
[DO NOT REVIEW][Incident Management] Render SLO suggestions

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.test.ts
@@ -12,6 +12,7 @@ describe('Suggestion Schemas and Types', () => {
     it('should validate a valid context', () => {
       const validContext = {
         'service.name': ['my-service'],
+        spaceId: 'default',
         timeRange: {
           from: '2023-01-01T00:00:00Z',
           to: '2023-01-02T00:00:00Z',
@@ -22,7 +23,7 @@ describe('Suggestion Schemas and Types', () => {
     });
 
     it('should allow optional fields to be omitted', () => {
-      const validContext = {};
+      const validContext = { spaceId: 'default' };
       expect(() => suggestionContextRt.parse(validContext)).not.toThrow();
     });
 

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.ts
@@ -11,6 +11,7 @@ import { OWNERS } from '../../../constants/owners';
 const suggestionOwnerSchema = z.enum(OWNERS);
 
 export const suggestionContextRt = z.object({
+  spaceId: z.string(),
   'service.name': z.array(z.string()).optional(),
   timeRange: z
     .object({

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.ts
@@ -35,6 +35,8 @@ export interface AttachmentItem<
   /* A plaintext description of the attachment */
   description: string;
   attachment: CaseAttachmentWithoutOwner;
+  /* Unique identifier for the attachment item */
+  id: string;
 }
 
 /* Corresponds to each individual suggestion box presented to the user on the Cases UI.

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/suggestion/v1.ts
@@ -35,8 +35,6 @@ export interface AttachmentItem<
   /* A plaintext description of the attachment */
   description: string;
   attachment: CaseAttachmentWithoutOwner;
-  /* Unique identifier for the attachment item */
-  id: string;
 }
 
 /* Corresponds to each individual suggestion box presented to the user on the Cases UI.
@@ -51,6 +49,7 @@ export interface SuggestionItem<
   /* Optional plaintext description of the entire suggestion payload.
    * This is used by the LLM to understand the context, but may also be used by the UI
    * to display a summary of all context items. */
+  componentId: string;
   description?: string;
   data: Array<AttachmentItem<TPayload>>; // The main data of the context, containing 1 or more context items
 }

--- a/x-pack/platform/plugins/shared/cases/common/ui/types.ts
+++ b/x-pack/platform/plugins/shared/cases/common/ui/types.ts
@@ -72,6 +72,9 @@ export interface CasesUiConfigType {
   stack: {
     enabled: boolean;
   };
+  unsafe?: {
+    enableCaseSuggestions: boolean;
+  };
 }
 
 export const UserActionTypeAll = 'all' as const;

--- a/x-pack/platform/plugins/shared/cases/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/cases/kibana.jsonc
@@ -31,14 +31,14 @@
       "ruleRegistry",
       "files",
       "contentManagement",
-      "uiActions"
+      "uiActions",
+      "spaces"
     ],
     "optionalPlugins": [
       "cloud",
       "home",
       "taskManager",
       "usageCollection",
-      "spaces",
       "serverless"
     ],
     "requiredBundles": [

--- a/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/types.ts
@@ -13,7 +13,6 @@ import type {
   SuggestionOwner,
   SuggestionItem,
   GenericSuggestionPayload,
-  AttachmentItem,
 } from '../../../common/types/domain';
 import type { CaseUI } from '../../containers/types';
 
@@ -91,7 +90,6 @@ export interface SuggestionChildrenProps<
   TPayload extends GenericSuggestionPayload = GenericSuggestionPayload
 > {
   suggestion: SuggestionItem<TPayload>;
-  attachment: AttachmentItem<TPayload>;
 }
 
 export interface AttachmentFramework {

--- a/x-pack/platform/plugins/shared/cases/public/common/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/translations.ts
@@ -412,6 +412,13 @@ export const DISMISS = i18n.translate('xpack.cases.suggestions.button.dismiss', 
   defaultMessage: 'Dismiss',
 });
 
+export const DISMISS_SUGGESTION_ARIA_LABEL = i18n.translate(
+  'xpack.cases.suggestions.button.dismissAriaLabel',
+  {
+    defaultMessage: 'Dismiss suggestion',
+  }
+);
+
 export const ADD_TO_CASE = i18n.translate('xpack.cases.suggestions.button.addToCase', {
   defaultMessage: 'Add to Case',
 });

--- a/x-pack/platform/plugins/shared/cases/public/common/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/translations.ts
@@ -404,21 +404,18 @@ export const EXPERIMENTAL_DESC = i18n.translate('xpack.cases.badge.experimentalD
     'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
 });
 
-export const SUGGESTION = i18n.translate('xpack.cases.caseSuggestions.label', {
+export const SUGGESTION = i18n.translate('xpack.cases.suggestions.label', {
   defaultMessage: 'Suggestion',
 });
 
-export const DISMISS = i18n.translate('xpack.cases.caseSuggestions.dismiss', {
+export const DISMISS = i18n.translate('xpack.cases.suggestions.button.dismiss', {
   defaultMessage: 'Dismiss',
 });
 
-export const ADD_TO_CASE = i18n.translate('xpack.cases.caseSuggestions.addToCase', {
+export const ADD_TO_CASE = i18n.translate('xpack.cases.suggestions.button.addToCase', {
   defaultMessage: 'Add to Case',
 });
 
-export const SUGGESTION_ADDED_TO_CASE = i18n.translate(
-  'xpack.cases.caseSuggestions.suggestionAddedToCase',
-  {
-    defaultMessage: 'Suggestion added to case',
-  }
-);
+export const SUGGESTION_ADDED_TO_CASE = i18n.translate('xpack.cases.suggestions.addedToCase', {
+  defaultMessage: 'Suggestion added to case',
+});

--- a/x-pack/platform/plugins/shared/cases/public/common/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/translations.ts
@@ -403,3 +403,22 @@ export const EXPERIMENTAL_DESC = i18n.translate('xpack.cases.badge.experimentalD
   defaultMessage:
     'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
 });
+
+export const SUGGESTION = i18n.translate('xpack.cases.caseSuggestions.label', {
+  defaultMessage: 'Suggestion',
+});
+
+export const DISMISS = i18n.translate('xpack.cases.caseSuggestions.dismiss', {
+  defaultMessage: 'Dismiss',
+});
+
+export const ADD_TO_CASE = i18n.translate('xpack.cases.caseSuggestions.addToCase', {
+  defaultMessage: 'Add to Case',
+});
+
+export const SUGGESTION_ADDED_TO_CASE = i18n.translate(
+  'xpack.cases.caseSuggestions.suggestionAddedToCase',
+  {
+    defaultMessage: 'Suggestion added to case',
+  }
+);

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
@@ -28,22 +28,31 @@ export const CaseSuggestionItem = ({
   suggestion,
   caseData,
   setDismissedIds,
+  componentById,
 }: {
-  suggestion: SuggestionItem & {
-    injectedComponent: SuggestionType['children'];
-  };
+  suggestion: SuggestionItem;
   caseData: CaseUI;
   setDismissedIds: (callback: (prev: string[]) => string[]) => void;
+  componentById: Map<string, SuggestionType['children']>;
 }) => {
-  const { isAddingSuggestionToCase, onAddSuggestionToCase, onDismissSuggestion } =
-    useCaseSuggestionItem({
-      suggestion,
-      caseData,
-      setDismissedIds,
-    });
+  const {
+    isAddingSuggestionToCase,
+    onAddSuggestionToCase,
+    onDismissSuggestion,
+    InjectedComponent,
+  } = useCaseSuggestionItem({
+    suggestion,
+    caseData,
+    setDismissedIds,
+    componentById,
+  });
+
+  if (!InjectedComponent) {
+    return null;
+  }
 
   return (
-    <EuiFlexItem>
+    <EuiFlexItem data-test-subj={`suggestion-${suggestion.id}`}>
       <EuiPanel
         paddingSize="m"
         style={{ height: ITEM_HEIGHT, display: 'flex', flexDirection: 'column', gap: 8 }}
@@ -63,16 +72,27 @@ export const CaseSuggestionItem = ({
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon iconType="cross" color="text" onClick={onDismissSuggestion} />
+            <EuiButtonIcon
+              iconType="cross"
+              color="text"
+              onClick={onDismissSuggestion}
+              aria-label={i18n.DISMISS_SUGGESTION_ARIA_LABEL}
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiText size="s">{suggestion.description}</EuiText>
         <div style={{ height: '100%', display: 'flex' }}>
-          <suggestion.injectedComponent suggestion={suggestion} />
+          <InjectedComponent suggestion={suggestion} />
         </div>
         <EuiFlexGroup justifyContent="flexEnd" gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty size="s" color="primary" onClick={onDismissSuggestion}>
+            <EuiButtonEmpty
+              size="s"
+              color="primary"
+              onClick={onDismissSuggestion}
+              aria-label={i18n.DISMISS_SUGGESTION_ARIA_LABEL}
+              data-test-subj={`dismiss-suggestion-${suggestion.id}-button`}
+            >
               {i18n.DISMISS}
             </EuiButtonEmpty>
           </EuiFlexItem>
@@ -83,6 +103,8 @@ export const CaseSuggestionItem = ({
               iconType="plusInCircle"
               isLoading={isAddingSuggestionToCase}
               onClick={onAddSuggestionToCase}
+              aria-label={i18n.ADD_TO_CASE}
+              data-test-subj={`add-suggestion-${suggestion.id}-button`}
             >
               {i18n.ADD_TO_CASE}
             </EuiButton>

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
@@ -16,7 +16,7 @@ import {
   EuiPanel,
   EuiText,
 } from '@elastic/eui';
-import type { AttachmentItem } from '../../../../common/types/domain';
+import type { SuggestionItem } from '../../../../common/types/domain';
 import type { SuggestionType } from '../../..';
 import type { CaseUI } from '../../../../common';
 import * as i18n from '../../../common/translations';
@@ -29,7 +29,7 @@ export const CaseSuggestionItem = ({
   caseData,
   setDismissedIds,
 }: {
-  suggestion: AttachmentItem & {
+  suggestion: SuggestionItem & {
     injectedComponent: SuggestionType['children'];
   };
   caseData: CaseUI;
@@ -67,7 +67,7 @@ export const CaseSuggestionItem = ({
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiText size="s">{suggestion.description}</EuiText>
-        <suggestion.injectedComponent suggestion={{ data: [suggestion], id: suggestion.id }} />
+        <suggestion.injectedComponent suggestion={suggestion} />
         <EuiFlexGroup justifyContent="flexEnd" gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty size="s" color="primary" onClick={onDismissSuggestion}>

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiPanel,
+  EuiText,
+} from '@elastic/eui';
+import type { AttachmentItem } from '../../../../common/types/domain';
+import type { SuggestionType } from '../../..';
+import type { CaseUI } from '../../../../common';
+import * as i18n from '../../../common/translations';
+import { useCaseSuggestionItem } from '../use_case_suggestion_item';
+
+const ITEM_HEIGHT = 200;
+
+export const CaseSuggestionItem = ({
+  suggestion,
+  caseData,
+  onDismissSuggestion,
+}: {
+  suggestion: AttachmentItem & {
+    injectedComponent: SuggestionType['children'];
+  };
+  caseData: CaseUI;
+  onDismissSuggestion: (id: string) => void;
+}) => {
+  const { isAddingSuggestionToCase, onAddSuggestionToCase, onDismissSuggestionNew } =
+    useCaseSuggestionItem({
+      suggestion,
+      caseData,
+      onDismissSuggestion,
+    });
+
+  return (
+    <EuiFlexItem>
+      <EuiPanel
+        paddingSize="m"
+        style={{ height: ITEM_HEIGHT, display: 'flex', flexDirection: 'column', gap: 8 }}
+      >
+        <EuiFlexGroup justifyContent="spaceBetween" gutterSize="m">
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiIcon type="sparkles" />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="s" css={{ fontWeight: 'bold' }}>
+                  {i18n.SUGGESTION}
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon iconType="cross" color="text" onClick={onDismissSuggestionNew} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        {suggestion.description && <EuiText size="s">{suggestion.description}</EuiText>}
+
+        <suggestion.injectedComponent suggestion={{ data: [suggestion], id: suggestion.id }} />
+
+        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty size="s" color="primary" onClick={onDismissSuggestionNew}>
+              {i18n.DISMISS}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              fill
+              iconType="plusInCircle"
+              isLoading={isAddingSuggestionToCase}
+              onClick={onAddSuggestionToCase}
+            >
+              {i18n.ADD_TO_CASE}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    </EuiFlexItem>
+  );
+};
+
+CaseSuggestionItem.displayName = 'CaseSuggestionItem';

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
@@ -67,7 +67,9 @@ export const CaseSuggestionItem = ({
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiText size="s">{suggestion.description}</EuiText>
-        <suggestion.injectedComponent suggestion={suggestion} />
+        <div style={{ height: '100%', display: 'flex' }}>
+          <suggestion.injectedComponent suggestion={suggestion} />
+        </div>
         <EuiFlexGroup justifyContent="flexEnd" gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty size="s" color="primary" onClick={onDismissSuggestion}>

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
@@ -27,19 +27,19 @@ const ITEM_HEIGHT = 350;
 export const CaseSuggestionItem = ({
   suggestion,
   caseData,
-  onDismissSuggestion,
+  setDismissedIds,
 }: {
   suggestion: AttachmentItem & {
     injectedComponent: SuggestionType['children'];
   };
   caseData: CaseUI;
-  onDismissSuggestion: (id: string) => void;
+  setDismissedIds: (callback: (prev: string[]) => string[]) => void;
 }) => {
-  const { isAddingSuggestionToCase, onAddSuggestionToCase, onDismissSuggestionNew } =
+  const { isAddingSuggestionToCase, onAddSuggestionToCase, onDismissSuggestion } =
     useCaseSuggestionItem({
       suggestion,
       caseData,
-      onDismissSuggestion,
+      setDismissedIds,
     });
 
   return (
@@ -63,17 +63,14 @@ export const CaseSuggestionItem = ({
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon iconType="cross" color="text" onClick={onDismissSuggestionNew} />
+            <EuiButtonIcon iconType="cross" color="text" onClick={onDismissSuggestion} />
           </EuiFlexItem>
         </EuiFlexGroup>
-
-        {suggestion.description && <EuiText size="s">{suggestion.description}</EuiText>}
-
+        <EuiText size="s">{suggestion.description}</EuiText>
         <suggestion.injectedComponent suggestion={{ data: [suggestion], id: suggestion.id }} />
-
         <EuiFlexGroup justifyContent="flexEnd" gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty size="s" color="primary" onClick={onDismissSuggestionNew}>
+            <EuiButtonEmpty size="s" color="primary" onClick={onDismissSuggestion}>
               {i18n.DISMISS}
             </EuiButtonEmpty>
           </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestion_item.tsx
@@ -22,7 +22,7 @@ import type { CaseUI } from '../../../../common';
 import * as i18n from '../../../common/translations';
 import { useCaseSuggestionItem } from '../use_case_suggestion_item';
 
-const ITEM_HEIGHT = 200;
+const ITEM_HEIGHT = 350;
 
 export const CaseSuggestionItem = ({
   suggestion,
@@ -71,7 +71,7 @@ export const CaseSuggestionItem = ({
 
         <suggestion.injectedComponent suggestion={{ data: [suggestion], id: suggestion.id }} />
 
-        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty size="s" color="primary" onClick={onDismissSuggestionNew}>
               {i18n.DISMISS}

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { useCasesContext } from '../../cases_context/use_cases_context';
+import { CaseSuggestions } from './case_suggestions';
+import { caseData } from '../mocks';
+import { renderWithTestingProviders } from '../../../common/mock';
+import userEvent from '@testing-library/user-event';
+import { useCasesToast } from '../../../common/use_cases_toast';
+import { useCreateAttachments } from '../../../containers/use_create_attachments';
+import * as ReactQuery from '@tanstack/react-query';
+
+jest.mock('../../cases_context/use_cases_context');
+jest.mock('../../../common/use_cases_toast');
+jest.mock('../../../containers/use_create_attachments', () => ({
+  useCreateAttachments: jest.fn(),
+}));
+
+let useQueryMock: jest.SpyInstance;
+const useCasesContextMock = useCasesContext as jest.Mock;
+const useCasesToastMock = useCasesToast as jest.Mock;
+const useCreateAttachmentsMock = useCreateAttachments as jest.Mock;
+
+const MOCK_COMPONENT_ID = 'test-component-id';
+
+const MOCK_SUGGESTION_1 = {
+  id: 's1',
+  componentId: MOCK_COMPONENT_ID,
+  description: 'desc1',
+  data: [],
+};
+const MOCK_SUGGESTION_2 = {
+  id: 's2',
+  componentId: MOCK_COMPONENT_ID,
+  description: 'desc2',
+  data: [],
+};
+const MOCK_SUGGESTION_3 = {
+  id: 's3',
+  componentId: MOCK_COMPONENT_ID,
+  description: 'desc3',
+  data: [],
+};
+
+const MOCK_INJECTED_COMPONENT_DATA_TEST_SUBJ = 'injected-component';
+
+describe('CaseSuggestions component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useQueryMock = jest.spyOn(ReactQuery, 'useQuery');
+
+    useCasesContextMock.mockReturnValue({
+      attachmentSuggestionRegistry: {
+        list: () => [
+          {
+            id: MOCK_COMPONENT_ID,
+            children: ({ suggestion: s }: { suggestion: typeof MOCK_SUGGESTION_1 }) => (
+              <div data-test-subj={MOCK_INJECTED_COMPONENT_DATA_TEST_SUBJ}>{s.id}</div>
+            ),
+          },
+        ],
+      },
+    });
+
+    useCasesToastMock.mockReturnValue({ showSuccessToast: jest.fn() });
+    useCreateAttachmentsMock.mockReturnValue({ mutateAsync: jest.fn(), isLoading: false });
+  });
+
+  it('renders the suggestion item when one suggestion is returned', async () => {
+    useQueryMock.mockReturnValueOnce({
+      data: { suggestions: [MOCK_SUGGESTION_1] },
+      isLoading: false,
+    });
+    renderWithTestingProviders(<CaseSuggestions caseData={caseData} />);
+
+    expect(await screen.findByTestId(`suggestion-${MOCK_SUGGESTION_1.id}`)).toBeInTheDocument();
+  });
+
+  it('renders a maximum of two suggestions even if three are returned', async () => {
+    useQueryMock.mockReturnValueOnce({
+      data: { suggestions: [MOCK_SUGGESTION_1, MOCK_SUGGESTION_2, MOCK_SUGGESTION_3] },
+      isLoading: false,
+    });
+
+    renderWithTestingProviders(<CaseSuggestions caseData={caseData} />);
+
+    expect(await screen.findByText(MOCK_SUGGESTION_1.id)).toBeInTheDocument();
+    expect(await screen.findByText(MOCK_SUGGESTION_2.id)).toBeInTheDocument();
+    expect(screen.queryByText(MOCK_SUGGESTION_3.id)).not.toBeInTheDocument();
+
+    expect(screen.getAllByTestId(MOCK_INJECTED_COMPONENT_DATA_TEST_SUBJ)).toHaveLength(2);
+  });
+
+  it('shows the third suggestion when the first one is dismissed', async () => {
+    useQueryMock.mockReturnValue({
+      data: { suggestions: [MOCK_SUGGESTION_1, MOCK_SUGGESTION_2, MOCK_SUGGESTION_3] },
+      isLoading: false,
+    });
+
+    renderWithTestingProviders(<CaseSuggestions caseData={caseData} />);
+
+    expect(await screen.findByTestId(`suggestion-${MOCK_SUGGESTION_1.id}`)).toBeInTheDocument();
+    expect(await screen.findByTestId(`suggestion-${MOCK_SUGGESTION_2.id}`)).toBeInTheDocument();
+    expect(screen.queryByTestId(`suggestion-${MOCK_SUGGESTION_3.id}`)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId(`dismiss-suggestion-${MOCK_SUGGESTION_1.id}-button`));
+
+    expect(await screen.findByTestId(`suggestion-${MOCK_SUGGESTION_3.id}`)).toBeInTheDocument();
+
+    expect(screen.queryByText(MOCK_SUGGESTION_1.id)).not.toBeInTheDocument();
+    expect(screen.getAllByTestId(MOCK_INJECTED_COMPONENT_DATA_TEST_SUBJ)).toHaveLength(2);
+  });
+
+  it('creates attachments when clicking Add to case', async () => {
+    const MOCK_ATTACHMENT = { id: 'a1' };
+    useQueryMock.mockReturnValue({
+      data: { suggestions: [{ ...MOCK_SUGGESTION_1, data: [{ attachment: MOCK_ATTACHMENT }] }] },
+      isLoading: false,
+    });
+
+    const mutateAsync = jest.fn();
+    useCreateAttachmentsMock.mockReturnValue({ mutateAsync, isLoading: false });
+
+    renderWithTestingProviders(<CaseSuggestions caseData={caseData} />);
+
+    await userEvent.click(
+      await screen.findByTestId(`add-suggestion-${MOCK_SUGGESTION_1.id}-button`)
+    );
+
+    expect(mutateAsync).toHaveBeenCalledWith({
+      caseId: caseData.id,
+      caseOwner: caseData.owner,
+      attachments: [MOCK_ATTACHMENT],
+    });
+  });
+
+  it('does not render a suggestion if its componentId is not registered', async () => {
+    useQueryMock.mockReturnValue({
+      data: { suggestions: [{ ...MOCK_SUGGESTION_1, componentId: 'unknown-component' }] },
+      isLoading: false,
+    });
+
+    renderWithTestingProviders(<CaseSuggestions caseData={caseData} />);
+
+    expect(screen.queryByTestId(MOCK_INJECTED_COMPONENT_DATA_TEST_SUBJ)).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.tsx
@@ -12,9 +12,10 @@ import { CaseSuggestionItem } from './case_suggestion_item';
 import { useCaseSuggestions } from '../use_case_suggestions';
 
 export const CaseSuggestions = ({ caseData }: { caseData: CaseUI }) => {
-  const { visibleSuggestions, isLoadingSuggestions, setDismissedIds } = useCaseSuggestions({
-    caseData,
-  });
+  const { visibleSuggestions, isLoadingSuggestions, setDismissedIds, componentById } =
+    useCaseSuggestions({
+      caseData,
+    });
 
   if (isLoadingSuggestions) {
     return <EuiLoadingSpinner size="m" />;
@@ -30,6 +31,7 @@ export const CaseSuggestions = ({ caseData }: { caseData: CaseUI }) => {
               suggestion={suggestion}
               caseData={caseData}
               setDismissedIds={setDismissedIds}
+              componentById={componentById}
             />
           );
         })}

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.tsx
@@ -12,7 +12,7 @@ import { CaseSuggestionItem } from './case_suggestion_item';
 import { useCaseSuggestions } from '../use_case_suggestions';
 
 export const CaseSuggestions = ({ caseData }: { caseData: CaseUI }) => {
-  const { visibleSuggestions, isLoadingSuggestions, onDismissSuggestion } = useCaseSuggestions({
+  const { visibleSuggestions, isLoadingSuggestions, setDismissedIds } = useCaseSuggestions({
     caseData,
   });
 
@@ -29,7 +29,7 @@ export const CaseSuggestions = ({ caseData }: { caseData: CaseUI }) => {
               key={suggestion.id}
               suggestion={suggestion}
               caseData={caseData}
-              onDismissSuggestion={onDismissSuggestion}
+              setDismissedIds={setDismissedIds}
             />
           );
         })}

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.tsx
@@ -22,7 +22,7 @@ export const CaseSuggestions = ({ caseData }: { caseData: CaseUI }) => {
 
   return (
     <EuiFlexItem grow={false}>
-      <EuiFlexGroup gutterSize="m" wrap>
+      <EuiFlexGroup gutterSize="m" wrap direction="column">
         {visibleSuggestions.map((suggestion) => {
           return (
             <CaseSuggestionItem

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.tsx
@@ -5,46 +5,37 @@
  * 2.0.
  */
 
-import { EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import type { CaseUI } from '../../../../common';
-import { getCaseSuggestions } from '../../../containers/api';
-import { useCasesContext } from '../../cases_context/use_cases_context';
+import { CaseSuggestionItem } from './case_suggestion_item';
+import { useCaseSuggestions } from '../use_case_suggestions';
 
-export const useFetchSuggestion = ({ caseData }: { caseData: CaseUI }) => {
-  const { data, isLoading, refetch } = useQuery({
-    queryKey: ['suggestions', caseData.id],
-    queryFn: () => getCaseSuggestions({ caseId: caseData.id }),
-    refetchOnWindowFocus: false,
+export const CaseSuggestions = ({ caseData }: { caseData: CaseUI }) => {
+  const { visibleSuggestions, isLoadingSuggestions, onDismissSuggestion } = useCaseSuggestions({
+    caseData,
   });
-
-  return {
-    isLoadingSuggestions: isLoading,
-    suggestions: data?.suggestions || [],
-    refetchSuggestions: refetch,
-  };
-};
-
-export const CaseSuggestions = React.memo(({ caseData }: { caseData: CaseUI }) => {
-  const { suggestions, isLoadingSuggestions } = useFetchSuggestion({ caseData });
-
-  const { attachmentSuggestionRegistry } = useCasesContext();
-  const components = attachmentSuggestionRegistry.list();
 
   if (isLoadingSuggestions) {
     return <EuiLoadingSpinner size="m" />;
   }
 
   return (
-    <EuiFlexItem>
-      {suggestions.map((suggestion) => {
-        const component = components.find((c) => c.id === suggestion.id);
-        if (!component) return null;
-        return <component.children key={suggestion.id} suggestion={suggestion} />;
-      })}
+    <EuiFlexItem grow={false}>
+      <EuiFlexGroup gutterSize="m" wrap>
+        {visibleSuggestions.map((suggestion) => {
+          return (
+            <CaseSuggestionItem
+              key={suggestion.id}
+              suggestion={suggestion}
+              caseData={caseData}
+              onDismissSuggestion={onDismissSuggestion}
+            />
+          );
+        })}
+      </EuiFlexGroup>
     </EuiFlexItem>
   );
-});
+};
 
 CaseSuggestions.displayName = 'CaseSuggestions';

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_suggestions.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiLoadingSpinner } from '@elastic/eui';
+import { EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { CaseUI } from '../../../../common';
@@ -20,31 +20,31 @@ export const useFetchSuggestion = ({ caseData }: { caseData: CaseUI }) => {
   });
 
   return {
-    isLoadingSloSuggestions: isLoading,
+    isLoadingSuggestions: isLoading,
     suggestions: data?.suggestions || [],
     refetchSuggestions: refetch,
   };
 };
 
-export const Suggestions = React.memo(({ caseData }: { caseData: CaseUI }) => {
-  const { suggestions, isLoadingSloSuggestions } = useFetchSuggestion({ caseData });
+export const CaseSuggestions = React.memo(({ caseData }: { caseData: CaseUI }) => {
+  const { suggestions, isLoadingSuggestions } = useFetchSuggestion({ caseData });
 
   const { attachmentSuggestionRegistry } = useCasesContext();
   const components = attachmentSuggestionRegistry.list();
 
-  if (isLoadingSloSuggestions) {
+  if (isLoadingSuggestions) {
     return <EuiLoadingSpinner size="m" />;
   }
 
   return (
-    <div>
+    <EuiFlexItem>
       {suggestions.map((suggestion) => {
         const component = components.find((c) => c.id === suggestion.id);
         if (!component) return null;
         return <component.children key={suggestion.id} suggestion={suggestion} />;
       })}
-    </div>
+    </EuiFlexItem>
   );
 });
 
-Suggestions.displayName = 'Suggestions';
+CaseSuggestions.displayName = 'CaseSuggestions';

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.tsx
@@ -53,6 +53,7 @@ import { EditCategory } from './edit_category';
 import { parseCaseUsers } from '../../utils';
 import { CustomFields } from './custom_fields';
 import { useReplaceCustomField } from '../../../containers/use_replace_custom_field';
+import { Suggestions } from './suggestions';
 
 const LOCALSTORAGE_SORT_ORDER_KEY = 'cases.userActivity.sortOrder';
 
@@ -266,6 +267,9 @@ export const CaseViewActivity = ({
           <h2>{i18n.CASE_SETTINGS}</h2>
         </EuiScreenReaderOnly>
         <EuiFlexGroup direction="column" responsive={false} gutterSize="xl">
+          <EuiFlexItem>
+            <Suggestions caseData={caseData} />
+          </EuiFlexItem>
           {caseAssignmentAuthorized ? (
             <>
               <AssignUsers

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.tsx
@@ -53,7 +53,8 @@ import { EditCategory } from './edit_category';
 import { parseCaseUsers } from '../../utils';
 import { CustomFields } from './custom_fields';
 import { useReplaceCustomField } from '../../../containers/use_replace_custom_field';
-import { Suggestions } from './suggestions';
+import { CaseSuggestions } from './case_suggestions';
+import { KibanaServices } from '../../../common/lib/kibana';
 
 const LOCALSTORAGE_SORT_ORDER_KEY = 'cases.userActivity.sortOrder';
 
@@ -267,9 +268,9 @@ export const CaseViewActivity = ({
           <h2>{i18n.CASE_SETTINGS}</h2>
         </EuiScreenReaderOnly>
         <EuiFlexGroup direction="column" responsive={false} gutterSize="xl">
-          <EuiFlexItem>
-            <Suggestions caseData={caseData} />
-          </EuiFlexItem>
+          {KibanaServices.getConfig()?.unsafe?.enableCaseSuggestions ? (
+            <CaseSuggestions caseData={caseData} />
+          ) : null}
           {caseAssignmentAuthorized ? (
             <>
               <AssignUsers

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/suggestions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/suggestions.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiLoadingSpinner } from '@elastic/eui';
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { CaseUI } from '../../../../common';
+import { getCaseSuggestions } from '../../../containers/api';
+import { useCasesContext } from '../../cases_context/use_cases_context';
+
+export const useFetchSuggestion = ({ caseData }: { caseData: CaseUI }) => {
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['suggestions', caseData.id],
+    queryFn: () => getCaseSuggestions({ caseId: caseData.id }),
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    isLoadingSloSuggestions: isLoading,
+    suggestions: data?.suggestions || [],
+    refetchSuggestions: refetch,
+  };
+};
+
+export const Suggestions = React.memo(({ caseData }: { caseData: CaseUI }) => {
+  const { suggestions, isLoadingSloSuggestions } = useFetchSuggestion({ caseData });
+
+  const { attachmentSuggestionRegistry } = useCasesContext();
+  const components = attachmentSuggestionRegistry.list();
+
+  if (isLoadingSloSuggestions) {
+    return <EuiLoadingSpinner size="m" />;
+  }
+
+  return (
+    <div>
+      {suggestions.map((suggestion) => {
+        const component = components.find((c) => c.id === suggestion.id);
+        if (!component) return null;
+        return <component.children key={suggestion.id} suggestion={suggestion} />;
+      })}
+    </div>
+  );
+});
+
+Suggestions.displayName = 'Suggestions';

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestion_item.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestion_item.ts
@@ -5,22 +5,25 @@
  * 2.0.
  */
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { SuggestionItem } from '../../../common/types/domain';
 import type { CaseUI } from '../../../common';
 import { useCasesToast } from '../../common/use_cases_toast';
 import { useRefreshCaseViewPage } from './use_on_refresh_case_view_page';
 import { useCreateAttachments } from '../../containers/use_create_attachments';
 import * as i18n from '../../common/translations';
+import type { SuggestionType } from '../../client/attachment_framework/types';
 
 export const useCaseSuggestionItem = ({
   caseData,
   suggestion,
   setDismissedIds,
+  componentById,
 }: {
   caseData: CaseUI;
   suggestion: SuggestionItem;
   setDismissedIds: (callback: (prev: string[]) => string[]) => void;
+  componentById: Map<string, SuggestionType['children']>;
 }) => {
   const { showSuccessToast } = useCasesToast();
   const refreshCaseViewPage = useRefreshCaseViewPage();
@@ -48,5 +51,14 @@ export const useCaseSuggestionItem = ({
     });
   }, [createAttachments, caseData.id, caseData.owner, suggestion.data]);
 
-  return { isAddingSuggestionToCase, onAddSuggestionToCase, onDismissSuggestion };
+  const InjectedComponent = useMemo(() => {
+    return componentById.get(suggestion.componentId);
+  }, [componentById, suggestion.componentId]);
+
+  return {
+    isAddingSuggestionToCase,
+    onAddSuggestionToCase,
+    onDismissSuggestion,
+    InjectedComponent,
+  };
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestion_item.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestion_item.ts
@@ -6,7 +6,7 @@
  */
 
 import { useCallback } from 'react';
-import type { AttachmentItem } from '../../../common/types/domain';
+import type { SuggestionItem } from '../../../common/types/domain';
 import type { CaseUI } from '../../../common';
 import { useCasesToast } from '../../common/use_cases_toast';
 import { useRefreshCaseViewPage } from './use_on_refresh_case_view_page';
@@ -19,7 +19,7 @@ export const useCaseSuggestionItem = ({
   setDismissedIds,
 }: {
   caseData: CaseUI;
-  suggestion: AttachmentItem;
+  suggestion: SuggestionItem;
   setDismissedIds: (callback: (prev: string[]) => string[]) => void;
 }) => {
   const { showSuccessToast } = useCasesToast();
@@ -44,9 +44,9 @@ export const useCaseSuggestionItem = ({
     createAttachments({
       caseId: caseData.id,
       caseOwner: caseData.owner,
-      attachments: [suggestion.attachment],
+      attachments: suggestion.data.map((d) => d.attachment),
     });
-  }, [createAttachments, caseData.id, caseData.owner, suggestion.attachment]);
+  }, [createAttachments, caseData.id, caseData.owner, suggestion.data]);
 
   return { isAddingSuggestionToCase, onAddSuggestionToCase, onDismissSuggestion };
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestion_item.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestion_item.ts
@@ -16,24 +16,24 @@ import * as i18n from '../../common/translations';
 export const useCaseSuggestionItem = ({
   caseData,
   suggestion,
-  onDismissSuggestion,
+  setDismissedIds,
 }: {
   caseData: CaseUI;
   suggestion: AttachmentItem;
-  onDismissSuggestion: (id: string) => void;
+  setDismissedIds: (callback: (prev: string[]) => string[]) => void;
 }) => {
   const { showSuccessToast } = useCasesToast();
   const refreshCaseViewPage = useRefreshCaseViewPage();
 
-  const onDismissSuggestionNew = useCallback(() => {
-    onDismissSuggestion(suggestion.id);
-  }, [onDismissSuggestion, suggestion.id]);
+  const onDismissSuggestion = useCallback(() => {
+    setDismissedIds((prev) => [...prev, suggestion.id]);
+  }, [setDismissedIds, suggestion.id]);
 
   const onSuggestionAddedToCase = useCallback(() => {
     refreshCaseViewPage();
     showSuccessToast(i18n.SUGGESTION_ADDED_TO_CASE);
-    onDismissSuggestionNew();
-  }, [showSuccessToast, refreshCaseViewPage, onDismissSuggestionNew]);
+    onDismissSuggestion();
+  }, [showSuccessToast, refreshCaseViewPage, onDismissSuggestion]);
 
   const { mutateAsync: createAttachments, isLoading: isAddingSuggestionToCase } =
     useCreateAttachments({
@@ -48,5 +48,5 @@ export const useCaseSuggestionItem = ({
     });
   }, [createAttachments, caseData.id, caseData.owner, suggestion.attachment]);
 
-  return { isAddingSuggestionToCase, onAddSuggestionToCase, onDismissSuggestionNew };
+  return { isAddingSuggestionToCase, onAddSuggestionToCase, onDismissSuggestion };
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestion_item.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestion_item.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback } from 'react';
+import type { AttachmentItem } from '../../../common/types/domain';
+import type { CaseUI } from '../../../common';
+import { useCasesToast } from '../../common/use_cases_toast';
+import { useRefreshCaseViewPage } from './use_on_refresh_case_view_page';
+import { useCreateAttachments } from '../../containers/use_create_attachments';
+import * as i18n from '../../common/translations';
+
+export const useCaseSuggestionItem = ({
+  caseData,
+  suggestion,
+  onDismissSuggestion,
+}: {
+  caseData: CaseUI;
+  suggestion: AttachmentItem;
+  onDismissSuggestion: (id: string) => void;
+}) => {
+  const { showSuccessToast } = useCasesToast();
+  const refreshCaseViewPage = useRefreshCaseViewPage();
+
+  const onDismissSuggestionNew = useCallback(() => {
+    onDismissSuggestion(suggestion.id);
+  }, [onDismissSuggestion, suggestion.id]);
+
+  const onSuggestionAddedToCase = useCallback(() => {
+    refreshCaseViewPage();
+    showSuccessToast(i18n.SUGGESTION_ADDED_TO_CASE);
+    onDismissSuggestionNew();
+  }, [showSuccessToast, refreshCaseViewPage, onDismissSuggestionNew]);
+
+  const { mutateAsync: createAttachments, isLoading: isAddingSuggestionToCase } =
+    useCreateAttachments({
+      onSuccess: onSuggestionAddedToCase,
+    });
+
+  const onAddSuggestionToCase = useCallback(() => {
+    createAttachments({
+      caseId: caseData.id,
+      caseOwner: caseData.owner,
+      attachments: [suggestion.attachment],
+    });
+  }, [createAttachments, caseData.id, caseData.owner, suggestion.attachment]);
+
+  return { isAddingSuggestionToCase, onAddSuggestionToCase, onDismissSuggestionNew };
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestions.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestions.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { AttachmentItem } from '../../../common/types/domain';
+import type { CaseUI } from '../../../common';
+import { useCasesContext } from '../cases_context/use_cases_context';
+import { getCaseSuggestions } from '../../containers/api';
+import type { SuggestionType } from '../../client/attachment_framework/types';
+
+const MAX_SUGGESTIONS = 2;
+
+export const useCaseSuggestions = ({ caseData }: { caseData: CaseUI }) => {
+  const [dismissedIds, setDismissedIds] = useState<string[]>([]);
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['suggestions', caseData.id],
+    queryFn: () => getCaseSuggestions({ caseId: caseData.id }),
+    refetchOnWindowFocus: false,
+  });
+
+  const { attachmentSuggestionRegistry } = useCasesContext();
+
+  const componentById = useMemo(
+    () =>
+      new Map(attachmentSuggestionRegistry.list().map((component) => [component.id, component])),
+    [attachmentSuggestionRegistry]
+  );
+
+  const suggestionAttachmentsWithInjectedComponent: (AttachmentItem & {
+    injectedComponent: SuggestionType['children'];
+  })[] = useMemo(() => {
+    return (data?.suggestions ?? []).flatMap((suggestion) => {
+      const component = componentById.get(suggestion.id);
+      if (!component) {
+        // TODO: if the suggestion component is not found, we should log an error
+        return [];
+      }
+      return suggestion.data.map((d) => ({
+        ...d,
+        injectedComponent: component.children,
+      }));
+    });
+  }, [data?.suggestions, componentById]);
+
+  const visibleSuggestions = useMemo(
+    () =>
+      suggestionAttachmentsWithInjectedComponent
+        .filter(({ id }) => !dismissedIds.includes(id))
+        .slice(0, MAX_SUGGESTIONS),
+    [suggestionAttachmentsWithInjectedComponent, dismissedIds]
+  );
+
+  const onDismissSuggestion = useCallback(
+    (id: string) => setDismissedIds((prev) => [...prev, id]),
+    [setDismissedIds]
+  );
+
+  return {
+    isLoadingSuggestions: isLoading,
+    visibleSuggestions,
+    refetchSuggestions: refetch,
+    onDismissSuggestion,
+  };
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestions.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestions.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { AttachmentItem } from '../../../common/types/domain';
 import type { CaseUI } from '../../../common';
@@ -38,7 +38,6 @@ export const useCaseSuggestions = ({ caseData }: { caseData: CaseUI }) => {
     return (data?.suggestions ?? []).flatMap((suggestion) => {
       const component = componentById.get(suggestion.id);
       if (!component) {
-        // TODO: if the suggestion component is not found, we should log an error
         return [];
       }
       return suggestion.data.map((d) => ({
@@ -56,15 +55,10 @@ export const useCaseSuggestions = ({ caseData }: { caseData: CaseUI }) => {
     [suggestionAttachmentsWithInjectedComponent, dismissedIds]
   );
 
-  const onDismissSuggestion = useCallback(
-    (id: string) => setDismissedIds((prev) => [...prev, id]),
-    [setDismissedIds]
-  );
-
   return {
     isLoadingSuggestions: isLoading,
     visibleSuggestions,
     refetchSuggestions: refetch,
-    onDismissSuggestion,
+    setDismissedIds,
   };
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestions.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_suggestions.ts
@@ -7,7 +7,7 @@
 
 import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import type { AttachmentItem } from '../../../common/types/domain';
+import type { SuggestionItem } from '../../../common/types/domain';
 import type { CaseUI } from '../../../common';
 import { useCasesContext } from '../cases_context/use_cases_context';
 import { getCaseSuggestions } from '../../containers/api';
@@ -32,18 +32,20 @@ export const useCaseSuggestions = ({ caseData }: { caseData: CaseUI }) => {
     [attachmentSuggestionRegistry]
   );
 
-  const suggestionAttachmentsWithInjectedComponent: (AttachmentItem & {
+  const suggestionAttachmentsWithInjectedComponent: (SuggestionItem & {
     injectedComponent: SuggestionType['children'];
   })[] = useMemo(() => {
     return (data?.suggestions ?? []).flatMap((suggestion) => {
-      const component = componentById.get(suggestion.id);
+      const component = componentById.get(suggestion.componentId);
       if (!component) {
         return [];
       }
-      return suggestion.data.map((d) => ({
-        ...d,
-        injectedComponent: component.children,
-      }));
+      return [
+        {
+          ...suggestion,
+          injectedComponent: component.children,
+        },
+      ];
     });
   }, [data?.suggestions, componentById]);
 

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_create_attachments.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_create_attachments.tsx
@@ -11,6 +11,7 @@ import * as i18n from './translations';
 import type { CaseAttachmentsWithoutOwner, ServerError } from '../types';
 import { useCasesToast } from '../common/use_cases_toast';
 import { casesMutationsKeys } from './constants';
+import type { CaseUI } from './types';
 
 export interface PostComment {
   caseId: string;
@@ -18,7 +19,11 @@ export interface PostComment {
   attachments: CaseAttachmentsWithoutOwner;
 }
 
-export const useCreateAttachments = () => {
+export const useCreateAttachments = ({
+  onSuccess,
+}: {
+  onSuccess?: (data: CaseUI, variables: PostComment, context: unknown) => unknown;
+} = {}) => {
   const { showErrorToast } = useCasesToast();
 
   return useMutation(
@@ -35,6 +40,7 @@ export const useCreateAttachments = () => {
       onError: (error: ServerError) => {
         showErrorToast(error, { title: i18n.ERROR_TITLE });
       },
+      onSuccess,
     }
   );
 };

--- a/x-pack/platform/plugins/shared/cases/server/attachment_framework/suggestion_registry.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/attachment_framework/suggestion_registry.test.ts
@@ -114,6 +114,7 @@ describe('AttachmentSuggestionRegistry', () => {
       registry.register(suggestionType);
 
       const context: SuggestionContext = {
+        spaceId: 'default',
         'service.name': ['test-service'],
         timeRange: {
           from: '2023-01-01T00:00:00Z',
@@ -177,6 +178,7 @@ describe('AttachmentSuggestionRegistry', () => {
       registry.register(suggestionType);
 
       const context: SuggestionContext = {
+        spaceId: 'default',
         'service.name': ['test-service'],
         timeRange: {
           from: '2023-01-01T00:00:00Z',
@@ -238,6 +240,7 @@ describe('AttachmentSuggestionRegistry', () => {
       registry.register(suggestionType);
 
       const context: SuggestionContext = {
+        spaceId: 'default',
         'service.name': ['test-service'],
         timeRange: {
           from: '2023-01-01T00:00:00Z',

--- a/x-pack/platform/plugins/shared/cases/server/attachment_framework/suggestion_registry.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/attachment_framework/suggestion_registry.test.ts
@@ -73,6 +73,7 @@ describe('AttachmentSuggestionRegistry', () => {
         suggestions: [
           {
             id: 'suggestion-1',
+            componentId: 'test-component',
             description: 'Test suggestion 1',
             data: [],
           },
@@ -83,6 +84,7 @@ describe('AttachmentSuggestionRegistry', () => {
         suggestions: [
           {
             id: 'suggestion-2',
+            componentId: 'test-component',
             description: 'Test suggestion 2',
             data: [],
           },
@@ -141,6 +143,7 @@ describe('AttachmentSuggestionRegistry', () => {
         suggestions: [
           {
             id: 'suggestion-1',
+            componentId: 'test-component',
             description: 'Test suggestion 1',
             data: [],
           },

--- a/x-pack/platform/plugins/shared/cases/server/client/suggestions/get.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/suggestions/get.test.ts
@@ -36,6 +36,7 @@ describe('getAllForOwners', () => {
     const args: GetAllForOwnersArgs = {
       owners: ['observability'],
       context: {
+        spaceId: 'default',
         'service.name': ['my-service'],
         timeRange: {
           from: '2023-01-01T00:00:00Z',

--- a/x-pack/platform/plugins/shared/cases/server/client/suggestions/get.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/suggestions/get.test.ts
@@ -17,6 +17,7 @@ describe('getAllForOwners', () => {
       suggestions: [
         {
           id: 'test-id',
+          componentId: 'test-component',
           description: 'desc',
           data: [],
         },

--- a/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
@@ -18,6 +18,7 @@ import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
 import { actionsMock } from '@kbn/actions-plugin/server/mocks';
 import { notificationsMock } from '@kbn/notifications-plugin/server/mocks';
 import { alertsMock } from '@kbn/alerting-plugin/server/mocks';
+import { spacesMock } from '@kbn/spaces-plugin/server/mocks';
 import { CasePlugin } from './plugin';
 import type { ConfigType } from './config';
 import { ALLOWED_MIME_TYPES } from '../common/constants/mime_types';
@@ -66,6 +67,7 @@ describe('Cases Plugin', () => {
       licensing: licensingMock.createSetup(),
       usageCollection: usageCollectionPluginMock.createSetupContract(),
       features: featuresPluginMock.createSetup(),
+      spaces: spacesMock.createSetup(),
     };
 
     pluginsStart = {
@@ -77,6 +79,7 @@ describe('Cases Plugin', () => {
       notifications: notificationsMock.createStart(),
       ruleRegistry: { getRacClientWithRequest: jest.fn(), alerting: alertsMock.createStart() },
       taskManager: taskManagerMock.createStart(),
+      spaces: spacesMock.createStart(),
     };
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -138,6 +138,11 @@ export class CasePlugin
       })
     );
 
+    core.http.registerRouteHandlerContext<CasesRequestHandlerContext, 'spacesService'>(
+      'spacesService',
+      () => plugins.spaces.spacesService
+    );
+
     if (plugins.taskManager && plugins.usageCollection) {
       createCasesTelemetry({
         core,

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/cases/suggestions/get_suggestions.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/cases/suggestions/get_suggestions.ts
@@ -30,7 +30,7 @@ export const getSuggestionsRoute = createCasesRoute({
   },
   handler: async ({ context, request, response }): Promise<IKibanaResponse<SuggestionResponse>> => {
     try {
-      const caseContext = await context.cases;
+      const [caseContext, spaceService] = await Promise.all([context.cases, context.spacesService]);
       const casesClient = await caseContext.getCasesClient();
       const caseData = await casesClient.cases.get({
         id: request.params.case_id,
@@ -63,7 +63,7 @@ export const getSuggestionsRoute = createCasesRoute({
 
       const suggestions = await casesClient.suggestions.getAllForOwners({
         owners,
-        context: metadata,
+        context: { ...metadata, spaceId: spaceService.getSpaceId(request) },
         request,
       });
       return response.ok({

--- a/x-pack/platform/plugins/shared/cases/server/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/types.ts
@@ -18,7 +18,11 @@ import type {
   PluginSetupContract as ActionsPluginSetup,
   PluginStartContract as ActionsPluginStart,
 } from '@kbn/actions-plugin/server';
-import type { SpacesPluginSetup, SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type {
+  SpacesPluginSetup,
+  SpacesPluginStart,
+  SpacesServiceSetup,
+} from '@kbn/spaces-plugin/server';
 import type { FeaturesPluginStart, FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type { LensServerPluginSetup } from '@kbn/lens-plugin/server';
 import type {
@@ -47,7 +51,7 @@ export interface CasesServerSetupDependencies {
   licensing: LicensingPluginSetup;
   taskManager: TaskManagerSetupContract;
   usageCollection?: UsageCollectionSetup;
-  spaces?: SpacesPluginSetup;
+  spaces: SpacesPluginSetup;
   cloud?: CloudSetup;
 }
 
@@ -58,7 +62,7 @@ export interface CasesServerStartDependencies {
   licensing: LicensingPluginStart;
   taskManager: TaskManagerStartContract;
   security: SecurityPluginStart;
-  spaces?: SpacesPluginStart;
+  spaces: SpacesPluginStart;
   notifications: NotificationsPluginStart;
   ruleRegistry: RuleRegistryPluginStartContract;
 }
@@ -69,6 +73,7 @@ export interface CaseRequestContext {
 
 export type CasesRequestHandlerContext = CustomRequestHandlerContext<{
   cases: CaseRequestContext;
+  spacesService: SpacesServiceSetup;
 }>;
 
 export type CasesRouter = IRouter<CasesRequestHandlerContext>;

--- a/x-pack/solutions/observability/plugins/slo/common/cases/attachments.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/cases/attachments.ts
@@ -6,7 +6,6 @@
  */
 
 import type { CaseAttachmentWithoutOwner } from '@kbn/cases-plugin/common';
-import { AttachmentType } from '@kbn/cases-plugin/common';
 import { i18n } from '@kbn/i18n';
 
 export function buildSloHistoryAttachment({
@@ -17,7 +16,7 @@ export function buildSloHistoryAttachment({
   pathAndQuery?: string;
 }): CaseAttachmentWithoutOwner {
   return {
-    type: AttachmentType.persistableState,
+    type: 'persistableState' as Extract<CaseAttachmentWithoutOwner['type'], 'persistableState'>,
     persistableStateAttachmentTypeId: '.page',
     persistableStateAttachmentState: {
       type: 'slo_history',

--- a/x-pack/solutions/observability/plugins/slo/common/cases/attachments.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/cases/attachments.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CaseAttachmentWithoutOwner } from '@kbn/cases-plugin/common';
+import { AttachmentType } from '@kbn/cases-plugin/common';
+import { i18n } from '@kbn/i18n';
+
+export function buildSloHistoryAttachment({
+  label,
+  pathAndQuery,
+}: {
+  label: string;
+  pathAndQuery?: string;
+}): CaseAttachmentWithoutOwner {
+  return {
+    type: AttachmentType.persistableState,
+    persistableStateAttachmentTypeId: '.page',
+    persistableStateAttachmentState: {
+      type: 'slo_history',
+      url: pathAndQuery
+        ? {
+            pathAndQuery,
+            label,
+            actionLabel: i18n.translate('xpack.slo.addToCase.caseAttachmentLabel', {
+              defaultMessage: 'Go to SLO history',
+            }),
+            iconType: 'metricbeatApp',
+          }
+        : null,
+    },
+  };
+}

--- a/x-pack/solutions/observability/plugins/slo/common/cases/constants.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/cases/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const SLO_SUGGESTION_COMPONENT_ID = 'slo';

--- a/x-pack/solutions/observability/plugins/slo/common/cases/suggestions.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/cases/suggestions.ts
@@ -8,6 +8,4 @@
 export interface SLOSuggestion {
   id: string;
   instanceId: string;
-  name: string;
-  summary: { status: string };
 }

--- a/x-pack/solutions/observability/plugins/slo/common/cases/suggestions.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/cases/suggestions.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface SLOSuggestion {
+  id: string;
+  instanceId: string;
+  name: string;
+}

--- a/x-pack/solutions/observability/plugins/slo/common/cases/suggestions.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/cases/suggestions.ts
@@ -5,9 +5,6 @@
  * 2.0.
  */
 
-export interface SLOSuggestion {
-  id: string;
-  instanceId: string;
-  name: string;
-  status: string;
-}
+import { SLOWithSummaryResponse } from '@kbn/slo-schema';
+
+export type SLOSuggestion = SLOWithSummaryResponse;

--- a/x-pack/solutions/observability/plugins/slo/common/cases/suggestions.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/cases/suggestions.ts
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
-import { SLOWithSummaryResponse } from '@kbn/slo-schema';
-
-export type SLOSuggestion = SLOWithSummaryResponse;
+export interface SLOSuggestion {
+  id: string;
+  instanceId: string;
+  name: string;
+  summary: { status: string };
+}

--- a/x-pack/solutions/observability/plugins/slo/common/cases/suggestions.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/cases/suggestions.ts
@@ -9,4 +9,5 @@ export interface SLOSuggestion {
   id: string;
   instanceId: string;
   name: string;
+  status: string;
 }

--- a/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_component.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_component.tsx
@@ -11,9 +11,7 @@ import type { SLOSuggestion } from '../../common/cases/suggestions';
 import { SloOverview } from '../embeddable/slo/overview/slo_overview';
 
 export function SLOSuggestionChildren(props: SuggestionChildrenProps<SLOSuggestion>) {
-  const { suggestion } = props;
-  if (suggestion.data.length === 1) {
-    const slo = suggestion.data[0].payload;
-    return <SloOverview sloId={slo.id} sloInstanceId={slo.instanceId} />;
-  }
+  return props.suggestion.data.map((slo) => {
+    return <SloOverview sloId={slo.payload.id} sloInstanceId={slo.payload.instanceId} />;
+  });
 }

--- a/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_component.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_component.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SuggestionChildrenProps } from '@kbn/cases-plugin/public';
+import React from 'react';
+import type { SLOSuggestion } from '../../common/cases/suggestions';
+
+export const SLOSuggestionChildren: React.FC<SuggestionChildrenProps<SLOSuggestion>> = (
+  props: SuggestionChildrenProps<SLOSuggestion>
+) => {
+  const { suggestion } = props;
+  return (
+    <div>
+      {suggestion.data.map((slo) => (
+        <div key={slo.payload.id}>
+          <h2>{slo.payload.name}</h2>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default SLOSuggestionChildren;

--- a/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_component.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_component.tsx
@@ -7,18 +7,48 @@
 
 import type { SuggestionChildrenProps } from '@kbn/cases-plugin/public';
 import React from 'react';
+import { EuiPanel } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { SloCardChart } from '../pages/slos/components/card_view/slo_card_item';
 import type { SLOSuggestion } from '../../common/cases/suggestions';
+import { SloCardItemBadges } from '../pages/slos/components/card_view/slo_card_item_badges';
 
 export function SLOSuggestionChildren(props: SuggestionChildrenProps<SLOSuggestion>) {
   const { suggestion } = props;
-  return (
-    <div>
-      {suggestion.data.map((slo) => (
-        <div key={slo.payload.id}>
-          <h2>{slo.payload.name}</h2>
-          <h2>{slo.payload.status}</h2>
-        </div>
-      ))}
-    </div>
-  );
+  // TODO: should this component receive multiple SLOs?
+  if (suggestion.data.length === 1) {
+    const slo = suggestion.data[0].payload;
+    return (
+      <EuiPanel
+        className="sloCardItem"
+        paddingSize="none"
+        css={css`
+          height: 182px;
+          overflow: hidden;
+          position: relative;
+
+          & .sloCardItemActions_hover {
+            pointer-events: none;
+            opacity: 0;
+
+            &:focus-within {
+              pointer-events: auto;
+              opacity: 1;
+            }
+          }
+          &:hover .sloCardItemActions_hover {
+            pointer-events: auto;
+            opacity: 1;
+          }
+        `}
+        title={slo.summary.status}
+      >
+        <SloCardChart
+          slo={slo}
+          badges={<SloCardItemBadges slo={slo} rules={[]} />}
+          historicalSliData={[]}
+        />
+      </EuiPanel>
+    );
+  }
 }

--- a/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_component.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_component.tsx
@@ -9,20 +9,16 @@ import type { SuggestionChildrenProps } from '@kbn/cases-plugin/public';
 import React from 'react';
 import type { SLOSuggestion } from '../../common/cases/suggestions';
 
-export const SLOSuggestionChildren: React.FC<SuggestionChildrenProps<SLOSuggestion>> = (
-  props: SuggestionChildrenProps<SLOSuggestion>
-) => {
+export function SLOSuggestionChildren(props: SuggestionChildrenProps<SLOSuggestion>) {
   const { suggestion } = props;
   return (
     <div>
       {suggestion.data.map((slo) => (
         <div key={slo.payload.id}>
           <h2>{slo.payload.name}</h2>
+          <h2>{slo.payload.status}</h2>
         </div>
       ))}
     </div>
   );
-};
-
-// eslint-disable-next-line import/no-default-export
-export default SLOSuggestionChildren;
+}

--- a/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_component.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_component.tsx
@@ -7,48 +7,13 @@
 
 import type { SuggestionChildrenProps } from '@kbn/cases-plugin/public';
 import React from 'react';
-import { EuiPanel } from '@elastic/eui';
-import { css } from '@emotion/react';
-import { SloCardChart } from '../pages/slos/components/card_view/slo_card_item';
 import type { SLOSuggestion } from '../../common/cases/suggestions';
-import { SloCardItemBadges } from '../pages/slos/components/card_view/slo_card_item_badges';
+import { SloOverview } from '../embeddable/slo/overview/slo_overview';
 
 export function SLOSuggestionChildren(props: SuggestionChildrenProps<SLOSuggestion>) {
   const { suggestion } = props;
-  // TODO: should this component receive multiple SLOs?
   if (suggestion.data.length === 1) {
     const slo = suggestion.data[0].payload;
-    return (
-      <EuiPanel
-        className="sloCardItem"
-        paddingSize="none"
-        css={css`
-          height: 182px;
-          overflow: hidden;
-          position: relative;
-
-          & .sloCardItemActions_hover {
-            pointer-events: none;
-            opacity: 0;
-
-            &:focus-within {
-              pointer-events: auto;
-              opacity: 1;
-            }
-          }
-          &:hover .sloCardItemActions_hover {
-            pointer-events: auto;
-            opacity: 1;
-          }
-        `}
-        title={slo.summary.status}
-      >
-        <SloCardChart
-          slo={slo}
-          badges={<SloCardItemBadges slo={slo} rules={[]} />}
-          historicalSliData={[]}
-        />
-      </EuiPanel>
-    );
+    return <SloOverview sloId={slo.id} sloInstanceId={slo.instanceId} />;
   }
 }

--- a/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
@@ -9,6 +9,7 @@ import { lazy } from 'react';
 import type { AttachmentFramework } from '@kbn/cases-plugin/public/client/attachment_framework/types';
 import type { SLOSuggestion } from '../../common/cases/suggestions';
 import type { LazyWithContextProviders } from '../utils/get_lazy_with_context_providers';
+import { SLO_SUGGESTION_COMPONENT_ID } from '../../common/cases/constants';
 
 export const registerSloSuggestion = (
   attachmentFramework: AttachmentFramework,
@@ -23,7 +24,7 @@ export const registerSloSuggestion = (
   const children = lazy(() => Promise.resolve({ default: WrappedWithProviders }));
 
   attachmentFramework.registerSuggestion<SLOSuggestion>({
-    id: 'slo',
+    id: SLO_SUGGESTION_COMPONENT_ID,
     owner: 'observability',
     children,
   });

--- a/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { SuggestionType } from '@kbn/cases-plugin/public';
 import { lazy } from 'react';
 import type { AttachmentFramework } from '@kbn/cases-plugin/public/client/attachment_framework/types';
 import type { SLOSuggestion } from '../../common/cases/suggestions';
@@ -15,21 +14,17 @@ export const registerSloSuggestion = (
   attachmentFramework: AttachmentFramework,
   lazyWithContextProviders: LazyWithContextProviders
 ) => {
-  const lazySuggestionComponent = lazy(() =>
+  const LazyChild = lazy(() =>
     import('./suggestion_component').then((m) => ({
       default: m.SLOSuggestionChildren,
     }))
   );
+  const WrappedWithProviders = lazyWithContextProviders(LazyChild);
+  const children = lazy(() => Promise.resolve({ default: WrappedWithProviders }));
 
-  const SuggestionWithProviders = lazyWithContextProviders(lazySuggestionComponent);
-  const LazySuggestionWithProviders = lazy(() =>
-    Promise.resolve({ default: SuggestionWithProviders })
-  );
-
-  const sloSuggestionDefinition: SuggestionType<SLOSuggestion> = {
+  attachmentFramework.registerSuggestion<SLOSuggestion>({
     id: 'slo',
     owner: 'observability',
-    children: LazySuggestionWithProviders,
-  };
-  attachmentFramework.registerSuggestion(sloSuggestionDefinition);
+    children,
+  });
 };

--- a/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
@@ -6,20 +6,30 @@
  */
 
 import type { SuggestionType } from '@kbn/cases-plugin/public';
-import React from 'react';
-import { AttachmentFramework } from '@kbn/cases-plugin/public/client/attachment_framework/types';
+import { lazy } from 'react';
+import type { AttachmentFramework } from '@kbn/cases-plugin/public/client/attachment_framework/types';
 import type { SLOSuggestion } from '../../common/cases/suggestions';
+import type { LazyWithContextProviders } from '../utils/get_lazy_with_context_providers';
 
-const sloSuggestionDefinition: SuggestionType<SLOSuggestion> = {
-  id: 'slo',
-  owner: 'observability',
-  children: React.lazy(() =>
+export const registerSloSuggestion = (
+  attachmentFramework: AttachmentFramework,
+  lazyWithContextProviders: LazyWithContextProviders
+) => {
+  const lazySuggestionComponent = lazy(() =>
     import('./suggestion_component').then((m) => ({
       default: m.SLOSuggestionChildren,
     }))
-  ),
-};
+  );
 
-export const registerSloSuggestion = (attachmentFramework: AttachmentFramework) => {
+  const SuggestionWithProviders = lazyWithContextProviders(lazySuggestionComponent);
+  const LazySuggestionWithProviders = lazy(() =>
+    Promise.resolve({ default: SuggestionWithProviders })
+  );
+
+  const sloSuggestionDefinition: SuggestionType<SLOSuggestion> = {
+    id: 'slo',
+    owner: 'observability',
+    children: LazySuggestionWithProviders,
+  };
   attachmentFramework.registerSuggestion(sloSuggestionDefinition);
 };

--- a/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
@@ -7,9 +7,10 @@
 
 import type { SuggestionType } from '@kbn/cases-plugin/public';
 import React from 'react';
+import { AttachmentFramework } from '@kbn/cases-plugin/public/client/attachment_framework/types';
 import type { SLOSuggestion } from '../../common/cases/suggestions';
 
-export const sloSuggestionDefinition: SuggestionType<SLOSuggestion> = {
+const sloSuggestionDefinition: SuggestionType<SLOSuggestion> = {
   id: 'slo',
   owner: 'observability',
   children: React.lazy(() =>
@@ -17,4 +18,8 @@ export const sloSuggestionDefinition: SuggestionType<SLOSuggestion> = {
       default: m.SLOSuggestionChildren,
     }))
   ),
+};
+
+export const registerSloSuggestion = (attachmentFramework: AttachmentFramework) => {
+  attachmentFramework.registerSuggestion(sloSuggestionDefinition);
 };

--- a/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SuggestionType } from '@kbn/cases-plugin/public';
+import React from 'react';
+import type { SLOSuggestion } from '../../common/cases/suggestions';
+
+export const sloSuggestionDefinition: SuggestionType<SLOSuggestion> = {
+  id: 'slo',
+  owner: 'observability',
+  children: React.lazy(() => import('./suggestion_component')),
+};

--- a/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/cases/suggestion_definition.tsx
@@ -12,5 +12,9 @@ import type { SLOSuggestion } from '../../common/cases/suggestions';
 export const sloSuggestionDefinition: SuggestionType<SLOSuggestion> = {
   id: 'slo',
   owner: 'observability',
-  children: React.lazy(() => import('./suggestion_component')),
+  children: React.lazy(() =>
+    import('./suggestion_component').then((m) => ({
+      default: m.SLOSuggestionChildren,
+    }))
+  ),
 };

--- a/x-pack/solutions/observability/plugins/slo/public/components/slo/add_to_case_action/add_to_case_action.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/slo/add_to_case_action/add_to_case_action.tsx
@@ -5,13 +5,12 @@
  * 2.0.
  */
 
-import type { CaseAttachmentsWithoutOwner } from '@kbn/cases-plugin/public';
-import { i18n } from '@kbn/i18n';
 import { sloDetailsHistoryLocatorID } from '@kbn/observability-plugin/common';
 import { encode } from '@kbn/rison';
 import type { SLODefinitionResponse, SLOWithSummaryResponse } from '@kbn/slo-schema';
 import { ALL_VALUE } from '@kbn/slo-schema';
 import React, { useEffect } from 'react';
+import { buildSloHistoryAttachment } from '../../../../common/cases/attachments';
 import { useKibana } from '../../../hooks/use_kibana';
 import { useUrlAppState } from '../../../pages/slo_details/components/history/hooks/use_url_app_state';
 
@@ -73,26 +72,15 @@ function Content({ slo, onCancel, onConfirm }: Props) {
     casesModal.open({
       getAttachments: () => {
         return [
-          {
-            persistableStateAttachmentState: {
-              type: 'slo_history',
-              url: {
-                pathAndQuery: locator?.getRedirectUrl({
-                  id: slo.id,
-                  instanceId: 'instanceId' in slo ? slo.instanceId : ALL_VALUE,
-                  encodedAppState: encode(state),
-                }),
-                label: slo.name,
-                actionLabel: i18n.translate('xpack.slo.addToCase.caseAttachmentLabel', {
-                  defaultMessage: 'Go to SLO history',
-                }),
-                iconType: 'metricbeatApp',
-              },
-            },
-            persistableStateAttachmentTypeId: '.page',
-            type: 'persistableState',
-          },
-        ] as CaseAttachmentsWithoutOwner;
+          buildSloHistoryAttachment({
+            label: slo.name,
+            pathAndQuery: locator?.getRedirectUrl({
+              id: slo.id,
+              instanceId: 'instanceId' in slo ? slo.instanceId : ALL_VALUE,
+              encodedAppState: encode(state),
+            }),
+          }),
+        ];
       },
     });
 

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/card_view/slo_card_item.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/card_view/slo_card_item.tsx
@@ -183,7 +183,7 @@ export function SloCardChart({
 }: {
   badges: React.ReactNode;
   slo: SLOWithSummaryResponse;
-  historicalSliData?: Array<{ key?: number; value?: number }>;
+  historicalSliData: Array<{ key?: number; value?: number }>;
   onClick?: () => void;
 }) {
   const {

--- a/x-pack/solutions/observability/plugins/slo/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/plugin.ts
@@ -41,8 +41,7 @@ import type {
 import { getLazyWithContextProviders } from './utils/get_lazy_with_context_providers';
 import { registerSloUiActions } from './ui_actions/register_ui_actions';
 import { SloDetailsHistoryLocatorDefinition } from './locators/slo_details_history';
-import type { SLOSuggestion } from '../common/cases/suggestions';
-import { sloSuggestionDefinition } from './cases/suggestion_definition';
+import { registerSloSuggestion } from './cases/suggestion_definition';
 
 export class SLOPlugin
   implements Plugin<SLOPublicSetup, SLOPublicStart, SLOPublicPluginsSetup, SLOPublicPluginsStart>
@@ -193,7 +192,9 @@ export class SLOPlugin
     };
     registerEmbeddables();
 
-    plugins.cases?.attachmentFramework.registerSuggestion<SLOSuggestion>(sloSuggestionDefinition);
+    if (plugins.cases?.attachmentFramework) {
+      registerSloSuggestion(plugins.cases.attachmentFramework);
+    }
 
     return {
       sloDetailsLocator,

--- a/x-pack/solutions/observability/plugins/slo/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/plugin.ts
@@ -105,7 +105,7 @@ export class SLOPlugin
     // Register an application into the side navigation menu
     core.application.register(app);
 
-    const registerRules = async () => {
+    const registerRulesAndSuggestions = async () => {
       const [coreStart, pluginsStart] = await core.getStartServices();
       const lazyWithContextProviders = getLazyWithContextProviders({
         core: coreStart,
@@ -123,8 +123,12 @@ export class SLOPlugin
         plugins.observability.observabilityRuleTypeRegistry,
         lazyWithContextProviders
       );
+
+      if (plugins.cases?.attachmentFramework) {
+        registerSloSuggestion(plugins.cases.attachmentFramework, lazyWithContextProviders);
+      }
     };
-    registerRules();
+    registerRulesAndSuggestions();
 
     const registerEmbeddables = async () => {
       const licensing = plugins.licensing;
@@ -191,10 +195,6 @@ export class SLOPlugin
       }
     };
     registerEmbeddables();
-
-    if (plugins.cases?.attachmentFramework) {
-      registerSloSuggestion(plugins.cases.attachmentFramework);
-    }
 
     return {
       sloDetailsLocator,

--- a/x-pack/solutions/observability/plugins/slo/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/plugin.ts
@@ -41,6 +41,8 @@ import type {
 import { getLazyWithContextProviders } from './utils/get_lazy_with_context_providers';
 import { registerSloUiActions } from './ui_actions/register_ui_actions';
 import { SloDetailsHistoryLocatorDefinition } from './locators/slo_details_history';
+import type { SLOSuggestion } from '../common/cases/suggestions';
+import { sloSuggestionDefinition } from './cases/suggestion_definition';
 
 export class SLOPlugin
   implements Plugin<SLOPublicSetup, SLOPublicStart, SLOPublicPluginsSetup, SLOPublicPluginsStart>
@@ -190,6 +192,8 @@ export class SLOPlugin
       }
     };
     registerEmbeddables();
+
+    plugins.cases?.attachmentFramework.registerSuggestion<SLOSuggestion>(sloSuggestionDefinition);
 
     return {
       sloDetailsLocator,

--- a/x-pack/solutions/observability/plugins/slo/public/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import type { AiopsPluginStart } from '@kbn/aiops-plugin/public/types';
-import type { CasesPublicStart } from '@kbn/cases-plugin/public';
+import type { CasesPublicSetup, CasesPublicStart } from '@kbn/cases-plugin/public';
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
 import type { DashboardStart } from '@kbn/dashboard-plugin/public';
@@ -73,6 +73,7 @@ export interface SLOPublicPluginsSetup {
   uiActions: UiActionsSetup;
   usageCollection: UsageCollectionSetup;
   security?: SecurityPluginSetup;
+  cases?: CasesPublicSetup;
 }
 
 export interface SLOPublicPluginsStart {

--- a/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getSLOByServiceName } from './suggestion';
+import type { CoreStart, KibanaRequest, Logger } from '@kbn/core/server';
+
+jest.mock('../../../common', () => ({
+  sloPaths: {
+    sloDetailsHistory: jest.fn().mockReturnValue('/mock/slo/path'),
+  },
+}));
+
+const createCoreStartMock = (hits: Record<string, unknown>[] = []): CoreStart =>
+  ({
+    elasticsearch: {
+      client: {
+        asScoped: jest.fn().mockReturnValue({
+          asCurrentUser: {
+            search: jest.fn().mockResolvedValue({ hits: { hits } }),
+          },
+        }),
+      },
+    },
+  } as unknown as CoreStart);
+
+const loggerMock = { debug: jest.fn() } as unknown as Logger;
+
+describe('getSLOByServiceName', () => {
+  test('returns empty suggestions when service.name is missing', async () => {
+    const coreStart = createCoreStartMock();
+    const handler = getSLOByServiceName(coreStart, loggerMock).handlers.searchSLOByServiceName
+      .handler;
+
+    const res = await handler({
+      context: {},
+      request: {} as KibanaRequest,
+    });
+
+    expect(res).toEqual({ suggestions: [] });
+  });
+
+  test('builds a suggestion for each returned SLO', async () => {
+    const coreStart = createCoreStartMock([
+      {
+        _source: {
+          slo: {
+            id: 'slo-1',
+            instanceId: 'inst-1',
+            name: 'Latency SLO',
+            groupings: { service: { name: 'synth-service-0' } },
+          },
+          status: 'DEGRADING',
+        },
+      },
+      {
+        _source: {
+          slo: {
+            id: 'slo-2',
+            instanceId: 'inst-2',
+            name: 'Another SLO',
+            groupings: { service: { name: 'synth-service-1' } },
+          },
+          status: 'VIOLATED',
+        },
+      },
+    ]);
+
+    const handler = getSLOByServiceName(coreStart, loggerMock).handlers.searchSLOByServiceName
+      .handler;
+
+    const res = await handler({
+      context: { 'service.name': ['synth-service-0', 'synth-service-1'] },
+      request: {} as KibanaRequest,
+    });
+
+    expect(res.suggestions).toHaveLength(2);
+    expect(res.suggestions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'slo-1-inst-1',
+          componentId: 'slo',
+          data: [
+            {
+              description: 'SLO "Latency SLO" is DEGRADING for the service "synth-service-0"',
+              payload: { id: 'slo-1', instanceId: 'inst-1' },
+              attachment: expect.objectContaining({
+                type: 'persistableState',
+                persistableStateAttachmentTypeId: '.page',
+                persistableStateAttachmentState: expect.objectContaining({
+                  type: 'slo_history',
+                  url: expect.objectContaining({
+                    pathAndQuery: '/mock/slo/path',
+                    label: 'Latency SLO',
+                  }),
+                }),
+              }),
+            },
+          ],
+        }),
+        expect.objectContaining({
+          id: 'slo-2-inst-2',
+          componentId: 'slo',
+          data: [
+            expect.objectContaining({
+              description: 'SLO "Another SLO" is VIOLATED for the service "synth-service-1"',
+              payload: { id: 'slo-2', instanceId: 'inst-2' },
+              attachment: expect.objectContaining({
+                type: 'persistableState',
+                persistableStateAttachmentTypeId: '.page',
+                persistableStateAttachmentState: expect.objectContaining({
+                  type: 'slo_history',
+                  url: expect.objectContaining({
+                    pathAndQuery: '/mock/slo/path',
+                    label: 'Another SLO',
+                  }),
+                }),
+              }),
+            }),
+          ],
+        }),
+      ])
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
@@ -32,7 +32,7 @@ export function getSLOByServiceName(
           description: 'Suggest SLOs operating on the same service.',
         },
         handler: async ({
-          context: { 'service.name': serviceNames },
+          context: { 'service.name': serviceNames, spaceId },
           request,
         }: {
           context: SuggestionContext;
@@ -61,6 +61,9 @@ export function getSLOByServiceName(
                     terms: {
                       'slo.groupings.service.name': serviceNames,
                     },
+                  },
+                  {
+                    term: { spaceId },
                   },
                 ],
                 must_not: [

--- a/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
@@ -6,46 +6,16 @@
  */
 
 import type { SuggestionHandlerResponse } from '@kbn/cases-plugin/common';
-import { AttachmentType, type SuggestionContext } from '@kbn/cases-plugin/common';
+import type { SuggestionContext } from '@kbn/cases-plugin/common';
 import type { SuggestionType } from '@kbn/cases-plugin/server';
 import type { CoreStart, KibanaRequest, Logger } from '@kbn/core/server';
-import { i18n } from '@kbn/i18n';
 import type { AttachmentFramework } from '@kbn/cases-plugin/server/attachment_framework/types';
 import type { AttachmentItem } from '@kbn/cases-plugin/common/types/domain';
-import { sloPaths } from '../../../common';
+import { buildSloHistoryAttachment } from '../../../common/cases/attachments';
 import type { SLOSuggestion } from '../../../common/cases/suggestions';
 import { SUMMARY_DESTINATION_INDEX_PATTERN } from '../../../common/constants';
 import type { EsSummaryDocument } from '../../services/summary_transform_generator/helpers/create_temp_summary';
-
-const buildPayload = (src: EsSummaryDocument): SLOSuggestion => ({
-  id: src.slo.id,
-  name: src.slo.name,
-  instanceId: src.slo.instanceId,
-  summary: { status: src.status },
-});
-
-const buildItem = (svcName: string, payload: SLOSuggestion): AttachmentItem<SLOSuggestion> => ({
-  description: `SLO "${payload.name}" is ${payload.summary.status} for the service "${svcName}"`,
-  payload,
-  attachment: {
-    type: AttachmentType.persistableState,
-    persistableStateAttachmentTypeId: '.page',
-    persistableStateAttachmentState: {
-      type: 'slo_history',
-      url: {
-        pathAndQuery: sloPaths.sloDetailsHistory({
-          id: payload.id,
-          instanceId: payload.instanceId,
-        }),
-        label: payload.name,
-        actionLabel: i18n.translate('xpack.slo.addToCase.caseAttachmentLabel', {
-          defaultMessage: 'Go to SLO history',
-        }),
-        iconType: 'metricbeatApp',
-      },
-    },
-  },
-});
+import { sloPaths } from '../../../common';
 
 export function getSLOByServiceName(
   coreStart: CoreStart,
@@ -59,15 +29,6 @@ export function getSLOByServiceName(
       searchSLOByServiceName: {
         tool: {
           description: 'Suggest SLOs operating on the same service.',
-          schema: {
-            type: 'object',
-            properties: {
-              serviceName: {
-                type: 'string',
-                description: 'Name of the relevant service',
-              },
-            },
-          },
         },
         handler: async ({
           context: { 'service.name': serviceNames },
@@ -121,29 +82,36 @@ export function getSLOByServiceName(
             },
           });
 
-          const itemsByService = results.hits.hits.reduce<
-            Record<string, AttachmentItem<SLOSuggestion>[]>
-          >((acc, { _source: src }) => {
-            if (!src) return acc;
-            const svcName = (src.slo?.groupings?.service as { name: string }).name;
-            if (!svcName) return acc;
-
-            const payload = buildPayload(src);
-            const item = buildItem(svcName, payload);
-
-            (acc[svcName] ??= []).push(item);
-            return acc;
-          }, {});
-
-          const suggestions = Object.values(itemsByService).flatMap((items) =>
-            items.map((item) => ({
-              id: `${item.payload.id}-${item.payload.instanceId}`,
-              componentId: 'slo',
-              data: [item],
-            }))
+          logger.debug(
+            `Found ${results.hits.hits.length} SLOs for service ${serviceNames.join(', ')}`
           );
 
-          return { suggestions };
+          return {
+            suggestions: results.hits.hits.map((hit) => {
+              const src = hit._source!;
+              const svcName = (src.slo?.groupings?.service as { name: string }).name!;
+
+              const item: AttachmentItem<SLOSuggestion> = {
+                description: `SLO "${src.slo.name}" is ${src.status} for the service "${svcName}"`,
+                payload: {
+                  id: src.slo.id,
+                  instanceId: src.slo.instanceId,
+                },
+                attachment: buildSloHistoryAttachment({
+                  label: src.slo.name,
+                  pathAndQuery: sloPaths.sloDetailsHistory({
+                    id: src.slo.id,
+                    instanceId: src.slo.instanceId,
+                  }),
+                }),
+              };
+              return {
+                id: `${item.payload.id}-${item.payload.instanceId}`,
+                componentId: 'slo',
+                data: [item],
+              };
+            }),
+          };
         },
       },
     },

--- a/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
@@ -11,6 +11,7 @@ import type { SuggestionType } from '@kbn/cases-plugin/server';
 import type { CoreStart, KibanaRequest, Logger } from '@kbn/core/server';
 import type { AttachmentFramework } from '@kbn/cases-plugin/server/attachment_framework/types';
 import type { AttachmentItem } from '@kbn/cases-plugin/common/types/domain';
+import { SLO_SUGGESTION_COMPONENT_ID } from '../../../common/cases/constants';
 import { buildSloHistoryAttachment } from '../../../common/cases/attachments';
 import type { SLOSuggestion } from '../../../common/cases/suggestions';
 import { SUMMARY_DESTINATION_INDEX_PATTERN } from '../../../common/constants';
@@ -107,7 +108,7 @@ export function getSLOByServiceName(
               };
               return {
                 id: `${item.payload.id}-${item.payload.instanceId}`,
-                componentId: 'slo',
+                componentId: SLO_SUGGESTION_COMPONENT_ID,
                 data: [item],
               };
             }),

--- a/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
@@ -10,6 +10,7 @@ import { AttachmentType, type SuggestionContext } from '@kbn/cases-plugin/common
 import type { SuggestionType } from '@kbn/cases-plugin/server';
 import type { CoreStart, KibanaRequest, Logger } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
+import type { AttachmentFramework } from '@kbn/cases-plugin/server/attachment_framework/types';
 import { sloPaths } from '../../../common';
 import type { SLOSuggestion } from '../../../common/cases/suggestions';
 import { SUMMARY_DESTINATION_INDEX_PATTERN } from '../../../common/constants';
@@ -177,3 +178,15 @@ export function getSLOByServiceName(
     },
   };
 }
+
+export const registerSloSuggestion = ({
+  attachmentFramework,
+  coreStart,
+  logger,
+}: {
+  attachmentFramework: AttachmentFramework;
+  coreStart: CoreStart;
+  logger: Logger;
+}) => {
+  attachmentFramework.registerSuggestion(getSLOByServiceName(coreStart, logger));
+};

--- a/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
@@ -11,6 +11,7 @@ import type { SuggestionType } from '@kbn/cases-plugin/server';
 import type { CoreStart, KibanaRequest, Logger } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import type { AttachmentFramework } from '@kbn/cases-plugin/server/attachment_framework/types';
+import type { AttachmentItem } from '@kbn/cases-plugin/common/types/domain';
 import { sloPaths } from '../../../common';
 import type { SLOSuggestion } from '../../../common/cases/suggestions';
 import { SUMMARY_DESTINATION_INDEX_PATTERN } from '../../../common/constants';
@@ -41,7 +42,7 @@ export function getSLOByServiceName(
           },
         },
         handler: async ({
-          context: { 'service.name': serviceName },
+          context: { 'service.name': serviceNames },
           request,
         }: {
           context: SuggestionContext;
@@ -49,7 +50,7 @@ export function getSLOByServiceName(
         }): Promise<SuggestionHandlerResponse<SLOSuggestion>> => {
           const scopedClusterClient = coreStart.elasticsearch.client.asScoped(request);
 
-          if (!serviceName) {
+          if (!serviceNames || !serviceNames.length) {
             return { suggestions: [] };
           }
 
@@ -67,8 +68,8 @@ export function getSLOByServiceName(
               bool: {
                 filter: [
                   {
-                    term: {
-                      'slo.groupings.service.name': serviceName[0],
+                    terms: {
+                      'slo.groupings.service.name': serviceNames,
                     },
                   },
                 ],
@@ -91,8 +92,15 @@ export function getSLOByServiceName(
               },
             },
           });
-          const suggestions = results.hits.hits.map((doc) => {
-            const src = doc._source!;
+
+          const itemsByService = new Map<string, AttachmentItem<SLOSuggestion>[]>();
+
+          // TODO: remove all casting and any
+          for (const doc of results.hits.hits) {
+            const src = doc._source;
+            if (!src) continue;
+            const svcName = (src.slo.groupings as { service: { name: string } }).service.name;
+
             const payload: SLOSuggestion = {
               id: src.slo.id,
               name: src.slo.name,
@@ -139,40 +147,46 @@ export function getSLOByServiceName(
                 summaryUpdatedAt: src.summaryUpdatedAt,
               },
             };
-            return { ...payload, status: src.status };
-          });
 
-          return {
-            suggestions: [
-              {
-                id: 'slo',
-                description: `Found ${suggestions.length} SLOs linked to service "${serviceName}"`,
-                data: suggestions.map((suggestion) => ({
-                  id: `${suggestion.id}-${suggestion.instanceId}`,
-                  description: `SLO "${suggestion.name}" is ${suggestion.status}`,
-                  payload: suggestion,
-                  attachment: {
-                    type: AttachmentType.persistableState,
-                    persistableStateAttachmentTypeId: '.page',
-                    persistableStateAttachmentState: {
-                      type: 'slo_history',
-                      url: {
-                        pathAndQuery: sloPaths.sloDetailsHistory({
-                          id: suggestion.id,
-                          instanceId: suggestion.instanceId,
-                        }),
-                        label: suggestion.name,
-                        actionLabel: i18n.translate('xpack.slo.addToCase.caseAttachmentLabel', {
-                          defaultMessage: 'Go to SLO history',
-                        }),
-                        iconType: 'metricbeatApp',
-                      },
-                    },
+            const item: AttachmentItem<SLOSuggestion> = {
+              id: `${payload.id}-${payload.instanceId}`,
+              description: `SLO "${payload.name}" is ${payload.summary.status} for the service "${svcName}"`,
+              payload,
+              attachment: {
+                type: AttachmentType.persistableState,
+                persistableStateAttachmentTypeId: '.page',
+                persistableStateAttachmentState: {
+                  type: 'slo_history',
+                  url: {
+                    pathAndQuery: sloPaths.sloDetailsHistory({
+                      id: payload.id,
+                      instanceId: payload.instanceId,
+                    }),
+                    label: payload.name,
+                    actionLabel: i18n.translate('xpack.slo.addToCase.caseAttachmentLabel', {
+                      defaultMessage: 'Go to SLO history',
+                    }),
+                    iconType: 'metricbeatApp',
                   },
-                })),
+                },
               },
-            ],
-          };
+            };
+
+            const existing = itemsByService.get(svcName);
+            if (existing) {
+              existing.push(item);
+            } else {
+              itemsByService.set(svcName, [item]);
+            }
+          }
+
+          const suggestions = Array.from(itemsByService.entries()).map(([svcName, data]) => ({
+            id: 'slo',
+            description: `Found ${data.length} SLOs linked to service "${svcName}"`,
+            data,
+          }));
+
+          return { suggestions };
         },
       },
     },

--- a/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SuggestionHandlerResponse } from '@kbn/cases-plugin/common';
+import { AttachmentType, type SuggestionContext } from '@kbn/cases-plugin/common';
+import type { SuggestionType } from '@kbn/cases-plugin/server';
+import type { CoreStart, KibanaRequest, Logger } from '@kbn/core/server';
+import { i18n } from '@kbn/i18n';
+import { sloPaths } from '../../../common';
+import type { SLOSuggestion } from '../../../common/cases/suggestions';
+import { SUMMARY_DESTINATION_INDEX_PATTERN } from '../../../common/constants';
+import type { EsSummaryDocument } from '../../services/summary_transform_generator/helpers/create_temp_summary';
+
+export function getSLOByServiceName(
+  coreStart: CoreStart,
+  logger: Logger
+): SuggestionType<SLOSuggestion> {
+  return {
+    id: 'sloByServiceName',
+    attachmentTypeId: '.page',
+    owner: 'observability',
+    handlers: {
+      searchSLOByServiceName: {
+        tool: {
+          description: 'Suggest SLOs operating on the same service.',
+          schema: {
+            type: 'object',
+            properties: {
+              serviceName: {
+                type: 'string',
+                description: 'Name of the relevant service',
+              },
+            },
+          },
+        },
+        handler: async ({
+          context: { 'service.name': serviceName },
+          request,
+        }: {
+          context: SuggestionContext;
+          request: KibanaRequest;
+        }): Promise<SuggestionHandlerResponse<SLOSuggestion>> => {
+          const scopedClusterClient = coreStart.elasticsearch.client.asScoped(request);
+
+          if (!serviceName) {
+            return { suggestions: [] };
+          }
+
+          const results = await scopedClusterClient.asCurrentUser.search<EsSummaryDocument>({
+            index: SUMMARY_DESTINATION_INDEX_PATTERN,
+            size: 10,
+            sort: [
+              {
+                summaryUpdatedAt: {
+                  order: 'desc',
+                },
+              },
+            ],
+            query: {
+              bool: {
+                filter: [
+                  {
+                    term: {
+                      'slo.groupings.service.name': serviceName[0],
+                    },
+                  },
+                ],
+                must_not: [
+                  {
+                    term: {
+                      status: {
+                        value: 'NO_DATA',
+                      },
+                    },
+                  },
+                  {
+                    term: {
+                      isTempDoc: {
+                        value: true,
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          });
+
+          const suggestions = results.hits.hits.map((doc) => {
+            return {
+              id: doc._source!.slo.id,
+              instanceId: doc._source!.slo.instanceId,
+              name: doc._source!.slo.name,
+              spaceId: doc._source!.spaceId,
+              status: doc._source!.status,
+            };
+          });
+
+          return {
+            suggestions: [
+              {
+                id: 'example',
+                description: `Found ${suggestions.length} SLOs linked to service "${serviceName}"`,
+                data: suggestions.map((suggestion) => ({
+                  description: `SLO "${suggestion.name}" is ${suggestion.status}`,
+                  payload: {
+                    id: suggestion.id,
+                    name: suggestion.name,
+                    instanceId: suggestion.instanceId,
+                  },
+                  attachment: {
+                    type: AttachmentType.persistableState,
+                    persistableStateAttachmentTypeId: '.page',
+                    persistableStateAttachmentState: {
+                      type: 'slo_history',
+                      url: {
+                        pathAndQuery: sloPaths.sloDetailsHistory({
+                          id: suggestion.id,
+                          instanceId: suggestion.instanceId,
+                        }),
+                        label: suggestion.name,
+                        actionLabel: i18n.translate('xpack.slo.addToCase.caseAttachmentLabel', {
+                          defaultMessage: 'Go to SLO history',
+                        }),
+                        iconType: 'metricbeatApp',
+                      },
+                    },
+                  },
+                })),
+              },
+            ],
+          };
+        },
+      },
+    },
+  };
+}

--- a/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
@@ -105,6 +105,7 @@ export function getSLOByServiceName(
                 id: 'slo',
                 description: `Found ${suggestions.length} SLOs linked to service "${serviceName}"`,
                 data: suggestions.map((suggestion) => ({
+                  id: `${suggestion.id}-${suggestion.instanceId}`,
                   description: `SLO "${suggestion.name}" is ${suggestion.status}`,
                   payload: {
                     id: suggestion.id,

--- a/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
@@ -14,6 +14,8 @@ import { sloPaths } from '../../../common';
 import type { SLOSuggestion } from '../../../common/cases/suggestions';
 import { SUMMARY_DESTINATION_INDEX_PATTERN } from '../../../common/constants';
 import type { EsSummaryDocument } from '../../services/summary_transform_generator/helpers/create_temp_summary';
+import { getFlattenedGroupings } from '../../services/utils';
+import { toHighPrecision } from '../../utils/number';
 
 export function getSLOByServiceName(
   coreStart: CoreStart,
@@ -88,15 +90,55 @@ export function getSLOByServiceName(
               },
             },
           });
-
           const suggestions = results.hits.hits.map((doc) => {
-            return {
-              id: doc._source!.slo.id,
-              instanceId: doc._source!.slo.instanceId,
-              name: doc._source!.slo.name,
-              spaceId: doc._source!.spaceId,
-              status: doc._source!.status,
+            const src = doc._source!;
+            const payload: SLOSuggestion = {
+              id: src.slo.id,
+              name: src.slo.name,
+              description: src.slo.description,
+              indicator: src.slo.indicator as any,
+              timeWindow: src.slo.timeWindow,
+              budgetingMethod: src.slo.budgetingMethod,
+              objective: {
+                target: src.slo.objective.target,
+                timesliceTarget: src.slo.objective.timesliceTarget ?? undefined,
+                timesliceWindow: src.slo.objective.timesliceWindow ?? undefined,
+              },
+              settings: {
+                syncDelay: '1m',
+                frequency: '1m',
+                preventInitialBackfill: false,
+              },
+              revision: src.slo.revision,
+              enabled: true,
+              tags: src.slo.tags,
+              createdAt: src.slo.createdAt ?? '2024-01-01T00:00:00.000Z',
+              updatedAt: src.slo.updatedAt ?? '2024-01-01T00:00:00.000Z',
+              groupBy: src.slo.groupBy,
+              version: 1,
+              ...(src.slo.createdBy ? { createdBy: src.slo.createdBy } : {}),
+              ...(src.slo.updatedBy ? { updatedBy: src.slo.updatedBy } : {}),
+              instanceId: src.slo.instanceId,
+              groupings: getFlattenedGroupings({
+                groupings: src.slo.groupings,
+                groupBy: src.slo.groupBy,
+              }),
+              summary: {
+                status: src.status,
+                sliValue: toHighPrecision(src.sliValue),
+                errorBudget: {
+                  initial: toHighPrecision(src.errorBudgetInitial),
+                  consumed: toHighPrecision(src.errorBudgetConsumed),
+                  remaining: toHighPrecision(src.errorBudgetRemaining),
+                  isEstimated: src.errorBudgetEstimated,
+                },
+                fiveMinuteBurnRate: toHighPrecision(src.fiveMinuteBurnRate?.value ?? 0),
+                oneHourBurnRate: toHighPrecision(src.oneHourBurnRate?.value ?? 0),
+                oneDayBurnRate: toHighPrecision(src.oneDayBurnRate?.value ?? 0),
+                summaryUpdatedAt: src.summaryUpdatedAt,
+              },
             };
+            return { ...payload, status: src.status };
           });
 
           return {
@@ -107,12 +149,7 @@ export function getSLOByServiceName(
                 data: suggestions.map((suggestion) => ({
                   id: `${suggestion.id}-${suggestion.instanceId}`,
                   description: `SLO "${suggestion.name}" is ${suggestion.status}`,
-                  payload: {
-                    id: suggestion.id,
-                    name: suggestion.name,
-                    instanceId: suggestion.instanceId,
-                    status: suggestion.status,
-                  },
+                  payload: suggestion,
                   attachment: {
                     type: AttachmentType.persistableState,
                     persistableStateAttachmentTypeId: '.page',

--- a/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
@@ -149,7 +149,6 @@ export function getSLOByServiceName(
             };
 
             const item: AttachmentItem<SLOSuggestion> = {
-              id: `${payload.id}-${payload.instanceId}`,
               description: `SLO "${payload.name}" is ${payload.summary.status} for the service "${svcName}"`,
               payload,
               attachment: {
@@ -180,11 +179,13 @@ export function getSLOByServiceName(
             }
           }
 
-          const suggestions = Array.from(itemsByService.entries()).map(([svcName, data]) => ({
-            id: 'slo',
-            description: `Found ${data.length} SLOs linked to service "${svcName}"`,
-            data,
-          }));
+          const suggestions = Array.from(itemsByService.entries()).flatMap(([svcName, data]) =>
+            data.map((item) => ({
+              id: `${item.payload.id}-${item.payload.instanceId}`,
+              componentId: 'slo',
+              data: [item],
+            }))
+          );
 
           return { suggestions };
         },

--- a/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/cases/suggestion.ts
@@ -102,7 +102,7 @@ export function getSLOByServiceName(
           return {
             suggestions: [
               {
-                id: 'example',
+                id: 'slo',
                 description: `Found ${suggestions.length} SLOs linked to service "${serviceName}"`,
                 data: suggestions.map((suggestion) => ({
                   description: `SLO "${suggestion.name}" is ${suggestion.status}`,
@@ -110,6 +110,7 @@ export function getSLOByServiceName(
                     id: suggestion.id,
                     name: suggestion.name,
                     instanceId: suggestion.instanceId,
+                    status: suggestion.status,
                   },
                   attachment: {
                     type: AttachmentType.persistableState,

--- a/x-pack/solutions/observability/plugins/slo/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/plugin.ts
@@ -248,15 +248,20 @@ export class SLOPlugin
       logFactory: this.initContext.logger,
     });
 
-    core.getStartServices().then(([coreStart]) => {
-      if (plugins.cases?.attachmentFramework) {
-        registerSloSuggestion({
-          attachmentFramework: plugins.cases.attachmentFramework,
-          coreStart,
-          logger: this.initContext.logger.get('cases-suggestion'),
-        });
-      }
-    });
+    core
+      .getStartServices()
+      .then(([coreStart]) => {
+        if (plugins.cases?.attachmentFramework) {
+          registerSloSuggestion({
+            attachmentFramework: plugins.cases.attachmentFramework,
+            coreStart,
+            logger: this.initContext.logger.get('cases-suggestion'),
+          });
+        }
+      })
+      .catch((err) => {
+        this.logger.debug('Cannot register SLO suggestion', err.message);
+      });
 
     return {};
   }

--- a/x-pack/solutions/observability/plugins/slo/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/plugin.ts
@@ -48,7 +48,7 @@ import type {
   SLOServerStart,
 } from './types';
 import { LOCK_ID_RESOURCE_INSTALLER } from '../common/constants';
-import { getSLOByServiceName } from './lib/cases/suggestion';
+import { registerSloSuggestion } from './lib/cases/suggestion';
 
 const sloRuleTypes = [SLO_BURN_RATE_RULE_TYPE_ID];
 
@@ -248,10 +248,14 @@ export class SLOPlugin
       logFactory: this.initContext.logger,
     });
 
-    core.getStartServices().then(([coreStart, pluginsStart]) => {
-      plugins.cases?.attachmentFramework.registerSuggestion(
-        getSLOByServiceName(coreStart, this.initContext.logger.get('cases-suggestion'))
-      );
+    core.getStartServices().then(([coreStart]) => {
+      if (plugins.cases?.attachmentFramework) {
+        registerSloSuggestion({
+          attachmentFramework: plugins.cases.attachmentFramework,
+          coreStart,
+          logger: this.initContext.logger.get('cases-suggestion'),
+        });
+      }
     });
 
     return {};

--- a/x-pack/solutions/observability/plugins/slo/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/plugin.ts
@@ -48,6 +48,7 @@ import type {
   SLOServerStart,
 } from './types';
 import { LOCK_ID_RESOURCE_INSTALLER } from '../common/constants';
+import { getSLOByServiceName } from './lib/cases/suggestion';
 
 const sloRuleTypes = [SLO_BURN_RATE_RULE_TYPE_ID];
 
@@ -135,7 +136,6 @@ export class SLOPlugin
     });
 
     const { ruleDataService } = plugins.ruleRegistry;
-
     core.savedObjects.registerType(slo);
     core.savedObjects.registerType(sloSettings);
 
@@ -246,6 +246,12 @@ export class SLOPlugin
       core,
       plugins: mappedPlugins,
       logFactory: this.initContext.logger,
+    });
+
+    core.getStartServices().then(([coreStart, pluginsStart]) => {
+      plugins.cases.attachmentFramework.registerSuggestion(
+        getSLOByServiceName(coreStart, this.initContext.logger.get('cases-suggestion'))
+      );
     });
 
     return {};

--- a/x-pack/solutions/observability/plugins/slo/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/plugin.ts
@@ -249,7 +249,7 @@ export class SLOPlugin
     });
 
     core.getStartServices().then(([coreStart, pluginsStart]) => {
-      plugins.cases.attachmentFramework.registerSuggestion(
+      plugins.cases?.attachmentFramework.registerSuggestion(
         getSLOByServiceName(coreStart, this.initContext.logger.get('cases-suggestion'))
       );
     });

--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_transform_generator/helpers/create_temp_summary.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_transform_generator/helpers/create_temp_summary.ts
@@ -34,11 +34,10 @@ export interface EsSummaryDocument {
   };
   // SLO definition
   slo: {
-    // >= 8.14: Add indicator.params on the temporary summary as well as real summary through summary pipeline
-    indicator: { type: IndicatorTypes } | Indicator;
+    indicator: { type: IndicatorTypes } | Indicator; // >= 8.14: Add indicator.params on the temporary summary as well as real summary through summary pipeline
     timeWindow: t.OutputOf<typeof timeWindowSchema>;
     groupBy: string | string[];
-    groupings: Record<string, unknown>;
+    groupings: Record<string, unknown>; // not flatten
     instanceId: string;
     name: string;
     description: string;

--- a/x-pack/solutions/observability/plugins/slo/server/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/types.ts
@@ -47,7 +47,7 @@ export interface SLOPluginSetupDependencies {
   licensing: LicensingPluginSetup;
   dataViews: DataViewsServerPluginStart;
   security: SecurityPluginStart;
-  cases: CasesServerSetup;
+  cases?: CasesServerSetup;
 }
 
 export interface SLOPluginStartDependencies {
@@ -57,5 +57,5 @@ export interface SLOPluginStartDependencies {
   ruleRegistry: RuleRegistryPluginStartContract;
   dataViews: DataViewsServerPluginStart;
   licensing: LicensingPluginStart;
-  cases: CasesServerStart;
+  cases?: CasesServerStart;
 }

--- a/x-pack/solutions/observability/plugins/slo/server/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/types.ts
@@ -7,6 +7,7 @@
 
 import type { AlertingServerSetup, AlertingServerStart } from '@kbn/alerting-plugin/server';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
+import type { CasesServerSetup, CasesServerStart } from '@kbn/cases-plugin/server';
 import type { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type { LicensingPluginSetup, LicensingPluginStart } from '@kbn/licensing-plugin/server';
@@ -46,6 +47,7 @@ export interface SLOPluginSetupDependencies {
   licensing: LicensingPluginSetup;
   dataViews: DataViewsServerPluginStart;
   security: SecurityPluginStart;
+  cases: CasesServerSetup;
 }
 
 export interface SLOPluginStartDependencies {
@@ -55,4 +57,5 @@ export interface SLOPluginStartDependencies {
   ruleRegistry: RuleRegistryPluginStartContract;
   dataViews: DataViewsServerPluginStart;
   licensing: LicensingPluginStart;
+  cases: CasesServerStart;
 }


### PR DESCRIPTION
✨ Experimental ✨

Issue https://github.com/elastic/kibana/issues/228518
Issue https://github.com/elastic/kibana/issues/230428

Make sure to have these 2 feature flags enabled:
```
xpack.observabilityShared.unsafe.investigativeExperienceEnabled: true
xpack.cases.unsafe.enableCaseSuggestions: true
```

## How to Test It

1. **Generate test data**  
`node scripts/synthtrace.js logs_and_metrics`

2. **Create a custom threshold rule**  
- Use the *Logs* data view.  
- Configure the rule so it triggers an alert.  
- Ensure it is **grouped by `service.name`**.  

3. **Create an SLO**  
- Use the *Logs* data view.  
- Ensure the SLO is **grouped by `service.name`**.  

4. **Create a new Case**  
- Navigate to the *Cases* section.  
- Open a new case.  

5. **Add a custom threshold alert to the case**  
- Attach one of the threshold rule alerts you created.  
- ✅ Verify that the related SLO suggestion for that service is displayed.  

6. **Add additional alerts**  
- Attach more alerts to the case.  
- ✅ Confirm that for each alert added, a related SLO suggestion is displayed.


https://github.com/user-attachments/assets/a69a69fc-b93e-4c12-8c46-295773a0f296

