### PR TITLE
[Oblt Onboarding] Unskip auto-detect FTR test

### DIFF
--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/onboarding/auto_detect.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/onboarding/auto_detect.ts
@@ -18,8 +18,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const synthtrace = getService('svlLogsSynthtraceClient');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/225147
-  describe.skip('Onboarding Auto-Detect', () => {
+  describe('Onboarding Auto-Detect', () => {
     before(async () => {
       await PageObjects.svlCommonPage.loginAsAdmin(); // Onboarding requires admin role
       await PageObjects.common.navigateToUrlWithBrowserHistory(


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/225147

Un-skipping the test as the change in the system package that was causing the test to fail [was now reverted](https://github.com/elastic/integrations/commit/59bed8ecce69a86fc12eeee6342c411cfadc337f#diff-bea9aab03549c6f9c60dffa62f81264b59b180754f3d8fd78cbb10eef33e8e62) and test doesn't fail anymore.

[Flaky runner job](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9239#0198eb92-7f3e-4f1c-b557-2522ef936e80)