### PR TITLE
[Significant Events] Fixes reloading the tab redirect !!

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/classic.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/classic.tsx
@@ -54,7 +54,7 @@ export function ClassicStreamDetailManagement({
     path: { key, tab },
   } = useStreamsAppParams('/{key}/management/{tab}');
 
-  const { processing, ...otherTabs } = useStreamsDetailManagementTabs({
+  const { processing, isLoading, ...otherTabs } = useStreamsDetailManagementTabs({
     definition,
     refreshDefinition,
   });
@@ -79,6 +79,7 @@ export function ClassicStreamDetailManagement({
         />
         <StreamsAppPageTemplate.Body>
           <EuiCallOut
+            announceOnMount
             title={i18n.translate('xpack.streams.unmanagedStreamOverview.missingDatastream.title', {
               defaultMessage: 'Data stream missing',
             })}
@@ -178,6 +179,9 @@ export function ClassicStreamDetailManagement({
   if (otherTabs.significantEvents) {
     tabs.significantEvents = otherTabs.significantEvents;
   }
+  if (isValidManagementSubTab(tab)) {
+    return <Wrapper tabs={tabs} streamId={key} tab={tab} />;
+  }
 
   const redirectConfig = tabRedirects[tab];
   if (redirectConfig) {
@@ -188,11 +192,8 @@ export function ClassicStreamDetailManagement({
       />
     );
   }
-
-  if (!isValidManagementSubTab(tab) || tabs[tab] === undefined) {
-    return (
-      <RedirectTo path="/{key}/management/{tab}" params={{ path: { key, tab: 'processing' } }} />
-    );
+  if (isLoading) {
+    return null;
   }
 
   return <Wrapper tabs={tabs} streamId={key} tab={tab} />;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/use_streams_detail_management_tabs.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/use_streams_detail_management_tabs.tsx
@@ -21,11 +21,13 @@ export function useStreamsDetailManagementTabs({
 }) {
   const {
     features: { significantEvents, groupStreams },
+    isLoading,
   } = useStreamsPrivileges();
 
   const isSignificantEventsEnabled = !!significantEvents?.available;
 
   return {
+    isLoading,
     processing: {
       content: (
         <StreamDetailEnrichment definition={definition} refreshDefinition={refreshDefinition} />

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired.tsx
@@ -52,7 +52,7 @@ export function WiredStreamDetailManagement({
     path: { key, tab },
   } = useStreamsAppParams('/{key}/management/{tab}');
 
-  const { processing, ...otherTabs } = useStreamsDetailManagementTabs({
+  const { processing, isLoading, ...otherTabs } = useStreamsDetailManagementTabs({
     definition,
     refreshDefinition,
   });
@@ -136,11 +136,13 @@ export function WiredStreamDetailManagement({
     );
   }
 
-  if (!isValidManagementSubTab(tab) || tabs[tab] === undefined) {
-    return (
-      <RedirectTo path="/{key}/management/{tab}" params={{ path: { key, tab: 'partitioning' } }} />
-    );
+  if (isValidManagementSubTab(tab)) {
+    return <Wrapper tabs={tabs} streamId={key} tab={tab} />;
   }
 
-  return <Wrapper tabs={tabs} streamId={key} tab={tab} />;
+  if (isLoading) {
+    return null;
+  }
+
+  <RedirectTo path="/{key}/management/{tab}" params={{ path: { key, tab: 'partitioning' } }} />
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired.tsx
@@ -144,5 +144,5 @@ export function WiredStreamDetailManagement({
     return null;
   }
 
-  <RedirectTo path="/{key}/management/{tab}" params={{ path: { key, tab: 'partitioning' } }} />
+  <RedirectTo path="/{key}/management/{tab}" params={{ path: { key, tab: 'partitioning' } }} />;
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_streams_privileges.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_streams_privileges.ts
@@ -33,6 +33,7 @@ export interface StreamsPrivileges {
     show: boolean;
   };
   features: StreamsFeatures;
+  isLoading?: boolean;
 }
 
 export function useStreamsPrivileges(): StreamsPrivileges {
@@ -82,5 +83,6 @@ export function useStreamsPrivileges(): StreamsPrivileges {
         enabled: groupStreamsEnabled,
       },
     },
+    isLoading: !license,
   };
 }


### PR DESCRIPTION
## Summary
Reloading the tab was redirecting to another tab, this PR fixes to make sure redirect waits until license reloading is done to check feature privileges for significant events .


### Before
Redirects to processing tab after refresh

https://github.com/user-attachments/assets/91298914-ff0d-467e-8c37-a2d2bc16f873





### After

Stays on same tab after refresh

https://github.com/user-attachments/assets/62a9fc08-4548-4e39-ba85-7e872bdb0935


