### PR TITLE
`@kbn/storage-adapter`: do not update settings when updating mappings

### DIFF
--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
@@ -245,13 +245,6 @@ export class StorageIndexAdapter<
       name: getBackingIndexName(this.storage.name, 999999),
     });
 
-    if (simulateIndexTemplateResponse.template.settings) {
-      await this.esClient.indices.putSettings({
-        index: name,
-        settings: simulateIndexTemplateResponse.template.settings,
-      });
-    }
-
     if (simulateIndexTemplateResponse.template.mappings) {
       await this.esClient.indices.putMapping({
         index: name,


### PR DESCRIPTION
## Summary

Fix a bug causing a mapping update of a `index-storage` to cause an error during `updateMappingsOfExistingIndex`. 

During that phase, we were trying to update the index's settings in addition to its mappings. However, the `simulateIndexTemplate` API returns the full set of settings, and not only the ones which can be updated, so the following `putSettings` call was failing with errors such as:

```
 Root causes:
                illegal_argument_exception: can not update private setting [index.allocation.existing_shards_allocator]; this setting is managed by Elasticsearch
```

Given there is apparently no proper way to identify which setting(s) are private vs which ones can be updated, this PR simply fully disables the setting update part, as discussed with @elastic/kibana-core.