### PR TITLE
[ES|QL] Fixes lookup indexes route failures on read permissions

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -619,17 +619,25 @@ const ESQLEditorInternal = function ESQLEditor({
   useEffect(() => {
     const setQueryToTheCache = async () => {
       if (editor1?.current) {
-        const parserMessages = await parseMessages();
-        const clientParserStatus = parserMessages.errors?.length
-          ? 'error'
-          : parserMessages.warnings.length
-          ? 'warning'
-          : 'success';
+        try {
+          const parserMessages = await parseMessages();
+          const clientParserStatus = parserMessages.errors?.length
+            ? 'error'
+            : parserMessages.warnings.length
+            ? 'warning'
+            : 'success';
 
-        addQueriesToCache({
-          queryString: code,
-          status: clientParserStatus,
-        });
+          addQueriesToCache({
+            queryString: code,
+            status: clientParserStatus,
+          });
+        } catch (error) {
+          // Default to warning when parseMessages fails
+          addQueriesToCache({
+            queryString: code,
+            status: 'warning',
+          });
+        }
       }
     };
     if (isQueryLoading || isLoading) {

--- a/src/platform/packages/shared/kbn-esql-types/src/extensions_autocomplete_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/extensions_autocomplete_types.ts
@@ -26,6 +26,7 @@ export interface RecommendedField {
 interface ResolveIndexResponseItem {
   name: string;
   mode?: 'lookup' | 'time_series' | string;
+  aliases?: string[];
 }
 
 export interface ResolveIndexResponse {

--- a/src/platform/packages/shared/kbn-esql-types/src/extensions_autocomplete_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/extensions_autocomplete_types.ts
@@ -25,6 +25,7 @@ export interface RecommendedField {
 
 interface ResolveIndexResponseItem {
   name: string;
+  mode?: 'lookup' | 'time_series' | string;
 }
 
 export interface ResolveIndexResponse {

--- a/src/platform/plugins/shared/esql/server/services/esql_service.ts
+++ b/src/platform/plugins/shared/esql/server/services/esql_service.ts
@@ -29,7 +29,6 @@ export class EsqlService {
     const { client } = this.options;
 
     const indices: IndexAutocompleteItem[] = [];
-    const indexNames: string[] = [];
 
     // It doesn't return hidden indices
     const sources = (await client.indices.resolveIndex({
@@ -40,7 +39,6 @@ export class EsqlService {
     sources.indices?.forEach((index) => {
       if (index.mode === mode) {
         indices.push({ name: index.name, mode, aliases: index.aliases ?? [] });
-        indexNames.push(index.name);
       }
     });
 


### PR DESCRIPTION
## Summary

This PR is fixing a bunch of bugs all related with lookup join route.

When you are on an instance with read privileges on indexes and try to use the ES|QL editor you will see 2 problems:

1. The lookup join route fails with 500
2. The failure makes the history component to not save anything at the local storage. The reason is that our validation api fails so we cant get the status so the item is not saved at the local storage

After an investigation I found out that:

- client.indices.getSettings fails when you have read priviliges
- the client.indices.getAlias fails if you pass an empty array

What I did:

- changed the client.indices.getSettings to client.indices.resolveIndex which works on read and doesnt return hidden indices
- I am  fetching the aliases from the same api
- I added the parseMessages to a try catch loop to be sure that even if something fails on the validation the history component will work


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->