### PR TITLE
remove yarn caches after install (8.17)

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -43,3 +43,6 @@ if [[ "$DISABLE_BOOTSTRAP_VALIDATION" != "true" ]]; then
   check_for_changed_files 'yarn kbn bootstrap'
 fi
 
+# Clear the cache after installation
+rm -rf ./.yarn-local-mirror
+yarn cache clean


### PR DESCRIPTION
## Summary
... to free up space on CI, and prevent `ENOSPC` errors.

Backport of https://github.com/elastic/kibana/pull/225999 + https://github.com/elastic/kibana/pull/225605