### PR TITLE
Adds documentation of baseline screenshotting network policy to disallow external

### DIFF
--- a/docs/reference/configuration-reference/reporting-settings.md
+++ b/docs/reference/configuration-reference/reporting-settings.md
@@ -196,6 +196,15 @@ xpack.screenshotting.networkPolicy:
   rules: [ { allow: true, host: "elastic.co", protocol: "https:" } ]
 ```
 
+Example of a baseline configuration for disallowing all requests to external paths:
+```yaml
+xpack.screenshotting.networkPolicy:
+  rules: [ { allow: true, host: "localhost:5601", protocol: "http:" } ]
+```
+::::{note}
+Typically, Chromium will connect to Kibana on a local interface, but this may be different based on the environment and specific [headless browser connection settings](#reporting-kibana-server-settings).
+::::
+
 A final `allow` rule with no host or protocol allows all requests that are not explicitly denied:
 
 ```yaml

--- a/docs/reference/configuration-reference/reporting-settings.md
+++ b/docs/reference/configuration-reference/reporting-settings.md
@@ -202,7 +202,7 @@ xpack.screenshotting.networkPolicy:
   rules: [ { allow: true, host: "localhost:5601", protocol: "http:" } ]
 ```
 ::::{note}
-Typically, Chromium will connect to Kibana on a local interface, but this may be different based on the environment and specific [headless browser connection settings](#reporting-kibana-server-settings).
+Typically, Chromium will connect to {{kib}} on a local interface, but this may be different based on the environment and specific [headless browser connection settings](#reporting-kibana-server-settings).
 ::::
 
 A final `allow` rule with no host or protocol allows all requests that are not explicitly denied:


### PR DESCRIPTION
## Summary

Adds an example of a baseline screenshotting network policy to disallowing all requests to external paths.

<!--ONMERGE {"backportTargets":["9.0","9.1"]} ONMERGE-->