### PR TITLE
[onechat] add `query` result for `nl` search strategy

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/nl_search.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/nl_search.ts
@@ -11,7 +11,16 @@ import type { EsqlResponse } from './steps/execute_esql';
 import { executeEsql } from './steps/execute_esql';
 import { generateEsql } from './generate_esql';
 
-export type NaturalLanguageSearchResponse = EsqlResponse;
+export interface NaturalLanguageSearchResponse {
+  /**
+   * The ES|QL query which was generated based on the provided NL query, index and context
+   */
+  generatedQuery: string;
+  /**
+   * The ES|QL data which was returned by executing the query.
+   */
+  esqlData: EsqlResponse;
+}
 
 export const naturalLanguageSearch = async ({
   nlQuery,
@@ -26,7 +35,7 @@ export const naturalLanguageSearch = async ({
   model: ScopedModel;
   esClient: ElasticsearchClient;
 }): Promise<NaturalLanguageSearchResponse> => {
-  const generateResponse = await generateEsql({
+  const queryGenResponse = await generateEsql({
     nlQuery,
     context,
     index,
@@ -34,12 +43,17 @@ export const naturalLanguageSearch = async ({
     esClient,
   });
 
-  if (generateResponse.queries.length < 1) {
+  if (queryGenResponse.queries.length < 1) {
     throw new Error(`No esql queries were generated for query=${nlQuery}`);
   }
 
-  return executeEsql({
-    query: generateResponse.queries[0], // TODO: handle multiple queries
+  const esqlData = await executeEsql({
+    query: queryGenResponse.queries[0], // TODO: handle multiple queries
     esClient,
   });
+
+  return {
+    generatedQuery: queryGenResponse.queries[0],
+    esqlData,
+  };
 };

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/inner_tools.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/inner_tools.ts
@@ -9,7 +9,7 @@ import { z } from '@kbn/zod';
 import { withExecuteToolSpan } from '@kbn/inference-tracing';
 import { tool as toTool } from '@langchain/core/tools';
 import type { ScopedModel } from '@kbn/onechat-server';
-import type { ResourceResult, TabularDataResult } from '@kbn/onechat-common/tools';
+import type { ResourceResult, ToolResult } from '@kbn/onechat-common/tools';
 import { ToolResultType } from '@kbn/onechat-common/tools';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { relevanceSearch } from '../relevance_search';
@@ -103,13 +103,21 @@ export const createNaturalLanguageSearchTool = ({
             esClient,
           });
 
-          const result: TabularDataResult = {
-            type: ToolResultType.tabularData,
-            data: response,
-          };
+          const results: ToolResult[] = [
+            {
+              type: ToolResultType.query,
+              data: {
+                esql: response.generatedQuery,
+              },
+            },
+            {
+              type: ToolResultType.tabularData,
+              data: response.esqlData,
+            },
+          ];
 
-          const content = JSON.stringify([result]);
-          const artifact = { results: [result] };
+          const content = JSON.stringify(results);
+          const artifact = { results };
           return [content, artifact];
         }
       );


### PR DESCRIPTION
## Summary

When implementing the structured result types PR, we lost the `query` return from the natural language search tool.

This PRs fixes it by adding it back

<img width="837" height="700" alt="Screenshot 2025-08-26 at 08 31 46" src="https://github.com/user-attachments/assets/68714b8d-1b23-473d-9623-069817d7bd8a" />
