### PR TITLE
[EASE] change attack discovery page to use kibana.alert.rule.rule_id to kibana.rule.parameters.related_integration.package

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/table.test.tsx
@@ -25,10 +25,6 @@ const packages: PackageListItem[] = [
     version: '0.1.0',
   },
 ];
-const ruleResponse = {
-  rules: [],
-  isLoading: false,
-};
 const id = 'id';
 const query = { ids: { values: ['abcdef'] } };
 
@@ -36,13 +32,7 @@ describe('<Table />', () => {
   it('should render all components', () => {
     const { getByTestId } = render(
       <TestProviders>
-        <Table
-          dataView={dataView}
-          id={id}
-          packages={packages}
-          query={query}
-          ruleResponse={ruleResponse}
-        />
+        <Table dataView={dataView} id={id} packages={packages} query={query} />
       </TestProviders>
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/table.tsx
@@ -28,7 +28,6 @@ import {
 import { ActionsCell } from '../../../../../../../detections/components/alert_summary/table/actions_cell';
 import { useKibana } from '../../../../../../../common/lib/kibana';
 import { CellValue } from '../../../../../../../detections/components/alert_summary/table/render_cell';
-import type { RuleResponse } from '../../../../../../../../common/api/detection_engine';
 import { useAdditionalBulkActions } from '../../../../../../../detections/hooks/alert_summary/use_additional_bulk_actions';
 
 export interface TableProps {
@@ -48,26 +47,13 @@ export interface TableProps {
    * Query that contains the id of the alerts to display in the table
    */
   query: Pick<QueryDslQueryContainer, 'bool' | 'ids'>;
-  /**
-   * Result from the useQuery to fetch all rules
-   */
-  ruleResponse: {
-    /**
-     * Result from fetching all rules
-     */
-    rules: RuleResponse[];
-    /**
-     * True while rules are being fetched
-     */
-    isLoading: boolean;
-  };
 }
 
 /**
  * Component used in the Attack Discovery alerts table, only in the AI4DSOC tier.
  * It leverages a lot of configurations and constants from the Alert summary page alerts table, and renders the ResponseOps AlertsTable.
  */
-export const Table = memo(({ dataView, id, packages, query, ruleResponse }: TableProps) => {
+export const Table = memo(({ dataView, id, packages, query }: TableProps) => {
   const {
     services: { application, cases, data, fieldFormats, http, licensing, notifications, settings },
   } = useKibana();
@@ -90,9 +76,8 @@ export const Table = memo(({ dataView, id, packages, query, ruleResponse }: Tabl
   const additionalContext: AdditionalTableContext = useMemo(
     () => ({
       packages,
-      ruleResponse,
     }),
-    [packages, ruleResponse]
+    [packages]
   );
 
   const refetchRef = useRef<AlertsTableImperativeApi>(null);
@@ -101,6 +86,8 @@ export const Table = memo(({ dataView, id, packages, query, ruleResponse }: Tabl
   }, []);
 
   const bulkActions = useAdditionalBulkActions({ refetch });
+
+  const runtimeMappings = useMemo(() => dataView.getRuntimeMappings(), [dataView]);
 
   return (
     <EuiDataGridStyleWrapper>
@@ -119,6 +106,7 @@ export const Table = memo(({ dataView, id, packages, query, ruleResponse }: Tabl
         renderActionsCell={ActionsCell}
         renderCellValue={CellValue}
         rowHeightsOptions={ROW_HEIGHTS_OPTIONS}
+        runtimeMappings={runtimeMappings}
         ruleTypeIds={RULE_TYPE_IDS}
         services={services}
         toolbarVisibility={TOOLBAR_VISIBILITY}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.test.tsx
@@ -10,7 +10,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { AiForSOCAlertsTab, CONTENT_TEST_ID, ERROR_TEST_ID, SKELETON_TEST_ID } from './wrapper';
 import { TestProviders } from '../../../../../../../common/mock';
 import { useFetchIntegrations } from '../../../../../../../detections/hooks/alert_summary/use_fetch_integrations';
-import { useFindRulesQuery } from '../../../../../../../detection_engine/rule_management/api/hooks/use_find_rules_query';
 import { useIsExperimentalFeatureEnabled } from '../../../../../../../common/hooks/use_experimental_features';
 import { useCreateDataView } from '../../../../../../../common/hooks/use_create_data_view';
 import { useDataView } from '../../../../../../../data_view_manager/hooks/use_data_view';
@@ -20,7 +19,6 @@ jest.mock('./table', () => ({
 }));
 jest.mock('../../../../../../../common/lib/kibana');
 jest.mock('../../../../../../../detections/hooks/alert_summary/use_fetch_integrations');
-jest.mock('../../../../../../../detection_engine/rule_management/api/hooks/use_find_rules_query');
 jest.mock('../../../../../../../common/hooks/use_create_data_view');
 jest.mock('../../../../../../../data_view_manager/hooks/use_data_view');
 jest.mock('../../../../../../../common/hooks/use_experimental_features');
@@ -34,10 +32,6 @@ describe('<AiForSOCAlertsTab />', () => {
 
     (useFetchIntegrations as jest.Mock).mockReturnValue({
       installedPackages: [],
-      isLoading: false,
-    });
-    (useFindRulesQuery as jest.Mock).mockReturnValue({
-      data: [],
       isLoading: false,
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.tsx
@@ -37,7 +37,7 @@ export const DATA_VIEW_ERROR_TEST_ID = 'alert-summary-data-view-error';
 export const SKELETON_TEST_ID = 'alert-summary-skeleton';
 export const CONTENT_TEST_ID = 'alert-summary-content';
 
-const RUNTIME_FIELD_MAP: Record<string, RuntimeFieldSpec> = {
+export const RUNTIME_FIELD_MAP: Record<string, RuntimeFieldSpec> = {
   [RELATED_INTEGRATION]: {
     type: 'keyword',
     script: {


### PR DESCRIPTION
## Summary

This PR fixes an issue introduced by this [previous one](https://github.com/elastic/kibana/pull/231436). The integration logo is no longer rendered on the attack discovery alerts table. 

### Reminder of the previous changes

The previous logic that was used throughout the entire alert summary page consisted of retrieving the rule_id value on the alert (via the `kibana.alert.rule.rule_id` field), to then retrieve the rule with the matching `rule_id` field. That rule has the `related_integrations` information used to find the matching integration (package).

We are now using the `kibana.rule.parameters` field on the alert, which contains the `related_integrations` information, accessible directly from the alert document. The `kibana.rule.parameters` value isn't a basic string or number value though, but a complex json object. Using a runTime field that parses that json and returns directly the package (integration) name did the trick!

### This PR

The changes done in the [previous PR](https://github.com/elastic/kibana/pull/231436) actually broke the `Integration` column in the attack discovery page. This PR makes the required changes to the dataView and removes the now unnecessary rules information.

| Before  | After |
| ------------- | ------------- |
| <img width="1055" height="753" alt="Screenshot 2025-08-27 at 11 37 12 PM" src="https://github.com/user-attachments/assets/02e2373b-2d5f-460e-bc91-90306711911d" /> | <img width="1052" height="757" alt="Screenshot 2025-08-27 at 11 52 36 PM" src="https://github.com/user-attachments/assets/a6290a42-ce48-4816-aa01-5be407410e8c" /> |

## How to test

**_You might need to clear localStorage as the table columns are saved in there and this PR changes the Integration column to the new runTime field._**

This needs to be ran in Serverless:
- `yarn es serverless --projectType security`
- `yarn serverless-security --no-base-path`

You also need to enable the AI for SOC tier, by adding the following to your `serverless.security.dev.yaml` file:
```
xpack.securitySolutionServerless.productTypes:
  [
    { product_line: 'ai_soc', product_tier: 'search_ai_lake' },
  ]
```

Use one of these Serverless users:
- `platform_engineer`
- `endpoint_operations_analyst`
- `endpoint_policy_manager`
- `admin`
- `system_indices_superuser`

Then:
- generate data: `yarn test:generate:serverless-dev`
- create multiple catch all rules, each with a name of a AI for SOC integration (`google_secops`, `microsoft_sentinel`,, `sentinel_one` and `crowdstrike`) and make sure to add the related integration (with the same names) => to do that you'll need to temporary comment the `serverless.security.dev.yaml` config changes as the rules page is not accessible in AI for SOC.
-  change [this line](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_fetch_integrations.ts#L73) to `installedPackages: availablePackages` to force having some packages installed

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/233302

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->