### PR TITLE
Skip serverless search index details test suite for MKI

### DIFF
--- a/x-pack/solutions/search/test/serverless/functional/test_suites/search_index_detail.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/search_index_detail.ts
@@ -49,6 +49,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   };
 
   describe('index details page - search solution', function () {
+    // fails on MKI, see https://github.com/elastic/kibana/issues/233476
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       await createIndices();
     });


### PR DESCRIPTION
## Summary

This PR skips the serverless search index details test suite for MKI runs.
Details about the test failure in #233476.