### PR TITLE
[ci] Extract legacy vault access early to prevent vault token expiration

### DIFF
--- a/.buildkite/scripts/common/setup_job_env.sh
+++ b/.buildkite/scripts/common/setup_job_env.sh
@@ -195,14 +195,9 @@ EOF
 
 # Acquire credentials for legacy vault if needed
 {
-  if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
-    VAULT_ROLE_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-role-id)"
-    VAULT_SECRET_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-secret-id)"
-  else
-    VAULT_ROLE_ID="$(vault_get kibana-buildkite-vault-credentials role-id)"
-    VAULT_SECRET_ID="$(vault_get kibana-buildkite-vault-credentials secret-id)"
-  fi
+  VAULT_ROLE_ID="$(vault_get kibana-buildkite-vault-credentials role-id)"
   export VAULT_ROLE_ID
+  VAULT_SECRET_ID="$(vault_get kibana-buildkite-vault-credentials secret-id)"
   export VAULT_SECRET_ID
 }
 

--- a/.buildkite/scripts/common/setup_job_env.sh
+++ b/.buildkite/scripts/common/setup_job_env.sh
@@ -193,6 +193,19 @@ EOF
   vault_get kibana-ci-sa-proxy-key key | base64 -d > "$KIBANA_SERVICE_ACCOUNT_PROXY_KEY"
 }
 
+# Acquire credentials for legacy vault if needed
+{
+  if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
+    VAULT_ROLE_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-role-id)"
+    VAULT_SECRET_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-secret-id)"
+  else
+    VAULT_ROLE_ID="$(vault_get kibana-buildkite-vault-credentials role-id)"
+    VAULT_SECRET_ID="$(vault_get kibana-buildkite-vault-credentials secret-id)"
+  fi
+  export VAULT_ROLE_ID
+  export VAULT_SECRET_ID
+}
+
 # Inject moon remote-cache credentials on CI
 if [[ "${CI:-}" =~ ^(1|true)$ ]]; then
   MOON_REMOTE_CACHE_TOKEN=$(vault_get moon-remote-cache token)

--- a/.buildkite/scripts/common/vault_fns.sh
+++ b/.buildkite/scripts/common/vault_fns.sh
@@ -67,33 +67,11 @@ vault_kv_set() {
   vault kv put "$VAULT_KV_PREFIX/$kv_path" "${fields[@]}"
 }
 
-function get_vault_role_id() {
-  if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
-    VAULT_ROLE_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-role-id)"
-  else
-    VAULT_ROLE_ID="$(vault_get kibana-buildkite-vault-credentials role-id)"
-  fi
-
-  echo "$VAULT_ROLE_ID"
-}
-
-function get_vault_secret_id() {
-    if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
-      VAULT_SECRET_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-secret-id)"
-    else
-      VAULT_SECRET_ID="$(vault_get kibana-buildkite-vault-credentials secret-id)"
-    fi
-
-    echo "$VAULT_SECRET_ID"
-}
-
 function set_in_legacy_vault() {
   key_path=$1
   shift
   fields=("$@")
 
-  VAULT_ROLE_ID="$(get_vault_role_id)"
-  VAULT_SECRET_ID="$(get_vault_secret_id)"
   VAULT_TOKEN_BAK="$VAULT_TOKEN"
 
   # Make sure to either keep this variable name `VAULT_TOKEN` or unset `VAULT_TOKEN`,
@@ -115,8 +93,6 @@ function set_in_legacy_vault() {
 function unset_in_legacy_vault() {
   key_path=$1
 
-  VAULT_ROLE_ID="$(get_vault_role_id)"
-  VAULT_SECRET_ID="$(get_vault_secret_id)"
   VAULT_TOKEN_BAK="$VAULT_TOKEN"
 
   # Make sure to either keep this variable name `VAULT_TOKEN` or unset `VAULT_TOKEN`,

--- a/.buildkite/scripts/steps/artifacts/publish.sh
+++ b/.buildkite/scripts/steps/artifacts/publish.sh
@@ -60,8 +60,6 @@ docker_with_retry pull docker.elastic.co/infra/release-manager:latest
 
 echo "--- Publish artifacts"
 if [[ "$BUILDKITE_BRANCH" == "$KIBANA_BASE_BRANCH" ]] || [[ "${DRY_RUN:-}" =~ ^(1|true)$ ]]; then
-  export VAULT_ROLE_ID="$(get_vault_role_id)"
-  export VAULT_SECRET_ID="$(get_vault_secret_id)"
   export VAULT_ADDR="https://secrets.elastic.co:8200"
 
   download_artifact beats_manifest.json /tmp --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"


### PR DESCRIPTION
## Summary
We're storing the cloud/project deployment credentials in the legacy vault so that developers have an easier time accessing them. However, it can happen, that by the time we get to the deployment part of the buildkite step, the main vault token that's used to retrieve the legacy vault credentials has been expired on the executor.

This PR extracts the required credentials, in case we need to use them to access the legacy vault later in the step.

Context: https://elastic.slack.com/archives/C5UDAFZQU/p1756311203557359

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->