### PR TITLE
[Controls] Reduce flakiness on ESQL Control Selections test

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.test.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.test.tsx
@@ -58,8 +58,10 @@ describe('initializeESQLControlSelections', () => {
         expect(mockIsSuccess).toHaveBeenCalledTimes(1);
       });
 
-      const availableOptions = selections.internalApi.availableOptions$.getValue();
-      expect(availableOptions?.length).toBe(5);
+      await waitFor(() => {
+        const availableOptions = selections.internalApi.availableOptions$.getValue();
+        expect(availableOptions?.length).toBe(5);
+      });
 
       const latestState = selections.getLatestState();
       expect('availableOptions' in latestState).toBeFalsy();
@@ -90,8 +92,10 @@ describe('initializeESQLControlSelections', () => {
 
       const selections = initializeESQLControlSelections(initialState, controlFetch$, jest.fn());
 
-      const availableOptions = selections.internalApi.availableOptions$.getValue();
-      expect(availableOptions?.length).toBe(2);
+      await waitFor(() => {
+        const availableOptions = selections.internalApi.availableOptions$.getValue();
+        expect(availableOptions?.length).toBe(2);
+      });
 
       const latestState = selections.getLatestState();
       expect(latestState).toMatchInlineSnapshot(`


### PR DESCRIPTION
## Summary

Fixes #232902

Wraps publishing subject assertions in `waitFor` to reduce flakiness on tests for `initializeESQLControlSelections`.




<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->