### PR TITLE
[8.19] [Security Solution] [Detections] Fix flakey EQL shard test (#215757)

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql.ts
@@ -54,7 +54,6 @@ import {
   deleteAllRules,
   deleteAllAlerts,
   waitForRuleFailure,
-  waitForRulePartialFailure,
   routeWithNamespace,
 } from '../../../../../../../common/utils/security_solution';
 import { FtrProviderContext } from '../../../../../../ftr_provider_context';

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql.ts
@@ -835,7 +835,7 @@ export default ({ getService }: FtrProviderContext) => {
       const expectedWarning =
         'This rule reached the maximum alert limit for the rule execution. Some alerts were not created.';
 
-      it('specifying only timestamp_field results in alert creation with an expect.expected warning', async () => {
+      it('specifying only timestamp_field results in alert creation with an expected warning', async () => {
         const rule: EqlRuleCreateProps = {
           ...getEqlRuleForAlertTesting(['auditbeat-*']),
           timestamp_field: 'event.created',
@@ -853,7 +853,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect_(previewAlerts).not.toHaveLength(0);
       });
 
-      it('specifying only timestamp_override results in alert creation with an expect.expected warning', async () => {
+      it('specifying only timestamp_override results in alert creation with an expected warning', async () => {
         const rule: EqlRuleCreateProps = {
           ...getEqlRuleForAlertTesting(['auditbeat-*']),
           timestamp_override: 'event.created',
@@ -871,7 +871,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect_(previewAlerts).not.toHaveLength(0);
       });
 
-      it('specifying both timestamp_override and timestamp_field results in alert creation with an expect.expected warning', async () => {
+      it('specifying both timestamp_override and timestamp_field results in alert creation with an expected warning', async () => {
         const rule: EqlRuleCreateProps = {
           ...getEqlRuleForAlertTesting(['auditbeat-*']),
           timestamp_field: 'event.created',

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/runtime.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/runtime.ts
@@ -25,6 +25,9 @@ export const setBrokenRuntimeField = async ({ es, index }: UpdateMappingsProps) 
     },
     index,
   });
+  await es.indices.refresh({
+    index,
+  });
 };
 
 export const unsetBrokenRuntimeField = async ({ es, index }: UpdateMappingsProps) => {
@@ -34,6 +37,9 @@ export const unsetBrokenRuntimeField = async ({ es, index }: UpdateMappingsProps
       // @ts-expect-error null is valid, see link above
       broken: null,
     },
+    index,
+  });
+  await es.indices.refresh({
     index,
   });
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] [Detections] Fix flakey EQL shard test (#215757)](https://github.com/elastic/kibana/pull/215757)
 
 Closes https://github.com/elastic/kibana/issues/209024; details can be found there.

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Devin W. Hurley","email":"devin.hurley@elastic.co"},"sourceCommit":{"committedDate":"2025-03-28T18:47:15Z","message":"[Security Solution] [Detections] Fix flakey EQL shard test (#215757)\n\n## Summary\n\nRef: https://github.com/elastic/kibana/issues/209024\n\nFlake caused by occasionally hitting max signals on the \"good\" shard and\nnever triggering the error from the runtime field on the \"bad\" shard. By\nmoving the bad runtime field to the `packetbeat` index and changing the\nrule query in the test to an `and` we can ensure the rule queries both\ngood and bad shards.\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"d869d472f0b9b55c635580c4d7d15faff8b8c215","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["review","release_note:skip","v9.0.0","Team:Detection Engine","backport:version","v9.1.0","v9.0.1"],"title":"[Security Solution] [Detections] Fix flakey EQL shard test","number":215757,"url":"https://github.com/elastic/kibana/pull/215757","mergeCommit":{"message":"[Security Solution] [Detections] Fix flakey EQL shard test (#215757)\n\n## Summary\n\nRef: https://github.com/elastic/kibana/issues/209024\n\nFlake caused by occasionally hitting max signals on the \"good\" shard and\nnever triggering the error from the runtime field on the \"bad\" shard. By\nmoving the bad runtime field to the `packetbeat` index and changing the\nrule query in the test to an `and` we can ensure the rule queries both\ngood and bad shards.\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"d869d472f0b9b55c635580c4d7d15faff8b8c215"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216375","number":216375,"state":"MERGED","mergeCommit":{"sha":"a2002e0bd3692dd9dfeca80d0dbc38dd3a2af18a","message":"[9.0] [Security Solution] [Detections] Fix flakey EQL shard test (#215757) (#216375)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Security Solution] [Detections] Fix flakey EQL shard test\n(#215757)](https://github.com/elastic/kibana/pull/215757)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215757","number":215757,"mergeCommit":{"message":"[Security Solution] [Detections] Fix flakey EQL shard test (#215757)\n\n## Summary\n\nRef: https://github.com/elastic/kibana/issues/209024\n\nFlake caused by occasionally hitting max signals on the \"good\" shard and\nnever triggering the error from the runtime field on the \"bad\" shard. By\nmoving the bad runtime field to the `packetbeat` index and changing the\nrule query in the test to an `and` we can ensure the rule queries both\ngood and bad shards.\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"d869d472f0b9b55c635580c4d7d15faff8b8c215"}}]}] BACKPORT-->