### PR TITLE
FTR - remove feature flagged security setting from regular test run

### DIFF
--- a/x-pack/solutions/security/test/serverless/functional/configs/config.ts
+++ b/x-pack/solutions/security/test/serverless/functional/configs/config.ts
@@ -30,8 +30,5 @@ export default createTestConfig({
     '--xpack.dataUsage.autoops.api.url=http://localhost:9000',
     `--xpack.dataUsage.autoops.api.tls.certificate=${KBN_CERT_PATH}`,
     `--xpack.dataUsage.autoops.api.tls.key=${KBN_KEY_PATH}`,
-    `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-      'continueSuppressionWindowAdvancedSettingEnabled',
-    ])}`,
   ],
 });

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/advanced_settings.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/advanced_settings.ts
@@ -7,6 +7,7 @@
 
 import expect from '@kbn/expect';
 import { SECURITY_PROJECT_SETTINGS } from '@kbn/serverless-security-settings';
+import { SECURITY_SOLUTION_SUPPRESSION_BEHAVIOR_ON_ALERT_CLOSURE_SETTING } from '@kbn/management-settings-ids';
 import { isEditorFieldSetting } from '@kbn/test-suites-xpack-platform/serverless/functional/test_suites/management/advanced_settings';
 import type { FtrProviderContext } from '../../ftr_provider_context';
 
@@ -15,6 +16,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const pageObjects = getPageObjects(['svlCommonPage', 'common']);
   const browser = getService('browser');
   const retry = getService('retry');
+
+  const featureFlaggedSettings: string[] = [
+    SECURITY_SOLUTION_SUPPRESSION_BEHAVIOR_ON_ALERT_CLOSURE_SETTING,
+  ];
 
   describe('Security advanced settings', function () {
     before(async () => {
@@ -35,6 +40,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       for (const settingId of SECURITY_PROJECT_SETTINGS) {
         // Code editors don't have their test subjects rendered
         if (isEditorFieldSetting(settingId)) {
+          continue;
+        }
+        // settings behind feature flags are not available in a general setup
+        if (featureFlaggedSettings.includes(settingId)) {
           continue;
         }
         it('renders ' + settingId + ' edit field', async () => {

--- a/x-pack/solutions/security/test/tsconfig.json
+++ b/x-pack/solutions/security/test/tsconfig.json
@@ -69,6 +69,7 @@
     "@kbn/rison",
     "@kbn/core-chrome-browser",
     "@kbn/openapi-common",
-    "@kbn/spaces-plugin"
+    "@kbn/spaces-plugin",
+    "@kbn/management-settings-ids"
   ]
 }


### PR DESCRIPTION
## Summary

This PR removes a feature flag from the serverless security FTR config and adjusts the advanced settings test suite such that it skips the feature flagged setting.

### Details

- The new setting has been introduced with #231079 and is behind a feature flag. There, the feature flag has been added to the serverless security FTR config which let the local runs pass, but makes tests fail on MKI where the feature flag is not enabled.
- Feature flags and corresponding tests must not be included in regular FTR config files but rather be implemented in feature flag configs (e.g. [this one](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/test/serverless/functional/configs/config.feature_flags.ts)).