### PR TITLE
[8.19] [Response Ops][Alerting] Maintenance windows with scoped query should apply to all rule types (#232307)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/alert/alert.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alert/alert.test.ts
@@ -26,6 +26,27 @@ describe('getId()', () => {
   });
 });
 
+describe('matchesUuid()', () => {
+  test('returns true if alert UUID matches given uuid', () => {
+    const alert = new Alert<AlertInstanceState, AlertInstanceContext, DefaultActionGroupId>('1');
+    const uuid = alert.getUuid();
+
+    expect(alert.matchesUuid(uuid)).toBe(true);
+  });
+
+  test('returns true if alert ID matches given uuid', () => {
+    const alert = new Alert<AlertInstanceState, AlertInstanceContext, DefaultActionGroupId>('123');
+
+    expect(alert.matchesUuid('123')).toBe(true);
+  });
+
+  test('returns false if neither alert ID or UUID matches given uuid', () => {
+    const alert = new Alert<AlertInstanceState, AlertInstanceContext, DefaultActionGroupId>('123');
+
+    expect(alert.matchesUuid('xyz')).toBe(false);
+  });
+});
+
 describe('hasScheduledActions()', () => {
   test('defaults to false', () => {
     const alert = new Alert<AlertInstanceState, AlertInstanceContext, DefaultActionGroupId>('1');

--- a/x-pack/platform/plugins/shared/alerting/server/alert/alert.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alert/alert.ts
@@ -81,6 +81,10 @@ export class Alert<
     return this.meta.uuid!;
   }
 
+  matchesUuid(uuid: string): boolean {
+    return this.meta.uuid === uuid || this.id === uuid;
+  }
+
   isAlertAsData() {
     return this.alertAsData !== undefined;
   }

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.mock.ts
@@ -25,6 +25,7 @@ const createAlertsClientMock = () => {
       determineDelayedAlerts: jest.fn(),
       determineFlappingAlerts: jest.fn(),
       getTrackedExecutions: jest.fn(),
+      updatePersistedAlertsWithMaintenanceWindowIds: jest.fn(),
     };
   });
 };

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.test.ts
@@ -347,6 +347,7 @@ describe('Alerts Client', () => {
     describe(`using ${label} for alert indices`, () => {
       beforeEach(() => {
         jest.clearAllMocks();
+        jest.restoreAllMocks();
         logger = loggingSystemMock.createLogger();
         alertsClientParams = {
           alertingEventLogger,
@@ -721,41 +722,6 @@ describe('Alerts Client', () => {
           });
         });
 
-        test('should index new alerts even if updatePersistedAlertsWithMaintenanceWindowIds fails', async () => {
-          const alertsClient = new AlertsClient<{}, {}, {}, 'default', 'recovered'>({
-            ...alertsClientParams,
-            isServerless: true,
-          });
-
-          await alertsClient.initializeExecution(defaultExecutionOpts);
-
-          // Report 2 new alerts
-          const alertExecutorService = alertsClient.factory();
-          alertExecutorService.create('1').scheduleActions('default');
-          alertExecutorService.create('2').scheduleActions('default');
-
-          await alertsClient.processAlerts();
-          alertsClient.determineFlappingAlerts();
-          alertsClient.determineDelayedAlerts(determineDelayedAlertsOpts);
-          alertsClient.logAlerts(logAlertsOpts);
-
-          maintenanceWindowsService.getMaintenanceWindows.mockRejectedValue(
-            'Failed to fetch maintenance windows'
-          );
-
-          const result = await alertsClient.persistAlerts();
-
-          expect(logger.error).toHaveBeenCalledWith(
-            'Error updating maintenance window IDs:',
-            'Failed to fetch maintenance windows'
-          );
-
-          expect(result).toEqual({
-            alertIds: [],
-            maintenanceWindowIds: [],
-          });
-        });
-
         test('should index new alerts with refresh: true in stateless', async () => {
           const alertsClient = new AlertsClient<{}, {}, {}, 'default', 'recovered'>({
             ...alertsClientParams,
@@ -1079,10 +1045,9 @@ describe('Alerts Client', () => {
 
           await alertsClient.persistAlerts();
 
-          expect(spy).toHaveBeenCalledTimes(5);
+          expect(spy).toHaveBeenCalledTimes(2);
           expect(spy).toHaveBeenNthCalledWith(1, 'active');
           expect(spy).toHaveBeenNthCalledWith(2, 'recovered');
-          expect(spy).toHaveBeenNthCalledWith(3, 'new');
 
           expect(logger.error).toHaveBeenCalledWith(
             `Error writing alert(2) to .alerts-test.alerts-default - alert(2) doesn't exist in active alerts ${ruleInfo}.`,
@@ -1871,10 +1836,7 @@ describe('Alerts Client', () => {
             alertsClientParams
           );
 
-          expect(await alertsClient.persistAlerts()).toStrictEqual({
-            alertIds: [],
-            maintenanceWindowIds: [],
-          });
+          await alertsClient.persistAlerts();
 
           expect(logger.debug).toHaveBeenCalledWith(
             `Resources registered and installed for test context but "shouldWrite" is set to false ${ruleInfo}.`,
@@ -2526,7 +2488,63 @@ describe('Alerts Client', () => {
       });
 
       describe('updatePersistedAlertsWithMaintenanceWindowIds', () => {
-        test('should update alerts with MW ids when provided with maintenance windows', async () => {
+        test('skips loading maintenance windows when there are no alerts', async () => {
+          const alertsClient = new AlertsClient(alertsClientParams);
+
+          jest.spyOn(LegacyAlertsClient.prototype, 'getProcessedAlerts').mockReturnValueOnce({});
+
+          const result = await alertsClient.updatePersistedAlertsWithMaintenanceWindowIds();
+
+          expect(maintenanceWindowsService.getMaintenanceWindows).not.toHaveBeenCalled();
+
+          expect(result).toEqual({ alertIds: [], maintenanceWindowIds: [] });
+        });
+
+        test('should not update alerts if none match the maintenenance window scoped query', async () => {
+          maintenanceWindowsService.getMaintenanceWindows.mockReturnValue({
+            maintenanceWindows: [
+              ...getParamsByUpdateMaintenanceWindowIds.maintenanceWindows,
+              { id: 'mw3' } as unknown as MaintenanceWindow,
+            ],
+            maintenanceWindowsWithoutScopedQueryIds: [],
+          });
+          const alertsClient = new AlertsClient(alertsClientParams);
+
+          const alert1 = new Alert('1');
+          const alert2 = new Alert('2');
+          const alert3 = new Alert('3');
+          const alert4 = new Alert('4');
+
+          jest.spyOn(LegacyAlertsClient.prototype, 'getProcessedAlerts').mockReturnValueOnce({
+            '1': alert1,
+            '2': alert2,
+            '3': alert3,
+            '4': alert4,
+          });
+
+          jest
+            // @ts-ignore
+            .spyOn(AlertsClient.prototype, 'getMaintenanceWindowScopedQueryAlerts')
+            // @ts-ignore
+            .mockResolvedValueOnce({});
+
+          const updateSpy = jest
+            // @ts-ignore
+            .spyOn(AlertsClient.prototype, 'updateAlertMaintenanceWindowIds')
+            // @ts-ignore
+            .mockResolvedValueOnce({});
+
+          const result = await alertsClient.updatePersistedAlertsWithMaintenanceWindowIds();
+
+          expect(alert1.getMaintenanceWindowIds()).toEqual([]);
+          expect(alert2.getMaintenanceWindowIds()).toEqual([]);
+          expect(alert3.getMaintenanceWindowIds()).toEqual([]);
+
+          expect(result).toEqual({ alertIds: [], maintenanceWindowIds: [] });
+          expect(updateSpy).not.toHaveBeenCalled();
+        });
+
+        test('should update alerts based on alert uuid with MW ids when provided with maintenance windows', async () => {
           maintenanceWindowsService.getMaintenanceWindows.mockReturnValueOnce({
             maintenanceWindows: [
               ...getParamsByUpdateMaintenanceWindowIds.maintenanceWindows,
@@ -2563,7 +2581,6 @@ describe('Alerts Client', () => {
             // @ts-ignore
             .mockResolvedValueOnce({});
 
-          // @ts-ignore - accessing private function
           const result = await alertsClient.updatePersistedAlertsWithMaintenanceWindowIds();
 
           expect(alert1.getMaintenanceWindowIds()).toEqual(['mw3', 'mw1']);
@@ -2580,6 +2597,123 @@ describe('Alerts Client', () => {
             alert2.getUuid(),
             alert3.getUuid(),
           ]);
+        });
+
+        test('should update alerts based on alert id with MW ids when provided with maintenance windows', async () => {
+          maintenanceWindowsService.getMaintenanceWindows.mockReturnValueOnce({
+            maintenanceWindows: [
+              ...getParamsByUpdateMaintenanceWindowIds.maintenanceWindows,
+              { id: 'mw3' } as unknown as MaintenanceWindow,
+            ],
+            maintenanceWindowsWithoutScopedQueryIds: [],
+          });
+          const alertsClient = new AlertsClient(alertsClientParams);
+
+          const alert1 = new Alert('1');
+          const alert2 = new Alert('2');
+          const alert3 = new Alert('3');
+          const alert4 = new Alert('4');
+
+          jest.spyOn(LegacyAlertsClient.prototype, 'getProcessedAlerts').mockReturnValueOnce({
+            '1': alert1,
+            '2': alert2,
+            '3': alert3,
+            '4': alert4,
+          });
+
+          jest
+            // @ts-ignore
+            .spyOn(AlertsClient.prototype, 'getMaintenanceWindowScopedQueryAlerts')
+            // @ts-ignore
+            .mockResolvedValueOnce({
+              mw1: [alert1.getId(), alert2.getId()],
+              mw2: [alert3.getId()],
+            });
+
+          const updateSpy = jest
+            // @ts-ignore
+            .spyOn(AlertsClient.prototype, 'updateAlertMaintenanceWindowIds')
+            // @ts-ignore
+            .mockResolvedValueOnce({});
+
+          const result = await alertsClient.updatePersistedAlertsWithMaintenanceWindowIds();
+
+          expect(alert1.getMaintenanceWindowIds()).toEqual(['mw3', 'mw1']);
+          expect(alert2.getMaintenanceWindowIds()).toEqual(['mw3', 'mw1']);
+          expect(alert3.getMaintenanceWindowIds()).toEqual(['mw3', 'mw2']);
+
+          expect(result).toEqual({
+            alertIds: [alert1.getId(), alert2.getId(), alert3.getId()],
+            maintenanceWindowIds: ['mw3', 'mw1', 'mw2'],
+          });
+
+          expect(updateSpy).toHaveBeenLastCalledWith([
+            alert1.getId(),
+            alert2.getId(),
+            alert3.getId(),
+          ]);
+        });
+
+        test('should handle errors update alerts with MW ids', async () => {
+          maintenanceWindowsService.getMaintenanceWindows.mockReturnValueOnce({
+            maintenanceWindows: [
+              ...getParamsByUpdateMaintenanceWindowIds.maintenanceWindows,
+              { id: 'mw3' } as unknown as MaintenanceWindow,
+            ],
+            maintenanceWindowsWithoutScopedQueryIds: [],
+          });
+          const alertsClient = new AlertsClient(alertsClientParams);
+
+          const alert1 = new Alert('1');
+          const alert2 = new Alert('2');
+          const alert3 = new Alert('3');
+          const alert4 = new Alert('4');
+
+          jest.spyOn(LegacyAlertsClient.prototype, 'getProcessedAlerts').mockReturnValueOnce({
+            '1': alert1,
+            '2': alert2,
+            '3': alert3,
+            '4': alert4,
+          });
+
+          jest
+            // @ts-ignore
+            .spyOn(AlertsClient.prototype, 'getMaintenanceWindowScopedQueryAlerts')
+            // @ts-ignore
+            .mockResolvedValueOnce({
+              mw1: [alert1.getId(), alert2.getId()],
+              mw2: [alert3.getId()],
+            });
+
+          const updateSpy = jest
+            // @ts-ignore
+            .spyOn(AlertsClient.prototype, 'updateAlertMaintenanceWindowIds')
+            // @ts-ignore
+            .mockImplementationOnce(() => {
+              throw new Error('Failed to update alerts with maintenance window IDs');
+            });
+
+          const result = await alertsClient.updatePersistedAlertsWithMaintenanceWindowIds();
+
+          expect(alert1.getMaintenanceWindowIds()).toEqual(['mw3', 'mw1']);
+          expect(alert2.getMaintenanceWindowIds()).toEqual(['mw3', 'mw1']);
+          expect(alert3.getMaintenanceWindowIds()).toEqual(['mw3', 'mw2']);
+
+          expect(result).toEqual({
+            alertIds: [],
+            maintenanceWindowIds: [],
+          });
+
+          expect(updateSpy).toHaveBeenLastCalledWith([
+            alert1.getId(),
+            alert2.getId(),
+            alert3.getId(),
+          ]);
+
+          expect(logger.error).toHaveBeenCalledWith(
+            `Error updating maintenance window IDs: Failed to update alerts with maintenance window IDs`,
+            logTags
+          );
         });
       });
 

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.ts
@@ -401,17 +401,6 @@ export class AlertsClient<
     return this.legacyAlertsClient.getProcessedAlerts(type);
   }
 
-  public async persistAlerts(): Promise<AlertsAffectedByMaintenanceWindows> {
-    // Persist alerts first
-    await this.persistAlertsHelper();
-    try {
-      return await this.updatePersistedAlertsWithMaintenanceWindowIds();
-    } catch (err) {
-      this.options.logger.error('Error updating maintenance window IDs:', err);
-      return { alertIds: [], maintenanceWindowIds: [] };
-    }
-  }
-
   public getRawAlertInstancesForState(shouldOptimizeTaskState?: boolean) {
     return this.legacyAlertsClient.getRawAlertInstancesForState(shouldOptimizeTaskState);
   }
@@ -478,7 +467,7 @@ export class AlertsClient<
     };
   }
 
-  private async persistAlertsHelper() {
+  public async persistAlerts() {
     if (!this.ruleType.alerts?.shouldWrite) {
       this.options.logger.debug(
         `Resources registered and installed for ${this.ruleType.alerts?.context} context but "shouldWrite" is set to false ${this.ruleInfoMessage}.`,
@@ -759,7 +748,7 @@ export class AlertsClient<
     const params: Record<string, string[]> = {};
 
     idsToUpdate.forEach((id) => {
-      const newAlert = newAlerts.find((alert) => alert.getUuid() === id);
+      const newAlert = newAlerts.find((alert) => alert.matchesUuid(id));
       if (newAlert) {
         params[id] = newAlert.getMaintenanceWindowIds();
       }
@@ -772,6 +761,7 @@ export class AlertsClient<
             _id: idsToUpdate,
           },
         },
+        refresh: true,
         conflicts: 'proceed',
         index: this.indexTemplateAndPattern.alias,
         script: {
@@ -794,102 +784,106 @@ export class AlertsClient<
     }
   }
 
-  private async updatePersistedAlertsWithMaintenanceWindowIds(): Promise<AlertsAffectedByMaintenanceWindows> {
-    // check if there are any alerts
-    const newAlerts = Object.values(this.legacyAlertsClient.getProcessedAlerts('new'));
-    const activeAlerts = Object.values(this.legacyAlertsClient.getProcessedAlerts('active'));
-    const recoveredAlerts = Object.values(this.legacyAlertsClient.getProcessedAlerts('recovered'));
+  public async updatePersistedAlertsWithMaintenanceWindowIds(): Promise<AlertsAffectedByMaintenanceWindows> {
+    try {
+      // check if there are any alerts
+      const newAlerts = Object.values(this.legacyAlertsClient.getProcessedAlerts('new'));
+      const activeAlerts = Object.values(this.legacyAlertsClient.getProcessedAlerts('active'));
+      const recoveredAlerts = Object.values(
+        this.legacyAlertsClient.getProcessedAlerts('recovered')
+      );
 
-    // return if there are no alerts written
-    if (
-      (!newAlerts.length && !activeAlerts.length && !recoveredAlerts.length) ||
-      !this.options.maintenanceWindowsService
-    ) {
+      // return if there are no alerts written
+      if (
+        (!newAlerts.length && !activeAlerts.length && !recoveredAlerts.length) ||
+        !this.options.maintenanceWindowsService
+      ) {
+        return {
+          alertIds: [],
+          maintenanceWindowIds: [],
+        };
+      }
+
+      const { maintenanceWindows } =
+        await this.options.maintenanceWindowsService.getMaintenanceWindows({
+          eventLogger: this.options.alertingEventLogger,
+          request: this.options.request,
+          ruleTypeCategory: this.ruleType.category,
+          spaceId: this.options.spaceId,
+        });
+
+      const maintenanceWindowsWithScopedQuery = filterMaintenanceWindows({
+        maintenanceWindows: maintenanceWindows ?? [],
+        withScopedQuery: true,
+      });
+      const maintenanceWindowsWithoutScopedQueryIds = filterMaintenanceWindowsIds({
+        maintenanceWindows: maintenanceWindows ?? [],
+        withScopedQuery: false,
+      });
+      if (maintenanceWindowsWithScopedQuery.length === 0) {
+        return {
+          alertIds: [],
+          maintenanceWindowIds: maintenanceWindowsWithoutScopedQueryIds,
+        };
+      }
+
+      // Run aggs to get all scoped query alert IDs, returns a record<maintenanceWindowId, alertIds>,
+      // indicating the maintenance window has matches a number of alerts with the scoped query.
+      const alertsByMaintenanceWindowIds = await this.getMaintenanceWindowScopedQueryAlerts({
+        ruleId: this.options.rule.id,
+        spaceId: this.options.rule.spaceId,
+        executionUuid: this.options.rule.executionId,
+        maintenanceWindows: maintenanceWindowsWithScopedQuery,
+      });
+
+      const alertsAffectedByScopedQuery: string[] = [];
+      const appliedMaintenanceWindowIds: string[] = [];
+
+      for (const [scopedQueryMaintenanceWindowId, alertIds] of Object.entries(
+        alertsByMaintenanceWindowIds
+      )) {
+        // Go through matched alerts, find the in memory object
+        alertIds.forEach((alertId) => {
+          const newAlert = newAlerts.find((alert) => alert.matchesUuid(alertId));
+          if (!newAlert) {
+            return;
+          }
+
+          const newMaintenanceWindowIds = [
+            // Keep existing Ids
+            ...newAlert.getMaintenanceWindowIds(),
+            // Add the ids that don't have scoped queries
+            ...maintenanceWindowsWithoutScopedQueryIds,
+            // Add the scoped query id
+            scopedQueryMaintenanceWindowId,
+          ];
+
+          // Update in memory alert with new maintenance window IDs
+          newAlert.setMaintenanceWindowIds([...new Set(newMaintenanceWindowIds)]);
+
+          alertsAffectedByScopedQuery.push(alertId);
+          appliedMaintenanceWindowIds.push(...newMaintenanceWindowIds);
+        });
+      }
+
+      const uniqueAlertsId = [...new Set(alertsAffectedByScopedQuery)];
+      const uniqueMaintenanceWindowIds = [...new Set(appliedMaintenanceWindowIds)];
+
+      if (uniqueAlertsId.length) {
+        await this.updateAlertMaintenanceWindowIds(uniqueAlertsId);
+      }
+
       return {
-        alertIds: [],
-        maintenanceWindowIds: [],
+        alertIds: uniqueAlertsId,
+        maintenanceWindowIds: uniqueMaintenanceWindowIds,
       };
+    } catch (err) {
+      this.options.logger.error(
+        `Error updating maintenance window IDs: ${err.message}`,
+        this.logTags
+      );
+      return { alertIds: [], maintenanceWindowIds: [] };
     }
-
-    const { maintenanceWindows } =
-      await this.options.maintenanceWindowsService.getMaintenanceWindows({
-        eventLogger: this.options.alertingEventLogger,
-        request: this.options.request,
-        ruleTypeCategory: this.ruleType.category,
-        spaceId: this.options.spaceId,
-      });
-
-    const maintenanceWindowsWithScopedQuery = filterMaintenanceWindows({
-      maintenanceWindows: maintenanceWindows ?? [],
-      withScopedQuery: true,
-    });
-    const maintenanceWindowsWithoutScopedQueryIds = filterMaintenanceWindowsIds({
-      maintenanceWindows: maintenanceWindows ?? [],
-      withScopedQuery: false,
-    });
-    if (maintenanceWindowsWithScopedQuery.length === 0) {
-      return {
-        alertIds: [],
-        maintenanceWindowIds: maintenanceWindowsWithoutScopedQueryIds,
-      };
-    }
-
-    // Run aggs to get all scoped query alert IDs, returns a record<maintenanceWindowId, alertIds>,
-    // indicating the maintenance window has matches a number of alerts with the scoped query.
-    const alertsByMaintenanceWindowIds = await this.getMaintenanceWindowScopedQueryAlerts({
-      ruleId: this.options.rule.id,
-      spaceId: this.options.rule.spaceId,
-      executionUuid: this.options.rule.executionId,
-      maintenanceWindows: maintenanceWindowsWithScopedQuery,
-    });
-
-    const alertsAffectedByScopedQuery: string[] = [];
-    const appliedMaintenanceWindowIds: string[] = [];
-
-    for (const [scopedQueryMaintenanceWindowId, alertIds] of Object.entries(
-      alertsByMaintenanceWindowIds
-    )) {
-      // Go through matched alerts, find the in memory object
-      alertIds.forEach((alertId) => {
-        const newAlert = newAlerts.find((alert) => alert.getUuid() === alertId);
-        if (!newAlert) {
-          return;
-        }
-
-        const newMaintenanceWindowIds = [
-          // Keep existing Ids
-          ...newAlert.getMaintenanceWindowIds(),
-          // Add the ids that don't have scoped queries
-          ...maintenanceWindowsWithoutScopedQueryIds,
-          // Add the scoped query id
-          scopedQueryMaintenanceWindowId,
-        ];
-
-        // Update in memory alert with new maintenance window IDs
-        newAlert.setMaintenanceWindowIds([...new Set(newMaintenanceWindowIds)]);
-
-        alertsAffectedByScopedQuery.push(newAlert.getUuid());
-        appliedMaintenanceWindowIds.push(...newMaintenanceWindowIds);
-      });
-    }
-
-    const uniqueAlertsId = [...new Set(alertsAffectedByScopedQuery)];
-    const uniqueMaintenanceWindowIds = [...new Set(appliedMaintenanceWindowIds)];
-
-    if (uniqueAlertsId.length) {
-      // Update alerts with new maintenance window IDs, await not needed
-      this.updateAlertMaintenanceWindowIds(uniqueAlertsId).catch(() => {
-        this.options.logger.debug(
-          `Failed to update new alerts with scoped query maintenance window Ids by updateByQuery ${this.ruleInfoMessage}.`,
-          this.logTags
-        );
-      });
-    }
-
-    return {
-      alertIds: uniqueAlertsId,
-      maintenanceWindowIds: uniqueMaintenanceWindowIds,
-    };
   }
 
   public client() {

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/legacy_alerts_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/legacy_alerts_client.mock.ts
@@ -23,6 +23,7 @@ const createLegacyAlertsClientMock = () => {
       determineDelayedAlerts: jest.fn(),
       determineFlappingAlerts: jest.fn(),
       getTrackedExecutions: jest.fn(),
+      updatePersistedAlertsWithMaintenanceWindowIds: jest.fn(),
     };
   });
 };

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/legacy_alerts_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/legacy_alerts_client.ts
@@ -282,6 +282,10 @@ export class LegacyAlertsClient<
   }
 
   public async persistAlerts() {
+    return;
+  }
+
+  public async updatePersistedAlertsWithMaintenanceWindowIds() {
     return null;
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/types.ts
@@ -82,7 +82,11 @@ export interface IAlertsClient<
   getProcessedAlerts(
     type: 'recovered' | 'trackedRecoveredAlerts'
   ): Record<string, LegacyAlert<State, Context, RecoveryActionGroupId>> | {};
-  persistAlerts(): Promise<{ alertIds: string[]; maintenanceWindowIds: string[] } | null>;
+  persistAlerts(): Promise<void>;
+  updatePersistedAlertsWithMaintenanceWindowIds(): Promise<{
+    alertIds: string[];
+    maintenanceWindowIds: string[];
+  } | null>;
   isTrackedAlert(id: string): boolean;
   getSummarizedAlerts?(params: GetSummarizedAlertsParams): Promise<SummarizedAlerts>;
   getRawAlertInstancesForState(shouldOptimizeTaskState?: boolean): {

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/action_scheduler.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/action_scheduler.test.ts
@@ -1890,13 +1890,13 @@ describe('Action Scheduler', () => {
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledTimes(3);
 
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledWith(
-      'no scheduling of summary actions "1" for rule "1": has active maintenance windows test-id-1.'
+      'no scheduling of actions "1" for alert "1" from rule "1": has active maintenance windows test-id-1.'
     );
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledWith(
-      'no scheduling of summary actions "1" for rule "1": has active maintenance windows test-id-2.'
+      'no scheduling of actions "1" for alert "2" from rule "1": has active maintenance windows test-id-2.'
     );
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledWith(
-      'no scheduling of summary actions "1" for rule "1": has active maintenance windows test-id-3.'
+      'no scheduling of actions "1" for alert "3" from rule "1": has active maintenance windows test-id-3.'
     );
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/per_alert_action_scheduler.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/per_alert_action_scheduler.test.ts
@@ -317,11 +317,11 @@ describe('Per-Alert Action Scheduler', () => {
       expect(logger.debug).toHaveBeenCalledTimes(2);
       expect(logger.debug).toHaveBeenNthCalledWith(
         1,
-        `no scheduling of summary actions \"action-1\" for rule \"rule-id-1\": has active maintenance windows mw-1.`
+        `no scheduling of actions \"action-1\" for alert \"1\" from rule \"rule-id-1\": has active maintenance windows mw-1.`
       );
       expect(logger.debug).toHaveBeenNthCalledWith(
         2,
-        `no scheduling of summary actions \"action-2\" for rule \"rule-id-1\": has active maintenance windows mw-1.`
+        `no scheduling of actions \"action-2\" for alert \"1\" from rule \"rule-id-1\": has active maintenance windows mw-1.`
       );
 
       expect(ruleRunMetricsStore.getNumberOfGeneratedActions()).toEqual(2);

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/per_alert_action_scheduler.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/per_alert_action_scheduler.ts
@@ -394,7 +394,7 @@ export class PerAlertActionScheduler<
     const alertMaintenanceWindowIds = alert.getMaintenanceWindowIds();
     if (alertMaintenanceWindowIds.length !== 0) {
       this.context.logger.debug(
-        `no scheduling of summary actions "${action.id}" for rule "${
+        `no scheduling of actions "${action.id}" for alert "${alert.getId()}" from rule "${
           this.context.rule.id
         }": has active maintenance windows ${alertMaintenanceWindowIds.join(', ')}.`
       );

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
@@ -1409,7 +1409,7 @@ describe('Ad Hoc Task Runner', () => {
         backfillRunAt: schedule1.runAt,
         backfillInterval: schedule1.interval,
       });
-      expect(logger.debug).toHaveBeenCalledTimes(4);
+      expect(logger.debug).toHaveBeenCalledTimes(5);
       expect(logger.debug).nthCalledWith(
         1,
         `Executing ad hoc run for rule test:rule-id for runAt ${schedule1.runAt}`
@@ -1425,6 +1425,10 @@ describe('Ad Hoc Task Runner', () => {
       expect(logger.debug).nthCalledWith(
         4,
         `skipping persisting alerts for rule test:rule-id: 'test': rule execution has been cancelled.`
+      );
+      expect(logger.debug).nthCalledWith(
+        5,
+        `skipping updating alerts with maintenance windows for rule test:rule-id: 'test': rule execution has been cancelled.`
       );
       expect(logger.error).not.toHaveBeenCalled();
     });
@@ -1491,7 +1495,7 @@ describe('Ad Hoc Task Runner', () => {
         backfillRunAt: schedule2.runAt,
         backfillInterval: schedule2.interval,
       });
-      expect(logger.debug).toHaveBeenCalledTimes(4);
+      expect(logger.debug).toHaveBeenCalledTimes(5);
       expect(logger.debug).nthCalledWith(
         1,
         `Executing ad hoc run for rule test:rule-id for runAt ${schedule2.runAt}`
@@ -1507,6 +1511,10 @@ describe('Ad Hoc Task Runner', () => {
       expect(logger.debug).nthCalledWith(
         4,
         `skipping persisting alerts for rule test:rule-id: 'test': rule execution has been cancelled.`
+      );
+      expect(logger.debug).nthCalledWith(
+        5,
+        `skipping updating alerts with maintenance windows for rule test:rule-id: 'test': rule execution has been cancelled.`
       );
       expect(logger.error).not.toHaveBeenCalled();
     });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.ts
@@ -354,18 +354,7 @@ export class RuleTypeRunner<
     await withAlertingSpan('alerting:index-alerts-as-data', () =>
       this.options.timer.runWithTimer(TaskRunnerTimerSpan.PersistAlerts, async () => {
         if (this.shouldLogAndScheduleActionsForAlerts(ruleType.cancelAlertsOnRuleTimeout)) {
-          const updateAlertsMaintenanceWindowResult = await alertsClient.persistAlerts();
-
-          // Set the event log MW ids again, this time including the ids that matched alerts with
-          // scoped query
-          if (
-            updateAlertsMaintenanceWindowResult?.maintenanceWindowIds &&
-            updateAlertsMaintenanceWindowResult?.maintenanceWindowIds.length > 0
-          ) {
-            context.alertingEventLogger.setMaintenanceWindowIds(
-              updateAlertsMaintenanceWindowResult.maintenanceWindowIds
-            );
-          }
+          await alertsClient.persistAlerts();
         } else {
           context.logger.debug(
             `skipping persisting alerts for rule ${context.ruleLogPrefix}: rule execution has been cancelled.`
@@ -373,6 +362,28 @@ export class RuleTypeRunner<
         }
       })
     );
+
+    await withAlertingSpan('alerting:updating-maintenance-windows', async () => {
+      if (this.shouldLogAndScheduleActionsForAlerts(ruleType.cancelAlertsOnRuleTimeout)) {
+        const updateAlertsMaintenanceWindowResult =
+          await alertsClient.updatePersistedAlertsWithMaintenanceWindowIds();
+
+        // Set the event log MW ids again, this time including the ids that matched alerts with
+        // scoped query
+        if (
+          updateAlertsMaintenanceWindowResult?.maintenanceWindowIds &&
+          updateAlertsMaintenanceWindowResult?.maintenanceWindowIds.length > 0
+        ) {
+          context.alertingEventLogger.setMaintenanceWindowIds(
+            updateAlertsMaintenanceWindowResult.maintenanceWindowIds
+          );
+        }
+      } else {
+        context.logger.debug(
+          `skipping updating alerts with maintenance windows for rule ${context.ruleLogPrefix}: rule execution has been cancelled.`
+        );
+      }
+    });
 
     alertsClient.logAlerts({
       ruleRunMetricsStore: context.ruleRunMetricsStore,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_cancel.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_cancel.test.ts
@@ -232,6 +232,11 @@ describe('Task Runner Cancel', () => {
     );
     expect(logger.debug).toHaveBeenNthCalledWith(
       6,
+      `skipping updating alerts with maintenance windows for rule test:1: 'rule-name': rule execution has been cancelled.`,
+      { tags: ['1', 'test'] }
+    );
+    expect(logger.debug).toHaveBeenNthCalledWith(
+      7,
       `no scheduling of actions for rule test:1: 'rule-name': rule execution has been cancelled.`,
       { tags: ['1', 'test'] }
     );

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/maintenance_window_scoped_query.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/maintenance_window_scoped_query.ts
@@ -19,22 +19,52 @@ import {
   runSoon,
 } from './test_helpers';
 import { Spaces } from '../../../scenarios';
+import { ES_TEST_DATA_STREAM_NAME, getRuleServices } from './builtin_alert_types/es_query/common';
+import { createDataStream, deleteDataStream, DOCUMENT_SOURCE } from '../create_test_data';
 
 const alertAsDataIndex = '.internal.alerts-test.patternfiring.alerts-default-000001';
+const securityAlertsAsDataIndex = '.alerts-security.alerts-default';
+
+export const ES_GROUPS_TO_WRITE = 2;
 
 export default function maintenanceWindowScopedQueryTests({ getService }: FtrProviderContext) {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const supertest = getService('supertest');
   const retry = getService('retry');
-  const es = getService('es');
+
+  const {
+    es,
+    esTestIndexTool,
+    esTestIndexToolDataStream,
+    createEsDocumentsInGroups,
+    removeAllAADDocs,
+  } = getRuleServices(getService);
 
   describe('maintenanceWindowScopedQuery', () => {
     const objectRemover = new ObjectRemover(supertestWithoutAuth);
 
+    beforeEach(async () => {
+      await esTestIndexTool.destroy();
+      await esTestIndexTool.setup();
+
+      await createDataStream(es, ES_TEST_DATA_STREAM_NAME);
+
+      await removeAllAADDocs();
+    });
+
     afterEach(async () => {
       await objectRemover.removeAll();
+      await esTestIndexTool.destroy();
+      await deleteDataStream(es, ES_TEST_DATA_STREAM_NAME);
       await es.deleteByQuery({
         index: alertAsDataIndex,
+        query: {
+          match_all: {},
+        },
+        conflicts: 'proceed',
+      });
+      await es.deleteByQuery({
+        index: securityAlertsAsDataIndex,
         query: {
           match_all: {},
         },
@@ -121,6 +151,110 @@ export default function maintenanceWindowScopedQueryTests({ getService }: FtrPro
       });
     });
 
+    it('should associate persistence alerts muted by maintenance window scoped query', async () => {
+      // write documents from now to the future end date in groups
+      await createEsDocumentsInGroups(
+        ES_GROUPS_TO_WRITE,
+        new Date().toISOString(),
+        esTestIndexToolDataStream,
+        ES_TEST_DATA_STREAM_NAME
+      );
+      // Create active maintenance window
+      const maintenanceWindow = await createMaintenanceWindow({
+        supertest,
+        objectRemover,
+        spaceId: 'default',
+        overwrites: {
+          scoped_query: {
+            kql: 'kibana.alert.rule.name: "test-rule"',
+            filters: [],
+          },
+          category_ids: ['securitySolution'],
+        },
+      });
+
+      // Create action and rule
+      const action = await createAction({ supertest, objectRemover, spaceId: 'default' });
+
+      const { body: rule } = await supertest
+        .post(`/api/alerting/rule`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          enabled: true,
+          name: 'test-rule',
+          rule_type_id: 'siem.queryRule',
+          schedule: { interval: '24h' },
+          consumer: 'siem',
+          actions: [
+            {
+              id: action.id,
+              params: {},
+              frequency: { notify_when: 'onActiveAlert', throttle: null, summary: false },
+              group: 'default',
+            },
+          ],
+          params: {
+            author: [],
+            description: 'test',
+            falsePositives: [],
+            from: 'now-86460s',
+            ruleId: '31c54f10-9d3b-45a8-b064-b92e8c6fcbe7',
+            immutable: false,
+            license: '',
+            outputIndex: '',
+            meta: {
+              from: '1m',
+              kibana_siem_app_url: 'https://localhost:5601/app/security',
+            },
+            maxSignals: 20,
+            riskScore: 21,
+            riskScoreMapping: [],
+            severity: 'low',
+            severityMapping: [],
+            threat: [],
+            to: 'now',
+            references: [],
+            version: 1,
+            exceptionsList: [],
+            relatedIntegrations: [],
+            requiredFields: [],
+            setup: '',
+            type: 'query',
+            language: 'kuery',
+            index: [ES_TEST_DATA_STREAM_NAME],
+            query: `source:${DOCUMENT_SOURCE}`,
+            filters: [],
+          },
+        })
+        .expect(200);
+      objectRemover.add(Spaces.default.id, rule.id, 'rule', 'alerting');
+
+      // should generate 10 alerts when run
+      await getRuleEvents({
+        id: rule.id,
+        activeInstance: 10,
+        retry,
+        getService,
+        spaceId: 'default',
+      });
+
+      await expectNoActionsFired({ id: rule.id, supertest, retry, spaceId: 'default' });
+
+      // Ensure we wrote the new maintenance window ID to the alert doc
+      await retry.try(async () => {
+        const result = await es.search<Alert>({
+          index: securityAlertsAsDataIndex,
+          query: { match_all: {} },
+        });
+
+        expect(result.hits.hits.length).to.be(10);
+
+        for (const hit of result.hits.hits) {
+          expect(hit._source?.[ALERT_MAINTENANCE_WINDOW_IDS]).to.eql([maintenanceWindow.id]);
+        }
+      });
+    });
+
     it('should not associate alerts if scoped query does not match the alert', async () => {
       const pattern = {
         instance: [true, true, false, true],
@@ -175,6 +309,109 @@ export default function maintenanceWindowScopedQueryTests({ getService }: FtrPro
         activeInstance: 2,
         retry,
         getService,
+      });
+    });
+
+    it('should not associate persistence alerts if scoped query does not match the alert', async () => {
+      // write documents from now to the future end date in groups
+      await createEsDocumentsInGroups(
+        ES_GROUPS_TO_WRITE,
+        new Date().toISOString(),
+        esTestIndexToolDataStream,
+        ES_TEST_DATA_STREAM_NAME
+      );
+      // Create active maintenance window
+      await createMaintenanceWindow({
+        supertest,
+        objectRemover,
+        spaceId: 'default',
+        overwrites: {
+          scoped_query: {
+            kql: 'kibana.alert.rule.name: "wrong-rule"',
+            filters: [],
+          },
+          category_ids: ['securitySolution'],
+        },
+      });
+
+      // Create action and rule
+      const action = await createAction({ supertest, objectRemover, spaceId: 'default' });
+
+      const { body: rule } = await supertest
+        .post(`/api/alerting/rule`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          enabled: true,
+          name: 'test-rule',
+          rule_type_id: 'siem.queryRule',
+          schedule: { interval: '24h' },
+          consumer: 'siem',
+          actions: [
+            {
+              id: action.id,
+              params: {},
+              frequency: { notify_when: 'onActiveAlert', throttle: null, summary: false },
+              group: 'default',
+            },
+          ],
+          params: {
+            author: [],
+            description: 'test',
+            falsePositives: [],
+            from: 'now-86460s',
+            ruleId: '31c54f10-9d3b-45a8-b064-b92e8c6fcbe7',
+            immutable: false,
+            license: '',
+            outputIndex: '',
+            meta: {
+              from: '1m',
+              kibana_siem_app_url: 'https://localhost:5601/app/security',
+            },
+            maxSignals: 20,
+            riskScore: 21,
+            riskScoreMapping: [],
+            severity: 'low',
+            severityMapping: [],
+            threat: [],
+            to: 'now',
+            references: [],
+            version: 1,
+            exceptionsList: [],
+            relatedIntegrations: [],
+            requiredFields: [],
+            setup: '',
+            type: 'query',
+            language: 'kuery',
+            index: [ES_TEST_DATA_STREAM_NAME],
+            query: `source:${DOCUMENT_SOURCE}`,
+            filters: [],
+          },
+        })
+        .expect(200);
+      objectRemover.add(Spaces.default.id, rule.id, 'rule', 'alerting');
+
+      // should generate 10 alerts and 10 actions when run
+      await getRuleEvents({
+        id: rule.id,
+        action: 10,
+        activeInstance: 10,
+        retry,
+        getService,
+        spaceId: 'default',
+      });
+
+      // Ensure no maintenance window ID in the alert doc
+      await retry.try(async () => {
+        const result = await es.search<Alert>({
+          index: securityAlertsAsDataIndex,
+          query: { match_all: {} },
+        });
+
+        expect(result.hits.hits.length).to.be(10);
+
+        for (const hit of result.hits.hits) {
+          expect(hit._source?.[ALERT_MAINTENANCE_WINDOW_IDS]).to.be(undefined);
+        }
       });
     });
 
@@ -309,6 +546,110 @@ export default function maintenanceWindowScopedQueryTests({ getService }: FtrPro
         id: rule.id,
         supertest,
         retry,
+      });
+    });
+
+    it('should associate persistence alerts when scoped query contains wildcards', async () => {
+      // write documents from now to the future end date in groups
+      await createEsDocumentsInGroups(
+        ES_GROUPS_TO_WRITE,
+        new Date().toISOString(),
+        esTestIndexToolDataStream,
+        ES_TEST_DATA_STREAM_NAME
+      );
+
+      const maintenanceWindow = await createMaintenanceWindow({
+        supertest,
+        objectRemover,
+        spaceId: 'default',
+        overwrites: {
+          scoped_query: {
+            kql: 'kibana.alert.rule.name: *test*',
+            filters: [],
+          },
+          category_ids: ['securitySolution'],
+        },
+      });
+
+      // Create action and rule
+      const action = await createAction({ supertest, objectRemover, spaceId: 'default' });
+
+      const { body: rule } = await supertest
+        .post(`/api/alerting/rule`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          enabled: true,
+          name: 'rule-test-rule',
+          rule_type_id: 'siem.queryRule',
+          schedule: { interval: '24h' },
+          consumer: 'siem',
+          actions: [
+            {
+              id: action.id,
+              params: {},
+              frequency: { notify_when: 'onActiveAlert', throttle: null, summary: false },
+              group: 'default',
+            },
+          ],
+          params: {
+            author: [],
+            description: 'test',
+            falsePositives: [],
+            from: 'now-86460s',
+            ruleId: '31c54f10-9d3b-45a8-b064-b92e8c6fcbe7',
+            immutable: false,
+            license: '',
+            outputIndex: '',
+            meta: {
+              from: '1m',
+              kibana_siem_app_url: 'https://localhost:5601/app/security',
+            },
+            maxSignals: 20,
+            riskScore: 21,
+            riskScoreMapping: [],
+            severity: 'low',
+            severityMapping: [],
+            threat: [],
+            to: 'now',
+            references: [],
+            version: 1,
+            exceptionsList: [],
+            relatedIntegrations: [],
+            requiredFields: [],
+            setup: '',
+            type: 'query',
+            language: 'kuery',
+            index: [ES_TEST_DATA_STREAM_NAME],
+            query: `source:${DOCUMENT_SOURCE}`,
+            filters: [],
+          },
+        })
+        .expect(200);
+      objectRemover.add(Spaces.default.id, rule.id, 'rule', 'alerting');
+
+      // should generate 10 alerts when run
+      await getRuleEvents({
+        id: rule.id,
+        activeInstance: 10,
+        retry,
+        getService,
+        spaceId: 'default',
+      });
+
+      await expectNoActionsFired({ id: rule.id, supertest, retry, spaceId: 'default' });
+
+      // Ensure we wrote the new maintenance window ID to the alert doc
+      await retry.try(async () => {
+        const result = await es.search<Alert>({
+          index: securityAlertsAsDataIndex,
+          query: { match_all: {} },
+        });
+
+        expect(result.hits.hits.length).to.be(10);
+
+        for (const hit of result.hits.hits) {
+          expect(hit._source?.[ALERT_MAINTENANCE_WINDOW_IDS]).to.eql([maintenanceWindow.id]);
+        }
       });
     });
   });

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/test_helpers.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/test_helpers.ts
@@ -10,7 +10,7 @@ import { setTimeout as setTimeoutAsync } from 'timers/promises';
 import type { RetryService } from '@kbn/ftr-common-functional-services';
 import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import type { Agent as SuperTestAgent } from 'supertest';
-import expect from '@kbn/expect/expect';
+import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import type { ObjectRemover } from '../../../../common/lib';
 import { getUrlPrefix, getTestRuleData, getEventLog } from '../../../../common/lib';

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/test_helpers.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/test_helpers.ts
@@ -10,7 +10,7 @@ import { setTimeout as setTimeoutAsync } from 'timers/promises';
 import type { RetryService } from '@kbn/ftr-common-functional-services';
 import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import type { Agent as SuperTestAgent } from 'supertest';
-import expect from '@kbn/expect';
+import expect from '@kbn/expect/expect';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import type { ObjectRemover } from '../../../../common/lib';
 import { getUrlPrefix, getTestRuleData, getEventLog } from '../../../../common/lib';
@@ -69,12 +69,15 @@ export const createRule = async ({
 export const createAction = async ({
   supertest,
   objectRemover,
+  spaceId = Spaces.space1.id,
 }: {
   supertest: SuperTestAgent;
   objectRemover: ObjectRemover;
+  spaceId?: string;
 }) => {
+  const spacePrefix = spaceId !== 'default' ? `${getUrlPrefix(spaceId)}` : '';
   const { body: createdAction } = await supertest
-    .post(`${getUrlPrefix(Spaces.space1.id)}/api/actions/connector`)
+    .post(`${spacePrefix}/api/actions/connector`)
     .set('kbn-xsrf', 'foo')
     .send({
       name: 'MY action',
@@ -84,7 +87,7 @@ export const createAction = async ({
     })
     .expect(200);
 
-  objectRemover.add(Spaces.space1.id, createdAction.id, 'action', 'actions');
+  objectRemover.add(spaceId, createdAction.id, 'action', 'actions');
   return createdAction;
 };
 
@@ -92,13 +95,16 @@ export const createMaintenanceWindow = async ({
   overwrites,
   supertest,
   objectRemover,
+  spaceId = Spaces.space1.id,
 }: {
   overwrites?: any;
   supertest: SuperTestAgent;
   objectRemover: ObjectRemover;
+  spaceId?: string;
 }) => {
+  const spacePrefix = spaceId !== 'default' ? `${getUrlPrefix(spaceId)}` : '';
   const { body: window } = await supertest
-    .post(`${getUrlPrefix(Spaces.space1.id)}/internal/alerting/rules/maintenance_window`)
+    .post(`${spacePrefix}/internal/alerting/rules/maintenance_window`)
     .set('kbn-xsrf', 'foo')
     .send({
       title: 'test-maintenance-window-1',
@@ -113,7 +119,7 @@ export const createMaintenanceWindow = async ({
     })
     .expect(200);
 
-  objectRemover.add(Spaces.space1.id, window.id, 'rules/maintenance_window', 'alerting', true);
+  objectRemover.add(spaceId, window.id, 'rules/maintenance_window', 'alerting', true);
 
   // wait so cache expires
   await setTimeoutAsync(TEST_CACHE_EXPIRATION_TIME);
@@ -155,6 +161,7 @@ export const getRuleEvents = async ({
   recoveredInstance,
   retry,
   getService,
+  spaceId = Spaces.space1.id,
 }: {
   id: string;
   action?: number;
@@ -163,6 +170,7 @@ export const getRuleEvents = async ({
   recoveredInstance?: number;
   retry: RetryService;
   getService: FtrProviderContext['getService'];
+  spaceId?: string;
 }) => {
   const actions: Array<[string, { equal: number }]> = [];
   if (action) {
@@ -180,7 +188,7 @@ export const getRuleEvents = async ({
   return retry.try(async () => {
     return await getEventLog({
       getService,
-      spaceId: Spaces.space1.id,
+      spaceId,
       type: 'alert',
       id,
       provider: 'alerting',
@@ -193,14 +201,17 @@ export const expectNoActionsFired = async ({
   id,
   supertest,
   retry,
+  spaceId = Spaces.space1.id,
 }: {
   id: string;
   supertest: SuperTestAgent;
   retry: RetryService;
+  spaceId?: string;
 }) => {
+  const spacePrefix = spaceId !== 'default' ? `${getUrlPrefix(spaceId)}` : '';
   const events = await retry.try(async () => {
     const { body: result } = await supertest
-      .get(`${getUrlPrefix(Spaces.space1.id)}/_test/event_log/alert/${id}/_find?per_page=5000`)
+      .get(`${spacePrefix}/_test/event_log/alert/${id}/_find?per_page=5000`)
       .expect(200);
 
     if (!result.total) {
@@ -221,15 +232,18 @@ export const expectActionsFired = async ({
   supertest,
   retry,
   expectedNumberOfActions,
+  spaceId = Spaces.space1.id,
 }: {
   id: string;
   supertest: SuperTestAgent;
   retry: RetryService;
   expectedNumberOfActions: number;
+  spaceId?: string;
 }) => {
+  const spacePrefix = spaceId !== 'default' ? `${getUrlPrefix(spaceId)}` : '';
   await retry.try(async () => {
     const { body: result } = await supertest
-      .get(`${getUrlPrefix(Spaces.space1.id)}/_test/event_log/alert/${id}/_find?per_page=5000`)
+      .get(`${spacePrefix}/_test/event_log/alert/${id}/_find?per_page=5000`)
       .expect(200);
 
     if (!result.total) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Response Ops][Alerting] Maintenance windows with scoped query should apply to all rule types (#232307)](https://github.com/elastic/kibana/pull/232307)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-08-25T20:17:09Z","message":"[Response Ops][Alerting] Maintenance windows with scoped query should apply to all rule types (#232307)\n\nResolves https://github.com/elastic/kibana/issues/230219\n\n## Summary\n\nThis fixes a bug where maintenance windows with scoped queries were not\nbeing correctly applied to detection rules that use the rule registry\npersistence rule type wrapper. In the alerts client, the framework:\n\n- write alerts \n- query for maintenance windows with scoped queries\n- query the alerts we just wrote using the filters from the maintenance\nwindows with filters\n- update the alerts with the maintenance window IDs if they match the\nquery\n\nWe did not update the rule registry to do this so when detection alerts\n(which don't use the alerts client to write alerts) are written, they\nare not updated with any scoped maintenance windows.\n\nThis PR decouples the writing of alerts from the maintenance window\nupdate logic, so regardless of how the alerts are written (in the\nframework alerts client or the rule registry data writer), they will be\nupdated with any matching scoped maintenance windows.\n\n## To Verify\n\n* Create a maintenance window with a scoped query (like\n`kibana.alert.rule.name: \"my-test\"`)\n* Create a detection rule that generates alerts that would match the\nscoped query. Make sure there's an action attached\n* Verify the rule runs, alerts are created but the action is not\ntriggered\n* Create a detection rule that generates alerts that does not match the\nscoped query. Make sure there's an action attached\n* Verify this rule runs, alerts are created and the actions are\ntriggered\n* Create an ES query rule that generates alerts that would match the\nscoped query. Make sure there's an action attached.\n* Verify the rule runs, alerts are created but the action is not\ntriggered.\n* Archive the maintenance window and verify that any subsequent alerts\nfrom the detection rules trigger actions.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"a343ea3b5246894346bbca35316bcbf80ed8653c","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:ResponseOps","backport:version","Feature:Maintenance Window","v9.2.0","v9.1.3","v8.19.3","v9.0.6","v8.18.6"],"title":"[Response Ops][Alerting] Maintenance windows with scoped query should apply to all rule types","number":232307,"url":"https://github.com/elastic/kibana/pull/232307","mergeCommit":{"message":"[Response Ops][Alerting] Maintenance windows with scoped query should apply to all rule types (#232307)\n\nResolves https://github.com/elastic/kibana/issues/230219\n\n## Summary\n\nThis fixes a bug where maintenance windows with scoped queries were not\nbeing correctly applied to detection rules that use the rule registry\npersistence rule type wrapper. In the alerts client, the framework:\n\n- write alerts \n- query for maintenance windows with scoped queries\n- query the alerts we just wrote using the filters from the maintenance\nwindows with filters\n- update the alerts with the maintenance window IDs if they match the\nquery\n\nWe did not update the rule registry to do this so when detection alerts\n(which don't use the alerts client to write alerts) are written, they\nare not updated with any scoped maintenance windows.\n\nThis PR decouples the writing of alerts from the maintenance window\nupdate logic, so regardless of how the alerts are written (in the\nframework alerts client or the rule registry data writer), they will be\nupdated with any matching scoped maintenance windows.\n\n## To Verify\n\n* Create a maintenance window with a scoped query (like\n`kibana.alert.rule.name: \"my-test\"`)\n* Create a detection rule that generates alerts that would match the\nscoped query. Make sure there's an action attached\n* Verify the rule runs, alerts are created but the action is not\ntriggered\n* Create a detection rule that generates alerts that does not match the\nscoped query. Make sure there's an action attached\n* Verify this rule runs, alerts are created and the actions are\ntriggered\n* Create an ES query rule that generates alerts that would match the\nscoped query. Make sure there's an action attached.\n* Verify the rule runs, alerts are created but the action is not\ntriggered.\n* Archive the maintenance window and verify that any subsequent alerts\nfrom the detection rules trigger actions.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"a343ea3b5246894346bbca35316bcbf80ed8653c"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.0","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232307","number":232307,"mergeCommit":{"message":"[Response Ops][Alerting] Maintenance windows with scoped query should apply to all rule types (#232307)\n\nResolves https://github.com/elastic/kibana/issues/230219\n\n## Summary\n\nThis fixes a bug where maintenance windows with scoped queries were not\nbeing correctly applied to detection rules that use the rule registry\npersistence rule type wrapper. In the alerts client, the framework:\n\n- write alerts \n- query for maintenance windows with scoped queries\n- query the alerts we just wrote using the filters from the maintenance\nwindows with filters\n- update the alerts with the maintenance window IDs if they match the\nquery\n\nWe did not update the rule registry to do this so when detection alerts\n(which don't use the alerts client to write alerts) are written, they\nare not updated with any scoped maintenance windows.\n\nThis PR decouples the writing of alerts from the maintenance window\nupdate logic, so regardless of how the alerts are written (in the\nframework alerts client or the rule registry data writer), they will be\nupdated with any matching scoped maintenance windows.\n\n## To Verify\n\n* Create a maintenance window with a scoped query (like\n`kibana.alert.rule.name: \"my-test\"`)\n* Create a detection rule that generates alerts that would match the\nscoped query. Make sure there's an action attached\n* Verify the rule runs, alerts are created but the action is not\ntriggered\n* Create a detection rule that generates alerts that does not match the\nscoped query. Make sure there's an action attached\n* Verify this rule runs, alerts are created and the actions are\ntriggered\n* Create an ES query rule that generates alerts that would match the\nscoped query. Make sure there's an action attached.\n* Verify the rule runs, alerts are created but the action is not\ntriggered.\n* Archive the maintenance window and verify that any subsequent alerts\nfrom the detection rules trigger actions.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"a343ea3b5246894346bbca35316bcbf80ed8653c"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232856","number":232856,"state":"OPEN"},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->