### PR TITLE
[Logs essentials] Show alert details actions button

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -88,7 +88,6 @@ const isTabId = (value: string): value is TabId => {
 export function AlertDetails() {
   const { services } = useKibana();
   const {
-    cases,
     http,
     triggersActionsUi: { ruleTypeRegistry },
     observabilityAIAssistant,
@@ -412,21 +411,17 @@ export function AlertDetails() {
         ) : (
           <EuiLoadingSpinner />
         ),
-        rightSideItems: cases
-          ? [
-              <ObsCasesContext>
-                <HeaderActions
-                  alert={alertDetail?.formatted ?? null}
-                  alertIndex={alertDetail?.raw._index}
-                  alertStatus={alertStatus}
-                  onUntrackAlert={onUntrackAlert}
-                  onUpdate={onUpdate}
-                  rule={rule}
-                  refetch={refetch}
-                />
-              </ObsCasesContext>,
-            ]
-          : [],
+        rightSideItems: [
+          <HeaderActions
+            alert={alertDetail?.formatted ?? null}
+            alertIndex={alertDetail?.raw._index}
+            alertStatus={alertStatus}
+            onUntrackAlert={onUntrackAlert}
+            onUpdate={onUpdate}
+            rule={rule}
+            refetch={refetch}
+          />,
+        ],
         bottomBorder: false,
         'data-test-subj': rule?.ruleTypeId || 'alertDetailsPageTitle',
       }}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/add_to_case_button.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/add_to_case_button.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import type { CaseAttachmentsWithoutOwner } from '@kbn/cases-plugin/public/types';
+import { AttachmentType } from '@kbn/cases-plugin/common';
+import { EuiButton, EuiText } from '@elastic/eui';
+import { ALERT_UUID } from '@kbn/rule-data-utils';
+
+import type { Rule } from '@kbn/alerts-ui-shared';
+import { useKibana } from '../../../utils/kibana_react';
+import type { TopAlert } from '../../../typings/alerts';
+
+export function AddToCaseButton({
+  alert,
+  alertIndex,
+  rule,
+  setIsPopoverOpen,
+}: {
+  alert: TopAlert | null;
+  alertIndex?: string;
+  rule?: Rule;
+  setIsPopoverOpen: (isOpen: boolean) => void;
+}) {
+  const { services } = useKibana();
+
+  const selectCaseModal = services.cases?.hooks.useCasesAddToExistingCaseModal();
+
+  const attachments: CaseAttachmentsWithoutOwner =
+    alert && rule
+      ? [
+          {
+            alertId: alert?.fields[ALERT_UUID] || '',
+            index: alertIndex || '',
+            rule: {
+              id: rule.id,
+              name: rule.name,
+            },
+            type: AttachmentType.alert,
+          },
+        ]
+      : [];
+
+  const handleAddToCase = () => {
+    setIsPopoverOpen(false);
+    selectCaseModal?.open({ getAttachments: () => attachments });
+  };
+
+  return (
+    <EuiButton fill iconType="plus" onClick={handleAddToCase} data-test-subj="add-to-case-button">
+      <EuiText size="s">
+        {i18n.translate('xpack.observability.alertDetails.addToCase', {
+          defaultMessage: 'Add to case',
+        })}
+      </EuiText>
+    </EuiButton>
+  );
+}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.tsx
@@ -8,10 +8,7 @@
 import React, { useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { noop } from 'lodash';
-import type { CaseAttachmentsWithoutOwner } from '@kbn/cases-plugin/public/types';
-import { AttachmentType } from '@kbn/cases-plugin/common';
 import {
-  EuiButton,
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiFlexGroup,
@@ -31,6 +28,8 @@ import {
   AlertDetailsRuleFormFlyout,
   type AlertDetailsRuleFormFlyoutBaseProps,
 } from './alert_details_rule_form_flyout';
+import { ObsCasesContext } from './obs_cases_context';
+import { AddToCaseButton } from './add_to_case_button';
 
 export interface HeaderActionsProps extends AlertDetailsRuleFormFlyoutBaseProps {
   alert: TopAlert | null;
@@ -58,8 +57,6 @@ export function HeaderActions({
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
   const [snoozeModalOpen, setSnoozeModalOpen] = useState<boolean>(false);
 
-  const selectCaseModal = cases?.hooks.useCasesAddToExistingCaseModal();
-
   const { mutateAsync: untrackAlerts } = useBulkUntrackAlerts();
 
   const handleUntrackAlert = useCallback(async () => {
@@ -77,26 +74,6 @@ export function HeaderActions({
   const handleTogglePopover = () => setIsPopoverOpen(!isPopoverOpen);
   const handleClosePopover = () => setIsPopoverOpen(false);
 
-  const attachments: CaseAttachmentsWithoutOwner =
-    alert && rule
-      ? [
-          {
-            alertId: alert?.fields[ALERT_UUID] || '',
-            index: alertIndex || '',
-            rule: {
-              id: rule.id,
-              name: rule.name,
-            },
-            type: AttachmentType.alert,
-          },
-        ]
-      : [];
-
-  const handleAddToCase = () => {
-    setIsPopoverOpen(false);
-    selectCaseModal?.open({ getAttachments: () => attachments });
-  };
-
   const handleOpenSnoozeModal = () => {
     setIsPopoverOpen(false);
     setSnoozeModalOpen(true);
@@ -107,18 +84,14 @@ export function HeaderActions({
       <EuiFlexGroup direction="row" gutterSize="s" justifyContent="flexEnd">
         {cases && (
           <EuiFlexItem grow={false}>
-            <EuiButton
-              fill
-              iconType="plus"
-              onClick={handleAddToCase}
-              data-test-subj="add-to-case-button"
-            >
-              <EuiText size="s">
-                {i18n.translate('xpack.observability.alertDetails.addToCase', {
-                  defaultMessage: 'Add to case',
-                })}
-              </EuiText>
-            </EuiButton>
+            <ObsCasesContext>
+              <AddToCaseButton
+                alert={alert}
+                alertIndex={alertIndex}
+                rule={rule}
+                setIsPopoverOpen={setIsPopoverOpen}
+              />
+            </ObsCasesContext>
           </EuiFlexItem>
         )}
         <EuiFlexItem grow={false}>


### PR DESCRIPTION
The actions button in the alert details page is currently not shown in logs essentials.

### Running instructions

```
yarn es serverless --projectType oblt --serverless.observability.tier=logs_essentials -E xpack.ml.enabled=false
yarn serverless-oblt --pricing.tiers.products='[{"name":"observability","tier":"logs_essentials"}]'
```

Before:
<img width="1512" height="824" alt="Screenshot 2025-08-27 at 15 25 26" src="https://github.com/user-attachments/assets/9143b980-d252-480b-8ca2-2282fa6d0ee3" />

After:
<img width="1512" height="825" alt="Screenshot 2025-08-27 at 15 24 44" src="https://github.com/user-attachments/assets/12a8b915-d9fb-44ec-b5ce-a5100b03e063" />
