### PR TITLE
[Dataset Quality] Increase table loading timeout in tests

### DIFF
--- a/x-pack/solutions/observability/test/functional/page_objects/dataset_quality.ts
+++ b/x-pack/solutions/observability/test/functional/page_objects/dataset_quality.ts
@@ -258,7 +258,7 @@ export function DatasetQualityPageObject({ getPageObjects, getService }: FtrProv
     },
 
     async waitUntilTableLoaded() {
-      await find.waitForDeletedByCssSelector('.euiBasicTable-loading', 20 * 1000);
+      await find.waitForDeletedByCssSelector('.euiBasicTable-loading', 30 * 1000);
     },
 
     async waitUntilSummaryPanelLoaded(isStateful: boolean = true) {


### PR DESCRIPTION
Addresses https://github.com/elastic/kibana/issues/232554
Addresses https://github.com/elastic/kibana/issues/232847
Addresses https://github.com/elastic/kibana/issues/232058

In the screenshots from the failed tests above, the table shows in the loading state and judging from kibana logs, there were no errors on the backend. It could be the case that infrastructure was particularly slow and the table would load eventually.

This change increases the timeout to test this assumption and see if these failures would repeat.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->