### PR TITLE
[Security Solution] Fix flaky EQL field Jest integration test

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/__integration_tests__/rules_upgrade/test_utils/rule_upgrade_helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/__integration_tests__/rules_upgrade/test_utils/rule_upgrade_helpers.ts
@@ -50,9 +50,11 @@ async function clickFieldSaveButton(wrapper: HTMLElement, buttonName: string): P
 
   expect(saveButton).toBeVisible();
 
-  // Wait for async validation to finish
+  // Wait for async validation to finish.
+  // It has been noticed some fields (like "EQL") can take more than 500ms to validate since
+  // it sums up with the 300ms debounce time.
   await waitFor(() => expect(saveButton).toBeEnabled(), {
-    timeout: 500,
+    timeout: 1500,
   });
 
   await act(async () => {


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/230461**

## Summary

This PR fixes the flaky Prebuilt Rule Upgrade Flyout EQL field Jest integration test.

## Details

The fix simply increases the timeout value to wait longer for field validation to complete. Taking into account that some fields have debounce time (e.g. EQL field has 300ms) and field validation may straggle in CI due to lower CPU resources it's reasonable to have higher a higher value.

The flakiness is easy reproducible locally by reducing the timeout value. Where values 300ms and below make the test always failing.


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->