### PR TITLE
fix: table columns width misconfigured

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
@@ -531,7 +531,6 @@ export const useHostsTable = () => {
       detailsItemId,
       setProperties,
       reportHostEntryClick,
-      showNetworkColumns,
     ]
   );
 

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
@@ -241,7 +241,20 @@ export const useHostsTable = () => {
     return items.sort(sortTableData(sorting)).slice(startIndex, endIndex);
   }, [items, pagination, sorting]);
 
-  const metricColumnsWidth = displayAlerts ? '12%' : '16%';
+  const showNetworkColumns = searchCriteria.preferredSchema !== 'semconv';
+  const metricColumnsWidth = useMemo(() => {
+    if (displayAlerts) {
+      return showNetworkColumns ? '12%' : '16%';
+    }
+    return showNetworkColumns ? '16%' : '20%';
+  }, [displayAlerts, showNetworkColumns]);
+
+  const titleColumnWidth = useMemo(() => {
+    if (displayAlerts) {
+      return showNetworkColumns ? '15%' : '20%';
+    }
+    return showNetworkColumns ? '20%' : '25%';
+  }, [displayAlerts, showNetworkColumns]);
 
   const columns: Array<EuiBasicTableColumn<HostNodeRow>> = useMemo(
     () => [
@@ -274,7 +287,7 @@ export const useHostsTable = () => {
                   showDocumentationLink={false}
                 />
               ),
-              width: '95px',
+              width: '80px',
               field: 'alertsCount',
               sortable: true,
               'data-test-subj': 'hostsView-tableRow-alertsCount',
@@ -371,7 +384,7 @@ export const useHostsTable = () => {
         render: (title: HostNodeRow['title']) => (
           <EntryTitle title={title} onClick={() => reportHostEntryClick(title)} />
         ),
-        width: displayAlerts ? '15%' : '20%',
+        width: titleColumnWidth,
       },
       {
         name: (
@@ -513,10 +526,12 @@ export const useHostsTable = () => {
       showApmHostTroubleshooting,
       formulas,
       metricColumnsWidth,
+      titleColumnWidth,
       searchCriteria.preferredSchema,
       detailsItemId,
       setProperties,
       reportHostEntryClick,
+      showNetworkColumns,
     ]
   );
 


### PR DESCRIPTION
# Infrastructure Hosts Alert Column Width Fix

Fix to Issue #233398.

## Problem Analysis

The issue was that when OpenTelemetry schema (`semconv`) is selected, the alerts column was taking up too much space compared to when System Integration schema (`ecs`) is used.

## Root Cause

1. **Schema-dependent columns**: When OpenTelemetry schema is selected, the network columns (rx/tx) are hidden based on this condition:
   ```tsx
   searchCriteria.preferredSchema !== 'semconv'
   ```

2. **Fixed width allocation**: The alerts column had a fixed width of `95px`, while metric columns used percentage-based widths (`12%` when alerts are shown, `16%` when not shown).

3. **Insufficient responsive calculation**: The column width calculations didn't account for the presence/absence of network columns based on the schema.

## Solution Implemented

### 1. Dynamic Metric Column Width Calculation
```tsx
const showNetworkColumns = searchCriteria.preferredSchema !== 'semconv';
const metricColumnsWidth = useMemo(() => {
  if (displayAlerts) {
    return showNetworkColumns ? '12%' : '16%';
  }
  return showNetworkColumns ? '16%' : '20%';
}, [displayAlerts, showNetworkColumns]);
```

### 2. Dynamic Title Column Width Calculation
```tsx
const titleColumnWidth = useMemo(() => {
  if (displayAlerts) {
    return showNetworkColumns ? '15%' : '20%';
  }
  return showNetworkColumns ? '20%' : '25%';
}, [displayAlerts, showNetworkColumns]);
```

### 3. Reduced Alert Column Width
- Changed from `width: '95px'` to `width: '80px'` for a more compact alerts column

## Width Allocation Summary

### ECS Schema (with network columns):
- **With alerts**: Alerts: 80px, Title: 15%, Metrics: 12% each (5 columns), Network: 12% each (2 columns)
- **Without alerts**: Title: 20%, Metrics: 16% each (5 columns), Network: 12% each (2 columns)

### OpenTelemetry Schema (without network columns):
- **With alerts**: Alerts: 80px, Title: 20%, Metrics: 16% each (5 columns)
- **Without alerts**: Title: 25%, Metrics: 20% each (5 columns)

## Files Modified

- `/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx`