### PR TITLE
[EASE] remove newDataViewPicker logic for the 3 places we use a custom dataView: alert summary, cases alerts tab and attack discovery alerts tab

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.test.tsx
@@ -10,9 +10,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { AiForSOCAlertsTab, CONTENT_TEST_ID, ERROR_TEST_ID, SKELETON_TEST_ID } from './wrapper';
 import { TestProviders } from '../../../../../../../common/mock';
 import { useFetchIntegrations } from '../../../../../../../detections/hooks/alert_summary/use_fetch_integrations';
-import { useIsExperimentalFeatureEnabled } from '../../../../../../../common/hooks/use_experimental_features';
 import { useCreateDataView } from '../../../../../../../common/hooks/use_create_data_view';
-import { useDataView } from '../../../../../../../data_view_manager/hooks/use_data_view';
 
 jest.mock('./table', () => ({
   Table: () => <div />,
@@ -20,8 +18,6 @@ jest.mock('./table', () => ({
 jest.mock('../../../../../../../common/lib/kibana');
 jest.mock('../../../../../../../detections/hooks/alert_summary/use_fetch_integrations');
 jest.mock('../../../../../../../common/hooks/use_create_data_view');
-jest.mock('../../../../../../../data_view_manager/hooks/use_data_view');
-jest.mock('../../../../../../../common/hooks/use_experimental_features');
 
 const id = 'id';
 const query = { ids: { values: ['abcdef'] } };
@@ -51,117 +47,54 @@ describe('<AiForSOCAlertsTab />', () => {
     expect(await screen.findByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
   });
 
-  describe('when the newDataViewPickerEnabled feature flag is not enabled', () => {
-    beforeEach(() => {
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
+  it('should render a loading skeleton while creating the dataView', async () => {
+    (useCreateDataView as jest.Mock).mockReturnValue({
+      dataView: undefined,
+      loading: true,
     });
 
-    it('should render a loading skeleton while creating the dataView', async () => {
-      (useCreateDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        loading: true,
-      });
+    render(<AiForSOCAlertsTab id={id} query={query} />);
 
-      render(<AiForSOCAlertsTab id={id} query={query} />);
-
-      await waitFor(() => {
-        expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
-      });
-    });
-
-    it('should render an error if the dataView fail to be created correctly', async () => {
-      (useCreateDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        loading: false,
-      });
-
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
-
-      render(<AiForSOCAlertsTab id={id} query={query} />);
-
-      expect(await screen.findByTestId(ERROR_TEST_ID)).toHaveTextContent(
-        'Unable to create data view'
-      );
-    });
-
-    it('should render the content', async () => {
-      (useCreateDataView as jest.Mock).mockReturnValue({
-        dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
-        loading: false,
-      });
-
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
-
-      render(
-        <TestProviders>
-          <AiForSOCAlertsTab id={id} query={query} />
-        </TestProviders>
-      );
-
-      expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
     });
   });
 
-  describe('when the newDataViewPickerEnabled feature flag is enabled', () => {
-    beforeEach(() => {
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+  it('should render an error if the dataView fail to be created correctly', async () => {
+    (useCreateDataView as jest.Mock).mockReturnValue({
+      dataView: undefined,
+      loading: false,
     });
 
-    it('should render a loading skeleton while creating the dataView', async () => {
-      (useDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        status: 'loading',
-      });
+    jest.mock('react', () => ({
+      ...jest.requireActual('react'),
+      useEffect: jest.fn((f) => f()),
+    }));
 
-      render(<AiForSOCAlertsTab id={id} query={query} />);
+    render(<AiForSOCAlertsTab id={id} query={query} />);
 
-      await waitFor(() => {
-        expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
-      });
+    expect(await screen.findByTestId(ERROR_TEST_ID)).toHaveTextContent(
+      'Unable to create data view'
+    );
+  });
+
+  it('should render the content', async () => {
+    (useCreateDataView as jest.Mock).mockReturnValue({
+      dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
+      loading: false,
     });
 
-    it('should render an error if the dataView fail to be created correctly', async () => {
-      (useDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        status: 'ready',
-      });
+    jest.mock('react', () => ({
+      ...jest.requireActual('react'),
+      useEffect: jest.fn((f) => f()),
+    }));
 
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
+    render(
+      <TestProviders>
+        <AiForSOCAlertsTab id={id} query={query} />
+      </TestProviders>
+    );
 
-      render(<AiForSOCAlertsTab id={id} query={query} />);
-
-      expect(await screen.findByTestId(ERROR_TEST_ID)).toHaveTextContent(
-        'Unable to create data view'
-      );
-    });
-
-    it('should render the content', async () => {
-      (useDataView as jest.Mock).mockReturnValue({
-        dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
-        status: 'ready',
-      });
-
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
-
-      render(
-        <TestProviders>
-          <AiForSOCAlertsTab id={id} query={query} />
-        </TestProviders>
-      );
-
-      expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.tsx
@@ -14,9 +14,6 @@ import { Table } from './table';
 import { useSpaceId } from '../../../../../../../common/hooks/use_space_id';
 import { useFetchIntegrations } from '../../../../../../../detections/hooks/alert_summary/use_fetch_integrations';
 import { useCreateDataView } from '../../../../../../../common/hooks/use_create_data_view';
-import { useIsExperimentalFeatureEnabled } from '../../../../../../../common/hooks/use_experimental_features';
-import { useDataView } from '../../../../../../../data_view_manager/hooks/use_data_view';
-import { SourcererScopeName } from '../../../../../../../sourcerer/store/model';
 import { DEFAULT_ALERTS_INDEX } from '../../../../../../../../common/constants';
 
 const DATAVIEW_ERROR = i18n.translate(
@@ -47,8 +44,6 @@ interface AiForSOCAlertsTabProps {
  * It renders a loading skeleton while packages are being fetched and while the dataView is being created.
  */
 export const AiForSOCAlertsTab = memo(({ id, query }: AiForSOCAlertsTabProps) => {
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-
   const spaceId = useSpaceId();
   const dataViewSpec = useMemo(
     () => ({
@@ -58,14 +53,7 @@ export const AiForSOCAlertsTab = memo(({ id, query }: AiForSOCAlertsTabProps) =>
     [spaceId]
   );
 
-  const { dataView: oldDataView, loading: oldDataViewLoading } = useCreateDataView({
-    dataViewSpec,
-    skip: newDataViewPickerEnabled, // skip data view creation if the new data view picker is enabled
-  });
-
-  const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.detections);
-  const dataViewLoading = newDataViewPickerEnabled ? status !== 'ready' : oldDataViewLoading;
-  const dataView = newDataViewPickerEnabled ? experimentalDataView : oldDataView;
+  const { dataView, loading: dataViewLoading } = useCreateDataView({ dataViewSpec });
 
   // Fetch all integrations
   const { installedPackages, isLoading: integrationIsLoading } = useFetchIntegrations();

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/wrapper.test.tsx
@@ -11,15 +11,11 @@ import { AiForSOCAlertsTable, CONTENT_TEST_ID, ERROR_TEST_ID, SKELETON_TEST_ID }
 import { TestProviders } from '../../../common/mock';
 import { useFetchIntegrations } from '../../../detections/hooks/alert_summary/use_fetch_integrations';
 import { useCreateDataView } from '../../../common/hooks/use_create_data_view';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
-import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 
 jest.mock('./table', () => ({
   Table: () => <div />,
 }));
 jest.mock('../../../detections/hooks/alert_summary/use_fetch_integrations');
-jest.mock('../../../common/hooks/use_experimental_features');
-jest.mock('../../../data_view_manager/hooks/use_data_view');
 jest.mock('../../../common/hooks/use_create_data_view');
 
 const id = 'id';
@@ -51,116 +47,54 @@ describe('<AiForSOCAlertsTab />', () => {
     expect(await screen.findByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
   });
 
-  describe('when the newDataViewPickerEnabled feature flag is not enabled', () => {
-    beforeEach(() => {
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
+  it('should render a loading skeleton while creating the dataView', async () => {
+    (useCreateDataView as jest.Mock).mockReturnValue({
+      dataView: undefined,
+      loading: true,
     });
 
-    it('should render a loading skeleton while creating the dataView', async () => {
-      (useCreateDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        loading: true,
-      });
+    render(<AiForSOCAlertsTable id={id} onLoaded={onLoaded} query={query} />);
 
-      render(<AiForSOCAlertsTable id={id} onLoaded={onLoaded} query={query} />);
-
-      await waitFor(() => {
-        expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
-      });
-    });
-
-    it('should render an error if the dataView fail to be created correctly', async () => {
-      (useCreateDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        loading: false,
-      });
-
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
-
-      render(<AiForSOCAlertsTable id={id} onLoaded={onLoaded} query={query} />);
-
-      expect(await screen.findByTestId(ERROR_TEST_ID)).toHaveTextContent(
-        'Unable to create data view'
-      );
-    });
-
-    it('should render the content', async () => {
-      (useCreateDataView as jest.Mock).mockReturnValue({
-        dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
-        loading: false,
-      });
-
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
-
-      render(
-        <TestProviders>
-          <AiForSOCAlertsTable id={id} onLoaded={onLoaded} query={query} />
-        </TestProviders>
-      );
-
-      expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
     });
   });
 
-  describe('when the newDataViewPickerEnabled feature flag is enabled', () => {
-    beforeEach(() => {
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-    });
-    it('should render a loading skeleton while creating the dataView', async () => {
-      (useDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        status: 'loading',
-      });
-
-      render(<AiForSOCAlertsTable id={id} onLoaded={onLoaded} query={query} />);
-
-      await waitFor(() => {
-        expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
-      });
+  it('should render an error if the dataView fail to be created correctly', async () => {
+    (useCreateDataView as jest.Mock).mockReturnValue({
+      dataView: undefined,
+      loading: false,
     });
 
-    it('should render an error if the dataView fail to be created correctly', async () => {
-      (useDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        status: 'ready',
-      });
+    jest.mock('react', () => ({
+      ...jest.requireActual('react'),
+      useEffect: jest.fn((f) => f()),
+    }));
 
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
+    render(<AiForSOCAlertsTable id={id} onLoaded={onLoaded} query={query} />);
 
-      render(<AiForSOCAlertsTable id={id} onLoaded={onLoaded} query={query} />);
+    expect(await screen.findByTestId(ERROR_TEST_ID)).toHaveTextContent(
+      'Unable to create data view'
+    );
+  });
 
-      expect(await screen.findByTestId(ERROR_TEST_ID)).toHaveTextContent(
-        'Unable to create data view'
-      );
+  it('should render the content', async () => {
+    (useCreateDataView as jest.Mock).mockReturnValue({
+      dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
+      loading: false,
     });
 
-    it('should render the content', async () => {
-      (useDataView as jest.Mock).mockReturnValue({
-        dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
-        status: 'ready',
-      });
+    jest.mock('react', () => ({
+      ...jest.requireActual('react'),
+      useEffect: jest.fn((f) => f()),
+    }));
 
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
+    render(
+      <TestProviders>
+        <AiForSOCAlertsTable id={id} onLoaded={onLoaded} query={query} />
+      </TestProviders>
+    );
 
-      render(
-        <TestProviders>
-          <AiForSOCAlertsTable id={id} onLoaded={onLoaded} query={query} />
-        </TestProviders>
-      );
-
-      expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/wrapper.tsx
@@ -13,11 +13,8 @@ import React, { memo, useMemo } from 'react';
 import { RUNTIME_FIELD_MAP } from '../../../detections/components/alert_summary/wrapper';
 import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
 import { useCreateDataView } from '../../../common/hooks/use_create_data_view';
-import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { useFetchIntegrations } from '../../../detections/hooks/alert_summary/use_fetch_integrations';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { Table } from './table';
 
 const DATAVIEW_ERROR = i18n.translate(
@@ -52,8 +49,6 @@ interface AiForSOCAlertsTableProps {
  * It renders a loading skeleton while packages are being fetched and while the dataView is being created.
  */
 export const AiForSOCAlertsTable = memo(({ id, onLoaded, query }: AiForSOCAlertsTableProps) => {
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-
   const spaceId = useSpaceId();
   const dataViewSpec = useMemo(
     () => ({
@@ -63,14 +58,7 @@ export const AiForSOCAlertsTable = memo(({ id, onLoaded, query }: AiForSOCAlerts
     [spaceId]
   );
 
-  const { dataView: oldDataView, loading: oldDataViewLoading } = useCreateDataView({
-    dataViewSpec,
-    skip: newDataViewPickerEnabled, // skip data view creation if the new data view picker is enabled
-  });
-
-  const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.detections);
-  const dataViewLoading = newDataViewPickerEnabled ? status !== 'ready' : oldDataViewLoading;
-  const dataView = newDataViewPickerEnabled ? experimentalDataView : oldDataView;
+  const { dataView, loading: dataViewLoading } = useCreateDataView({ dataViewSpec });
 
   // Fetch all integrations
   const { installedPackages, isLoading: integrationIsLoading } = useFetchIntegrations();

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_create_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_create_data_view.ts
@@ -21,7 +21,7 @@ interface UseCreateDataViewParams {
   /**
    * Whether to skip the data view creation.
    */
-  skip: boolean;
+  skip?: boolean;
 }
 
 interface UseCreateDataViewResults {
@@ -43,7 +43,7 @@ interface UseCreateDataViewResults {
 export const useCreateDataView = ({
   dataViewSpec,
   loading = false,
-  skip,
+  skip = false,
 }: UseCreateDataViewParams): UseCreateDataViewResults => {
   const { dataViews } = useKibana().services;
   const [dataView, setDataView] = useState<DataView | undefined>(undefined);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.test.tsx
@@ -23,9 +23,7 @@ import { SEARCH_BAR_TEST_ID } from './search_bar/search_bar_section';
 import { KPIS_SECTION } from './kpis/kpis_section';
 import { GROUPED_TABLE_TEST_ID } from './table/table_section';
 import { useNavigateToIntegrationsPage } from '../../hooks/alert_summary/use_navigate_to_integrations_page';
-import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { useCreateDataView } from '../../../common/hooks/use_create_data_view';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { useKibana } from '../../../common/lib/kibana';
 
 jest.mock('../../../common/components/search_bar', () => ({
@@ -38,9 +36,7 @@ jest.mock('../alerts_table/alerts_grouping', () => ({
 jest.mock('../../../common/lib/kibana');
 jest.mock('../../hooks/alert_summary/use_navigate_to_integrations_page');
 jest.mock('../../hooks/alert_summary/use_integration_last_alert_ingested');
-jest.mock('../../../common/hooks/use_experimental_features');
 jest.mock('../../../common/hooks/use_create_data_view');
-jest.mock('../../../data_view_manager/hooks/use_data_view');
 
 const packages: PackageListItem[] = [
   {
@@ -53,151 +49,71 @@ const packages: PackageListItem[] = [
 ];
 
 describe('<Wrapper />', () => {
-  describe('when the newDataViewPickerEnabled feature flag is not enabled', () => {
-    beforeEach(() => {
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
+  it('should render a loading skeleton while creating the dataView', async () => {
+    (useCreateDataView as jest.Mock).mockReturnValue({
+      dataView: undefined,
+      loading: true,
     });
 
-    it('should render a loading skeleton while creating the dataView', async () => {
-      (useCreateDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        loading: true,
-      });
+    render(<Wrapper packages={packages} />);
 
-      render(<Wrapper packages={packages} />);
-
-      await waitFor(() => {
-        expect(screen.getByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-        expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
-      });
-    });
-
-    it('should render an error if the dataView fail to be created correctly', async () => {
-      (useCreateDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        loading: false,
-      });
-
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
-
-      render(<Wrapper packages={packages} />);
-
-      expect(await screen.findByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-      expect(await screen.findByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
-        'Unable to create data view'
-      );
-    });
-
-    it('should render the content if the dataView is created correctly', async () => {
-      (useKibana as jest.Mock).mockReturnValue({
-        services: {
-          data: { query: { filterManager: { getFilters: jest.fn().mockReturnValue([]) } } },
-        },
-      });
-      (useNavigateToIntegrationsPage as jest.Mock).mockReturnValue(jest.fn());
-      (useIntegrationLastAlertIngested as jest.Mock).mockReturnValue({
-        isLoading: true,
-        lastAlertIngested: {},
-      });
-      (useCreateDataView as jest.Mock).mockReturnValue({
-        dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
-        loading: false,
-      });
-
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
-
-      render(
-        <TestProviders>
-          <Wrapper packages={packages} />
-        </TestProviders>
-      );
-
-      expect(await screen.findByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-      expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
-      expect(await screen.findByTestId(ADD_INTEGRATIONS_BUTTON_TEST_ID)).toBeInTheDocument();
-      expect(await screen.findByTestId(SEARCH_BAR_TEST_ID)).toBeInTheDocument();
-      expect(await screen.findByTestId(KPIS_SECTION)).toBeInTheDocument();
-      expect(await screen.findByTestId(GROUPED_TABLE_TEST_ID)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
+      expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
     });
   });
 
-  describe('when the newDataViewPickerEnabled feature flag is enabled', () => {
-    beforeEach(() => {
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+  it('should render an error if the dataView fail to be created correctly', async () => {
+    (useCreateDataView as jest.Mock).mockReturnValue({
+      dataView: undefined,
+      loading: false,
     });
 
-    it('should render a loading skeleton while creating the dataView', async () => {
-      (useDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        status: 'loading',
-      });
+    jest.mock('react', () => ({
+      ...jest.requireActual('react'),
+      useEffect: jest.fn((f) => f()),
+    }));
 
-      render(<Wrapper packages={packages} />);
+    render(<Wrapper packages={packages} />);
 
-      await waitFor(() => {
-        expect(screen.getByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-        expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
-      });
+    expect(await screen.findByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
+    expect(await screen.findByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
+      'Unable to create data view'
+    );
+  });
+
+  it('should render the content if the dataView is created correctly', async () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        data: { query: { filterManager: { getFilters: jest.fn().mockReturnValue([]) } } },
+      },
+    });
+    (useNavigateToIntegrationsPage as jest.Mock).mockReturnValue(jest.fn());
+    (useIntegrationLastAlertIngested as jest.Mock).mockReturnValue({
+      isLoading: true,
+      lastAlertIngested: {},
+    });
+    (useCreateDataView as jest.Mock).mockReturnValue({
+      dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
+      loading: false,
     });
 
-    it('should render an error if the dataView fail to be created correctly', async () => {
-      (useDataView as jest.Mock).mockReturnValue({
-        dataView: undefined,
-        status: 'ready',
-      });
+    jest.mock('react', () => ({
+      ...jest.requireActual('react'),
+      useEffect: jest.fn((f) => f()),
+    }));
 
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
+    render(
+      <TestProviders>
+        <Wrapper packages={packages} />
+      </TestProviders>
+    );
 
-      render(<Wrapper packages={packages} />);
-
-      expect(await screen.findByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-      expect(await screen.findByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
-        'Unable to create data view'
-      );
-    });
-
-    it('should render the content if the dataView is created correctly', async () => {
-      (useKibana as jest.Mock).mockReturnValue({
-        services: {
-          data: { query: { filterManager: { getFilters: jest.fn().mockReturnValue([]) } } },
-        },
-      });
-      (useNavigateToIntegrationsPage as jest.Mock).mockReturnValue(jest.fn());
-      (useIntegrationLastAlertIngested as jest.Mock).mockReturnValue({
-        isLoading: true,
-        lastAlertIngested: {},
-      });
-      (useDataView as jest.Mock).mockReturnValue({
-        dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
-        status: 'ready',
-      });
-
-      jest.mock('react', () => ({
-        ...jest.requireActual('react'),
-        useEffect: jest.fn((f) => f()),
-      }));
-
-      render(
-        <TestProviders>
-          <Wrapper packages={packages} />
-        </TestProviders>
-      );
-
-      expect(await screen.findByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-      expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
-      expect(await screen.findByTestId(ADD_INTEGRATIONS_BUTTON_TEST_ID)).toBeInTheDocument();
-      expect(await screen.findByTestId(SEARCH_BAR_TEST_ID)).toBeInTheDocument();
-      expect(await screen.findByTestId(KPIS_SECTION)).toBeInTheDocument();
-      expect(await screen.findByTestId(GROUPED_TABLE_TEST_ID)).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
+    expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
+    expect(await screen.findByTestId(ADD_INTEGRATIONS_BUTTON_TEST_ID)).toBeInTheDocument();
+    expect(await screen.findByTestId(SEARCH_BAR_TEST_ID)).toBeInTheDocument();
+    expect(await screen.findByTestId(KPIS_SECTION)).toBeInTheDocument();
+    expect(await screen.findByTestId(GROUPED_TABLE_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.tsx
@@ -17,14 +17,11 @@ import { i18n } from '@kbn/i18n';
 import type { PackageListItem } from '@kbn/fleet-plugin/common';
 import type { DataViewSpec, RuntimeFieldSpec } from '@kbn/data-views-plugin/common';
 import { RELATED_INTEGRATION } from '../../constants';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { KPIsSection } from './kpis/kpis_section';
 import { IntegrationSection } from './integrations/integration_section';
 import { SearchBarSection } from './search_bar/search_bar_section';
 import { TableSection } from './table/table_section';
 import { useCreateDataView } from '../../../common/hooks/use_create_data_view';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
-import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
 
@@ -61,28 +58,16 @@ export interface WrapperProps {
  */
 export const Wrapper = memo(({ packages }: WrapperProps) => {
   const spaceId = useSpaceId();
-  const oldSignalIndexName = `${DEFAULT_ALERTS_INDEX}-${spaceId}`;
+  const signalIndexName = `${DEFAULT_ALERTS_INDEX}-${spaceId}`;
   const dataViewSpec: DataViewSpec = useMemo(
     () => ({
-      title: oldSignalIndexName,
+      title: signalIndexName,
       runtimeFieldMap: RUNTIME_FIELD_MAP,
     }),
-    [oldSignalIndexName]
+    [signalIndexName]
   );
 
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-
-  const { dataView: oldDataView, loading: oldDataViewLoading } = useCreateDataView({
-    dataViewSpec,
-    skip: newDataViewPickerEnabled, // skip data view creation if the new data view picker is enabled
-  });
-
-  const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.detections);
-  const signalIndexName = newDataViewPickerEnabled
-    ? experimentalDataView?.getIndexPattern() ?? ''
-    : oldSignalIndexName;
-  const loading = newDataViewPickerEnabled ? status !== 'ready' : oldDataViewLoading;
-  const dataView = newDataViewPickerEnabled ? experimentalDataView : oldDataView;
+  const { dataView, loading } = useCreateDataView({ dataViewSpec });
 
   return (
     <EuiSkeletonLoading


### PR DESCRIPTION
## Summary

This PR simplifies the code to create/fetch the dataViewfor 3 pages used in EASE:
- alert summary
- cases alerts tab
- attack discovery alerts tab

> [!IMPORTANT]
> As the `newDataViewPickerEnabled` feature flag has not been enabled yet, the changes here are not impacting any code that's been in production yet.

## How to test

There isn't much to actually test as the code removed never made it to production. **_No UI or application behavior have been introduced in this PR!_**

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.