### PR TITLE
[SideNav] Fallbacks icons to `deepLink.icon`

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v2/navigation/__snapshots__/to_navigation_items.test.tsx.snap
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v2/navigation/__snapshots__/to_navigation_items.test.tsx.snap
@@ -15,7 +15,7 @@ Array [
     "badgeType": undefined,
     "data-test-subj": "nav-item nav-item-security_solution_nav_footer.dev_tools nav-item-deepLinkId-undefined nav-item-id-dev_tools",
     "href": "/tzo/s/sec/app/dev_tools",
-    "iconType": "devToolsApp",
+    "iconType": "editorCodeBlock",
     "id": "dev_tools",
     "label": "Developer tools",
     "sections": undefined,

--- a/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v2/navigation/to_navigation_items.test.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v2/navigation/to_navigation_items.test.tsx
@@ -33,7 +33,7 @@ describe('toNavigationItems', () => {
     expect(logoItem).toMatchInlineSnapshot(`
       Object {
         "href": "/missing-href-😭",
-        "iconType": "logoKibana",
+        "iconType": "broom",
         "id": "kibana",
         "label": "Kibana",
       }
@@ -58,29 +58,29 @@ describe('toNavigationItems', () => {
       === Navigation Warnings ===
       • No \\"home\\" node found in primary nodes. There should be a logo node with solution logo, name and home page href. renderAs: \\"home\\" is expected.
       • Navigation item is missing. Using fallback value: \\"/missing-href-😭\\".
-      • Navigation item is missing. Using fallback value: \\"logoKibana\\".
+      • No icon found for node \\"undefined\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
       • Navigation item is missing. Using fallback value: \\"kibana\\".
       • Navigation item is missing. Using fallback value: \\"Kibana\\".
       • Navigation node \\"node-2\\" is missing href and is not a panel opener. This node was likely used as a sub-section. Ignoring this node and flattening its children: securityGroup:rules, alerts, attack_discovery, cloud_security_posture-findings, cases.
-      • Navigation item \\"securityGroup:rules\\" is missing all of \\"iconV2, icon\\". Using fallback value: \\"broom\\".
-      • Navigation item \\"alerts\\" is missing all of \\"iconV2, icon\\". Using fallback value: \\"broom\\".
-      • Navigation item \\"attack_discovery\\" is missing all of \\"iconV2, icon\\". Using fallback value: \\"broom\\".
-      • Navigation item \\"cloud_security_posture-findings\\" is missing all of \\"iconV2, icon\\". Using fallback value: \\"broom\\".
-      • Navigation item \\"cases\\" is missing all of \\"iconV2, icon\\". Using fallback value: \\"broom\\".
+      • No icon found for node \\"securityGroup:rules\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
+      • No icon found for node \\"alerts\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
+      • No icon found for node \\"attack_discovery\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
+      • No icon found for node \\"cloud_security_posture-findings\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
+      • No icon found for node \\"cases\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
       • Navigation node \\"node-3\\" is missing href and is not a panel opener. This node was likely used as a sub-section. Ignoring this node and flattening its children: securityGroup:entityAnalytics, securityGroup:explore, securityGroup:investigations, threat_intelligence.
       • Panel opener node \\"securityGroup:entityAnalytics\\" has no children. Ignoring it.
       • Panel opener node \\"securityGroup:explore\\" should contain panel sections, not direct links. Flattening links \\"hosts, network, users\\" into secondary items and creating a placeholder section for these links.
-      • Navigation item \\"securityGroup:explore\\" is missing all of \\"iconV2, icon\\". Using fallback value: \\"broom\\".
+      • No icon found for node \\"securityGroup:explore\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
       • Panel opener node \\"securityGroup:investigations\\" should contain panel sections, not direct links. Flattening links \\"timelines, notes, osquery\\" into secondary items and creating a placeholder section for these links.
-      • Navigation item \\"securityGroup:investigations\\" is missing all of \\"iconV2, icon\\". Using fallback value: \\"broom\\".
-      • Navigation item \\"threat_intelligence\\" is missing all of \\"iconV2, icon\\". Using fallback value: \\"broom\\".
+      • No icon found for node \\"securityGroup:investigations\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
+      • No icon found for node \\"threat_intelligence\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
       • Navigation node \\"node-4\\" is missing href and is not a panel opener. This node was likely used as a sub-section. Ignoring this node and flattening its children: securityGroup:assets.
       • Secondary menu item node \\"fleet\\" has a href \\"/tzo/s/sec/app/fleet\\", but it should not. We're using it as a section title that doesn't have a link.
       • Navigation item \\"node-0\\" is missing a \\"title\\". Using fallback value: \\"Missing Title 😭\\".
       • Navigation item \\"node-0\\" is missing a \\"href\\". Using fallback value: \\"Missing Href 😭\\".
-      • Navigation item \\"securityGroup:assets\\" is missing all of \\"iconV2, icon\\". Using fallback value: \\"broom\\".
-      • Navigation item \\"securityGroup:machineLearning\\" is missing all of \\"iconV2, icon\\". Using fallback value: \\"broom\\".
-      • Navigation item \\"stack_management\\" is missing all of \\"iconV2, icon\\". Using fallback value: \\"broom\\".
+      • No icon found for node \\"securityGroup:assets\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
+      • No icon found for node \\"securityGroup:machineLearning\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
+      • No icon found for node \\"stack_management\\". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon \\"broom\\".
       • Accordion items are not supported in the new navigation. Flattening them \\"stack_management, monitoring, integrations\\" and dropping accordion node \\"node-2\\"."
     `);
   });

--- a/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v2/navigation/to_navigation_items.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v2/navigation/to_navigation_items.tsx
@@ -111,7 +111,7 @@ export const toNavigationItems = (
 
   const logoItem: SideNavLogo = {
     href: warnIfMissing(logoNode, 'href', '/missing-href-😭'),
-    iconType: warnIfMissing(logoNode, ['iconV2', 'icon'], 'logoKibana') as string,
+    iconType: getIcon(logoNode),
     id: warnIfMissing(logoNode, 'id', 'kibana'),
     label: warnIfMissing(logoNode, 'title', 'Kibana'),
   };
@@ -277,14 +277,7 @@ export const toNavigationItems = (
     return {
       id: navNode.id,
       label: warnIfMissing(navNode, 'title', 'Missing Title 😭'),
-      iconType: warnIfMissing(
-        {
-          iconV2: AppDeepLinkIdToIcon[navNode.id],
-          ...navNode,
-        },
-        ['iconV2', 'icon'],
-        'broom'
-      ),
+      iconType: getIcon(navNode),
       href: itemHref,
       sections: secondarySections,
       'data-test-subj': getTestSubj(navNode),
@@ -413,4 +406,32 @@ const getTestSubj = (navNode: ChromeProjectNavigationNode, isActive = false): st
     [`nav-item-id-${id}`]: id,
     [`nav-item-isActive`]: isActive,
   });
+};
+
+const getIcon = (node: ChromeProjectNavigationNode | null): string => {
+  if (node?.iconV2) {
+    return node.iconV2 as string;
+  }
+
+  if (node?.icon) {
+    return node.icon as string;
+  }
+
+  if (node && AppDeepLinkIdToIcon[node.id]) {
+    return AppDeepLinkIdToIcon[node.id];
+  }
+
+  if (node?.deepLink?.euiIconType) {
+    return node.deepLink.euiIconType;
+  }
+
+  if (node?.deepLink?.icon) {
+    return node.deepLink.icon;
+  }
+
+  warnOnce(
+    `No icon found for node "${node?.id}". Expected iconV2, icon, deepLink.euiIconType, deepLink.icon or a known deep link id. Using fallback icon "broom".`
+  );
+
+  return 'broom';
 };


### PR DESCRIPTION
## Summary

close https://github.com/elastic/kibana/issues/232772

Improve the fallback icons in the new navigation to include the icons set up in deep links.


cc @semd, I didn't realize that we already had icons available in deep link definitions.