### PR TITLE
[Fleet] fix telemetry error with `sync_integrations`

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -138,6 +138,7 @@ export const fleetAgentsSchema: RootSchema<any> = {
         _meta: {
           description:
             'Boolean field, indicates if remote sync integrations feature is enabled on the remote elasticsearch output',
+          optional: true,
         },
       },
     },


### PR DESCRIPTION
## Summary

Fixed telemetry error showing up in kibana logs when `sync_integrations` is undefined.

```
 [2025-08-28T13:33:53.723+02:00][ERROR][plugins.fleet] Error occurred while sending Fleet Usage telemetry: Error: Failed to validate payload coming from "Event Type 'fleet_agents'":
        - [agents_per_output_type.sync_integrations]: {"expected":"boolean","actual":"undefined","value":"undefined"}
```
