### PR TITLE
[One Discover] Replicate fix for flaky test to other embeddables and stateful tests

### DIFF
--- a/src/platform/test/functional/apps/discover/observability/embeddable/_get_doc_viewer.ts
+++ b/src/platform/test/functional/apps/discover/observability/embeddable/_get_doc_viewer.ts
@@ -116,7 +116,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should open the flyout with stacktrace accordion open and quality issues accordion closed when stacktrace icon is clicked', async () => {
-        await dataGrid.clickStacktraceLeadingControl(0);
+        await dataGrid.clickStacktraceLeadingControl(1);
 
         // Ensure Log overview flyout is open
         await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
@@ -139,7 +139,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should open the flyout with stacktrace accordion closed and quality issues accordion open when quality issues icon is clicked', async () => {
-        await dataGrid.clickQualityIssueLeadingControl(0);
+        await dataGrid.clickQualityIssueLeadingControl(2);
 
         // Ensure Log overview flyout is open
         await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');

--- a/src/platform/test/functional/apps/discover/observability/logs/_get_doc_viewer.ts
+++ b/src/platform/test/functional/apps/discover/observability/logs/_get_doc_viewer.ts
@@ -96,7 +96,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should open the flyout with stacktrace accordion open and quality issues accordion closed when stacktrace icon is clicked', async () => {
-        await dataGrid.clickStacktraceLeadingControl(0);
+        await dataGrid.clickStacktraceLeadingControl(1);
 
         // Ensure Log overview flyout is open
         await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
@@ -119,7 +119,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should open the flyout with stacktrace accordion closed and quality issues accordion open when quality issues icon is clicked', async () => {
-        await dataGrid.clickQualityIssueLeadingControl(0);
+        await dataGrid.clickQualityIssueLeadingControl(2);
 
         // Ensure Log overview flyout is open
         await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/embeddables/_get_doc_viewer.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/embeddables/_get_doc_viewer.ts
@@ -116,7 +116,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should open the flyout with stacktrace accordion open and quality issues accordion closed when stacktrace icon is clicked', async () => {
-        await dataGrid.clickStacktraceLeadingControl(0);
+        await dataGrid.clickStacktraceLeadingControl(1);
 
         // Ensure Log overview flyout is open
         await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
@@ -139,7 +139,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should open the flyout with stacktrace accordion closed and quality issues accordion open when quality issues icon is clicked', async () => {
-        await dataGrid.clickQualityIssueLeadingControl(0);
+        await dataGrid.clickQualityIssueLeadingControl(2);
 
         // Ensure Log overview flyout is open
         await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');


### PR DESCRIPTION
## Summary

As part of this [PR](https://github.com/elastic/kibana/pull/231924), i missed to replicate the fix to

- Embeddables (stateful and serverless)
- Doc viewer Stateful

With this PR, i am simply replicating the fix. This should fix - https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/6450