### PR TITLE
[9.0] [Search] Add Redirects for deprecated deeplink paths (#231890)

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/index.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/index.tsx
@@ -12,12 +12,13 @@ import { Routes, Route } from '@kbn/shared-ux-router';
 import { NotFound } from './components/not_found';
 import { PlaygroundRedirect } from './components/playground_redirect';
 import { SearchApplicationsRouter } from './components/search_applications/search_applications_router';
-import { ROOT_PATH, SEARCH_APPLICATIONS_PATH } from './routes';
+import { OLD_PLAYGROUND_PATH, ROOT_PATH, SEARCH_APPLICATIONS_PATH } from './routes';
 
 export const Applications = () => {
   return (
     <Routes>
       <Route exact path={ROOT_PATH} component={PlaygroundRedirect} />
+      <Route exact path={OLD_PLAYGROUND_PATH} component={PlaygroundRedirect} />
       <Route path={SEARCH_APPLICATIONS_PATH} component={SearchApplicationsRouter} />
       <Route>
         <NotFound />

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/routes.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/routes.ts
@@ -7,6 +7,7 @@
 
 export const ROOT_PATH = '/';
 
+export const OLD_PLAYGROUND_PATH = `${ROOT_PATH}playground`;
 export const SEARCH_APPLICATIONS_PATH = `${ROOT_PATH}search_applications`;
 
 export enum SearchApplicationViewTabs {

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawlers_router.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawlers_router.tsx
@@ -6,16 +6,18 @@
  */
 
 import React from 'react';
+import { Redirect } from 'react-router-dom';
 
 import { Routes, Route } from '@kbn/shared-ux-router';
 
-import { CRAWLERS_PATH, CRAWLERS_ELASTIC_MANAGED_PATH } from '../../routes';
+import { CRAWLERS_PATH, CRAWLERS_ELASTIC_MANAGED_PATH, CRAWLERS_NEW_PATH } from '../../routes';
 
 import { Connectors } from './connectors';
 
 export const CrawlersRouter: React.FC = () => {
   return (
     <Routes>
+      <Redirect exact path={CRAWLERS_NEW_PATH} to={CRAWLERS_PATH} />
       <Route exact path={CRAWLERS_PATH}>
         <Connectors isCrawler isCrawlerSelfManaged />
       </Route>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/routes.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/routes.ts
@@ -12,6 +12,7 @@ export const ERROR_STATE_PATH = '/error_state';
 export const SEARCH_INDICES_PATH = `${ROOT_PATH}search_indices`;
 export const CONNECTORS_PATH = `${ROOT_PATH}connectors`;
 export const CRAWLERS_PATH = `${ROOT_PATH}crawlers`;
+export const CRAWLERS_NEW_PATH = `${CRAWLERS_PATH}/new_crawler`;
 export const CRAWLERS_ELASTIC_MANAGED_PATH = `${CRAWLERS_PATH}/elastic_managed`;
 export const SETTINGS_PATH = `${ROOT_PATH}settings`;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Search] Add Redirects for deprecated deeplink paths (#231890)](https://github.com/elastic/kibana/pull/231890)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Rodney Norris","email":"rodney.norris@elastic.co"},"sourceCommit":{"committedDate":"2025-08-15T14:40:12Z","message":"[Search] Add Redirects for deprecated deeplink paths (#231890)\n\n## Summary\n\nAdded redirects for paths that no longer exist, but are used in\nonboarding deeplinks.\n\n- `'/app/enterprise_search/ai_search'` -> `'/app/elasticsearch/home'` \n- `'/app/enterprise_search/elasticsearch'` ->\n`'/app/elasticsearch/home'`\n- `'/app/enterprise_search/vector_search'` ->\n`'/app/elasticsearch/home'`\n- `'/app/enterprise_search/semantic_search'` ->\n`'/app/elasticsearch/home'`\n- `'/app/elasticsearch/content/crawlers/new_crawler` ->\n`'/app/elasticsearch/content/crawlers'`\n- `'/app/enterprise_search/applications/playground'` ->\n`'/app/search_playground/chat'`\n\n### Notes\n\nI will manually backport this to v9.1 & v9.0 since I need to remove the\nchanges to`public/applications/enterprise_search_redirect/index.tsx` as\nthey are not applicable to v9.0 & v9.1 since those paths are removed in\nv9.2.","sha":"beb2deec6880a164cc6b149460f7dbe2a94fa157","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Search","v9.2.0"],"title":"[Search] Add Redirects for deprecated deeplink paths","number":231890,"url":"https://github.com/elastic/kibana/pull/231890","mergeCommit":{"message":"[Search] Add Redirects for deprecated deeplink paths (#231890)\n\n## Summary\n\nAdded redirects for paths that no longer exist, but are used in\nonboarding deeplinks.\n\n- `'/app/enterprise_search/ai_search'` -> `'/app/elasticsearch/home'` \n- `'/app/enterprise_search/elasticsearch'` ->\n`'/app/elasticsearch/home'`\n- `'/app/enterprise_search/vector_search'` ->\n`'/app/elasticsearch/home'`\n- `'/app/enterprise_search/semantic_search'` ->\n`'/app/elasticsearch/home'`\n- `'/app/elasticsearch/content/crawlers/new_crawler` ->\n`'/app/elasticsearch/content/crawlers'`\n- `'/app/enterprise_search/applications/playground'` ->\n`'/app/search_playground/chat'`\n\n### Notes\n\nI will manually backport this to v9.1 & v9.0 since I need to remove the\nchanges to`public/applications/enterprise_search_redirect/index.tsx` as\nthey are not applicable to v9.0 & v9.1 since those paths are removed in\nv9.2.","sha":"beb2deec6880a164cc6b149460f7dbe2a94fa157"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231890","number":231890,"mergeCommit":{"message":"[Search] Add Redirects for deprecated deeplink paths (#231890)\n\n## Summary\n\nAdded redirects for paths that no longer exist, but are used in\nonboarding deeplinks.\n\n- `'/app/enterprise_search/ai_search'` -> `'/app/elasticsearch/home'` \n- `'/app/enterprise_search/elasticsearch'` ->\n`'/app/elasticsearch/home'`\n- `'/app/enterprise_search/vector_search'` ->\n`'/app/elasticsearch/home'`\n- `'/app/enterprise_search/semantic_search'` ->\n`'/app/elasticsearch/home'`\n- `'/app/elasticsearch/content/crawlers/new_crawler` ->\n`'/app/elasticsearch/content/crawlers'`\n- `'/app/enterprise_search/applications/playground'` ->\n`'/app/search_playground/chat'`\n\n### Notes\n\nI will manually backport this to v9.1 & v9.0 since I need to remove the\nchanges to`public/applications/enterprise_search_redirect/index.tsx` as\nthey are not applicable to v9.0 & v9.1 since those paths are removed in\nv9.2.","sha":"beb2deec6880a164cc6b149460f7dbe2a94fa157"}}]}] BACKPORT-->