### PR TITLE
[Security Assistant] `DocumentsDataWriter` user query fix

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/data_stream/documents_data_writer.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/data_stream/documents_data_writer.ts
@@ -13,7 +13,6 @@ import type {
 } from '@elastic/elasticsearch/lib/api/types';
 import type { AuthenticatedUser, Logger, ElasticsearchClient } from '@kbn/core/server';
 import type { UUID } from '@kbn/elastic-assistant-common';
-import { getResourceName } from '../../ai_assistant_service';
 
 export interface BulkOperationError {
   message: string;
@@ -220,7 +219,9 @@ export class DocumentsDataWriter implements DocumentsDataWriter {
     authenticatedUser?: AuthenticatedUser
   ) => {
     const updatedAt = new Date().toISOString();
-    const isConversationUpdate = this.options.index.includes(getResourceName('conversation'));
+    const isConversationUpdate = this.options.index.includes(
+      '.kibana-elastic-ai-assistant-conversation'
+    );
     const responseToUpdate = await this.options.esClient.search({
       query: {
         bool: {
@@ -272,7 +273,9 @@ export class DocumentsDataWriter implements DocumentsDataWriter {
     documentsToDelete: string[],
     authenticatedUser?: AuthenticatedUser
   ) => {
-    const isConversationUpdate = this.options.index.includes(getResourceName('conversation'));
+    const isConversationUpdate = this.options.index.includes(
+      '.kibana-elastic-ai-assistant-conversation'
+    );
     const responseToDelete = await this.options.esClient.search({
       query: {
         bool: {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/data_stream/documents_data_writer.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/data_stream/documents_data_writer.ts
@@ -13,6 +13,7 @@ import type {
 } from '@elastic/elasticsearch/lib/api/types';
 import type { AuthenticatedUser, Logger, ElasticsearchClient } from '@kbn/core/server';
 import type { UUID } from '@kbn/elastic-assistant-common';
+import { getResourceName } from '../../ai_assistant_service';
 
 export interface BulkOperationError {
   message: string;
@@ -118,6 +119,46 @@ export class DocumentsDataWriter implements DocumentsDataWriter {
         should: [
           {
             bool: {
+              must_not: {
+                nested: {
+                  path: 'users',
+                  query: {
+                    exists: {
+                      field: 'users',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          {
+            nested: {
+              path: 'users',
+              query: {
+                bool: {
+                  should: [
+                    // Match on users.id if profile_uid exists
+                    ...(authenticatedUser.profile_uid
+                      ? [{ term: { 'users.id': authenticatedUser.profile_uid } }]
+                      : []),
+                    // Always try to match on users.name
+                    { term: { 'users.name': authenticatedUser.username } },
+                  ],
+                  minimum_should_match: 1,
+                },
+              },
+            },
+          },
+        ],
+      },
+    },
+  });
+  getFilterByConversationUser = (authenticatedUser: AuthenticatedUser) => ({
+    filter: {
+      bool: {
+        should: [
+          {
+            bool: {
               must: [
                 {
                   exists: { field: 'created_by' },
@@ -179,6 +220,7 @@ export class DocumentsDataWriter implements DocumentsDataWriter {
     authenticatedUser?: AuthenticatedUser
   ) => {
     const updatedAt = new Date().toISOString();
+    const isConversationUpdate = this.options.index.includes(getResourceName('conversation'));
     const responseToUpdate = await this.options.esClient.search({
       query: {
         bool: {
@@ -195,7 +237,11 @@ export class DocumentsDataWriter implements DocumentsDataWriter {
               },
             },
           ],
-          ...(authenticatedUser ? this.getFilterByUser(authenticatedUser) : {}),
+          ...(authenticatedUser
+            ? isConversationUpdate
+              ? this.getFilterByConversationUser(authenticatedUser)
+              : this.getFilterByUser(authenticatedUser)
+            : {}),
         },
       },
       _source: false,
@@ -226,6 +272,7 @@ export class DocumentsDataWriter implements DocumentsDataWriter {
     documentsToDelete: string[],
     authenticatedUser?: AuthenticatedUser
   ) => {
+    const isConversationUpdate = this.options.index.includes(getResourceName('conversation'));
     const responseToDelete = await this.options.esClient.search({
       query: {
         bool: {
@@ -242,7 +289,11 @@ export class DocumentsDataWriter implements DocumentsDataWriter {
               },
             },
           ],
-          ...(authenticatedUser ? this.getFilterByUser(authenticatedUser) : {}),
+          ...(authenticatedUser
+            ? isConversationUpdate
+              ? this.getFilterByConversationUser(authenticatedUser)
+              : this.getFilterByUser(authenticatedUser)
+            : {}),
         },
       },
       _source: false,


### PR DESCRIPTION
# Add user-specific filtering to `DocumentsDataWriter`

## Summary

Conversation sharing introduced a new concept of users/ownership for conversations. However, the users filter in `DocumentsDataWriter` is used on more than just the conversations data stream. Therefore, this change broke updates/deletes on other data stream types.

This PR implements proper user-specific filtering in the `DocumentsDataWriter` class to ensure users can only access and modify documents they have permission to view. The implementation adds different filtering strategies for conversation documents and other (kb, prompt, etc) documents.

- **Re-added `getFilterByUser` method**: Implements filtering for non-conversation documents using nested user queries (previous implementation)
- **Added `getFilterByConversationUser` method**: Implements filtering for conversation documents using `created_by` field
- **Enhanced bulk operations**: Both `bulk` and `delete` methods now apply appropriate user filtering based on document type
- **Added index type detection**: Uses `getResourceName('conversation')` to determine if operations are on conversation documents
