### PR TITLE
[9.1] [ML][AI Connector] Ensure testing validation for Elastic Managed LLM works as expected (#231873)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference/inference.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference/inference.test.tsx
@@ -91,7 +91,7 @@ describe('OpenAI action params validation', () => {
 
     expect(await actionTypeModel.validateParams(actionParams)).toEqual({
       errors: {
-        body: ['Messages is required.'],
+        body: ['The request body is not in a valid JSON format.'],
         inputType: [],
         query: [],
         subAction: [],

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference/inference.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference/inference.tsx
@@ -58,9 +58,20 @@ export function getConnectorType(): InferenceConnector {
         subAction === SUB_ACTION.UNIFIED_COMPLETION_STREAM ||
         subAction === SUB_ACTION.UNIFIED_COMPLETION_ASYNC_ITERATOR
       ) {
+        let parsedBody;
+        try {
+          // Attempt to parse the body only if it is a string, otherwise it is already an object
+          parsedBody =
+            typeof subActionParams.body === 'string'
+              ? JSON.parse(subActionParams.body)
+              : subActionParams.body;
+        } catch {
+          errors.body.push(translations.BODY_INVALID);
+        }
+
         if (
-          !Array.isArray(subActionParams.body.messages) ||
-          !subActionParams.body.messages.length
+          parsedBody &&
+          (!parsedBody.messages?.length || !Array.isArray(subActionParams.body.messages))
         ) {
           errors.body.push(translations.getRequiredMessage('Messages'));
         }

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference/params.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference/params.tsx
@@ -195,7 +195,14 @@ const UnifiedCompletionParamsFields: React.FunctionComponent<{
         label={i18n.BODY}
         errors={errors.body as string[]}
         onDocumentsChange={(json: string) => {
-          editSubActionParams({ body: JSON.parse(json) });
+          let parsedJson;
+          try {
+            parsedJson = JSON.parse(json);
+          } catch (e) {
+            // If the JSON is invalid, we keep the original string so it can go through validation
+          }
+          // Update with parsedJson, when valid, to ensure the body is sent as an object when action params are submitted
+          editSubActionParams({ body: parsedJson ?? json });
         }}
         onBlur={() => {
           if (!subActionParams.body) {

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference/translations.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference/translations.ts
@@ -105,3 +105,10 @@ export const COPIED_TOOLTIP = i18n.translate(
     defaultMessage: 'Copied!',
   }
 );
+
+export const BODY_INVALID = i18n.translate(
+  'xpack.stackConnectors.components.inference.error.invalidBodyText',
+  {
+    defaultMessage: 'The request body is not in a valid JSON format.',
+  }
+);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ML][AI Connector] Ensure testing validation for Elastic Managed LLM works as expected (#231873)](https://github.com/elastic/kibana/pull/231873)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Melissa Alvarez","email":"melissa.alvarez@elastic.co"},"sourceCommit":{"committedDate":"2025-08-27T19:35:05Z","message":"[ML][AI Connector] Ensure testing validation for Elastic Managed LLM works as expected (#231873)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/222006\n### TODO: Needs to be backported to 9.1.4\n(After Aug 28)\n\nProblem was occurring in the `UnifiedCompletionParamsFields` component\nin the `onDocumentChange` - `JSON.parse(json)` had an unhandled error\nwhen the string was not valid JSON. This was preventing the validation\nfrom running and allowing the `Run` button to remain active.\n\nThis PR handles the case of invalid JSON and updates messaging for the\nuser when that is the case. The `Run` button is now disabled when the\ntest string is invalid JSON.\n\n\n\nhttps://github.com/user-attachments/assets/3c206596-3bd2-409a-8d31-fbc5b8a7c491\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Dima Arnautov <arnautov.dima@gmail.com>","sha":"00ad9b9ed09355a65220d90ac6961c8685313da7","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","backport:skip","Feature:Inference UI","v9.2.0"],"title":"[ML][AI Connector] Ensure testing validation for Elastic Managed LLM works as expected","number":231873,"url":"https://github.com/elastic/kibana/pull/231873","mergeCommit":{"message":"[ML][AI Connector] Ensure testing validation for Elastic Managed LLM works as expected (#231873)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/222006\n### TODO: Needs to be backported to 9.1.4\n(After Aug 28)\n\nProblem was occurring in the `UnifiedCompletionParamsFields` component\nin the `onDocumentChange` - `JSON.parse(json)` had an unhandled error\nwhen the string was not valid JSON. This was preventing the validation\nfrom running and allowing the `Run` button to remain active.\n\nThis PR handles the case of invalid JSON and updates messaging for the\nuser when that is the case. The `Run` button is now disabled when the\ntest string is invalid JSON.\n\n\n\nhttps://github.com/user-attachments/assets/3c206596-3bd2-409a-8d31-fbc5b8a7c491\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Dima Arnautov <arnautov.dima@gmail.com>","sha":"00ad9b9ed09355a65220d90ac6961c8685313da7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231873","number":231873,"mergeCommit":{"message":"[ML][AI Connector] Ensure testing validation for Elastic Managed LLM works as expected (#231873)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/222006\n### TODO: Needs to be backported to 9.1.4\n(After Aug 28)\n\nProblem was occurring in the `UnifiedCompletionParamsFields` component\nin the `onDocumentChange` - `JSON.parse(json)` had an unhandled error\nwhen the string was not valid JSON. This was preventing the validation\nfrom running and allowing the `Run` button to remain active.\n\nThis PR handles the case of invalid JSON and updates messaging for the\nuser when that is the case. The `Run` button is now disabled when the\ntest string is invalid JSON.\n\n\n\nhttps://github.com/user-attachments/assets/3c206596-3bd2-409a-8d31-fbc5b8a7c491\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Dima Arnautov <arnautov.dima@gmail.com>","sha":"00ad9b9ed09355a65220d90ac6961c8685313da7"}}]}] BACKPORT-->