### PR TITLE
[ES|QL] Fix grouping for unary operators (`NOT`, `+`, `-`) in AST query printer

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/ast/grouping.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/ast/grouping.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { isBinaryExpression } from './is';
+import { isBinaryExpression, isUnaryExpression } from './is';
 import type { ESQLAstNode } from '../types';
 
 /**
@@ -96,4 +96,43 @@ export const binaryExpressionGroup = (node: ESQLAstNode): BinaryExpressionGroup 
     return BinaryExpressionGroup.unknown;
   }
   return BinaryExpressionGroup.none;
+};
+
+/**
+ * The group name of a unary expression. Groups are ordered by precedence.
+ */
+export enum UnaryExpressionGroup {
+  /**
+   * No group, not a unary expression.
+   */
+  none = 0,
+
+  /**
+   * Unary expression, but its group is unknown.
+   */
+  unknown = 1,
+
+  /**
+   * Logical: `not`
+   */
+  not = 13,
+
+  /**
+   * Additive: `+`, `-`
+   */
+  additive = 50,
+}
+
+export const unaryExpressionGroup = (node: ESQLAstNode): UnaryExpressionGroup => {
+  if (isUnaryExpression(node)) {
+    switch (node.name.toUpperCase()) {
+      case 'NOT':
+        return UnaryExpressionGroup.not;
+      case '+':
+      case '-':
+        return UnaryExpressionGroup.additive;
+    }
+    return UnaryExpressionGroup.unknown;
+  }
+  return UnaryExpressionGroup.none;
 };

--- a/src/platform/packages/shared/kbn-esql-ast/src/ast/is.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/ast/is.ts
@@ -27,6 +27,9 @@ export const isCommand = (node: unknown): node is types.ESQLCommand =>
 export const isFunctionExpression = (node: unknown): node is types.ESQLFunction =>
   isProperNode(node) && node.type === 'function';
 
+export const isUnaryExpression = (node: unknown): node is types.ESQLUnaryExpression =>
+  isFunctionExpression(node) && node.subtype === 'unary-expression';
+
 /**
  * Returns true if the given node is a binary expression, i.e. an operator
  * surrounded by two operands:

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
@@ -909,4 +909,60 @@ describe('single line expression', () => {
   });
 });
 
-it.todo('test for NOT unary expression');
+describe('unary operator precedence and grouping', () => {
+  test('NOT should not parenthesize literals', () => {
+    assertReprint('ROW NOT a');
+  });
+
+  test('NOT should not parenthesize literals unnecessarily', () => {
+    assertReprint('ROW NOT (a)', 'ROW NOT a');
+  });
+
+  test('NOT should parenthesize OR expressions', () => {
+    assertReprint('ROW NOT (a OR b)');
+  });
+
+  test('NOT should parenthesize AND expressions', () => {
+    assertReprint('ROW NOT (a AND b)');
+  });
+
+  test('NOT should not parenthesize expressions with higher precedence', () => {
+    assertReprint('ROW NOT (a > b)', 'ROW NOT a > b');
+  });
+
+  test('unary minus should parenthesize addition', () => {
+    assertReprint('ROW -(a + b)');
+  });
+
+  test('unary minus should parenthesize subtraction', () => {
+    assertReprint('ROW -(a - b)');
+  });
+
+  test('unary minus should not parenthesize addition of negative number', () => {
+    assertReprint('ROW -a + -b');
+  });
+
+  test('unary minus should not parenthesize subtraction of negative number', () => {
+    assertReprint('ROW -a - -b');
+  });
+
+  test('unary minus should not parenthesize multiplication', () => {
+    assertReprint('ROW -a * b');
+  });
+
+  test('should not unnecessarily parenthesize multiplication', () => {
+    assertReprint('ROW a * b', 'ROW a * b');
+  });
+
+  test('should parenthesize addition in multiplication', () => {
+    assertReprint('ROW (a + b) * c');
+  });
+
+  test('should not parenthesize multiplication in addition', () => {
+    assertReprint('ROW a + b * c');
+  });
+
+  test('should parenthesize multiplication of addition', () => {
+    assertReprint('ROW (a + b) * (c + d)');
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
@@ -930,6 +930,10 @@ describe('unary operator precedence and grouping', () => {
     assertReprint('ROW NOT (a > b)', 'ROW NOT a > b');
   });
 
+  test('NOT should parenthesize OR expressions on the right side', () => {
+    assertReprint('ROW NOT a OR NOT (a == b OR b == c)');
+  });
+
   test('unary minus should parenthesize addition', () => {
     assertReprint('ROW -(a + b)');
   });


### PR DESCRIPTION
## Summary

While working on [[Streamlang] ES|QL Transpiler](https://github.com/elastic/kibana/pull/232503), it's observed that the ES|QL AST printer [`BasicPrettyPrinter`](https://github.com/elastic/kibana/blob/80d4e452cec93e3d45d155affaa6ae4b3b31d282/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/basic_pretty_printer.ts#L72) has an issue where binary expressions like `OR` and `AND` weren't properly wrapped in parentheses when used as operands of the `NOT` unary operator. This caused incorrect precedence in the printed output and semantic errors in the generated ES|QL queries.

As a result, an AST representing:
```yaml
not: {
  or: [
    { field: 'A', eq: 'B' },
    { field: 'C', eq: 'D' },
  ],
},
```
would result in an incorrent ([see failing test](https://github.com/elastic/kibana/pull/232503/commits/b088aa0b84a714f9cb66f5427b276f75d1e289da#diff-3a8adc03dd3614b3d0b75bd2f3cbd8cce661461859d60ab358d931a66c3ee9d7R41)):
```SQL
NOT A == "B" OR B == "C"
```
instead of
```SQL
NOT (A == "B" OR B == "C")
```
 

### Changes
The PR addresses the issue by:
- Updating the pretty printer to detect when binary expressions are operands of unary operators
- Adding logic to automatically wrap binary expressions in parentheses when they appear as operands of unary operators like `NOT` and `-`
- Adding comprehensive test coverage for unary operator precedence with different expression types


| AST | Before | After |
|-------------------|--------|-------|
| <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/7dc38d90-42df-45b9-b5ba-728a201ec44f" />  | ```NOT field1 == "value1" OR field2 == "value2"``` | ```NOT (field1 == "value1" OR field2 == "value2")``` |

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->