### PR TITLE
[EDR Workflows] MDE Cancel - add connector subaction

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
@@ -10945,7 +10945,32 @@ Object {
     "presence": "optional",
   },
   "keys": Object {
-    "id": Object {
+    "actionId": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+    "comment": Object {
       "flags": Object {
         "error": [Function],
       },
@@ -10976,6 +11001,46 @@ Object {
 `;
 
 exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 10`] = `
+Object {
+  "flags": Object {
+    "default": Object {
+      "special": "deep",
+    },
+    "error": [Function],
+    "presence": "optional",
+  },
+  "keys": Object {
+    "id": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 11`] = `
 Object {
   "flags": Object {
     "default": Object {
@@ -11115,7 +11180,7 @@ Object {
 }
 `;
 
-exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 11`] = `
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 12`] = `
 Object {
   "flags": Object {
     "default": Object {
@@ -11155,7 +11220,7 @@ Object {
 }
 `;
 
-exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 12`] = `
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 13`] = `
 Object {
   "flags": Object {
     "default": Object {

--- a/x-pack/platform/plugins/shared/stack_connectors/common/microsoft_defender_endpoint/constants.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/microsoft_defender_endpoint/constants.ts
@@ -18,4 +18,5 @@ export enum MICROSOFT_DEFENDER_ENDPOINT_SUB_ACTION {
   GET_LIBRARY_FILES = 'getLibraryFiles',
   RUN_SCRIPT = 'runScript',
   GET_ACTION_RESULTS = 'getActionResults',
+  CANCEL_ACTION = 'cancelAction',
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/common/microsoft_defender_endpoint/schema.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/microsoft_defender_endpoint/schema.ts
@@ -157,6 +157,11 @@ export const RunScriptParamsSchema = schema.object({
   }),
 });
 
+export const CancelParamsSchema = schema.object({
+  comment: schema.string({ minLength: 1 }),
+  actionId: schema.string({ minLength: 1 }),
+});
+
 const MachineActionTypeSchema = schema.oneOf([
   schema.literal('RunAntiVirusScan'),
   schema.literal('Offboard'),

--- a/x-pack/platform/plugins/shared/stack_connectors/common/microsoft_defender_endpoint/types.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/microsoft_defender_endpoint/types.ts
@@ -20,6 +20,7 @@ import type {
   AgentListParamsSchema,
   GetLibraryFilesResponse,
   RunScriptParamsSchema,
+  CancelParamsSchema,
 } from './schema';
 
 export type MicrosoftDefenderEndpointConfig = TypeOf<typeof MicrosoftDefenderEndpointConfigSchema>;
@@ -185,6 +186,7 @@ export type MicrosoftDefenderEndpointIsolateHostParams = TypeOf<typeof IsolateHo
 
 export type MicrosoftDefenderEndpointReleaseHostParams = TypeOf<typeof ReleaseHostParamsSchema>;
 export type MicrosoftDefenderEndpointRunScriptParams = TypeOf<typeof RunScriptParamsSchema>;
+export type MicrosoftDefenderEndpointCancelParams = TypeOf<typeof CancelParamsSchema>;
 
 export type MicrosoftDefenderEndpointActionParams = TypeOf<
   typeof MicrosoftDefenderEndpointActionParamsSchema

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/index.ts
@@ -126,7 +126,7 @@ export function registerConnectorTypes({
   if (!experimentalFeatures.inferenceConnectorOff) {
     actions.registerSubActionConnectorType(getInferenceConnectorType());
   }
-  if (experimentalFeatures.microsoftDefenderEndpointOn) {
-    actions.registerSubActionConnectorType(getMicrosoftDefenderEndpointConnectorType());
-  }
+  actions.registerSubActionConnectorType(
+    getMicrosoftDefenderEndpointConnectorType(experimentalFeatures)
+  );
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/index.ts
@@ -126,7 +126,5 @@ export function registerConnectorTypes({
   if (!experimentalFeatures.inferenceConnectorOff) {
     actions.registerSubActionConnectorType(getInferenceConnectorType());
   }
-  actions.registerSubActionConnectorType(
-    getMicrosoftDefenderEndpointConnectorType(experimentalFeatures)
-  );
+  actions.registerSubActionConnectorType(getMicrosoftDefenderEndpointConnectorType());
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/microsoft_defender_endpoint/microsoft_defender_endpoint.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/microsoft_defender_endpoint/microsoft_defender_endpoint.ts
@@ -11,7 +11,6 @@ import type { AxiosError, AxiosResponse } from 'axios';
 import type { SubActionRequestParams } from '@kbn/actions-plugin/server/sub_action_framework/types';
 import type { ConnectorUsageCollector } from '@kbn/actions-plugin/server/types';
 import type { Stream } from 'stream';
-import type { ExperimentalFeatures } from '../../../common/experimental_features';
 import { OAuthTokenManager } from './o_auth_token_manager';
 import { MICROSOFT_DEFENDER_ENDPOINT_SUB_ACTION } from '../../../common/microsoft_defender_endpoint/constants';
 import {


### PR DESCRIPTION
This PR adds a new sub-action in MDE connector that allows users to Cancel pending actions. 