### PR TITLE
[ResponseOps][Reporting] Missing encryption password length validation

### DIFF
--- a/x-pack/platform/plugins/private/reporting/server/config/create_config.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/config/create_config.test.ts
@@ -43,6 +43,17 @@ describe('Reporting server createConfig', () => {
     expect(mockLogger.warn).not.toHaveBeenCalled();
   });
 
+  it('it logs a warning if the user-provided encryption key is less than 32 characters', () => {
+    const mockConfig = createMockConfigSchema({ encryptionKey: 'iiii', kibanaServer: {} });
+    const result = createConfig(mockCoreSetup, mockConfig, mockLogger);
+
+    expect(result.encryptionKey).toMatch('iiii');
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'The xpack.reporting.encryptionKey config is shorter than the recommended minimum length of 32 characters. For enhanced security, please update the encryption key to be at least 32 characters long.'
+    );
+  });
+
   it('uses the user-provided encryption key, reporting kibanaServer settings to override server info', () => {
     const mockConfig = createMockConfigSchema({
       encryptionKey: 'iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii',

--- a/x-pack/platform/plugins/private/reporting/server/config/create_config.ts
+++ b/x-pack/platform/plugins/private/reporting/server/config/create_config.ts
@@ -33,6 +33,11 @@ export function createConfig(
     );
     encryptionKey = crypto.randomBytes(16).toString('hex');
   }
+  if (encryptionKey.length < 32) {
+    logger.warn(
+      'The xpack.reporting.encryptionKey config is shorter than the recommended minimum length of 32 characters. For enhanced security, please update the encryption key to be at least 32 characters long.'
+    );
+  }
 
   const hashedEncryptionKey = crypto.createHash('sha3-256').update(encryptionKey).digest('base64');
   logger.info(`Hashed 'xpack.reporting.encryptionKey' for this instance: ${hashedEncryptionKey}`);

--- a/x-pack/platform/plugins/private/reporting/server/config/create_config.ts
+++ b/x-pack/platform/plugins/private/reporting/server/config/create_config.ts
@@ -33,9 +33,10 @@ export function createConfig(
     );
     encryptionKey = crypto.randomBytes(16).toString('hex');
   }
-  if (encryptionKey.length < 32) {
+  const minEncryptionKeyLength = 32;
+  if (encryptionKey.length < minEncryptionKeyLength) {
     logger.warn(
-      'The xpack.reporting.encryptionKey config is shorter than the recommended minimum length of 32 characters. For enhanced security, please update the encryption key to be at least 32 characters long.'
+      `The xpack.reporting.encryptionKey config is shorter than the recommended minimum length of ${minEncryptionKeyLength} characters. For enhanced security, please update the encryption key to be at least ${minEncryptionKeyLength} characters long.`
     );
   }
 


### PR DESCRIPTION
Resolves https://github.com/elastic/response-ops-team/issues/391

## Summary

For other configs we enforce the encryption key to be at least 32 characters for better security. Updating the reporting encryption key to enforce this would be a breaking change, so this PR adds a log warning to the user that their `xpack.reporting.encryptionKey` config is less than 32 characters.


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### To verify

1. Add a short value for`xpack.reporting.encryptionKey` in kibana.yml
2. Start Kibana and verify that you see this log message:
```
The xpack.reporting.encryptionKey config is shorter than the recommended minimum length of 32 characters. For enhanced security, please update the encryption key to be at least 32 characters long.
```



