### PR TITLE
[Streams] OTel GROK suggestion for subset of classic streams

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/grok_suggestions_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/grok_suggestions_handler.ts
@@ -77,7 +77,7 @@ export const handleProcessingGrokSuggestions = async ({
         ? field.ecs_field.replace('@timestamp', 'custom.timestamp')
         : field.ecs_field;
       return {
-        // if the stream is wired, or if it matches the logs-*otel-* pattern, use the OTEL field names
+        // if the stream is wired, or if it matches the logs-*.otel-* pattern, use the OTEL field names
         name: (isWiredStream || params.path.name.match(/^logs-.*\.otel-/)) ? getOtelFieldName(name) : name,
         columns: field.columns,
         grok_components: field.grok_components,

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/grok_suggestions_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/grok_suggestions_handler.ts
@@ -70,6 +70,9 @@ export const handleProcessingGrokSuggestions = async ({
   });
   const reviewResult = response.toolCalls[0].function.arguments;
 
+  // if the stream is wired, or if it matches the logs-*.otel-* pattern, use the OTEL field names
+  const useOtelFieldNames = isWiredStream || params.path.name.match(/^logs-.*\.otel-/);
+
   return {
     log_source: reviewResult.log_source,
     fields: reviewResult.fields.map((field) => {
@@ -77,11 +80,7 @@ export const handleProcessingGrokSuggestions = async ({
         ? field.ecs_field.replace('@timestamp', 'custom.timestamp')
         : field.ecs_field;
       return {
-        // if the stream is wired, or if it matches the logs-*.otel-* pattern, use the OTEL field names
-        name:
-          isWiredStream || params.path.name.match(/^logs-.*\.otel-/)
-            ? getOtelFieldName(name)
-            : name,
+        name: useOtelFieldNames ? getOtelFieldName(name) : name,
         columns: field.columns,
         grok_components: field.grok_components,
       };

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/grok_suggestions_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/grok_suggestions_handler.ts
@@ -78,7 +78,10 @@ export const handleProcessingGrokSuggestions = async ({
         : field.ecs_field;
       return {
         // if the stream is wired, or if it matches the logs-*.otel-* pattern, use the OTEL field names
-        name: (isWiredStream || params.path.name.match(/^logs-.*\.otel-/)) ? getOtelFieldName(name) : name,
+        name:
+          isWiredStream || params.path.name.match(/^logs-.*\.otel-/)
+            ? getOtelFieldName(name)
+            : name,
         columns: field.columns,
         grok_components: field.grok_components,
       };

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/grok_suggestions_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/grok_suggestions_handler.ts
@@ -77,7 +77,8 @@ export const handleProcessingGrokSuggestions = async ({
         ? field.ecs_field.replace('@timestamp', 'custom.timestamp')
         : field.ecs_field;
       return {
-        name: isWiredStream ? getOtelFieldName(name) : name,
+        // if the stream is wired, or if it matches the logs-*otel-* pattern, use the OTEL field names
+        name: (isWiredStream || params.path.name.match(/^logs-.*\.otel-/)) ? getOtelFieldName(name) : name,
         columns: field.columns,
         grok_components: field.grok_components,
       };


### PR DESCRIPTION
follow up to comment in this issue here https://github.com/elastic/kibana/issues/224103#issuecomment-3073217306

This allow-lists `logs-*.otel-*` to create otel specific suggestions. 

It matches classic stream names like: `logs-generic.otel-default`, which is a default name we use when ingesting otel data

Question: 
Should we include the dot in the regex, or make it slightly broader? 


Before: 
<img width="3456" height="1916" alt="CleanShot 2025-08-27 at 08 52 03@2x" src="https://github.com/user-attachments/assets/ea710b99-6c97-4fdd-aa61-2dee9c9b791a" />

After:

<img width="3456" height="1916" alt="CleanShot 2025-08-27 at 08 53 51@2x" src="https://github.com/user-attachments/assets/452e843b-da9e-47e4-9acc-28adcd5e416c" />
