### PR TITLE
search: skip es3 index details error test (flake)

### DIFF
--- a/x-pack/solutions/search/test/serverless/functional/test_suites/search_index_detail.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/search_index_detail.ts
@@ -204,7 +204,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           });
         });
 
-        describe('page loading error', () => {
+        describe.skip('page loading error', () => {
           before(async () => {
             // manually navigate to index detail page for an index that doesn't exist
             await pageObjects.common.navigateToApp(


### PR DESCRIPTION
## Summary

Skipping flakey test while I diagnose root cause