### PR TITLE
OpenAPI Items expects a single schema, not a list

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -64566,17 +64566,17 @@ paths:
                     bcc:
                       default: []
                       items:
-                        - type: string
+                        type: string
                       type: array
                     cc:
                       default: []
                       items:
-                        - type: string
+                        type: string
                       type: array
                     to:
                       default: []
                       items:
-                        - type: string
+                        type: string
                       type: array
                 heartbeatIndices:
                   default: heartbeat-*

--- a/src/platform/packages/private/kbn-validate-oas/oas_error_baseline.json
+++ b/src/platform/packages/private/kbn-validate-oas/oas_error_baseline.json
@@ -1,4 +1,4 @@
 {
-  "./oas_docs/output/kibana.yaml": 320,
+  "./oas_docs/output/kibana.yaml": 314,
   "./oas_docs/output/kibana.serverless.yaml": 294
 }

--- a/x-pack/solutions/observability/plugins/uptime/docs/openapi/uptime_apis.yaml
+++ b/x-pack/solutions/observability/plugins/uptime/docs/openapi/uptime_apis.yaml
@@ -83,17 +83,17 @@ paths:
                     bcc:
                       type: array
                       items:
-                        - type: string
+                        type: string
                       default: []
                     cc:
                       type: array
                       items:
-                        - type: string
+                        type: string
                       default: []
                     to:
                       type: array
                       items:
-                        - type: string
+                        type: string
                       default: []
                 heartbeatIndices:
                   type: string


### PR DESCRIPTION
## Summary

From the [spec](https://swagger.io/docs/specification/v3_0/data-models/data-types/#arrays) the `items` field should be a single schema defining the types within an array. If the array may contain multiple types then the schema should combine those types via `oneOf`. 

Related to https://github.com/elastic/kibana/issues/228077


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->