### PR TITLE
[OneChat] Evaluation error handling and judge prompt fixes

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/index.ts
@@ -27,12 +27,17 @@ export function createCorrectnessAnalysisEvaluator({
   return {
     evaluate: async ({ input, output, expected }) => {
       async function runCorrectnessAnalysis(): Promise<CorrectnessAnalysis> {
+        const userQuery = input.question;
+        const messages = (output as any)?.messages ?? [];
+        const latestMessage = messages[messages.length - 1]?.message;
+        const groundTruthResponse = expected?.expected;
+
         const response = await inferenceClient.prompt({
           prompt: LlmCorrectnessEvaluationPrompt,
           input: {
-            user_query: JSON.stringify(input),
-            agent_response: JSON.stringify(output),
-            ground_truth_response: JSON.stringify(expected),
+            user_query: `${userQuery}`,
+            agent_response: `${latestMessage}`,
+            ground_truth_response: `${groundTruthResponse}`,
           },
         });
 

--- a/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/src/evaluate_dataset.ts
+++ b/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/src/evaluate_dataset.ts
@@ -42,7 +42,7 @@ export function createEvaluateDataset({
   phoenixClient: KibanaPhoenixClient;
   chatClient: OnechatEvaluationChatClient;
 }): EvaluateDataset {
-  return async function evaluateEsqlDataset({
+  return async function evaluateDataset({
     dataset: { name, description, examples },
   }: {
     dataset: {
@@ -62,7 +62,7 @@ export function createEvaluateDataset({
         dataset,
         task: async ({ input, output, metadata }) => {
           const response = await chatClient.converse({
-            messages: input.question,
+            messages: [{ message: input.question }],
           });
 
           // Running correctness evaluator as part of the task since quantitative correctness evaluators need its output
@@ -84,25 +84,7 @@ export function createEvaluateDataset({
           };
         },
       },
-      [
-        {
-          name: 'Criteria',
-          kind: 'LLM',
-          evaluate: async ({ input, output, expected, metadata }) => {
-            const result = await evaluators
-              .criteria([`The response contains the following information: ${expected.expected}`])
-              .evaluate({
-                input,
-                expected,
-                output,
-                metadata,
-              });
-
-            return result;
-          },
-        },
-        ...createQuantitativeCorrectnessEvaluators(),
-      ]
+      createQuantitativeCorrectnessEvaluators()
     );
   };
 }

--- a/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/src/evaluate_dataset.ts
+++ b/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/src/evaluate_dataset.ts
@@ -66,16 +66,13 @@ export function createEvaluateDataset({
           });
 
           // Running correctness evaluator as part of the task since quantitative correctness evaluators need its output
-          let correctnessAnalysis = null;
-          if (!response.errors?.length) {
-            const correctnessResult = await evaluators.correctnessAnalysis().evaluate({
-              input,
-              expected: output,
-              output: response,
-              metadata,
-            });
-            correctnessAnalysis = correctnessResult.metadata;
-          }
+          const correctnessResult = await evaluators.correctnessAnalysis().evaluate({
+            input,
+            expected: output,
+            output: response,
+            metadata,
+          });
+          const correctnessAnalysis = correctnessResult.metadata;
 
           return {
             errors: response.errors,


### PR DESCRIPTION
Closes: https://github.com/elastic/search-team/issues/10864

## Summary

Updates to error handling in onechat evaluations and improvements to the LLM judge prompt construction:
- Added retries on the `converse` API calls
- Upon retry exhaustion providing default message to the LLM judge
- Fixed user prompt template to inject string format of the input, ground truth and agent response
- Other: removed Criteria evaluator from OneChat evaluations (it was there as a first, dummy evaluator, but no longer needed).

## Testing
- Ran experiments with the new configuration: 
  - Confirmed the user prompt for correctness analysis now looks correct (screenshot below)
     <img width="709" height="760" alt="image" src="https://github.com/user-attachments/assets/f35339b2-b833-4f14-9afd-c54152b699c7" />
  - Confirmed the default error propagates to the LLM judge:
      <img width="709" height="760" alt="image" src="https://github.com/user-attachments/assets/bc3e8703-6991-44ca-a58b-4694857a54df" />




