### PR TITLE
[APM][Agent Configuration] Validate against whitespace characters

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
@@ -285,6 +285,11 @@ describe('Agent configuration', () => {
           cy.contains('Key cannot be empty').should('be.visible');
         });
 
+        it('should show error when key is only whitespace', () => {
+          cy.getByTestSubj('apmSettingsAdvancedConfigurationKeyField').first().type(' ');
+          cy.contains('Key cannot be only whitespace characters').should('be.visible');
+        });
+
         it('should show error when key conflicts with predefined settings', () => {
           cy.getByTestSubj('apmSettingsAdvancedConfigurationKeyField')
             .first()

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/advanced_config_key_input.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/advanced_config_key_input.tsx
@@ -59,14 +59,14 @@ export function AdvancedConfigKeyInput({
           defaultMessage: 'This key is already predefined in the standard configuration above',
         });
       }
-      if (touched && checkIfAdvancedConfigKeyExists(key)) {
+      if (key !== configKey && checkIfAdvancedConfigKeyExists(key)) {
         return i18n.translate('xpack.apm.agentConfig.settingsPage.keyDuplicateError', {
           defaultMessage: 'This key is already used in another advanced configuration',
         });
       }
       return null;
     },
-    [checkIfAdvancedConfigKeyExists, checkIfPredefinedConfigKeyExists, touched]
+    [checkIfAdvancedConfigKeyExists, checkIfPredefinedConfigKeyExists, configKey]
   );
 
   useEffect(() => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/advanced_config_key_input.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/advanced_config_key_input.tsx
@@ -49,6 +49,11 @@ export function AdvancedConfigKeyInput({
           defaultMessage: 'Key cannot be empty',
         });
       }
+      if (key !== '' && key.trim() === '') {
+        return i18n.translate('xpack.apm.agentConfig.settingsPage.keyEmptyError', {
+          defaultMessage: 'Key cannot be only whitespace characters',
+        });
+      }
       if (checkIfPredefinedConfigKeyExists(key)) {
         return i18n.translate('xpack.apm.agentConfig.settingsPage.keyPredefinedError', {
           defaultMessage: 'This key is already predefined in the standard configuration above',

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/advanced_config_key_input.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/advanced_config_key_input.tsx
@@ -40,7 +40,7 @@ export function AdvancedConfigKeyInput({
     setLocalKey(configKey);
   }, [configKey]);
 
-  const touched = useCallback((key: string) => key !== configKey, [configKey]);
+  const [touched, setTouched] = useState(false);
 
   const getErrorMsg = useCallback(
     (key: string) => {
@@ -49,7 +49,7 @@ export function AdvancedConfigKeyInput({
           defaultMessage: 'Key cannot be empty',
         });
       }
-      if (key !== '' && key.trim() === '') {
+      if (key.trim() === '') {
         return i18n.translate('xpack.apm.agentConfig.settingsPage.keyEmptyError', {
           defaultMessage: 'Key cannot be only whitespace characters',
         });
@@ -59,7 +59,7 @@ export function AdvancedConfigKeyInput({
           defaultMessage: 'This key is already predefined in the standard configuration above',
         });
       }
-      if (touched(key) && checkIfAdvancedConfigKeyExists(key)) {
+      if (touched && checkIfAdvancedConfigKeyExists(key)) {
         return i18n.translate('xpack.apm.agentConfig.settingsPage.keyDuplicateError', {
           defaultMessage: 'This key is already used in another advanced configuration',
         });
@@ -71,15 +71,14 @@ export function AdvancedConfigKeyInput({
 
   useEffect(() => {
     const errorId = `key${id}`;
-    const isTouched = touched(localKey);
     const newErrorMsg = getErrorMsg(localKey);
     const hasValidationErrors = newErrorMsg !== null;
 
     setErrorMsg(newErrorMsg);
-    setIsFormInvalid((isTouched || revalidate) && hasValidationErrors);
+    setIsFormInvalid((touched || revalidate) && hasValidationErrors);
 
     if (hasValidationErrors) {
-      addValidationError(errorId, isTouched);
+      addValidationError(errorId, touched);
     } else {
       removeValidationError(errorId);
     }
@@ -90,6 +89,7 @@ export function AdvancedConfigKeyInput({
     const noValidationErrors = newErrorMsg === null;
 
     setLocalKey(key);
+    setTouched(true);
 
     if (noValidationErrors) {
       onChange({ key, oldKey: configKey });


### PR DESCRIPTION
Follow up of https://github.com/elastic/kibana/pull/230086

Prevent users from saving advanced settings with key containing only whitespace characters. Otherwise, it causes API error.

<img width="2549" height="1007" alt="image" src="https://github.com/user-attachments/assets/60a2fab8-22a8-45d3-bc24-b5803e9cbe2f" />
