### PR TITLE
[Shared UX] Fix side nav popover and tooltip position on scroll

### DIFF
--- a/src/core/packages/chrome/navigation/src/components/popover/index.tsx
+++ b/src/core/packages/chrome/navigation/src/components/popover/index.tsx
@@ -146,6 +146,7 @@ export const SideNavPopover = ({
         offset={POPOVER_OFFSET}
         ownFocus={false}
         panelPaddingSize="none"
+        repositionOnScroll
       >
         <div
           ref={popoverRef}

--- a/src/core/packages/chrome/navigation/src/components/side_nav/footer_item.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/footer_item.tsx
@@ -80,6 +80,7 @@ export const SideNavFooterItem = forwardRef<HTMLDivElement, SideNavFooterItemPro
           disableScreenReaderOutput
           onMouseOut={handleMouseOut}
           position="right"
+          repositionOnScroll
         >
           {menuItem}
         </EuiToolTip>

--- a/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu_item.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu_item.tsx
@@ -115,6 +115,7 @@ export const SideNavPrimaryMenuItem = forwardRef<HTMLAnchorElement, SideNavPrima
           disableScreenReaderOutput
           onMouseOut={handleMouseOut}
           position="right"
+          repositionOnScroll
         >
           {menuItem}
         </EuiToolTip>


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/233065 

## Summary

Fixed side nav popover and tooltip position on scroll. [Related EUI docs](https://eui.elastic.co/docs/components/containers/popover/#popover-on-a-fixed-element).

### Testing

Before:

https://github.com/user-attachments/assets/3902c821-eb20-4444-908b-655e0c2b5360

After:

https://github.com/user-attachments/assets/caffe159-2574-4d93-a4d9-cc763ccd605c
