### PR TITLE
[9.1] [Inference] Refactor anonymization to walk JSON objects instead of stringifying (#232319)

### DIFF
--- a/x-pack/platform/packages/shared/ai-infra/inference-common/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/index.ts
@@ -70,7 +70,6 @@ export {
   type DeanonymizationOutput,
   type DeanonymizedMessage,
   type AnonymizationSettings,
-  type AnonymizationRegexWorkerTaskPayload,
 } from './src/chat_complete';
 
 export type { BoundInferenceClient, InferenceClient } from './src/inference_client';

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/anonymization/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/anonymization/index.ts
@@ -16,5 +16,4 @@ export type {
   RegexAnonymizationRule,
   NamedEntityRecognitionRule,
   AnonymizationSettings,
-  AnonymizationRegexWorkerTaskPayload,
 } from './types';

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/anonymization/types.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/anonymization/types.ts
@@ -64,7 +64,3 @@ export interface DeanonymizationOutput {
 }
 
 export type DeanonymizedMessage = Message & { deanonymizations: Deanonymization[] };
-export interface AnonymizationRegexWorkerTaskPayload {
-  rules: RegexAnonymizationRule[];
-  records: Array<Record<string, string>>;
-}

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/index.ts
@@ -79,5 +79,4 @@ export type {
   RegexAnonymizationRule,
   NamedEntityRecognitionRule,
   AnonymizationSettings,
-  AnonymizationRegexWorkerTaskPayload,
 } from './anonymization';

--- a/x-pack/platform/plugins/shared/inference/README.md
+++ b/x-pack/platform/plugins/shared/inference/README.md
@@ -533,3 +533,5 @@ POST /internal/inference/chat_complete
 ```
 
 </details>
+
+For more information on anonymization see [elastic docs](https://www.elastic.co/docs/solutions/observability/observability-ai-assistant#obs-ai-anonymization)

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_messages.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_messages.test.ts
@@ -75,9 +75,11 @@ describe('anonymizeMessages', () => {
       },
     ];
 
-    const serialized = messageToAnonymizationRecords(messages[0]);
+    const rec = messageToAnonymizationRecords(messages[0]);
+    const q = rec['/toolCalls/0/function/arguments/query']!;
 
     setupMockResponse([
+      { entities: [] }, // /toolCalls/0/function/name
       {
         predicted_value: '',
         entities: [
@@ -85,11 +87,11 @@ describe('anonymizeMessages', () => {
             entity: 'Bob',
             class_name: 'PER',
             class_probability: 0.9828533515650252,
-            start_pos: serialized.data!.indexOf('Bob'),
-            end_pos: serialized.data!.indexOf('Bob') + 3,
+            start_pos: q.indexOf('Bob'),
+            end_pos: q.indexOf('Bob') + 3,
           },
         ],
-      },
+      }, // /toolCalls/0/function/arguments/query
     ]);
 
     // Execute
@@ -238,9 +240,12 @@ describe('anonymizeMessages', () => {
       },
     ];
 
-    const serialized = messageToAnonymizationRecords(messages[0]);
+    const rec = messageToAnonymizationRecords(messages[0]);
+    const q0 = rec['/toolCalls/0/function/arguments/query']!;
+    const q1 = rec['/toolCalls/1/function/arguments/query']!;
 
     setupMockResponse([
+      { entities: [] }, // /toolCalls/0/function/name
       {
         predicted_value: '',
         entities: [
@@ -248,18 +253,24 @@ describe('anonymizeMessages', () => {
             entity: 'Bob',
             class_name: 'PER',
             class_probability: 0.99,
-            start_pos: serialized.data!.indexOf('Bob'),
-            end_pos: serialized.data!.indexOf('Bob') + 3,
+            start_pos: q0.indexOf('Bob'),
+            end_pos: q0.indexOf('Bob') + 3,
           },
+        ],
+      }, // /toolCalls/0/function/arguments/query
+      { entities: [] }, // /toolCalls/1/function/name
+      {
+        predicted_value: '',
+        entities: [
           {
             entity: 'Bob',
             class_name: 'PER',
             class_probability: 0.99,
-            start_pos: serialized.data!.lastIndexOf('Bob'),
-            end_pos: serialized.data!.lastIndexOf('Bob') + 3,
+            start_pos: q1.indexOf('Bob'),
+            end_pos: q1.indexOf('Bob') + 3,
           },
         ],
-      },
+      }, // /toolCalls/1/function/arguments/query
     ]);
 
     const result = await anonymizeMessages({
@@ -373,5 +384,36 @@ describe('anonymizeMessages', () => {
     expect(maskedContent).toBe(
       'my name is PER_ee4587b4ba681e38996a1b716facbf375786bff7 and I live in los angeles'
     );
+  });
+
+  it('mixed text/image content preserves indices and masks correct leaf', async () => {
+    const messages: Message[] = [
+      {
+        role: MessageRole.User,
+        content: [
+          { type: 'text', text: 'hello' },
+          { type: 'image', source: { data: 'img', mimeType: 'image/png' } },
+          { type: 'text', text: 'my email is a@example.com' },
+        ],
+      },
+    ];
+
+    const result = await anonymizeMessages({
+      messages,
+      anonymizationRules: [regexRule],
+      regexWorker,
+      esClient: mockEsClient,
+    });
+
+    const anonymizedContent = result.messages[0] as UserMessage;
+    const content = anonymizedContent.content;
+
+    const emailMask = getEntityMask({ class_name: 'EMAIL', value: 'a@example.com' });
+    const expected = [
+      { type: 'text', text: 'hello' },
+      { type: 'image', source: { data: 'img', mimeType: 'image/png' } },
+      { type: 'text', text: `my email is ${emailMask}` },
+    ];
+    expect(content).toEqual(expected);
   });
 });

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_messages.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_messages.ts
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import { ElasticsearchClient } from '@kbn/core/server';
-import { AnonymizationOutput, AnonymizationRule, Message } from '@kbn/inference-common';
-import { merge } from 'lodash';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { AnonymizationOutput, AnonymizationRule, Message } from '@kbn/inference-common';
 import { anonymizeRecords } from './anonymize_records';
 import { messageFromAnonymizationRecords } from './message_from_anonymization_records';
 import { messageToAnonymizationRecords } from './message_to_anonymization_records';
@@ -41,7 +40,7 @@ export async function anonymizeMessages({
     ...(system ? [{ system }] : []),
   ];
 
-  const { records, anonymizations } = await anonymizeRecords({
+  const { records: anonymizedRecords, anonymizations } = await anonymizeRecords({
     input: toAnonymize,
     anonymizationRules: rules,
     regexWorker,
@@ -49,12 +48,14 @@ export async function anonymizeMessages({
   });
 
   const anonymizedMessages = messages.map((original, index) => {
-    const map = records[index];
+    const anonymizedRecord = anonymizedRecords[index];
 
-    return merge({}, original, messageFromAnonymizationRecords(map));
+    return messageFromAnonymizationRecords(original, anonymizedRecord);
   });
 
-  const anonymizedSystem = records.find((r) => 'system' in r) as { system?: string } | undefined;
+  const anonymizedSystem = anonymizedRecords.find((r) => 'system' in r) as
+    | { system?: string }
+    | undefined;
 
   return {
     system: anonymizedSystem?.system,

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/get_anonymizable_message_parts.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/get_anonymizable_message_parts.ts
@@ -32,7 +32,5 @@ export function getAnonymizableMessageParts(message: Message) {
     };
   }
 
-  return {
-    content: message.content,
-  };
+  return { content: message.content };
 }

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_from_anonymization_records.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_from_anonymization_records.test.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Message } from '@kbn/inference-common';
+import { MessageRole } from '@kbn/inference-common';
+import type { AnonymizationRecord } from './types';
+import { messageFromAnonymizationRecords } from './message_from_anonymization_records';
+
+describe('messageFromAnonymizationRecords', () => {
+  it('applies single leaf at /content for user string content', () => {
+    const original: Message = {
+      role: MessageRole.User,
+      content: 'email a@example.com',
+    };
+
+    const record: AnonymizationRecord = {
+      '/content': 'email EMAIL_12345',
+    };
+
+    const out = messageFromAnonymizationRecords(original, record);
+
+    expect(out).toEqual({
+      role: MessageRole.User,
+      content: 'email EMAIL_12345',
+    });
+  });
+
+  it('applies nested leaf under /content array items (index preserved)', () => {
+    const original: Message = {
+      role: MessageRole.User,
+      content: [
+        { type: 'text', text: 'first' },
+        { type: 'text', text: 'a@example.com' },
+        { type: 'text', text: 'third' },
+      ],
+    };
+
+    const record: AnonymizationRecord = {
+      '/content/1/text': 'EMAIL_12345',
+    };
+
+    const out = messageFromAnonymizationRecords(original, record);
+
+    expect(out).toEqual({
+      role: MessageRole.User,
+      content: [
+        { type: 'text', text: 'first' },
+        { type: 'text', text: 'EMAIL_12345' },
+        { type: 'text', text: 'third' },
+      ],
+    });
+  });
+
+  it('applies to tool response leaf and preserves other types', () => {
+    const original: Message = {
+      role: MessageRole.Tool,
+      name: 'context',
+      toolCallId: 't1',
+      response: {
+        msg: 'See http://example.com',
+        n: 42,
+        ok: true,
+        nested: { note: 'contact me at a@example.com' },
+      },
+    };
+
+    const record: AnonymizationRecord = {
+      '/response/msg': 'See URL_12345',
+      '/response/nested/note': 'contact me at EMAIL_12345',
+    };
+
+    const out = messageFromAnonymizationRecords(original, record);
+
+    expect(out).toEqual({
+      role: MessageRole.Tool,
+      name: 'context',
+      toolCallId: 't1',
+      response: {
+        msg: 'See URL_12345',
+        n: 42,
+        ok: true,
+        nested: { note: 'contact me at EMAIL_12345' },
+      },
+    });
+  });
+
+  it('handles RFC-6901 escaped keys ("/" → "~1", "~" → "~0")', () => {
+    const original: Message = {
+      role: MessageRole.Tool,
+      name: 'tool',
+      toolCallId: 't2',
+      response: {
+        'a/b': 'x',
+        'a~b': 'y',
+        nested: { 'c/d~e': 'z' },
+      },
+    };
+
+    const record: AnonymizationRecord = {
+      '/response/a~1b': 'X',
+      '/response/a~0b': 'Y',
+      '/response/nested/c~1d~0e': 'Z',
+    };
+
+    const out = messageFromAnonymizationRecords(original, record);
+
+    expect(out).toEqual({
+      role: MessageRole.Tool,
+      name: 'tool',
+      toolCallId: 't2',
+      response: {
+        'a/b': 'X',
+        'a~b': 'Y',
+        nested: { 'c/d~e': 'Z' },
+      },
+    });
+  });
+
+  it('throws on invalid path under a primitive (property does not exist)', () => {
+    const original: Message = {
+      role: MessageRole.User,
+      content: 'hello',
+    };
+
+    const record: AnonymizationRecord = {
+      '/content': 'hi',
+      '/content/missing': 'nope',
+    };
+
+    expect(() => messageFromAnonymizationRecords(original, record)).toThrow(
+      'Invalid path at "/content/missing": expected object or array while traversing'
+    );
+  });
+
+  it('refuses to create new properties on existing objects', () => {
+    const original: Message = {
+      role: MessageRole.User,
+      content: [
+        { type: 'text', text: 'first' },
+        { type: 'text', text: 'second' },
+      ],
+    };
+
+    const record: AnonymizationRecord = {
+      '/content/1/other': 'X',
+    };
+
+    expect(() => messageFromAnonymizationRecords(original, record)).toThrow(
+      'Invalid leaf at "/content/1/other": property does not exist'
+    );
+  });
+
+  it('throws on array out-of-bounds at path segment', () => {
+    const original: Message = {
+      role: MessageRole.User,
+      content: [
+        { type: 'text', text: 'a' },
+        { type: 'text', text: 'b' },
+      ],
+    };
+
+    const record: AnonymizationRecord = {
+      '/content/2/text': 'X',
+    };
+
+    expect(() => messageFromAnonymizationRecords(original, record)).toThrow(
+      'Invalid path segment "2" at "/content/2/text": array index out of bounds'
+    );
+  });
+
+  it('throws when traversing into a non-object/array (primitive in path)', () => {
+    const original: Message = {
+      role: MessageRole.User,
+      content: 'hello',
+    };
+
+    const record: AnonymizationRecord = {
+      '/content/text': 'X',
+    };
+
+    expect(() => messageFromAnonymizationRecords(original, record)).toThrow(
+      'Invalid path at "/content/text": expected object or array while traversing'
+    );
+  });
+
+  it('throws when a parent object property is missing', () => {
+    const original: Message = {
+      role: MessageRole.Tool,
+      name: 'ctx',
+      toolCallId: 't1',
+      response: {},
+    };
+
+    const record: AnonymizationRecord = {
+      '/response/nested/msg': 'X',
+    };
+
+    expect(() => messageFromAnonymizationRecords(original, record)).toThrow(
+      'Invalid path segment "nested" at "/response/nested/msg": missing property'
+    );
+  });
+
+  it('requires pointers to start with "/"', () => {
+    const original: Message = {
+      role: MessageRole.User,
+      content: 'hello',
+    };
+
+    const record: AnonymizationRecord = {
+      content: 'hi',
+    } as any;
+
+    expect(() => messageFromAnonymizationRecords(original, record)).toThrow(
+      'Invalid JSON Pointer: must start with "/". Got: "content"'
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_from_anonymization_records.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_from_anonymization_records.ts
@@ -5,16 +5,85 @@
  * 2.0.
  */
 
-import { Message, MessageContent } from '@kbn/inference-common';
-import { AnonymizationRecord } from './types';
+import type { Message } from '@kbn/inference-common';
+import type { AnonymizationRecord } from './types';
 
-export function messageFromAnonymizationRecords(map: AnonymizationRecord): Message {
-  const anonymizableMessage = map;
-  const { content, contentParts, data } = anonymizableMessage;
+/**
+ * RFC-6901 unescape for a single JSON Pointer token:
+ *  - "~1" -> "/"
+ *  - "~0" -> "~"
+ */
+function unescapePointerToken(token: string): string {
+  return token.replace(/~1/g, '/').replace(/~0/g, '~');
+}
 
-  return {
-    ...(content ? { content } : {}),
-    ...(contentParts ? { content: JSON.parse(contentParts) as MessageContent[] } : {}),
-    ...(data ? JSON.parse(data) : {}),
-  };
+/**
+ * Set a string leaf on an object by JSON Pointer.
+ * Throws an error if the path is invalid or doesn't exist.
+ */
+function setByPointer(root: Message, pointer: string, value: string): void {
+  if (!pointer?.startsWith('/')) {
+    throw new Error(`Invalid JSON Pointer: must start with "/". Got: "${pointer}"`);
+  }
+
+  const pathParts = pointer.split('/').slice(1).map(unescapePointerToken);
+
+  // Navigate to the parent of the target location
+  let cursor: any = root; // Start at the root message
+  for (let i = 0; i < pathParts.length - 1; i++) {
+    const pathPart = pathParts[i];
+
+    if (Array.isArray(cursor)) {
+      const idx = Number(pathPart);
+      if (!Number.isInteger(idx) || idx < 0 || idx >= cursor.length) {
+        throw new Error(
+          `Invalid path segment "${pathPart}" at "${pointer}": array index out of bounds`
+        );
+      }
+      cursor = cursor[idx];
+    } else if (cursor && typeof cursor === 'object') {
+      if (!Object.prototype.hasOwnProperty.call(cursor, pathPart)) {
+        throw new Error(`Invalid path segment "${pathPart}" at "${pointer}": missing property`);
+      }
+      cursor = (cursor as Record<string, unknown>)[pathPart];
+    } else {
+      throw new Error(`Invalid path at "${pointer}": expected object or array while traversing`);
+    }
+  }
+
+  // Set the value at the final location
+  const leaf = pathParts[pathParts.length - 1];
+  if (Array.isArray(cursor)) {
+    const idx = Number(leaf);
+    if (!Number.isInteger(idx) || idx < 0 || idx >= cursor.length) {
+      throw new Error(`Invalid leaf at "${pointer}": array index out of bounds`);
+    }
+    cursor[idx] = value;
+  } else if (cursor && typeof cursor === 'object') {
+    if (!Object.prototype.hasOwnProperty.call(cursor, leaf)) {
+      throw new Error(`Invalid leaf at "${pointer}": property does not exist`);
+    }
+    (cursor as Record<string, unknown>)[leaf] = value;
+  } else {
+    throw new Error(`Invalid path at "${pointer}": expected object or array while traversing`);
+  }
+}
+
+/**
+ * Apply a flattened AnonymizationRecord (JSON Pointer -> string) onto a clone of `original`.
+ */
+export function messageFromAnonymizationRecords(
+  original: Message,
+  anonymizedRecord: AnonymizationRecord
+): Message {
+  const cloned: Message = structuredClone(original);
+
+  for (const [pointer, anonymizedValue] of Object.entries(anonymizedRecord)) {
+    // in practice, should always be a string
+    if (typeof anonymizedValue === 'string') {
+      setByPointer(cloned, pointer, anonymizedValue);
+    }
+  }
+
+  return cloned;
 }

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_to_anonymization_records.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_to_anonymization_records.test.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Message } from '@kbn/inference-common';
+import { MessageRole } from '@kbn/inference-common';
+import { messageToAnonymizationRecords } from './message_to_anonymization_records';
+
+describe('messageToAnonymizationRecords', () => {
+  it('User message string content becomes /content', () => {
+    const msg: Message = {
+      role: MessageRole.User,
+      content: 'email a@example.com',
+    };
+
+    const rec = messageToAnonymizationRecords(msg);
+
+    expect(rec).toEqual({
+      '/content': 'email a@example.com',
+    });
+  });
+
+  it('User message array/object content flattens to leaf strings', () => {
+    const msg: Message = {
+      role: MessageRole.User,
+      content: [
+        { type: 'text', text: 'a@example.com' },
+        { type: 'text', text: 'ok' },
+      ],
+    };
+
+    const rec = messageToAnonymizationRecords(msg);
+
+    expect(rec).toEqual({
+      '/content/0/text': 'a@example.com',
+      '/content/1/text': 'ok',
+    });
+  });
+
+  it('Tool message only /response subtree is considered; non-strings ignored', () => {
+    const msg: Message = {
+      role: MessageRole.Tool,
+      name: 'tool-1',
+      toolCallId: 't1',
+      response: { msg: 'a@example.com', n: 1, ok: true, nil: null },
+    };
+
+    const rec = messageToAnonymizationRecords(msg);
+
+    expect(rec).toEqual({
+      '/response/msg': 'a@example.com',
+    });
+  });
+
+  it('Assistant message /content and /toolCalls/*/function/arguments', () => {
+    const msg: Message = {
+      role: MessageRole.Assistant,
+      content: 'See results',
+      toolCalls: [
+        {
+          id: 'call-1',
+          type: 'function',
+          function: {
+            name: 'doThing',
+            arguments: 'a@example.com',
+          },
+        } as any,
+      ],
+    };
+
+    const rec = messageToAnonymizationRecords(msg);
+
+    expect(rec).toEqual({
+      '/content': 'See results',
+      '/toolCalls/0/function/arguments': 'a@example.com',
+      '/toolCalls/0/function/name': 'doThing',
+    });
+  });
+
+  it('Escaping in keys — "/" → "~1", "~" → "~0"', () => {
+    const msg: Message = {
+      role: MessageRole.Tool,
+      name: 'tool-1',
+      toolCallId: 't1',
+      response: {
+        'a/b': 'x',
+        'a~b': 'y',
+        nested: { 'c/d~e': 'z' },
+      },
+    };
+
+    const rec = messageToAnonymizationRecords(msg);
+
+    expect(rec).toEqual({
+      '/response/a~1b': 'x', // "a/b"
+      '/response/a~0b': 'y', // "a~b"
+      '/response/nested/c~1d~0e': 'z', // "c/d~e"
+    });
+  });
+
+  it('Non-string leaves are ignored', () => {
+    const msg: Message = {
+      role: MessageRole.Tool,
+      name: 'tool-1',
+      toolCallId: 't1',
+      response: {
+        a: 1,
+        b: false,
+        c: null,
+        d: ['x', 2, true, null],
+      },
+    };
+
+    const rec = messageToAnonymizationRecords(msg);
+
+    expect(rec).toEqual({
+      '/response/d/0': 'x',
+    });
+  });
+
+  it('User message with mixed text/image content only processes text', () => {
+    const msg: Message = {
+      role: MessageRole.User,
+      content: [
+        { type: 'text', text: 'a@example.com' },
+        { type: 'image', source: { data: 'image data', mimeType: 'image/png' } },
+        { type: 'text', text: 'ok' },
+      ],
+    };
+
+    const rec = messageToAnonymizationRecords(msg);
+
+    expect(rec).toEqual({
+      '/content/0/text': 'a@example.com',
+      '/content/2/text': 'ok',
+    });
+  });
+
+  it('User message with image-only content yields an empty record', () => {
+    const msg: Message = {
+      role: MessageRole.User,
+      content: [
+        { type: 'image', source: { data: 'img1', mimeType: 'image/png' } },
+        { type: 'image', source: { data: 'img2', mimeType: 'image/jpeg' } },
+      ],
+    };
+
+    const rec = messageToAnonymizationRecords(msg);
+    expect(rec).toEqual({});
+  });
+});

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_to_anonymization_records.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_to_anonymization_records.ts
@@ -5,18 +5,67 @@
  * 2.0.
  */
 
-import { Message } from '@kbn/inference-common';
-import { isEmpty } from 'lodash';
+import type { Message } from '@kbn/inference-common';
 import { getAnonymizableMessageParts } from './get_anonymizable_message_parts';
 import { AnonymizationRecord } from './types';
 
-export function messageToAnonymizationRecords(message: Message): AnonymizationRecord {
-  const anonymizableMessage = getAnonymizableMessageParts(message);
-  const { content, ...rest } = anonymizableMessage;
+/**
+ * Escape a single JSON Pointer token per RFC-6901:
+ *  - "~" -> "~0"
+ *  - "/" -> "~1"
+ */
+function escapePointerToken(token: string): string {
+  return token.replace(/~/g, '~0').replace(/\//g, '~1');
+}
 
-  return {
-    ...(content && typeof content === 'string' ? { content } : {}),
-    ...(content && typeof content !== 'string' ? { contentParts: JSON.stringify(content) } : {}),
-    ...(!isEmpty(rest) ? { data: JSON.stringify(rest) } : {}),
-  };
+/**
+ * Recursively walk a value and collect only string leaves as path-value tuples.
+ * Keys in the returned tuples are absolute JSON Pointers from the message root,
+ * rooted at the top-level key returned by getAnonymizableMessageParts (e.g. "/content", "/response").
+ */
+function collectStringEntries(value: unknown, basePointer: string): Array<[string, string]> {
+  if (typeof value === 'string') {
+    return [[basePointer, value]];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item, i) => collectStringEntries(item, `${basePointer}/${i}`));
+  }
+
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+
+    // Skip images entirely (do not traverse into source.{data,mimeType})
+    if (obj.type === 'image') {
+      return [];
+    }
+
+    // For text content objects, only collect the text field to avoid adding pointers
+    // for the `type` property.
+    if (obj.type === 'text' && typeof obj.text === 'string') {
+      return [[`${basePointer}/text`, obj.text]];
+    }
+
+    return Object.entries(obj).flatMap(([k, v]) => {
+      const next = `${basePointer}/${escapePointerToken(k)}`;
+      return collectStringEntries(v, next);
+    });
+  }
+
+  // Non-string primitives (number/boolean/null/undefined) are ignored
+  return [];
+}
+
+/**
+ * Flattens anonymizable parts of a message into a map of JSON Pointer -> string leaf.
+ */
+export function messageToAnonymizationRecords(message: Message): AnonymizationRecord {
+  const anonymizableParts = getAnonymizableMessageParts(message);
+
+  const entries = Object.entries(anonymizableParts).flatMap(([key, value]) => {
+    const basePath = `/${escapePointerToken(key)}`;
+    return collectStringEntries(value, basePath);
+  });
+
+  return Object.fromEntries(entries);
 }

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/regex_worker_service.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/regex_worker_service.ts
@@ -7,7 +7,7 @@
 
 import Piscina from 'piscina';
 import type { Logger } from '@kbn/logging';
-import type { AnonymizationRegexWorkerTaskPayload } from '@kbn/inference-common';
+import type { AnonymizationRegexWorkerTaskPayload } from './types';
 import type { AnonymizationWorkerConfig } from '../../config';
 import type { DetectedMatch } from './types';
 import { executeRegexRulesTask } from './execute_regex_rule_task';

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/regex_worker_task.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/regex_worker_task.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { AnonymizationRegexWorkerTaskPayload } from '@kbn/inference-common';
+import type { AnonymizationRegexWorkerTaskPayload } from './types';
 import { executeRegexRulesTask } from './execute_regex_rule_task';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/types.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/types.ts
@@ -5,21 +5,17 @@
  * 2.0.
  */
 
-import { Anonymization } from '@kbn/inference-common';
+import type { Anonymization, RegexAnonymizationRule } from '@kbn/inference-common';
 
 /**
- * AnonymizationRecord are named strings that will be anonymized
- * per key-value pair. This allows us to pass in plain text strings
- * like `content` as a single document, instead of JSON.stringifying
- * the entire message.
+ * AnonymizationRecord maps JSON Pointer paths to string values that need anonymization.
+ * Keys are RFC-6901 JSON Pointer paths (e.g. "/content", "/toolCalls/0/function/arguments").
+ *
+ * Note: JSON Pointer paths should always contain string values.
+ * The undefined is for system messages which may be optional.
  */
 export interface AnonymizationRecord {
-  // make sure it matches Record<string, string | undefined>
-  [x: string]: string | undefined;
-  data?: string;
-  contentParts?: string;
-  content?: string;
-  system?: string;
+  [jsonPointerPath: string]: string | undefined;
 }
 
 /**
@@ -39,4 +35,9 @@ export interface DetectedMatch {
   matchValue: string;
   class_name: string;
   ruleIndex: number;
+}
+
+export interface AnonymizationRegexWorkerTaskPayload {
+  rules: RegexAnonymizationRule[];
+  records: Array<Record<string, string>>;
 }

--- a/x-pack/platform/plugins/shared/inference/server/test_utils/regex_worker_service.mock.ts
+++ b/x-pack/platform/plugins/shared/inference/server/test_utils/regex_worker_service.mock.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { AnonymizationRegexWorkerTaskPayload } from '@kbn/inference-common';
+import type { AnonymizationRegexWorkerTaskPayload } from '../chat_complete/anonymization/types';
 import type { AnonymizationState } from '../chat_complete/anonymization/types';
 import { RegexWorkerService } from '../chat_complete/anonymization/regex_worker_service';
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Inference] Refactor anonymization to walk JSON objects instead of stringifying (#232319)](https://github.com/elastic/kibana/pull/232319)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sandra G","email":"neptunian@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-25T19:04:23Z","message":"[Inference] Refactor anonymization to walk JSON objects instead of stringifying (#232319)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/228461\n\nCurrently, anonymization stringifies objects with JSON.stringify()\nbefore applying rules, which can corrupt JSON when rules accidentally\nmatch quotes, escape sequences, or other syntax. This PR changes the\napproach to walk JSON objects directly so rules only apply to leaf\nstring values. We track locations using JSON Pointer paths, allowing us\nto reconstruct the original object with anonymized data before sending\nit to the LLM.\n\nThis makes anonymization safer and more reliable, but introduces a\ntradeoff for NER inference. Large JSON objects with many leaf values now\ngenerate more documents per request, which will increase latency\ndepending on the size. Configurable model timeouts (added in\n[#228497](https://github.com/elastic/kibana/issues/228497)) help\nmitigate timeouts, and future optimizations can further reduce overhead.\n\n## Key changes\n- Replace JSON.stringify() anonymization with JSON Pointer–based\ntraversal.\n- Anonymization now only applies to leaf string values (booleans,\nnumbers, image types, etc are ignored).\n\n## Example\n\n### Scenario\nA greedy regex rule to match a url:\n```\n{\n  \"entityClass\": \"URL\",\n  \"type\": \"RegExp\",\n  \"pattern\": \"https?://.+\",\n  \"enabled\": true\n}\n```\n\nWhen the assistant calls the context function and a message like this\ngets created:\n```\n{\n  \"@timestamp\": \"2025-08-20T13:55:40.264Z\",\n  \"message\": {\n    \"content\": \"{\\\"screen_description\\\":\\\"The user is looking at http://localhost:5601/app/observabilityAIAssistant/conversations/new. The current time range is 2025-08-20T13:40:38.609Z - 2025-08-20T13:55:38.609Z.\\\",\\\"learnings\\\":[]}\",\n    \"name\": \"context\",\n    \"role\": \"user\"\n  }\n}\n```\n\n#### Before\ncauses the chat to fail with `Unterminated string in JSON at position\n102 (line 1 column 103)`\n<details>\n<summary>screenshot</summary>\n<img width=\"1174\" height=\"792\" alt=\"Screenshot 2025-08-20 at 09 34 06\"\nsrc=\"https://github.com/user-attachments/assets/49e9bd53-5176-425b-aef1-055352e01240\"\n/>\n</details>\n\n#### After\nNo error and looking in Phoenix, the url was properly anonymized \n`{\"screen_description\":\"The user is looking at\nURL_2bc72338ee1820de9882fc56c5098e9d374d64f2\",\"learnings\":[]}`\n\n---------\n\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>","sha":"c9661098d74c46a773568b3ae0dfa93febe836d6","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Inference] Refactor anonymization to walk JSON objects instead of stringifying","number":232319,"url":"https://github.com/elastic/kibana/pull/232319","mergeCommit":{"message":"[Inference] Refactor anonymization to walk JSON objects instead of stringifying (#232319)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/228461\n\nCurrently, anonymization stringifies objects with JSON.stringify()\nbefore applying rules, which can corrupt JSON when rules accidentally\nmatch quotes, escape sequences, or other syntax. This PR changes the\napproach to walk JSON objects directly so rules only apply to leaf\nstring values. We track locations using JSON Pointer paths, allowing us\nto reconstruct the original object with anonymized data before sending\nit to the LLM.\n\nThis makes anonymization safer and more reliable, but introduces a\ntradeoff for NER inference. Large JSON objects with many leaf values now\ngenerate more documents per request, which will increase latency\ndepending on the size. Configurable model timeouts (added in\n[#228497](https://github.com/elastic/kibana/issues/228497)) help\nmitigate timeouts, and future optimizations can further reduce overhead.\n\n## Key changes\n- Replace JSON.stringify() anonymization with JSON Pointer–based\ntraversal.\n- Anonymization now only applies to leaf string values (booleans,\nnumbers, image types, etc are ignored).\n\n## Example\n\n### Scenario\nA greedy regex rule to match a url:\n```\n{\n  \"entityClass\": \"URL\",\n  \"type\": \"RegExp\",\n  \"pattern\": \"https?://.+\",\n  \"enabled\": true\n}\n```\n\nWhen the assistant calls the context function and a message like this\ngets created:\n```\n{\n  \"@timestamp\": \"2025-08-20T13:55:40.264Z\",\n  \"message\": {\n    \"content\": \"{\\\"screen_description\\\":\\\"The user is looking at http://localhost:5601/app/observabilityAIAssistant/conversations/new. The current time range is 2025-08-20T13:40:38.609Z - 2025-08-20T13:55:38.609Z.\\\",\\\"learnings\\\":[]}\",\n    \"name\": \"context\",\n    \"role\": \"user\"\n  }\n}\n```\n\n#### Before\ncauses the chat to fail with `Unterminated string in JSON at position\n102 (line 1 column 103)`\n<details>\n<summary>screenshot</summary>\n<img width=\"1174\" height=\"792\" alt=\"Screenshot 2025-08-20 at 09 34 06\"\nsrc=\"https://github.com/user-attachments/assets/49e9bd53-5176-425b-aef1-055352e01240\"\n/>\n</details>\n\n#### After\nNo error and looking in Phoenix, the url was properly anonymized \n`{\"screen_description\":\"The user is looking at\nURL_2bc72338ee1820de9882fc56c5098e9d374d64f2\",\"learnings\":[]}`\n\n---------\n\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>","sha":"c9661098d74c46a773568b3ae0dfa93febe836d6"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232319","number":232319,"mergeCommit":{"message":"[Inference] Refactor anonymization to walk JSON objects instead of stringifying (#232319)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/228461\n\nCurrently, anonymization stringifies objects with JSON.stringify()\nbefore applying rules, which can corrupt JSON when rules accidentally\nmatch quotes, escape sequences, or other syntax. This PR changes the\napproach to walk JSON objects directly so rules only apply to leaf\nstring values. We track locations using JSON Pointer paths, allowing us\nto reconstruct the original object with anonymized data before sending\nit to the LLM.\n\nThis makes anonymization safer and more reliable, but introduces a\ntradeoff for NER inference. Large JSON objects with many leaf values now\ngenerate more documents per request, which will increase latency\ndepending on the size. Configurable model timeouts (added in\n[#228497](https://github.com/elastic/kibana/issues/228497)) help\nmitigate timeouts, and future optimizations can further reduce overhead.\n\n## Key changes\n- Replace JSON.stringify() anonymization with JSON Pointer–based\ntraversal.\n- Anonymization now only applies to leaf string values (booleans,\nnumbers, image types, etc are ignored).\n\n## Example\n\n### Scenario\nA greedy regex rule to match a url:\n```\n{\n  \"entityClass\": \"URL\",\n  \"type\": \"RegExp\",\n  \"pattern\": \"https?://.+\",\n  \"enabled\": true\n}\n```\n\nWhen the assistant calls the context function and a message like this\ngets created:\n```\n{\n  \"@timestamp\": \"2025-08-20T13:55:40.264Z\",\n  \"message\": {\n    \"content\": \"{\\\"screen_description\\\":\\\"The user is looking at http://localhost:5601/app/observabilityAIAssistant/conversations/new. The current time range is 2025-08-20T13:40:38.609Z - 2025-08-20T13:55:38.609Z.\\\",\\\"learnings\\\":[]}\",\n    \"name\": \"context\",\n    \"role\": \"user\"\n  }\n}\n```\n\n#### Before\ncauses the chat to fail with `Unterminated string in JSON at position\n102 (line 1 column 103)`\n<details>\n<summary>screenshot</summary>\n<img width=\"1174\" height=\"792\" alt=\"Screenshot 2025-08-20 at 09 34 06\"\nsrc=\"https://github.com/user-attachments/assets/49e9bd53-5176-425b-aef1-055352e01240\"\n/>\n</details>\n\n#### After\nNo error and looking in Phoenix, the url was properly anonymized \n`{\"screen_description\":\"The user is looking at\nURL_2bc72338ee1820de9882fc56c5098e9d374d64f2\",\"learnings\":[]}`\n\n---------\n\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>","sha":"c9661098d74c46a773568b3ae0dfa93febe836d6"}}]}] BACKPORT-->