### PR TITLE
[8.18] [DOCS][Reporting] Adds documentation of baseline screenshotting network policy to disallow external (#233526)

### DIFF
--- a/docs/settings/reporting-settings.asciidoc
+++ b/docs/settings/reporting-settings.asciidoc
@@ -241,6 +241,16 @@ xpack.screenshotting.networkPolicy:
   rules: [ { allow: true, host: "elastic.co", protocol: "https:" } ]
 -------------------------------------------------------
 
+Example of a baseline configuration for disallowing all requests to external paths:
+
+[source,yaml]
+-------------------------------------------------------
+xpack.screenshotting.networkPolicy:
+  rules: [ { allow: true, host: "localhost:5601", protocol: "http:" } ]
+-------------------------------------------------------
+
+NOTE: Typically, Chromium will connect to {kib} on a local interface, but this may be different based on the environment and specific <<reporting-kibana-server-settings>>.
+
 A final `allow` rule with no host or protocol allows all requests that are not explicitly denied:
 
 [source,yaml]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.18`:
 - [[DOCS][Reporting] Adds documentation of baseline screenshotting network policy to disallow external (#233526)](https://github.com/elastic/kibana/pull/233526)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nastasha Solomon","email":"79124755+nastasha-solomon@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-29T19:45:17Z","message":"[DOCS][Reporting] Adds documentation of baseline screenshotting network policy to disallow external (#233526)\n\n## Summary\n\nUpdates the 8.18 and 8.19 docs to include an example of a baseline\nscreenshotting network policy to disallowing all requests to external\npaths.\n\nCorresponding 9.x/Serverless docs updates:\nhttps://github.com/elastic/kibana/pull/233522","sha":"ee692dbd2aef3bfd53bedf683b11ac934179b707","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","docs","backport:version","v8.18.0","v8.19.0"],"title":"[DOCS][Reporting] Adds documentation of baseline screenshotting network policy to disallow external","number":233526,"url":"https://github.com/elastic/kibana/pull/233526","mergeCommit":{"message":"[DOCS][Reporting] Adds documentation of baseline screenshotting network policy to disallow external (#233526)\n\n## Summary\n\nUpdates the 8.18 and 8.19 docs to include an example of a baseline\nscreenshotting network policy to disallowing all requests to external\npaths.\n\nCorresponding 9.x/Serverless docs updates:\nhttps://github.com/elastic/kibana/pull/233522","sha":"ee692dbd2aef3bfd53bedf683b11ac934179b707"}},"sourceBranch":"8.19","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/233526","number":233526,"mergeCommit":{"message":"[DOCS][Reporting] Adds documentation of baseline screenshotting network policy to disallow external (#233526)\n\n## Summary\n\nUpdates the 8.18 and 8.19 docs to include an example of a baseline\nscreenshotting network policy to disallowing all requests to external\npaths.\n\nCorresponding 9.x/Serverless docs updates:\nhttps://github.com/elastic/kibana/pull/233522","sha":"ee692dbd2aef3bfd53bedf683b11ac934179b707"}}]}] BACKPORT-->