### PR TITLE
[ES|QL]  LOOKUP JOIN - Allow saving without closing flyout

### DIFF
--- a/src/platform/packages/private/kbn-index-editor/src/components/error_callout.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/error_callout.tsx
@@ -52,6 +52,12 @@ const errorTitles: Record<IndexEditorErrors, string> = {
       defaultMessage: 'An error occurred while analyzing the files.',
     }
   ),
+  [IndexEditorErrors.NO_DATA_TO_SAVE_ERROR]: i18n.translate(
+    'indexEditor.flyout.error.noDataToSaveError',
+    {
+      defaultMessage: 'Taken operations resulted in no data to save.',
+    }
+  ),
 };
 
 export const ErrorCallout = () => {

--- a/src/platform/packages/private/kbn-index-editor/src/components/error_callout.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/error_callout.tsx
@@ -55,7 +55,7 @@ const errorTitles: Record<IndexEditorErrors, string> = {
   [IndexEditorErrors.NO_DATA_TO_SAVE_ERROR]: i18n.translate(
     'indexEditor.flyout.error.noDataToSaveError',
     {
-      defaultMessage: 'Taken operations resulted in no data to save.',
+      defaultMessage: 'The operations taken resulted in no data to save',
     }
   ),
 };

--- a/src/platform/packages/private/kbn-index-editor/src/components/file_drop_zone.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/file_drop_zone.tsx
@@ -110,7 +110,7 @@ export const FileDropzone: FC<PropsWithChildren<{ noResults: boolean }>> = ({
     // Generic errors
     if (uploadStatus.errors.length) {
       const errorDetail = uploadStatus.errors
-        .map((error) => `- ${error.title}: \n ${JSON.stringify(error.error)}`)
+        .map((errorItem) => `- ${errorItem.title}: \n ${errorItem?.error?.error?.reason}`)
         .join('\n');
       indexUpdateService.setError(IndexEditorErrors.FILE_UPLOAD_ERROR, errorDetail);
     }

--- a/src/platform/packages/private/kbn-index-editor/src/components/file_preview.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/file_preview.tsx
@@ -176,7 +176,7 @@ export const FilesPreview: FC = () => {
 
   if (!filePreviewItems.length) return null;
 
-  return uploadStatus.overallImportStatus === STATUS.NOT_STARTED && filesStatus.length > 0 ? (
+  return filesStatus.length > 0 ? (
     <div>
       {filePreviewItems.map((filePreviewItem, i) => {
         const tabs: EuiTabbedContentTab[] = [];

--- a/src/platform/packages/private/kbn-index-editor/src/components/flyout_content.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/flyout_content.tsx
@@ -24,6 +24,7 @@ import React, { lazy } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
+import type { FileUploadResults } from '@kbn/file-upload-common';
 import { ErrorCallout } from './error_callout';
 import { isPlaceholderColumn } from '../utils';
 import { UnsavedChangesModal } from './modals/unsaved_changes_modal';
@@ -56,7 +57,14 @@ export const FlyoutContent: FC<FlyoutContentProps> = ({ deps, props }) => {
     deps.data,
     coreStart.application,
     coreStart.http,
-    coreStart.notifications
+    coreStart.notifications,
+    // onUploadComplete
+    (results: FileUploadResults | null) => {
+      fileUploadContextValue.setExistingIndexName(results.index);
+      results?.files.forEach((_, index) => {
+        deps.fileManager.removeFile(index);
+      });
+    }
   );
 
   const columnsWithoutPlaceholders = dataViewColumns?.filter(

--- a/src/platform/packages/private/kbn-index-editor/src/components/flyout_content.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/flyout_content.tsx
@@ -60,10 +60,12 @@ export const FlyoutContent: FC<FlyoutContentProps> = ({ deps, props }) => {
     coreStart.notifications,
     // onUploadComplete
     (results: FileUploadResults | null) => {
-      fileUploadContextValue.setExistingIndexName(results.index);
-      results?.files.forEach((_, index) => {
-        deps.fileManager.removeFile(index);
-      });
+      if (results) {
+        fileUploadContextValue.setExistingIndexName(results.index);
+        results.files.forEach((_, index) => {
+          deps.fileManager.removeFile(index);
+        });
+      }
     }
   );
 

--- a/src/platform/packages/private/kbn-index-editor/src/components/flyout_footer.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/flyout_footer.tsx
@@ -39,7 +39,9 @@ export const FlyoutFooter: FC<FlyoutFooterProps> = ({ onClose }) => {
   );
   const hasUnsavedChanges = useObservable(indexUpdateService.hasUnsavedChanges$, false);
 
-  const { uploadStatus, onImportClick, canImport } = useFileUploadContext();
+  const indexName = useObservable(indexUpdateService.indexName$, indexUpdateService.getIndexName());
+
+  const { uploadStatus, onImportClick, canImport, setExistingIndexName } = useFileUploadContext();
 
   const onImport = useCallback(async () => {
     indexUpdateService.setIsSaving(true);
@@ -54,6 +56,9 @@ export const FlyoutFooter: FC<FlyoutFooterProps> = ({ onClose }) => {
 
     try {
       await indexUpdateService.createIndex({ exitAfterFlush });
+      if (!exitAfterFlush) {
+        setExistingIndexName(indexName);
+      }
     } catch (error) {
       notifications.toasts.addError(error as Error, {
         title: i18n.translate('indexEditor.saveIndex.ErrorTitle', {
@@ -112,7 +117,7 @@ export const FlyoutFooter: FC<FlyoutFooterProps> = ({ onClose }) => {
               </>
             ) : null}
 
-            {uploadStatus.overallImportStatus === STATUS.NOT_STARTED && canImport ? (
+            {uploadStatus.overallImportStatus !== STATUS.STARTED && canImport ? (
               <EuiFlexItem grow={false}>
                 <EuiButton data-test-subj="indexEditorImportButton" onClick={onImport}>
                   <FormattedMessage

--- a/src/platform/packages/private/kbn-index-editor/src/components/flyout_footer.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/flyout_footer.tsx
@@ -46,9 +46,9 @@ export const FlyoutFooter: FC<FlyoutFooterProps> = ({ onClose }) => {
     await onImportClick();
   }, [indexUpdateService, onImportClick]);
 
-  const onSave = async () => {
+  const onSave = async ({ exitAfterFlush = false }) => {
     if (isIndexCreated) {
-      indexUpdateService.flush();
+      indexUpdateService.flush({ exitAfterFlush });
       return;
     }
 
@@ -86,14 +86,31 @@ export const FlyoutFooter: FC<FlyoutFooterProps> = ({ onClose }) => {
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="s" alignItems="center">
             {isSaveButtonVisible ? (
-              <EuiFlexItem grow={false}>
-                <EuiButton data-test-subj="indexEditorSaveChangesButton" onClick={onSave}>
-                  <FormattedMessage
-                    id="indexEditor.flyout.footer.primaryButtonLabel.saveIndex"
-                    defaultMessage="Save changes"
-                  />
-                </EuiButton>
-              </EuiFlexItem>
+              <>
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    data-test-subj="indexEditorSaveAndCloseButton"
+                    onClick={() => onSave({ exitAfterFlush: true })}
+                  >
+                    <FormattedMessage
+                      id="indexEditor.flyout.footer.primaryButtonLabel.saveAndClose"
+                      defaultMessage="Save and close"
+                    />
+                  </EuiButton>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    data-test-subj="indexEditorSaveChangesButton"
+                    fill
+                    onClick={() => onSave({ exitAfterFlush: false })}
+                  >
+                    <FormattedMessage
+                      id="indexEditor.flyout.footer.primaryButtonLabel.saveIndex"
+                      defaultMessage="Save"
+                    />
+                  </EuiButton>
+                </EuiFlexItem>
+              </>
             ) : null}
 
             {uploadStatus.overallImportStatus === STATUS.NOT_STARTED && canImport ? (

--- a/src/platform/packages/private/kbn-index-editor/src/components/flyout_footer.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/flyout_footer.tsx
@@ -53,8 +53,7 @@ export const FlyoutFooter: FC<FlyoutFooterProps> = ({ onClose }) => {
     }
 
     try {
-      await indexUpdateService.createIndex();
-      onClose();
+      await indexUpdateService.createIndex({ exitAfterFlush });
     } catch (error) {
       notifications.toasts.addError(error as Error, {
         title: i18n.translate('indexEditor.saveIndex.ErrorTitle', {

--- a/src/platform/packages/private/kbn-index-editor/src/components/grid_custom_renderers/column_input_renderer.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/grid_custom_renderers/column_input_renderer.tsx
@@ -21,31 +21,27 @@ export const getColumnInputRenderer = (
   columnName: string,
   indexUpdateService: IndexUpdateService
 ): ((props: CustomGridColumnProps) => EuiDataGridColumn) => {
-  const isPlaceholder = isPlaceholderColumn(columnName);
-
   return ({ column }) => ({
     ...column,
     display: <AddColumnHeader initialColumnName={columnName} containerId={column.id} />,
     actions: {
       showHide: false,
-      additional: !isPlaceholder
-        ? [
-            {
-              'data-test-subj': 'indexEditorindexEditorDeleteColumnButton',
-              label: (
-                <FormattedMessage
-                  id="indexEditor.flyout.grid.columnHeader.deleteAction"
-                  defaultMessage="Delete field and values"
-                />
-              ),
-              size: 'xs',
-              iconType: 'trash',
-              onClick: () => {
-                indexUpdateService.deleteColumn(columnName);
-              },
-            },
-          ]
-        : [],
+      additional: [
+        {
+          'data-test-subj': 'indexEditorindexEditorDeleteColumnButton',
+          label: (
+            <FormattedMessage
+              id="indexEditor.flyout.grid.columnHeader.deleteAction"
+              defaultMessage="Delete field and values"
+            />
+          ),
+          size: 'xs',
+          iconType: 'trash',
+          onClick: () => {
+            indexUpdateService.deleteColumn(columnName);
+          },
+        },
+      ],
     },
   });
 };

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.test.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.test.ts
@@ -41,7 +41,7 @@ describe('IndexUpdateService', () => {
     const query = await firstValueFrom(service.esqlQuery$);
 
     expect(query.toLowerCase()).toBe(
-      'from my-index metadata _id, _source | where qstr("response:200") | limit 1000 | sort @timestamp desc'
+      'from "my-index" metadata _id, _source | where qstr("response:200") | limit 1000 | sort @timestamp desc'
     );
   });
 
@@ -51,7 +51,7 @@ describe('IndexUpdateService', () => {
 
     const query = await firstValueFrom(service.esqlDiscoverQuery$);
 
-    expect(query).toBe('FROM logs-* | WHERE QSTR("level:ERROR") | LIMIT 1000');
+    expect(query).toBe('FROM "logs-*" | WHERE QSTR("level:ERROR") | LIMIT 1000');
   });
 
   it('marks unsaved changes after adding a new row', async () => {
@@ -117,6 +117,6 @@ describe('IndexUpdateService', () => {
 
   it('throws when calling bulkUpdate with empty operations', async () => {
     service.setIndexName('idx');
-    expect(() => service.bulkUpdate([] as any)).toThrow('empty operations');
+    await expect(service.bulkUpdate([] as any)).rejects.toThrow('empty operations');
   });
 });

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -259,7 +259,7 @@ export class IndexUpdateService {
       query.sort(firstSort, ...restSort);
     }
 
-    return query.print();
+    return query.print('basic');
   }
 
   // Accumulate actions in a buffer

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -962,17 +962,14 @@ export class IndexUpdateService {
     this.data.dataViews.clearInstanceCache();
   }
 
-  public async createIndex() {
+  public async createIndex({ exitAfterFlush = false }) {
     try {
       this._isSaving$.next(true);
 
-      const updates = await firstValueFrom(this.bufferState$);
-
       await this.http.post(`/internal/esql/lookup_index/${this.getIndexName()}`);
-      await this.bulkUpdate(updates);
 
       this.setIndexCreated(true);
-      this.addAction('discard-unsaved-changes');
+      this.flush({ exitAfterFlush });
     } catch (error) {
       throw error;
     } finally {

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -555,18 +555,25 @@ export class IndexUpdateService {
           next: ({ updates, response, bulkOperations, exitAfterFlush, docs, savingDocs }) => {
             this._isSaving$.next(false);
 
+            if (!bulkOperations.length) {
+              this.setError(IndexEditorErrors.NO_DATA_TO_SAVE_ERROR);
+              this.addAction('saved', {
+                response,
+                updates: [],
+              });
+              return;
+            }
+
             if (!response.errors) {
               if (exitAfterFlush) {
                 this.destroy();
               }
             } else {
               const errorDetail = response.items
-                ? response.items
-                    .map((item) => Object.values(item)[0])
-                    .filter((res) => res.error)
-                    .map((res) => `- ${res.error?.type}: ${res.error?.reason}`)
-                    .join('\n')
-                : '';
+                .map((item) => Object.values(item)[0])
+                .filter((res) => res.error)
+                .map((res) => `- ${res.error?.type}: ${res.error?.reason}`)
+                .join('\n');
 
               this.setError(IndexEditorErrors.PARTIAL_SAVING_ERROR, errorDetail);
             }

--- a/src/platform/packages/private/kbn-index-editor/src/types.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/types.ts
@@ -74,6 +74,7 @@ export interface IndexEditorError {
 
 export enum IndexEditorErrors {
   GENERIC_SAVING_ERROR = 'genericSavingError',
+  NO_DATA_TO_SAVE_ERROR = 'noDataToSaveError',
   PARTIAL_SAVING_ERROR = 'partialSavingError',
   FILE_REJECTION_ERROR = 'fileRejectionError',
   FILE_TOO_BIG_ERROR = 'fileTooBigError',

--- a/src/platform/packages/private/kbn-index-editor/tsconfig.json
+++ b/src/platform/packages/private/kbn-index-editor/tsconfig.json
@@ -37,5 +37,6 @@
     "@kbn/restorable-state",
     "@kbn/esql-ast",
     "@kbn/es-types",
+    "@kbn/file-upload-common",
   ]
 }

--- a/src/platform/test/functional/page_objects/index_editor.ts
+++ b/src/platform/test/functional/page_objects/index_editor.ts
@@ -70,7 +70,7 @@ export class IndexEditorObject extends FtrService {
   }
 
   public async saveChanges(): Promise<void> {
-    await this.testSubjects.click('indexEditorSaveChangesButton');
+    await this.testSubjects.click('indexEditorSaveAndCloseButton');
     await this.testSubjects.waitForDeleted('lookupIndexFlyout');
   }
 


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/207330
## Summary
Adds a new button that allows to save changes without closing the flyout.

After saving we need to reconciliate the data shown in the table, we need to update the deleted rows and add the new created ones, for these last had to expose the bulkOperations made in the update request to be able to access the updated value of the new rows.

Considered the alternative of just re-fetching after saving, but we will have problems with race conditions waiting for the new data to be queryable and we will loose the order of the rows, that in big tables can push them several pages away, making editions akward.

<img width="1291" height="824" alt="image" src="https://github.com/user-attachments/assets/cb19f781-d88d-4004-b91a-1f62ab03dc6a" />



