### PR TITLE
Make appex-qa the single owner of esArchiver

### DIFF
--- a/src/platform/packages/shared/kbn-es-archiver/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-es-archiver/kibana.jsonc
@@ -2,7 +2,6 @@
   "type": "test-helper",
   "id": "@kbn/es-archiver",
   "owner": [
-    "@elastic/kibana-operations",
     "@elastic/appex-qa"
   ],
   "group": "platform",


### PR DESCRIPTION
## Summary

This makes the appex-qa team the single owner of esArchiver and removes the kibana-operations team form the owners list.

As part of the hand-over, we decided ~2 years ago to go with shared ownership for some time. Since then, the QA team has taken full ownership of esArchiver and it's time to reflect that in the package definition.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->