### PR TITLE
feat: show workflow yaml as it was at the time of execution

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -32,6 +32,7 @@ export interface EsWorkflowExecution {
   status: ExecutionStatus;
   context: Record<string, any>;
   workflowDefinition: WorkflowYaml;
+  yaml: string;
   currentNodeId?: string; // The node currently being executed
   stack: string[];
   createdAt: string;
@@ -103,6 +104,7 @@ export interface WorkflowExecutionDto {
   stepExecutions: EsWorkflowStepExecution[];
   duration: number | null;
   triggeredBy?: string; // 'manual' or 'scheduled'
+  yaml: string;
 }
 
 export type WorkflowExecutionListItemDto = Omit<WorkflowExecutionDto, 'stepExecutions'>;
@@ -212,7 +214,7 @@ export interface WorkflowListDto {
   results: WorkflowListItemDto[];
 }
 export interface WorkflowExecutionEngineModel
-  extends Pick<EsWorkflow, 'id' | 'name' | 'enabled' | 'definition'> {
+  extends Pick<EsWorkflow, 'id' | 'name' | 'enabled' | 'definition' | 'yaml'> {
   isTestRun?: boolean;
 }
 

--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -107,7 +107,7 @@ export interface WorkflowExecutionDto {
   yaml: string;
 }
 
-export type WorkflowExecutionListItemDto = Omit<WorkflowExecutionDto, 'stepExecutions'>;
+export type WorkflowExecutionListItemDto = Omit<WorkflowExecutionDto, 'stepExecutions' | 'yaml'>;
 
 export interface WorkflowExecutionListDto {
   results: WorkflowExecutionListItemDto[];

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -166,6 +166,7 @@ export class WorkflowsExecutionEnginePlugin
         workflowId: workflow.id,
         isTestRun: workflow.isTestRun,
         workflowDefinition: workflow.definition,
+        yaml: workflow.yaml,
         context,
         status: ExecutionStatus.PENDING,
         createdAt: workflowCreatedAt.toISOString(),

--- a/src/platform/plugins/shared/workflows_management/common/lib/yaml_utils.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/yaml_utils.test.ts
@@ -9,8 +9,8 @@
 
 import type { SafeParseReturnType } from '@kbn/zod';
 import { z } from '@kbn/zod';
-import { parseWorkflowYamlToJSON } from './yaml_utils';
-import type { ConnectorContract } from '@kbn/workflows';
+import { stringifyWorkflowDefinition, parseWorkflowYamlToJSON } from './yaml_utils';
+import type { ConnectorContract, WorkflowYaml } from '@kbn/workflows';
 import { generateYamlSchemaFromConnectors } from '@kbn/workflows';
 
 describe('parseWorkflowYamlToJSON', () => {
@@ -114,5 +114,32 @@ describe('parseWorkflowYamlToJSON', () => {
     );
     expect(result.success).toBe(false);
     expect(result.error?.message).toContain('Invalid key type: map in range');
+  });
+});
+
+describe('getYamlStringFromJSON', () => {
+  it('should sort keys according to the order of the keys in the workflow definition', () => {
+    const json: Partial<WorkflowYaml> = {
+      enabled: true,
+      steps: [
+        {
+          name: 'step1',
+          type: 'noop',
+          with: { message: 'Hello, world!' },
+        },
+      ],
+      description: 'test',
+      name: 'test',
+    };
+    const yaml = stringifyWorkflowDefinition(json);
+    expect(yaml).toBe(`name: test
+description: test
+enabled: true
+steps:
+  - name: step1
+    type: noop
+    with:
+      message: Hello, world!
+`);
   });
 });

--- a/src/platform/plugins/shared/workflows_management/common/lib/yaml_utils.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/yaml_utils.test.ts
@@ -142,4 +142,9 @@ steps:
       message: Hello, world!
 `);
   });
+
+  it('it should throw an error if the input is not a plain object', () => {
+    const json: any = [1, 2, 3];
+    expect(() => stringifyWorkflowDefinition(json)).toThrow();
+  });
 });

--- a/src/platform/plugins/shared/workflows_management/common/lib/yaml_utils.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/yaml_utils.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { WorkflowYaml } from '@kbn/workflows/spec/schema';
 import type { z } from '@kbn/zod';
 import type { Node, Pair, Scalar, YAMLMap } from 'yaml';
 import {
@@ -27,8 +28,46 @@ const YAML_STRINGIFY_OPTIONS = {
   lineWidth: -1,
 };
 
-export function getYamlStringFromJSON(json: any) {
-  const doc = new Document(json);
+const WORKFLOW_DEFINITION_KEYS_ORDER: Array<keyof WorkflowYaml> = [
+  'name',
+  'description',
+  'enabled',
+  'tags',
+  'settings',
+  'triggers',
+  'inputs',
+  'consts',
+  'steps',
+];
+
+/**
+ * Stringify the workflow definition to a YAML string.
+ * @param workflowDefinition - The workflow definition as a JSON object.
+ * @param sortKeys - Whether to sort the keys of the workflow definition.
+ * @returns The YAML string of the workflow definition.
+ */
+export function stringifyWorkflowDefinition(
+  workflowDefinition: Record<string, any>,
+  sortKeys: boolean = true
+) {
+  const doc = new Document(workflowDefinition);
+  if (sortKeys) {
+    if (!doc.contents) {
+      throw new Error('doc.contents is null');
+    }
+    if (!isMap(doc.contents)) {
+      throw new Error('doc.contents should be a map');
+    }
+    const map = doc.contents as YAMLMap;
+    map.items.sort((a, b) => {
+      if (!isScalar(a.key) || !isScalar(b.key)) {
+        return 0;
+      }
+      const aIndex = WORKFLOW_DEFINITION_KEYS_ORDER.indexOf(a.key.value as keyof WorkflowYaml);
+      const bIndex = WORKFLOW_DEFINITION_KEYS_ORDER.indexOf(b.key.value as keyof WorkflowYaml);
+      return aIndex - bIndex;
+    });
+  }
   return doc.toString(YAML_STRINGIFY_OPTIONS);
 }
 

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_list.stories.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_list.stories.tsx
@@ -29,6 +29,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionList> = {
       finishedAt: new Date().toISOString(),
       duration: 1000,
       spaceId: 'default',
+      yaml: '',
       stepExecutions: [
         {
           id: '3',

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
@@ -165,6 +165,8 @@ export function WorkflowDetailPage({ id }: { id: string }) {
   const originalWorkflowYaml = useMemo(() => workflow?.yaml ?? '', [workflow]);
   const [hasChanges, setHasChanges] = useState(false);
 
+  const yamlValue = selectedExecutionId && execution ? execution.yaml : workflowYaml;
+
   useEffect(() => {
     setWorkflowYaml(workflow?.yaml ?? '');
     setHasChanges(false);
@@ -218,12 +220,13 @@ export function WorkflowDetailPage({ id }: { id: string }) {
                 <WorkflowYAMLEditor
                   workflowId={workflow?.id ?? 'unknown'}
                   filename={`${workflow?.id ?? 'unknown'}.yaml`}
-                  value={workflowYaml}
+                  value={yamlValue}
                   onChange={(v) => handleChange(v ?? '')}
                   lastUpdatedAt={workflow?.lastUpdatedAt}
                   hasChanges={hasChanges}
                   highlightStep={selectedStepId}
                   stepExecutions={execution?.stepExecutions}
+                  readOnly={activeTab === 'executions'}
                 />
               </React.Suspense>
             </EuiFlexItem>
@@ -231,7 +234,7 @@ export function WorkflowDetailPage({ id }: { id: string }) {
               <EuiFlexItem css={styles.workflowVisualEditorColumn}>
                 <React.Suspense fallback={<EuiLoadingSpinner />}>
                   <WorkflowVisualEditor
-                    workflowYaml={workflowYaml}
+                    workflowYaml={yamlValue}
                     workflowExecutionId={selectedExecutionId}
                   />
                 </React.Suspense>
@@ -244,7 +247,7 @@ export function WorkflowDetailPage({ id }: { id: string }) {
             {workflow && (
               <WorkflowExecutionDetail
                 workflowExecutionId={selectedExecutionId}
-                workflowYaml={workflow.yaml}
+                workflowYaml={yamlValue}
               />
             )}
           </EuiFlexItem>

--- a/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_runner.ts
+++ b/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_runner.ts
@@ -59,6 +59,7 @@ export function createWorkflowTaskRunner({
             name: workflow.name,
             enabled: workflow.enabled,
             definition: workflow.definition,
+            yaml: workflow.yaml,
           };
 
           // Execute the workflow

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
@@ -189,6 +189,7 @@ export class WorkflowsManagementApi {
         name: workflowToCreate.name,
         enabled: workflowToCreate.enabled,
         definition: workflowToCreate.definition,
+        yaml: workflowYaml,
         isTestRun: true,
       },
       context


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/13780

## Summary
*(ai-generated)* 

This PR enables showing workflow YAML as it existed at the time of execution, providing historical context for executed workflows.

- Adds `yaml` field to workflow executions to store the YAML definition that was used during execution
- Implements backward compatibility for executions created before this feature
- Updates the UI to display execution-specific YAML when viewing executions and makes the editor read-only

### DEMO

https://github.com/user-attachments/assets/f3cb9d0f-9613-4940-87b8-6b65db4d6686


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



