### PR TITLE
[dashboard] fix unified search typeahead does not include adhoc data views

### DIFF
--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_data_views.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_data_views.ts
@@ -11,11 +11,14 @@ import type { DataView } from '@kbn/data-views-plugin/common';
 import type { PublishingSubject } from '../publishing_subject';
 
 /**
- * This API publishes a list of data views that it uses. Note that this should not contain any
- * ad-hoc data views.
+ * This API publishes a list of data views that it uses.
  */
 export interface PublishesDataViews {
-  dataViews$: PublishingSubject<DataView[] | undefined>;
+  allDataViews$?: PublishingSubject<DataView[] | undefined>;
+  /**
+   * Excludes ad-hoc data views.
+   */
+  dataViews$: PublishingSubject<DataView[] | undefined>; 
 }
 
 export type PublishesWritableDataViews = PublishesDataViews & {

--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_data_views.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_data_views.ts
@@ -18,7 +18,7 @@ export interface PublishesDataViews {
   /**
    * Excludes ad-hoc data views.
    */
-  dataViews$: PublishingSubject<DataView[] | undefined>; 
+  dataViews$: PublishingSubject<DataView[] | undefined>;
 }
 
 export type PublishesWritableDataViews = PublishesDataViews & {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/types.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/types.ts
@@ -103,7 +103,7 @@ export type DashboardApi = CanExpandPanels &
   PassThroughContext &
   PresentationContainer &
   PublishesDataLoading &
-  PublishesDataViews &
+  Required<PublishesDataViews> &
   PublishesDescription &
   Pick<PublishesTitle, 'title$'> &
   PublishesReload &

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -96,7 +96,7 @@ export function InternalDashboardTopNav({
     title,
     viewMode,
   ] = useBatchedPublishingSubjects(
-    dashboardApi.dataViews$,
+    dashboardApi.allDataViews$,
     dashboardApi.focusedPanelId$,
     dashboardApi.fullScreenMode$,
     dashboardApi.hasUnsavedChanges$,

--- a/src/platform/plugins/shared/dashboard/public/services/mocks.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/mocks.ts
@@ -49,10 +49,16 @@ export const setStubKibanaServices = () => {
   const core = coreMock.createStart();
   (core.application.capabilities as any).dashboard_v2 = defaultDashboardCapabilities;
 
+  const dataServiceMock = dataPluginMock.createStartContract();
+  dataServiceMock.dataViews.getDefaultDataView = jest.fn().mockImplementation(async () => ({
+    isPersisted: () => true, // provide isPersisted implement when not provided by original mock
+    ...(await dataServiceMock.dataViews.getDefaultDataView()),
+  }));
+
   setKibanaServices(core, {
     contentManagement: contentManagementMock.createStartContract(),
     customBranding: customBrandingServiceMock.createStartContract(),
-    data: dataPluginMock.createStartContract(),
+    data: dataServiceMock,
     dataViewEditor: indexPatternEditorPluginMock.createStartContract(),
     embeddable: embeddablePluginMock.createStartContract(),
     fieldFormats: fieldFormatsServiceMock.createStartContract(),

--- a/src/platform/plugins/shared/dashboard/public/services/mocks.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/mocks.ts
@@ -51,8 +51,8 @@ export const setStubKibanaServices = () => {
 
   const dataServiceMock = dataPluginMock.createStartContract();
   dataServiceMock.dataViews.getDefaultDataView = jest.fn().mockImplementation(async () => ({
-    isPersisted: () => true, // provide isPersisted implement when not provided by original mock
     ...(await dataServiceMock.dataViews.getDefaultDataView()),
+    isPersisted: () => true,
   }));
 
   setKibanaServices(core, {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/232669

PR adds `allDataViews$` to `PublishesDataViews` interface. Dashboard uses this to pass all data views to unified search.