### PR TITLE
[OAS] Remove dashboards api from capture oas snapshot script

### DIFF
--- a/.buildkite/scripts/steps/checks/capture_oas_snapshot.sh
+++ b/.buildkite/scripts/steps/checks/capture_oas_snapshot.sh
@@ -17,7 +17,6 @@ cmd="node scripts/capture_oas_snapshot \
   --include-path /api/spaces \
   --include-path /api/streams \
   --include-path /api/fleet \
-  --include-path /api/dashboards \
   --include-path /api/saved_objects/_import \
   --include-path /api/saved_objects/_export \
   --include-path /api/maintenance_window"


### PR DESCRIPTION
## Summary

Removes the dashboards API endpoints from the capture oas snapshot script. These endpoints are currently under development and no snapshots can be captured.

We can re-enable OAS capture once https://github.com/elastic/kibana/issues/219139 is complete.