### PR TITLE
Replace ditto with ZIP

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/kibana_migrator_archive_utils.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/kibana_migrator_archive_utils.ts
@@ -104,7 +104,11 @@ export const createBaselineArchive = async ({
 };
 
 const compressBaselineArchive = async (esFolder: string, archiveFile: string) => {
-  const dataFolder = join(esFolder, 'es-test-cluster', 'data');
-  const cmd = `ditto -c -k --sequesterRsrc --keepParent ${dataFolder}  ${archiveFile}`;
-  await execPromise(cmd);
+  const baseName = 'data';
+  const dataFolder = join(esFolder, 'es-test-cluster', baseName);
+  const parentDir = join(dataFolder, '..');
+  const cmd = `zip -rq "${archiveFile}" "${baseName}"`;
+  await execPromise(cmd, {
+    cwd: parentDir,
+  });
 };


### PR DESCRIPTION
## Summary

`ditto` is MacOS-specific, so folks on Linux cannot run the script atm.