### PR TITLE
[Search][Homepage] re-arrange sections to move docs above alt solutions

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
@@ -33,13 +33,13 @@ export const SearchHomepageBody = () => {
           <EuiHorizontalRule />
         </EuiFlexItem>
         <EuiFlexItem>
-          <AlternateSolutions />
+          <DiveDeeperWithElasticsearch />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiHorizontalRule />
         </EuiFlexItem>
         <EuiFlexItem>
-          <DiveDeeperWithElasticsearch />
+          <AlternateSolutions />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiHorizontalRule />


### PR DESCRIPTION
## Summary

Moves the docs section above the alternate solution section on the search homepage

### Screenshot
<img width="1704" height="1192" alt="image" src="https://github.com/user-attachments/assets/42a74cde-cec6-4dcf-be2c-837164686fc8" />

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



