### PR TITLE
[8.19] [Lens][ES|QL] Listens to allowLeadingWildcards uiSetting (#232609)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.test.ts
@@ -6,6 +6,7 @@
  */
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import { getESQLResults, formatESQLColumns } from '@kbn/esql-utils';
+import type { IUiSettingsClient } from '@kbn/core/public';
 import type { LensPluginStartDependencies } from '../../../plugin';
 import type { TypedLensSerializedState } from '../../../react_embeddable/types';
 import { createMockStartDependencies } from '../../../editor_frame_service/mocks';
@@ -74,6 +75,10 @@ describe('Lens inline editing helpers', () => {
     const dataViews = dataViewPluginMocks.createStartContract();
     dataViews.create.mockResolvedValue(mockDataViewWithTimefield);
     mockStartDependencies.data.dataViews = dataViews;
+    const uiSettingsMock = {
+      get: jest.fn(),
+    } as unknown as IUiSettingsClient;
+
     const dataviewSpecArr = [
       {
         id: 'd2588ae7-9ea0-4439-9f5b-f808754a3b97',
@@ -96,6 +101,7 @@ describe('Lens inline editing helpers', () => {
       const suggestionsAttributes = await getSuggestions(
         query,
         startDependencies.data,
+        uiSettingsMock,
         mockDatasourceMap(),
         mockVisualizationMap(),
         dataviewSpecArr,
@@ -112,6 +118,7 @@ describe('Lens inline editing helpers', () => {
       const suggestionsAttributes = await getSuggestions(
         query,
         startDependencies.data,
+        uiSettingsMock,
         mockDatasourceMap(),
         mockVisualizationMap(),
         dataviewSpecArr,
@@ -128,6 +135,7 @@ describe('Lens inline editing helpers', () => {
       const suggestionsAttributes = await getSuggestions(
         query,
         startDependencies.data,
+        uiSettingsMock,
         mockDatasourceMap(),
         mockVisualizationMap(),
         dataviewSpecArr,
@@ -235,6 +243,10 @@ describe('Lens inline editing helpers', () => {
       dataViews,
     };
 
+    const uiSettingsMock = {
+      get: jest.fn(),
+    } as unknown as IUiSettingsClient;
+
     it('returns the columns if the array is not empty in the response', async () => {
       mockFetchData.mockImplementation(() => {
         return {
@@ -244,7 +256,12 @@ describe('Lens inline editing helpers', () => {
           },
         };
       });
-      const gridAttributes = await getGridAttrs(query, dataviewSpecArr, startDependencies.data);
+      const gridAttributes = await getGridAttrs(
+        query,
+        dataviewSpecArr,
+        startDependencies.data,
+        uiSettingsMock
+      );
       expect(gridAttributes.columns).toStrictEqual(queryResponseColumns);
     });
 
@@ -268,7 +285,12 @@ describe('Lens inline editing helpers', () => {
         };
       });
       mockformatESQLColumns.mockImplementation(() => emptyColumns);
-      const gridAttributes = await getGridAttrs(query, dataviewSpecArr, startDependencies.data);
+      const gridAttributes = await getGridAttrs(
+        query,
+        dataviewSpecArr,
+        startDependencies.data,
+        uiSettingsMock
+      );
       expect(gridAttributes.columns).toStrictEqual(emptyColumns);
     });
   });

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
@@ -13,6 +13,8 @@ import {
 } from '@kbn/esql-utils';
 import { isEqual } from 'lodash';
 import { type AggregateQuery, buildEsQuery } from '@kbn/es-query';
+import type { IUiSettingsClient } from '@kbn/core/public';
+import { getEsQueryConfig } from '@kbn/data-plugin/public';
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { ESQLRow } from '@kbn/es-types';
 import {
@@ -35,7 +37,12 @@ export interface ESQLDataGridAttrs {
   columns: DatatableColumn[];
 }
 
-const getDSLFilter = (queryService: DataPublicPluginStart['query'], timeFieldName?: string) => {
+const getDSLFilter = (
+  queryService: DataPublicPluginStart['query'],
+  uiSettings: IUiSettingsClient,
+  timeFieldName?: string
+) => {
+  const esQueryConfigs = getEsQueryConfig(uiSettings);
   const kqlQuery = queryService.queryString.getQuery();
   const filters = queryService.filterManager.getFilters();
   const timeFilter =
@@ -44,16 +51,19 @@ const getDSLFilter = (queryService: DataPublicPluginStart['query'], timeFieldNam
       fieldName: timeFieldName,
     });
 
-  return buildEsQuery(undefined, kqlQuery || [], [
-    ...(filters ?? []),
-    ...(timeFilter ? [timeFilter] : []),
-  ]);
+  return buildEsQuery(
+    undefined,
+    kqlQuery || [],
+    [...(filters ?? []), ...(timeFilter ? [timeFilter] : [])],
+    esQueryConfigs
+  );
 };
 
 export const getGridAttrs = async (
   query: AggregateQuery,
   adHocDataViews: DataViewSpec[],
   data: DataPublicPluginStart,
+  uiSettings: IUiSettingsClient,
   abortController?: AbortController,
   esqlVariables: ESQLControlVariable[] = []
 ): Promise<ESQLDataGridAttrs> => {
@@ -66,7 +76,7 @@ export const getGridAttrs = async (
     ? await data.dataViews.create(dataViewSpec)
     : await getESQLAdHocDataview(query.esql, data.dataViews);
 
-  const filter = getDSLFilter(data.query, dataView.timeFieldName);
+  const filter = getDSLFilter(data.query, uiSettings, dataView.timeFieldName);
 
   const results = await getESQLResults({
     esqlQuery: query.esql,
@@ -97,6 +107,7 @@ export const getGridAttrs = async (
 export const getSuggestions = async (
   query: AggregateQuery,
   data: DataPublicPluginStart,
+  uiSettings: IUiSettingsClient,
   datasourceMap: DatasourceMap,
   visualizationMap: VisualizationMap,
   adHocDataViews: DataViewSpec[],
@@ -112,6 +123,7 @@ export const getSuggestions = async (
       query,
       adHocDataViews,
       data,
+      uiSettings,
       abortController,
       esqlVariables
     );

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/esql_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/esql_editor.tsx
@@ -9,6 +9,7 @@ import { EuiFlexItem } from '@elastic/eui';
 import { AggregateQuery, Query, isOfAggregateQueryType } from '@kbn/es-query';
 import { DefaultInspectorAdapters } from '@kbn/expressions-plugin/common';
 import { useStateFromPublishingSubject } from '@kbn/presentation-publishing';
+import type { IUiSettingsClient } from '@kbn/core/public';
 import { isEqual } from 'lodash';
 import { MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
 import { ESQLLangEditor } from '@kbn/esql/public';
@@ -35,6 +36,7 @@ import { useInitializeChart } from './use_initialize_chart';
 export type ESQLEditorProps = Simplify<
   {
     isTextBasedLanguage: boolean;
+    uiSettings: IUiSettingsClient;
   } & Pick<
     LayerPanelProps,
     | 'attributes'
@@ -65,6 +67,7 @@ export type ESQLEditorProps = Simplify<
  */
 export function ESQLEditor({
   data,
+  uiSettings,
   attributes,
   framePublicAPI,
   isTextBasedLanguage,
@@ -148,6 +151,7 @@ export function ESQLEditor({
       const attrs = await getSuggestions(
         q,
         data,
+        uiSettings,
         datasourceMap,
         visualizationMap,
         adHocDataViews,
@@ -167,14 +171,15 @@ export function ESQLEditor({
       setIsVisualizationLoading(false);
     },
     [
+      uiSettings,
       data,
       datasourceMap,
       visualizationMap,
       adHocDataViews,
       esqlVariables,
+      currentAttributes,
       setCurrentAttributes,
       updateSuggestion,
-      currentAttributes,
     ]
   );
 

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -446,6 +446,7 @@ export function LayerPanel(props: LayerPanelProps) {
               />
             )}
             <ESQLEditor
+              uiSettings={core.uiSettings}
               isTextBasedLanguage={isTextBasedLanguage}
               framePublicAPI={framePublicAPI}
               datasourceMap={datasourceMap}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Lens][ES|QL] Listens to allowLeadingWildcards uiSetting (#232609)](https://github.com/elastic/kibana/pull/232609)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2025-08-25T13:29:39Z","message":"[Lens][ES|QL] Listens to allowLeadingWildcards uiSetting (#232609)\n\n## Summary\n\nI recently discovered the `allowLeadingWildcards` advanced setting.\nApparently when you are building the DSL filters you need to pass the\nvalue if the setting is enabled, otherwise the `buildEsQuery` will fail.\n\nTo test it create an ES|QL chart and then write a KQL query with a\nleading wildcard. If you open the inline editing in main you will see\nthat the query didnt run and there is an error in the editor.\n\n<img width=\"1572\" height=\"479\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b4aa710c-6bdd-4639-b0ef-be6718ff8dbb\"\n/>\n\n\nThe reason was that we don't pass to the buildEsQuery function the ui\nsetting value and as the default [is false in the\nfunction](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-es-query/src/es_query/build_es_query.ts#L53)\n(but true in the advanced setting!!) this fails.\n\nIn this PR everything works fine as now we are passing the value in the\nfunction.\n<img width=\"1577\" height=\"756\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/846e74f3-8cf2-4356-82ee-8ff7eff41ba9\"\n/>","sha":"2024afdfe2f76a86b74a6e95f3f7028bf2a07541","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","Feature:ES|QL","backport:version","v9.2.0","v8.19.3"],"title":"[Lens][ES|QL] Listens to allowLeadingWildcards uiSetting","number":232609,"url":"https://github.com/elastic/kibana/pull/232609","mergeCommit":{"message":"[Lens][ES|QL] Listens to allowLeadingWildcards uiSetting (#232609)\n\n## Summary\n\nI recently discovered the `allowLeadingWildcards` advanced setting.\nApparently when you are building the DSL filters you need to pass the\nvalue if the setting is enabled, otherwise the `buildEsQuery` will fail.\n\nTo test it create an ES|QL chart and then write a KQL query with a\nleading wildcard. If you open the inline editing in main you will see\nthat the query didnt run and there is an error in the editor.\n\n<img width=\"1572\" height=\"479\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b4aa710c-6bdd-4639-b0ef-be6718ff8dbb\"\n/>\n\n\nThe reason was that we don't pass to the buildEsQuery function the ui\nsetting value and as the default [is false in the\nfunction](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-es-query/src/es_query/build_es_query.ts#L53)\n(but true in the advanced setting!!) this fails.\n\nIn this PR everything works fine as now we are passing the value in the\nfunction.\n<img width=\"1577\" height=\"756\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/846e74f3-8cf2-4356-82ee-8ff7eff41ba9\"\n/>","sha":"2024afdfe2f76a86b74a6e95f3f7028bf2a07541"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232609","number":232609,"mergeCommit":{"message":"[Lens][ES|QL] Listens to allowLeadingWildcards uiSetting (#232609)\n\n## Summary\n\nI recently discovered the `allowLeadingWildcards` advanced setting.\nApparently when you are building the DSL filters you need to pass the\nvalue if the setting is enabled, otherwise the `buildEsQuery` will fail.\n\nTo test it create an ES|QL chart and then write a KQL query with a\nleading wildcard. If you open the inline editing in main you will see\nthat the query didnt run and there is an error in the editor.\n\n<img width=\"1572\" height=\"479\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b4aa710c-6bdd-4639-b0ef-be6718ff8dbb\"\n/>\n\n\nThe reason was that we don't pass to the buildEsQuery function the ui\nsetting value and as the default [is false in the\nfunction](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-es-query/src/es_query/build_es_query.ts#L53)\n(but true in the advanced setting!!) this fails.\n\nIn this PR everything works fine as now we are passing the value in the\nfunction.\n<img width=\"1577\" height=\"756\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/846e74f3-8cf2-4356-82ee-8ff7eff41ba9\"\n/>","sha":"2024afdfe2f76a86b74a6e95f3f7028bf2a07541"}},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->