### PR TITLE
[Fleet] Refactor abortController usage in Fleet task

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/tasks/agent_status_change_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/agent_status_change_task.ts
@@ -27,7 +27,7 @@ import { SO_SEARCH_LIMIT } from '../constants';
 import { getAgentPolicySavedObjectType } from '../services/agent_policy';
 
 export const TYPE = 'fleet:agent-status-change-task';
-export const VERSION = '1.0.0';
+export const VERSION = '1.0.1';
 const TITLE = 'Fleet Agent Status Change Task';
 const SCOPE = ['fleet'];
 const DEFAULT_INTERVAL = '1m';

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/agent_status_change_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/agent_status_change_task.ts
@@ -58,7 +58,6 @@ interface AgentStatusChangeTaskStartContract {
 export class AgentStatusChangeTask {
   private logger: Logger;
   private wasStarted: boolean = false;
-  private abortController?: AbortController;
   private taskInterval: string;
 
   constructor(setupContract: AgentStatusChangeTaskSetupContract) {
@@ -70,15 +69,18 @@ export class AgentStatusChangeTask {
       [TYPE]: {
         title: TITLE,
         timeout: TIMEOUT,
-        createTaskRunner: ({ taskInstance }: { taskInstance: ConcreteTaskInstance }) => {
+        createTaskRunner: ({
+          taskInstance,
+          abortController,
+        }: {
+          taskInstance: ConcreteTaskInstance;
+          abortController: AbortController;
+        }) => {
           return {
             run: async () => {
-              this.abortController = new AbortController();
-              return this.runTask(taskInstance, core);
+              return this.runTask(taskInstance, core, abortController);
             },
-            cancel: async () => {
-              this.abortController?.abort('Task timed out');
-            },
+            cancel: async () => {},
           };
         },
       },
@@ -118,7 +120,11 @@ export class AgentStatusChangeTask {
     this.logger.info(`[AgentStatusChangeTask] runTask ended${msg ? ': ' + msg : ''}`);
   }
 
-  public runTask = async (taskInstance: ConcreteTaskInstance, core: CoreSetup) => {
+  public runTask = async (
+    taskInstance: ConcreteTaskInstance,
+    core: CoreSetup,
+    abortController: AbortController
+  ) => {
     if (!appContextService.getExperimentalFeatures().enableAgentStatusAlerting) {
       this.logger.debug(
         '[AgentStatusChangeTask] Aborting runTask: agent status alerting feature is disabled'
@@ -144,7 +150,7 @@ export class AgentStatusChangeTask {
     const soClient = new SavedObjectsClient(coreStart.savedObjects.createInternalRepository());
 
     try {
-      await this.persistAgentStatusChanges(esClient, soClient);
+      await this.persistAgentStatusChanges(esClient, soClient, abortController);
 
       this.endRun('success');
     } catch (err) {
@@ -160,7 +166,8 @@ export class AgentStatusChangeTask {
 
   private persistAgentStatusChanges = async (
     esClient: ElasticsearchClient,
-    soClient: SavedObjectsClientContract
+    soClient: SavedObjectsClientContract,
+    abortController: AbortController
   ) => {
     let agentlessPolicies: string[] | undefined;
     const agentsFetcher = await fetchAllAgentsByKuery(esClient, soClient, {
@@ -176,7 +183,7 @@ export class AgentStatusChangeTask {
       const agentsToUpdate = [];
 
       for (const agent of agentPageResults) {
-        this.throwIfAborted();
+        this.throwIfAborted(abortController);
 
         if (agent.status !== agent.last_known_status) {
           agentsToUpdate.push(agent);
@@ -262,8 +269,8 @@ export class AgentStatusChangeTask {
     });
   };
 
-  private throwIfAborted() {
-    if (this.abortController?.signal.aborted) {
+  private throwIfAborted(abortController: AbortController) {
+    if (abortController.signal.aborted) {
       throw new Error('Task was aborted');
     }
   }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/216804

Most of Fleet tasks were fixed in https://github.com/elastic/kibana/pull/230017

Tested locally by calling `abortController.abort()` to the first task run, and then verifying that the task still runs next time.

```
[2025-08-26T09:56:08.158+02:00][INFO ][plugins.fleet.fleet:agent-status-change-task:1.0.3] [runTask()] started
[2025-08-26T09:56:08.158+02:00][INFO ][plugins.fleet.fleet:agent-status-change-task:1.0.3] [runTask()] abort task
[2025-08-26T09:56:08.361+02:00][ERROR][plugins.fleet.fleet:agent-status-change-task:1.0.3] [AgentStatusChangeTask] error: Error: Task was aborted
[2025-08-26T09:56:08.361+02:00][INFO ][plugins.fleet.fleet:agent-status-change-task:1.0.3] [AgentStatusChangeTask] runTask ended: error
[2025-08-26T09:56:21.114+02:00][INFO ][plugins.fleet.fleet:agent-status-change-task:1.0.3] [runTask()] started
[2025-08-26T09:56:21.296+02:00][DEBUG][plugins.fleet.fleet:agent-status-change-task:1.0.3] [AgentStatusChangeTask] Recording 10000 status changes
[2025-08-26T09:56:24.215+02:00][DEBUG][plugins.fleet.fleet:agent-status-change-task:1.0.3] [AgentStatusChangeTask] Recording 10000 status changes
[2025-08-26T09:56:26.294+02:00][DEBUG][plugins.fleet.fleet:agent-status-change-task:1.0.3] [AgentStatusChangeTask] Recording 10000 status changes
[2025-08-26T09:56:28.357+02:00][DEBUG][plugins.fleet.fleet:agent-status-change-task:1.0.3] [AgentStatusChangeTask] Recording 10000 status changes
[2025-08-26T09:56:30.367+02:00][DEBUG][plugins.fleet.fleet:agent-status-change-task:1.0.3] [AgentStatusChangeTask] Recording 10000 status changes
[2025-08-26T09:56:32.404+02:00][INFO ][plugins.fleet.fleet:agent-status-change-task:1.0.3] [AgentStatusChangeTask] runTask ended: success
[2025-08-26T09:56:33.109+02:00][INFO ][plugins.fleet.fleet:agent-status-change-task:1.0.3] [runTask()] started
[2025-08-26T09:56:33.481+02:00][INFO ][plugins.fleet.fleet:agent-status-change-task:1.0.3] [AgentStatusChangeTask] runTask ended: success
[2025-08-26T09:56:45.117+02:00][INFO ][plugins.fleet.fleet:agent-status-change-task:1.0.3] [runTask()] started
[2025-08-26T09:56:45.496+02:00][INFO ][plugins.fleet.fleet:agent-status-change-task:1.0.3] [AgentStatusChangeTask] runTask ended: success
[2025-08-26T09:56:54.120+02:00][INFO ][plugins.fleet.fleet:agent-status-change-task:1.0.3] [runTask()] started
[2025-08-26T09:56:54.508+02:00][INFO ][plugins.fleet.fleet:agent-status-change-task:1.0.3] [AgentStatusChangeTask] runTask ended: success
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



