### PR TITLE
Add retry to setUserInstructionContent

### DIFF
--- a/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
+++ b/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
@@ -139,10 +139,18 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
 
       async function setUserInstructionContent(content?: string) {
         const editor = await find.byCssSelector(`#${ui.pages.kbManagementTab.entryMarkdownEditor}`);
-        await editor.clearValue();
-        if (content) {
-          await editor.type(content);
-        }
+        await retry.try(async () => {
+          await editor.clearValue();
+          if (content) {
+            await editor.type(content);
+          }
+          const actualValue = await editor.getAttribute('value');
+          if (actualValue !== (content ?? '')) {
+            throw new Error(
+              `Expected editor value to be "${content ?? ''}" but found "${actualValue}"`
+            );
+          }
+        });
       }
 
       before(async () => {

--- a/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
+++ b/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
@@ -119,8 +119,7 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/230988
-    describe.skip('User instruction management', () => {
+    describe('User instruction management', () => {
       async function openUserInstructionFlyout() {
         await testSubjects.click(ui.pages.kbManagementTab.editUserInstructionButton);
         await testSubjects.exists(ui.pages.kbManagementTab.saveEntryButton);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/230988

Add retry to setUserInstructionContent to address flakiness.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.