### PR TITLE
[Observability] Fix sidenav flaky test

### DIFF
--- a/x-pack/solutions/observability/test/observability_functional/apps/observability/sidenav/sidenav.ts
+++ b/x-pack/solutions/observability/test/observability_functional/apps/observability/sidenav/sidenav.ts
@@ -17,6 +17,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const spaces = getService('spaces');
   const browser = getService('browser');
   const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
 
   describe('o11y sidenav', () => {
     let cleanUp: () => Promise<unknown>;
@@ -37,10 +38,12 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await cleanUp();
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/228057
-    describe.skip('sidenav & breadcrumbs', () => {
+    describe('sidenav & breadcrumbs', () => {
       it('renders the correct nav and navigate to links', async () => {
-        await solutionNavigation.sidenav.clickLink({ navId: 'observabilityAIAssistant' }); // click on AI Assistant link
+        await retry.waitFor('redirect or status response', async () => {
+          await solutionNavigation.sidenav.clickLink({ navId: 'observabilityAIAssistant' }); // click on AI Assistant link
+          return (await browser.getCurrentUrl()).includes('/app/observabilityAIAssistant');
+        });
         await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'AI Assistant' });
 
         // check Other Tools section


### PR DESCRIPTION
It closes https://github.com/elastic/kibana/issues/228057

This is the screenshot taken when the test failed:
<img width="1600" height="861" alt="ObservabilityApp o11y sidenav sidenav  breadcrumbs renders the correct nav and n-7828c6fc697cb39203b2258cf9cf36f799cdfba55c4074ea3796c6a1bda741a5" src="https://github.com/user-attachments/assets/886ce5d9-8ea2-4f8d-bf53-ea42751f8410" />


For some reason when clicking on the `observabilityAIAssistant` sidenav it was redirecting to a different page.
I've added a retry to make sure the test is on the correct page before continuing.