### PR TITLE
chore(login form): Fix layout for Login assistance message

### DIFF
--- a/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/login_form.scss
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/login_form.scss
@@ -51,7 +51,7 @@
 
 .secLoginAssistanceMessage {
   // This tightens up the layout if message is present
-  margin-top: -($euiSizeXXL + $euiSizeS);
+  margin-top: -($euiSizeXL);
   padding: 0 $euiSize;
 
   img {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/227824

Fixes margin for EUI Horizontal rule component when Login Assistance Message is present


### Test
Run kibana with the following setting in kibana.(dev.)yaml
```
xpack.security.loginAssistanceMessage: Test Login assistance message
```
On main vs this PR branch, you should see the difference as shown below.


| Main | After fix |
|--------|--------|
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/ab00606f-aaf2-446f-9118-4f8ce30bf6bb" /> | <img width="500" alt="Screenshot 2025-08-29 at 15 39 42" src="https://github.com/user-attachments/assets/0bdc8948-00a5-4b5f-b4fb-52f0ae04709c" /> |





<!--ONMERGE {"backportTargets":["8.18","8.19","9.1"]} ONMERGE-->