### PR TITLE
[Data set quality] Fix error for stateful in updateFailureStore

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/update_failure_store/index.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/update_failure_store/index.ts
@@ -30,7 +30,7 @@ export async function updateFailureStore({
           enabled: failureStoreEnabled,
           lifecycle: {
             data_retention: customRetentionPeriod,
-            ...(isServerless ? {} : { enabled: !!customRetentionPeriod }),
+            ...(isServerless ? {} : { enabled: failureStoreEnabled }),
           },
         },
       },


### PR DESCRIPTION
## Summary
I did an error when implementing https://github.com/elastic/kibana/pull/231846. In Stateful, when a data stream has the failure retention period set to default, I set the lifecycle to enabled: false, which is wrong. This is the config for a data stream with failure store enabled by default (before interacting with the modal).
<img width="706" height="326" alt="Screenshot 2025-08-28 at 12 03 44" src="https://github.com/user-attachments/assets/4a0f78d9-f593-4b7c-bfe1-ee7c7eb90aeb" />

Before this PR: The lifecycle is set to false when no custom retention period, so the retention is not determined by the default value, which is incorrect:
<img width="636" height="287" alt="Screenshot 2025-08-28 at 12 04 37" src="https://github.com/user-attachments/assets/387f423f-e3cf-4864-9508-124a60fcc38e" />

With this change: The enabled lifecycle is determined by the enabled fault storage and not by  a customRetentionPeriod being assigned.
<img width="688" height="321" alt="Screenshot 2025-08-28 at 12 05 45" src="https://github.com/user-attachments/assets/7b05b988-96ac-4fd2-a0d3-bbe1663ba926" />


With customPeriod:
<img width="619" height="346" alt="Screenshot 2025-08-28 at 12 27 33" src="https://github.com/user-attachments/assets/1d2d2846-7399-42cd-9f5d-fe96f0b09adc" />


