### PR TITLE
[ci] Provision project build tasks with 85g

### DIFF
--- a/.buildkite/pipelines/pull_request/build_project.yml
+++ b/.buildkite/pipelines/pull_request/build_project.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-16
       preemptible: true
+      diskSizeGb: 85
     timeout_in_minutes: 60
     soft_fail: true
     retry:

--- a/.buildkite/pipelines/pull_request/deploy_project.yml
+++ b/.buildkite/pipelines/pull_request/deploy_project.yml
@@ -5,6 +5,7 @@ steps:
     agents:
       machineType: n2-standard-16
       preemptible: true
+      diskSizeGb: 85
     timeout_in_minutes: 60
     retry:
       automatic:

--- a/.buildkite/pipelines/serverless_deployment/build_pr_and_deploy_project.yml
+++ b/.buildkite/pipelines/serverless_deployment/build_pr_and_deploy_project.yml
@@ -62,6 +62,7 @@ steps:
           imageProject: elastic-images-prod
           machineType: n2-standard-16
           preemptible: true
+          diskSizeGb: 85
         timeout_in_minutes: 60
         retry:
           automatic:


### PR DESCRIPTION
## Summary
Increase disk size requests from the default (80gb) to 85g after the introduction of solution-specific builds (https://github.com/elastic/kibana/pull/231017).