### PR TITLE
[Dashboard] Fix panel borders

### DIFF
--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_hover_actions_wrapper.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_hover_actions_wrapper.tsx
@@ -39,7 +39,7 @@ export const PresentationPanelHoverActionsWrapper = (props: PresentationPanelHov
       props.api?.hasLockedHoverActions$,
       props.api?.overrideHoverActions$
     );
-  const containerStyles = useHoverActionStyles(true, props.showBorder);
+  const containerStyles = useHoverActionStyles(props.viewMode === 'edit', props.showBorder);
 
   let OverriddenHoverActionsComponent = null;
   if (canOverrideHoverActions(props.api) && overrideHoverActions) {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/232671

## Summary

The `PresentationPanelHoverActionsWrapper` styles were hard coded to be in edit mode, which meant that the panel border wasn't changing to solid in view mode as it should. This PR fixes that by properly passing the view mode to the panel styles.

| Before | After |
|--------|--------|
| ![Aug-22-2025 09-23-48](https://github.com/user-attachments/assets/800d70d7-7e0b-4fb0-b18d-33701f8d2c9a) | ![Aug-22-2025 09-23-02](https://github.com/user-attachments/assets/fb3b8987-d437-4b41-a404-f60af691deed) | 




### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

