### PR TITLE
[8.17] [Cases] Hide connectors for license < gold (#232506)

### DIFF
--- a/x-pack/plugins/cases/public/common/use_cases_features.test.tsx
+++ b/x-pack/plugins/cases/public/common/use_cases_features.test.tsx
@@ -52,6 +52,8 @@ describe('useCasesFeatures', () => {
         metricsFeatures: [],
         caseAssignmentAuthorized: false,
         pushToServiceAuthorized: false,
+        observablesAuthorized: false,
+        connectorsAuthorized: false,
       });
     }
   );
@@ -74,6 +76,8 @@ describe('useCasesFeatures', () => {
       metricsFeatures: [CaseMetricsFeature.CONNECTORS],
       caseAssignmentAuthorized: false,
       pushToServiceAuthorized: false,
+      observablesAuthorized: false,
+      connectorsAuthorized: false,
     });
   });
 
@@ -84,8 +88,27 @@ describe('useCasesFeatures', () => {
       type === 'platinum' || type === 'enterprise' || type === 'trial' ? true : false,
     ]);
 
+  it('allows gold features on gold license', () => {
+    const license = licensingMock.createLicense({
+      license: { type: 'gold' },
+    });
+
+    const { result } = renderHook<React.PropsWithChildren<{}>, UseCasesFeatures>(
+      () => useCasesFeatures(),
+      {
+        wrapper: ({ children }) => <TestProviders license={license}>{children}</TestProviders>,
+      }
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        connectorsAuthorized: true,
+      })
+    );
+  });
+
   it.each(licenseTests)(
-    'allows platinum features on a platinum license',
+    'allows platinum features on a platinum license (license = %s)',
     async (type, expectedResult) => {
       const license = licensingMock.createLicense({
         license: { type },
@@ -98,13 +121,16 @@ describe('useCasesFeatures', () => {
         }
       );
 
-      expect(result.current).toEqual({
-        isAlertsEnabled: true,
-        isSyncAlertsEnabled: true,
-        metricsFeatures: [],
-        caseAssignmentAuthorized: expectedResult,
-        pushToServiceAuthorized: expectedResult,
-      });
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isAlertsEnabled: true,
+          isSyncAlertsEnabled: true,
+          metricsFeatures: [],
+          caseAssignmentAuthorized: expectedResult,
+          pushToServiceAuthorized: expectedResult,
+          observablesAuthorized: expectedResult,
+        })
+      );
     }
   );
 });

--- a/x-pack/plugins/cases/public/common/use_cases_features.tsx
+++ b/x-pack/plugins/cases/public/common/use_cases_features.tsx
@@ -13,6 +13,8 @@ import { useLicense } from './use_license';
 export interface UseCasesFeatures {
   isAlertsEnabled: boolean;
   isSyncAlertsEnabled: boolean;
+  observablesAuthorized: boolean;
+  connectorsAuthorized: boolean;
   caseAssignmentAuthorized: boolean;
   pushToServiceAuthorized: boolean;
   metricsFeatures: SingleCaseMetricsFeature[];
@@ -20,8 +22,9 @@ export interface UseCasesFeatures {
 
 export const useCasesFeatures = (): UseCasesFeatures => {
   const { features } = useCasesContext();
-  const { isAtLeastPlatinum } = useLicense();
+  const { isAtLeastGold, isAtLeastPlatinum } = useLicense();
   const hasLicenseGreaterThanPlatinum = isAtLeastPlatinum();
+  const hasLicenseWithAtLeastGold = isAtLeastGold();
 
   const casesFeatures = useMemo(
     () => ({
@@ -38,8 +41,16 @@ export const useCasesFeatures = (): UseCasesFeatures => {
       metricsFeatures: features.metrics,
       caseAssignmentAuthorized: hasLicenseGreaterThanPlatinum,
       pushToServiceAuthorized: hasLicenseGreaterThanPlatinum,
+      observablesAuthorized: hasLicenseGreaterThanPlatinum,
+      connectorsAuthorized: hasLicenseWithAtLeastGold,
     }),
-    [features.alerts.enabled, features.alerts.sync, features.metrics, hasLicenseGreaterThanPlatinum]
+    [
+      features.alerts.enabled,
+      features.alerts.sync,
+      features.metrics,
+      hasLicenseGreaterThanPlatinum,
+      hasLicenseWithAtLeastGold,
+    ]
   );
 
   return casesFeatures;

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -178,7 +178,7 @@ describe.skip('AllCasesListGeneric', () => {
     useGetCaseConfigurationMock.mockImplementation(() => useCaseConfigureResponse);
     useBulkGetUserProfilesMock.mockReturnValue({ data: userProfilesMap });
     useUpdateCaseMock.mockReturnValue({ mutate: updateCaseProperty });
-    useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => false });
+    useLicenseMock.mockReturnValue({ isAtLeastGold: () => false, isAtLeastPlatinum: () => false });
     useSuggestUserProfilesMock.mockReturnValue({ data: userProfiles, isLoading: false });
     mockKibana();
     moment.tz.setDefault('UTC');
@@ -190,7 +190,7 @@ describe.skip('AllCasesListGeneric', () => {
   });
 
   it('should render AllCasesList', async () => {
-    useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => true });
+    useLicenseMock.mockReturnValue({ isAtLeastGold: () => true, isAtLeastPlatinum: () => true });
     appMockRenderer.render(<AllCasesList />);
 
     const caseDetailsLinks = await screen.findAllByTestId('case-details-link');
@@ -218,7 +218,7 @@ describe.skip('AllCasesListGeneric', () => {
   });
 
   it("should show a tooltip with the assignee's email when hover over the assignee avatar", async () => {
-    useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => true });
+    useLicenseMock.mockReturnValue({ isAtLeastGold: () => true, isAtLeastPlatinum: () => true });
 
     appMockRenderer.render(<AllCasesList />);
 
@@ -638,7 +638,7 @@ describe.skip('AllCasesListGeneric', () => {
   });
 
   it('should clear the filters correctly', async () => {
-    useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => true });
+    useLicenseMock.mockReturnValue({ isAtLeastGold: () => true, isAtLeastPlatinum: () => true });
 
     appMockRenderer.render(<AllCasesList />);
 
@@ -917,7 +917,10 @@ describe.skip('AllCasesListGeneric', () => {
 
     describe('Assignees', () => {
       it('should hide the assignees column on basic license', async () => {
-        useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => false });
+        useLicenseMock.mockReturnValue({
+          isAtLeastGold: () => false,
+          isAtLeastPlatinum: () => false,
+        });
 
         appMockRenderer.render(<AllCasesList />);
 
@@ -926,7 +929,10 @@ describe.skip('AllCasesListGeneric', () => {
       });
 
       it('should show the assignees column on platinum license', async () => {
-        useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => true });
+        useLicenseMock.mockReturnValue({
+          isAtLeastGold: () => true,
+          isAtLeastPlatinum: () => true,
+        });
 
         appMockRenderer.render(<AllCasesList />);
 
@@ -935,7 +941,10 @@ describe.skip('AllCasesListGeneric', () => {
       });
 
       it('should hide the assignees filters on basic license', async () => {
-        useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => false });
+        useLicenseMock.mockReturnValue({
+          isAtLeastGold: () => false,
+          isAtLeastPlatinum: () => false,
+        });
 
         appMockRenderer.render(<AllCasesList />);
 
@@ -944,7 +953,10 @@ describe.skip('AllCasesListGeneric', () => {
       });
 
       it('should show the assignees filters on platinum license', async () => {
-        useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => true });
+        useLicenseMock.mockReturnValue({
+          isAtLeastGold: () => true,
+          isAtLeastPlatinum: () => true,
+        });
 
         appMockRenderer.render(<AllCasesList />);
 
@@ -955,7 +967,10 @@ describe.skip('AllCasesListGeneric', () => {
       });
 
       it('should reset the assignees when deactivating the filter', async () => {
-        useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => true });
+        useLicenseMock.mockReturnValue({
+          isAtLeastGold: () => true,
+          isAtLeastPlatinum: () => true,
+        });
 
         appMockRenderer.render(<AllCasesList />);
 

--- a/x-pack/plugins/cases/public/components/create/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.test.tsx
@@ -102,7 +102,6 @@ describe('CreateCaseForm', () => {
     expect(await screen.findByTestId('caseTags')).toBeInTheDocument();
     expect(await screen.findByTestId('caseDescription')).toBeInTheDocument();
     expect(await screen.findByTestId('caseSyncAlerts')).toBeInTheDocument();
-    expect(await screen.findByTestId('caseConnectors')).toBeInTheDocument();
     expect(await screen.findByTestId('categories-list')).toBeInTheDocument();
     expect(screen.queryByText('caseOwnerSelector')).not.toBeInTheDocument();
   });
@@ -115,7 +114,6 @@ describe('CreateCaseForm', () => {
     expect(await screen.findByTestId('caseTags')).toBeInTheDocument();
     expect(await screen.findByTestId('caseDescription')).toBeInTheDocument();
     expect(await screen.findByTestId('caseSyncAlerts')).toBeInTheDocument();
-    expect(await screen.findByTestId('caseConnectors')).toBeInTheDocument();
     expect(await screen.findByTestId('categories-list')).toBeInTheDocument();
     expect(await screen.findByTestId('caseOwnerSelector')).toBeInTheDocument();
   });
@@ -133,6 +131,23 @@ describe('CreateCaseForm', () => {
     appMockRenderer.render(<CreateCaseForm {...casesFormProps} />);
 
     expect(screen.queryByText('Sync alert')).not.toBeInTheDocument();
+  });
+
+  it('should not render connectors on basic license', () => {
+    renderWithTestingProviders(<CreateCaseForm {...casesFormProps} />);
+    expect(screen.queryByTestId('caseConnectors')).not.toBeInTheDocument();
+  });
+
+  it('should render connectors on gold license', async () => {
+    const license = licensingMock.createLicense({
+      license: { type: 'gold' },
+    });
+
+    renderWithTestingProviders(<CreateCaseForm {...casesFormProps} />, {
+      wrapperProps: { license },
+    });
+
+    expect(await screen.findByTestId('caseConnectors')).toBeInTheDocument();
   });
 
   it('should not render the assignees on basic license', () => {

--- a/x-pack/plugins/cases/public/components/create/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.test.tsx
@@ -134,7 +134,7 @@ describe('CreateCaseForm', () => {
   });
 
   it('should not render connectors on basic license', () => {
-    renderWithTestingProviders(<CreateCaseForm {...casesFormProps} />);
+    appMockRenderer.render(<CreateCaseForm {...casesFormProps} />);
     expect(screen.queryByTestId('caseConnectors')).not.toBeInTheDocument();
   });
 
@@ -143,9 +143,8 @@ describe('CreateCaseForm', () => {
       license: { type: 'gold' },
     });
 
-    renderWithTestingProviders(<CreateCaseForm {...casesFormProps} />, {
-      wrapperProps: { license },
-    });
+    appMockRenderer = createAppMockRenderer({ license });
+    appMockRenderer.render(<CreateCaseForm {...casesFormProps} />);
 
     expect(await screen.findByTestId('caseConnectors')).toBeInTheDocument();
   });

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -231,7 +231,7 @@ describe('Create case', () => {
       iconClass: 'logoSecurity',
     });
 
-    useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => true });
+    useLicenseMock.mockReturnValue({ isAtLeastGold: () => true, isAtLeastPlatinum: () => true });
   });
 
   afterAll(() => {
@@ -1115,7 +1115,10 @@ describe('Create case', () => {
     });
 
     it('should not render the assignees on basic license', async () => {
-      useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => false });
+      useLicenseMock.mockReturnValue({
+        isAtLeastGold: () => false,
+        isAtLeastPlatinum: () => false,
+      });
 
       appMockRender.render(
         <FormContext

--- a/x-pack/plugins/cases/public/components/create/form_fields.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_fields.tsx
@@ -66,7 +66,7 @@ const DEFAULT_EMPTY_TEMPLATE_KEY = 'defaultEmptyTemplateKey';
 export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.memo(
   ({ configuration, connectors, isLoading, withSteps, draftStorageKey }) => {
     const { reset, updateFieldValues, isSubmitting, setFieldValue } = useFormContext();
-    const { isSyncAlertsEnabled } = useCasesFeatures();
+    const { isSyncAlertsEnabled, connectorsAuthorized } = useCasesFeatures();
     const configurationOwner = configuration.owner;
 
     /**
@@ -161,8 +161,13 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
     );
 
     const allSteps = useMemo(
-      () => [firstStep, secondStep, ...(isSyncAlertsEnabled ? [thirdStep] : []), fourthStep],
-      [firstStep, secondStep, isSyncAlertsEnabled, thirdStep, fourthStep]
+      () => [
+        firstStep,
+        secondStep,
+        ...(isSyncAlertsEnabled ? [thirdStep] : []),
+        ...(connectorsAuthorized ? [fourthStep] : []),
+      ],
+      [firstStep, secondStep, isSyncAlertsEnabled, thirdStep, connectorsAuthorized, fourthStep]
     );
 
     return (
@@ -215,14 +220,16 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
                   <EuiFlexItem>{thirdStep.children}</EuiFlexItem>
                 </EuiFlexGroup>
               )}
-              <EuiFlexGroup direction="column">
-                <EuiFlexItem>
-                  <EuiTitle size="s">
-                    <h2>{i18n.STEP_FOUR_TITLE}</h2>
-                  </EuiTitle>
-                </EuiFlexItem>
-                <EuiFlexItem>{fourthStep.children}</EuiFlexItem>
-              </EuiFlexGroup>
+              {connectorsAuthorized && (
+                <EuiFlexGroup direction="column">
+                  <EuiFlexItem>
+                    <EuiTitle size="s">
+                      <h2>{i18n.STEP_FOUR_TITLE}</h2>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                  <EuiFlexItem>{fourthStep.children}</EuiFlexItem>
+                </EuiFlexGroup>
+              )}
             </EuiFlexGroup>
           </>
         )}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Cases] Hide connectors for license < gold (#232506)](https://github.com/elastic/kibana/pull/232506)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jan Monschke","email":"jan.monschke@elastic.co"},"sourceCommit":{"committedDate":"2025-08-25T15:31:53Z","message":"[Cases] Hide connectors for license < gold (#232506)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/183229\n\nCase connectors are only available for customers with at least a gold\nsubscription. Therefore connectors should not show in the create case\nflow. This PR fixes that.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"93640478c19d76ee3ceb412d1e50c2b44fbb5b3d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","Team:Cases","v9.2.0","v9.0.6"],"title":"[Cases] Hide connectors for license < gold","number":232506,"url":"https://github.com/elastic/kibana/pull/232506","mergeCommit":{"message":"[Cases] Hide connectors for license < gold (#232506)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/183229\n\nCase connectors are only available for customers with at least a gold\nsubscription. Therefore connectors should not show in the create case\nflow. This PR fixes that.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"93640478c19d76ee3ceb412d1e50c2b44fbb5b3d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232506","number":232506,"mergeCommit":{"message":"[Cases] Hide connectors for license < gold (#232506)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/183229\n\nCase connectors are only available for customers with at least a gold\nsubscription. Therefore connectors should not show in the create case\nflow. This PR fixes that.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"93640478c19d76ee3ceb412d1e50c2b44fbb5b3d"}},{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232859","number":232859,"state":"MERGED","mergeCommit":{"sha":"ef32e95a5b37b9684aee39915099ac7fe25e9934","message":"[9.0] [Cases] Hide connectors for license < gold (#232506) (#232859)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Cases] Hide connectors for license < gold\n(#232506)](https://github.com/elastic/kibana/pull/232506)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jan Monschke <jan.monschke@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"url":"https://github.com/elastic/kibana/pull/232857","number":232857,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/232858","number":232858,"branch":"8.19","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/232860","number":232860,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->