### PR TITLE
[Security Solution] Fix and unskip API integration tests for preventing non-customizable fields from updating for Prebuilt rule types

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/index.ts
@@ -13,6 +13,7 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
     loadTestFile(require.resolve('./import_export'));
     loadTestFile(require.resolve('./install_prebuilt_rules'));
     loadTestFile(require.resolve('./prebuilt_rules_package'));
+    loadTestFile(require.resolve('./non_customizable_fields'));
     loadTestFile(require.resolve('./revert_prebuilt_rules'));
     loadTestFile(require.resolve('./status'));
   });

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/non_customizable_fields/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/non_customizable_fields/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  loadTestFile(require.resolve('./non_customizable_fields'));
+}

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/non_customizable_fields/non_customizable_fields.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/non_customizable_fields/non_customizable_fields.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+
+import { PREBUILT_RULES_PACKAGE_NAME } from '@kbn/security-solution-plugin/common/detection_engine/constants';
+import { deleteAllRules } from '../../../../../../config/services/detections_response';
+import type { FtrProviderContext } from '../../../../../../ftr_provider_context';
+import {
+  getCustomQueryRuleParams,
+  createPrebuiltRulesPackage,
+  installFleetPackageByUpload,
+  installPrebuiltRules,
+} from '../../../../utils';
+import {
+  MOCK_PKG_VERSION,
+  PREBUILT_RULE_ASSET_A,
+  PREBUILT_RULE_ASSET_B,
+  PREBUILT_RULE_ID_A,
+} from '../configs/edge_cases/ess_air_gapped_with_bundled_packages.config';
+
+export default ({ getService }: FtrProviderContext) => {
+  const supertest = getService('supertest');
+  const securitySolutionApi = getService('securitySolutionApi');
+  const log = getService('log');
+  const es = getService('es');
+
+  describe('@ess @serverless @serverlessQA modifying non-customizable fields', () => {
+    describe('patch rules', () => {
+      beforeEach(async () => {
+        await deleteAllRules(supertest, log);
+      });
+
+      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+        const securityDetectionEnginePackageZip = createPrebuiltRulesPackage({
+          packageName: PREBUILT_RULES_PACKAGE_NAME,
+          packageSemver: MOCK_PKG_VERSION,
+          prebuiltRuleAssets: [PREBUILT_RULE_ASSET_A, PREBUILT_RULE_ASSET_B],
+        });
+
+        await installFleetPackageByUpload({
+          getService,
+          packageBuffer: securityDetectionEnginePackageZip.toBuffer(),
+        });
+
+        await installPrebuiltRules(es, supertest);
+
+        const { body } = await securitySolutionApi
+          .patchRule({
+            body: {
+              rule_id: PREBUILT_RULE_ID_A,
+              author: ['new user'],
+            },
+          })
+          .expect(400);
+
+        expect(body.message).toEqual('Cannot update "author" field for prebuilt rules');
+      });
+    });
+
+    describe('update rules', () => {
+      afterEach(async () => {
+        await deleteAllRules(supertest, log);
+      });
+
+      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+        const securityDetectionEnginePackageZip = createPrebuiltRulesPackage({
+          packageName: PREBUILT_RULES_PACKAGE_NAME,
+          packageSemver: MOCK_PKG_VERSION,
+          prebuiltRuleAssets: [PREBUILT_RULE_ASSET_A, PREBUILT_RULE_ASSET_B],
+        });
+
+        await installFleetPackageByUpload({
+          getService,
+          packageBuffer: securityDetectionEnginePackageZip.toBuffer(),
+        });
+
+        await installPrebuiltRules(es, supertest);
+
+        const { body: existingRule } = await securitySolutionApi
+          .readRule({
+            query: { rule_id: PREBUILT_RULE_ID_A },
+          })
+          .expect(200);
+
+        const { body } = await securitySolutionApi
+          .updateRule({
+            body: getCustomQueryRuleParams({
+              ...existingRule,
+              rule_id: PREBUILT_RULE_ID_A,
+              id: undefined,
+              license: 'new license',
+            }),
+          })
+          .expect(400);
+
+        expect(body.message).toEqual('Cannot update "license" field for prebuilt rules');
+      });
+    });
+  });
+};

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
@@ -7,33 +7,22 @@
 
 import expect from 'expect';
 
-import { PREBUILT_RULES_PACKAGE_NAME } from '@kbn/security-solution-plugin/common/detection_engine/constants';
 import { createRule, deleteAllRules } from '../../../../../config/services/detections_response';
 import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 import {
-  createPrebuiltRulesPackage,
   getCustomQueryRuleParams,
   getSimpleRule,
   getSimpleRuleOutput,
   getSimpleRuleOutputWithoutRuleId,
-  installFleetPackageByUpload,
-  installPrebuiltRules,
   removeServerGeneratedProperties,
   removeServerGeneratedPropertiesIncludingRuleId,
   updateUsername,
 } from '../../../utils';
-import {
-  MOCK_PKG_VERSION,
-  PREBUILT_RULE_ASSET_A,
-  PREBUILT_RULE_ASSET_B,
-  PREBUILT_RULE_ID_A,
-} from '../../prebuilt_rules/common/configs/edge_cases/ess_air_gapped_with_bundled_packages.config';
 
 export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const securitySolutionApi = getService('securitySolutionApi');
   const log = getService('log');
-  const es = getService('es');
   const utils = getService('securitySolutionUtils');
 
   describe('@ess @serverless @serverlessQA patch_rules', () => {
@@ -236,32 +225,6 @@ export default ({ getService }: FtrProviderContext) => {
           status_code: 404,
           message: 'rule_id: "fake_id" not found',
         });
-      });
-
-      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
-        const securityDetectionEnginePackageZip = createPrebuiltRulesPackage({
-          packageName: PREBUILT_RULES_PACKAGE_NAME,
-          packageSemver: MOCK_PKG_VERSION,
-          prebuiltRuleAssets: [PREBUILT_RULE_ASSET_A, PREBUILT_RULE_ASSET_B],
-        });
-
-        await installFleetPackageByUpload({
-          getService,
-          packageBuffer: securityDetectionEnginePackageZip.toBuffer(),
-        });
-
-        await installPrebuiltRules(es, supertest);
-
-        const { body } = await securitySolutionApi
-          .patchRule({
-            body: {
-              rule_id: PREBUILT_RULE_ID_A,
-              author: ['new user'],
-            },
-          })
-          .expect(400);
-
-        expect(body.message).toEqual('Cannot update "author" field for prebuilt rules');
       });
 
       describe('max signals', () => {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
@@ -232,7 +232,7 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      it('@skipInServerlessMKI throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
         await deleteAllPrebuiltRuleAssets(es, log);
         // Install base prebuilt detection rule
         await createHistoricalPrebuiltRuleAssetSavedObjects(es, [

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
@@ -7,21 +7,26 @@
 
 import expect from 'expect';
 
+import { PREBUILT_RULES_PACKAGE_NAME } from '@kbn/security-solution-plugin/common/detection_engine/constants';
 import { createRule, deleteAllRules } from '../../../../../config/services/detections_response';
 import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 import {
-  createHistoricalPrebuiltRuleAssetSavedObjects,
-  createRuleAssetSavedObject,
-  deleteAllPrebuiltRuleAssets,
+  createPrebuiltRulesPackage,
   getCustomQueryRuleParams,
   getSimpleRule,
   getSimpleRuleOutput,
   getSimpleRuleOutputWithoutRuleId,
+  installFleetPackageByUpload,
   installPrebuiltRules,
   removeServerGeneratedProperties,
   removeServerGeneratedPropertiesIncludingRuleId,
   updateUsername,
 } from '../../../utils';
+import {
+  PREBUILT_RULE_ASSET_A,
+  PREBUILT_RULE_ASSET_B,
+  PREBUILT_RULE_ID_A,
+} from '../../prebuilt_rules/common/configs/edge_cases/ess_air_gapped_with_bundled_packages.config';
 
 export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
@@ -29,6 +34,7 @@ export default ({ getService }: FtrProviderContext) => {
   const log = getService('log');
   const es = getService('es');
   const utils = getService('securitySolutionUtils');
+  const retryService = getService('retry');
 
   describe('@ess @serverless @serverlessQA patch_rules', () => {
     describe('patch rules', () => {
@@ -233,17 +239,35 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
-        await deleteAllPrebuiltRuleAssets(es, log);
-        // Install base prebuilt detection rule
-        await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
-          createRuleAssetSavedObject({ rule_id: 'rule-1', author: ['elastic'] }),
-        ]);
+        await retryService.tryWithRetries(
+          'installSecurityDetectionEnginePackage',
+          async () => {
+            const securityDetectionEnginePackageZip = createPrebuiltRulesPackage({
+              packageName: PREBUILT_RULES_PACKAGE_NAME,
+              // Use a high version to avoid conflicts with real packages
+              // including mock bundled packages path configured via "xpack.fleet.developer.bundledPackageLocation"
+              packageSemver: '99.0.0',
+              prebuiltRuleAssets: [PREBUILT_RULE_ASSET_A, PREBUILT_RULE_ASSET_B],
+            });
+
+            await installFleetPackageByUpload({
+              getService,
+              packageBuffer: securityDetectionEnginePackageZip.toBuffer(),
+            });
+          },
+          {
+            retryCount: 5,
+            retryDelay: 5000,
+            timeout: 15000, // total timeout applied to all attempts altogether
+          }
+        );
+
         await installPrebuiltRules(es, supertest);
 
         const { body } = await securitySolutionApi
           .patchRule({
             body: {
-              rule_id: 'rule-1',
+              rule_id: PREBUILT_RULE_ID_A,
               author: ['new user'],
             },
           })

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules.ts
@@ -313,8 +313,7 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      // Unskip: https://github.com/elastic/kibana/issues/195921
-      it('@skipInServerlessMKI throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
         // Install base prebuilt detection rule
         await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
           createRuleAssetSavedObject({ rule_id: 'rule-1', license: 'elastic' }),

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules.ts
@@ -19,9 +19,9 @@ import {
   getSimpleMlRuleUpdate,
   getSimpleRule,
   updateUsername,
-  installPrebuiltRules,
   installFleetPackageByUpload,
   createPrebuiltRulesPackage,
+  installPrebuiltRules,
 } from '../../../utils';
 import {
   createAlertsIndex,
@@ -30,6 +30,7 @@ import {
   deleteAllAlerts,
 } from '../../../../../config/services/detections_response';
 import {
+  MOCK_PKG_VERSION,
   PREBUILT_RULE_ASSET_A,
   PREBUILT_RULE_ASSET_B,
   PREBUILT_RULE_ID_A,
@@ -41,7 +42,6 @@ export default ({ getService }: FtrProviderContext) => {
   const log = getService('log');
   const es = getService('es');
   const utils = getService('securitySolutionUtils');
-  const retryService = getService('retry');
 
   describe('@ess @serverless @serverlessQA update_rules', () => {
     describe('update rules', () => {
@@ -321,28 +321,17 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
-        await retryService.tryWithRetries(
-          'installSecurityDetectionEnginePackage',
-          async () => {
-            const securityDetectionEnginePackageZip = createPrebuiltRulesPackage({
-              packageName: PREBUILT_RULES_PACKAGE_NAME,
-              // Use a high version to avoid conflicts with real packages
-              // including mock bundled packages path configured via "xpack.fleet.developer.bundledPackageLocation"
-              packageSemver: '99.0.0',
-              prebuiltRuleAssets: [PREBUILT_RULE_ASSET_A, PREBUILT_RULE_ASSET_B],
-            });
+        const securityDetectionEnginePackageZip = createPrebuiltRulesPackage({
+          packageName: PREBUILT_RULES_PACKAGE_NAME,
+          packageSemver: MOCK_PKG_VERSION,
+          prebuiltRuleAssets: [PREBUILT_RULE_ASSET_A, PREBUILT_RULE_ASSET_B],
+        });
 
-            await installFleetPackageByUpload({
-              getService,
-              packageBuffer: securityDetectionEnginePackageZip.toBuffer(),
-            });
-          },
-          {
-            retryCount: 5,
-            retryDelay: 5000,
-            timeout: 15000, // total timeout applied to all attempts altogether
-          }
-        );
+        await installFleetPackageByUpload({
+          getService,
+          packageBuffer: securityDetectionEnginePackageZip.toBuffer(),
+        });
+
         await installPrebuiltRules(es, supertest);
 
         const { body: existingRule } = await securitySolutionApi

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_fleet_package.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_fleet_package.ts
@@ -119,7 +119,8 @@ export const installFleetPackageByUpload = async ({
     },
     {
       retryCount: MAX_RETRIES,
-      timeout: FLEET_RATE_LIMIT_TIMEOUT * 3,
+      retryDelay: FLEET_RATE_LIMIT_TIMEOUT,
+      timeout: FLEET_RATE_LIMIT_TIMEOUT * 2,
     }
   );
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_prebuilt_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_prebuilt_rules.ts
@@ -12,7 +12,6 @@ import type {
 import { PERFORM_RULE_INSTALLATION_URL } from '@kbn/security-solution-plugin/common/api/detection_engine/prebuilt_rules';
 import type { Client } from '@elastic/elasticsearch';
 import type SuperTest from 'supertest';
-import { refreshSavedObjectIndices } from '../../refresh_index';
 
 /**
  * Installs available prebuilt rules in Kibana. Rules are
@@ -46,8 +45,6 @@ export const installPrebuiltRules = async (
     .set('x-elastic-internal-origin', 'foo')
     .send(payload)
     .expect(200);
-
-  await refreshSavedObjectIndices(es);
 
   return response.body;
 };


### PR DESCRIPTION
 **Resolves: #195921**

## Summary

I am modifying the skipped tests and unskipping them in MKI.

The first attempt of only relying on removing the call to `refreshSavedObjectIndices` improved the situation for `installPrebuiltRules` but another problem was that similar error with privileges occurred for preparing the assets (reason under the hood being the same). 
The failing periodic pipeline build: https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3265/steps/canvas

That is why I am replacing the logic of installing the rule for test. Instead of creating assets I am building a zip with our fake rules and calling the `installFleetPackageByUpload` function, as we already do in other tests. This allows our test security_detection_engine package to be installed the `official` way.
**The successful periodic pipeline build**: https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3270/steps/canvas

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->