### PR TITLE
[ES|QL] LOOKUP JOIN - Dont show save button if nothing to save

### DIFF
--- a/src/platform/packages/private/kbn-index-editor/src/components/error_callout.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/error_callout.tsx
@@ -52,12 +52,6 @@ const errorTitles: Record<IndexEditorErrors, string> = {
       defaultMessage: 'An error occurred while analyzing the files.',
     }
   ),
-  [IndexEditorErrors.NO_DATA_TO_SAVE_ERROR]: i18n.translate(
-    'indexEditor.flyout.error.noDataToSaveError',
-    {
-      defaultMessage: 'The operations taken resulted in no data to save',
-    }
-  ),
 };
 
 export const ErrorCallout = () => {

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.test.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.test.ts
@@ -68,7 +68,6 @@ describe('IndexUpdateService', () => {
     service.setIndexName('my-index');
 
     const updates = [
-      { type: 'add-doc', payload: { id: 'abc123', value: { a: 1 } } },
       {
         type: 'add-doc',
         payload: { id: `${ROW_PLACEHOLDER_PREFIX}xyz`, value: { b: 2 } },

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -565,15 +565,6 @@ export class IndexUpdateService {
           next: ({ updates, response, bulkOperations, exitAfterFlush, docs, savingDocs }) => {
             this._isSaving$.next(false);
 
-            if (!bulkOperations.length) {
-              this.setError(IndexEditorErrors.NO_DATA_TO_SAVE_ERROR);
-              this.addAction('saved', {
-                response,
-                updates: [],
-              });
-              return;
-            }
-
             if (!response.errors) {
               if (exitAfterFlush) {
                 this.destroy();

--- a/src/platform/packages/private/kbn-index-editor/src/types.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/types.ts
@@ -74,7 +74,6 @@ export interface IndexEditorError {
 
 export enum IndexEditorErrors {
   GENERIC_SAVING_ERROR = 'genericSavingError',
-  NO_DATA_TO_SAVE_ERROR = 'noDataToSaveError',
   PARTIAL_SAVING_ERROR = 'partialSavingError',
   FILE_REJECTION_ERROR = 'fileRejectionError',
   FILE_TOO_BIG_ERROR = 'fileTooBigError',


### PR DESCRIPTION
## Summary
If operations result in nothing to save, don't show save button, for instance adding a new row and then deleting it.


