### PR TITLE
Skip Oblt AI assistant KB basic operations test suite for MKI

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/knowledge_base/knowledge_base_basic_operations.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/knowledge_base/knowledge_base_basic_operations.spec.ts
@@ -60,6 +60,9 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   }
 
   describe('Knowledge base: Basic operations', function () {
+    // fails/flaky on MKI, see https://github.com/elastic/kibana/issues/233089
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       await deployTinyElserAndSetupKb(getService);
     });


### PR DESCRIPTION
## Summary

This PR skips the Observability AI assistant knowledge base basic operations  test suite for MKI runs.
More details about the failures/flakiness in https://github.com/elastic/kibana/issues/233089


