### PR TITLE
[Observability Onboarding] Remove references of tech preview for mOTLP

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/instructions/otel_agent.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/instructions/otel_agent.tsx
@@ -338,7 +338,7 @@ function ManagedOTLPEndpointInstructions({
       <EuiMarkdownFormat>
         {i18n.translate('xpack.apm.onboarding.otel.configureAgent.textPre', {
           defaultMessage:
-            'The Managed OTLP Endpoint provides native support for handling of log, metric, and trace data from OpenTelemetry sources. It preserves OpenTelemetry semantic conventions and resource attributes, offering a native experience aligned with OpenTelemetry standards. Managed OTLP endpoint is currently in **Technical Preview.** Specify the following OpenTelemetry settings as part of the startup of your application.',
+            'The Managed OTLP Endpoint provides native support for handling of log, metric, and trace data from OpenTelemetry sources. It preserves OpenTelemetry semantic conventions and resource attributes, offering a native experience aligned with OpenTelemetry standards. Specify the following OpenTelemetry settings as part of the startup of your application.',
         })}
       </EuiMarkdownFormat>
       <EuiSpacer />


### PR DESCRIPTION
## 📓 Summary
The managed OTLP endpoint is not the default option for OTel APM onboarding as part of https://github.com/elastic/kibana/pull/232074. This is a follow up to remove the tech preview reference from the description (See https://github.com/elastic/kibana/pull/232074#issuecomment-3227938482).