### PR TITLE
[8.19] [Attack discovery] Fixes Attack discovery telemetry when securitySolution.attackDiscoveryAlertsEnabled is true

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/helpers.test.ts
@@ -438,5 +438,40 @@ describe('helpers', () => {
         expect.any(Object)
       );
     });
+
+    it('still reports telemetry when getAttackDiscovery returns null', async () => {
+      getAttackDiscovery.mockResolvedValue(null);
+      updateAttackDiscovery.mockResolvedValue({});
+
+      await updateAttackDiscoveries({
+        anonymizedAlerts: mockAnonymizedAlerts,
+        apiConfig: mockApiConfig,
+        attackDiscoveries: mockAttackDiscoveries,
+        executionUuid: 'attack-discovery-id',
+        authenticatedUser: mockAuthenticatedUser,
+        dataClient: mockDataClient,
+        hasFilter: false,
+        end: 'now',
+        latestReplacements: mockReplacements,
+        logger: mockLogger,
+        size: 10,
+        start: 'now-24h',
+        startTime: mockStartTime,
+        telemetry: mockTelemetry,
+      });
+
+      expect(mockTelemetry.reportEvent).toHaveBeenCalledWith('attack_discovery_success', {
+        actionTypeId: '.gen-ai',
+        alertsContextCount: 2,
+        alertsCount: 18,
+        configuredAlertsCount: 10,
+        dateRangeDuration: 24,
+        discoveriesGenerated: 2,
+        durationMs: 0,
+        hasFilter: false,
+        isDefaultDateRange: true,
+        model: 'gpt-4',
+      });
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/helpers.ts
@@ -161,6 +161,22 @@ export const updateAttackDiscoveries = async ({
   telemetry: AnalyticsServiceSetup;
 }) => {
   try {
+    const endTime = moment();
+    const durationMs = endTime.diff(startTime);
+    const alertsContextCount = anonymizedAlerts.length;
+
+    reportAttackDiscoveryGenerationSuccess({
+      alertsContextCount,
+      apiConfig,
+      attackDiscoveries,
+      durationMs,
+      end,
+      hasFilter,
+      size,
+      start,
+      telemetry,
+    });
+
     const currentAd = await dataClient.getAttackDiscovery({
       id: executionUuid,
       authenticatedUser,
@@ -168,9 +184,7 @@ export const updateAttackDiscoveries = async ({
     if (currentAd === null || currentAd?.status === 'canceled') {
       return;
     }
-    const endTime = moment();
-    const durationMs = endTime.diff(startTime);
-    const alertsContextCount = anonymizedAlerts.length;
+
     const updateProps = {
       alertsContextCount,
       attackDiscoveries: attackDiscoveries ?? undefined,
@@ -191,18 +205,6 @@ export const updateAttackDiscoveries = async ({
     await dataClient.updateAttackDiscovery({
       attackDiscoveryUpdateProps: updateProps,
       authenticatedUser,
-    });
-
-    reportAttackDiscoveryGenerationSuccess({
-      alertsContextCount,
-      apiConfig,
-      attackDiscoveries,
-      durationMs,
-      end,
-      hasFilter,
-      size,
-      start,
-      telemetry,
     });
   } catch (updateErr) {
     logger.error(updateErr);


### PR DESCRIPTION
## [8.19] [Attack discovery] Fixes Attack discovery telemetry when `securitySolution.attackDiscoveryAlertsEnabled` is `true`

This PR fixes an issue where Attack discovery telemetry was not reported when the `securitySolution.attackDiscoveryAlertsEnabled` feature flag is `true`, which is the default for 8.19.

### Details

When the `securitySolution.attackDiscoveryAlertsEnabled` feature flag is enabled, calls to `dataClient.getAttackDiscovery()` in `updateAttackDiscoveries` return `null`, and as a result, the early return for this condition prevented `reportAttackDiscoveryGenerationSuccess` from being called.

The `still reports telemetry when getAttackDiscovery returns null` unit test added in this PR reproduces the issue (and fails without the fix).
