### PR TITLE
[Oblt Onboarding] Fix Helm version typo

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -141,7 +141,7 @@ helm upgrade --install opentelemetry-kube-stack open-telemetry/opentelemetry-kub
                 <p>
                   <FormattedMessage
                     id="xpack.observability_onboarding.otelKubernetesPanel.injectAutoinstrumentationLibrariesForLabel"
-                    defaultMessage="Install the OpenTelemetry Operator using the kube-stack Helm chart and the provided values file. Compatible with Helm up to version 8.14. For automatic certificate renewal, we recommend installing the {link}, and customize the values.yaml file before the installation as described {doc}."
+                    defaultMessage="Install the OpenTelemetry Operator using the kube-stack Helm chart and the provided values file. Compatible with Helm up to version 3.18.4. For automatic certificate renewal, we recommend installing the {link}, and customize the values.yaml file before the installation as described {doc}."
                     values={{
                       link: (
                         <EuiLink


### PR DESCRIPTION
Follow up after [previous change](https://github.com/elastic/kibana/pull/232618), fixes Helm version in the note about the version requirement.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->