### PR TITLE
[Snapshot and restore] fix restore status tab for system indices

### DIFF
--- a/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/restore.test.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/restore.test.ts
@@ -27,6 +27,10 @@ describe('[Snapshot and Restore API Routes] Restore', () => {
     });
   });
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   /**
    * ES APIs used by these endpoints
    */
@@ -103,6 +107,19 @@ describe('[Snapshot and Restore API Routes] Restore', () => {
       await expect(router.runRequest(mockRequest)).resolves.toEqual({
         body: expectedResponse,
       });
+    });
+
+    it('should include expand_wildcards parameter when calling indices.recovery', async () => {
+      await router.runRequest({
+        method: 'get',
+        path: addBasePath('restores'),
+      });
+
+      expect(indicesRecoveryFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expand_wildcards: 'all',
+        })
+      );
     });
 
     it('should return empty array if no repositories returned from ES', async () => {

--- a/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/restore.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/restore.ts
@@ -39,6 +39,7 @@ export function registerRestoreRoutes({
         const snapshotRestores: SnapshotRestore[] = [];
         const recoveryByIndexName = await clusterClient.asCurrentUser.indices.recovery({
           human: true,
+          expand_wildcards: 'all',
         });
 
         // Filter to snapshot-recovered shards only


### PR DESCRIPTION
fixes #228531

add expand_wildcards parameter and clear mocks

- Add `expand_wildcards: 'all'` to indices.recovery call in server/routes/api/restore.ts
- Add beforeEach hook to clear all mocks in restore.test.ts
- Add test case to verify expand_wildcards parameter usage in restore.test.ts

## How to verify

### Before Fix State

First run local es/kibana. Set `path.repo` config setting.

You can do it in `elasticsearch.yml` or simply from cli passing `-E` flag 

For example:

```bash
yarn es snapshot -E path.repo=/tmp/snapshots # run es in one window
yarn start --no-base-path # run kibana in the other
```

After kibana/es are ready

Do this to test the before state (on main branch for example)
```graphql

# Create a test repository (filesystem type for simplicity) (once)
PUT _snapshot/test_repo
{
  "type": "fs",
  "settings": {
    "location": "/tmp/snapshots"
  }
}

# Create a regular index/populate it
PUT test_index/_doc/1
{
  "data": "regular index"
}

# Create a system index
PUT .test_system_index
{
  "settings": {
    "index.hidden": true
  }
}
# Populate it as well
PUT .test_system_index/_doc/1
{
  "data": "system index"
}

# Create a snapshot including system indices
PUT _snapshot/test_repo/snapshot_with_system?wait_for_completion=true
{
  "indices": ["test_index", ".test_system_index"],
  "include_global_state": false,
  "expand_wildcards": "all"
}

# Delete both indices to prepare for restore
DELETE test_index
DELETE .test_system_index

# Check that they are gone
GET test_index
GET .test_system_index

# Restore system index
POST _snapshot/test_repo/snapshot_with_system/_restore
{
  "indices": ".test_system_index"
}
```

Now go to `app/management/data/snapshot_restore/restore_status` and observe no restored snapshot

<img width="1516" height="1163" alt="image" src="https://github.com/user-attachments/assets/324fb0ef-c9cd-4f64-a1de-f927a677bd8a" />


### After Fix State

Checkout PR branch repeat the same kibana/es setup steps

Go to devtools
```
# resetting state
DELETE _snapshot/test_repo/snapshot_with_system?wait_for_completion=true
```

The rest is the same

The restore status tab should show

<img width="1563" height="834" alt="SCR-20250825-qtzl" src="https://github.com/user-attachments/assets/18123170-7837-4bc6-942a-9f78fbaca923" />


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->