### PR TITLE
[ML] Log Rate Analysis: disable smart grouping 

### DIFF
--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_options.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_options.tsx
@@ -131,26 +131,31 @@ export const LogRateAnalysisOptions: FC<LogRateAnalysisOptionsProps> = ({
     },
   ];
 
+  // Temporarily hide smart grouping controls as it is disabled until https://github.com/elastic/kibana/issues/232849 is resolved
+  const smartGroupingDisabled = true;
+
   return (
     <>
-      <EuiFlexItem grow={growFirstItem}>
-        <EuiFlexGroup gutterSize="s" alignItems="center">
-          <EuiFlexItem grow={false}>
-            <EuiText size="xs">{groupResultsMessage}</EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonGroup
-              data-test-subj={`aiopsLogRateAnalysisGroupSwitch${groupResults ? ' checked' : ''}`}
-              buttonSize="s"
-              isDisabled={disabledGroupResultsSwitch}
-              legend={groupResultsMessage}
-              options={toggleButtons}
-              idSelected={toggleIdSelected}
-              onChange={onGroupResultsToggle}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
+      {smartGroupingDisabled ? null : (
+        <EuiFlexItem grow={growFirstItem}>
+          <EuiFlexGroup gutterSize="s" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs">{groupResultsMessage}</EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonGroup
+                data-test-subj={`aiopsLogRateAnalysisGroupSwitch${groupResults ? ' checked' : ''}`}
+                buttonSize="s"
+                isDisabled={disabledGroupResultsSwitch}
+                legend={groupResultsMessage}
+                options={toggleButtons}
+                idSelected={toggleIdSelected}
+                onChange={onGroupResultsToggle}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      )}
       <EuiFlexItem grow={false}>
         <FieldFilterPopover
           dataTestSubj="aiopsFieldFilterButton"

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_results.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_results.tsx
@@ -359,8 +359,7 @@ export const LogRateAnalysisResults: FC<LogRateAnalysisResultsProps> = ({
               <EuiToolTip
                 position="top"
                 content={i18n.translate('xpack.aiops.logRateAnalysis.optionsButtonTooltip', {
-                  defaultMessage:
-                    'Options to customize the analysis, such as filtering fields and grouping.',
+                  defaultMessage: 'Options to customize the analysis, such as filtering fields.',
                 })}
               >
                 <EuiButtonIcon

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_results.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_results.tsx
@@ -258,7 +258,8 @@ export const LogRateAnalysisResults: FC<LogRateAnalysisResultsProps> = ({
         // TODO Handle data view without time fields.
         timeFieldName: dataView.timeFieldName ?? '',
         index: dataView.getIndexPattern(),
-        grouping: true,
+        // Temporarily disable grouping until https://github.com/elastic/kibana/issues/232849 is resolved.
+        grouping: false,
         flushFix: true,
         // If analysis type is `spike`, pass on window parameters as is,
         // if it's `dip`, swap baseline and deviation.

--- a/x-pack/platform/test/functional/apps/aiops/log_rate_analysis.ts
+++ b/x-pack/platform/test/functional/apps/aiops/log_rate_analysis.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import { orderBy } from 'lodash';
-
 import expect from '@kbn/expect';
 
 import type { FtrProviderContext } from '../../ftr_provider_context';
@@ -18,7 +16,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const browser = getService('browser');
   const elasticChart = getService('elasticChart');
   const aiops = getService('aiops');
-  const retry = getService('retry');
 
   // AIOps / Log Rate Analysis lives in the ML UI so we need some related services.
   const ml = getService('ml');
@@ -187,39 +184,39 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       );
 
       // The group switch should be disabled by default
-      await aiops.logRateAnalysisPage.assertLogRateAnalysisResultsGroupSwitchExists(false);
+      // await aiops.logRateAnalysisPage.assertLogRateAnalysisResultsGroupSwitchExists(false);
 
-      await retry.tryForTime(30 * 1000, async () => {
-        if (!isTestDataExpectedWithSampleProbability(testData.expected)) {
-          // Enabled grouping
-          await aiops.logRateAnalysisPage.clickLogRateAnalysisResultsGroupSwitchOn();
+      // await retry.tryForTime(30 * 1000, async () => {
+      //   if (!isTestDataExpectedWithSampleProbability(testData.expected)) {
+      //     // Enabled grouping
+      //     await aiops.logRateAnalysisPage.clickLogRateAnalysisResultsGroupSwitchOn();
 
-          await aiops.logRateAnalysisResultsGroupsTable.assertLogRateAnalysisResultsTableExists();
-          await aiops.logRateAnalysisResultsGroupsTable.scrollAnalysisTableIntoView();
+      //     await aiops.logRateAnalysisResultsGroupsTable.assertLogRateAnalysisResultsTableExists();
+      //     await aiops.logRateAnalysisResultsGroupsTable.scrollAnalysisTableIntoView();
 
-          const analysisGroupsTable =
-            await aiops.logRateAnalysisResultsGroupsTable.parseAnalysisTable();
+      //     const analysisGroupsTable =
+      //       await aiops.logRateAnalysisResultsGroupsTable.parseAnalysisTable();
 
-          const actualAnalysisGroupsTable = orderBy(analysisGroupsTable, 'group');
-          const expectedAnalysisGroupsTable = orderBy(
-            testData.expected.analysisGroupsTable,
-            'group'
-          );
+      //     const actualAnalysisGroupsTable = orderBy(analysisGroupsTable, 'group');
+      //     const expectedAnalysisGroupsTable = orderBy(
+      //       testData.expected.analysisGroupsTable,
+      //       'group'
+      //     );
 
-          expect(actualAnalysisGroupsTable).to.be.eql(
-            expectedAnalysisGroupsTable,
-            `Expected analysis groups table to be ${JSON.stringify(
-              expectedAnalysisGroupsTable
-            )}, got ${JSON.stringify(actualAnalysisGroupsTable)}`
-          );
-        }
-      });
+      //     expect(actualAnalysisGroupsTable).to.be.eql(
+      //       expectedAnalysisGroupsTable,
+      //       `Expected analysis groups table to be ${JSON.stringify(
+      //         expectedAnalysisGroupsTable
+      //       )}, got ${JSON.stringify(actualAnalysisGroupsTable)}`
+      //     );
+      //   }
+      // });
 
       if (!isTestDataExpectedWithSampleProbability(testData.expected)) {
-        await ml.testExecution.logTestStep('expand table row');
-        await aiops.logRateAnalysisResultsGroupsTable.assertExpandRowButtonExists();
-        await aiops.logRateAnalysisResultsGroupsTable.expandRow();
-        await aiops.logRateAnalysisResultsGroupsTable.scrollAnalysisTableIntoView();
+        // await ml.testExecution.logTestStep('expand table row');
+        // await aiops.logRateAnalysisResultsGroupsTable.assertExpandRowButtonExists();
+        // await aiops.logRateAnalysisResultsGroupsTable.expandRow();
+        // await aiops.logRateAnalysisResultsGroupsTable.scrollAnalysisTableIntoView();
 
         await ml.testExecution.logTestStep('open the column filter');
         await aiops.logRateAnalysisPage.assertFilterPopoverButtonExists(
@@ -227,35 +224,35 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           false
         );
         await aiops.logRateAnalysisPage.clickFilterPopoverButton('aiopsColumnFilterButton', true);
-        await aiops.logRateAnalysisPage.assertFieldSelectorFieldNameList(
-          testData.expected.columnSelectorPopover
-        );
+        // await aiops.logRateAnalysisPage.assertFieldSelectorFieldNameList(
+        //   testData.expected.columnSelectorPopover
+        // );
 
         await ml.testExecution.logTestStep('filter columns');
         await aiops.logRateAnalysisPage.setFieldSelectorSearch(testData.columnSelectorSearch);
-        await aiops.logRateAnalysisPage.assertFieldSelectorFieldNameList([
-          testData.columnSelectorSearch,
-        ]);
+        // await aiops.logRateAnalysisPage.assertFieldSelectorFieldNameList([
+        //   testData.columnSelectorSearch,
+        // ]);
         await aiops.logRateAnalysisPage.clickFieldSelectorListItem(
           'aiopsFieldSelectorFieldNameListItem'
         );
         await aiops.logRateAnalysisPage.assertFieldFilterApplyButtonExists(false);
         await aiops.logRateAnalysisPage.clickFieldFilterApplyButton('aiopsColumnFilterButton');
 
-        const analysisTable = await aiops.logRateAnalysisResultsTable.parseAnalysisTable();
+        // const analysisTable = await aiops.logRateAnalysisResultsTable.parseAnalysisTable();
 
-        const actualAnalysisTable = orderBy(analysisTable, ['fieldName', 'fieldValue']);
-        const expectedAnalysisTable = orderBy(testData.expected.analysisTable, [
-          'fieldName',
-          'fieldValue',
-        ]);
+        // const actualAnalysisTable = orderBy(analysisTable, ['fieldName', 'fieldValue']);
+        // const expectedAnalysisTable = orderBy(testData.expected.analysisTable, [
+        //   'fieldName',
+        //   'fieldValue',
+        // ]);
 
-        expect(actualAnalysisTable).to.be.eql(
-          expectedAnalysisTable,
-          `Expected analysis table results to be ${JSON.stringify(
-            expectedAnalysisTable
-          )}, got ${JSON.stringify(actualAnalysisTable)}`
-        );
+        // expect(actualAnalysisTable).to.be.eql(
+        //   expectedAnalysisTable,
+        //   `Expected analysis table results to be ${JSON.stringify(
+        //     expectedAnalysisTable
+        //   )}, got ${JSON.stringify(actualAnalysisTable)}`
+        // );
 
         await ml.testExecution.logTestStep('open the field filter');
         await aiops.logRateAnalysisPage.assertFilterPopoverButtonExists(
@@ -277,50 +274,49 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           !testData.fieldSelectorApplyAvailable
         );
 
-        if (testData.fieldSelectorApplyAvailable) {
-          await ml.testExecution.logTestStep('regroup results');
-          await aiops.logRateAnalysisPage.clickFieldFilterApplyButton('aiopsFieldFilterButton');
+        // if (testData.fieldSelectorApplyAvailable) {
+        //   await ml.testExecution.logTestStep('regroup results');
+        //   await aiops.logRateAnalysisPage.clickFieldFilterApplyButton('aiopsFieldFilterButton');
 
-          const filteredAnalysisGroupsTable =
-            await aiops.logRateAnalysisResultsGroupsTable.parseAnalysisTable();
+        //   const filteredAnalysisGroupsTable =
+        //     await aiops.logRateAnalysisResultsGroupsTable.parseAnalysisTable();
 
-          const actualFilteredAnalysisGroupsTable = orderBy(filteredAnalysisGroupsTable, 'group');
-          const expectedFilteredAnalysisGroupsTable = orderBy(
-            testData.expected.filteredAnalysisGroupsTable,
-            'group'
-          );
+        //   const actualFilteredAnalysisGroupsTable = orderBy(filteredAnalysisGroupsTable, 'group');
+        //   const expectedFilteredAnalysisGroupsTable = orderBy(
+        //     testData.expected.filteredAnalysisGroupsTable,
+        //     'group'
+        //   );
 
-          expect(actualFilteredAnalysisGroupsTable).to.be.eql(
-            expectedFilteredAnalysisGroupsTable,
-            `Expected filtered analysis groups table to be ${JSON.stringify(
-              expectedFilteredAnalysisGroupsTable
-            )}, got ${JSON.stringify(actualFilteredAnalysisGroupsTable)}`
-          );
-        }
+        //   expect(actualFilteredAnalysisGroupsTable).to.be.eql(
+        //     expectedFilteredAnalysisGroupsTable,
+        //     `Expected filtered analysis groups table to be ${JSON.stringify(
+        //       expectedFilteredAnalysisGroupsTable
+        //     )}, got ${JSON.stringify(actualFilteredAnalysisGroupsTable)}`
+        //   );
+        // }
 
-        if (testData.action !== undefined) {
-          await ml.testExecution.logTestStep('check all table row actions are present');
-          await aiops.logRateAnalysisResultsGroupsTable.assertRowActions(
-            testData.action.tableRowId
-          );
-
-          await ml.testExecution.logTestStep('click log pattern analysis action');
-          await aiops.logRateAnalysisResultsGroupsTable.clickRowAction(
-            testData.action.tableRowId,
-            testData.action.type
-          );
-
-          await ml.testExecution.logTestStep('check log pattern analysis page loaded correctly');
-          await aiops.logPatternAnalysisPage.assertLogPatternAnalysisPageExists();
-          await aiops.logPatternAnalysisPage.assertTotalDocumentCount(
-            testData.action.expected.totalDocCount
-          );
-          await aiops.logPatternAnalysisPage.assertQueryInput(testData.action.expected.queryBar);
-        }
+        // if (testData.action !== undefined) {
+        //   await ml.testExecution.logTestStep('check all table row actions are present');
+        //   await aiops.logRateAnalysisResultsGroupsTable.assertRowActions(
+        //     testData.action.tableRowId
+        //   );
+        //   await ml.testExecution.logTestStep('click log pattern analysis action');
+        //   await aiops.logRateAnalysisResultsGroupsTable.clickRowAction(
+        //     testData.action.tableRowId,
+        //     testData.action.type
+        //   );
+        //   await ml.testExecution.logTestStep('check log pattern analysis page loaded correctly');
+        //   await aiops.logPatternAnalysisPage.assertLogPatternAnalysisPageExists();
+        //   await aiops.logPatternAnalysisPage.assertTotalDocumentCount(
+        //     testData.action.expected.totalDocCount
+        //   );
+        //   await aiops.logPatternAnalysisPage.assertQueryInput(testData.action.expected.queryBar);
+        // }
       }
     });
   }
-
+  // Temporarily comment out tests referencing smart grouping controls/table
+  // as it is disabled until https://github.com/elastic/kibana/issues/232849 is resolved
   describe('log rate analysis', function () {
     for (const testData of logRateAnalysisTestData) {
       describe(`with '${testData.sourceIndexOrSavedSearch}'`, function () {


### PR DESCRIPTION
## Summary

Related issue: https://github.com/elastic/kibana/issues/232849
The grouping functionality in log rate analysis might require some performance optimizations. This PR disables the grouping functionality in the short term, while potential long term optimizations are investigated.

- [x] disable smart grouping
- [x] hide smart grouping controls

<img width="1498" height="950" alt="image" src="https://github.com/user-attachments/assets/afd93ee5-a611-420c-b94e-8448ecf81e91" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




