### PR TITLE
[8.18] [ML] Anomaly Explorer: Improves error handling in `Anomalies Table` (#231779)

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/components/anomalies_table/anomalies_table.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/anomalies_table/anomalies_table.tsx
@@ -14,6 +14,7 @@ import type { CriteriaWithPagination, EuiBasicTableColumn } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiInMemoryTable, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import useUpdateEffect from 'react-use/lib/useUpdateEffect';
+import { extractErrorMessage } from '@kbn/ml-error-utils';
 import type {
   AnomaliesTableData,
   ExplorerJob,
@@ -125,6 +126,7 @@ export const AnomaliesTable: FC<AnomaliesTableProps> = React.memo(
               ? get(tableData, ['examplesByJobId', item.jobId, item.entityValue])
               : undefined;
           let definition;
+          let categoryDefinitionError: string | undefined;
 
           if (examples !== undefined) {
             try {
@@ -141,7 +143,7 @@ export const AnomaliesTable: FC<AnomaliesTableProps> = React.memo(
                 definition.terms = `${definition.regex.substring(0, MAX_CHARS)}...`;
               }
             } catch (error) {
-              // Do nothing
+              categoryDefinitionError = extractErrorMessage(error);
             }
           }
 
@@ -153,6 +155,7 @@ export const AnomaliesTable: FC<AnomaliesTableProps> = React.memo(
               anomaly={item}
               examples={examples}
               definition={definition}
+              categoryDefinitionError={categoryDefinitionError}
               isAggregatedData={isShowingAggregatedData}
               filter={filter}
               influencerFilter={influencerFilter}

--- a/x-pack/platform/plugins/shared/ml/public/application/components/anomalies_table/anomaly_details.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/anomalies_table/anomaly_details.tsx
@@ -17,6 +17,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
+  EuiCallOut,
   EuiIcon,
   EuiIconTip,
   EuiLink,
@@ -46,6 +47,7 @@ interface Props {
   job: ExplorerJob;
   definition?: CategoryDefinition;
   examples?: string[];
+  categoryDefinitionError?: string;
   filter?: EntityCellFilter;
   influencerFilter?: EntityCellFilter;
 }
@@ -54,6 +56,7 @@ export const AnomalyDetails: FC<Props> = ({
   anomaly,
   examples,
   definition,
+  categoryDefinitionError,
   isAggregatedData,
   filter,
   influencersLimit,
@@ -84,7 +87,13 @@ export const AnomalyDetails: FC<Props> = ({
         name: i18n.translate('xpack.ml.anomaliesTable.anomalyDetails.categoryExamplesTitle', {
           defaultMessage: 'Category examples',
         }),
-        content: <CategoryExamples examples={examples} definition={definition} />,
+        content: (
+          <CategoryExamples
+            examples={examples}
+            definition={definition}
+            error={categoryDefinitionError}
+          />
+        ),
       },
     ];
 
@@ -302,10 +311,11 @@ const Influencers: FC<{
   return null;
 };
 
-const CategoryExamples: FC<{ definition?: CategoryDefinition; examples: string[] }> = ({
-  definition,
-  examples,
-}) => {
+const CategoryExamples: FC<{
+  definition?: CategoryDefinition;
+  examples: string[];
+  error?: string;
+}> = ({ definition, examples, error }) => {
   return (
     <EuiFlexGroup
       direction="column"
@@ -313,6 +323,23 @@ const CategoryExamples: FC<{ definition?: CategoryDefinition; examples: string[]
       gutterSize="xs"
       className="mlAnomalyCategoryExamples"
     >
+      {error && (
+        <EuiFlexItem>
+          <EuiCallOut
+            size="s"
+            color="danger"
+            iconType="warning"
+            title={i18n.translate(
+              'xpack.ml.anomaliesTable.anomalyDetails.categoryDefinitionErrorTitle',
+              { defaultMessage: 'An error occurred loading category definition:' }
+            )}
+            data-test-subj="mlAnomaliesTableCategoryDefinitionError"
+          >
+            <EuiText size="xs">{error}</EuiText>
+          </EuiCallOut>
+          <EuiSpacer size="s" />
+        </EuiFlexItem>
+      )}
       {definition !== undefined && definition.terms && (
         <>
           <EuiFlexItem key={`example-terms`}>

--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/explorer.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/explorer.tsx
@@ -281,6 +281,7 @@ export const Explorer: FC<ExplorerUIProps> = ({
   } = useAnomalyExplorerContext();
 
   const tableData = useObservable(anomalyTableService.tableData$, anomalyTableService.tableData);
+  const tableError = useObservable(anomalyTableService.tableError$, anomalyTableService.tableError);
 
   const htmlIdGen = useMemo(() => htmlIdGenerator(), []);
 
@@ -587,6 +588,8 @@ export const Explorer: FC<ExplorerUIProps> = ({
           </EuiFlexItem>
         </EuiFlexGroup>
 
+        <EuiSpacer size="s" />
+
         <EuiFlexGroup direction="row" gutterSize="l" responsive={true} alignItems="center">
           <EuiFlexItem grow={false}>
             <SelectSeverity />
@@ -621,7 +624,18 @@ export const Explorer: FC<ExplorerUIProps> = ({
 
         <EuiSpacer size="m" />
 
-        {tableData ? (
+        {tableError ? (
+          <EuiCallOut
+            color="danger"
+            iconType="warning"
+            title={i18n.translate('xpack.ml.explorer.anomaliesTableErrorTitle', {
+              defaultMessage: 'An error occurred loading anomalies table data',
+            })}
+            data-test-subj="mlAnomaliesTableErrorCallout"
+          >
+            {tableError}
+          </EuiCallOut>
+        ) : tableData ? (
           <AnomaliesTable
             bounds={bounds}
             tableData={tableData}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ML] Anomaly Explorer: Improves error handling in `Anomalies Table` (#231779)](https://github.com/elastic/kibana/pull/231779)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Robert Jaszczurek","email":"92210485+rbrtj@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-25T10:50:35Z","message":"[ML] Anomaly Explorer: Improves error handling in `Anomalies Table` (#231779)\n\nResolves https://github.com/elastic/kibana/issues/215666\n\nThis PR improves error handling for cases when:\n* Fetching table data fails\n* Fetching category definition fails\n\nIt also adds some space between `Anomalies` title and the controls in\nthe Anomalies Table\n\n<img width=\"1732\" height=\"1282\" alt=\"SCR-20250814-ldys\"\nsrc=\"https://github.com/user-attachments/assets/856d02c8-c3cd-461b-ae61-affa7f5a2cf2\"\n/>\n\n<img width=\"1368\" height=\"397\" alt=\"SCR-20250814-lexo\"\nsrc=\"https://github.com/user-attachments/assets/d30ce186-0725-46a5-976a-71cb3818eff3\"\n/>","sha":"7c5a7f2e4e632834d9edfcfbf1b6703a425bb722","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement",":ml","Team:ML","backport:version","v9.2.0","v9.1.3","v8.19.3","v8.18.6"],"title":"[ML] Anomaly Explorer: Improves error handling in `Anomalies Table`","number":231779,"url":"https://github.com/elastic/kibana/pull/231779","mergeCommit":{"message":"[ML] Anomaly Explorer: Improves error handling in `Anomalies Table` (#231779)\n\nResolves https://github.com/elastic/kibana/issues/215666\n\nThis PR improves error handling for cases when:\n* Fetching table data fails\n* Fetching category definition fails\n\nIt also adds some space between `Anomalies` title and the controls in\nthe Anomalies Table\n\n<img width=\"1732\" height=\"1282\" alt=\"SCR-20250814-ldys\"\nsrc=\"https://github.com/user-attachments/assets/856d02c8-c3cd-461b-ae61-affa7f5a2cf2\"\n/>\n\n<img width=\"1368\" height=\"397\" alt=\"SCR-20250814-lexo\"\nsrc=\"https://github.com/user-attachments/assets/d30ce186-0725-46a5-976a-71cb3818eff3\"\n/>","sha":"7c5a7f2e4e632834d9edfcfbf1b6703a425bb722"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231779","number":231779,"mergeCommit":{"message":"[ML] Anomaly Explorer: Improves error handling in `Anomalies Table` (#231779)\n\nResolves https://github.com/elastic/kibana/issues/215666\n\nThis PR improves error handling for cases when:\n* Fetching table data fails\n* Fetching category definition fails\n\nIt also adds some space between `Anomalies` title and the controls in\nthe Anomalies Table\n\n<img width=\"1732\" height=\"1282\" alt=\"SCR-20250814-ldys\"\nsrc=\"https://github.com/user-attachments/assets/856d02c8-c3cd-461b-ae61-affa7f5a2cf2\"\n/>\n\n<img width=\"1368\" height=\"397\" alt=\"SCR-20250814-lexo\"\nsrc=\"https://github.com/user-attachments/assets/d30ce186-0725-46a5-976a-71cb3818eff3\"\n/>","sha":"7c5a7f2e4e632834d9edfcfbf1b6703a425bb722"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232761","number":232761,"state":"OPEN"},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->