### PR TITLE
[ES|QL] Implement RERANK Ast Parser + basic template

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/autocomplete.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ESQLCommand } from '../../../types';
+import { pipeCompleteItem } from '../../complete_items';
+import type { ICommandCallbacks } from '../../types';
+import { type ISuggestionItem, type ICommandContext } from '../../types';
+
+export async function autocomplete(
+  query: string,
+  command: ESQLCommand,
+  callbacks?: ICommandCallbacks,
+  context?: ICommandContext,
+  cursorPosition?: number
+): Promise<ISuggestionItem[]> {
+  if (!callbacks?.getByType) {
+    return [];
+  }
+
+  const suggestions: ISuggestionItem[] = [];
+
+  // TODO: Add more specific autocomplete logic for RERANK command
+  const fieldSuggestions = await callbacks.getByType('any');
+  suggestions.push(...fieldSuggestions);
+
+  // Add the pipe completion item when appropriate
+  suggestions.push(pipeCompleteItem);
+
+  return suggestions;
+}

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/index.ts
@@ -10,14 +10,12 @@
 import { i18n } from '@kbn/i18n';
 import type { ICommandMethods } from '../../registry';
 import { autocomplete } from './autocomplete';
-import { columnsAfter } from './columns_after';
 import { validate } from './validate';
 import type { ICommandContext } from '../../types';
 
 const rerankCommandMethods: ICommandMethods<ICommandContext> = {
   autocomplete,
   validate,
-  columnsAfter,
 };
 
 export const rerankCommand = {

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/index.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { ICommandMethods } from '../../registry';
+import { autocomplete } from './autocomplete';
+import { columnsAfter } from './columns_after';
+import { validate } from './validate';
+import type { ICommandContext } from '../../types';
+
+const rerankCommandMethods: ICommandMethods<ICommandContext> = {
+  autocomplete,
+  validate,
+  columnsAfter,
+};
+
+export const rerankCommand = {
+  name: 'rerank',
+  methods: rerankCommandMethods,
+  hidden: true,
+  metadata: {
+    description: i18n.translate('kbn-esql-ast.esql.definitions.rerankDoc', {
+      defaultMessage:
+        'Uses an inference model to compute new relevance scores for documents, directly within your ES|QL queries.',
+    }),
+    declaration:
+      'RERANK [target_field =] query_text ON field1 [, field2, ...] WITH { "inference_id": "model_id" }',
+    examples: [
+      'FROM movies | RERANK "star wars" ON title WITH { "inference_id": "reranker" }',
+      'FROM books | RERANK rerank_score = "hobbit" ON title, description WITH { "inference_id": "my_reranker" }',
+    ],
+    preview: true,
+  },
+};

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { ESQLCommand, ESQLMessage, ESQLAst, ESQLAstRerankCommand } from '../../../types';
+import type { ICommandContext, ICommandCallbacks } from '../../types';
+import { validateCommandArguments } from '../../../definitions/utils/validation';
+
+export const validate = (
+  command: ESQLCommand,
+  ast: ESQLAst,
+  context?: ICommandContext,
+  callbacks?: ICommandCallbacks
+): ESQLMessage[] => {
+  const messages: ESQLMessage[] = [];
+
+  // Run standard argument validation
+  messages.push(...validateCommandArguments(command, ast, context, callbacks));
+
+  // Cast to RERANK command for type-specific validation
+  const rerankCommand = command as ESQLAstRerankCommand;
+
+  // Validate that query text is provided
+  if (!rerankCommand.query) {
+    messages.push({
+      location: command.location,
+      text: i18n.translate('kbn-esql-ast.esql.validation.rerankMissingQuery', {
+        defaultMessage: '[RERANK] Query text is required.',
+      }),
+      type: 'error',
+      code: 'rerankMissingQuery',
+    });
+  }
+
+  // Validate that at least one field is specified in ON clause
+  if (!rerankCommand.fields || rerankCommand.fields.length === 0) {
+    messages.push({
+      location: command.location,
+      text: i18n.translate('kbn-esql-ast.esql.validation.rerankMissingFields', {
+        defaultMessage: '[RERANK] At least one field must be specified in the ON clause.',
+      }),
+      type: 'error',
+      code: 'rerankMissingFields',
+    });
+  }
+
+  // Validate that inference ID is provided
+  if (!rerankCommand.inferenceId) {
+    messages.push({
+      location: command.location,
+      text: i18n.translate('kbn-esql-ast.esql.validation.rerankMissingInferenceId', {
+        defaultMessage: '[RERANK] Inference endpoint must be specified using WITH clause.',
+      }),
+      type: 'error',
+      code: 'rerankMissingInferenceId',
+    });
+  }
+
+  return messages;
+};

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.ts
@@ -50,17 +50,5 @@ export const validate = (
     });
   }
 
-  // Validate that inference ID is provided
-  if (!rerankCommand.inferenceId) {
-    messages.push({
-      location: command.location,
-      text: i18n.translate('kbn-esql-ast.esql.validation.rerankMissingInferenceId', {
-        defaultMessage: '[RERANK] Inference endpoint must be specified using WITH clause.',
-      }),
-      type: 'error',
-      code: 'rerankMissingInferenceId',
-    });
-  }
-
   return messages;
 };

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/index.ts
@@ -31,6 +31,7 @@ import { showCommand } from './commands/show';
 import { timeseriesCommand } from './commands/timeseries';
 import { whereCommand } from './commands/where';
 import { fuseCommand } from './commands/fuse';
+import { rerankCommand } from './commands/rerank';
 import { mergeCommandWithGeneratedCommandData } from './elastisearch_command_data_loader';
 
 const esqlCommandRegistry = new CommandRegistry();
@@ -59,6 +60,7 @@ const baseCommands = [
   timeseriesCommand,
   whereCommand,
   fuseCommand,
+  rerankCommand,
 ];
 
 baseCommands.forEach((command) => {

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/rerank.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/rerank.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EsqlQuery } from '../../query';
+import type { ESQLAstRerankCommand } from '../../types';
+
+describe('RERANK', () => {
+  describe('basic parsing', () => {
+    it('should parse basic RERANK query without target field assignment', () => {
+      const text = 'FROM movies | RERANK "star wars" ON title WITH { "inference_id" : "reranker" }';
+      const { ast } = EsqlQuery.fromSrc(text);
+
+      expect(ast.commands[1]).toMatchObject({
+        type: 'command',
+        name: 'rerank',
+        query: {
+          type: 'literal',
+          literalType: 'keyword',
+          value: '"star wars"',
+        },
+        fields: [
+          {
+            type: 'column',
+            name: 'title',
+          },
+        ],
+        args: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'literal',
+            value: '"star wars"',
+          }),
+        ]),
+      });
+
+      expect(ast.commands[1]).not.toHaveProperty('targetField');
+    });
+
+    it('should parse RERANK with multiple fields', () => {
+      const text =
+        'FROM movies | RERANK "star wars" ON title, description, actors WITH { "inference_id" : "reranker" }';
+      const { ast } = EsqlQuery.fromSrc(text);
+
+      expect(ast.commands[1]).toMatchObject({
+        type: 'command',
+        name: 'rerank',
+        fields: [
+          { type: 'column', name: 'title' },
+          { type: 'column', name: 'description' },
+          { type: 'column', name: 'actors' },
+        ],
+      });
+    });
+  });
+
+  describe('target field assignment', () => {
+    it('should parse target field assignment with correct AST structure', () => {
+      const text =
+        'FROM movies | RERANK rerank_score = "star wars" ON title WITH { "inference_id" : "reranker" }';
+      const { ast } = EsqlQuery.fromSrc(text);
+
+      const rerankCmd = ast.commands[1];
+
+      expect(rerankCmd).toMatchObject({
+        type: 'command',
+        name: 'rerank',
+        query: {
+          type: 'literal',
+          literalType: 'keyword',
+          value: '"star wars"',
+        },
+        targetField: {
+          type: 'column',
+          name: 'rerank_score',
+        },
+        args: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'function',
+            subtype: 'binary-expression',
+            name: '=',
+          }),
+        ]),
+      });
+    });
+  });
+
+  describe('field assignments', () => {
+    it('should parse computed field assignments with correct binary expression', () => {
+      const text =
+        'FROM movies | RERANK "star wars" ON title, overview=SUBSTRING(overview, 0, 100) WITH { "inference_id" : "reranker" }';
+      const { ast } = EsqlQuery.fromSrc(text);
+
+      expect(ast.commands[1]).toMatchObject({
+        type: 'command',
+        name: 'rerank',
+        fields: [
+          {
+            type: 'column',
+            name: 'title',
+          },
+          {
+            type: 'function',
+            subtype: 'binary-expression',
+            name: '=',
+            args: expect.arrayContaining([
+              expect.objectContaining({ type: 'column', name: 'overview' }),
+              expect.arrayContaining([
+                expect.objectContaining({
+                  type: 'function',
+                  name: 'substring',
+                }),
+              ]),
+            ]),
+          },
+        ],
+      });
+    });
+
+    it('should parse multiple field assignments', () => {
+      const text =
+        'FROM movies | RERANK "star wars" ON title=BOOST(title, 2), description=BOOST(description, 1.5) WITH { "inference_id" : "reranker" }';
+      const { ast } = EsqlQuery.fromSrc(text);
+      const rerankCmd = ast.commands[1] as ESQLAstRerankCommand;
+
+      expect(rerankCmd).toMatchObject({
+        type: 'command',
+        name: 'rerank',
+        fields: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'function',
+            subtype: 'binary-expression',
+            name: '=',
+          }),
+          expect.objectContaining({
+            type: 'function',
+            subtype: 'binary-expression',
+            name: '=',
+          }),
+        ]),
+      });
+
+      expect(rerankCmd.fields).toHaveLength(2);
+    });
+  });
+
+  describe('error cases and edge scenarios and catch errors', () => {
+    it('should handle missing query text gracefully', () => {
+      const text = 'FROM movies | RERANK ON title WITH { "inference_id" : "reranker" }';
+      const { ast, errors } = EsqlQuery.fromSrc(text);
+
+      expect(ast.commands).toHaveLength(2);
+      expect(ast.commands[1]).toMatchObject({
+        type: 'command',
+        name: 'rerank',
+        fields: [], // Parser returns empty fields when query is missing
+      });
+
+      expect(errors).toHaveLength(2);
+    });
+
+    it('should handle missing WITH clause', () => {
+      const text = 'FROM movies | RERANK "star wars" ON title';
+      const { ast } = EsqlQuery.fromSrc(text);
+      const rerankCmd = ast.commands[1] as ESQLAstRerankCommand;
+
+      expect(rerankCmd).toMatchObject({
+        type: 'command',
+        name: 'rerank',
+        query: {
+          type: 'literal',
+          value: '"star wars"',
+        },
+        fields: [{ type: 'column', name: 'title' }],
+      });
+
+      expect(rerankCmd).not.toHaveProperty('inferenceId');
+    });
+
+    it('should handle malformed assignment syntax and catch an error', () => {
+      const text = 'FROM movies | RERANK score = ON title WITH { "inference_id" : "test" }';
+      const { ast, errors } = EsqlQuery.fromSrc(text);
+
+      expect(ast.commands).toHaveLength(2);
+      expect(ast.commands[1]).toMatchObject({
+        type: 'command',
+        name: 'rerank',
+      });
+
+      expect(errors).toHaveLength(1);
+    });
+
+    it('should handle empty field list and catch an error', () => {
+      const text = 'FROM movies | RERANK "query" ON WITH { "inference_id" : "test" }';
+      const { ast, errors } = EsqlQuery.fromSrc(text);
+      const rerankCmd = ast.commands[1] as ESQLAstRerankCommand;
+
+      expect(rerankCmd).toMatchObject({
+        type: 'command',
+        name: 'rerank',
+        fields: [
+          expect.objectContaining({
+            type: 'column',
+            incomplete: true,
+          }),
+        ],
+      });
+
+      expect(errors).toHaveLength(1);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/cst_to_ast_converter.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/cst_to_ast_converter.ts
@@ -1252,7 +1252,7 @@ export class CstToAstConverter {
 
     this.parseRerankQuery(ctx, command);
     this.parseRerankFields(ctx, command);
-    this.parseRerankInferenceId(ctx, command);
+    this.parseRerankWithParameters(ctx, command);
 
     return command;
   }
@@ -1306,10 +1306,10 @@ export class CstToAstConverter {
   }
 
   /**
-   * Parses WITH parameters and extracts inference_id.
-   * Handles: ... WITH {"inference_id": "model"}
+   * Parses WITH parameters as a generic map.
+   * Handles: ... WITH {inference_id: "model", scoreColumn: "score", ...}
    */
-  private parseRerankInferenceId(
+  private parseRerankWithParameters(
     ctx: cst.RerankCommandContext,
     command: ast.ESQLAstRerankCommand
   ): void {
@@ -1320,11 +1320,7 @@ export class CstToAstConverter {
     }
 
     const withOption = this.fromCommandNamedParameters(namedParamsCtx);
-    const map = withOption.args[0] as ast.ESQLMap | undefined;
-    const inferenceIdExpr = this.getMapEntry(map, 'inference_id');
-
-    if (withOption && inferenceIdExpr) {
-      command.inferenceId = inferenceIdExpr as ast.ESQLIdentifierOrParam;
+    if (withOption) {
       command.args.push(withOption);
     }
   }
@@ -1793,16 +1789,6 @@ export class CstToAstConverter {
     withOption.incomplete = map.incomplete;
 
     return withOption;
-  }
-
-  /**
-   * Looks up a key inside an ES|QL map expression and returns its value if present.
-   */
-  private getMapEntry(
-    map: ast.ESQLMap | undefined,
-    key: string
-  ): ast.ESQLAstExpression | undefined {
-    return map?.entries.find((entry) => entry.key.valueUnquoted === key)?.value;
   }
 
   private collectInlineCast(ctx: cst.InlineCastContext): ast.ESQLInlineCast {

--- a/src/platform/packages/shared/kbn-esql-ast/src/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/types.ts
@@ -132,7 +132,6 @@ export interface ESQLAstCompletionCommand extends ESQLCommand<'completion'> {
 export interface ESQLAstRerankCommand extends ESQLCommand<'rerank'> {
   query: ESQLLiteral | ESQLUnknownItem;
   fields: ESQLAstField[];
-  inferenceId: ESQLIdentifierOrParam;
   targetField?: ESQLColumn;
 }
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/types.ts
@@ -130,9 +130,10 @@ export interface ESQLAstCompletionCommand extends ESQLCommand<'completion'> {
 }
 
 export interface ESQLAstRerankCommand extends ESQLCommand<'rerank'> {
-  query: ESQLLiteral;
+  query: ESQLLiteral | ESQLUnknownItem;
   fields: ESQLAstField[];
   inferenceId: ESQLIdentifierOrParam;
+  targetField?: ESQLColumn;
 }
 
 export type ESQLIdentifierOrParam = ESQLIdentifier | ESQLParamLiteral;

--- a/src/platform/packages/shared/kbn-esql-ast/src/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/types.ts
@@ -130,8 +130,9 @@ export interface ESQLAstCompletionCommand extends ESQLCommand<'completion'> {
 }
 
 export interface ESQLAstRerankCommand extends ESQLCommand<'rerank'> {
-  query: ESQLLiteral | ESQLUnknownItem;
+  query: ESQLLiteral;
   fields: ESQLAstField[];
+  inferenceId: ESQLIdentifierOrParam;
   targetField?: ESQLColumn;
 }
 

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/esql_lexer_rules.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/esql_lexer_rules.ts
@@ -28,6 +28,7 @@ export const keywords = [
   'limit',
   'mv_expand',
   'rename',
+  'rerank',
   'row',
   'show',
   'sort',


### PR DESCRIPTION
## Summary

Part of: https://github.com/elastic/kibana/issues/217285

Grammar:

`  rerankCommand: RERANK (targetField=qualifiedName ASSIGN)? queryText=constant ON rerankFields commandNamedParameters
`

Grammar -> commandParameters expanded:

`commandNamedParameters: (WITH mapExpression)?`
`mapExpression:
    LEFT_BRACES (entryExpression (COMMA entryExpression)*)? RIGHT_BRACES`

Syntax: 

`RERANK [column =] query ON field [, field, ...] [WITH { "inference_id" : "my_inference_endpoint" }]`
