### PR TITLE
fix: missing announcements in logistics step of policy form

### DIFF
--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/disable_tooltip.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/disable_tooltip.tsx
@@ -35,12 +35,14 @@ export interface Props {
   isManaged?: boolean;
   /** The message to display inside the tooltip. */
   tooltipMessage: string;
-  /** The component to wrap with the tooltip. */
+  /** Tooltip anchor element  */
   children: ReactElement;
 }
 
 export const DisableToolTip = ({ isManaged, tooltipMessage, children, ...props }: Props) => {
-  // Ensures that any additional props passed down by EuiFormRow (e.g. id, aria-describedby) are forwarded to the wrapped component
+  // Ensures that any implicitly passed down props from meta parent component via `cloneElement` like in EuiFormRow [here](https://github.com/elastic/eui/blob/bc9c0a0b3faab449f88e45a588dfe0a53d842cf7/packages/eui/src/components/form/form_row/form_row.tsx#L210-L213) are forwarded down to anchor element. 
+  
+// At the same time, explicitly provided props on anchor component, should always take precedence to avoid confusion.
   const childrenWithProps = cloneElement(children, {
     ...props,
     ...children.props,

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/disable_tooltip.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/disable_tooltip.tsx
@@ -28,6 +28,8 @@ interface Props {
   isManaged?: boolean;
   tooltipMessage: string;
   component: ReactElement;
+  id?: string;
+  'aria-describedby'?: string;
 }
 
 /**
@@ -37,15 +39,21 @@ interface Props {
  * @param {boolean} isManaged - Determines if the tooltip should be displayed.
  * @param {string} tooltipMessage - The message to display inside the tooltip.
  * @param {React.ReactElement} component - The component to wrap with the tooltip.
+ * @param {string} id - The id of the wrapped component.
+ * @param {string} 'aria-describedby' - The aria-describedby attribute for the wrapped component.
  */
 export const DisableToolTip: React.FunctionComponent<Props> = ({
   isManaged,
   tooltipMessage,
   component,
-  ...rest
+  id,
+  'aria-describedby': ariaDescribedBy,
 }) => {
-  // Ensures that any additional props (e.g. id, aria-describedby) are forwarded to the wrapped component
-  const componentWithProps = cloneElement(component, { ...rest });
+  // Props 'id' and 'aria-describedby' are passed to the wrapped component for accessibility support, as required by EuiFormRow.
+  const componentWithProps = cloneElement(component, {
+    id,
+    'aria-describedby': ariaDescribedBy,
+  });
 
   return isManaged ? (
     <EuiToolTip content={tooltipMessage} display="block">

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/disable_tooltip.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/disable_tooltip.tsx
@@ -24,42 +24,33 @@ export const MANAGED_POLICY_TOOLTIP_MESSAGE = i18n.translate(
   }
 );
 
-interface Props {
-  isManaged?: boolean;
-  tooltipMessage: string;
-  component: ReactElement;
-  id?: string;
-  'aria-describedby'?: string;
-}
-
 /**
  * Component that wraps a given component (disabled field) with a tooltip if a repository
  * or policy is managed (isManaged === true).
- *
- * @param {boolean} isManaged - Determines if the tooltip should be displayed.
- * @param {string} tooltipMessage - The message to display inside the tooltip.
- * @param {React.ReactElement} component - The component to wrap with the tooltip.
- * @param {string} id - The id of the wrapped component.
- * @param {string} 'aria-describedby' - The aria-describedby attribute for the wrapped component.
  */
-export const DisableToolTip: React.FunctionComponent<Props> = ({
-  isManaged,
-  tooltipMessage,
-  component,
-  id,
-  'aria-describedby': ariaDescribedBy,
-}) => {
-  // Props 'id' and 'aria-describedby' are passed to the wrapped component for accessibility support, as required by EuiFormRow.
-  const componentWithProps = cloneElement(component, {
-    id,
-    'aria-describedby': ariaDescribedBy,
+export interface Props {
+  /** Determines if the tooltip should be displayed.
+   *  @optional
+   */
+  isManaged?: boolean;
+  /** The message to display inside the tooltip. */
+  tooltipMessage: string;
+  /** The component to wrap with the tooltip. */
+  children: ReactElement;
+}
+
+export const DisableToolTip = ({ isManaged, tooltipMessage, children, ...props }: Props) => {
+  // Ensures that any additional props passed down by EuiFormRow (e.g. id, aria-describedby) are forwarded to the wrapped component
+  const childrenWithProps = cloneElement(children, {
+    ...props,
+    ...children.props,
   });
 
   return isManaged ? (
     <EuiToolTip content={tooltipMessage} display="block">
-      {componentWithProps}
+      {childrenWithProps}
     </EuiToolTip>
   ) : (
-    componentWithProps
+    childrenWithProps
   );
 };

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/disable_tooltip.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/disable_tooltip.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { cloneElement } from 'react';
 import { EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -42,12 +42,16 @@ export const DisableToolTip: React.FunctionComponent<Props> = ({
   isManaged,
   tooltipMessage,
   component,
+  ...rest
 }) => {
+  // Ensures that any additional props (e.g. id, aria-describedby) are forwarded to the wrapped component
+  const componentWithProps = cloneElement(component, { ...rest });
+
   return isManaged ? (
     <EuiToolTip content={tooltipMessage} display="block">
-      {component}
+      {componentWithProps}
     </EuiToolTip>
   ) : (
-    component
+    componentWithProps
   );
 };

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/disable_tooltip.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/disable_tooltip.tsx
@@ -40,9 +40,8 @@ export interface Props {
 }
 
 export const DisableToolTip = ({ isManaged, tooltipMessage, children, ...props }: Props) => {
-  // Ensures that any implicitly passed down props from meta parent component via `cloneElement` like in EuiFormRow [here](https://github.com/elastic/eui/blob/bc9c0a0b3faab449f88e45a588dfe0a53d842cf7/packages/eui/src/components/form/form_row/form_row.tsx#L210-L213) are forwarded down to anchor element. 
-  
-// At the same time, explicitly provided props on anchor component, should always take precedence to avoid confusion.
+  // Ensures that any implicitly passed down props from meta parent component via `cloneElement` like in EuiFormRow [here](https://github.com/elastic/eui/blob/bc9c0a0b3faab449f88e45a588dfe0a53d842cf7/packages/eui/src/components/form/form_row/form_row.tsx#L210-L213) are forwarded down to anchor element.
+  // At the same time, explicitly provided props on anchor component, should always take precedence to avoid confusion.
   const childrenWithProps = cloneElement(children, {
     ...props,
     ...children.props,

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/policy_form/steps/step_logistics.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/policy_form/steps/step_logistics.tsx
@@ -264,26 +264,25 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
       <DisableToolTip
         isManaged={policy?.isManagedPolicy}
         tooltipMessage={MANAGED_POLICY_TOOLTIP_MESSAGE}
-        component={
-          <EuiSelect
-            options={repositories.map(({ name }: Repository) => ({
-              value: name,
-              text: name,
-            }))}
-            hasNoInitialSelection={!doesRepositoryExist}
-            value={!doesRepositoryExist ? '' : policy.repository}
-            onBlur={() => setTouched({ ...touched, repository: true })}
-            onChange={(e) => {
-              updatePolicy({
-                repository: e.target.value,
-              });
-            }}
-            fullWidth
-            data-test-subj="repositorySelect"
-            disabled={policy?.isManagedPolicy && isEditing}
-          />
-        }
-      />
+      >
+        <EuiSelect
+          options={repositories.map(({ name }: Repository) => ({
+            value: name,
+            text: name,
+          }))}
+          hasNoInitialSelection={!doesRepositoryExist}
+          value={!doesRepositoryExist ? '' : policy.repository}
+          onBlur={() => setTouched({ ...touched, repository: true })}
+          onChange={(e) => {
+            updatePolicy({
+              repository: e.target.value,
+            });
+          }}
+          fullWidth
+          data-test-subj="repositorySelect"
+          disabled={policy?.isManagedPolicy && isEditing}
+        />
+      </DisableToolTip>
     );
   };
 
@@ -337,29 +336,28 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
         <DisableToolTip
           isManaged={policy?.isManagedPolicy}
           tooltipMessage={MANAGED_POLICY_TOOLTIP_MESSAGE}
-          component={
-            <EuiFieldText
-              defaultValue={policy.snapshotName}
-              fullWidth
-              onChange={(e) => {
-                updatePolicy({
-                  snapshotName: e.target.value,
-                });
-              }}
-              onBlur={() => setTouched({ ...touched, snapshotName: true })}
-              placeholder={i18n.translate(
-                'xpack.snapshotRestore.policyForm.stepLogistics.policySnapshotNamePlaceholder',
-                {
-                  defaultMessage: `'<daily-snap-{now/d}>'`,
-                  description:
-                    'Example date math snapshot name. Keeping the same syntax is important: <SOME-TRANSLATION-{now/d}>',
-                }
-              )}
-              data-test-subj="snapshotNameInput"
-              disabled={policy?.isManagedPolicy && isEditing}
-            />
-          }
-        />
+        >
+          <EuiFieldText
+            defaultValue={policy.snapshotName}
+            fullWidth
+            onChange={(e) => {
+              updatePolicy({
+                snapshotName: e.target.value,
+              });
+            }}
+            onBlur={() => setTouched({ ...touched, snapshotName: true })}
+            placeholder={i18n.translate(
+              'xpack.snapshotRestore.policyForm.stepLogistics.policySnapshotNamePlaceholder',
+              {
+                defaultMessage: `'<daily-snap-{now/d}>'`,
+                description:
+                  'Example date math snapshot name. Keeping the same syntax is important: <SOME-TRANSLATION-{now/d}>',
+              }
+            )}
+            data-test-subj="snapshotNameInput"
+            disabled={policy?.isManagedPolicy && isEditing}
+          />
+        </DisableToolTip>
       </EuiFormRow>
     </EuiDescribedFormGroup>
   );

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/repository_form/type_settings/azure_settings.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/repository_form/type_settings/azure_settings.tsx
@@ -110,21 +110,20 @@ export const AzureSettings: React.FunctionComponent<Props> = ({
           <DisableToolTip
             isManaged={isManagedRepository}
             tooltipMessage={MANAGED_REPOSITORY_TOOLTIP_MESSAGE}
-            component={
-              <EuiFieldText
-                defaultValue={client || ''}
-                fullWidth
-                onChange={(e) => {
-                  updateRepositorySettings({
-                    client: e.target.value,
-                  });
-                }}
-                data-test-subj="clientInput"
-                disabled={isManagedRepository}
-                aria-labelledby={clientId}
-              />
-            }
-          />
+          >
+            <EuiFieldText
+              defaultValue={client || ''}
+              fullWidth
+              onChange={(e) => {
+                updateRepositorySettings({
+                  client: e.target.value,
+                });
+              }}
+              data-test-subj="clientInput"
+              disabled={isManagedRepository}
+              aria-labelledby={clientId}
+            />
+          </DisableToolTip>
         </EuiFormRow>
       </EuiDescribedFormGroup>
 
@@ -164,21 +163,20 @@ export const AzureSettings: React.FunctionComponent<Props> = ({
           <DisableToolTip
             isManaged={isManagedRepository}
             tooltipMessage={MANAGED_REPOSITORY_TOOLTIP_MESSAGE}
-            component={
-              <EuiFieldText
-                defaultValue={container || ''}
-                fullWidth
-                onChange={(e) => {
-                  updateRepositorySettings({
-                    container: e.target.value,
-                  });
-                }}
-                data-test-subj="containerInput"
-                disabled={isManagedRepository}
-                aria-labelledby={containerId}
-              />
-            }
-          />
+          >
+            <EuiFieldText
+              defaultValue={container || ''}
+              fullWidth
+              onChange={(e) => {
+                updateRepositorySettings({
+                  container: e.target.value,
+                });
+              }}
+              data-test-subj="containerInput"
+              disabled={isManagedRepository}
+              aria-labelledby={containerId}
+            />
+          </DisableToolTip>
         </EuiFormRow>
       </EuiDescribedFormGroup>
 
@@ -218,21 +216,20 @@ export const AzureSettings: React.FunctionComponent<Props> = ({
           <DisableToolTip
             isManaged={isManagedRepository}
             tooltipMessage={MANAGED_REPOSITORY_TOOLTIP_MESSAGE}
-            component={
-              <EuiFieldText
-                defaultValue={basePath || ''}
-                fullWidth
-                onChange={(e) => {
-                  updateRepositorySettings({
-                    basePath: e.target.value,
-                  });
-                }}
-                data-test-subj="basePathInput"
-                disabled={isManagedRepository}
-                aria-labelledby={basePathId}
-              />
-            }
-          />
+          >
+            <EuiFieldText
+              defaultValue={basePath || ''}
+              fullWidth
+              onChange={(e) => {
+                updateRepositorySettings({
+                  basePath: e.target.value,
+                });
+              }}
+              data-test-subj="basePathInput"
+              disabled={isManagedRepository}
+              aria-labelledby={basePathId}
+            />
+          </DisableToolTip>
         </EuiFormRow>
       </EuiDescribedFormGroup>
 

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/repository_form/type_settings/gcs_settings.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/repository_form/type_settings/gcs_settings.tsx
@@ -98,21 +98,20 @@ export const GCSSettings: React.FunctionComponent<Props> = ({
           <DisableToolTip
             isManaged={isManagedRepository}
             tooltipMessage={MANAGED_REPOSITORY_TOOLTIP_MESSAGE}
-            component={
-              <EuiFieldText
-                defaultValue={client || ''}
-                fullWidth
-                onChange={(e) => {
-                  updateRepositorySettings({
-                    client: e.target.value,
-                  });
-                }}
-                data-test-subj="clientInput"
-                disabled={isManagedRepository}
-                aria-labelledby={clientId}
-              />
-            }
-          />
+          >
+            <EuiFieldText
+              defaultValue={client || ''}
+              fullWidth
+              onChange={(e) => {
+                updateRepositorySettings({
+                  client: e.target.value,
+                });
+              }}
+              data-test-subj="clientInput"
+              disabled={isManagedRepository}
+              aria-labelledby={clientId}
+            />
+          </DisableToolTip>
         </EuiFormRow>
       </EuiDescribedFormGroup>
 
@@ -152,21 +151,20 @@ export const GCSSettings: React.FunctionComponent<Props> = ({
           <DisableToolTip
             isManaged={isManagedRepository}
             tooltipMessage={MANAGED_REPOSITORY_TOOLTIP_MESSAGE}
-            component={
-              <EuiFieldText
-                defaultValue={bucket || ''}
-                fullWidth
-                onChange={(e) => {
-                  updateRepositorySettings({
-                    bucket: e.target.value,
-                  });
-                }}
-                data-test-subj="bucketInput"
-                disabled={isManagedRepository}
-                aria-labelledby={bucketId}
-              />
-            }
-          />
+          >
+            <EuiFieldText
+              defaultValue={bucket || ''}
+              fullWidth
+              onChange={(e) => {
+                updateRepositorySettings({
+                  bucket: e.target.value,
+                });
+              }}
+              data-test-subj="bucketInput"
+              disabled={isManagedRepository}
+              aria-labelledby={bucketId}
+            />
+          </DisableToolTip>
         </EuiFormRow>
       </EuiDescribedFormGroup>
 
@@ -206,21 +204,20 @@ export const GCSSettings: React.FunctionComponent<Props> = ({
           <DisableToolTip
             isManaged={isManagedRepository}
             tooltipMessage={MANAGED_REPOSITORY_TOOLTIP_MESSAGE}
-            component={
-              <EuiFieldText
-                defaultValue={basePath || ''}
-                fullWidth
-                onChange={(e) => {
-                  updateRepositorySettings({
-                    basePath: e.target.value,
-                  });
-                }}
-                data-test-subj="basePathInput"
-                disabled={isManagedRepository}
-                aria-labelledby={basePathId}
-              />
-            }
-          />
+          >
+            <EuiFieldText
+              defaultValue={basePath || ''}
+              fullWidth
+              onChange={(e) => {
+                updateRepositorySettings({
+                  basePath: e.target.value,
+                });
+              }}
+              data-test-subj="basePathInput"
+              disabled={isManagedRepository}
+              aria-labelledby={basePathId}
+            />
+          </DisableToolTip>
         </EuiFormRow>
       </EuiDescribedFormGroup>
 

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/repository_form/type_settings/s3_settings.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/repository_form/type_settings/s3_settings.tsx
@@ -126,21 +126,20 @@ export const S3Settings: React.FunctionComponent<Props> = ({
           <DisableToolTip
             isManaged={isManagedRepository}
             tooltipMessage={MANAGED_REPOSITORY_TOOLTIP_MESSAGE}
-            component={
-              <EuiFieldText
-                defaultValue={client || ''}
-                fullWidth
-                onChange={(e) => {
-                  updateRepositorySettings({
-                    client: e.target.value,
-                  });
-                }}
-                data-test-subj="clientInput"
-                disabled={isManagedRepository}
-                aria-labelledby={clientId}
-              />
-            }
-          />
+          >
+            <EuiFieldText
+              defaultValue={client || ''}
+              fullWidth
+              onChange={(e) => {
+                updateRepositorySettings({
+                  client: e.target.value,
+                });
+              }}
+              data-test-subj="clientInput"
+              disabled={isManagedRepository}
+              aria-labelledby={clientId}
+            />
+          </DisableToolTip>
         </EuiFormRow>
       </EuiDescribedFormGroup>
 
@@ -180,21 +179,20 @@ export const S3Settings: React.FunctionComponent<Props> = ({
           <DisableToolTip
             isManaged={isManagedRepository}
             tooltipMessage={MANAGED_REPOSITORY_TOOLTIP_MESSAGE}
-            component={
-              <EuiFieldText
-                defaultValue={bucket || ''}
-                fullWidth
-                onChange={(e) => {
-                  updateRepositorySettings({
-                    bucket: e.target.value,
-                  });
-                }}
-                data-test-subj="bucketInput"
-                disabled={isManagedRepository}
-                aria-labelledby={bucketId}
-              />
-            }
-          />
+          >
+            <EuiFieldText
+              defaultValue={bucket || ''}
+              fullWidth
+              onChange={(e) => {
+                updateRepositorySettings({
+                  bucket: e.target.value,
+                });
+              }}
+              data-test-subj="bucketInput"
+              disabled={isManagedRepository}
+              aria-labelledby={bucketId}
+            />
+          </DisableToolTip>
         </EuiFormRow>
       </EuiDescribedFormGroup>
 
@@ -234,21 +232,20 @@ export const S3Settings: React.FunctionComponent<Props> = ({
           <DisableToolTip
             isManaged={isManagedRepository}
             tooltipMessage={MANAGED_REPOSITORY_TOOLTIP_MESSAGE}
-            component={
-              <EuiFieldText
-                defaultValue={basePath || ''}
-                fullWidth
-                onChange={(e) => {
-                  updateRepositorySettings({
-                    basePath: e.target.value,
-                  });
-                }}
-                data-test-subj="basePathInput"
-                disabled={isManagedRepository}
-                aria-labelledby={basePathId}
-              />
-            }
-          />
+          >
+            <EuiFieldText
+              defaultValue={basePath || ''}
+              fullWidth
+              onChange={(e) => {
+                updateRepositorySettings({
+                  basePath: e.target.value,
+                });
+              }}
+              data-test-subj="basePathInput"
+              disabled={isManagedRepository}
+              aria-labelledby={basePathId}
+            />
+          </DisableToolTip>
         </EuiFormRow>
       </EuiDescribedFormGroup>
 


### PR DESCRIPTION
Closes #219366, closes #219367

## Summary

This PR:

-  fixes an issue where titles where not announced for Snapshot Name Input and Repository Select
-  fixes an issue where error message was not announced for Snapshot Name Input 

| Before | After |
| -------- | ------- |
| <img width="1916" height="952" alt="Screenshot 2025-08-25 at 08 24 42" src="https://github.com/user-attachments/assets/a7a4a1d0-a56b-4594-8e6b-fafa5fe2ccab" /> | <img width="1916" height="955" alt="Screenshot 2025-08-25 at 08 25 51" src="https://github.com/user-attachments/assets/7675546d-4db3-4b57-8d7d-4f71e18c94d2" /> |
| <img width="1921" height="958" alt="Screenshot 2025-08-25 at 08 25 08" src="https://github.com/user-attachments/assets/b6d585aa-ed59-439c-8fb8-0a5abed3c0f5" /> | <img width="1914" height="954" alt="Screenshot 2025-08-25 at 08 25 38" src="https://github.com/user-attachments/assets/b484f0d9-dbe8-4278-833f-4841838e86fd" /> |

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->