### PR TITLE
[DOCS][Reporting] Adds documentation of baseline screenshotting network policy to disallow external

### DIFF
--- a/docs/settings/reporting-settings.asciidoc
+++ b/docs/settings/reporting-settings.asciidoc
@@ -241,6 +241,16 @@ xpack.screenshotting.networkPolicy:
   rules: [ { allow: true, host: "elastic.co", protocol: "https:" } ]
 -------------------------------------------------------
 
+Example of a baseline configuration for disallowing all requests to external paths:
+
+[source,yaml]
+-------------------------------------------------------
+xpack.screenshotting.networkPolicy:
+  rules: [ { allow: true, host: "localhost:5601", protocol: "http:" } ]
+-------------------------------------------------------
+
+NOTE: Typically, Chromium will connect to {kib} on a local interface, but this may be different based on the environment and specific <<reporting-kibana-server-settings>>.
+
 A final `allow` rule with no host or protocol allows all requests that are not explicitly denied:
 
 [source,yaml]


### PR DESCRIPTION
## Summary

Updates the 8.18 and 8.19 docs to include an example of a baseline screenshotting network policy to disallowing all requests to external paths. 

Corresponding 9.x/Serverless docs updates: https://github.com/elastic/kibana/pull/233522


