### PR TITLE
[8.17] [Observability Onboarding] Add note about the supported helm versions in the K8s OTel flow (#232618)

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -102,7 +102,7 @@ helm upgrade --install opentelemetry-kube-stack open-telemetry/opentelemetry-kub
                 <p>
                   <FormattedMessage
                     id="xpack.observability_onboarding.otelKubernetesPanel.injectAutoinstrumentationLibrariesForLabel"
-                    defaultMessage="Install the OpenTelemetry Operator using the kube-stack Helm chart and the provided values file. For automatic certificate renewal, we recommend installing the {link}, and customize the values.yaml file before the installation as described {doc}."
+                    defaultMessage="Install the OpenTelemetry Operator using the kube-stack Helm chart and the provided values file. Compatible with Helm up to version 8.14. For automatic certificate renewal, we recommend installing the {link}, and customize the values.yaml file before the installation as described {doc}."
                     values={{
                       link: (
                         <EuiLink


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Observability Onboarding] Add note about the supported helm versions in the K8s OTel flow (#232618)](https://github.com/elastic/kibana/pull/232618)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Giorgos Bamparopoulos","email":"georgios.bamparopoulos@elastic.co"},"sourceCommit":{"committedDate":"2025-08-22T13:15:18Z","message":"[Observability Onboarding] Add note about the supported helm versions in the K8s OTel flow (#232618)\n\n## 📓 Summary\nThe onboarding flow doesn't work for helm versions `3.18.5` and `3.18.6`\n(See\nhttps://github.com/open-telemetry/opentelemetry-helm-charts/pull/1805\nand\nhttps://github.com/open-telemetry/opentelemetry-helm-charts/pull/1809).\n\nUntil\nhttps://github.com/open-telemetry/opentelemetry-helm-charts/pull/1809\nand an update in Elastic Agent is merged, this PR adds a note about the\nsupported helm versions.","sha":"4c7b867f289b9be9387110a69668b38b5ac0c56d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:feature","backport:all-open","Feature: Observability Onboarding","v9.2.0"],"title":"[Observability Onboarding] Add note about the supported helm versions in the K8s OTel flow","number":232618,"url":"https://github.com/elastic/kibana/pull/232618","mergeCommit":{"message":"[Observability Onboarding] Add note about the supported helm versions in the K8s OTel flow (#232618)\n\n## 📓 Summary\nThe onboarding flow doesn't work for helm versions `3.18.5` and `3.18.6`\n(See\nhttps://github.com/open-telemetry/opentelemetry-helm-charts/pull/1805\nand\nhttps://github.com/open-telemetry/opentelemetry-helm-charts/pull/1809).\n\nUntil\nhttps://github.com/open-telemetry/opentelemetry-helm-charts/pull/1809\nand an update in Elastic Agent is merged, this PR adds a note about the\nsupported helm versions.","sha":"4c7b867f289b9be9387110a69668b38b5ac0c56d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232618","number":232618,"mergeCommit":{"message":"[Observability Onboarding] Add note about the supported helm versions in the K8s OTel flow (#232618)\n\n## 📓 Summary\nThe onboarding flow doesn't work for helm versions `3.18.5` and `3.18.6`\n(See\nhttps://github.com/open-telemetry/opentelemetry-helm-charts/pull/1805\nand\nhttps://github.com/open-telemetry/opentelemetry-helm-charts/pull/1809).\n\nUntil\nhttps://github.com/open-telemetry/opentelemetry-helm-charts/pull/1809\nand an update in Elastic Agent is merged, this PR adds a note about the\nsupported helm versions.","sha":"4c7b867f289b9be9387110a69668b38b5ac0c56d"}},{"url":"https://github.com/elastic/kibana/pull/232650","number":232650,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/232651","number":232651,"branch":"8.19","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/232652","number":232652,"branch":"9.0","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/232653","number":232653,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->