### PR TITLE
Temporarily skip broken tests related to alert closure in mki

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/suppression_window_advanced_setting.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/suppression_window_advanced_setting.cy.ts
@@ -31,7 +31,7 @@ import { IS_SERVERLESS } from '../../../../env_var_names_constants';
 describe(
   'Alert suppression - advanced settings',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
   },
   () => {
     const setupRuleAndAlerts = () => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -132,6 +132,10 @@ export const closeFirstAlertModalOff = () => {
 };
 
 export const confirmAlertCloseModal = () => {
+  // TODO remove this if statement when the FF continueSuppressionWindowAdvancedSettingEnabled is GA.
+  if (Cypress.env('CLOUD_SERVERLESS')) {
+    return;
+  }
   cy.get('[data-test-subj="confirmModalConfirmButton"]').click();
   cy.get('[data-test-subj="alertCloseInfoModal"]').should('not.exist');
 };


### PR DESCRIPTION
# Summary
https://github.com/elastic/kibana/pull/231079 introduced a feature flag that breaks the tests in MKI. This PR temporarily skips the Cypress tests in MKI that are related to the modal triggered upon alert closure, including the verification of the presence of its confirmation button, until the feature flag is removed when the docs for the feature in question are ready.

The failures occurring in FTR tests are addressed in a separate PR https://github.com/elastic/kibana/pull/232751.