### PR TITLE
[8.17] [NL2ESQL] Add max function calls allowed to prevent tool being called recursively  (#231719)

### DIFF
--- a/x-pack/plugins/inference/server/tasks/nl_to_esql/actions/generate_esql.ts
+++ b/x-pack/plugins/inference/server/tasks/nl_to_esql/actions/generate_esql.ts
@@ -17,6 +17,7 @@ import {
   OutputCompleteEvent,
   OutputEventType,
   FunctionCallingMode,
+  ToolChoiceType,
 } from '@kbn/inference-common';
 import { correctCommonEsqlMistakes, generateFakeToolCallId } from '../../../../common';
 import { InferenceClient } from '../../..';
@@ -24,6 +25,8 @@ import { INLINE_ESQL_QUERY_REGEX } from '../../../../common/tasks/nl_to_esql/con
 import { EsqlDocumentBase } from '../doc_base';
 import { requestDocumentationSchema } from './shared';
 import type { NlToEsqlTaskEvent } from '../types';
+
+const MAX_CALLS = 5;
 
 export const generateEsqlTask = <TToolOptions extends ToolOptions>({
   chatCompleteApi,
@@ -34,6 +37,9 @@ export const generateEsqlTask = <TToolOptions extends ToolOptions>({
   docBase,
   functionCalling,
   logger,
+  system,
+  metadata,
+  maxCallsAllowed = MAX_CALLS,
 }: {
   connectorId: string;
   systemMessage: string;
@@ -43,12 +49,18 @@ export const generateEsqlTask = <TToolOptions extends ToolOptions>({
   docBase: EsqlDocumentBase;
   functionCalling?: FunctionCallingMode;
   logger: Pick<Logger, 'debug'>;
-}) => {
+  metadata?: ChatCompleteMetadata;
+  system?: string;
+  maxCallsAllowed?: number;
+} & Pick<ChatCompleteOptions, 'maxRetries' | 'retryConfiguration' | 'functionCalling'>) => {
   return function askLlmToRespond({
     documentationRequest: { commands, functions },
+    callCount = 0,
   }: {
     documentationRequest: { commands?: string[]; functions?: string[] };
+    callCount?: number;
   }): Observable<NlToEsqlTaskEvent<TToolOptions>> {
+    const functionLimitReached = callCount >= maxCallsAllowed;
     const keywords = [...(commands ?? []), ...(functions ?? [])];
     const requestedDocumentation = docBase.getDocumentation(keywords);
     const fakeRequestDocsToolCall = createFakeTooCall(commands, functions);
@@ -113,14 +125,16 @@ export const generateEsqlTask = <TToolOptions extends ToolOptions>({
             toolCallId: fakeRequestDocsToolCall.toolCallId,
           },
         ],
-        toolChoice,
-        tools: {
-          ...tools,
-          request_documentation: {
-            description: 'Request additional ES|QL documentation if needed',
-            schema: requestDocumentationSchema,
-          },
-        },
+        toolChoice: !functionLimitReached ? toolChoice : ToolChoiceType.none,
+        tools: functionLimitReached
+          ? {}
+          : {
+              ...tools,
+              request_documentation: {
+                description: 'Request additional ES|QL documentation if needed',
+                schema: requestDocumentationSchema,
+              },
+            },
       }).pipe(
         withoutTokenCountEvents(),
         map((generateEvent) => {
@@ -137,18 +151,32 @@ export const generateEsqlTask = <TToolOptions extends ToolOptions>({
         }),
         switchMap((generateEvent) => {
           if (isChatCompletionMessageEvent(generateEvent)) {
-            const onlyToolCall =
-              generateEvent.toolCalls.length === 1 ? generateEvent.toolCalls[0] : undefined;
+            const toolCalls = generateEvent.toolCalls as ToolCall[];
+            const onlyToolCall = toolCalls.length === 1 ? toolCalls[0] : undefined;
 
-            if (onlyToolCall?.function.name === 'request_documentation') {
-              const args = onlyToolCall.function.arguments;
+            if (onlyToolCall && onlyToolCall.function.name === 'request_documentation') {
+              if (functionLimitReached) {
+                return of({
+                  ...generateEvent,
+                  content: `You have reached the maximum number of documentation requests. Do not try to request documentation again for commands ${commands?.join(
+                    ', '
+                  )} and functions ${functions?.join(
+                    ', '
+                  )}. Try to answer the user's question using currently available information.`,
+                });
+              }
 
-              return askLlmToRespond({
-                documentationRequest: {
-                  commands: args.commands,
-                  functions: args.functions,
-                },
-              });
+              const args =
+                'arguments' in onlyToolCall.function ? onlyToolCall.function.arguments : undefined;
+              if (args && (args.commands?.length || args.functions?.length)) {
+                return askLlmToRespond({
+                  documentationRequest: {
+                    commands: args.commands ?? [],
+                    functions: args.functions ?? [],
+                  },
+                  callCount: callCount + 1,
+                });
+              }
             }
           }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[NL2ESQL] Add max function calls allowed to prevent tool being called recursively  (#231719)](https://github.com/elastic/kibana/pull/231719)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Quynh Nguyen (Quinn)","email":"43350163+qn895@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-26T19:37:18Z","message":"[NL2ESQL] Add max function calls allowed to prevent tool being called recursively  (#231719)\n\nFollow up of https://github.com/elastic/kibana/pull/231217. This PR\nfixes https://github.com/elastic/kibana/issues/229979 and implements a\nmechanism to stop the nl2esql tool being called indefinitely, and to\nstop after 5 tries maximum.\n\n<img width=\"776\" height=\"1193\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69d16eb3-bb0a-45b8-8513-7b39edea448a\"\n/>\n\n\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDoxMTAy/traces/e035f0e5f983d2e61c1153f6f41abd80?selected=&selectedSpanNodeId=U3Bhbjo2NjczNjE%3D\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"58869ae814518b61c9d2203d735077466efde722","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","backport:version","ci:all-gen-ai-suites","ci:security-genai-run-evals","v9.2.0","v8.17.11","v9.1.3","v8.19.3","v9.0.6","v8.18.6"],"title":"[NL2ESQL] Add max function calls allowed to prevent tool being called recursively ","number":231719,"url":"https://github.com/elastic/kibana/pull/231719","mergeCommit":{"message":"[NL2ESQL] Add max function calls allowed to prevent tool being called recursively  (#231719)\n\nFollow up of https://github.com/elastic/kibana/pull/231217. This PR\nfixes https://github.com/elastic/kibana/issues/229979 and implements a\nmechanism to stop the nl2esql tool being called indefinitely, and to\nstop after 5 tries maximum.\n\n<img width=\"776\" height=\"1193\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69d16eb3-bb0a-45b8-8513-7b39edea448a\"\n/>\n\n\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDoxMTAy/traces/e035f0e5f983d2e61c1153f6f41abd80?selected=&selectedSpanNodeId=U3Bhbjo2NjczNjE%3D\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"58869ae814518b61c9d2203d735077466efde722"}},"sourceBranch":"main","suggestedTargetBranches":["8.17","9.1","8.19","9.0","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231719","number":231719,"mergeCommit":{"message":"[NL2ESQL] Add max function calls allowed to prevent tool being called recursively  (#231719)\n\nFollow up of https://github.com/elastic/kibana/pull/231217. This PR\nfixes https://github.com/elastic/kibana/issues/229979 and implements a\nmechanism to stop the nl2esql tool being called indefinitely, and to\nstop after 5 tries maximum.\n\n<img width=\"776\" height=\"1193\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69d16eb3-bb0a-45b8-8513-7b39edea448a\"\n/>\n\n\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDoxMTAy/traces/e035f0e5f983d2e61c1153f6f41abd80?selected=&selectedSpanNodeId=U3Bhbjo2NjczNjE%3D\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"58869ae814518b61c9d2203d735077466efde722"}},{"branch":"8.17","label":"v8.17.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->