### PR TITLE
fix issue with reporting user prompt choice selection

### DIFF
--- a/x-pack/platform/plugins/private/product_intercept/public/intercept_registration_config.tsx
+++ b/x-pack/platform/plugins/private/product_intercept/public/intercept_registration_config.tsx
@@ -138,14 +138,14 @@ export const productInterceptRegistrationConfig = ({
       });
     },
     onFinish: ({ response: feedbackResponse, runId }) => {
-      eventReporter.reportInterceptInteraction({
+      eventReporter.reportInterceptInteractionTermination({
         interactionType: 'completion',
         interceptRunId: runId,
       });
     },
     onDismiss: ({ runId }) => {
       // still update user profile run count, a dismissal is still an interaction
-      eventReporter.reportInterceptInteraction({
+      eventReporter.reportInterceptInteractionTermination({
         interactionType: 'dismissal',
         interceptRunId: runId,
       });

--- a/x-pack/platform/plugins/private/product_intercept/public/telemetry/event_reporter.test.ts
+++ b/x-pack/platform/plugins/private/product_intercept/public/telemetry/event_reporter.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PromptTelemetry } from './event_reporter';
+import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
+
+describe('event reporter', () => {
+  it('exports a setup and start function', () => {
+    // Test implementation
+    const eventReporter = new PromptTelemetry();
+
+    expect(eventReporter).toHaveProperty('setup', expect.any(Function));
+    expect(eventReporter).toHaveProperty('start', expect.any(Function));
+  });
+
+  it('should register events types for intercept', () => {
+    const eventReporter = new PromptTelemetry();
+
+    const analyticsSetup = analyticsServiceMock.createAnalyticsServiceSetup();
+
+    eventReporter.setup({
+      analytics: analyticsSetup,
+    });
+
+    expect(analyticsSetup.registerEventType).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return reporting functions on start', () => {
+    const eventReporter = new PromptTelemetry();
+
+    const analyticsSetup = analyticsServiceMock.createAnalyticsServiceSetup();
+    const analyticsStart = analyticsServiceMock.createAnalyticsServiceStart();
+
+    eventReporter.setup({
+      analytics: analyticsSetup,
+    });
+
+    const reportingFunctions = eventReporter.start({ analytics: analyticsStart });
+
+    expect(reportingFunctions).toHaveProperty(
+      'reportInterceptInteractionTermination',
+      expect.any(Function)
+    );
+    expect(reportingFunctions).toHaveProperty(
+      'reportInterceptInteractionProgress',
+      expect.any(Function)
+    );
+    expect(reportingFunctions).toHaveProperty('reportTriggerFetchError', expect.any(Function));
+  });
+
+  describe('reportInterceptInteractionTermination', () => {
+    it('should report the interaction', () => {
+      const eventReporter = new PromptTelemetry();
+
+      const analyticsSetup = analyticsServiceMock.createAnalyticsServiceSetup();
+      const analyticsStart = analyticsServiceMock.createAnalyticsServiceStart();
+
+      eventReporter.setup({
+        analytics: analyticsSetup,
+      });
+
+      const reportingFunctions = eventReporter.start({ analytics: analyticsStart });
+
+      reportingFunctions.reportInterceptInteractionTermination({
+        interceptRunId: 1,
+        interactionType: 'dismissal',
+      });
+
+      expect(analyticsStart.reportEvent).toHaveBeenCalledWith(
+        'product_intercept_termination_interaction',
+        {
+          interaction_run_id: String(1),
+          interaction_type: 'dismissal',
+        }
+      );
+    });
+  });
+
+  describe('reportInterceptInteractionProgress', () => {
+    it('should report the interaction', () => {
+      const eventReporter = new PromptTelemetry();
+
+      const analyticsSetup = analyticsServiceMock.createAnalyticsServiceSetup();
+      const analyticsStart = analyticsServiceMock.createAnalyticsServiceStart();
+
+      eventReporter.setup({
+        analytics: analyticsSetup,
+      });
+
+      const reportingFunctions = eventReporter.start({ analytics: analyticsStart });
+
+      reportingFunctions.reportInterceptInteractionProgress({
+        interceptRunId: 1,
+        metricId: 'satisfaction',
+        value: 5,
+      });
+
+      expect(analyticsStart.reportEvent).toHaveBeenCalledWith(
+        'product_intercept_interaction_progress',
+        {
+          interaction_run_id: String(1),
+          interaction_metric: 'satisfaction',
+          interaction_metric_value: 5,
+        }
+      );
+    });
+  });
+
+  describe('reportTriggerFetchError', () => {
+    it('should report the error', () => {
+      const eventReporter = new PromptTelemetry();
+
+      const analyticsSetup = analyticsServiceMock.createAnalyticsServiceSetup();
+      const analyticsStart = analyticsServiceMock.createAnalyticsServiceStart();
+
+      eventReporter.setup({
+        analytics: analyticsSetup,
+      });
+
+      const reportingFunctions = eventReporter.start({ analytics: analyticsStart });
+
+      reportingFunctions.reportTriggerFetchError({
+        errorMessage: 'Fetch failed',
+      });
+
+      expect(analyticsStart.reportEvent).toHaveBeenCalledWith(
+        'product_intercept_trigger_fetch_error',
+        {
+          trigger_fetch_error_message: 'Fetch failed',
+        }
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/private/product_intercept/public/telemetry/event_reporter.ts
+++ b/x-pack/platform/plugins/private/product_intercept/public/telemetry/event_reporter.ts
@@ -23,9 +23,9 @@ export class PromptTelemetry {
     this.reportEvent = analytics.reportEvent;
 
     return {
-      reportInterceptInteraction: this.reportInterceptTermination,
-      reportInterceptInteractionProgress: this.reportInterceptInteractionProgress,
-      reportTriggerFetchError: this.reportTriggerFetchError,
+      reportInterceptInteractionTermination: this.reportInterceptTermination.bind(this),
+      reportInterceptInteractionProgress: this.reportInterceptInteractionProgress.bind(this),
+      reportTriggerFetchError: this.reportTriggerFetchError.bind(this),
     };
   }
 

--- a/x-pack/platform/plugins/private/product_intercept/tsconfig.json
+++ b/x-pack/platform/plugins/private/product_intercept/tsconfig.json
@@ -19,7 +19,8 @@
     "@kbn/i18n",
     "@kbn/intercepts-plugin",
     "@kbn/i18n-react",
-    "@kbn/cloud-plugin"
+    "@kbn/cloud-plugin",
+    "@kbn/core-analytics-browser-mocks"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue that caused selections for input provided by the user not to be transmitted.

### How to test

- Add the following config to your `kibana.dev.yml` file

	```
	 xpack.product_intercept.interval: '10s'
	```
	So you have intercepts show up frequently.
- participate in the survey presented, on participating when a score is selected, verify that a request is made that includes the payload for the selected option, by examining the `kibana-browser` request path, the property to look for is `properties`. You'd be presented with a payload similar to the screenshot below;
	
	<img width="1546" height="717" alt="Screenshot 2025-08-26 at 11 57 59" src="https://github.com/user-attachments/assets/0825e5e0-a1e5-411b-bcfd-268ea3a489bd" />


<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


-->


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->