### PR TITLE
[Docs] Adds security advisory note to release notes

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -27,7 +27,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 ## 9.1.3 [kibana-9.1.3-release-notes]
 
 :::{important}
-The 9.1.3 release contains fixes for potential security vulnerabilities. Check our [security advisory for more details](https://discuss.elastic.co/c/announcements/security-announcements/31).
+The 9.1.3 release contains fixes for potential security vulnerabilities. Check our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
 :::
 
 ### Fixes [kibana-9.1.3-fixes]
@@ -374,7 +374,7 @@ For the Elastic Security 9.1.0 release information, refer to [Elastic Security S
 ## 9.0.6 [kibana-9.0.6-release-notes]
 
 :::{important}
-The 9.0.6 release contains fixes for potential security vulnerabilities. Check our [security advisory for more details](https://discuss.elastic.co/c/announcements/security-announcements/31).
+The 9.0.6 release contains fixes for potential security vulnerabilities. Check our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
 :::
 
 ### Features and enhancements [kibana-9.0.6-features-enhancements]

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -26,6 +26,10 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 ## 9.1.3 [kibana-9.1.3-release-notes]
 
+:::{important}
+The 9.1.3 release contains fixes for potential security vulnerabilities. Check our [security advisory for more details](https://discuss.elastic.co/c/announcements/security-announcements/31).
+:::
+
 ### Fixes [kibana-9.1.3-fixes]
 
 **Alerting**:
@@ -368,6 +372,10 @@ For the Elastic Security 9.1.0 release information, refer to [Elastic Security S
 * Fixes an issue preventing solution navigation submenu items from being displayed when the navigation is collapsed [#227705]({{kib-pull}}227705).
 
 ## 9.0.6 [kibana-9.0.6-release-notes]
+
+:::{important}
+The 9.0.6 release contains fixes for potential security vulnerabilities. Check our [security advisory for more details](https://discuss.elastic.co/c/announcements/security-announcements/31).
+:::
 
 ### Features and enhancements [kibana-9.0.6-features-enhancements]
 


### PR DESCRIPTION
## Summary

Adds the security advisory note to the 9.0.6 and 9.1.3 release notes.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->