### PR TITLE
[Fleet] remove output warning in serverless

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
@@ -80,6 +80,7 @@ export const EditOutputFlyout: React.FunctionComponent<EditOutputFlyoutProps> = 
   const inputs = form.inputs;
   const { docLinks, cloud } = useStartServices();
   const fleetStatus = useFleetStatus();
+  const isServerless = !!cloud?.isServerlessEnabled;
 
   const [secretsToggleState, setSecretsToggleState] = useState<'disabled' | true | false>(
     'disabled'
@@ -190,38 +191,48 @@ export const EditOutputFlyout: React.FunctionComponent<EditOutputFlyoutProps> = 
             defaultMessage:
               'This output type does not support connectivity to a remote Elasticsearch cluster, please use the Remote Elasticsearch type for that.',
           });
+        case outputType.RemoteElasticsearch:
+          return i18n.translate('xpack.fleet.settings.editOutputFlyout.remoteESOutputTypeCallout', {
+            defaultMessage:
+              'Remote Elasticsearch output does not support connectivity to a serverless project.',
+          });
       }
     };
-    return isRemoteESOutput ? (
+    return (
       <>
-        <EuiSpacer size="m" />
-        <EuiText size="s">
-          <FormattedMessage
-            id="xpack.fleet.settings.editOutputFlyout.remoteESTypeText"
-            defaultMessage="Enter your output hosts, service token for your remote cluster, and any advanced YAML configuration. Learn more about how to use these parameters in {doc}."
-            values={{
-              doc: (
-                <EuiLink href={docLinks.links.fleet.remoteESOoutput} target="_blank">
-                  {i18n.translate('xpack.fleet.settings.editOutputFlyout.docLabel', {
-                    defaultMessage: 'our documentation',
-                  })}
-                </EuiLink>
-              ),
-            }}
-          />
-        </EuiText>
-      </>
-    ) : (
-      <>
-        <EuiSpacer size="xs" />
-        <EuiCallOut
-          data-test-subj={`settingsOutputsFlyout.${inputs.typeInput.value}OutputTypeCallout`}
-          title={generateWarningMessage()}
-          iconType="alert"
-          color="warning"
-          size="s"
-          heading="p"
-        />
+        {!isServerless ? (
+          <>
+            <EuiSpacer size="xs" />
+            <EuiCallOut
+              data-test-subj={`settingsOutputsFlyout.${inputs.typeInput.value}OutputTypeCallout`}
+              title={generateWarningMessage()}
+              iconType="alert"
+              color="warning"
+              size="s"
+              heading="p"
+            />
+          </>
+        ) : null}
+        {isRemoteESOutput ? (
+          <>
+            <EuiSpacer size="m" />
+            <EuiText size="s">
+              <FormattedMessage
+                id="xpack.fleet.settings.editOutputFlyout.remoteESTypeText"
+                defaultMessage="Enter your output hosts, service token for your remote cluster, and any advanced YAML configuration. Learn more about how to use these parameters in {doc}."
+                values={{
+                  doc: (
+                    <EuiLink href={docLinks.links.fleet.remoteESOoutput} target="_blank">
+                      {i18n.translate('xpack.fleet.settings.editOutputFlyout.docLabel', {
+                        defaultMessage: 'our documentation',
+                      })}
+                    </EuiLink>
+                  ),
+                }}
+              />
+            </EuiText>
+          </>
+        ) : null}
       </>
     );
   };


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/230819

Removed remote ES output warning in serverless.
<img width="2548" height="1289" alt="image" src="https://github.com/user-attachments/assets/a7244523-49ee-4473-8f79-d08afebf8e74" />

Stateful warning:
<img width="832" height="468" alt="image" src="https://github.com/user-attachments/assets/521dfcbf-3241-46a9-832b-06301ff57b19" />

Added another warning in stateful that remote ES is not supported to a serverless project.
<img width="829" height="499" alt="image" src="https://github.com/user-attachments/assets/f631be0e-73fa-485a-a320-fb7049fe32a6" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.1"]} ONMERGE-->