### PR TITLE
[Obs AI Assistant] flaky test fix - disable save button until file exists

### DIFF
--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_bulk_import_flyout.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_bulk_import_flyout.tsx
@@ -195,6 +195,7 @@ export function KnowledgeBaseBulkImportFlyout({ onClose }: { onClose: () => void
               data-test-subj="knowledgeBaseBulkImportFlyoutSaveButton"
               fill
               isLoading={isLoading}
+              disabled={files.length === 0}
               onClick={handleSubmitNewEntryClick}
             >
               {i18n.translate(

--- a/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
+++ b/x-pack/solutions/observability/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
@@ -200,8 +200,7 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/231420
-    describe.skip('Bulk import knowledge base entries', () => {
+    describe('Bulk import knowledge base entries', () => {
       const tempDir = os.tmpdir();
       const tempFilePath = path.join(tempDir, 'bulk_import.ndjson');
 
@@ -239,6 +238,13 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
 
         try {
           await common.setFileInputPath(tempFilePath);
+          // Wait for the file to be processed and save button to be enabled
+          await retry.waitFor('save button to be enabled after file upload', async () => {
+            const saveButton = await testSubjects.find(
+              ui.pages.kbManagementTab.bulkImportSaveButton
+            );
+            return await saveButton.isEnabled();
+          });
         } catch (error) {
           log.debug(`Error uploading file: ${error}`);
           throw error;


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/231420

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->