### PR TITLE
[9.0] [Fleet] Fix unexpected logsdb rollover (#232817)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -2482,5 +2482,56 @@ describe('EPM template', () => {
         })
       );
     });
+
+    it('should not rollover when package do not define index mode and defaut source mode is logsdb', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.indices.getDataStream.mockResponse({
+        data_streams: [{ name: 'logs.prefix1-default' }],
+      } as any);
+      esClient.indices.get.mockResponse({
+        'logs.prefix1-default': {
+          mappings: {},
+          settings: {
+            index: {
+              mode: 'logsdb',
+              mapping: {
+                source: {
+                  mode: 'STORED',
+                },
+              },
+            },
+          },
+        },
+      } as any);
+      esClient.indices.simulateTemplate.mockResponse({
+        template: {
+          settings: { index: {} },
+          mappings: {},
+        },
+      } as any);
+
+      const logger = loggerMock.create();
+      await updateCurrentWriteIndices(esClient, logger, [
+        {
+          templateName: 'logs.prefix1',
+          indexTemplate: {
+            index_patterns: ['logs.prefix1-*'],
+            template: {
+              settings: { index: {} },
+              mappings: {},
+            },
+          } as any,
+        },
+      ]);
+
+      expect(esClient.transport.request).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/test.prefix1-default/_rollover',
+          querystring: {
+            lazy: true,
+          },
+        })
+      );
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -1160,11 +1160,16 @@ const updateExistingDataStream = async ({
     updatedDynamicDimensionMappings.sort(sortMappings)
   );
 
+  const packageDefinedIndexMode = settings?.index?.mode;
+  // @ts-expect-error Property 'source.mode' does not exist on type 'IndicesMappingLimitSettings'
+  const packageDefinedSourceMode = settings?.index?.mapping?.source?.mode;
+
   // Trigger a rollover if the index mode or source type has changed
   if (
-    currentIndexMode !== settings?.index?.mode ||
-    // @ts-expect-error Property 'source.mode' does not exist on type 'IndicesMappingLimitSettings'
-    currentSourceType !== settings?.index?.mapping?.source?.mode ||
+    (packageDefinedIndexMode !== undefined && currentIndexMode !== settings?.index?.mode) ||
+    (packageDefinedSourceMode !== undefined &&
+      // @ts-expect-error Property 'source.mode' does not exist on type 'IndicesMappingLimitSettings'
+      currentSourceType !== settings?.index?.mapping?.source?.mode) ||
     dynamicDimensionMappingsChanged
   ) {
     if (options?.skipDataStreamRollover === true) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Fleet] Fix unexpected logsdb rollover (#232817)](https://github.com/elastic/kibana/pull/232817)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-08-25T18:30:41Z","message":"[Fleet] Fix unexpected logsdb rollover (#232817)","sha":"fff236bff7a7c6d489130892b4f8374286e4b4fb","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Fleet","backport:prev-minor","backport:prev-major","v9.2.0","v9.1.3","v8.19.3"],"title":"[Fleet] Fix unexpected logsdb rollover","number":232817,"url":"https://github.com/elastic/kibana/pull/232817","mergeCommit":{"message":"[Fleet] Fix unexpected logsdb rollover (#232817)","sha":"fff236bff7a7c6d489130892b4f8374286e4b4fb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232817","number":232817,"mergeCommit":{"message":"[Fleet] Fix unexpected logsdb rollover (#232817)","sha":"fff236bff7a7c6d489130892b4f8374286e4b4fb"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232846","number":232846,"state":"MERGED","mergeCommit":{"sha":"283112e9ff73882944896c4010e9017c05f6afc8","message":"[9.1] [Fleet] Fix unexpected logsdb rollover (#232817) (#232846)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Fleet] Fix unexpected logsdb rollover\n(#232817)](https://github.com/elastic/kibana/pull/232817)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>"}},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232843","number":232843,"state":"MERGED","mergeCommit":{"sha":"431f59d86ba33a08ca3f2b32998eb0881638ae8c","message":"[8.19] [Fleet] Fix unexpected logsdb rollover (#232817) (#232843)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Fleet] Fix unexpected logsdb rollover\n(#232817)](https://github.com/elastic/kibana/pull/232817)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>"}},{"url":"https://github.com/elastic/kibana/pull/232960","number":232960,"branch":"deploy-fix@1756102496","state":"MERGED","mergeCommit":{"sha":"30732a8c07286b74200022134a529b4d6f9af807","message":"Fix Fleet rollover (#232960)\n\n## Summary\n\nPR containing:\n* https://github.com/elastic/kibana/pull/232830\n* https://github.com/elastic/kibana/pull/232817 \n\nThose fixes avoid infinite rollover for project using cloud connectors"}}]}] BACKPORT-->