### PR TITLE
[Observability] Fix Metric threshold rule flaky test

### DIFF
--- a/x-pack/solutions/observability/test/functional/services/observability/alerts/rules_page.ts
+++ b/x-pack/solutions/observability/test/functional/services/observability/alerts/rules_page.ts
@@ -13,6 +13,7 @@ export function ObservabilityAlertsRulesProvider({ getService }: FtrProviderCont
   const testSubjects = getService('testSubjects');
   const find = getService('find');
   const log = getService('log');
+  const retry = getService('retry');
 
   const getManageRulesPageHref = async () => {
     const manageRulesPageButton = await testSubjects.find('manageRulesPageButton');
@@ -21,9 +22,13 @@ export function ObservabilityAlertsRulesProvider({ getService }: FtrProviderCont
 
   const clickCreateRuleButton = async () => {
     await testSubjects.existOrFail('createRuleButton');
+    await retry.waitFor(
+      'Create Rule button is enabled',
+      async () => await testSubjects.isEnabled('createRuleButton')
+    );
     const createRuleButton = await testSubjects.find('createRuleButton');
     log.debug(`clicking on ${await createRuleButton.getAttribute('innerText')}`);
-    return await createRuleButton.click();
+    return createRuleButton.click();
   };
 
   const clickRuleStatusDropDownMenu = async () => testSubjects.click('statusDropdown');

--- a/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/metric_threshold.ts
+++ b/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/metric_threshold.ts
@@ -11,8 +11,7 @@ export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const testSubjects = getService('testSubjects');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/227919
-  describe.skip('Metric threshold rule', function () {
+  describe('Metric threshold rule', function () {
     this.tags('includeFirefox');
 
     const observability = getService('observability');


### PR DESCRIPTION
It closes https://github.com/elastic/kibana/issues/227919.

Always wait for the create rule button to be enabled before clicking it.


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->