### PR TITLE
Fix flaky tests

### DIFF
--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_bulk_import_flyout.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_bulk_import_flyout.tsx
@@ -167,6 +167,7 @@ export function KnowledgeBaseBulkImportFlyout({ onClose }: { onClose: () => void
           display="large"
           fullWidth
           id={filePickerId}
+          data-test-subj="knowledgeBaseBulkImportFilePicker"
           initialPromptText={i18n.translate(
             'xpack.observabilityAiAssistantManagement.knowledgeBaseBulkImportFlyout.euiFilePicker.selectOrDragAndLabel',
             { defaultMessage: 'Select or drag and drop a .ndjson file' }

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_bulk_import_flyout.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_bulk_import_flyout.tsx
@@ -192,6 +192,7 @@ export function KnowledgeBaseBulkImportFlyout({ onClose }: { onClose: () => void
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButton
+              disabled={files.length === 0}
               data-test-subj="knowledgeBaseBulkImportFlyoutSaveButton"
               fill
               isLoading={isLoading}

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/complete/functions/recall.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/complete/functions/recall.spec.ts
@@ -27,7 +27,6 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
 
   describe('tool: recall', function () {
     // fails/flaky on MKI, see https://github.com/elastic/kibana/issues/232588
-    this.tags(['failsOnMKI']);
 
     before(async () => {
       await deployTinyElserAndSetupKb(getService);

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/complete/functions/recall.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/complete/functions/recall.spec.ts
@@ -27,6 +27,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
 
   describe('tool: recall', function () {
     // fails/flaky on MKI, see https://github.com/elastic/kibana/issues/232588
+    this.tags(['failsOnMKI']);
 
     before(async () => {
       await deployTinyElserAndSetupKb(getService);

--- a/x-pack/solutions/observability/test/observability_ai_assistant_functional/common/ui/index.ts
+++ b/x-pack/solutions/observability/test/observability_ai_assistant_functional/common/ui/index.ts
@@ -41,6 +41,7 @@ const pages = {
     bulkImportSaveButton: 'knowledgeBaseBulkImportFlyoutSaveButton',
     bulkImportCancelButton: 'knowledgeBaseBulkImportFlyoutCancelButton',
     bulkImportFlyout: 'knowledgeBaseBulkImportFlyout',
+    bulkImportFilePicker: 'knowledgeBaseBulkImportFilePicker',
     toastTitle: 'euiToastHeader__title',
   },
   conversations: {

--- a/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
+++ b/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
@@ -288,9 +288,11 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
         await uploadBulkImportFile(entries.map((entry) => JSON.stringify(entry)).join('\n'));
         await retry.try(async () => {
           const fileInput = await find.byCssSelector('input[type="file"]');
-          const value = (await fileInput.getAttribute('value')) ?? '';
-          if (!value.includes('bulk_import.ndjson')) {
+          const value = await fileInput.getAttribute('value');
+          if (!value || !value.includes('bulk_import.ndjson')) {
             throw new Error(`File not bound yet: ${value}`);
+          } else {
+            log.debug('Value: ', value);
           }
         });
         await testSubjects.click(ui.pages.kbManagementTab.bulkImportSaveButton);

--- a/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
+++ b/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
@@ -246,7 +246,8 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
         log.debug(`File saved to: ${tempFilePath}`);
 
         try {
-          await common.setFileInputPath(tempFilePath);
+          const fileInput = await find.byCssSelector('input[type="file"]');
+          await fileInput.type(tempFilePath);
         } catch (error) {
           log.debug(`Error uploading file: ${error}`);
           throw error;
@@ -285,8 +286,9 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
         await openBulkImportFlyout();
 
         const entries = await prepareBulkImportData();
-        await uploadBulkImportFile(entries.map((entry) => JSON.stringify(entry)).join('\n'));
+
         await retry.try(async () => {
+          await uploadBulkImportFile(entries.map((entry) => JSON.stringify(entry)).join('\n'));
           const fileInput = await find.byCssSelector('input[type="file"]');
           const value = await fileInput.getAttribute('value');
           if (!value || !value.includes('bulk_import.ndjson')) {
@@ -295,6 +297,7 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
             log.debug('Value: ', value);
           }
         });
+
         await testSubjects.click(ui.pages.kbManagementTab.bulkImportSaveButton);
 
         const toastText = await retry.try(async () => {

--- a/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
+++ b/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
@@ -283,6 +283,9 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
 
         await openBulkImportFlyout();
         const entries = await prepareBulkImportData();
+        const saveButton = await testSubjects.find(ui.pages.kbManagementTab.bulkImportSaveButton);
+
+        expect(await saveButton.isEnabled()).to.be(false);
 
         await retry.try(async () => {
           await uploadBulkImportFile(entries.map((entry) => JSON.stringify(entry)).join('\n'));
@@ -295,7 +298,9 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
           }
         });
 
-        await testSubjects.click(ui.pages.kbManagementTab.bulkImportSaveButton);
+        expect(await saveButton.isEnabled()).to.be(true);
+        await saveButton.click();
+
         const toastText = await retry.try(async () => {
           const toast = await testSubjects.find(ui.pages.kbManagementTab.toastTitle);
           return await toast.getVisibleText();


### PR DESCRIPTION
## Summary
This PR attempts to close https://github.com/elastic/kibana/issues/231420 and https://github.com/elastic/kibana/issues/230988.

Address test flakiness by adding retries.

I have not been able to reproduce failure for the `cancels editing without saving changes when the cancel button is clicked` test, but I believe adding the retry will make it more resilient.

 For the `NDJSON` test, I have been able to reproduce the failures using the flaky test runner. The issue is that in certain cases, the file does not get uploaded and therefore the "save" button doesn't have any effect. It also causes a JS TypeError that I've opened a separate issue for.
 
I've now ran the flaky test runner with the changes in this PR, and it passed (100 reps).

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
