### PR TITLE
[Search] remove connectors & crawlers from nav

### DIFF
--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -8,7 +8,6 @@
 import type { AppDeepLinkId, NavigationTreeDefinition } from '@kbn/core-chrome-browser';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import { i18n } from '@kbn/i18n';
-import { CONNECTORS_LABEL, WEB_CRAWLERS_LABEL } from '../common/i18n_string';
 
 export const navigationTree = ({ isAppRegistered }: ApplicationStart): NavigationTreeDefinition => {
   function isAvailable<T>(appId: string, content: T): T[] {
@@ -96,14 +95,6 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                 link: 'searchPlayground' as AppDeepLinkId,
                 breadcrumbStatus: 'hidden' as 'hidden',
               }),
-              {
-                title: CONNECTORS_LABEL,
-                link: 'serverlessConnectors',
-              },
-              {
-                title: WEB_CRAWLERS_LABEL,
-                link: 'serverlessWebCrawlers',
-              },
             ],
           },
           {

--- a/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
@@ -120,7 +120,7 @@ export class ServerlessSearchPlugin
       appRoute: '/app/connectors',
       euiIconType: 'logoElastic',
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
-      visibleIn: [],
+      visibleIn: ['globalSearch'],
       async mount({ element, history }: AppMountParameters) {
         const { renderApp } = await import('./application/connectors');
         const [coreStart, services] = await core.getStartServices();
@@ -137,7 +137,7 @@ export class ServerlessSearchPlugin
       appRoute: '/app/web_crawlers',
       euiIconType: 'logoElastic',
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
-      visibleIn: [],
+      visibleIn: ['globalSearch'],
       async mount({ element, history }: AppMountParameters) {
         const { renderApp } = await import('./application/web_crawlers');
         const [coreStart, services] = await core.getStartServices();

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/navigation.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/navigation.ts
@@ -80,16 +80,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
           pageTestSubject: 'playgroundsListPage',
         },
         {
-          deepLinkId: 'serverlessConnectors',
-          breadcrumbs: ['Build', 'Connectors'],
-          pageTestSubject: 'svlSearchConnectorsPage',
-        },
-        {
-          deepLinkId: 'serverlessWebCrawlers',
-          breadcrumbs: ['Build', 'Web crawlers'],
-          pageTestSubject: 'serverlessSearchConnectorsTitle',
-        },
-        {
           deepLinkId: 'searchSynonyms',
           breadcrumbs: ['Relevance', 'Synonyms'],
           pageTestSubject: 'searchSynonymsOverviewPage',
@@ -218,8 +208,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Build' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Index Management' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'RAG Playground' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Connectors' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Web crawlers' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Relevance' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Synonyms' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Query rules' });
@@ -244,8 +232,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
         'build',
         'elasticsearchIndexManagement',
         'searchPlayground',
-        'serverlessConnectors',
-        'serverlessWebCrawlers',
         'relevance',
         'searchSynonyms',
         'searchQueryRules',


### PR DESCRIPTION
## Summary

- Removed Connectors & Web Crawlers form serverless side navigation
- Updated serverless Connectors & Web Crawlers to be included in global search results

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
