### PR TITLE
[Fleet] add discovery field to package info

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.test.ts
@@ -475,6 +475,33 @@ owner:
       'Name input_only and version 0.2.0 do not match top-level directory input_only-0.1.0'
     );
   });
+
+  it('should parse package successfully with discovery field', async () => {
+    const packageInfo: ArchivePackage = await _generatePackageInfoFromPaths(
+      [
+        'x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/good_content/0.1.0/docs/README.md',
+        'x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/good_content/0.1.0/manifest.yml',
+      ],
+      'x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/good_content/0.1.0'
+    );
+
+    expect(packageInfo).toEqual(
+      expect.objectContaining({
+        discovery: {
+          fields: [
+            {
+              name: 'process.pid',
+            },
+          ],
+          datasets: [
+            {
+              name: 'good_content.dataset',
+            },
+          ],
+        },
+      })
+    );
+  });
 });
 
 describe('parseAndVerifyDataStreams', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.ts
@@ -131,6 +131,7 @@ const optionalArchivePackageProps: readonly OptionalPackageProp[] = [
   'elasticsearch',
   'description',
   'format_version',
+  'discovery',
 ] as const;
 
 const registryInputProps = Object.values(RegistryInputKeys);

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/good_content/0.1.0/manifest.yml
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/good_content/0.1.0/manifest.yml
@@ -17,6 +17,8 @@ conditions:
 discovery:
   fields:
     - name: process.pid
+  datasets:
+    - name: good_content.dataset 
 screenshots:
   - src: /img/kibana-system.png
     title: kibana system


### PR DESCRIPTION
## Summary

Follow up for https://github.com/elastic/ingest-dev/issues/5685

When checking telemetry about content packages, found that the discovery fields are missing:
https://telemetry-v2-staging.elastic.dev/app/r/s/R7PwU

```
  "_source": {
    "dryRun": false,
    "package_name": "system_otel",
    "cluster_uuid": "qqbuErmCRJG74U6EJFuz7A",
    "@timestamp": "2025-08-27T09:00:23.020000Z",
    "package_type": "content",
    "install_type": "install",
    "error_message": [],
    "current_version": "not_installed",
    "status": "success",
    "new_version": "0.2.0",
    "event_type": "package-install",
    "version": "9.2.0-SNAPSHOT",
    "timestamp": "2025-08-27T09:00:23.020000Z",
    "automatic_install": true
  }
```

Added `discovery` field to the package archive parsing logic.
Tested locally by logging out the telemetry event generated when the content package is installed, now containing the correct values:
```
{
  "packageName": "system_otel",
  "currentVersion": "not_installed",
  "newVersion": "0.2.0",
  "status": "failure",
  "dryRun": false,
  "eventType": "package-install",
  "installType": "install",
  "packageType": "content",
  "discoveryDatasets": [
    {
      "name": "hostmetricsreceiver.otel"
    }
  ],
  "automaticInstall": true
}
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



