### PR TITLE
[ES|QL]  Update other AST Tools

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/mutate/commands/rerank/index.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/mutate/commands/rerank/index.test.ts
@@ -64,6 +64,17 @@ describe('commands.rerank', () => {
         'FROM index | RERANK "star wars" ON a, b, @timestamp WITH {"inference_id": "model_id"} | LIMIT 2'
       );
     });
+
+    it('should throw error when ON option is missing', () => {
+      const src = 'FROM index | RERANK "star wars"';
+      const query = EsqlQuery.fromSrc(src);
+
+      const cmd = [...commands.rerank.list(query.ast)][0];
+
+      expect(() => commands.rerank.setFields(cmd, ['newField'])).toThrow(
+        'RERANK command must have a ON option'
+      );
+    });
   });
 
   describe('.setWithParameter()', () => {

--- a/src/platform/packages/shared/kbn-esql-ast/src/mutate/commands/rerank/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/mutate/commands/rerank/index.ts
@@ -55,17 +55,20 @@ export const setFields = (
     });
   }
 
-  cmd.fields.length = 0;
-  cmd.fields.push(...(fields as ESQLAstRerankCommand['fields']));
-
   const isOnOption = (arg: ESQLAstItem): arg is ESQLCommandOption =>
     !!arg && !Array.isArray(arg) && arg.type === 'option' && arg.name === 'on';
 
   const onOption = cmd.args.find(isOnOption);
-  if (onOption) {
-    onOption.args.length = 0;
-    onOption.args.push(...(fields as ESQLAstRerankCommand['fields']));
+
+  if (!onOption) {
+    throw new Error('RERANK command must have a ON option');
   }
+
+  cmd.fields.length = 0;
+  cmd.fields.push(...(fields as ESQLAstRerankCommand['fields']));
+
+  onOption.args.length = 0;
+  onOption.args.push(...(fields as ESQLAstRerankCommand['fields']));
 };
 
 export const setWithParameter = (

--- a/src/platform/packages/shared/kbn-esql-ast/src/mutate/commands/rerank/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/mutate/commands/rerank/index.ts
@@ -12,8 +12,12 @@ import type {
   ESQLAstQueryExpression,
   ESQLAstRerankCommand,
   ESQLCommandOption,
-  ESQLIdentifierOrParam,
   ESQLStringLiteral,
+  ESQLParamLiteral,
+  ESQLMap,
+  ESQLAstItem,
+  ESQLMapEntry,
+  ESQLLiteral,
 } from '../../../types';
 import * as generic from '../../generic';
 
@@ -53,19 +57,84 @@ export const setFields = (
 
   cmd.fields.length = 0;
   cmd.fields.push(...(fields as ESQLAstRerankCommand['fields']));
+
+  const isOnOption = (arg: ESQLAstItem): arg is ESQLCommandOption =>
+    !!arg && !Array.isArray(arg) && arg.type === 'option' && arg.name === 'on';
+
+  const onOption = cmd.args.find(isOnOption);
+  if (onOption) {
+    onOption.args.length = 0;
+    onOption.args.push(...(fields as ESQLAstRerankCommand['fields']));
+  }
 };
 
-export const setInferenceId = (cmd: ESQLAstRerankCommand, id: string | ESQLIdentifierOrParam) => {
-  if (typeof id === 'string') {
-    id = id[0] === '?' ? Builder.param.build(id) : Builder.identifier(id);
+export const setWithParameter = (
+  cmd: ESQLAstRerankCommand,
+  key: string,
+  value: string | ESQLStringLiteral | ESQLParamLiteral
+) => {
+  // Converts a value to an appropriate ESQLExpression based on its type
+  const toExpression = (val: string | ESQLLiteral | ESQLParamLiteral) => {
+    if (typeof val === 'string') {
+      return val.startsWith('?')
+        ? Builder.param.build(val)
+        : Builder.expression.literal.string(val);
+    }
+    return val;
+  };
+
+  // Type guard to check if an AST item is a WITH option
+  const isWithOption = (arg: ESQLAstItem): arg is ESQLCommandOption =>
+    !!arg && !Array.isArray(arg) && arg.type === 'option' && arg.name === 'with';
+
+  // Validates and retrieves the map from a WITH option
+  const getWithOptionMap = (withOption: ESQLCommandOption): ESQLMap => {
+    const mapArg = withOption.args[0];
+
+    if (!mapArg || typeof mapArg === 'string' || Array.isArray(mapArg) || mapArg.type !== 'map') {
+      throw new Error('WITH option must contain a map');
+    }
+
+    return mapArg as ESQLMap;
+  };
+
+  // Normalizes a key for comparison by removing quotes
+  const normalizeKey = (keyValue: string | undefined): string => {
+    return keyValue?.replace(/"/g, '') ?? '';
+  };
+
+  // Checks if an entry in the map has the specified key
+  // normalizeKey avoid cases like: "inference_id" === "'inferenceId"' -> this is false
+  const getExistingEntry = (entry: ESQLMapEntry) =>
+    normalizeKey(entry.key.valueUnquoted ?? entry.key.value) === key;
+
+  // Creates a new map entry with the given key and value
+  const createMapEntry = (entryKey: string, entryValue: ESQLLiteral | ESQLParamLiteral) => ({
+    type: 'map-entry' as const,
+    name: 'map-entry' as const,
+    key: Builder.expression.literal.string(entryKey),
+    value: entryValue,
+    location: { min: 0, max: 0 },
+    text: '',
+    incomplete: false,
+  });
+
+  // Find the WITH option in the command arguments
+  const withOption = cmd.args.find(isWithOption);
+
+  if (!withOption) {
+    throw new Error('RERANK command must have a WITH option');
   }
 
-  if (id.type !== 'identifier' && id.type !== 'literal') {
-    throw new Error(`Invalid RERANK inferenceId: ${id}`);
+  // Get and validate the map from the WITH option
+  const valueExpression = toExpression(value);
+  // Look for existing entry with the same key
+  const map = getWithOptionMap(withOption);
+  const existingEntry = map.entries.find(getExistingEntry);
+
+  if (existingEntry) {
+    existingEntry.value = valueExpression;
+  } else {
+    map.entries.push(createMapEntry(key, valueExpression));
   }
-
-  cmd.inferenceId = id;
-
-  const withOption = cmd.args[2] as ESQLCommandOption;
-  withOption.args[0] = id;
 };

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/comments.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/comments.test.ts
@@ -9,7 +9,7 @@
 
 import { parse } from '..';
 import { EsqlQuery } from '../../query';
-import type { ESQLAstRerankCommand } from '../../types';
+import type { ESQLAstItem, ESQLAstRerankCommand, ESQLCommandOption, ESQLMap } from '../../types';
 import { Walker } from '../../walker';
 
 describe('Comments', () => {
@@ -129,7 +129,7 @@ FROM index`;
     it('to an expression', () => {
       const text = `
         FROM
-  
+
         // "abc" is the best source
         abc`;
       const { ast } = parse(text, { withFormatting: true });
@@ -241,7 +241,7 @@ FROM index`;
     it('to first binary expression operand', () => {
       const text = `
         ROW
-        
+
         // 1
         1 +
         2`;
@@ -1054,16 +1054,12 @@ FROM a
   });
 
   describe('many comments', () => {
-    /**
-     * @todo Tests skipped, while RERANK command grammar is being stabilized. We will
-     * get back to it after 9.1 release.
-     */
-    test.skip('can attach all possible inline comments in basic RERANK command', () => {
+    test('can attach all possible inline comments in basic RERANK command', () => {
       const src = `
         FROM a
           | /*0*/ RERANK /*1*/ "query" /*2*/
                 ON /*3*/ field /*4*/
-                WITH /*5*/ id /*6*/`;
+                WITH /*5*/ { /*6*/ "inference_id" /*7*/ : /*8*/ "model" /*9*/, /*10*/ "scoreColumn" /*11*/ : /*12*/ "rank_score" /*13*/ } /*14*/`;
       const query = EsqlQuery.fromSrc(src, { withFormatting: true });
       const cmd = query.ast.commands[1] as ESQLAstRerankCommand;
 
@@ -1095,38 +1091,126 @@ FROM a
       });
 
       expect(cmd.fields[0].formatting).toMatchObject({
-        left: [
-          {
+        left: expect.arrayContaining([
+          expect.objectContaining({
             type: 'comment',
             subtype: 'multi-line',
             text: '3',
-          },
-        ],
-        right: [
-          {
+          }),
+        ]),
+        right: expect.arrayContaining([
+          expect.objectContaining({
             type: 'comment',
             subtype: 'multi-line',
             text: '4',
-          },
-        ],
+          }),
+        ]),
       });
 
-      expect(cmd.inferenceId.formatting).toMatchObject({
-        left: [
-          {
-            type: 'comment',
-            subtype: 'multi-line',
-            text: '5',
-          },
-        ],
-        right: [
-          {
-            type: 'comment',
-            subtype: 'multi-line',
-            text: '6',
-          },
-        ],
-      });
+      // Test WITH option with map parameters
+      const isWithOption = (arg: ESQLAstItem): arg is ESQLCommandOption =>
+        !!arg && !Array.isArray(arg) && arg.type === 'option' && arg.name === 'with';
+      const withOption = cmd.args.find(isWithOption);
+
+      expect(withOption).toBeDefined();
+
+      if (withOption) {
+        const map = withOption.args[0] as ESQLMap;
+        expect(map.type).toBe('map');
+
+        // Check comments around the map structure (/*5*/ and /*14*/)
+        expect(map.formatting).toMatchObject({
+          left: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'comment',
+              subtype: 'multi-line',
+              text: '5',
+            }),
+          ]),
+          right: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'comment',
+              subtype: 'multi-line',
+              text: '14',
+            }),
+          ]),
+        });
+
+        const entries = map.entries;
+        expect(entries).toHaveLength(2);
+
+        // "inference_id": "model" with comments /*6*/, /*7*/, /*8*/, /*9*/
+        const firstEntry = entries[0];
+        expect(firstEntry.key.formatting).toMatchObject({
+          left: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'comment',
+              subtype: 'multi-line',
+              text: '6',
+            }),
+          ]),
+          right: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'comment',
+              subtype: 'multi-line',
+              text: '7',
+            }),
+          ]),
+        });
+
+        expect(firstEntry.value.formatting).toMatchObject({
+          left: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'comment',
+              subtype: 'multi-line',
+              text: '8',
+            }),
+          ]),
+          right: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'comment',
+              subtype: 'multi-line',
+              text: '9',
+            }),
+          ]),
+        });
+
+        // "scoreColumn": "rank_score" with comments /*10*/, /*11*/, /*12*/, /*13*/
+        const secondEntry = entries[1];
+        expect(secondEntry.key.formatting).toMatchObject({
+          left: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'comment',
+              subtype: 'multi-line',
+              text: '10',
+            }),
+          ]),
+          right: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'comment',
+              subtype: 'multi-line',
+              text: '11',
+            }),
+          ]),
+        });
+
+        expect(secondEntry.value.formatting).toMatchObject({
+          left: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'comment',
+              subtype: 'multi-line',
+              text: '12',
+            }),
+          ]),
+          right: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'comment',
+              subtype: 'multi-line',
+              text: '13',
+            }),
+          ]),
+        });
+      }
     });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.comments.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.comments.test.ts
@@ -259,20 +259,16 @@ describe('commands', () => {
     });
   });
 
-  /**
-   * @todo Tests skipped, while RERANK command grammar is being stabilized. We will
-   * get back to it after 9.1 release.
-   */
-  describe.skip('RERANK', () => {
+  describe('RERANK', () => {
     test('comments around all elements', () => {
       assertPrint(
-        'FROM a | /*0*/ RERANK /*1*/ "query" /*2*/ ON /*3*/ field /*4*/ WITH /*5*/ id /*6*/'
+        'FROM a | /*0*/ RERANK /*1*/ "query" /*2*/ ON /*3*/ field /*4*/ WITH /*5*/ {"id1": "value1"} /*6*/'
       );
     });
 
     test('comments around all elements, two fields', () => {
       assertPrint(
-        'FROM a | /*0*/ RERANK /*1*/ "query" /*2*/ ON /*3*/ field1 /*4*/, /*5*/ field2 /*6*/ WITH /*7*/ id1 /*8*/'
+        'FROM a | /*0*/ RERANK /*1*/ "query" /*2*/ ON /*3*/ field1 /*4*/, /*5*/ field2 /*6*/ WITH /*7*/ {"id1": "value1"} /*8*/'
       );
     });
   });

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
@@ -205,39 +205,49 @@ describe('single line query', () => {
       });
     });
 
-    /**
-     * @todo Tests skipped, while RERANK command grammar is being stabilized. We will
-     * get back to it after 9.1 release.
-     */
-    describe.skip('RERANK', () => {
-      test('single field', () => {
-        const { text } = reprint(`FROM a | RERANK "query" ON field1 WITH some_id`);
+    describe('RERANK', () => {
+      test('single field with inference map', () => {
+        const { text } = reprint(
+          `FROM a | RERANK "query" ON field1 WITH {"inference_id": "reranker"}`
+        );
 
-        expect(text).toBe('FROM a | RERANK "query" ON field1 WITH some_id');
+        expect(text).toBe('FROM a | RERANK "query" ON field1 WITH {"inference_id": "reranker"}');
       });
 
-      test('two fields', () => {
-        const { text } = reprint(`FROM a | RERANK "query" ON field1,field2 WITH some_id`);
+      test('target assignment and multiple fields', () => {
+        const { text } = reprint(
+          `FROM a | RERANK col = "query" ON field1, field2 WITH {"inference_id": "my_reranker"}`
+        );
 
-        expect(text).toBe('FROM a | RERANK "query" ON field1, field2 WITH some_id');
+        expect(text).toBe(
+          'FROM a | RERANK col = "query" ON field1, field2 WITH {"inference_id": "my_reranker"}'
+        );
       });
 
-      test('param as query', () => {
-        const { text } = reprint(`FROM a | RERANK ?param ON field1,field2 WITH some_id`);
+      test('field assignment in ON clause', () => {
+        const { text } = reprint(
+          `FROM a | RERANK "query" ON field1 = X(field1, 2), field2 WITH {"inference_id": "model"}`
+        );
 
-        expect(text).toBe('FROM a | RERANK ?param ON field1, field2 WITH some_id');
+        expect(text).toBe(
+          'FROM a | RERANK "query" ON field1 = X(field1, 2), field2 WITH {"inference_id": "model"}'
+        );
       });
 
-      test('param as field part', () => {
-        const { text } = reprint(`FROM a | RERANK ?param ON nested.?par, field2 WITH some_id`);
+      test('multi props in WITH clause', () => {
+        const { text } = reprint(
+          `FROM a | RERANK "query" ON field1 WITH {"inference_id": "model", "another_id": "another_model"}`
+        );
 
-        expect(text).toBe('FROM a | RERANK ?param ON nested.?par, field2 WITH some_id');
+        expect(text).toBe(
+          'FROM a | RERANK "query" ON field1 WITH {"inference_id": "model", "another_id": "another_model"}'
+        );
       });
 
-      test('param as inference ID', () => {
-        const { text } = reprint(`FROM a | RERANK ?param ON nested.?par, field2 WITH ?`);
+      test('without WITH clause', () => {
+        const { text } = reprint(`FROM a | RERANK "query" ON field1`);
 
-        expect(text).toBe('FROM a | RERANK ?param ON nested.?par, field2 WITH ?');
+        expect(text).toBe('FROM a | RERANK "query" ON field1');
       });
     });
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/wrapping_pretty_printer.comments.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/wrapping_pretty_printer.comments.test.ts
@@ -110,13 +110,13 @@ FROM index
    * @todo Tests skipped, while RERANK command grammar is being stabilized. We will
    * get back to it after 9.1 release.
    */
-  describe.skip('RERANK', () => {
+  describe('RERANK', () => {
     test('comments around all elements', () => {
       assertReprint(
         `FROM a
   | /*0*/ RERANK /*1*/ "query" /*2*/
         ON /*3*/ field /*4*/
-        WITH /*5*/ id /*6*/`
+        WITH /*5*/ {"id": "value"} /*6*/`
       );
     });
   });

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/wrapping_pretty_printer.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/wrapping_pretty_printer.test.ts
@@ -164,43 +164,42 @@ FROM index
     });
   });
 
-  /**
-   * @todo Tests skipped, while RERANK command grammar is being stabilized. We will
-   * get back to it after 9.1 release.
-   */
-  describe.skip('RERANK', () => {
+  describe('RERANK', () => {
     test('default example', () => {
-      const { text } = reprint(`FROM a | RERANK "query" ON field1 WITH some_id`);
+      const { text } = reprint(`FROM a | RERANK "query" ON field1 WITH {"inference_id": "model"}`);
 
-      expect(text).toBe('FROM a | RERANK "query" ON field1 WITH some_id');
+      expect(text).toBe('FROM a | RERANK "query" ON field1 WITH {"inference_id": "model"}');
     });
 
     test('wraps long query', () => {
       const { text } = reprint(
-        `FROM a | RERANK "asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf" ON field1 WITH some_id`
+        `FROM a | RERANK "this is a very long long long long long long long long long long long long text" ON field1 WITH {"inference_id": "model"}`
       );
 
       expect(text).toBe(`FROM a
-  | RERANK "asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf"
+  | RERANK
+      "this is a very long long long long long long long long long long long long text"
         ON field1
-        WITH some_id`);
+        WITH {"inference_id": "model"}`);
     });
 
     test('two fields', () => {
-      const { text } = reprint(`FROM a | RERANK "query" ON field1,field2 WITH some_id`);
+      const { text } = reprint(
+        `FROM a | RERANK "query" ON field1,field2 WITH {"inference_id": "model"}`
+      );
 
-      expect(text).toBe('FROM a | RERANK "query" ON field1, field2 WITH some_id');
+      expect(text).toBe('FROM a | RERANK "query" ON field1, field2 WITH {"inference_id": "model"}');
     });
 
     test('wraps many fields', () => {
       const { text } = reprint(
-        `FROM a | RERANK "query" ON field1,field2,field3,field4,field5,field6,field7,field8,field9,field10,field11,field12 WITH some_id`
+        `FROM a | RERANK "query" ON field1,field2,field3,field4,field5,field6,field7,field8,field9,field10,field11,field12 WITH {"inference_id": "model"}`
       );
       expect(text).toBe(`FROM a
   | RERANK "query"
         ON field1, field2, field3, field4, field5, field6, field7, field8, field9,
           field10, field11, field12
-        WITH some_id`);
+        WITH {"inference_id": "model"}`);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-ast/src/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/types.ts
@@ -132,7 +132,6 @@ export interface ESQLAstCompletionCommand extends ESQLCommand<'completion'> {
 export interface ESQLAstRerankCommand extends ESQLCommand<'rerank'> {
   query: ESQLLiteral;
   fields: ESQLAstField[];
-  inferenceId: ESQLIdentifierOrParam;
   targetField?: ESQLColumn;
 }
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/types.ts
@@ -132,6 +132,7 @@ export interface ESQLAstCompletionCommand extends ESQLCommand<'completion'> {
 export interface ESQLAstRerankCommand extends ESQLCommand<'rerank'> {
   query: ESQLLiteral;
   fields: ESQLAstField[];
+  inferenceId: ESQLIdentifierOrParam;
   targetField?: ESQLColumn;
 }
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/__tests__/commands.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/__tests__/commands.test.ts
@@ -143,18 +143,55 @@ test('can visit CHANGE_POINT command', () => {
 
 test('can visit RERANK command', () => {
   const { ast } = EsqlQuery.fromSrc(`
-    FROM k8s
-      | RERANK "test" ON field WITH id
+    FROM movies
+      | RERANK "star wars" ON title=X(title, 2), description=X(description, 1.5) WITH {"inferenceId":"rerankerInferenceId", "scoreColumn":"rerank_score"}
       | LIMIT 123
   `);
+
   const visitor = new Visitor()
-    .on('visitExpression', (ctx) => {
+    .on('visitLiteralExpression', (ctx) => {
+      if (ctx.node.literalType === 'keyword') {
+        return ctx.node.value;
+      }
+      return null;
+    })
+    .on('visitMapExpression', (ctx) => {
+      return [...ctx.visitEntries(null)].flat();
+    })
+    .on('visitMapEntryExpression', (ctx) => {
+      return [ctx.visitKey(null), ctx.visitValue(null)];
+    })
+    .on('visitFunctionCallExpression', (ctx) => {
+      if (ctx.node.subtype === 'binary-expression' && ctx.node.name === '=') {
+        const results = ['FIELD_ASSIGNMENT'];
+        results.push(...[...ctx.visitArguments(null)].flat());
+        return results;
+      }
+
+      if (ctx.node.name === 'x') {
+        return 'X';
+      }
+
+      return null;
+    })
+    .on('visitExpression', () => {
+      return null;
+    })
+    .on('visitCommandOption', (ctx) => {
+      if (ctx.node.name === 'on') {
+        return [...ctx.visitArguments()].flat();
+      }
+
+      if (ctx.node.name === 'with') {
+        return [...ctx.visitArguments()].flat();
+      }
+
       return null;
     })
     .on('visitRerankCommand', (ctx) => {
-      return 'RERANK';
+      return [...ctx.visitOptions()].flat();
     })
-    .on('visitCommand', (ctx) => {
+    .on('visitCommand', () => {
       return null;
     })
     .on('visitQuery', (ctx) => {
@@ -162,7 +199,13 @@ test('can visit RERANK command', () => {
     });
   const list = visitor.visitQuery(ast).flat().filter(Boolean);
 
-  expect(list).toEqual(['RERANK']);
+  expect(list.filter((item) => item === 'FIELD_ASSIGNMENT')).toHaveLength(2);
+  expect(list.filter((item) => item === 'X')).toHaveLength(2);
+
+  expect(list).toContain('"inferenceId"');
+  expect(list).toContain('"rerankerInferenceId"');
+  expect(list).toContain('"scoreColumn"');
+  expect(list).toContain('"rerank_score"');
 });
 
 test('can visit COMPLETION command', () => {


### PR DESCRIPTION
## Summary
part of https://github.com/elastic/kibana/pull/232885

- Remove inferenceId from ESQLAstRerankCommand type
- Update Pretty printer, visitor, walker, mutate ....

note: most of these updates are tests


