### PR TITLE
[9.1] [Dataset quality] include failed docs when redirecting to discover (#232635)

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/table/columns.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/table/columns.tsx
@@ -480,7 +480,7 @@ const RedirectLink = ({
 }) => {
   const { sendTelemetry } = useDatasetRedirectLinkTelemetry({ rawName: dataStreamStat.rawName });
   const redirectLinkProps = useRedirectLink({
-    dataStreamStat,
+    dataStreamStat: `${dataStreamStat.rawName},${dataStreamStat.rawName}${FAILURE_STORE_SELECTOR}`,
     sendTelemetry,
     timeRangeConfig: timeRange,
   });

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/header.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/header.tsx
@@ -22,6 +22,7 @@ import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
 import { DEGRADED_DOCS_RULE_TYPE_ID } from '@kbn/rule-data-utils';
 import { createAlertText, openInDiscoverText } from '../../../common/translations';
+import { FAILURE_STORE_SELECTOR } from '../../../common/constants';
 import { AlertFlyout } from '../../alerts/alert_flyout';
 import { getAlertingCapabilities } from '../../alerts/get_alerting_capabilities';
 import {
@@ -51,7 +52,7 @@ export function Header() {
     navigationSource: navigationSources.Header,
   });
   const redirectLinkProps = useRedirectLink({
-    dataStreamStat: datasetDetails,
+    dataStreamStat: `${datasetDetails.rawName},${datasetDetails.rawName}${FAILURE_STORE_SELECTOR}`,
     timeRangeConfig: timeRange,
     sendTelemetry,
   });

--- a/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_redirect_link.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_redirect_link.ts
@@ -6,7 +6,7 @@
  */
 
 import { DISCOVER_APP_LOCATOR, DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
-import { AggregateQuery, Query, buildPhraseFilter } from '@kbn/es-query';
+import { AggregateQuery, Filter, Query, buildPhraseFilter } from '@kbn/es-query';
 import { getRouterLinkProps } from '@kbn/router-utils';
 import { RouterLinkProps } from '@kbn/router-utils/src/get_router_link_props';
 import { LocatorClient } from '@kbn/shared-ux-prompt-no-data-views-types';
@@ -15,7 +15,7 @@ import { BasicDataStream, DataStreamSelector, TimeRangeConfig } from '../../comm
 import { useKibanaContextForPlugin } from '../utils';
 import { SendTelemetryFn } from './use_redirect_link_telemetry';
 
-export const useRedirectLink = <T extends BasicDataStream>({
+export const useRedirectLink = <T extends BasicDataStream | string>({
   dataStreamStat,
   query,
   timeRangeConfig,
@@ -83,7 +83,7 @@ export const useRedirectLink = <T extends BasicDataStream>({
   ]);
 };
 
-const buildDiscoverConfig = <T extends BasicDataStream>({
+const buildDiscoverConfig = <T extends BasicDataStream | string>({
   locatorClient,
   dataStreamStat,
   query,
@@ -103,28 +103,17 @@ const buildDiscoverConfig = <T extends BasicDataStream>({
   navigate: () => void;
   routerLinkProps: RouterLinkProps;
 } => {
-  const dataViewNamespace = `${selector ? dataStreamStat.namespace : '*'}`;
-  const dataViewSelector = selector ? `${selector}` : '';
-  const dataViewId = `${dataStreamStat.type}-${dataStreamStat.name}-${dataViewNamespace}${dataViewSelector}`;
-  const dataViewTitle = dataStreamStat.integration
-    ? `[${dataStreamStat.integration.title}] ${dataStreamStat.name}-${dataViewNamespace}${dataViewSelector}`
-    : `${dataViewId}`;
+  const { dataViewId, dataViewTitle } = getDataView({
+    dataStreamStat,
+    selector,
+  });
 
-  const filters = selector
-    ? []
-    : [
-        buildPhraseFilter(
-          {
-            name: 'data_stream.namespace',
-            type: 'string',
-          },
-          dataStreamStat.namespace,
-          {
-            id: dataViewId,
-            title: dataViewTitle,
-          }
-        ),
-      ];
+  const filters = getFilters({
+    dataStreamStat,
+    dataViewId,
+    dataViewTitle,
+    selector,
+  });
 
   const params: DiscoverAppLocatorParams = {
     timeRange: {
@@ -163,4 +152,59 @@ const buildDiscoverConfig = <T extends BasicDataStream>({
   });
 
   return { routerLinkProps: discoverLinkProps, navigate: navigateToDiscover };
+};
+
+const getDataView = <T extends BasicDataStream | string>({
+  dataStreamStat,
+  selector,
+}: {
+  dataStreamStat: T;
+  selector?: DataStreamSelector;
+}): { dataViewId: string; dataViewTitle: string } => {
+  if (dataStreamStat && typeof dataStreamStat === 'string') {
+    return { dataViewId: dataStreamStat, dataViewTitle: dataStreamStat };
+  }
+
+  const { name, namespace, type, integration } = dataStreamStat as BasicDataStream;
+
+  const dataViewNamespace = `${namespace || '*'}`;
+  const dataViewSelector = selector ? `${selector}` : '';
+  const dataViewId = `${type}-${name}-${dataViewNamespace}${dataViewSelector}`;
+  const dataViewTitle = integration
+    ? `[${integration.title}] ${name}-${dataViewNamespace}${dataViewSelector}`
+    : `${dataViewId}`;
+
+  return { dataViewId, dataViewTitle };
+};
+
+const getFilters = <T extends BasicDataStream | string>({
+  dataStreamStat,
+  dataViewId,
+  dataViewTitle,
+  selector,
+}: {
+  dataStreamStat: T;
+  dataViewId: string;
+  dataViewTitle: string;
+  selector?: DataStreamSelector;
+}): Filter[] => {
+  if (dataStreamStat && typeof dataStreamStat === 'string') {
+    return [];
+  }
+
+  return selector
+    ? []
+    : [
+        buildPhraseFilter(
+          {
+            name: 'data_stream.namespace',
+            type: 'string',
+          },
+          (dataStreamStat as BasicDataStream).namespace,
+          {
+            id: dataViewId,
+            title: dataViewTitle,
+          }
+        ),
+      ];
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Dataset quality] include failed docs when redirecting to discover (#232635)](https://github.com/elastic/kibana/pull/232635)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Yngrid Coello","email":"yngrid.coello@elastic.co"},"sourceCommit":{"committedDate":"2025-08-22T14:37:21Z","message":"[Dataset quality] include failed docs when redirecting to discover (#232635)\n\nCloses https://github.com/elastic/kibana/issues/231565\n\n### 🎥  Demo\n\n#### Before\n\n\nhttps://github.com/user-attachments/assets/19db12b3-091e-4bd5-a3a8-52cde53425bc\n\n#### After\n\n\nhttps://github.com/user-attachments/assets/2595fa1b-49fb-417b-89e5-4a681e60cc0d\n\n### How to test?\n1. Run synthtrace scenario `failed_logs`\n2. Navigate to `Data set quality` page\n3. Click on `Open` within Actions column\n4. You will be redirected to discover and the dataView will include\nfailed docs index","sha":"279fb3c661e4776b8de621b808a2eec886c0630a","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.1.0","v8.19.0","v9.2.0","v9.1.3","v8.19.3"],"title":"[Dataset quality] include failed docs when redirecting to discover","number":232635,"url":"https://github.com/elastic/kibana/pull/232635","mergeCommit":{"message":"[Dataset quality] include failed docs when redirecting to discover (#232635)\n\nCloses https://github.com/elastic/kibana/issues/231565\n\n### 🎥  Demo\n\n#### Before\n\n\nhttps://github.com/user-attachments/assets/19db12b3-091e-4bd5-a3a8-52cde53425bc\n\n#### After\n\n\nhttps://github.com/user-attachments/assets/2595fa1b-49fb-417b-89e5-4a681e60cc0d\n\n### How to test?\n1. Run synthtrace scenario `failed_logs`\n2. Navigate to `Data set quality` page\n3. Click on `Open` within Actions column\n4. You will be redirected to discover and the dataView will include\nfailed docs index","sha":"279fb3c661e4776b8de621b808a2eec886c0630a"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232635","number":232635,"mergeCommit":{"message":"[Dataset quality] include failed docs when redirecting to discover (#232635)\n\nCloses https://github.com/elastic/kibana/issues/231565\n\n### 🎥  Demo\n\n#### Before\n\n\nhttps://github.com/user-attachments/assets/19db12b3-091e-4bd5-a3a8-52cde53425bc\n\n#### After\n\n\nhttps://github.com/user-attachments/assets/2595fa1b-49fb-417b-89e5-4a681e60cc0d\n\n### How to test?\n1. Run synthtrace scenario `failed_logs`\n2. Navigate to `Data set quality` page\n3. Click on `Open` within Actions column\n4. You will be redirected to discover and the dataView will include\nfailed docs index","sha":"279fb3c661e4776b8de621b808a2eec886c0630a"}}]}] BACKPORT-->