### PR TITLE
fix: log rate charts not working

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/host_charts.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/host_charts.tsx
@@ -31,7 +31,7 @@ export const HostCharts = React.forwardRef<HTMLDivElement, Props>(
   ({ entityId, dataView, dateRange, metric, onShowAll, overview = false, schema }, ref) => {
     const { charts } = useHostCharts({
       metric,
-      dataViewId: dataView?.id,
+      dataViewId: dataView?.getIndexPattern(),
       overview,
       schema,
     });


### PR DESCRIPTION
Changed the incorrect index pattern in Lens:

[https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/host_charts.tsx#L34](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/host_charts.tsx#L34)

from `dataview?.id` to `dataview?.getIndexPattern()`. Fix to Issue #233401.