### PR TITLE
[8.19] Fix VM cache update trigger

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/promote.sh
+++ b/.buildkite/scripts/steps/es_snapshots/promote.sh
@@ -25,7 +25,7 @@ steps:
     async: true
     build:
       env:
-        IMAGES_CONFIG: 'kibana/image_cache.yml'
-        BASE_IMAGES_CONFIG: 'core/images.yml,kibana/base_image.yml'
+        IMAGES_CONFIG: 'kibana/image_cache.tpl.yml'
+        BASE_IMAGES_CONFIG: 'core/images.yml,kibana/base_image.yml,kibana/packages_layer.yml'
         RETRY: "1"
 EOF


### PR DESCRIPTION
## Summary
Currently some cache warmup triggers are failing: https://buildkite.com/elastic/kibana-vm-images/builds/2643

After https://github.com/elastic/ci-agent-images/pull/1537, the trigger format changed, this was updated in main, and backported to all old branches triggering the cache warmup.