### PR TITLE
[8.19] Add coordinator for hooking into notification system (#218703)

### DIFF
--- a/src/core/packages/notifications/browser-internal/src/notification_coordinator.test.ts
+++ b/src/core/packages/notifications/browser-internal/src/notification_coordinator.test.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as Rx from 'rxjs';
+import { Coordinator, notificationCoordinator } from './notification_coordinator';
+
+describe('notification coordination', () => {
+  describe('Coordinator', () => {
+    it('instantiates with default properties', async () => {
+      const coordinator = new Coordinator();
+
+      expect(await Rx.firstValueFrom(coordinator.lock$)).toStrictEqual({
+        locked: false,
+        controller: null,
+      });
+    });
+
+    it("updates to the source observable propagate to the coordinated observable when it's optin condition is met", async () => {
+      const coordinator = new Coordinator();
+
+      const optInCondition = jest.fn(() => true);
+
+      const items = new Rx.BehaviorSubject<Array<{ id: string }>>([]);
+
+      const coordinatedItems$ = coordinator.optInToCoordination(
+        'test',
+        items.asObservable(),
+        optInCondition
+      );
+
+      const nextFn = jest.fn();
+
+      coordinatedItems$.subscribe(nextFn);
+
+      items.next([{ id: '1' }]);
+
+      expect(nextFn).toHaveBeenLastCalledWith([{ id: '1' }]);
+      expect(optInCondition).toHaveBeenCalled();
+    });
+
+    it('updates to the source observable do not propagate to the coordinated observable if the optin condition is not met', async () => {
+      const coordinator = new Coordinator();
+
+      const optInCondition = jest.fn(() => false);
+
+      const items = new Rx.BehaviorSubject<Array<{ id: string }>>([]);
+
+      const coordinatedItems$ = coordinator.optInToCoordination(
+        'test',
+        items.asObservable(),
+        optInCondition
+      );
+
+      const subscriptionHandler = jest.fn();
+
+      coordinatedItems$.subscribe(subscriptionHandler);
+
+      items.next([{ id: '1' }]);
+
+      expect(subscriptionHandler).not.toHaveBeenCalled();
+    });
+
+    it('will acquire a lock and emit to just the coordinated with a condition that is fulfilled even in race type scenarios', async () => {
+      const coordinator = new Coordinator();
+
+      // only emit values when the lock has not been acquired
+      const optInCondition = jest.fn(({ locked }) => !locked);
+
+      const SUT1 = new Rx.BehaviorSubject<Array<{ id: string }>>([]);
+      const SUT2 = new Rx.BehaviorSubject<Array<{ id: string }>>([]);
+      const SUT3 = new Rx.BehaviorSubject<Array<{ id: string }>>([]);
+
+      const coordinatedSUT1SubscriptionHandler = jest.fn();
+      const coordinatedSUT2SubscriptionHandler = jest.fn();
+      const coordinatedSUT3SubscriptionHandler = jest.fn();
+
+      const coordinatedSUT1Sub = coordinator
+        .optInToCoordination('test1', SUT1.asObservable(), optInCondition)
+        .subscribe(coordinatedSUT1SubscriptionHandler);
+
+      const coordinatedSUT2Sub = coordinator
+        .optInToCoordination('test2', SUT2.asObservable(), optInCondition)
+        .subscribe(coordinatedSUT2SubscriptionHandler);
+
+      const coordinatedSUT3Sub = coordinator
+        .optInToCoordination('test3', SUT3.asObservable(), optInCondition)
+        .subscribe(coordinatedSUT3SubscriptionHandler);
+
+      // simulate as best as we can the scenario where all 3 observables emit at the same time
+      await Promise.all([
+        Promise.resolve('1').then((id) => SUT1.next([{ id }])),
+        Promise.resolve('2').then((id) => SUT2.next([{ id }])),
+        Promise.resolve('3').then((id) => SUT3.next([{ id }])),
+      ]);
+
+      expect(await Rx.firstValueFrom(coordinator.lock$)).toEqual(
+        expect.objectContaining({ locked: true })
+      );
+
+      // only one of the subscription handlers should have been called
+      expect(
+        [
+          coordinatedSUT1SubscriptionHandler,
+          coordinatedSUT2SubscriptionHandler,
+          coordinatedSUT3SubscriptionHandler,
+        ].filter((handler) => {
+          return handler.mock.calls.length > 0;
+        })
+      ).toHaveLength(1);
+
+      [coordinatedSUT1Sub, coordinatedSUT2Sub, coordinatedSUT3Sub].forEach((sub) => {
+        sub.unsubscribe();
+      });
+    });
+
+    it("automatically releases an acquired lock if the source observable has no values to be emitted anymore despite it's optin condition being met", async () => {
+      const coordinator = new Coordinator();
+
+      const optInCondition = jest.fn(() => true);
+
+      const items = new Rx.BehaviorSubject<Array<{ id: string }>>([]);
+
+      const coordinatedItems$ = coordinator.optInToCoordination(
+        'test',
+        items.asObservable(),
+        optInCondition
+      );
+
+      const sub = coordinatedItems$.subscribe();
+
+      items.next([{ id: '1' }]);
+
+      expect(await Rx.firstValueFrom(coordinator.lock$)).toEqual({
+        locked: true,
+        controller: 'test',
+      });
+
+      items.next([]);
+
+      expect(await Rx.firstValueFrom(coordinator.lock$)).toEqual({
+        locked: false,
+        controller: null,
+      });
+
+      sub.unsubscribe();
+    });
+
+    it('automatically releases an acquired lock if the coordinated observable that owns the current lock is unsubscribed from', async () => {
+      const coordinator = new Coordinator();
+
+      const optInCondition = jest.fn(() => true);
+
+      const items = new Rx.BehaviorSubject<Array<{ id: string }>>([]);
+
+      const coordinatedItems$ = coordinator.optInToCoordination(
+        'test',
+        items.asObservable(),
+        optInCondition
+      );
+
+      const sub = coordinatedItems$.subscribe();
+
+      items.next([{ id: '1' }]);
+
+      expect(await Rx.firstValueFrom(coordinator.lock$)).toEqual({
+        locked: true,
+        controller: 'test',
+      });
+
+      sub.unsubscribe();
+
+      // the lock should be released when unsubscribed
+      expect(await Rx.firstValueFrom(coordinator.lock$)).toEqual({
+        locked: false,
+        controller: null,
+      });
+    });
+  });
+
+  describe('notificationCoordinator', () => {
+    it('should error if not bound to an instance of the NotificationCoordinator class', () => {
+      expect(() =>
+        // @ts-expect-error - we expect an error because the function has not been bound to the Coordinator class
+        notificationCoordinator('test')
+      ).toThrowError();
+    });
+
+    it('returns a object with the expected properties', () => {
+      const result = notificationCoordinator.call(new Coordinator(), 'test');
+      expect(result).toEqual({
+        lock$: expect.any(Rx.Observable),
+        releaseLock: expect.any(Function),
+        acquireLock: expect.any(Function),
+        optInToCoordination: expect.any(Function),
+      });
+    });
+  });
+});

--- a/src/core/packages/notifications/browser-internal/src/notification_coordinator.ts
+++ b/src/core/packages/notifications/browser-internal/src/notification_coordinator.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  BehaviorSubject,
+  filter,
+  share,
+  mergeMap,
+  merge,
+  bufferToggle,
+  windowToggle,
+  tap,
+  finalize,
+  type Observable,
+} from 'rxjs';
+import { i18n } from '@kbn/i18n';
+import {
+  NotificationCoordinatorState,
+  NotificationCoordinatorPublicApi,
+} from '@kbn/core-notifications-browser';
+
+export class Coordinator {
+  private readonly coordinationLock$ = new BehaviorSubject<NotificationCoordinatorState>({
+    locked: false,
+    controller: null,
+  });
+
+  public lock$ = this.coordinationLock$.asObservable();
+
+  public acquireLock(owner: string) {
+    const { locked, controller } = this.coordinationLock$.getValue();
+
+    if (locked && controller !== owner) {
+      throw new Error(
+        i18n.translate('core.notifications.notificationLockError', {
+          defaultMessage: 'Notification lock is already acquired',
+        })
+      );
+    }
+
+    this.coordinationLock$.next({ locked: true, controller: owner });
+  }
+
+  public releaseLock(owner: string) {
+    const { locked, controller } = this.coordinationLock$.getValue();
+
+    if (locked && controller === owner) {
+      this.coordinationLock$.next({ locked: false, controller: null });
+    }
+  }
+
+  /**
+   * @description This method is used to control the flow of notifications, it will automatically acquire
+   * a lock for the registered entity and buffer new values to be emitted when the provided condition is not met.
+   * Also when the passed observable has been emptied if the current lock still belongs to the registrar it will be released automatically, however an acquired lock can
+   * also be released as deemed fit using {@link releaseLock}.
+   * @param registrar - A unique identifier for the caller of this method
+   * @param $ - Observable to be controlled
+   * @param cond - Condition under which updates from the provided observable should be emitted
+   */
+  public optInToCoordination<T extends Array<{ id: string }>>(
+    registrar: string,
+    $: Observable<T>,
+    cond: (coordinatorState: NotificationCoordinatorState) => boolean
+  ) {
+    // signal used to determine when to emit values from the source observable based on the provided opt-in condition
+    const on$ = this.coordinationLock$.pipe(filter((state) => cond(state)));
+    // signal used to determine when to buffer values from the source observable based on the provided opt-in condition
+    const off$ = this.coordinationLock$.pipe(filter((state) => !cond(state)));
+    const multicast$ = $.pipe(share());
+
+    return merge(
+      multicast$.pipe(bufferToggle(off$, () => on$)),
+      multicast$.pipe(windowToggle(on$, () => off$))
+    ).pipe(
+      mergeMap((x) => x),
+      tap((value) => {
+        const lock = this.coordinationLock$.getValue();
+        // if the source has values to emit and the lock is not owned (because of values that were buffered whilst the lock was owned by another registrar) we acquire a lock for said source.
+        if (value.length && !lock.locked) {
+          this.acquireLock(registrar);
+        } else if (!value.length && lock.controller === registrar) {
+          // here we handle the scenario where the source observable has been emptied out,
+          // in such event if the lock is still held by the registrar we release it
+          this.releaseLock(registrar);
+        }
+      }),
+      finalize(() => {
+        // when the coordinated observable is completed we release the lock if it is still held by the registrar
+        const lock = this.coordinationLock$.getValue();
+        if (lock.locked && lock.controller === registrar) {
+          this.releaseLock(registrar);
+        }
+      })
+    );
+  }
+}
+
+export function notificationCoordinator(
+  this: Coordinator,
+  registrar: string
+): NotificationCoordinatorPublicApi {
+  return {
+    optInToCoordination: <T extends Array<{ id: string }>>(
+      $: Observable<T>,
+      cond: (coordinatorState: NotificationCoordinatorState) => boolean
+    ) =>
+      this.optInToCoordination.apply<
+        Coordinator,
+        Parameters<typeof this.optInToCoordination<T>>,
+        Observable<T>
+      >(this, [registrar, $, cond]),
+    acquireLock: this.acquireLock.bind(this, registrar),
+    releaseLock: this.releaseLock.bind(this, registrar),
+    lock$: this.lock$,
+  };
+}

--- a/src/core/packages/notifications/browser-internal/src/notifications_service.ts
+++ b/src/core/packages/notifications/browser-internal/src/notifications_service.ts
@@ -9,7 +9,7 @@
 
 import { i18n } from '@kbn/i18n';
 
-import { Subscription } from 'rxjs';
+import * as Rx from 'rxjs';
 import type { AnalyticsServiceStart, AnalyticsServiceSetup } from '@kbn/core-analytics-browser';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { OverlayStart } from '@kbn/core-overlays-browser';
@@ -17,7 +17,7 @@ import type { NotificationsSetup, NotificationsStart } from '@kbn/core-notificat
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import type { RenderingService } from '@kbn/core-rendering-browser';
 import { showErrorDialog, ToastsService } from './toasts';
-import { EventReporter, eventTypes } from './toasts/telemetry';
+import { Coordinator, notificationCoordinator } from './notification_coordinator';
 
 export interface SetupDeps {
   analytics: AnalyticsServiceSetup;
@@ -34,19 +34,19 @@ export interface StartDeps {
 /** @public */
 export class NotificationsService {
   private readonly toasts: ToastsService;
-  private uiSettingsErrorSubscription?: Subscription;
+  private uiSettingsErrorSubscription?: Rx.Subscription;
   private targetDomElement?: HTMLElement;
+  private readonly coordinator = notificationCoordinator.bind(new Coordinator());
 
   constructor() {
     this.toasts = new ToastsService();
   }
 
   public setup({ uiSettings, analytics }: SetupDeps): NotificationsSetup {
-    eventTypes.forEach((eventType) => {
-      analytics.registerEventType(eventType);
-    });
-
-    const notificationSetup = { toasts: this.toasts.setup({ uiSettings }) };
+    const notificationSetup = {
+      toasts: this.toasts.setup({ uiSettings, analytics }),
+      coordinator: this.coordinator,
+    };
 
     this.uiSettingsErrorSubscription = uiSettings.getUpdateErrors$().subscribe((error: Error) => {
       notificationSetup.toasts.addDanger({
@@ -65,13 +65,11 @@ export class NotificationsService {
     const toastsContainer = document.createElement('div');
     targetDomElement.appendChild(toastsContainer);
 
-    const eventReporter = new EventReporter({ analytics: startDeps.analytics });
-
     return {
       toasts: this.toasts.start({
-        eventReporter,
         overlays,
         targetDomElement: toastsContainer,
+        notificationCoordinator: this.coordinator,
         ...startDeps,
       }),
       showErrorDialog: ({ title, error }) =>

--- a/src/core/packages/notifications/browser-internal/src/toasts/__snapshots__/toasts_service.test.tsx.snap
+++ b/src/core/packages/notifications/browser-internal/src/toasts/__snapshots__/toasts_service.test.tsx.snap
@@ -8,20 +8,24 @@ Array [
         <GlobalToastList
           dismissToast={[Function]}
           reportEvent={
-            EventReporter {
-              "reportEvent": [MockFunction],
+            Object {
+              "onDismissToast": [Function],
             }
           }
           toasts$={
             Observable {
-              "source": BehaviorSubject {
-                "_value": Array [],
-                "closed": false,
-                "currentObservers": null,
-                "hasError": false,
-                "isStopped": false,
-                "observers": Array [],
-                "thrownError": null,
+              "operator": [Function],
+              "source": Observable {
+                "operator": [Function],
+                "source": Observable {
+                  "operator": [Function],
+                  "source": Observable {
+                    "operator": [Function],
+                    "source": Observable {
+                      "_subscribe": [Function],
+                    },
+                  },
+                },
               },
             }
           }

--- a/src/core/packages/notifications/browser-internal/src/toasts/global_toast_list.test.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/global_toast_list.test.tsx
@@ -13,16 +13,20 @@ import { Observable, from, EMPTY, BehaviorSubject } from 'rxjs';
 import { screen, render, fireEvent, act } from '@testing-library/react';
 import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
 import { EuiToast } from '@elastic/eui';
-import { EventReporter } from './telemetry';
+import { ToastsTelemetry } from './telemetry';
 
 import { GlobalToastList } from './global_toast_list';
 
 const mockAnalytics = analyticsServiceMock.createAnalyticsServiceStart();
 
+const toastsTelemetry = new ToastsTelemetry();
+
+toastsTelemetry.setup({ analytics: analyticsServiceMock.createAnalyticsServiceSetup() });
+
 const sharedProps = {
   toasts$: EMPTY,
   dismissToast: jest.fn(),
-  reportEvent: new EventReporter({ analytics: mockAnalytics }),
+  reportEvent: toastsTelemetry.start({ analytics: mockAnalytics }),
 };
 
 function RenderToastList(props: Partial<ComponentProps<typeof GlobalToastList>> = {}) {

--- a/src/core/packages/notifications/browser-internal/src/toasts/global_toast_list.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/global_toast_list.tsx
@@ -16,11 +16,11 @@ import { i18n } from '@kbn/i18n';
 import type { Toast } from '@kbn/core-notifications-browser';
 import { MountWrapper } from '@kbn/core-mount-utils-browser-internal';
 import { deduplicateToasts, ToastWithRichTitle } from './deduplicate_toasts';
-import { EventReporter } from './telemetry';
+import { ToastsTelemetry } from './telemetry';
 
 interface Props {
   toasts$: Observable<Toast[]>;
-  reportEvent: EventReporter;
+  reportEvent: ReturnType<ToastsTelemetry['start']>;
   dismissToast: (toastId: string) => void;
 }
 

--- a/src/core/packages/notifications/browser-internal/src/toasts/telemetry/index.ts
+++ b/src/core/packages/notifications/browser-internal/src/toasts/telemetry/index.ts
@@ -7,5 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { EventReporter } from './event_reporter';
-export { eventTypes } from './event_types';
+export { ToastsTelemetry } from './toasts_telemetry';

--- a/src/core/packages/notifications/browser-internal/src/toasts/toasts_api.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/toasts_api.tsx
@@ -78,7 +78,7 @@ export class ToastsApi implements IToasts {
     this.startDeps = startDeps;
   }
 
-  /** Observable of the toast messages to show to the user. */
+  /** Observable of the toast messages queued to be shown to the user. */
   public get$() {
     return this.toasts$.asObservable();
   }

--- a/src/core/packages/notifications/browser-internal/src/toasts/toasts_service.test.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/toasts_service.test.tsx
@@ -14,21 +14,26 @@ import { ToastsApi } from './toasts_api';
 import { overlayServiceMock } from '@kbn/core-overlays-browser-mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
-import { EventReporter } from './telemetry';
 import { renderingServiceMock } from '@kbn/core-rendering-browser-mocks';
+import { notificationCoordinator, Coordinator } from '../notification_coordinator';
 
 const mockOverlays = overlayServiceMock.createStartContract();
 const mockAnalytics = analyticsServiceMock.createAnalyticsServiceStart();
 const mockRendering = renderingServiceMock.create();
 
-const eventReporter = new EventReporter({ analytics: mockAnalytics });
+const mockAnalyticsSetup = analyticsServiceMock.createAnalyticsServiceSetup();
+
+const coordinator = notificationCoordinator.bind(new Coordinator());
 
 describe('#setup()', () => {
   it('returns a ToastsApi', () => {
     const toasts = new ToastsService();
 
     expect(
-      toasts.setup({ uiSettings: uiSettingsServiceMock.createSetupContract() })
+      toasts.setup({
+        uiSettings: uiSettingsServiceMock.createSetupContract(),
+        analytics: mockAnalyticsSetup,
+      })
     ).toBeInstanceOf(ToastsApi);
   });
 });
@@ -40,12 +45,16 @@ describe('#start()', () => {
     const toasts = new ToastsService();
 
     expect(mockReactDomRender).not.toHaveBeenCalled();
-    toasts.setup({ uiSettings: uiSettingsServiceMock.createSetupContract() });
+    toasts.setup({
+      uiSettings: uiSettingsServiceMock.createSetupContract(),
+      analytics: mockAnalyticsSetup,
+    });
     toasts.start({
       rendering: mockRendering,
       targetDomElement,
       overlays: mockOverlays,
-      eventReporter,
+      analytics: mockAnalytics,
+      notificationCoordinator: coordinator,
     });
     expect(mockReactDomRender.mock.calls).toMatchSnapshot();
   });
@@ -55,14 +64,18 @@ describe('#start()', () => {
     const toasts = new ToastsService();
 
     expect(
-      toasts.setup({ uiSettings: uiSettingsServiceMock.createSetupContract() })
+      toasts.setup({
+        uiSettings: uiSettingsServiceMock.createSetupContract(),
+        analytics: mockAnalyticsSetup,
+      })
     ).toBeInstanceOf(ToastsApi);
     expect(
       toasts.start({
         rendering: mockRendering,
         targetDomElement,
         overlays: mockOverlays,
-        eventReporter,
+        analytics: mockAnalytics,
+        notificationCoordinator: coordinator,
       })
     ).toBeInstanceOf(ToastsApi);
   });
@@ -74,12 +87,16 @@ describe('#stop()', () => {
     targetDomElement.setAttribute('test', 'target-dom-element');
     const toasts = new ToastsService();
 
-    toasts.setup({ uiSettings: uiSettingsServiceMock.createSetupContract() });
+    toasts.setup({
+      uiSettings: uiSettingsServiceMock.createSetupContract(),
+      analytics: mockAnalyticsSetup,
+    });
     toasts.start({
       rendering: mockRendering,
       targetDomElement,
       overlays: mockOverlays,
-      eventReporter,
+      analytics: mockAnalytics,
+      notificationCoordinator: coordinator,
     });
 
     expect(mockReactDomUnmount).not.toHaveBeenCalled();
@@ -98,12 +115,16 @@ describe('#stop()', () => {
     const targetDomElement = document.createElement('div');
     const toasts = new ToastsService();
 
-    toasts.setup({ uiSettings: uiSettingsServiceMock.createSetupContract() });
+    toasts.setup({
+      uiSettings: uiSettingsServiceMock.createSetupContract(),
+      analytics: mockAnalyticsSetup,
+    });
     toasts.start({
       rendering: mockRendering,
       targetDomElement,
       overlays: mockOverlays,
-      eventReporter,
+      analytics: mockAnalytics,
+      notificationCoordinator: coordinator,
     });
     toasts.stop();
     expect(targetDomElement.childNodes).toHaveLength(0);

--- a/src/core/packages/notifications/browser-internal/src/toasts/toasts_service.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/toasts_service.tsx
@@ -9,44 +9,64 @@
 
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
-
+import type { AnalyticsServiceStart, AnalyticsServiceSetup } from '@kbn/core-analytics-browser';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { OverlayStart } from '@kbn/core-overlays-browser';
 import type { RenderingService } from '@kbn/core-rendering-browser';
+import { NotificationCoordinator } from '@kbn/core-notifications-browser';
 import { GlobalToastList } from './global_toast_list';
 import { ToastsApi } from './toasts_api';
-import { EventReporter } from './telemetry';
+import { ToastsTelemetry } from './telemetry';
 
 interface SetupDeps {
+  analytics: AnalyticsServiceSetup;
   uiSettings: IUiSettingsClient;
 }
 
 interface StartDeps {
   overlays: OverlayStart;
   rendering: RenderingService;
-  eventReporter: EventReporter;
+  analytics: AnalyticsServiceStart;
   targetDomElement: HTMLElement;
+  notificationCoordinator: NotificationCoordinator;
 }
 
 export class ToastsService {
   private api?: ToastsApi;
   private targetDomElement?: HTMLElement;
+  private readonly telemetry = new ToastsTelemetry();
 
-  public setup({ uiSettings }: SetupDeps) {
+  public setup({ uiSettings, analytics }: SetupDeps) {
     this.api = new ToastsApi({ uiSettings });
+    this.telemetry.setup({ analytics });
     return this.api!;
   }
 
-  public start({ eventReporter, overlays, targetDomElement, rendering }: StartDeps) {
+  public start({
+    overlays,
+    targetDomElement,
+    rendering,
+    analytics,
+    notificationCoordinator,
+  }: StartDeps) {
     this.api!.start({ overlays, rendering });
     this.targetDomElement = targetDomElement;
+
+    const reportEvent = this.telemetry.start({ analytics });
+
+    const coordinator = notificationCoordinator(ToastsService.name);
+
+    const toasts$ = coordinator.optInToCoordination(this.api!.get$(), ({ locked, controller }) => {
+      // new toasts will only be emitted when there are no locks, or when the current lock is owned by the toast service
+      return !locked || controller === ToastsService.name;
+    });
 
     render(
       rendering.addContext(
         <GlobalToastList
           dismissToast={(toastId: string) => this.api!.remove(toastId)}
-          toasts$={this.api!.get$()}
-          reportEvent={eventReporter}
+          toasts$={toasts$}
+          reportEvent={reportEvent}
         />
       ),
       targetDomElement

--- a/src/core/packages/notifications/browser-mocks/src/notification_coordinator.mock.ts
+++ b/src/core/packages/notifications/browser-mocks/src/notification_coordinator.mock.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { NotificationCoordinator } from '@kbn/core-notifications-browser';
+import { Observable, ObservedValueOf } from 'rxjs';
+
+export function createNotificationCoordinatorMock() {
+  const notificationCoordinatorMock = jest.fn();
+
+  notificationCoordinatorMock.mockReturnValue({
+    optInToCoordination: jest.fn((input$, cb) => input$),
+    acquireLock: jest.fn(),
+    releaseLock: jest.fn(),
+    lock$: new Observable<ObservedValueOf<ReturnType<NotificationCoordinator>['lock$']>>(),
+  } satisfies ReturnType<NotificationCoordinator>);
+
+  return notificationCoordinatorMock;
+}

--- a/src/core/packages/notifications/browser-mocks/src/notifications_service.mock.ts
+++ b/src/core/packages/notifications/browser-mocks/src/notifications_service.mock.ts
@@ -7,14 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DeeplyMockedKeys, MockedKeys } from '@kbn/utility-types-jest';
+import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
 import type { NotificationsSetup, NotificationsStart } from '@kbn/core-notifications-browser';
 import { toastsServiceMock } from './toasts_service.mock';
+import { createNotificationCoordinatorMock } from './notification_coordinator.mock';
 
 const createSetupContractMock = () => {
-  const setupContract: MockedKeys<NotificationsSetup> = {
+  const setupContract: DeeplyMockedKeys<NotificationsSetup> = {
     // we have to suppress type errors until decide how to mock es6 class
     toasts: toastsServiceMock.createSetupContract(),
+    coordinator: createNotificationCoordinatorMock(),
   };
   return setupContract;
 };

--- a/src/core/packages/notifications/browser/index.ts
+++ b/src/core/packages/notifications/browser/index.ts
@@ -14,6 +14,9 @@ export type {
   ToastInput,
   IToasts,
   ToastInputFields,
+  NotificationCoordinator,
+  NotificationCoordinatorState,
+  NotificationCoordinatorPublicApi,
 } from './src/types';
 export type {
   ToastsSetup,

--- a/src/core/packages/notifications/browser/src/contracts.ts
+++ b/src/core/packages/notifications/browser/src/contracts.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { IToasts } from './types';
+import type { IToasts, NotificationCoordinator } from './types';
 
 /**
  * {@link IToasts}
@@ -25,6 +25,10 @@ export type ToastsStart = IToasts;
 export interface NotificationsSetup {
   /** {@link ToastsSetup} */
   toasts: ToastsSetup;
+  /**
+   * {@link NotificationCoordinator}
+   */
+  coordinator: NotificationCoordinator;
 }
 
 /** @public */

--- a/src/core/packages/notifications/browser/src/types.ts
+++ b/src/core/packages/notifications/browser/src/types.ts
@@ -6,7 +6,6 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-
 import type { Observable } from 'rxjs';
 import type { EuiGlobalToastListToast as EuiToast } from '@elastic/eui';
 import type { MountPoint } from '@kbn/core-mount-utils-browser';
@@ -77,3 +76,49 @@ export interface IToasts {
   addDanger: (toastOrTitle: ToastInput, options?: any) => Toast;
   addError: (error: Error, options: ErrorToastOptions) => Toast;
 }
+
+/**
+ * Specifies the internal state of {@link NotificationCoordinatorPublicApi}.
+ */
+export interface NotificationCoordinatorState {
+  locked: boolean;
+  controller: string | null;
+}
+
+/**
+ * @public
+ * @description This is the public API for the notification coordinator.
+ * It allows to opt in to coordination of notifications and acquiring/releasing locks on the notifications displayed to the user.
+ */
+export interface NotificationCoordinatorPublicApi {
+  /**
+   * Method that opts in a some observable to the notification coordination.
+   */
+  optInToCoordination: <
+    T extends Array<{
+      id: string;
+    }>
+  >(
+    $: Observable<T>,
+    cond: (coordinatorState: NotificationCoordinatorState) => boolean
+  ) => Observable<T>;
+  /**
+   * Acquires a lock for the registrar bounded to this method.
+   */
+  acquireLock: () => void;
+  /**
+   * Releases the lock for the registrar bounded to this method.
+   */
+  releaseLock: () => void;
+  /**
+   * Observable that emits the current state of the notification coordinator.
+   */
+  lock$: Observable<NotificationCoordinatorState>;
+}
+
+/**
+ * @public
+ * @description notification coordinator function,
+ * that returns an instance that of the notification coordinator that will be bound to the registrar value provided.
+ */
+export type NotificationCoordinator = (registrar: string) => NotificationCoordinatorPublicApi;

--- a/src/platform/plugins/shared/console/public/application/components/variables/variables_editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/components/variables/variables_editor.tsx
@@ -26,7 +26,7 @@ import {
   type EuiBasicTableColumn,
 } from '@elastic/eui';
 
-import { NotificationsSetup } from '@kbn/core/public';
+import { NotificationsStart } from '@kbn/core/public';
 import { useServicesContext } from '../../contexts';
 import { VariableEditorForm } from './variables_editor_form';
 import * as utils from './utils';
@@ -45,7 +45,7 @@ const sendToBrowserClipboard = async (text: string) => {
   throw new Error('Could not copy to clipboard!');
 };
 
-const copyToClipboard = async (text: string, notifications: NotificationsSetup) => {
+const copyToClipboard = async (text: string, notifications: Pick<NotificationsStart, 'toasts'>) => {
   try {
     await sendToBrowserClipboard(text);
 

--- a/src/platform/plugins/shared/console/public/application/containers/editor/components/context_menu/context_menu.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/components/context_menu/context_menu.tsx
@@ -19,7 +19,7 @@ import {
   EuiLoadingSpinner,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { NotificationsSetup } from '@kbn/core/public';
+import { NotificationsStart } from '@kbn/core/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { LanguageSelectorModal } from './language_selector_modal';
@@ -38,7 +38,7 @@ interface Props {
   getRequests: () => Promise<EditorRequest[]>;
   getDocumentation: () => Promise<string | null>;
   autoIndent: (ev: React.MouseEvent) => void;
-  notifications: NotificationsSetup;
+  notifications: Pick<NotificationsStart, 'toasts'>;
   /* A function that returns true if any of the selected requests is an internal Kibana request
    * (starting with the kbn: prefix). This is needed here as we display only the curl language
    * for internal Kibana requests since the other languages are not supported yet. */

--- a/src/platform/plugins/shared/console/public/application/contexts/services_context.mock.ts
+++ b/src/platform/plugins/shared/console/public/application/contexts/services_context.mock.ts
@@ -46,7 +46,7 @@ export const serviceContextMock = {
         settings: new SettingsMock(storage),
         routeHistory: createMemoryHistory(),
         history: new HistoryMock(storage),
-        notifications: notificationServiceMock.createSetupContract(),
+        notifications: notificationServiceMock.createStartContract(),
         objectStorageClient: {} as unknown as ObjectStorageClient,
         http,
         autocompleteInfo: new AutocompleteInfoMock(),

--- a/src/platform/plugins/shared/console/public/application/contexts/services_context.tsx
+++ b/src/platform/plugins/shared/console/public/application/contexts/services_context.tsx
@@ -25,7 +25,7 @@ interface ContextServices {
   history: History;
   storage: Storage;
   settings: Settings;
-  notifications: NotificationsSetup;
+  notifications: Pick<NotificationsSetup, 'toasts'>;
   objectStorageClient: ObjectStorageClient;
   trackUiMetric: MetricsTracker;
   esHostService: EsHostService;

--- a/src/platform/plugins/shared/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
+++ b/src/platform/plugins/shared/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
@@ -316,7 +316,7 @@ exports[`TelemetryManagementSectionComponent renders null because allowChangingO
       },
       "isScreenshotMode": false,
       "notifications": Object {
-        "showErrorDialog": [MockFunction],
+        "coordinator": [MockFunction],
         "toasts": Object {
           "add": [MockFunction],
           "addDanger": [MockFunction],

--- a/src/platform/plugins/shared/telemetry_management_section/public/components/telemetry_management_section.test.tsx
+++ b/src/platform/plugins/shared/telemetry_management_section/public/components/telemetry_management_section.test.tsx
@@ -37,7 +37,7 @@ describe('TelemetryManagementSectionComponent', () => {
       isScreenshotMode: false,
       reportOptInStatusChange: false,
       currentKibanaVersion: 'mock_kibana_version',
-      notifications: coreStart.notifications,
+      notifications: coreSetup.notifications,
       http: coreSetup.http,
     });
 
@@ -67,7 +67,7 @@ describe('TelemetryManagementSectionComponent', () => {
       },
       isScreenshotMode: false,
       reportOptInStatusChange: false,
-      notifications: coreStart.notifications,
+      notifications: coreSetup.notifications,
       currentKibanaVersion: 'mock_kibana_version',
       http: coreSetup.http,
     });
@@ -118,7 +118,7 @@ describe('TelemetryManagementSectionComponent', () => {
       },
       isScreenshotMode: false,
       reportOptInStatusChange: false,
-      notifications: coreStart.notifications,
+      notifications: coreSetup.notifications,
       currentKibanaVersion: 'mock_kibana_version',
       http: coreSetup.http,
     });
@@ -159,7 +159,7 @@ describe('TelemetryManagementSectionComponent', () => {
       },
       isScreenshotMode: false,
       reportOptInStatusChange: false,
-      notifications: coreStart.notifications,
+      notifications: coreSetup.notifications,
       currentKibanaVersion: 'mock_kibana_version',
       http: coreSetup.http,
     });
@@ -194,7 +194,7 @@ describe('TelemetryManagementSectionComponent', () => {
       },
       isScreenshotMode: false,
       reportOptInStatusChange: false,
-      notifications: coreStart.notifications,
+      notifications: coreSetup.notifications,
       currentKibanaVersion: 'mock_kibana_version',
       http: coreSetup.http,
     });
@@ -234,7 +234,7 @@ describe('TelemetryManagementSectionComponent', () => {
       },
       isScreenshotMode: false,
       reportOptInStatusChange: false,
-      notifications: coreStart.notifications,
+      notifications: coreSetup.notifications,
       currentKibanaVersion: 'mock_kibana_version',
       http: coreSetup.http,
     });
@@ -281,7 +281,7 @@ describe('TelemetryManagementSectionComponent', () => {
       },
       isScreenshotMode: false,
       reportOptInStatusChange: false,
-      notifications: coreStart.notifications,
+      notifications: coreSetup.notifications,
       currentKibanaVersion: 'mock_kibana_version',
       http: coreSetup.http,
     });

--- a/x-pack/platform/packages/private/ml/date_picker/src/hooks/use_date_picker_context.tsx
+++ b/x-pack/platform/packages/private/ml/date_picker/src/hooks/use_date_picker_context.tsx
@@ -10,11 +10,11 @@ import React, { createContext, useContext, type FC, type PropsWithChildren } fro
 import type { UI_SETTINGS } from '@kbn/data-plugin/common';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type {
-  CoreSetup,
   I18nStart,
   IUiSettingsClient,
   ThemeServiceStart,
   UserProfileService,
+  NotificationsStart,
 } from '@kbn/core/public';
 import type { HttpStart } from '@kbn/core/public';
 
@@ -33,7 +33,7 @@ export interface DatePickerDependencies {
   /**
    * notifications service
    */
-  notifications: CoreSetup['notifications'];
+  notifications: NotificationsStart;
   /**
    * Kibana Security User Profile Service
    */

--- a/x-pack/platform/plugins/shared/aiops/public/hooks/use_aiops_app_context.ts
+++ b/x-pack/platform/plugins/shared/aiops/public/hooks/use_aiops_app_context.ts
@@ -16,13 +16,13 @@ import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type {
   AnalyticsServiceStart,
-  CoreSetup,
   CoreStart,
   ExecutionContextStart,
   HttpStart,
   IUiSettingsClient,
   ThemeServiceStart,
   UserProfileService,
+  NotificationsStart,
 } from '@kbn/core/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
 import type { EmbeddableStart } from '@kbn/embeddable-plugin/public';
@@ -70,7 +70,7 @@ export interface AiopsAppContextValue {
   /**
    * Used for toast notifications.
    */
-  notifications: CoreSetup['notifications'];
+  notifications: NotificationsStart;
   /**
    * Used to store user settings in local storage.
    */

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/index.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/index.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 
 import { ApplicationStart } from '@kbn/core/public';
-import { NotificationsSetup, IUiSettingsClient, OverlayStart, HttpStart } from '@kbn/core/public';
+import { NotificationsStart, IUiSettingsClient, OverlayStart, HttpStart } from '@kbn/core/public';
 import { ManagementAppMountParams } from '@kbn/management-plugin/public';
 import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
@@ -39,7 +39,7 @@ export interface AppServices {
   documentation: DocumentationService;
   api: ApiService;
   fileReader: FileReaderService;
-  notifications: NotificationsSetup;
+  notifications: NotificationsStart;
   history: ManagementAppMountParams['history'];
   uiSettings: IUiSettingsClient;
   settings: SettingsStart;

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/mount_management_section.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/mount_management_section.ts
@@ -24,7 +24,7 @@ export interface AppParams extends ManagementAppMountParams {
 }
 
 export async function mountManagementSection(
-  { http, getStartServices, notifications }: CoreSetup<StartDependencies>,
+  { http, getStartServices }: CoreSetup<StartDependencies>,
   params: AppParams
 ) {
   const { element, setBreadcrumbs, history, license, config } = params;
@@ -40,7 +40,7 @@ export async function mountManagementSection(
     documentation: documentationService,
     api: apiService,
     fileReader: fileReaderService,
-    notifications,
+    notifications: coreStart.notifications,
     history,
     uiSettings: coreStart.uiSettings,
     settings: coreStart.settings,

--- a/x-pack/platform/plugins/shared/security/public/session/session_timeout.test.ts
+++ b/x-pack/platform/plugins/shared/security/public/session/session_timeout.test.ts
@@ -37,8 +37,7 @@ const nowMock = jest.spyOn(Date, 'now');
 const visibilityStateMock = jest.spyOn(document, 'visibilityState', 'get');
 
 function createSessionTimeout(expiresInMs: number | null = 60 * 60 * 1000, canBeExtended = true) {
-  const { notifications, http } = coreMock.createSetup();
-  const coreStart = coreMock.createStart();
+  const { http, notifications, ...coreStart } = coreMock.createStart();
   const toast = Symbol();
   notifications.toasts.add.mockReturnValue(toast as any);
   const sessionExpired = createSessionExpiredMock();

--- a/x-pack/platform/plugins/shared/security/public/session/session_timeout.ts
+++ b/x-pack/platform/plugins/shared/security/public/session/session_timeout.ts
@@ -11,7 +11,7 @@ import { BehaviorSubject, skip, tap, throttleTime } from 'rxjs';
 import type {
   HttpFetchOptionsWithPath,
   HttpSetup,
-  NotificationsSetup,
+  NotificationsStart,
   Toast,
 } from '@kbn/core/public';
 
@@ -59,7 +59,7 @@ export class SessionTimeout {
 
   constructor(
     private startServices: StartServices,
-    private notifications: NotificationsSetup,
+    private notifications: NotificationsStart,
     private sessionExpired: Pick<SessionExpired, 'logout'>,
     private http: HttpSetup,
     private tenant: string


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add coordinator for hooking into notification system (#218703)](https://github.com/elastic/kibana/pull/218703)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-29T18:42:11Z","message":"Add coordinator for hooking into notification system (#218703)\n\n## Summary\n\nThis PR implements a rudimentary coordination system for hooking into\nthe notification system, such that an external plugin is able to\nleverage the notification lock when queuing it's own custom message, and\nfurther more managed how it's message gets delivered.\n\nThe coordinator is exposed on the notification setup contract, and\nrequires that the `optInToCoordination` method on the coordinator be\ninvoked passing an observable that receives new messages that should be\ncoordinated with the core kibana toast notifications.\n\nUsage for the coordinator, is along the following lines; \n\n```ts\n// create a coordinator that's scoped to jabbaHutt, when releasing and acquiring locks\nconst coordinator = notificationCoordinator('jabbaHutt');\n\n// pass along a source, and define the condition for it's emissions\nconst messages$ = coordinator.optInToCoordination(source$(), ({ locked, controller }) => {\n\t// new messages will only be emitted when there are no locks (meaning some other opted in source isn't currently displaying a message), \n\t//or when the current lock is owned by jabbaHutt\n\treturn !locked || controller === 'jabbaHutt';\n});\n```\n\nIn the example above the value of `locked` and `controller` might not\nstart off satisfying the emission criteria, and while that is the case\ndespite `source# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [Add coordinator for hooking into notification system (#218703)](https://github.com/elastic/kibana/pull/218703){{{{/raw}}}}

<!--- Backport version: 10.0.1 -->
