### PR TITLE
[Discover][DocViewerTable] Clean up and fix memoization of ComponentStyles

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
@@ -20,7 +20,6 @@ import {
   useResizeObserver,
   EuiSwitch,
   type UseEuiTheme,
-  euiFontSize,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
@@ -404,64 +403,6 @@ const componentStyles = {
         },
       },
     }),
-  fieldsGrid: (themeContext: UseEuiTheme) => {
-    const { euiTheme } = themeContext;
-    const { fontSize } = euiFontSize(themeContext, 's');
-
-    return css({
-      '&.euiDataGrid--noControls.euiDataGrid--bordersHorizontal .euiDataGridHeader': {
-        borderTop: 'none',
-      },
-
-      '&.euiDataGrid--headerUnderline .euiDataGridHeader': {
-        borderBottom: euiTheme.border.thin,
-      },
-
-      '& [data-gridcell-column-id="name"] .euiDataGridRowCell__content': {
-        paddingTop: 0,
-        paddingBottom: 0,
-      },
-
-      '& [data-gridcell-column-id="pin_field"] .euiDataGridRowCell__content': {
-        padding: `calc(${euiTheme.size.xs} / 2) 0 0 ${euiTheme.size.xs}`,
-      },
-
-      '.kbnDocViewer__fieldName': {
-        padding: euiTheme.size.xs,
-        paddingLeft: 0,
-        lineHeight: euiTheme.font.lineHeightMultiplier,
-
-        '.euiDataGridRowCell__popover &': {
-          fontSize,
-        },
-      },
-
-      '.kbnDocViewer__fieldName_icon': {
-        paddingTop: `calc(${euiTheme.size.xs} * 1.5)`,
-        lineHeight: euiTheme.font.lineHeightMultiplier,
-      },
-
-      '.kbnDocViewer__fieldName_multiFieldBadge': {
-        margin: `${euiTheme.size.xs} 0`,
-        fontWeight: euiTheme.font.weight.regular,
-        fontFamily: euiTheme.font.family,
-      },
-
-      '.kbnDocViewer__fieldsGrid__pinAction': {
-        opacity: 0,
-      },
-
-      '& [data-gridcell-column-id="pin_field"]:focus-within': {
-        '.kbnDocViewer__fieldsGrid__pinAction': {
-          opacity: 1,
-        },
-      },
-
-      '.euiDataGridRow:hover .kbnDocViewer__fieldsGrid__pinAction': {
-        opacity: 1,
-      },
-    });
-  },
   noFieldsFound: css({
     minHeight: 300,
   }),

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_grid.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_grid.tsx
@@ -314,7 +314,7 @@ const componentStyles = {
   hideDataGridHeader: (themeContext: UseEuiTheme) => {
     const { euiTheme } = themeContext;
     return css({
-      '.euiDataGridHeader': { height: euiTheme.size.l },
+      '.euiDataGridHeader': { height: `calc(${euiTheme.size.base} * 1.25)` },
       '.euiDataGridHeaderCell': { display: 'none' },
     });
   },

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_grid.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_grid.tsx
@@ -103,7 +103,7 @@ export function TableGrid({
   gridStyle,
   hideDataGridHeader = false,
 }: TableGridProps) {
-  const styles = useMemoCss(componentStyles({ hideDataGridHeader }));
+  const styles = useMemoCss(componentStyles);
   const { toasts } = getUnifiedDocViewerServices();
 
   const onToggleColumn = useMemo(() => {
@@ -240,7 +240,7 @@ export function TableGrid({
         defaultMessage: 'Field values',
       })}
       className="kbnDocViewer__fieldsGrid"
-      css={styles.fieldsGrid}
+      css={[styles.fieldsGrid, hideDataGridHeader && styles.hideDataGridHeader]}
       columns={gridColumns}
       toolbarVisibility={false}
       rowCount={rows.length}
@@ -252,71 +252,70 @@ export function TableGrid({
   );
 }
 
-const componentStyles = ({ hideDataGridHeader }: { hideDataGridHeader: boolean }) => {
-  return {
-    fieldsGrid: (themeContext: UseEuiTheme) => {
-      const { euiTheme } = themeContext;
-      const { fontSize } = euiFontSize(themeContext, 's');
+const componentStyles = {
+  fieldsGrid: (themeContext: UseEuiTheme) => {
+    const { euiTheme } = themeContext;
+    const { fontSize } = euiFontSize(themeContext, 's');
 
-      return css({
-        '&.euiDataGrid--noControls.euiDataGrid--bordersHorizontal .euiDataGridHeader': {
-          borderTop: 'none',
+    return css({
+      '&.euiDataGrid--noControls.euiDataGrid--bordersHorizontal .euiDataGridHeader': {
+        borderTop: 'none',
+      },
+
+      '&.euiDataGrid--headerUnderline .euiDataGridHeader': {
+        borderBottom: euiTheme.border.thin,
+      },
+
+      '& [data-gridcell-column-id="name"] .euiDataGridRowCell__content': {
+        paddingTop: 0,
+        paddingBottom: 0,
+      },
+
+      '& [data-gridcell-column-id="pin_field"] .euiDataGridRowCell__content': {
+        padding: `calc(${euiTheme.size.xs} / 2) 0 0 ${euiTheme.size.xs}`,
+      },
+
+      '.kbnDocViewer__fieldName': {
+        padding: euiTheme.size.xs,
+        paddingLeft: 0,
+        lineHeight: euiTheme.font.lineHeightMultiplier,
+
+        '.euiDataGridRowCell__popover &': {
+          fontSize,
         },
+      },
 
-        '&.euiDataGrid--headerUnderline .euiDataGridHeader': {
-          borderBottom: euiTheme.border.thin,
-        },
+      '.kbnDocViewer__fieldName_icon': {
+        paddingTop: `calc(${euiTheme.size.xs} * 1.5)`,
+        lineHeight: euiTheme.font.lineHeightMultiplier,
+      },
 
-        '& [data-gridcell-column-id="name"] .euiDataGridRowCell__content': {
-          paddingTop: 0,
-          paddingBottom: 0,
-        },
+      '.kbnDocViewer__fieldName_multiFieldBadge': {
+        margin: `${euiTheme.size.xs} 0`,
+        fontWeight: euiTheme.font.weight.regular,
+        fontFamily: euiTheme.font.family,
+      },
 
-        '& [data-gridcell-column-id="pin_field"] .euiDataGridRowCell__content': {
-          padding: `calc(${euiTheme.size.xs} / 2) 0 0 ${euiTheme.size.xs}`,
-        },
+      '.kbnDocViewer__fieldsGrid__pinAction': {
+        opacity: 0,
+      },
 
-        '.kbnDocViewer__fieldName': {
-          padding: euiTheme.size.xs,
-          paddingLeft: 0,
-          lineHeight: euiTheme.font.lineHeightMultiplier,
-
-          '.euiDataGridRowCell__popover &': {
-            fontSize,
-          },
-        },
-
-        '.kbnDocViewer__fieldName_icon': {
-          paddingTop: `calc(${euiTheme.size.xs} * 1.5)`,
-          lineHeight: euiTheme.font.lineHeightMultiplier,
-        },
-
-        '.kbnDocViewer__fieldName_multiFieldBadge': {
-          margin: `${euiTheme.size.xs} 0`,
-          fontWeight: euiTheme.font.weight.regular,
-          fontFamily: euiTheme.font.family,
-        },
-
+      '& [data-gridcell-column-id="pin_field"]:focus-within': {
         '.kbnDocViewer__fieldsGrid__pinAction': {
-          opacity: 0,
-        },
-
-        '& [data-gridcell-column-id="pin_field"]:focus-within': {
-          '.kbnDocViewer__fieldsGrid__pinAction': {
-            opacity: 1,
-          },
-        },
-
-        '.euiDataGridRow:hover .kbnDocViewer__fieldsGrid__pinAction': {
           opacity: 1,
         },
-        ...(hideDataGridHeader
-          ? {
-              '.euiDataGridHeader': { height: '20px' }, // use euiTheme variable
-              '.euiDataGridHeaderCell': { display: 'none' },
-            }
-          : {}),
-      });
-    },
-  };
+      },
+
+      '.euiDataGridRow:hover .kbnDocViewer__fieldsGrid__pinAction': {
+        opacity: 1,
+      },
+    });
+  },
+  hideDataGridHeader: (themeContext: UseEuiTheme) => {
+    const { euiTheme } = themeContext;
+    return css({
+      '.euiDataGridHeader': { height: euiTheme.size.l },
+      '.euiDataGridHeaderCell': { display: 'none' },
+    });
+  },
 };


### PR DESCRIPTION
## Summary

Follow-up PR for https://github.com/elastic/kibana/pull/231782

This PR addresses a couple of comments that were left out of the review of the original PR.

The affected components are available in Storybook for exploration and testing:
````
yarn storybook unified_doc_viewer
````