### PR TITLE
[Security Assistant] Fix missing `X-Elastic-Product-Use-Case` header

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/gen_ai_token_tracking.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/gen_ai_token_tracking.test.ts
@@ -459,7 +459,7 @@ describe('getGenAiTokenTracking', () => {
     );
   });
 
-  it.only('should return the total, prompt, and completion token counts when given a valid Inference stream response', async () => {
+  it('should return the total, prompt, and completion token counts when given a valid Inference stream response', async () => {
     const actionTypeId = '.inference';
     const mockReader = new IncomingMessage(new Socket());
     const result = {

--- a/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/gen_ai_token_tracking.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/gen_ai_token_tracking.test.ts
@@ -459,6 +459,54 @@ describe('getGenAiTokenTracking', () => {
     );
   });
 
+  it.only('should return the total, prompt, and completion token counts when given a valid Inference stream response', async () => {
+    const actionTypeId = '.inference';
+    const mockReader = new IncomingMessage(new Socket());
+    const result = {
+      actionId: '123',
+      status: 'ok' as const,
+      data: mockReader,
+    };
+    const validatedParams = {
+      subAction: 'unified_completion_stream',
+      subActionParams: {
+        body: {
+          messages: [
+            {
+              role: 'user',
+              content: 'Sample message',
+            },
+          ],
+        },
+      },
+    };
+
+    const tokenTracking = await getGenAiTokenTracking({
+      actionTypeId,
+      logger,
+      result,
+      validatedParams,
+    });
+
+    expect(tokenTracking).toEqual({
+      total_tokens: 100,
+      prompt_tokens: 50,
+      completion_tokens: 50,
+    });
+    expect(logger.error).not.toHaveBeenCalled();
+
+    expect(JSON.stringify(mockGetTokenCountFromInvokeStream.mock.calls[0][0].body)).toStrictEqual(
+      JSON.stringify({
+        messages: [
+          {
+            role: 'user',
+            content: 'Sample message',
+          },
+        ],
+      })
+    );
+  });
+
   it('should return the total, prompt, and completion token counts when given a valid Gemini response', async () => {
     const actionTypeId = '.gemini';
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.test.ts
@@ -301,7 +301,22 @@ describe('callAssistantGraph', () => {
         status: 'ok',
         conversationId: 'new-conversation-id',
       });
-      expect(getChatModel).toHaveBeenCalled();
+      expect(getChatModel).toHaveBeenCalledWith({
+        chatModelOptions: {
+          maxRetries: 0,
+          model: 'test-model',
+          telemetryMetadata: {
+            pluginId: 'security_ai_assistant',
+          },
+          temperature: 0.2,
+        },
+        connectorId: 'test-connector',
+        request: {
+          body: {
+            model: 'test-model',
+          },
+        },
+      });
     });
 
     it('calls streamGraph with correct parameters for streaming', async () => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.ts
@@ -87,10 +87,8 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
             // prevents the agent from retrying on failure
             // failure could be due to bad connector, we should deliver that result to the client asap
             maxRetries: 0,
-            metadata: {
-              connectorTelemetry: {
-                pluginId: 'security_ai_assistant',
-              },
+            telemetryMetadata: {
+              pluginId: 'security_ai_assistant',
             },
             // TODO add timeout to inference once resolved https://github.com/elastic/kibana/issues/221318
             // timeout,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
@@ -337,10 +337,8 @@ export const postEvaluateRoute = (
                         // prevents the agent from retrying on failure
                         // failure could be due to bad connector, we should deliver that result to the client asap
                         maxRetries: 0,
-                        metadata: {
-                          connectorTelemetry: {
-                            pluginId: 'security_ai_assistant',
-                          },
+                        telemetryMetadata: {
+                          pluginId: 'security_ai_assistant',
                         },
                         // TODO add timeout to inference once resolved https://github.com/elastic/kibana/issues/221318
                         // timeout: ROUTE_HANDLER_TIMEOUT,


### PR DESCRIPTION
## Summary

We were sending the incorrect JSON for `telemetryMetadata` to be properly passed through `InferenceChatModel` to the inference connector. This PR fixes the JSON format.

Additionally, we needed token tracking for the inference `unified_completion_stream` method so it was added here.

## Testing
1. Have EIS installed and running:
  - First authenticate with `vault login -method oidc`
  - Next in a dedicated terminal, in Kibana root run `node scripts/eis.js`
  - And then start ES with the `-E xpack.inference.elastic.url=http://localhost:8443` parameter.
  - Finally, start kibana with the preconfigured connector in `kibana.dev.yml`, using the output from running `node scripts/eis.js`

2. Add a console log to `x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference/inference.ts` at the beginning of the `performApiUnifiedCompletionStream` function:
```
console.log('pluginId ==>', params.telemetryMetadata?.pluginId);
```
3. With the log in place on `main`, send a message through the assistant with the Elastic LLM connector. `pluginId` will be undefined
4. Checkout this branch, and keep that `console.log` in place. Send another message through the assistant with the Elastic LLM connector. Notice the correct `pluginId` is now logged




<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->