### PR TITLE
index_template.composed_of may be undefined

### DIFF
--- a/x-pack/platform/plugins/private/indices_metadata/server/lib/services/indices_metadata.types.ts
+++ b/x-pack/platform/plugins/private/indices_metadata/server/lib/services/indices_metadata.types.ts
@@ -64,7 +64,7 @@ export interface IndexTemplateInfo {
   managed_by?: string;
   beat?: string;
   is_managed?: boolean;
-  composed_of: string[];
+  composed_of?: string[];
   source_enabled?: boolean;
   source_includes: string[];
   source_excludes: string[];

--- a/x-pack/platform/plugins/private/indices_metadata/server/lib/services/indices_metadata.types.ts
+++ b/x-pack/platform/plugins/private/indices_metadata/server/lib/services/indices_metadata.types.ts
@@ -64,7 +64,7 @@ export interface IndexTemplateInfo {
   managed_by?: string;
   beat?: string;
   is_managed?: boolean;
-  composed_of?: string[];
+  composed_of: string[];
   source_enabled?: boolean;
   source_includes: string[];
   source_excludes: string[];

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/check_and_load_integration/validate_custom_component_template.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/check_and_load_integration/validate_custom_component_template.ts
@@ -26,7 +26,7 @@ export async function validateCustomComponentTemplate({
     });
 
     return indexTemplates.some((template) =>
-      template.index_template.composed_of.includes(componentTemplateName + '@custom')
+      template.index_template.composed_of?.includes(componentTemplateName + '@custom')
     );
   } catch (error) {
     return false;

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/stream_crud.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/stream_crud.ts
@@ -68,7 +68,7 @@ export async function getUnmanagedElasticsearchAssets({
     name: templateName,
   });
   if (template.index_templates.length) {
-    template.index_templates[0].index_template.composed_of.forEach((componentTemplateName) => {
+    template.index_templates[0].index_template.composed_of?.forEach((componentTemplateName) => {
       componentTemplates.push(componentTemplateName);
     });
   }
@@ -142,7 +142,7 @@ async function fetchComponentTemplates(
     .map((componentTemplate) => ({
       ...componentTemplate,
       used_by: allIndexTemplates
-        .filter((template) => template.index_template.composed_of.includes(componentTemplate.name))
+        .filter((template) => template.index_template.composed_of?.includes(componentTemplate.name))
         .map((template) => template.name),
     }));
 }

--- a/x-pack/platform/test/fleet_api_integration/apis/data_streams/list.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/data_streams/list.ts
@@ -122,7 +122,7 @@ export default function (providerContext: FtrProviderContext) {
         template: sourceIndexTemplate.template,
         _meta: sourceIndexTemplate._meta,
         data_stream: sourceIndexTemplate.data_stream,
-        composed_of: sourceIndexTemplate.composed_of.filter(
+        composed_of: sourceIndexTemplate.composed_of?.filter(
           (template) => template.includes('@settings') || template.includes('@package')
         ),
         index_patterns: [`${logsTemplateName}-testwithoutfinalpipeline`],

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
@@ -143,9 +143,11 @@ const createLatestIndex = async (
       name: indexName,
     });
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { template, composed_of = [], _meta } =
-      indexTemplateResponse.index_templates[0].index_template;
+    const {
+      template,
+      composed_of = [],
+      _meta,
+    } = indexTemplateResponse.index_templates[0].index_template;
 
     const indexTemplateParams = {
       template,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
@@ -145,8 +145,9 @@ const createLatestIndex = async (
 
     const {
       template,
-      composed_of = [],
       _meta,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      composed_of = [],
     } = indexTemplateResponse.index_templates[0].index_template;
 
     const indexTemplateParams = {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
@@ -144,7 +144,7 @@ const createLatestIndex = async (
     });
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { template, composed_of, _meta } =
+    const { template, composed_of = [], _meta } =
       indexTemplateResponse.index_templates[0].index_template;
 
     const indexTemplateParams = {


### PR DESCRIPTION
`composed_of` could be undefined which is not reflected in the esclient type, I've updated unguarded access in few places.

The client spec will be updated separately

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->