### PR TITLE
[Shared UX] Add side nav translations

### DIFF
--- a/src/core/packages/chrome/navigation/src/components/beta_badge/index.tsx
+++ b/src/core/packages/chrome/navigation/src/components/beta_badge/index.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { EuiBetaBadge, EuiThemeProvider } from '@elastic/eui';
 import { css } from '@emotion/react';
 
+import { i18n } from '@kbn/i18n';
 import type { BadgeType } from '../../../types';
 
 interface BetaBadgeProps {
@@ -30,11 +31,20 @@ export const BetaBadge = ({ type, isInverted, alignment = 'bottom' }: BetaBadgeP
     vertical-align: ${alignment === 'text-bottom' ? 'text-bottom' : 'bottom'};
   `;
 
-  // TODO: translate
   const config =
     type === 'techPreview'
-      ? { iconType: 'flask', label: 'Tech preview' }
-      : { iconType: 'beta', label: 'Beta' };
+      ? {
+          iconType: 'flask',
+          label: i18n.translate('core.ui.chrome.sideNavigation.techPreviewBadgeLabel', {
+            defaultMessage: 'Tech preview',
+          }),
+        }
+      : {
+          iconType: 'beta',
+          label: i18n.translate('core.ui.chrome.sideNavigation.betaBadgeLabel', {
+            defaultMessage: 'Beta',
+          }),
+        };
 
   return (
     <EuiThemeProvider

--- a/src/core/packages/chrome/navigation/src/components/navigation.tsx
+++ b/src/core/packages/chrome/navigation/src/components/navigation.tsx
@@ -12,6 +12,8 @@ import React from 'react';
 import { useIsWithinBreakpoints } from '@elastic/eui';
 import { css } from '@emotion/react';
 
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import type { MenuItem, NavigationStructure, SecondaryMenuItem, SideNavLogo } from '../../types';
 import { NestedSecondaryMenu } from './nested_secondary_menu';
 import { SecondaryMenu } from './secondary_menu';
@@ -158,7 +160,9 @@ export const Navigation = ({
               container={document.documentElement}
               hasContent
               isSidePanelOpen={false}
-              label="More" // TODO: translate
+              label={i18n.translate('core.ui.chrome.sideNavigation.moreMenuLabel', {
+                defaultMessage: 'More',
+              })}
               persistent
               trigger={
                 <SideNav.PrimaryMenuItem
@@ -170,10 +174,14 @@ export const Navigation = ({
                   hasContent
                   href=""
                   id="more-menu"
-                  label="More" // TODO: translate
+                  label={i18n.translate('core.ui.chrome.sideNavigation.moreMenuItemLabel', {
+                    defaultMessage: 'More',
+                  })}
                 >
-                  {/* TODO: translate */}
-                  More
+                  <FormattedMessage
+                    id="core.ui.chrome.sideNavigation.moreMenuItemText"
+                    defaultMessage="More"
+                  />
                 </SideNav.PrimaryMenuItem>
               }
             >

--- a/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/header.tsx
+++ b/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/header.tsx
@@ -12,6 +12,7 @@ import type { FC } from 'react';
 import React from 'react';
 import { css } from '@emotion/react';
 
+import { i18n } from '@kbn/i18n';
 import { useNestedMenu } from './use_nested_menu';
 import { useMenuHeaderStyle } from '../../hooks/use_menu_header_style';
 
@@ -35,8 +36,14 @@ export const Header: FC<HeaderProps> = ({ title }) => {
 
   return (
     <div css={titleStyle}>
-      {/* TODO: translate */}
-      <EuiButtonIcon aria-label="Go back" color="text" iconType="arrowLeft" onClick={goBack} />
+      <EuiButtonIcon
+        aria-label={i18n.translate('core.ui.chrome.sideNavigation.goBackButtonIconAriaLabel', {
+          defaultMessage: 'Go back',
+        })}
+        color="text"
+        iconType="arrowLeft"
+        onClick={goBack}
+      />
       {title && (
         <EuiTitle size="xs">
           <h4>{title}</h4>

--- a/src/core/packages/chrome/navigation/src/components/side_nav/footer.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/footer.tsx
@@ -12,6 +12,7 @@ import React, { useRef } from 'react';
 import { css } from '@emotion/react';
 import { useEuiTheme } from '@elastic/eui';
 
+import { i18n } from '@kbn/i18n';
 import { useRovingIndex } from '../../utils/use_roving_index';
 
 export interface SideNavFooterProps {
@@ -28,8 +29,9 @@ export const SideNavFooter = ({ children, isCollapsed }: SideNavFooterProps): JS
 
   return (
     <footer
-      // TODO: translate
-      aria-label="Side navigation footer"
+      aria-label={i18n.translate('core.ui.chrome.sideNavigation.footerAriaLabel', {
+        defaultMessage: 'Side navigation footer',
+      })}
       css={css`
         align-items: center;
         border-top: 1px solid ${euiTheme.colors.borderBaseSubdued};

--- a/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu.tsx
@@ -12,6 +12,7 @@ import type { ForwardedRef, ReactNode } from 'react';
 import React, { forwardRef, useRef, useImperativeHandle } from 'react';
 import { useEuiTheme } from '@elastic/eui';
 
+import { i18n } from '@kbn/i18n';
 import { useRovingIndex } from '../../utils/use_roving_index';
 
 export interface SideNavPrimaryMenuProps {
@@ -31,8 +32,9 @@ export const SideNavPrimaryMenu = forwardRef<HTMLElement, SideNavPrimaryMenuProp
     return (
       <nav
         id="primary-navigation"
-        // TODO: translate
-        aria-label="Main navigation"
+        aria-label={i18n.translate('core.ui.chrome.sideNavigation.primaryMenuAriaLabel', {
+          defaultMessage: 'Main navigation',
+        })}
         ref={localRef}
         css={css`
           align-items: center;

--- a/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu_item.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu_item.tsx
@@ -13,6 +13,7 @@ import { css } from '@emotion/react';
 import type { IconType } from '@elastic/eui';
 import { EuiToolTip, useEuiTheme } from '@elastic/eui';
 
+import { i18n } from '@kbn/i18n';
 import type { MenuItem } from '../../../types';
 import { MenuItem as MenuItemComponent } from '../menu_item';
 import { useTooltip } from '../../hooks/use_tooltip';
@@ -70,10 +71,17 @@ export const SideNavPrimaryMenuItem = forwardRef<HTMLAnchorElement, SideNavPrima
     const getTooltipContent = () => {
       if (isHorizontal || (isCollapsed && hasContent)) return null;
       if (isCollapsed) return badgeType ? getLabelWithBeta(children) : children;
-      // TODO: translate
       if (!isCollapsed && badgeType)
         return getLabelWithBeta(
-          badgeType === 'beta' ? 'Beta' : badgeType === 'techPreview' ? 'Tech preview' : children
+          badgeType === 'beta'
+            ? i18n.translate('core.ui.chrome.sideNavigation.betaTooltipLabel', {
+                defaultMessage: 'Beta',
+              })
+            : badgeType === 'techPreview'
+            ? i18n.translate('core.ui.chrome.sideNavigation.techPreviewTooltipLabel', {
+                defaultMessage: 'Tech preview',
+              })
+            : children
         );
 
       return null;

--- a/src/core/packages/chrome/navigation/tsconfig.json
+++ b/src/core/packages/chrome/navigation/tsconfig.json
@@ -17,5 +17,7 @@
   "kbn_references": [
     "@kbn/core-chrome-layout-components",
     "@kbn/core-chrome-layout-constants",
+    "@kbn/i18n",
+    "@kbn/i18n-react",
   ]
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/232738

## Summary

Added translations and removed related `TODO` comments.

### Testing

Visually verified that the More menu item, go back button, footer and main nav look as expected:

<img width="2048" height="280" alt="image" src="https://github.com/user-attachments/assets/def319da-c990-4fcf-8e68-bf246befbca2" />


Verified badge type labels in Storybook:

<img width="325" height="195" alt="image" src="https://github.com/user-attachments/assets/f5fb40c5-769f-4048-b3f4-60b84f332bb6" />




