### PR TITLE
[Security Solution][AI Assistant] Revert conversation mappings changes

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -61660,8 +61660,6 @@ components:
           type: string
         replacements:
           $ref: '#/components/schemas/Security_AI_Assistant_API_Replacements'
-        summary:
-          $ref: '#/components/schemas/Security_AI_Assistant_API_ConversationSummary'
         timestamp:
           $ref: '#/components/schemas/Security_AI_Assistant_API_NonEmptyTimestamp'
         title:
@@ -61684,29 +61682,6 @@ components:
         - users
         - namespace
         - category
-    Security_AI_Assistant_API_ConversationSummary:
-      allOf:
-        - $ref: '#/components/schemas/Security_AI_Assistant_API_ConversationSummaryBase'
-        - type: object
-          properties:
-            timestamp:
-              $ref: '#/components/schemas/Security_AI_Assistant_API_NonEmptyTimestamp'
-              description: The timestamp summary was updated.
-              example: '2025-04-30T16:00:00Z'
-          required:
-            - timestamp
-    Security_AI_Assistant_API_ConversationSummaryBase:
-      type: object
-      properties:
-        semanticContent:
-          description: Summary text of the conversation over time.
-          example: This conversation covered how to configure the Security AI Assistant.
-          type: string
-        summarizedMessageIds:
-          description: The list of summarized messages.
-          items:
-            $ref: '#/components/schemas/Security_AI_Assistant_API_NonEmptyString'
-          type: array
     Security_AI_Assistant_API_ConversationUpdateProps:
       type: object
       properties:
@@ -61729,8 +61704,6 @@ components:
           type: array
         replacements:
           $ref: '#/components/schemas/Security_AI_Assistant_API_Replacements'
-        summary:
-          $ref: '#/components/schemas/Security_AI_Assistant_API_ConversationSummaryBase'
         title:
           description: The conversation title.
           example: Updated Security AI Assistant Setup

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -74215,8 +74215,6 @@ components:
           type: string
         replacements:
           $ref: '#/components/schemas/Security_AI_Assistant_API_Replacements'
-        summary:
-          $ref: '#/components/schemas/Security_AI_Assistant_API_ConversationSummary'
         timestamp:
           $ref: '#/components/schemas/Security_AI_Assistant_API_NonEmptyTimestamp'
         title:
@@ -74239,29 +74237,6 @@ components:
         - users
         - namespace
         - category
-    Security_AI_Assistant_API_ConversationSummary:
-      allOf:
-        - $ref: '#/components/schemas/Security_AI_Assistant_API_ConversationSummaryBase'
-        - type: object
-          properties:
-            timestamp:
-              $ref: '#/components/schemas/Security_AI_Assistant_API_NonEmptyTimestamp'
-              description: The timestamp summary was updated.
-              example: '2025-04-30T16:00:00Z'
-          required:
-            - timestamp
-    Security_AI_Assistant_API_ConversationSummaryBase:
-      type: object
-      properties:
-        semanticContent:
-          description: Summary text of the conversation over time.
-          example: This conversation covered how to configure the Security AI Assistant.
-          type: string
-        summarizedMessageIds:
-          description: The list of summarized messages.
-          items:
-            $ref: '#/components/schemas/Security_AI_Assistant_API_NonEmptyString'
-          type: array
     Security_AI_Assistant_API_ConversationUpdateProps:
       type: object
       properties:
@@ -74284,8 +74259,6 @@ components:
           type: array
         replacements:
           $ref: '#/components/schemas/Security_AI_Assistant_API_Replacements'
-        summary:
-          $ref: '#/components/schemas/Security_AI_Assistant_API_ConversationSummaryBase'
         title:
           description: The conversation title.
           example: Updated Security AI Assistant Setup

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -2032,8 +2032,6 @@ components:
           type: string
         replacements:
           $ref: '#/components/schemas/Replacements'
-        summary:
-          $ref: '#/components/schemas/ConversationSummary'
         timestamp:
           $ref: '#/components/schemas/NonEmptyTimestamp'
         title:
@@ -2056,31 +2054,6 @@ components:
         - users
         - namespace
         - category
-    ConversationSummary:
-      allOf:
-        - $ref: '#/components/schemas/ConversationSummaryBase'
-        - type: object
-          properties:
-            timestamp:
-              $ref: '#/components/schemas/NonEmptyTimestamp'
-              description: The timestamp summary was updated.
-              example: '2025-04-30T16:00:00Z'
-          required:
-            - timestamp
-    ConversationSummaryBase:
-      type: object
-      properties:
-        semanticContent:
-          description: Summary text of the conversation over time.
-          example: >-
-            This conversation covered how to configure the Security AI
-            Assistant.
-          type: string
-        summarizedMessageIds:
-          description: The list of summarized messages.
-          items:
-            $ref: '#/components/schemas/NonEmptyString'
-          type: array
     ConversationUpdateProps:
       type: object
       properties:
@@ -2103,8 +2076,6 @@ components:
           type: array
         replacements:
           $ref: '#/components/schemas/Replacements'
-        summary:
-          $ref: '#/components/schemas/ConversationSummaryBase'
         title:
           description: The conversation title.
           example: Updated Security AI Assistant Setup

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -2032,8 +2032,6 @@ components:
           type: string
         replacements:
           $ref: '#/components/schemas/Replacements'
-        summary:
-          $ref: '#/components/schemas/ConversationSummary'
         timestamp:
           $ref: '#/components/schemas/NonEmptyTimestamp'
         title:
@@ -2056,31 +2054,6 @@ components:
         - users
         - namespace
         - category
-    ConversationSummary:
-      allOf:
-        - $ref: '#/components/schemas/ConversationSummaryBase'
-        - type: object
-          properties:
-            timestamp:
-              $ref: '#/components/schemas/NonEmptyTimestamp'
-              description: The timestamp summary was updated.
-              example: '2025-04-30T16:00:00Z'
-          required:
-            - timestamp
-    ConversationSummaryBase:
-      type: object
-      properties:
-        semanticContent:
-          description: Summary text of the conversation over time.
-          example: >-
-            This conversation covered how to configure the Security AI
-            Assistant.
-          type: string
-        summarizedMessageIds:
-          description: The list of summarized messages.
-          items:
-            $ref: '#/components/schemas/NonEmptyString'
-          type: array
     ConversationUpdateProps:
       type: object
       properties:
@@ -2103,8 +2076,6 @@ components:
           type: array
         replacements:
           $ref: '#/components/schemas/Replacements'
-        summary:
-          $ref: '#/components/schemas/ConversationSummaryBase'
         title:
           description: The conversation title.
           example: Updated Security AI Assistant Setup

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/conversations/common_attributes.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/conversations/common_attributes.gen.ts
@@ -232,14 +232,6 @@ export type ConversationCategoryEnum = typeof ConversationCategory.enum;
 export const ConversationCategoryEnum = ConversationCategory.enum;
 
 /**
- * The conversation confidence.
- */
-export type ConversationConfidence = z.infer<typeof ConversationConfidence>;
-export const ConversationConfidence = z.enum(['low', 'medium', 'high']);
-export type ConversationConfidenceEnum = typeof ConversationConfidence.enum;
-export const ConversationConfidenceEnum = ConversationConfidence.enum;
-
-/**
  * AI assistant conversation message.
  */
 export type Message = z.infer<typeof Message>;
@@ -306,28 +298,6 @@ export const ApiConfig = z.object({
   model: z.string().optional(),
 });
 
-export type ConversationSummaryBase = z.infer<typeof ConversationSummaryBase>;
-export const ConversationSummaryBase = z.object({
-  /**
-   * Summary text of the conversation over time.
-   */
-  semanticContent: z.string().optional(),
-  /**
-   * The list of summarized messages.
-   */
-  summarizedMessageIds: z.array(NonEmptyString).optional(),
-});
-
-export type ConversationSummary = z.infer<typeof ConversationSummary>;
-export const ConversationSummary = ConversationSummaryBase.merge(
-  z.object({
-    /**
-     * The timestamp summary was updated.
-     */
-    timestamp: NonEmptyTimestamp,
-  })
-);
-
 export type ErrorSchema = z.infer<typeof ErrorSchema>;
 export const ErrorSchema = z
   .object({
@@ -350,7 +320,6 @@ export const ConversationResponse = z.object({
    * The conversation category.
    */
   category: ConversationCategory,
-  summary: ConversationSummary.optional(),
   timestamp: NonEmptyTimestamp.optional(),
   /**
    * The last time conversation was updated.
@@ -403,7 +372,6 @@ export const ConversationUpdateProps = z.object({
    * LLM API configuration.
    */
   apiConfig: ApiConfig.optional(),
-  summary: ConversationSummaryBase.optional(),
   /**
    * Exclude from last conversation storage.
    */

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/conversations/common_attributes.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/conversations/common_attributes.schema.yaml
@@ -236,15 +236,6 @@ components:
         - insights
       example: 'assistant'
 
-    ConversationConfidence:
-      type: string
-      description: The conversation confidence.
-      enum:
-        - low
-        - medium
-        - high
-      example: 'high'
-
     Message:
       type: object
       description: AI assistant conversation message.
@@ -312,31 +303,6 @@ components:
           description: Model
           example: 'gpt-4'
 
-    ConversationSummaryBase:
-      type: object
-      properties:
-        semanticContent:
-          type: string
-          description: Summary text of the conversation over time.
-          example: 'This conversation covered how to configure the Security AI Assistant.'
-        summarizedMessageIds:
-          type: array
-          description: The list of summarized messages.
-          items:
-            $ref: '../common_attributes.schema.yaml#/components/schemas/NonEmptyString'
-
-    ConversationSummary:
-      allOf:
-        - $ref: '#/components/schemas/ConversationSummaryBase'
-        - type: object
-          required:
-            - timestamp
-          properties:
-            timestamp:
-              $ref: '../common_attributes.schema.yaml#/components/schemas/NonEmptyTimestamp'
-              description: The timestamp summary was updated.
-              example: '2025-04-30T16:00:00Z'
-
     ErrorSchema:
       type: object
       required:
@@ -380,8 +346,6 @@ components:
           $ref: '#/components/schemas/ConversationCategory'
           description: The conversation category.
           example: 'assistant'
-        summary:
-          $ref: '#/components/schemas/ConversationSummary'
         timestamp:
           $ref: '../common_attributes.schema.yaml#/components/schemas/NonEmptyTimestamp'
         updatedAt:
@@ -440,8 +404,6 @@ components:
         apiConfig:
           $ref: '#/components/schemas/ApiConfig'
           description: LLM API configuration.
-        summary:
-          $ref: '#/components/schemas/ConversationSummaryBase'
         excludeFromLastConversationStorage:
           description: Exclude from last conversation storage.
           type: boolean

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/conversations_schema.mock.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/conversations_schema.mock.ts
@@ -14,7 +14,6 @@ import type {
   ConversationResponse,
   DeleteAllConversationsRequestBody,
   ConversationUpdateProps,
-  ConversationSummary,
 } from '@kbn/elastic-assistant-common';
 import type {
   CreateMessageSchema,
@@ -100,7 +99,7 @@ export const getDeleteAllConversationsSchemaMock = (): DeleteAllConversationsReq
 
 export const getUpdateConversationSchemaMock = (
   conversationId = 'conversation-1'
-): ConversationUpdateProps & { summary?: ConversationSummary } => ({
+): ConversationUpdateProps => ({
   title: 'Welcome 2',
   apiConfig: {
     actionTypeId: '.gen-ai',
@@ -138,9 +137,7 @@ export const getAppendConversationMessagesSchemaMock =
     ],
   });
 
-export type ConversationMockParams = (ConversationCreateProps | ConversationUpdateProps) & {
-  summary?: ConversationSummary;
-};
+export type ConversationMockParams = ConversationCreateProps | ConversationUpdateProps;
 
 export const getConversationMock = (params: ConversationMockParams): ConversationResponse => ({
   id: '04128c15-0d1b-4716-a4c5-46997ac7f3bd',

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/field_maps_configuration.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/field_maps_configuration.ts
@@ -5,28 +5,6 @@
  * 2.0.
  */
 import type { FieldMap } from '@kbn/data-stream-adapter';
-import { defaultInferenceEndpoints } from '@kbn/inference-common';
-
-/**
- * These are legacy fields that were never used, but we cannot just remove it from mapping.
- */
-const legacySummaryFields: FieldMap = {
-  'summary.content': {
-    type: 'text',
-    array: false,
-    required: false,
-  },
-  'summary.public': {
-    type: 'boolean',
-    array: false,
-    required: false,
-  },
-  'summary.confidence': {
-    type: 'keyword',
-    array: false,
-    required: false,
-  },
-};
 
 export const conversationsFieldMap: FieldMap = {
   '@timestamp': {
@@ -164,23 +142,26 @@ export const conversationsFieldMap: FieldMap = {
     array: false,
     required: false,
   },
+  'summary.content': {
+    type: 'text',
+    array: false,
+    required: false,
+  },
   'summary.@timestamp': {
     type: 'date',
     array: false,
     required: true,
   },
-  'summary.semantic_content': {
-    type: 'semantic_text',
+  'summary.public': {
+    type: 'boolean',
     array: false,
     required: false,
-    inference_id: defaultInferenceEndpoints.ELSER,
   },
-  'summary.summarized_message_ids': {
+  'summary.confidence': {
     type: 'keyword',
-    array: true,
+    array: false,
     required: false,
   },
-  ...legacySummaryFields,
   api_config: {
     type: 'object',
     array: false,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/get_conversation.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/get_conversation.test.ts
@@ -30,10 +30,6 @@ export const getConversationResponseMock = (): ConversationResponse => ({
     model: 'test',
     provider: 'Azure OpenAI',
   },
-  summary: {
-    timestamp: '2020-04-20T15:25:31.830Z',
-    semanticContent: 'test',
-  },
   category: 'assistant',
   users: [
     {
@@ -79,10 +75,6 @@ export const getSearchConversationMock = (): estypes.SearchResponse<EsConversati
             default_system_prompt_id: 'prompt-1',
             model: 'test',
             provider: 'Azure OpenAI',
-          },
-          summary: {
-            '@timestamp': '2020-04-20T15:25:31.830Z',
-            semantic_content: 'test',
           },
           category: 'assistant',
           users: [

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/helpers.test.ts
@@ -10,10 +10,6 @@ import type { UpdateConversationSchema } from './update_conversation';
 
 const getUpdateConversationMock = (): UpdateConversationSchema => {
   return {
-    summary: {
-      '@timestamp': '2025-08-19T13:26:01.746Z',
-      semantic_content: 'Very nice demo semantic content 4.',
-    },
     updated_at: '2025-08-19T13:26:01.746Z',
     api_config: {
       action_type_id: '.gen-ai',

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transform.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transform.test.ts
@@ -21,10 +21,6 @@ const userAsUser = {
 
 const getEsConversationMock = (): EsConversationSchema => {
   return {
-    summary: {
-      '@timestamp': '2025-08-19T13:26:01.746Z',
-      semantic_content: 'Very nice demo semantic content 4.',
-    },
     '@timestamp': '2025-08-19T10:49:52.884Z',
     updated_at: '2025-08-19T13:26:01.746Z',
     api_config: {
@@ -120,10 +116,6 @@ describe('transforms', () => {
         users: [userAsUser],
         title: 'Viewing the Number of Open Alerts in Elastic Security',
         category: 'assistant',
-        summary: {
-          timestamp: '2025-08-19T13:26:01.746Z',
-          semanticContent: 'Very nice demo semantic content 4.',
-        },
         apiConfig: { actionTypeId: '.gen-ai', connectorId: 'gpt-4-1' },
         messages: [
           {
@@ -162,10 +154,6 @@ describe('transforms', () => {
           users: [userAsUser],
           title: 'Viewing the Number of Open Alerts in Elastic Security',
           category: 'assistant',
-          summary: {
-            timestamp: '2025-08-19T13:26:01.746Z',
-            semanticContent: 'Very nice demo semantic content 4.',
-          },
           apiConfig: { actionTypeId: '.gen-ai', connectorId: 'gpt-4-1' },
           messages: [
             {
@@ -207,10 +195,6 @@ describe('transforms', () => {
           users: [userAsUser],
           title: 'Viewing the Number of Open Alerts in Elastic Security',
           category: 'assistant',
-          summary: {
-            timestamp: '2025-08-19T13:26:01.746Z',
-            semanticContent: 'Very nice demo semantic content 4.',
-          },
           apiConfig: { actionTypeId: '.gen-ai', connectorId: 'gpt-4-1' },
           messages: [
             {
@@ -255,10 +239,6 @@ describe('transforms', () => {
         'apiConfig.defaultSystemPromptId',
         'apiConfig.model',
         'apiConfig.provider',
-        'summary',
-        'summary.timestamp',
-        'summary.semanticContent',
-        'summary.summarizedMessageIds',
       ];
       const sourceNames = transformFieldNamesToSourceScheme(fields);
       expect(sourceNames).toEqual([
@@ -269,10 +249,6 @@ describe('transforms', () => {
         'api_config.default_system_prompt_id',
         'api_config.model',
         'api_config.provider',
-        'summary',
-        'summary.@timestamp',
-        'summary.semantic_content',
-        'summary.summarized_message_ids',
       ]);
     });
   });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transforms.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transforms.ts
@@ -29,15 +29,6 @@ export const transformESToConversation = (
       })) ?? [],
     title: conversationSchema.title,
     category: conversationSchema.category,
-    ...(conversationSchema.summary
-      ? {
-          summary: {
-            timestamp: conversationSchema.summary['@timestamp'],
-            semanticContent: conversationSchema.summary.semantic_content,
-            summarizedMessageIds: conversationSchema.summary.summarized_message_ids,
-          },
-        }
-      : {}),
     ...(conversationSchema.api_config
       ? {
           apiConfig: {
@@ -132,12 +123,6 @@ export const transformFieldNamesToSourceScheme = (fields: string[]) => {
         return 'api_config.model';
       case 'apiConfig.provider':
         return 'api_config.provider';
-      case 'summary.timestamp':
-        return 'summary.@timestamp';
-      case 'summary.semanticContent':
-        return 'summary.semantic_content';
-      case 'summary.summarizedMessageIds':
-        return 'summary.summarized_message_ids';
       default:
         return _.snakeCase(f);
     }

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/types.ts
@@ -22,11 +22,6 @@ export interface EsConversationSchema {
   '@timestamp': string;
   created_at: string;
   title: string;
-  summary?: {
-    '@timestamp': string;
-    semantic_content?: string;
-    summarized_message_ids?: string[];
-  };
   category: ConversationCategory;
   messages?: Array<{
     '@timestamp': string;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/update_conversation.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/update_conversation.test.ts
@@ -27,9 +27,6 @@ export const getUpdateConversationOptionsMock = (): ConversationUpdateProps => (
   excludeFromLastConversationStorage: false,
   messages: [],
   replacements: {},
-  summary: {
-    semanticContent: 'Updated semantic content.',
-  },
 });
 
 const mockUser1 = authenticatedUser;
@@ -39,10 +36,6 @@ const userAsUser = {
 };
 const getEsConversationMock = (): EsConversationSchema => {
   return {
-    summary: {
-      '@timestamp': '2025-08-19T13:26:01.746Z',
-      semantic_content: 'Very nice demo semantic content 4.',
-    },
     '@timestamp': '2025-08-19T10:49:52.884Z',
     updated_at: '2025-08-19T13:26:01.746Z',
     api_config: {
@@ -143,11 +136,6 @@ describe('updateConversation', () => {
           id: 'test',
           messages: [],
           replacements: [],
-          summary: {
-            '@timestamp': expect.anything(),
-            semantic_content: 'Updated semantic content.',
-            summarized_message_ids: undefined,
-          },
           title: 'test',
           updated_at: expect.anything(),
         },
@@ -179,10 +167,6 @@ describe('updateConversation', () => {
       users: [userAsUser],
       title: 'Viewing the Number of Open Alerts in Elastic Security',
       category: 'assistant',
-      summary: {
-        timestamp: '2025-08-19T13:26:01.746Z',
-        semanticContent: 'Very nice demo semantic content 4.',
-      },
       apiConfig: {
         actionTypeId: '.gen-ai',
         connectorId: 'gpt-4-1',
@@ -323,10 +307,6 @@ describe('transformToUpdateScheme', () => {
           role: 'user',
         },
       ],
-      summary: {
-        '@timestamp': updateAt,
-        semantic_content: 'Updated semantic content.',
-      },
     };
     expect(transformed).toEqual(expected);
   });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/update_conversation.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/update_conversation.ts
@@ -47,11 +47,6 @@ export interface UpdateConversationSchema {
     provider?: Provider;
     model?: string;
   };
-  summary?: {
-    '@timestamp': string;
-    semantic_content?: string;
-    summarized_message_ids?: UUID[];
-  };
   exclude_from_last_conversation_storage?: boolean;
   replacements?: EsReplacementSchema[];
   updated_at?: string;
@@ -104,7 +99,6 @@ export const transformToUpdateScheme = (
     replacements,
     id,
     users,
-    summary,
   }: ConversationUpdateProps
 ): UpdateConversationSchema => {
   return {
@@ -163,15 +157,6 @@ export const transformToUpdateScheme = (
                 }
               : {}),
           })),
-        }
-      : {}),
-    ...(summary
-      ? {
-          summary: {
-            '@timestamp': updatedAt,
-            semantic_content: summary.semanticContent,
-            summarized_message_ids: summary.summarizedMessageIds,
-          },
         }
       : {}),
   };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/find.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/find.test.ts
@@ -42,10 +42,6 @@ export const getSearchConversationMock = (): estypes.SearchResponse<EsConversati
             model: 'test',
             provider: 'Azure OpenAI',
           },
-          summary: {
-            '@timestamp': '2020-04-20T15:25:31.830Z',
-            semantic_content: 'test',
-          },
           category: 'assistant',
           users: [
             {
@@ -121,10 +117,6 @@ describe('findDocuments', () => {
                 messages: [],
                 namespace: 'default',
                 replacements: undefined,
-                summary: {
-                  '@timestamp': '2020-04-20T15:25:31.830Z',
-                  semantic_content: 'test',
-                },
                 title: 'title-1',
                 updated_at: '2020-04-20T15:25:31.830Z',
                 users: [


### PR DESCRIPTION
## Summary

Epic: https://github.com/elastic/security-team/issues/12768
Meta: https://github.com/elastic/security-team/issues/13657
RFC: [internal link](https://docs.google.com/document/d/13jAJ5Q3_At_zAuwKjvpYehnM5uzKJSwZIZ1aJJNAf5k)

This PR reverts conversation mappings changes introduced in https://github.com/elastic/kibana/pull/232288. Since we decided to put on hold the Using Past Conversation as Context feature, we decided to remove added summary field backed by the `semantic_text` field to avoid potential issues that users mights have when updating a conversation while the inference endpoint is not available.

**Changes**:
* Removed mapping fields: `semantic_content` and `summarized_message_ids`
* As part of these changes, the `summary` field was hidden on the API level and conversations response object won't have it anymore
