### PR TITLE
[8.19] [Security Solution] Fix and unskip API integration tests for preventing non-customizable fields from updating for Prebuilt rule types (#232956)

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/index.ts
@@ -13,6 +13,7 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
     loadTestFile(require.resolve('./import_export'));
     loadTestFile(require.resolve('./install_prebuilt_rules'));
     loadTestFile(require.resolve('./prebuilt_rules_package'));
+    loadTestFile(require.resolve('./non_customizable_fields'));
     loadTestFile(require.resolve('./revert_prebuilt_rules'));
     loadTestFile(require.resolve('./status'));
   });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/non_customizable_fields/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/non_customizable_fields/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  loadTestFile(require.resolve('./non_customizable_fields'));
+}

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/non_customizable_fields/non_customizable_fields.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/non_customizable_fields/non_customizable_fields.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+
+import { PREBUILT_RULES_PACKAGE_NAME } from '@kbn/security-solution-plugin/common/detection_engine/constants';
+import { deleteAllRules } from '../../../../../../../common/utils/security_solution';
+import type { FtrProviderContext } from '../../../../../../ftr_provider_context';
+import {
+  getCustomQueryRuleParams,
+  createPrebuiltRulesPackage,
+  installFleetPackageByUpload,
+  installPrebuiltRules,
+} from '../../../../utils';
+import {
+  MOCK_PKG_VERSION,
+  PREBUILT_RULE_ASSET_A,
+  PREBUILT_RULE_ASSET_B,
+  PREBUILT_RULE_ID_A,
+} from '../configs/edge_cases/ess_air_gapped_with_bundled_packages.config';
+
+export default ({ getService }: FtrProviderContext) => {
+  const supertest = getService('supertest');
+  const securitySolutionApi = getService('securitySolutionApi');
+  const log = getService('log');
+  const es = getService('es');
+
+  describe('@ess @serverless @serverlessQA modifying non-customizable fields', () => {
+    describe('patch rules', () => {
+      beforeEach(async () => {
+        await deleteAllRules(supertest, log);
+      });
+
+      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+        const securityDetectionEnginePackageZip = createPrebuiltRulesPackage({
+          packageName: PREBUILT_RULES_PACKAGE_NAME,
+          packageSemver: MOCK_PKG_VERSION,
+          prebuiltRuleAssets: [PREBUILT_RULE_ASSET_A, PREBUILT_RULE_ASSET_B],
+        });
+
+        await installFleetPackageByUpload({
+          getService,
+          packageBuffer: securityDetectionEnginePackageZip.toBuffer(),
+        });
+
+        await installPrebuiltRules(es, supertest);
+
+        const { body } = await securitySolutionApi
+          .patchRule({
+            body: {
+              rule_id: PREBUILT_RULE_ID_A,
+              author: ['new user'],
+            },
+          })
+          .expect(400);
+
+        expect(body.message).toEqual('Cannot update "author" field for prebuilt rules');
+      });
+    });
+
+    describe('update rules', () => {
+      afterEach(async () => {
+        await deleteAllRules(supertest, log);
+      });
+
+      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+        const securityDetectionEnginePackageZip = createPrebuiltRulesPackage({
+          packageName: PREBUILT_RULES_PACKAGE_NAME,
+          packageSemver: MOCK_PKG_VERSION,
+          prebuiltRuleAssets: [PREBUILT_RULE_ASSET_A, PREBUILT_RULE_ASSET_B],
+        });
+
+        await installFleetPackageByUpload({
+          getService,
+          packageBuffer: securityDetectionEnginePackageZip.toBuffer(),
+        });
+
+        await installPrebuiltRules(es, supertest);
+
+        const { body: existingRule } = await securitySolutionApi
+          .readRule({
+            query: { rule_id: PREBUILT_RULE_ID_A },
+          })
+          .expect(200);
+
+        const { body } = await securitySolutionApi
+          .updateRule({
+            body: getCustomQueryRuleParams({
+              ...existingRule,
+              rule_id: PREBUILT_RULE_ID_A,
+              id: undefined,
+              license: 'new license',
+            }),
+          })
+          .expect(400);
+
+        expect(body.message).toEqual('Cannot update "license" field for prebuilt rules');
+      });
+    });
+  });
+};

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
@@ -10,14 +10,10 @@ import expect from 'expect';
 import { createRule, deleteAllRules } from '../../../../../../common/utils/security_solution';
 import { FtrProviderContext } from '../../../../../ftr_provider_context';
 import {
-  createHistoricalPrebuiltRuleAssetSavedObjects,
-  createRuleAssetSavedObject,
-  deleteAllPrebuiltRuleAssets,
   getCustomQueryRuleParams,
   getSimpleRule,
   getSimpleRuleOutput,
   getSimpleRuleOutputWithoutRuleId,
-  installPrebuiltRules,
   removeServerGeneratedProperties,
   removeServerGeneratedPropertiesIncludingRuleId,
   updateUsername,
@@ -27,7 +23,6 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const securitySolutionApi = getService('securitySolutionApi');
   const log = getService('log');
-  const es = getService('es');
   const utils = getService('securitySolutionUtils');
 
   describe('@ess @serverless @serverlessQA patch_rules', () => {
@@ -230,26 +225,6 @@ export default ({ getService }: FtrProviderContext) => {
           status_code: 404,
           message: 'rule_id: "fake_id" not found',
         });
-      });
-
-      it('@skipInServerlessMKI throws an error if rule has external rule source and non-customizable fields are changed', async () => {
-        await deleteAllPrebuiltRuleAssets(es, log);
-        // Install base prebuilt detection rule
-        await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
-          createRuleAssetSavedObject({ rule_id: 'rule-1', author: ['elastic'] }),
-        ]);
-        await installPrebuiltRules(es, supertest);
-
-        const { body } = await securitySolutionApi
-          .patchRule({
-            body: {
-              rule_id: 'rule-1',
-              author: ['new user'],
-            },
-          })
-          .expect(400);
-
-        expect(body.message).toEqual('Cannot update "author" field for prebuilt rules');
       });
 
       describe('max signals', () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules.ts
@@ -18,9 +18,6 @@ import {
   getSimpleMlRuleUpdate,
   getSimpleRule,
   updateUsername,
-  createHistoricalPrebuiltRuleAssetSavedObjects,
-  installPrebuiltRules,
-  createRuleAssetSavedObject,
 } from '../../../utils';
 import {
   createAlertsIndex,
@@ -311,33 +308,6 @@ export default ({ getService }: FtrProviderContext) => {
 
           expect(updatedRuleResponse).toMatchObject(expectedRule);
         });
-      });
-
-      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
-        // Install base prebuilt detection rule
-        await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
-          createRuleAssetSavedObject({ rule_id: 'rule-1', license: 'elastic' }),
-        ]);
-        await installPrebuiltRules(es, supertest);
-
-        const { body: existingRule } = await securitySolutionApi
-          .readRule({
-            query: { rule_id: 'rule-1' },
-          })
-          .expect(200);
-
-        const { body } = await securitySolutionApi
-          .updateRule({
-            body: getCustomQueryRuleParams({
-              ...existingRule,
-              rule_id: 'rule-1',
-              id: undefined,
-              license: 'new license',
-            }),
-          })
-          .expect(400);
-
-        expect(body.message).toEqual('Cannot update "license" field for prebuilt rules');
       });
     });
   });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_fleet_package.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_fleet_package.ts
@@ -119,7 +119,8 @@ export const installFleetPackageByUpload = async ({
     },
     {
       retryCount: MAX_RETRIES,
-      timeout: FLEET_RATE_LIMIT_TIMEOUT * 3,
+      retryDelay: FLEET_RATE_LIMIT_TIMEOUT,
+      timeout: FLEET_RATE_LIMIT_TIMEOUT * 2,
     }
   );
 

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_prebuilt_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_prebuilt_rules.ts
@@ -12,7 +12,6 @@ import {
 } from '@kbn/security-solution-plugin/common/api/detection_engine/prebuilt_rules';
 import type { Client } from '@elastic/elasticsearch';
 import type SuperTest from 'supertest';
-import { refreshSavedObjectIndices } from '../../refresh_index';
 
 /**
  * Installs available prebuilt rules in Kibana. Rules are
@@ -46,8 +45,6 @@ export const installPrebuiltRules = async (
     .set('x-elastic-internal-origin', 'foo')
     .send(payload)
     .expect(200);
-
-  await refreshSavedObjectIndices(es);
 
   return response.body;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Fix and unskip API integration tests for preventing non-customizable fields from updating for Prebuilt rule types (#232956)](https://github.com/elastic/kibana/pull/232956)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jacek Kolezynski","email":"jacek.kolezynski@elastic.co"},"sourceCommit":{"committedDate":"2025-08-29T22:42:47Z","message":"[Security Solution] Fix and unskip API integration tests for preventing non-customizable fields from updating for Prebuilt rule types (#232956)\n\n**Resolves: #195921**\n\n## Summary\n\nI am modifying the skipped tests and unskipping them in MKI.\n\nThe first attempt of only relying on removing the call to\n`refreshSavedObjectIndices` improved the situation for\n`installPrebuiltRules` but another problem was that similar error with\nprivileges occurred for preparing the assets (reason under the hood\nbeing the same).\nThe failing periodic pipeline build:\nhttps://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3265/steps/canvas\n\nThat is why I am replacing the logic of installing the rule for test.\nInstead of creating assets I am building a zip with our fake rules and\ncalling the `installFleetPackageByUpload` function, as we already do in\nother tests. This allows our test security_detection_engine package to\nbe installed the `official` way.\n**The successful periodic pipeline build**:\nhttps://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3270/steps/canvas\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6cde3f7e92a299fa688f4586f9867711e60836e8","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","release_note:skip","v9.0.0","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:version","v8.18.0","v9.1.0","v8.19.0","v9.2.0","v9.1.4"],"title":"[Security Solution] Fix and unskip API integration tests for preventing non-customizable fields from updating for Prebuilt rule types","number":232956,"url":"https://github.com/elastic/kibana/pull/232956","mergeCommit":{"message":"[Security Solution] Fix and unskip API integration tests for preventing non-customizable fields from updating for Prebuilt rule types (#232956)\n\n**Resolves: #195921**\n\n## Summary\n\nI am modifying the skipped tests and unskipping them in MKI.\n\nThe first attempt of only relying on removing the call to\n`refreshSavedObjectIndices` improved the situation for\n`installPrebuiltRules` but another problem was that similar error with\nprivileges occurred for preparing the assets (reason under the hood\nbeing the same).\nThe failing periodic pipeline build:\nhttps://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3265/steps/canvas\n\nThat is why I am replacing the logic of installing the rule for test.\nInstead of creating assets I am building a zip with our fake rules and\ncalling the `installFleetPackageByUpload` function, as we already do in\nother tests. This allows our test security_detection_engine package to\nbe installed the `official` way.\n**The successful periodic pipeline build**:\nhttps://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3270/steps/canvas\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6cde3f7e92a299fa688f4586f9867711e60836e8"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18","8.19"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/233547","number":233547,"state":"MERGED","mergeCommit":{"sha":"4aad0e9405e290e8dc49e80b56e2a61b3577e05a","message":"[9.1] [Security Solution] Fix and unskip API integration tests for preventing non-customizable fields from updating for Prebuilt rule types (#232956) (#233547)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution] Fix and unskip API integration tests for\npreventing non-customizable fields from updating for Prebuilt rule types\n(#232956)](https://github.com/elastic/kibana/pull/232956)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jacek Kolezynski <jacek.kolezynski@elastic.co>"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232956","number":232956,"mergeCommit":{"message":"[Security Solution] Fix and unskip API integration tests for preventing non-customizable fields from updating for Prebuilt rule types (#232956)\n\n**Resolves: #195921**\n\n## Summary\n\nI am modifying the skipped tests and unskipping them in MKI.\n\nThe first attempt of only relying on removing the call to\n`refreshSavedObjectIndices` improved the situation for\n`installPrebuiltRules` but another problem was that similar error with\nprivileges occurred for preparing the assets (reason under the hood\nbeing the same).\nThe failing periodic pipeline build:\nhttps://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3265/steps/canvas\n\nThat is why I am replacing the logic of installing the rule for test.\nInstead of creating assets I am building a zip with our fake rules and\ncalling the `installFleetPackageByUpload` function, as we already do in\nother tests. This allows our test security_detection_engine package to\nbe installed the `official` way.\n**The successful periodic pipeline build**:\nhttps://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3270/steps/canvas\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6cde3f7e92a299fa688f4586f9867711e60836e8"}}]}] BACKPORT-->