### PR TITLE
[Dataset quality] totalDocs was failing when the number was higher than 1000

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_overview_summary_panel.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_overview_summary_panel.ts
@@ -55,19 +55,17 @@ export const useOverviewSummaryPanel = () => {
   );
 
   const totalFailedDocsCount = formatNumber(dataStreamDetails?.failedDocsCount ?? 0, NUMBER_FORMAT);
+  const totalDocs = (dataStreamDetails.docsCount ?? 0) + (dataStreamDetails?.failedDocsCount ?? 0);
 
-  const totalDocsCount = formatNumber(
-    (dataStreamDetails.docsCount ?? 0) + (dataStreamDetails?.failedDocsCount ?? 0),
-    NUMBER_FORMAT
-  );
+  const totalDocsCount = formatNumber(totalDocs, NUMBER_FORMAT);
 
   const degradedPercentage = calculatePercentage({
-    totalDocs: +totalDocsCount,
+    totalDocs,
     count: dataStreamDetails?.degradedDocsCount,
   });
 
   const failedPercentage = calculatePercentage({
-    totalDocs: +totalDocsCount,
+    totalDocs,
     count: dataStreamDetails?.failedDocsCount,
   });
 


### PR DESCRIPTION
While trying to solve degraded and failed docs percentage in https://github.com/elastic/kibana/pull/233061, we introduced a new bug. The fix it's only working is `totalDocsCount` is less than 1000, after 1000 it gets formatted to `1,000` and using the `+` return a `NaN`

### before this change
<img width="1912" height="1421" alt="image" src="https://github.com/user-attachments/assets/762d7aa9-2944-4c76-89d2-cc02ed46a4cd" />


### After this change
<img width="1914" height="1422" alt="image" src="https://github.com/user-attachments/assets/bc9802d1-6bd5-420a-acf2-97071f337935" />


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->