### PR TITLE
fix: [ML] Field Statistics: Contradicting element announcement and presentation on the page

### DIFF
--- a/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/stats_table/data_visualizer_stats_table.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/stats_table/data_visualizer_stats_table.tsx
@@ -303,6 +303,7 @@ const UnmemoizedDataVisualizerTable = <T extends DataVisualizerTableItem>({
                         defaultMessage: 'Hide distributions',
                       })
                 }
+                disableScreenReaderOutput={true}
               >
                 <EuiButtonIcon
                   style={{ marginLeft: 4 }}
@@ -310,7 +311,7 @@ const UnmemoizedDataVisualizerTable = <T extends DataVisualizerTableItem>({
                   iconType={!showDistributions ? 'eye' : 'eyeClosed'}
                   onClick={() => toggleShowDistribution()}
                   aria-label={
-                    showDistributions
+                    !showDistributions
                       ? i18n.translate('xpack.dataVisualizer.dataGrid.showDistributionsAriaLabel', {
                           defaultMessage: 'Show distributions',
                         })


### PR DESCRIPTION
Closes: #214560

**Description**
All interactive elements when user reaches them has to be announced correctly, for user to understand where he/she is at the moment, how to interact with the element.

**Changes made:**
1. Fixed `aria-label` for `EuiButton`
2. added `disableScreenReaderOutput` to avoid extra announcing



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->