### PR TITLE
[Fleet] Do not force reinstall packages when creating content connector policies

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/server/services/index.test.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/services/index.test.ts
@@ -498,7 +498,7 @@ describe('AgentlessConnectorsInfraService', () => {
               supports_agentless: true,
             }),
           ]),
-          options: expect.objectContaining({ force: true }),
+          options: expect.objectContaining({ forcePackagePolicyCreation: true }),
         })
       );
 

--- a/x-pack/platform/plugins/shared/content_connectors/server/services/index.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/services/index.ts
@@ -244,7 +244,7 @@ export class AgentlessConnectorsInfraService {
       options: {
         withSysMonitoring: true,
         spaceId: this.soClient.getCurrentNamespace() ?? DEFAULT_SPACE_ID,
-        force: true,
+        forcePackagePolicyCreation: true,
       },
     });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -518,6 +518,7 @@ class AgentPolicyService {
       user,
       authorizationHeader,
       force,
+      forcePackagePolicyCreation,
     },
   }: {
     soClient: SavedObjectsClientContract;
@@ -531,7 +532,10 @@ class AgentPolicyService {
       spaceId: string;
       user?: AuthenticatedUser;
       authorizationHeader?: HTTPAuthorizationHeader | null;
+      /** Pass force to all following calls: package install, policy creation */
       force?: boolean;
+      /** Pass force only to package policy creation */
+      forcePackagePolicyCreation?: boolean;
     };
   }) {
     const logger = appContextService.getLogger().get('createWithPackagePolicies');
@@ -550,6 +554,7 @@ class AgentPolicyService {
       user,
       authorizationHeader,
       force,
+      forcePackagePolicyCreation,
     });
 
     const createdPackagePolicyIds = [];

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
@@ -114,7 +114,10 @@ interface CreateAgentPolicyParams {
   spaceId: string;
   user?: AuthenticatedUser;
   authorizationHeader?: HTTPAuthorizationHeader | null;
+  /** Pass force to all following calls: package install, policy creation */
   force?: boolean;
+  /** Pass force only to package policy creation */
+  forcePackagePolicyCreation?: boolean;
 }
 
 export async function createAgentPolicyWithPackages({
@@ -129,6 +132,7 @@ export async function createAgentPolicyWithPackages({
   user,
   authorizationHeader,
   force,
+  forcePackagePolicyCreation,
 }: CreateAgentPolicyParams) {
   const logger = appContextService.getLogger().get('createAgentPolicyWithPackages');
 
@@ -192,7 +196,7 @@ export async function createAgentPolicyWithPackages({
         spaceId,
         user,
         authorizationHeader,
-        force,
+        force: force || forcePackagePolicyCreation,
       }
     );
   }
@@ -209,7 +213,7 @@ export async function createAgentPolicyWithPackages({
         spaceId,
         user,
         authorizationHeader,
-        force,
+        force: force || forcePackagePolicyCreation,
       }
     );
   }


### PR DESCRIPTION
## Description 

Do not force reinstalling package when creating connector policies.

This is causing issue, as we are reinstall packages that are already installed potentially creating useless load or creating concurrent install calls.

## Details

To fix that, that PR introduce a new options to only force the package policy (this is needed as it's managed policy)