### PR TITLE
[9.1] [Controls] Remove availableOptions from ES|QL values from query saved object (#231690)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-types/src/variables_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/variables_types.ts
@@ -49,12 +49,14 @@ export interface ESQLControlState {
   grow?: boolean;
   width?: ControlWidthOptions;
   title: string;
-  availableOptions: string[];
   selectedOptions: string[];
   variableName: string;
   variableType: ESQLVariableType;
   esqlQuery: string;
   controlType: EsqlControlType;
+  // If the controlType is STATIC_VALUES, store the list of availableOptions in the control state
+  // VALUES_FROM_QUERY controls will instead fetch available options at runtime
+  availableOptions?: string[];
 }
 
 export const apiPublishesESQLVariable = (

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.test.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { waitFor } from '@testing-library/react';
+import { EsqlControlType, type ESQLControlState } from '@kbn/esql-types';
+import { getMockedControlGroupApi } from '../mocks/control_mocks';
+import type { ControlFetchContext } from '../../control_group/control_fetch';
+import { initializeESQLControlSelections } from './esql_control_selections';
+import type { BehaviorSubject } from 'rxjs';
+
+const MOCK_VALUES_FROM_QUERY = ['option1', 'option2', 'option3', 'option4', 'option5'];
+
+const mockGetESQLSingleColumnValues = jest.fn();
+const mockIsSuccess = jest.fn();
+
+jest.mock('./utils/get_esql_single_column_values', () => {
+  const getESQLSingleColumnValues = () => {
+    mockGetESQLSingleColumnValues();
+    return { values: MOCK_VALUES_FROM_QUERY };
+  };
+  getESQLSingleColumnValues.isSuccess = () => {
+    mockIsSuccess();
+    return true;
+  };
+  return {
+    getESQLSingleColumnValues,
+  };
+});
+
+describe('initializeESQLControlSelections', () => {
+  const uuid = 'myESQLControl';
+
+  const dashboardApi = {};
+  const controlGroupApi = getMockedControlGroupApi(dashboardApi);
+  const controlFetch$ = controlGroupApi.controlFetch$(uuid) as BehaviorSubject<ControlFetchContext>;
+
+  describe('values from query', () => {
+    test('should load availableOptions but not serialize them', async () => {
+      const initialState = {
+        selectedOptions: ['option1'],
+        availableOptions: ['option1', 'option2'], // Test backwards compatibility with serialized availableOptions
+        variableName: 'variable1',
+        variableType: 'values',
+        esqlQuery: 'FROM foo | STATS BY column',
+        controlType: EsqlControlType.VALUES_FROM_QUERY,
+      } as ESQLControlState;
+
+      const selections = initializeESQLControlSelections(initialState, controlFetch$, jest.fn());
+
+      await waitFor(() => {
+        expect(mockGetESQLSingleColumnValues).toHaveBeenCalledTimes(1);
+        expect(mockIsSuccess).toHaveBeenCalledTimes(1);
+      });
+
+      const availableOptions = selections.internalApi.availableOptions$.getValue();
+      expect(availableOptions?.length).toBe(5);
+
+      const latestState = selections.getLatestState();
+      expect('availableOptions' in latestState).toBeFalsy();
+      expect(latestState).toMatchInlineSnapshot(`
+        Object {
+          "controlType": "VALUES_FROM_QUERY",
+          "esqlQuery": "FROM foo | STATS BY column",
+          "selectedOptions": Array [
+            "option1",
+          ],
+          "title": "",
+          "variableName": "variable1",
+          "variableType": "values",
+        }
+      `);
+    });
+  });
+
+  describe('static values', () => {
+    test('should not load availableOptions and instead just serialize them', async () => {
+      const initialState = {
+        selectedOptions: ['option1'],
+        availableOptions: ['option1', 'option2'],
+        variableName: 'variable1',
+        variableType: 'values',
+        controlType: EsqlControlType.STATIC_VALUES,
+      } as ESQLControlState;
+
+      const selections = initializeESQLControlSelections(initialState, controlFetch$, jest.fn());
+
+      const availableOptions = selections.internalApi.availableOptions$.getValue();
+      expect(availableOptions?.length).toBe(2);
+
+      const latestState = selections.getLatestState();
+      expect(latestState).toMatchInlineSnapshot(`
+        Object {
+          "availableOptions": Array [
+            "option1",
+            "option2",
+          ],
+          "controlType": "STATIC_VALUES",
+          "esqlQuery": "",
+          "selectedOptions": Array [
+            "option1",
+          ],
+          "title": "",
+          "variableName": "variable1",
+          "variableType": "values",
+        }
+      `);
+    });
+
+    expect(mockGetESQLSingleColumnValues).toHaveBeenCalledTimes(0);
+    expect(mockIsSuccess).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
@@ -38,7 +38,16 @@ export const selectionComparators: StateComparators<
   >
 > = {
   selectedOptions: selectedOptionsComparatorFunction,
-  availableOptions: 'referenceEquality',
+  availableOptions: (a, b, lastState, currentState) => {
+    // Only compare availableOptions for static values controls; values from query fetch these at runtime
+    if (
+      lastState?.controlType === currentState?.controlType &&
+      currentState?.controlType === EsqlControlType.VALUES_FROM_QUERY
+    ) {
+      return true;
+    }
+    return deepEqual(a ?? [], b ?? []);
+  },
   variableName: 'referenceEquality',
   variableType: 'referenceEquality',
   controlType: 'referenceEquality',
@@ -48,7 +57,8 @@ export const selectionComparators: StateComparators<
 
 export function initializeESQLControlSelections(
   initialState: ESQLControlState,
-  controlFetch$: ReturnType<ControlGroupApi['controlFetch$']>
+  controlFetch$: ReturnType<ControlGroupApi['controlFetch$']>,
+  setDataLoading: (loading: boolean) => void
 ) {
   const availableOptions$ = new BehaviorSubject<string[]>(initialState.availableOptions ?? []);
   const selectedOptions$ = new BehaviorSubject<string[]>(initialState.selectedOptions ?? []);
@@ -83,16 +93,17 @@ export function initializeESQLControlSelections(
   const fetchSubscription = controlFetch$
     .pipe(
       filter(() => controlType$.getValue() === EsqlControlType.VALUES_FROM_QUERY),
-      switchMap(
-        async ({ timeRange }) =>
-          await getESQLSingleColumnValues({
-            query: esqlQuery$.getValue(),
-            search: dataService.search.search,
-            timeRange,
-          })
-      )
+      switchMap(async ({ timeRange }) => {
+        setDataLoading(true);
+        return await getESQLSingleColumnValues({
+          query: esqlQuery$.getValue(),
+          search: dataService.search.search,
+          timeRange,
+        });
+      })
     )
     .subscribe((result) => {
+      setDataLoading(false);
       if (getESQLSingleColumnValues.isSuccess(result)) {
         availableOptions$.next(result.values.map((value) => value));
       }
@@ -157,7 +168,9 @@ export function initializeESQLControlSelections(
     getLatestState: () => {
       return {
         selectedOptions: selectedOptions$.getValue() ?? [],
-        availableOptions: availableOptions$.getValue() ?? [],
+        ...(controlType$.getValue() === EsqlControlType.STATIC_VALUES
+          ? { availableOptions: availableOptions$.getValue() ?? [] }
+          : {}),
         variableName: variableName$.getValue() ?? '',
         variableType: variableType$.getValue() ?? ESQLVariableType.VALUES,
         controlType: controlType$.getValue(),

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
@@ -41,7 +41,8 @@ export const getESQLControlFactory = (): ControlFactory<ESQLControlState, ESQLCo
       const defaultControlManager = initializeDefaultControlManager(initialState);
       const selections = initializeESQLControlSelections(
         initialState,
-        controlGroupApi.controlFetch$(uuid)
+        controlGroupApi.controlFetch$(uuid),
+        defaultControlManager.api.setDataLoading
       );
 
       const closeOverlay = () => {

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/types.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/types.ts
@@ -6,15 +6,20 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { PublishesESQLVariable } from '@kbn/esql-types';
-import type { HasEditCapabilities, PublishesTitle } from '@kbn/presentation-publishing';
+import type { PublishesESQLVariable } from '@kbn/esql-types';
+import type {
+  HasEditCapabilities,
+  PublishesDataLoading,
+  PublishesTitle,
+} from '@kbn/presentation-publishing';
 import type { DefaultControlApi } from '../types';
 import { OptionsListState } from '../data_controls/options_list_control/types';
 
 export type ESQLControlApi = DefaultControlApi &
   PublishesESQLVariable &
   HasEditCapabilities &
-  Pick<Required<PublishesTitle>, 'defaultTitle$'>;
+  Pick<Required<PublishesTitle>, 'defaultTitle$'> &
+  PublishesDataLoading;
 
 type HideExcludeUnusedState = Pick<OptionsListState, 'exclude'>;
 type HideExistsUnusedState = Pick<OptionsListState, 'existsSelected'>;

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/identifier_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/identifier_control_form.tsx
@@ -57,7 +57,7 @@ export function IdentifierControlForm({
   >([]);
 
   const [selectedIdentifiers, setSelectedIdentifiers] = useState<EuiComboBoxOptionOption[]>(
-    initialState
+    initialState?.availableOptions
       ? initialState.availableOptions.map((option) => {
           return {
             label: option,

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/index.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/index.tsx
@@ -138,12 +138,12 @@ export function ESQLControlsFlyout({
       !variableNameWithoutQuestionmark ||
         variableExists ||
         !areValuesValid ||
-        !controlState?.availableOptions.length
+        !controlState?.availableOptions?.length
     );
   }, [
     isControlInEditMode,
     areValuesValid,
-    controlState?.availableOptions.length,
+    controlState?.availableOptions?.length,
     esqlVariables,
     variableName,
     variableType,
@@ -154,7 +154,7 @@ export function ESQLControlsFlyout({
   }, []);
 
   const onCreateControl = useCallback(async () => {
-    if (controlState && controlState.availableOptions.length) {
+    if (controlState && controlState.availableOptions?.length) {
       if (!isControlInEditMode) {
         if (cursorPosition) {
           const query = updateQueryStringWithVariable(queryString, variableName, cursorPosition);

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -84,7 +84,7 @@ export function ValueControlForm({
   );
 
   const [selectedValues, setSelectedValues] = useState<EuiComboBoxOptionOption[]>(
-    initialState
+    initialState?.availableOptions
       ? initialState.availableOptions.map((option) => {
           return {
             label: option,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Controls] Remove availableOptions from ES|QL values from query saved object (#231690)](https://github.com/elastic/kibana/pull/231690)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Zac Xeper","email":"Zacqary@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-25T20:55:19Z","message":"[Controls] Remove availableOptions from ES|QL values from query saved object (#231690)\n\n## Summary\n\nCloses #231668 \n\nFor `VALUES_FROM_QUERY` ES|QL controls, omit the `availableOptions`\nproperty from the control state before saving, from both the control\neditor and the dashboard. These controls always fetch their\n`availableOptions` on page load and dashboard refresh, and when the list\nis extremely long, saving it in a saved object has been causing serious\nperformance issues for some users.\n\n`STATIC_VALUES` controls are unaffected, and still save their\n`availableOptions` in the control state.","sha":"56cfa2b8c214cb7d3d01a8487e85754bf45815e5","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","loe:small","impact:critical","Project:Controls","Team:ESQL","backport:version","v9.2.0","v9.1.3","v8.19.3"],"title":"[Controls] Remove availableOptions from ES|QL values from query saved object","number":231690,"url":"https://github.com/elastic/kibana/pull/231690","mergeCommit":{"message":"[Controls] Remove availableOptions from ES|QL values from query saved object (#231690)\n\n## Summary\n\nCloses #231668 \n\nFor `VALUES_FROM_QUERY` ES|QL controls, omit the `availableOptions`\nproperty from the control state before saving, from both the control\neditor and the dashboard. These controls always fetch their\n`availableOptions` on page load and dashboard refresh, and when the list\nis extremely long, saving it in a saved object has been causing serious\nperformance issues for some users.\n\n`STATIC_VALUES` controls are unaffected, and still save their\n`availableOptions` in the control state.","sha":"56cfa2b8c214cb7d3d01a8487e85754bf45815e5"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231690","number":231690,"mergeCommit":{"message":"[Controls] Remove availableOptions from ES|QL values from query saved object (#231690)\n\n## Summary\n\nCloses #231668 \n\nFor `VALUES_FROM_QUERY` ES|QL controls, omit the `availableOptions`\nproperty from the control state before saving, from both the control\neditor and the dashboard. These controls always fetch their\n`availableOptions` on page load and dashboard refresh, and when the list\nis extremely long, saving it in a saved object has been causing serious\nperformance issues for some users.\n\n`STATIC_VALUES` controls are unaffected, and still save their\n`availableOptions` in the control state.","sha":"56cfa2b8c214cb7d3d01a8487e85754bf45815e5"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->