### PR TITLE
[chore][Lens] Remove EUI vars deprecated usage

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/esql_data_grid_accordion.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/esql_data_grid_accordion.tsx
@@ -8,9 +8,15 @@
 import React, { useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
-import { EuiTitle, EuiAccordion, EuiSpacer, EuiFlexItem, EuiNotificationBadge } from '@elastic/eui';
+import {
+  EuiTitle,
+  EuiAccordion,
+  EuiSpacer,
+  EuiFlexItem,
+  EuiNotificationBadge,
+  useEuiTheme,
+} from '@elastic/eui';
 import type { AggregateQuery } from '@kbn/es-query';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { ESQLDataGrid } from '@kbn/esql-datagrid/public';
 import type { ESQLDataGridAttrs } from './helpers';
 
@@ -38,6 +44,7 @@ export const ESQLDataGridAccordion = ({
     },
     [isAccordionOpen, onAccordionToggleCb, setIsAccordionOpen]
   );
+  const { euiTheme } = useEuiTheme();
   return (
     <EuiFlexItem
       grow={isAccordionOpen ? 1 : false}
@@ -46,8 +53,8 @@ export const ESQLDataGridAccordion = ({
         .euiAccordion__childWrapper {
           flex: ${isAccordionOpen ? 1 : 'none'};
         }
-        padding: 0 ${euiThemeVars.euiSize};
-        border-bottom: ${euiThemeVars.euiBorderThin};
+        padding: 0 ${euiTheme.size.base}
+        border-bottom: ${euiTheme.border.thin};
       `}
     >
       <EuiAccordion

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/esql_data_grid_accordion.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/esql_data_grid_accordion.tsx
@@ -53,7 +53,7 @@ export const ESQLDataGridAccordion = ({
         .euiAccordion__childWrapper {
           flex: ${isAccordionOpen ? 1 : 'none'};
         }
-        padding: 0 ${euiTheme.size.base}
+        padding: 0 ${euiTheme.size.base};
         border-bottom: ${euiTheme.border.thin};
       `}
     >

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
@@ -20,8 +20,8 @@ import {
   EuiBetaBadge,
   EuiText,
   EuiCallOut,
+  useEuiTheme,
 } from '@elastic/eui';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -40,6 +40,7 @@ export const FlyoutWrapper = ({
   onApply,
   isReadOnly,
 }: FlyoutWrapperProps) => {
+  const { euiTheme } = useEuiTheme();
   return (
     <>
       {isInlineFlyoutVisible && displayFlyoutHeader && (
@@ -47,7 +48,7 @@ export const FlyoutWrapper = ({
           hasBorder
           css={css`
             pointer-events: auto;
-            background-color: ${euiThemeVars.euiColorEmptyShade};
+            background-color: ${euiTheme.colors.emptyShade};
           `}
           data-test-subj="editFlyoutHeader"
         >
@@ -118,8 +119,8 @@ export const FlyoutWrapper = ({
         css={css`
           // styles needed to display extra drop targets that are outside of the config panel main area
           overflow-y: auto;
-          padding-left: ${euiThemeVars.euiFormMaxWidth};
-          margin-left: -${euiThemeVars.euiFormMaxWidth};
+          padding-left: ${euiTheme.components.forms.maxWidth};
+          margin-left: -${euiTheme.components.forms.maxWidth};
           pointer-events: none;
           .euiFlyoutBody__overflow {
             transform: initial;

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -20,7 +20,6 @@ import {
   EuiWindowEvent,
   keys,
 } from '@elastic/eui';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { getLanguageDisplayName, isOfAggregateQueryType } from '@kbn/es-query';
 import type { TypedLensSerializedState } from '../../../react_embeddable/types';
 import { buildExpression } from '../../../editor_frame_service/editor_frame/expression_helpers';
@@ -352,8 +351,9 @@ export function LensEditConfigurationFlyout({
               ${euiScrollBarStyles(euiTheme)}
               overflow-y: auto !important;
               pointer-events: none;
-              padding-left: ${euiThemeVars.euiFormMaxWidth};
-              margin-left: -${euiThemeVars.euiFormMaxWidth};
+
+              padding-left: ${euiTheme.euiTheme.components.forms.maxWidth};
+              margin-left: -${euiTheme.euiTheme.components.forms.maxWidth};
               > * {
                 pointer-events: auto;
               }
@@ -386,7 +386,7 @@ export function LensEditConfigurationFlyout({
               .euiAccordion__childWrapper {
                 flex: ${isLayerAccordionOpen ? 1 : 'none'};
               }
-              padding: 0 ${euiThemeVars.euiSize};
+              padding: 0 ${euiTheme.euiTheme.size.base};
             `}
           >
             <EuiAccordion
@@ -450,10 +450,10 @@ export function LensEditConfigurationFlyout({
             grow={isSuggestionsAccordionOpen ? 1 : false}
             data-test-subj="InlineEditingSuggestions"
             css={css`
-              border-top: ${euiThemeVars.euiBorderThin};
-              border-bottom: ${euiThemeVars.euiBorderThin};
-              padding-left: ${euiThemeVars.euiSize};
-              padding-right: ${euiThemeVars.euiSize};
+              border-top: ${euiTheme.euiTheme.border.thin};
+              border-bottom: ${euiTheme.euiTheme.border.thin};
+              padding-left: ${euiTheme.euiTheme.size.base};
+              padding-right: ${euiTheme.euiTheme.size.base};
               .euiAccordion__childWrapper {
                 flex: ${isSuggestionsAccordionOpen ? 1 : 'none'};
               }

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/dimension_panel/dimension_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/dimension_panel/dimension_editor.tsx
@@ -1158,9 +1158,10 @@ export function DimensionEditor(props: DimensionEditorProps) {
                 />
               ) : null,
             },
-            ...(operationDefinitionMap[selectedColumn.operationType].getAdvancedOptions?.(
-              paramEditorProps
-            ) || []),
+            ...(operationDefinitionMap[selectedColumn.operationType].getAdvancedOptions?.({
+              ...paramEditorProps,
+              euiTheme,
+            }) || []),
           ]}
         />
       )}

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/esql_layer/components/dimension_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/esql_layer/components/dimension_editor.tsx
@@ -8,7 +8,6 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFormRow, useEuiTheme, EuiText } from '@elastic/eui';
-import { euiThemeVars } from '@kbn/ui-theme';
 import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
 import { fetchFieldsFromESQL } from '@kbn/esql-editor';
 import { NameInput } from '@kbn/visualization-ui-components';
@@ -176,8 +175,8 @@ export function TextBasedDimensionEditor(props: TextBasedDimensionEditorProps) {
       {props.dataSectionExtra && (
         <div
           style={{
-            paddingLeft: euiThemeVars.euiSize,
-            paddingRight: euiThemeVars.euiSize,
+            paddingLeft: euiTheme.size.base,
+            paddingRight: euiTheme.size.base,
           }}
         >
           {props.dataSectionExtra}

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/cardinality.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/cardinality.tsx
@@ -7,8 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { EuiSwitch, EuiText } from '@elastic/eui';
-import { euiThemeVars } from '@kbn/ui-theme';
+import { EuiSwitch, EuiText, useEuiTheme } from '@elastic/eui';
 import type { AggFunctionsMapping } from '@kbn/data-plugin/public';
 import { buildExpressionFunction } from '@kbn/expressions-plugin/public';
 import { CARDINALITY_ID, CARDINALITY_NAME } from '@kbn/lens-formula-docs';
@@ -140,12 +139,13 @@ export const cardinalityOperation: OperationDefinition<
       },
     };
   },
-  getAdvancedOptions: ({
+  getAdvancedOptions: function UniqueValueAdvancedOptions({
     layer,
     columnId,
     currentColumn,
     paramEditorUpdater,
-  }: ParamEditorProps<CardinalityIndexPatternColumn>) => {
+  }: ParamEditorProps<CardinalityIndexPatternColumn>) {
+    const { euiTheme } = useEuiTheme();
     return [
       {
         dataTestSubj: 'hide-zero-values',
@@ -160,7 +160,7 @@ export const cardinalityOperation: OperationDefinition<
             }
             labelProps={{
               style: {
-                fontWeight: euiThemeVars.euiFontWeightMedium,
+                fontWeight: euiTheme.font.weight.medium,
               },
             }}
             checked={Boolean(currentColumn.params?.emptyAsNull)}

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/cardinality.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/cardinality.tsx
@@ -7,7 +7,8 @@
 
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { EuiSwitch, EuiText, useEuiTheme } from '@elastic/eui';
+import type { EuiThemeComputed } from '@elastic/eui';
+import { EuiSwitch, EuiText } from '@elastic/eui';
 import type { AggFunctionsMapping } from '@kbn/data-plugin/public';
 import { buildExpressionFunction } from '@kbn/expressions-plugin/public';
 import { CARDINALITY_ID, CARDINALITY_NAME } from '@kbn/lens-formula-docs';
@@ -139,13 +140,13 @@ export const cardinalityOperation: OperationDefinition<
       },
     };
   },
-  getAdvancedOptions: function UniqueValueAdvancedOptions({
+  getAdvancedOptions: ({
     layer,
     columnId,
     currentColumn,
     paramEditorUpdater,
-  }: ParamEditorProps<CardinalityIndexPatternColumn>) {
-    const { euiTheme } = useEuiTheme();
+    euiTheme,
+  }: ParamEditorProps<CardinalityIndexPatternColumn> & { euiTheme: EuiThemeComputed }) => {
     return [
       {
         dataTestSubj: 'hide-zero-values',

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/count.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/count.tsx
@@ -7,7 +7,8 @@
 
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { EuiSwitch, EuiText, useEuiTheme } from '@elastic/eui';
+import type { EuiThemeComputed } from '@elastic/eui';
+import { EuiSwitch, EuiText } from '@elastic/eui';
 import type { AggFunctionsMapping } from '@kbn/data-plugin/public';
 import { buildExpressionFunction } from '@kbn/expressions-plugin/public';
 import { COUNT_ID, COUNT_NAME } from '@kbn/lens-formula-docs';
@@ -144,13 +145,13 @@ export const countOperation: OperationDefinition<CountIndexPatternColumn, 'field
       },
     };
   },
-  getAdvancedOptions: function CountAdvancedOptions({
+  getAdvancedOptions: ({
     layer,
     columnId,
     currentColumn,
     paramEditorUpdater,
-  }: ParamEditorProps<CountIndexPatternColumn>) {
-    const { euiTheme } = useEuiTheme();
+    euiTheme,
+  }: ParamEditorProps<CountIndexPatternColumn> & { euiTheme: EuiThemeComputed }) => {
     return [
       {
         dataTestSubj: 'hide-zero-values',

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/count.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/count.tsx
@@ -7,8 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { euiThemeVars } from '@kbn/ui-theme';
-import { EuiSwitch, EuiText } from '@elastic/eui';
+import { EuiSwitch, EuiText, useEuiTheme } from '@elastic/eui';
 import type { AggFunctionsMapping } from '@kbn/data-plugin/public';
 import { buildExpressionFunction } from '@kbn/expressions-plugin/public';
 import { COUNT_ID, COUNT_NAME } from '@kbn/lens-formula-docs';
@@ -145,12 +144,13 @@ export const countOperation: OperationDefinition<CountIndexPatternColumn, 'field
       },
     };
   },
-  getAdvancedOptions: ({
+  getAdvancedOptions: function CountAdvancedOptions({
     layer,
     columnId,
     currentColumn,
     paramEditorUpdater,
-  }: ParamEditorProps<CountIndexPatternColumn>) => {
+  }: ParamEditorProps<CountIndexPatternColumn>) {
+    const { euiTheme } = useEuiTheme();
     return [
       {
         dataTestSubj: 'hide-zero-values',
@@ -165,7 +165,7 @@ export const countOperation: OperationDefinition<CountIndexPatternColumn, 'field
             }
             labelProps={{
               style: {
-                fontWeight: euiThemeVars.euiFontWeightMedium,
+                fontWeight: euiTheme.font.weight.medium,
               },
             }}
             checked={Boolean(currentColumn.params?.emptyAsNull)}

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/index.ts
@@ -15,6 +15,7 @@ import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import type { EuiThemeComputed } from '@elastic/eui';
 import { termsOperation } from './terms';
 import { filtersOperation } from './filters';
 import { cardinalityOperation } from './cardinality';
@@ -294,7 +295,9 @@ interface BaseOperationDefinitionProps<
   paramEditor?: React.ComponentType<
     AR extends true ? ParamEditorProps<C, GenericIndexPatternColumn> : ParamEditorProps<C>
   >;
-  getAdvancedOptions?: (params: ParamEditorProps<C>) => AdvancedOption[] | undefined;
+  getAdvancedOptions?: (
+    params: ParamEditorProps<C> & { euiTheme: EuiThemeComputed }
+  ) => AdvancedOption[] | undefined;
   /**
    * Returns true if the `column` can also be used on `newIndexPattern`.
    * If this function returns false, the column is removed when switching index pattern

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/metrics.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/metrics.tsx
@@ -7,8 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { EuiSwitch, EuiText } from '@elastic/eui';
-import { euiThemeVars } from '@kbn/ui-theme';
+import { EuiSwitch, EuiText, useEuiTheme } from '@elastic/eui';
 import { buildExpressionFunction } from '@kbn/expressions-plugin/public';
 import {
   AVG_ID,
@@ -181,12 +180,13 @@ function buildMetricOperation<T extends MetricColumn<string>>({
         sourceField: field.name,
       };
     },
-    getAdvancedOptions: ({
+    getAdvancedOptions: function UniqueValueAdvancedOptions({
       layer,
       columnId,
       currentColumn,
       paramEditorUpdater,
-    }: ParamEditorProps<T>) => {
+    }: ParamEditorProps<T>) {
+      const { euiTheme } = useEuiTheme();
       if (!hideZeroOption) return [];
       return [
         {
@@ -202,7 +202,7 @@ function buildMetricOperation<T extends MetricColumn<string>>({
               }
               labelProps={{
                 style: {
-                  fontWeight: euiThemeVars.euiFontWeightMedium,
+                  fontWeight: euiTheme.font.weight.medium,
                 },
               }}
               checked={Boolean(currentColumn.params?.emptyAsNull)}

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/metrics.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/metrics.tsx
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { EuiSwitch, EuiText, useEuiTheme } from '@elastic/eui';
+import { EuiSwitch, EuiText } from '@elastic/eui';
 import { buildExpressionFunction } from '@kbn/expressions-plugin/public';
 import {
   AVG_ID,
@@ -24,7 +24,7 @@ import {
   SUM_NAME,
 } from '@kbn/lens-formula-docs';
 import { sanitazeESQLInput } from '@kbn/esql-utils';
-import type { LayerSettingsFeatures, OperationDefinition, ParamEditorProps } from '.';
+import type { LayerSettingsFeatures, OperationDefinition } from '.';
 import {
   getFormatFromPreviousColumn,
   getInvalidFieldMessage,

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/metrics.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/metrics.tsx
@@ -180,13 +180,7 @@ function buildMetricOperation<T extends MetricColumn<string>>({
         sourceField: field.name,
       };
     },
-    getAdvancedOptions: function UniqueValueAdvancedOptions({
-      layer,
-      columnId,
-      currentColumn,
-      paramEditorUpdater,
-    }: ParamEditorProps<T>) {
-      const { euiTheme } = useEuiTheme();
+    getAdvancedOptions: ({ layer, columnId, currentColumn, paramEditorUpdater, euiTheme }) => {
       if (!hideZeroOption) return [];
       return [
         {

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/buttons/empty_dimension_button.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/buttons/empty_dimension_button.tsx
@@ -12,7 +12,7 @@ import type { DragDropIdentifier, DropType, DroppableProps } from '@kbn/dom-drag
 import { useDragDropContext, DropTargetSwapDuplicateCombine, Droppable } from '@kbn/dom-drag-drop';
 import { EmptyDimensionButton as EmptyDimensionButtonInner } from '@kbn/visualization-ui-components';
 import { css } from '@emotion/react';
-import { euiThemeVars } from '@kbn/ui-theme';
+import { useEuiTheme } from '@elastic/eui';
 import { isDraggedField } from '../../../../utils';
 import { generateId } from '../../../../id_generator';
 
@@ -126,6 +126,7 @@ export function EmptyDimensionButton({
   };
   isInlineEditing: boolean;
 }) {
+  const { euiTheme } = useEuiTheme();
   const [{ dragging }] = useDragDropContext();
 
   let getDropProps;
@@ -203,7 +204,7 @@ export function EmptyDimensionButton({
       >
         <div
           css={css`
-            border-radius: ${euiThemeVars.euiBorderRadius};
+            border-radius: ${euiTheme.border.radius.medium};
           `}
         >
           {typeof group.suggestedValue?.() === 'number' ? (

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/buttons/fake_dimension_button.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/buttons/fake_dimension_button.tsx
@@ -6,25 +6,28 @@
  */
 
 import React from 'react';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
 import { DimensionTrigger } from '@kbn/visualization-ui-components';
+import { useEuiTheme } from '@elastic/eui';
 
-export const FakeDimensionButton = ({ label }: { label: string }) => (
-  <div
-    css={css`
-      display: flex;
-      align-items: center;
-      border-radius: ${euiThemeVars.euiBorderRadius};
-      min-height: ${euiThemeVars.euiSizeXL};
+export const FakeDimensionButton = ({ label }: { label: string }) => {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <div
+      css={css`
+        display: flex;
+        align-items: center;
+        border-radius: ${euiTheme.border.radius.medium};
+        min-height: ${euiTheme.size.xl};
 
-      cursor: default !important;
-      background-color: ${euiThemeVars.euiColorLightShade} !important;
-      border-color: transparent !important;
-      box-shadow: none !important;
-      padding: 0 ${euiThemeVars.euiSizeS};
-    `}
-  >
-    <DimensionTrigger label={label} id="lns-fakeDimension" dataTestSubj="lns-fakeDimension" />
-  </div>
-);
+        cursor: default !important;
+        background-color: ${euiTheme.colors.lightShade} !important;
+        border-color: transparent !important;
+        box-shadow: none !important;
+        padding: 0 ${euiTheme.size.s};
+      `}
+    >
+      <DimensionTrigger label={label} id="lns-fakeDimension" dataTestSubj="lns-fakeDimension" />
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -19,7 +19,6 @@ import {
 import { BehaviorSubject } from 'rxjs';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
-import { euiThemeVars } from '@kbn/ui-theme';
 import type { DragDropIdentifier, DropType } from '@kbn/dom-drag-drop';
 import { ReorderProvider } from '@kbn/dom-drag-drop';
 import { DimensionButton } from '@kbn/visualization-ui-components';
@@ -744,7 +743,7 @@ export function LayerPanel(props: LayerPanelProps) {
                 <EuiText
                   size="s"
                   css={css`
-                    margin-bottom: ${euiThemeVars.euiSize};
+                    margin-bottom: ${euiTheme.size.base};
                   `}
                 >
                   <h4>
@@ -771,7 +770,7 @@ export function LayerPanel(props: LayerPanelProps) {
                 <EuiText
                   size="s"
                   css={css`
-                    margin-bottom: ${euiThemeVars.euiSize};
+                    margin-bottom: ${euiTheme.size.base};
                   `}
                 >
                   <h4>

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/load_annotation_library_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/load_annotation_library_flyout.tsx
@@ -6,10 +6,15 @@
  */
 
 import React from 'react';
-import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiFlyoutFooter } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutFooter,
+  useEuiTheme,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { EventAnnotationServiceType } from '@kbn/event-annotation-plugin/public';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
 import { FlyoutContainer } from '../../shared_components/flyout_container';
 import type { ExtraAppendLayerArg } from './visualization';
@@ -31,6 +36,7 @@ export function LoadAnnotationLibraryFlyout({
     renderEventAnnotationGroupSavedObjectFinder: EventAnnotationGroupSavedObjectFinder,
     loadAnnotationGroup,
   } = eventAnnotationService || {};
+  const { euiTheme } = useEuiTheme();
 
   return (
     <FlyoutContainer
@@ -71,7 +77,7 @@ export function LoadAnnotationLibraryFlyout({
     >
       <div
         css={css`
-          padding: ${euiThemeVars.euiSize};
+          padding: ${euiTheme.size.base}
           height: 100%;
         `}
       >

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/xy_config_panel/layer_header.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/xy_config_panel/layer_header.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { useEuiTheme, EuiIconTip } from '@elastic/eui';
 import { IconChartBarReferenceLine, IconChartBarAnnotations } from '@kbn/chart-icons';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
 import { getIgnoreGlobalFilterIcon } from '../../../shared_components/ignore_global_filter/data_view_picker_icon';
 import type {
@@ -70,6 +69,7 @@ export function AnnotationsLayerHeader({
   title: string | undefined;
   hasUnsavedChanges: boolean;
 }) {
+  const { euiTheme } = useEuiTheme();
   return (
     <StaticHeader
       icon={IconChartBarAnnotations}
@@ -92,7 +92,7 @@ export function AnnotationsLayerHeader({
                 defaultMessage: 'Unsaved changes',
               })}
               type="dot"
-              color={euiThemeVars.euiColorSuccess}
+              color={euiTheme.colors.success}
             />
           </div>
         )


### PR DESCRIPTION
## Summary

This PR removes some of the deprecated `euiThemeVars` usage where it is possible to safely replace it.



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->