### PR TITLE
Add max_score to some Elasticsearch SearchHitsMetadata

### DIFF
--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/find.isolated.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/find.isolated.test.ts
@@ -52,6 +52,7 @@ const createSuccessSearchResponse = (objects: ObjectInfo[]): estypes.SearchRespo
     _shards: {} as any,
     hits: {
       total: objects.length,
+      max_score: 1,
       hits: objects.map(createHit),
     },
   };

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/repository.encryption_extension.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/repository.encryption_extension.test.ts
@@ -668,6 +668,7 @@ describe('SavedObjectsRepository Encryption Extension', () => {
         _shards: {} as any,
         hits: {
           total: 2,
+          max_score: 2,
           hits: [
             {
               _index: MAIN_SAVED_OBJECT_INDEX,

--- a/src/core/packages/saved-objects/api-server-internal/src/test_helpers/repository.test.common.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/test_helpers/repository.test.common.ts
@@ -731,6 +731,7 @@ export const generateIndexPatternSearchResults = (namespace?: string) => {
     _shards: {} as any,
     hits: {
       total: 4,
+      max_score: 4,
       hits: [
         {
           _index: MAIN_SAVED_OBJECT_INDEX,

--- a/src/platform/packages/private/kbn-generate-csv/src/generate_csv.test.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/generate_csv.test.ts
@@ -1016,6 +1016,7 @@ describe('CsvGenerator', () => {
               _id: 'my-cool-id',
               _index: 'my-cool-index',
               _version: 4,
+              _score: 1,
               fields: {
                 sku: [`This is a cool SKU.`, `This is also a cool SKU.`],
               },
@@ -1054,6 +1055,7 @@ describe('CsvGenerator', () => {
               _id: 'my-cool-id',
               _index: 'my-cool-index',
               _version: 4,
+              _score: 1,
               fields: {
                 date: ['2020-12-31T00:14:28.000Z'],
                 message: [`it's nice to see you`],
@@ -1104,6 +1106,7 @@ describe('CsvGenerator', () => {
               _id: 'my-cool-id',
               _index: 'my-cool-index',
               _version: 4,
+              _score: 1,
               fields: {
                 date: ['2020-12-31T00:14:28.000Z'],
                 message_z: [`test field Z`],
@@ -1161,6 +1164,7 @@ describe('CsvGenerator', () => {
               _id: 'my-cool-id',
               _index: 'my-cool-index',
               _version: 4,
+              _score: 1,
               fields: {
                 product: 'coconut',
                 category: [`cool`, `rad`],
@@ -1200,6 +1204,7 @@ describe('CsvGenerator', () => {
               _id: 'my-cool-id',
               _index: 'my-cool-index',
               _version: 4,
+              _score: 1,
               fields: {
                 product: 'coconut',
                 category: [`cool`, `rad`],
@@ -1239,6 +1244,7 @@ describe('CsvGenerator', () => {
               _id: 'my-cool-id',
               _index: 'my-cool-index',
               _version: 4,
+              _score: 1,
               fields: {
                 product: 'coconut',
                 category: [`cool`, `rad`],
@@ -1570,6 +1576,7 @@ describe('CsvGenerator', () => {
               range(0, 5).map(() => ({
                 _index: 'lasdf',
                 _id: 'lasdf123',
+                _score: 1,
                 fields: {
                   date: ['2020-12-31T00:14:28.000Z'],
                   ip: ['110.135.176.89'],

--- a/src/platform/packages/private/kbn-generate-csv/src/lib/search_cursor_pit.test.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/lib/search_cursor_pit.test.ts
@@ -114,7 +114,10 @@ describe('CSV Export Search Cursor', () => {
     });
 
     it('can update internal cursor ID', () => {
-      cursor.updateIdFromResults({ pit_id: 'very-typical-pit-id', hits: { max_score: null, hits: [] } });
+      cursor.updateIdFromResults({
+        pit_id: 'very-typical-pit-id',
+        hits: { max_score: null, hits: [] },
+      });
       expect(cursor.getCursorId()).toBe('very-typical-pit-id');
     });
 

--- a/src/platform/packages/private/kbn-generate-csv/src/lib/search_cursor_pit.test.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/lib/search_cursor_pit.test.ts
@@ -114,7 +114,7 @@ describe('CSV Export Search Cursor', () => {
     });
 
     it('can update internal cursor ID', () => {
-      cursor.updateIdFromResults({ pit_id: 'very-typical-pit-id', hits: { hits: [] } });
+      cursor.updateIdFromResults({ pit_id: 'very-typical-pit-id', hits: { max_score: null, hits: [] } });
       expect(cursor.getCursorId()).toBe('very-typical-pit-id');
     });
 
@@ -123,6 +123,7 @@ describe('CSV Export Search Cursor', () => {
         {
           _index: 'test-index',
           _id: 'test-doc-id',
+          _score: 1,
           sort: ['Wed Jan 17 15:35:47 MST 2024', 42],
         },
       ]);

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/calc_field_counts.test.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/calc_field_counts.test.ts
@@ -13,8 +13,8 @@ import { buildDataTableRecord } from './build_data_record';
 describe('calcFieldCounts', () => {
   test('returns valid field count data', async () => {
     const rows = [
-      { _id: '1', _index: 'test', _source: { message: 'test1', bytes: 20 } },
-      { _id: '2', _index: 'test', _source: { name: 'test2', extension: 'jpg' } },
+      { _id: '1', _index: 'test', _score: 1 ,_source: { message: 'test1', bytes: 20 } },
+      { _id: '2', _index: 'test', _score: 1 ,_source: { name: 'test2', extension: 'jpg' } },
     ].map((row) => buildDataTableRecord(row));
     const result = calcFieldCounts(rows);
     expect(result).toMatchInlineSnapshot(`
@@ -28,8 +28,8 @@ describe('calcFieldCounts', () => {
   });
   test('updates field count data', async () => {
     const rows = [
-      { _id: '1', _index: 'test', _source: { message: 'test1', bytes: 20 } },
-      { _id: '2', _index: 'test', _source: { name: 'test2', extension: 'jpg' } },
+      { _id: '1', _index: 'test', _score: 1, _source: { message: 'test1', bytes: 20 } },
+      { _id: '2', _index: 'test', _score: 1, _source: { name: 'test2', extension: 'jpg' } },
     ].map((row) => buildDataTableRecord(row));
     const result = calcFieldCounts(rows);
     expect(result).toMatchInlineSnapshot(`

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/calc_field_counts.test.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/calc_field_counts.test.ts
@@ -13,8 +13,8 @@ import { buildDataTableRecord } from './build_data_record';
 describe('calcFieldCounts', () => {
   test('returns valid field count data', async () => {
     const rows = [
-      { _id: '1', _index: 'test', _score: 1 ,_source: { message: 'test1', bytes: 20 } },
-      { _id: '2', _index: 'test', _score: 1 ,_source: { name: 'test2', extension: 'jpg' } },
+      { _id: '1', _index: 'test', _score: 1, _source: { message: 'test1', bytes: 20 } },
+      { _id: '2', _index: 'test', _score: 1, _source: { name: 'test2', extension: 'jpg' } },
     ].map((row) => buildDataTableRecord(row));
     const result = calcFieldCounts(rows);
     expect(result).toMatchInlineSnapshot(`

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.test.tsx
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.test.tsx
@@ -58,7 +58,7 @@ describe('convertValueToString', () => {
         flattenedValue: 'test',
         dataTableRecord: {
           id: '1',
-          raw: {},
+          raw: { _score: 1 },
           flattened: { testKey: 'testValue' },
         },
         fieldFormats: fieldFormatsMock,
@@ -83,7 +83,7 @@ describe('convertValueToString', () => {
           flattenedValue: ['value1', 'value2'],
           dataTableRecord: {
             id: '1',
-            raw: {},
+            raw: { _score: 1 },
             flattened: { testKey: 'testValue' },
           },
           fieldFormats: fieldFormatsMock,
@@ -107,7 +107,7 @@ describe('convertValueToString', () => {
           flattenedValue: 'value',
           dataTableRecord: {
             id: '1',
-            raw: {},
+            raw: { _score: 1 },
             flattened: { testKey: 'testValue' },
           },
           fieldFormats: fieldFormatsMock,

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/format_hit.test.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/format_hit.test.ts
@@ -20,6 +20,7 @@ describe('formatHit', () => {
     hit = {
       _id: '1',
       _index: 'logs',
+      _score: 1,
       fields: {
         message: ['foobar'],
         extension: ['png'],
@@ -111,6 +112,7 @@ describe('formatHit', () => {
       {
         _id: '2',
         _index: 'logs',
+        _score: 1,
         fields: {
           object: ['object'],
           'object.value': [42, 13],

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/format_value.test.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/format_value.test.ts
@@ -23,6 +23,7 @@ const services = {
 const hit = {
   _id: '1',
   _index: 'index',
+  _score: 1,
   fields: {
     message: 'foo',
   },

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/get_field_value.test.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/get_field_value.test.ts
@@ -12,7 +12,7 @@ import { getFieldValue } from './get_field_value';
 
 const dataTableRecord: DataTableRecord = {
   id: '1',
-  raw: {},
+  raw: { _score: 1 },
   flattened: {
     'field1.value': 'value1',
     'field2.value': ['value2'],

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/get_formatted_fields.test.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/get_formatted_fields.test.ts
@@ -33,7 +33,7 @@ describe('getFormattedFields', () => {
       field3: null,
       field4: undefined,
     },
-    raw: {},
+    raw: { _score: 1 },
   };
 
   beforeEach(() => {

--- a/src/platform/packages/shared/kbn-search-response-warnings/src/extract_warnings.test.ts
+++ b/src/platform/packages/shared/kbn-search-response-warnings/src/extract_warnings.test.ts
@@ -70,7 +70,7 @@ describe('extract search response warnings', () => {
         took: 999,
         timed_out: true,
         _shards: {} as estypes.ShardStatistics,
-        hits: { hits: [] },
+        hits: { max_score: null, hits: [] },
       };
       expect(
         extractWarnings(response, mockInspectorService, mockRequestAdapter, 'My request')

--- a/src/platform/packages/shared/kbn-search-response-warnings/src/handle_warnings.test.ts
+++ b/src/platform/packages/shared/kbn-search-response-warnings/src/handle_warnings.test.ts
@@ -52,7 +52,7 @@ describe('handleWarnings', () => {
         took: 999,
         timed_out: true,
         _shards: {} as estypes.ShardStatistics,
-        hits: { hits: [] },
+        hits: { max_score: null, hits: [] },
       } as estypes.SearchResponse,
       services: {
         inspector: {} as unknown as InspectorStart,
@@ -75,7 +75,7 @@ describe('handleWarnings', () => {
         took: 999,
         timed_out: true,
         _shards: {} as estypes.ShardStatistics,
-        hits: { hits: [] },
+        hits: { max_score: null, hits: [] },
       } as estypes.SearchResponse,
       services: {
         inspector: {} as unknown as InspectorStart,
@@ -99,7 +99,7 @@ describe('handleWarnings', () => {
         took: 999,
         timed_out: true,
         _shards: {} as estypes.ShardStatistics,
-        hits: { hits: [] },
+        hits: { max_score: null, hits: [] },
       } as estypes.SearchResponse,
       services: {
         inspector: {} as unknown as InspectorStart,

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -782,6 +782,7 @@ describe('UnifiedDataTable', () => {
             id: 'test',
             raw: {
               _index: 'test_i',
+              _score: 1,
               _id: 'test',
             },
             flattened: { test: jest.fn() },
@@ -816,6 +817,7 @@ describe('UnifiedDataTable', () => {
             id: 'test',
             raw: {
               _index: 'test_i',
+              _score: 1,
               _id: 'test',
             },
             flattened: { test: jest.fn() },
@@ -845,6 +847,7 @@ describe('UnifiedDataTable', () => {
             id: 'test',
             raw: {
               _index: 'test_i',
+              _score: 1,
               _id: 'test',
             },
             flattened: { test: jest.fn() },
@@ -868,6 +871,7 @@ describe('UnifiedDataTable', () => {
         id: 'test',
         raw: {
           _index: 'test_i',
+          _score: 1,
           _id: 'test',
         },
         flattened: { test: jest.fn() },
@@ -983,6 +987,7 @@ describe('UnifiedDataTable', () => {
             id: 'test',
             raw: {
               _index: 'test_i',
+              _score: 1,
               _id: 'test',
             },
             flattened: { test: jest.fn() },

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_document_selection.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_document_selection.test.tsx
@@ -35,6 +35,7 @@ describe('document selection', () => {
       const doc = {
         _id: 'test-id',
         _index: 'test-indices',
+        _score: 1,
         _routing: 'why-not',
       };
       expect(getDocId(doc)).toMatchInlineSnapshot(`"test-indices::test-id::why-not"`);
@@ -44,6 +45,7 @@ describe('document selection', () => {
       const doc = {
         _id: 'test-id',
         _index: 'test-indices',
+        _score: 1,
       };
       expect(getDocId(doc)).toMatchInlineSnapshot(`"test-indices::test-id::"`);
     });

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
@@ -106,7 +106,7 @@ describe('<DocViewer />', () => {
       },
     });
     const renderProps = {
-      hit: buildDataTableRecord({ _index: 't', _score: 1,_id: '1' }),
+      hit: buildDataTableRecord({ _index: 't', _score: 1, _id: '1' }),
     } as DocViewRenderProps;
     render(<WrappedDocViewer docViews={registry.getAll()} {...renderProps} />);
     expect(screen.queryByTestId('sectionErrorBoundaryPromptBody')).not.toBeInTheDocument();

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
@@ -81,7 +81,7 @@ describe('<DocViewer />', () => {
       },
     });
     const renderProps = {
-      hit: buildDataTableRecord({ _index: 't', _id: '1' }),
+      hit: buildDataTableRecord({ _index: 't', _score: 1, _id: '1' }),
     } as DocViewRenderProps;
     render(<WrappedDocViewer docViews={registry.getAll()} {...renderProps} />);
     expect(screen.getByTestId('sectionErrorBoundaryPromptBody')).toBeInTheDocument();
@@ -106,7 +106,7 @@ describe('<DocViewer />', () => {
       },
     });
     const renderProps = {
-      hit: buildDataTableRecord({ _index: 't', _id: '1' }),
+      hit: buildDataTableRecord({ _index: 't', _score: 1,_id: '1' }),
     } as DocViewRenderProps;
     render(<WrappedDocViewer docViews={registry.getAll()} {...renderProps} />);
     expect(screen.queryByTestId('sectionErrorBoundaryPromptBody')).not.toBeInTheDocument();

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/sub_components/stacktrace/apm_stacktrace.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/sub_components/stacktrace/apm_stacktrace.test.tsx
@@ -28,7 +28,7 @@ describe('APM Stacktrace component', () => {
     const comp = mountWithIntl(
       <ApmStacktrace
         hit={{
-          raw: { _id: '1', _index: 'index1' },
+          raw: { _id: '1', _score: 1, _index: 'index1' },
           flattened: {},
           id: '',
         }}
@@ -46,7 +46,7 @@ describe('APM Stacktrace component', () => {
     const comp = mountWithIntl(
       <ApmStacktrace
         hit={{
-          raw: { _id: '1', _index: 'index1' },
+          raw: { _id: '1', _score: 1, _index: 'index1' },
           flattened: {},
           id: '',
         }}
@@ -100,7 +100,7 @@ describe('APM Stacktrace component', () => {
       <EuiThemeProvider>
         <ApmStacktrace
           hit={{
-            raw: { _id: '1', _index: 'index1' },
+            raw: { _id: '1', _score: 1, _index: 'index1' },
             flattened: {},
             id: '',
           }}
@@ -167,7 +167,7 @@ describe('APM Stacktrace component', () => {
       <EuiThemeProvider>
         <ApmStacktrace
           hit={{
-            raw: { _id: '1', _index: 'index1' },
+            raw: { _id: '1', _score: 1, _index: 'index1' },
             flattened: {},
             id: '',
           }}
@@ -200,7 +200,7 @@ describe('APM Stacktrace component', () => {
       <EuiThemeProvider>
         <ApmStacktrace
           hit={{
-            raw: { _id: '1', _index: 'index1' },
+            raw: { _id: '1', _score: 1, _index: 'index1' },
             flattened: {},
             id: '',
           }}

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_source/source.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_source/source.test.tsx
@@ -103,6 +103,7 @@ describe('Source Viewer component', () => {
     const record = {
       _index: 'logstash-2014.09.09',
       _id: 'id123',
+      _score: 1,
       message: 'Lorem ipsum dolor sit amet',
       extension: 'html',
     };

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/get_pin_control.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/get_pin_control.test.tsx
@@ -26,6 +26,7 @@ describe('getPinControl', () => {
           _ignored: [],
           _index: 'test',
           _id: '1',
+          _score: 1,
           _source: {
             message: 'test',
           },

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.test.tsx
@@ -40,6 +40,7 @@ describe('TableActions', () => {
           _ignored: [],
           _index: 'test',
           _id: '1',
+          _score: 1,
           _source: {
             [fieldName]: fieldValue,
           },

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/test_filters.test.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/test_filters.test.ts
@@ -25,6 +25,7 @@ const hit = buildDataTableRecord(
   {
     _ignored: [],
     _index: 'test',
+    _score: 1,
     _id: '1',
     _source: {
       'extension.keyword': 'zip',

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/scheduled/scheduled_query.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/scheduled/scheduled_query.test.ts
@@ -1347,6 +1347,7 @@ describe('transformResponse', () => {
       ...lastRunResponse,
       hits: {
         total: { value: 1, relation: 'eq' },
+        max_score: lastRunResponse.hits.max_score,
         hits: [lastRunResponse.hits.hits[0]],
       },
     };

--- a/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.test.ts
@@ -3407,6 +3407,7 @@ describe('getGlobalExecutionLogWithAuth()', () => {
       },
     },
     hits: {
+      max_score: null,
       total: { value: 5, relation: 'eq' },
       hits: [],
     } as estypes.SearchHitsMetadata<unknown>,
@@ -3460,6 +3461,7 @@ describe('getGlobalExecutionKpiWithAuth()', () => {
       },
     },
     hits: {
+      max_score: null,
       total: { value: 5, relation: 'eq' },
       hits: [],
     } as estypes.SearchHitsMetadata<unknown>,

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_execution_log_aggregation.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_execution_log_aggregation.test.ts
@@ -490,6 +490,7 @@ describe('formatExecutionLogResult', () => {
       formatExecutionLogResult({
         aggregations: undefined,
         hits: {
+          max_score: null,
           total: { value: 0, relation: 'eq' },
           hits: [],
         } as estypes.SearchHitsMetadata<unknown>,
@@ -504,6 +505,7 @@ describe('formatExecutionLogResult', () => {
       formatExecutionLogResult({
         aggregations: { executionLogAgg: undefined as unknown as ExecutionUuidAggResult },
         hits: {
+          max_score: null,
           total: { value: 5, relation: 'eq' },
           hits: [],
         } as estypes.SearchHitsMetadata<unknown>,
@@ -568,6 +570,7 @@ describe('formatExecutionLogResult', () => {
         },
       },
       hits: {
+        max_score: null,
         total: { value: 5, relation: 'eq' },
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
@@ -693,6 +696,7 @@ describe('formatExecutionLogResult', () => {
         },
       },
       hits: {
+        max_score: null,
         total: { value: 10, relation: 'eq' },
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
@@ -940,6 +944,7 @@ describe('formatExecutionKPIAggBuckets', () => {
       formatExecutionKPIResult({
         aggregations: undefined,
         hits: {
+          max_score: null,
           total: { value: 0, relation: 'eq' },
           hits: [],
         } as estypes.SearchHitsMetadata<unknown>,
@@ -978,6 +983,7 @@ describe('formatExecutionKPIAggBuckets', () => {
       },
       hits: {
         total: { value: 21, relation: 'eq' },
+        max_score: null,
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
     };

--- a/x-pack/platform/plugins/shared/actions/server/usage/actions_telemetry.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/usage/actions_telemetry.test.ts
@@ -40,6 +40,7 @@ describe('actions telemetry', () => {
           },
         },
         hits: {
+          max_score: 0,
           hits: [
             {
               _id: 'action:541efb3d-f82a-4d2c-a5c3-636d1ce49b53',
@@ -503,6 +504,7 @@ describe('actions telemetry', () => {
           },
         },
         hits: {
+          max_score: 0,
           hits: [
             {
               _id: 'action:541efb3d-f82a-4d2c-a5c3-636d1ce49b53',
@@ -629,6 +631,7 @@ describe('actions telemetry', () => {
           },
         },
         hits: {
+          max_score: null,
           hits: [],
         },
       }

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/utils/map_result.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/utils/map_result.test.ts
@@ -16,6 +16,7 @@ const createHit = (
   return {
     _index: '.foo',
     _source: attrs,
+    _score: 1,
     ...(highlights ? { highlight: { content_body: highlights } } : {}),
   };
 };

--- a/x-pack/platform/plugins/shared/alerting/server/alert_deletion/lib/get_last_run.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alert_deletion/lib/get_last_run.test.ts
@@ -74,10 +74,12 @@ describe('getLastRun', () => {
       _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
       hits: {
         total: { relation: 'eq', value: 1 },
+        max_score: 1,
         hits: [
           {
             _id: '123',
             _index: '.kibana-event-log',
+            _score: 1,
             _source: {
               '@timestamp': '2025-03-25T15:20:44.704Z',
               event: {
@@ -135,6 +137,7 @@ describe('getLastRun', () => {
       _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
       hits: {
         total: { relation: 'eq', value: 0 },
+        max_score: null,
         hits: [],
       },
     });

--- a/x-pack/platform/plugins/shared/alerting/server/alert_deletion/lib/run.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alert_deletion/lib/run.test.ts
@@ -38,6 +38,7 @@ interface Opts {
 const getMockAlert = ({ id, ruleId, searchAfter }: Opts) => ({
   _id: id,
   _index: '.internal.alerts-test.alerts-default-000001',
+  _score: 1,
   _seq_no: 41,
   _primary_term: 665,
   ...(searchAfter ? { sort: searchAfter } : {}),
@@ -113,6 +114,7 @@ describe('runTask', () => {
       _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
       hits: {
         total: { relation: 'eq', value: 2 },
+        max_score: 1,
         hits: [getMockAlert({ id: 'abc' }), getMockAlert({ id: 'def' })],
       },
     });
@@ -126,6 +128,7 @@ describe('runTask', () => {
       _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
       hits: {
         total: { relation: 'eq', value: 2 },
+        max_score: 1,
         hits: [getMockAlert({ id: 'xyz' }), getMockAlert({ id: 'rst' })],
       },
     });
@@ -139,6 +142,7 @@ describe('runTask', () => {
       _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
       hits: {
         total: { relation: 'eq', value: 2 },
+        max_score: 1,
         hits: [getMockAlert({ id: 'mno', ruleId: '1' }), getMockAlert({ id: 'pqr', ruleId: '3' })],
       },
     });
@@ -334,6 +338,7 @@ describe('runTask', () => {
       _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
       hits: {
         total: { relation: 'eq', value: 2 },
+        max_score: 1,
         hits: [
           getMockAlert({ id: 'abc', searchAfter: ['111'] }),
           getMockAlert({ id: 'def', searchAfter: ['222'] }),
@@ -346,6 +351,7 @@ describe('runTask', () => {
       _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
       hits: {
         total: { relation: 'eq', value: 2 },
+        max_score: 1,
         hits: [
           getMockAlert({ id: 'ghi', searchAfter: ['333'] }),
           getMockAlert({ id: 'jkl', searchAfter: ['444'] }),
@@ -358,7 +364,10 @@ describe('runTask', () => {
       _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
       hits: {
         total: { relation: 'eq', value: 2 },
-        hits: [getMockAlert({ id: 'mno', searchAfter: ['555'] })],
+        max_score: 1,
+        hits: [
+          getMockAlert({ id: 'mno', searchAfter: ['555'] }),
+        ],
       },
     });
     esClient.search.mockResolvedValueOnce({
@@ -367,6 +376,7 @@ describe('runTask', () => {
       _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
       hits: {
         total: { relation: 'eq', value: 0 },
+        max_score: null,
         hits: [],
       },
     });
@@ -543,6 +553,7 @@ describe('runTask', () => {
       _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
       hits: {
         total: { relation: 'eq', value: 2 },
+        max_score: 1,
         hits: [getMockAlert({ id: 'abc' }), getMockAlert({ id: 'def' })],
       },
     });
@@ -556,6 +567,7 @@ describe('runTask', () => {
       _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
       hits: {
         total: { relation: 'eq', value: 2 },
+        max_score: 1,
         hits: [getMockAlert({ id: 'xyz' }), getMockAlert({ id: 'rst' })],
       },
     });
@@ -827,6 +839,7 @@ describe('runTask', () => {
         _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
         hits: {
           total: { relation: 'eq', value: 2 },
+          max_score: 1,
           hits: [getMockAlert({ id: 'ghi' }), getMockAlert({ id: 'jkl' })],
         },
       });
@@ -927,6 +940,7 @@ describe('runTask', () => {
         _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
         hits: {
           total: { relation: 'eq', value: 2 },
+          max_score: 1,
           hits: [getMockAlert({ id: 'abc' }), getMockAlert({ id: 'def', ruleId: '3' })],
         },
       });

--- a/x-pack/platform/plugins/shared/alerting/server/alert_deletion/lib/run.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alert_deletion/lib/run.test.ts
@@ -365,9 +365,7 @@ describe('runTask', () => {
       hits: {
         total: { relation: 'eq', value: 2 },
         max_score: 1,
-        hits: [
-          getMockAlert({ id: 'mno', searchAfter: ['555'] }),
-        ],
+        hits: [getMockAlert({ id: 'mno', searchAfter: ['555'] })],
       },
     });
     esClient.search.mockResolvedValueOnce({

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.test.ts
@@ -393,6 +393,7 @@ describe('Alerts Client', () => {
           _shards: { failed: 0, successful: 1, total: 0, skipped: 0 },
           hits: {
             total: { relation: 'eq', value: 0 },
+            max_score: null,
             hits: [],
           },
         });
@@ -405,6 +406,7 @@ describe('Alerts Client', () => {
               _shards: { failed: 0, successful: 1, total: 0, skipped: 0 },
               hits: {
                 total: { relation: 'eq', value: 0 },
+                max_score: null,
                 hits: [],
               },
             },
@@ -586,12 +588,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 2 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
                   _seq_no: 41,
                   _primary_term: 665,
+                  _score: 1,
                   _source: fetchedAlert1,
                 },
                 {
@@ -599,6 +603,7 @@ describe('Alerts Client', () => {
                   _index: '.internal.alerts-test.alerts-default-000002',
                   _seq_no: 42,
                   _primary_term: 666,
+                  _score: 1,
                   _source: fetchedAlert2,
                 },
                 {
@@ -606,6 +611,7 @@ describe('Alerts Client', () => {
                   _index: '.internal.alerts-test.alerts-default-000002',
                   _seq_no: 43,
                   _primary_term: 667,
+                  _score: 1,
                   _source: fetchedAlert3,
                 },
               ],
@@ -638,12 +644,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 2 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
                   _seq_no: 41,
                   _primary_term: 665,
+                  _score: 1,
                   _source: fetchedAlert1,
                 },
                 {
@@ -651,6 +659,7 @@ describe('Alerts Client', () => {
                   _index: '.internal.alerts-test.alerts-default-000002',
                   _seq_no: 42,
                   _primary_term: 666,
+                  _score: 1,
                   _source: fetchedAlert2,
                 },
               ],
@@ -802,12 +811,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 1 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
                   _seq_no: 41,
                   _primary_term: 665,
+                  _score: 1,
                   _source: fetchedAlert1,
                 },
               ],
@@ -877,12 +888,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 1 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
                   _seq_no: 41,
                   _primary_term: 665,
+                  _score: 1,
                   _source: expandFlattenedAlert(fetchedAlert1),
                 },
               ],
@@ -1009,10 +1022,12 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 1 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
+                  _score: 1,
                   _source: fetchedAlert1,
                 },
               ],
@@ -1081,12 +1096,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 2 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
                   _seq_no: 41,
                   _primary_term: 665,
+                  _score: 1,
                   _source: fetchedAlert1,
                 },
                 {
@@ -1094,6 +1111,7 @@ describe('Alerts Client', () => {
                   _index: '.internal.alerts-test.alerts-default-000002',
                   _seq_no: 42,
                   _primary_term: 666,
+                  _score: 1,
                   _source: fetchedAlert2,
                 },
               ],
@@ -1182,12 +1200,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 2 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
                   _seq_no: 41,
                   _primary_term: 665,
+                  _score: 1,
                   _source: expandFlattenedAlert(fetchedAlert1),
                 },
                 {
@@ -1195,6 +1215,7 @@ describe('Alerts Client', () => {
                   _index: '.internal.alerts-test.alerts-default-000002',
                   _seq_no: 42,
                   _primary_term: 666,
+                  _score: 1,
                   _source: expandFlattenedAlert(fetchedAlert2),
                 },
               ],
@@ -1342,12 +1363,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 2 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
                   _seq_no: 41,
                   _primary_term: 665,
+                  _score: 1,
                   _source: fetchedAlert1,
                 },
                 {
@@ -1355,6 +1378,7 @@ describe('Alerts Client', () => {
                   _index: '.internal.alerts-test.alerts-default-000002',
                   _seq_no: 42,
                   _primary_term: 666,
+                  _score: 1,
                   _source: fetchedAlert2,
                 },
               ],
@@ -1461,12 +1485,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 2 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
                   _seq_no: 41,
                   _primary_term: 665,
+                  _score: 1,
                   _source: fetchedAlert1,
                 },
                 {
@@ -1474,6 +1500,7 @@ describe('Alerts Client', () => {
                   _index: '.internal.alerts-test.alerts-default-000002',
                   _seq_no: 42,
                   _primary_term: 666,
+                  _score: 1,
                   _source: fetchedAlert2,
                 },
               ],
@@ -1676,12 +1703,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 2 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: 'partial-.internal.alerts-test.alerts-default-000001',
                   _seq_no: 41,
                   _primary_term: 665,
+                  _score: 1,
                   _source: fetchedAlert1,
                 },
                 {
@@ -1689,6 +1718,7 @@ describe('Alerts Client', () => {
                   _index: '.internal.alerts-test.alerts-default-000002',
                   _seq_no: 42,
                   _primary_term: 666,
+                  _score: 1,
                   _source: fetchedAlert2,
                 },
               ],
@@ -1764,6 +1794,7 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 2 },
+              max_score: null,
               hits: [],
             },
           });
@@ -2244,9 +2275,11 @@ describe('Alerts Client', () => {
                 _shards: { failed: 0, successful: 1, total: 0, skipped: 0 },
                 hits: {
                   total: { relation: 'eq', value: 0 },
+                  max_score: 1,
                   hits: [
                     {
                       _index: '.internal.alerts-test.alerts-default-000001',
+                      _score: 1,
                       fields: {
                         [ALERT_UUID]: ['alert_id_1'],
                         [RUNTIME_MAINTENANCE_WINDOW_ID_FIELD]: ['mw1'],
@@ -2254,6 +2287,7 @@ describe('Alerts Client', () => {
                     },
                     {
                       _index: '.internal.alerts-test.alerts-default-000001',
+                      _score: 1,
                       fields: {
                         [ALERT_UUID]: ['alert_id_2'],
                         [RUNTIME_MAINTENANCE_WINDOW_ID_FIELD]: ['mw1'],
@@ -2268,9 +2302,11 @@ describe('Alerts Client', () => {
                 _shards: { failed: 0, successful: 1, total: 0, skipped: 0 },
                 hits: {
                   total: { relation: 'eq', value: 0 },
+                  max_score: 1,
                   hits: [
                     {
                       _index: '.internal.alerts-test.alerts-default-000001',
+                      _score: 1,
                       fields: {
                         [ALERT_UUID]: ['alert_id_1'],
                         [RUNTIME_MAINTENANCE_WINDOW_ID_FIELD]: ['mw2'],
@@ -2377,9 +2413,11 @@ describe('Alerts Client', () => {
                 _shards: { failed: 0, successful: 1, total: 0, skipped: 0 },
                 hits: {
                   total: { relation: 'eq', value: 0 },
+                  max_score: 1,
                   hits: [
                     {
                       _index: '.internal.alerts-test.alerts-default-000001',
+                      _score: 1,
                       fields: {
                         [ALERT_UUID]: ['alert_id_1'],
                         [RUNTIME_MAINTENANCE_WINDOW_ID_FIELD]: ['mw1'],
@@ -2387,6 +2425,7 @@ describe('Alerts Client', () => {
                     },
                     {
                       _index: '.internal.alerts-test.alerts-default-000001',
+                      _score: 1,
                       fields: {
                         [ALERT_UUID]: ['alert_id_2'],
                         [RUNTIME_MAINTENANCE_WINDOW_ID_FIELD]: ['mw1'],
@@ -3024,10 +3063,12 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 1 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
+                  _score: 1,
                   _source: alertSource,
                 },
               ],
@@ -3071,10 +3112,12 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 1 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
+                  _score: 1,
                   _source: alertSource,
                 },
               ],
@@ -3177,6 +3220,7 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 0 },
+              max_score: null,
               hits: [],
             },
           });
@@ -3265,10 +3309,12 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 1 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
+                  _score: 1,
                   _source: {
                     ...fetchedAlert1,
                     count: 1,
@@ -3368,12 +3414,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 1 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
                   _seq_no: 42,
                   _primary_term: 666,
+                  _score: 1,
                   _source: {
                     ...fetchedAlert1,
                     count: 1,
@@ -3492,12 +3540,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 1 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
                   _seq_no: 42,
                   _primary_term: 666,
+                  _score: 1,
                   _source: fetchedAlert1,
                 },
               ],
@@ -3532,6 +3582,7 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 0 },
+              max_score: null,
               hits: [],
             },
           });
@@ -3569,12 +3620,14 @@ describe('Alerts Client', () => {
             _shards: { failed: 0, successful: 1, total: 1, skipped: 0 },
             hits: {
               total: { relation: 'eq', value: 0 },
+              max_score: 1,
               hits: [
                 {
                   _id: 'abc',
                   _index: '.internal.alerts-test.alerts-default-000001',
                   _seq_no: 42,
                   _primary_term: 666,
+                  _score: 1,
                   _source: fetchedAlert1,
                 },
                 {
@@ -3582,6 +3635,7 @@ describe('Alerts Client', () => {
                   _index: '.internal.alerts-test.alerts-default-000002',
                   _seq_no: 42,
                   _primary_term: 666,
+                  _score: 1,
                   _source: fetchedAlert2,
                 },
               ],

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
@@ -34,6 +34,7 @@ describe('setAlertsToUntracked()', () => {
         failed: 0,
       },
       hits: {
+        max_score: null,
         hits: [],
       },
     });
@@ -208,6 +209,7 @@ describe('setAlertsToUntracked()', () => {
           failed: 0,
         },
         hits: {
+          max_score: null,
           hits: [],
         },
         aggregations: {
@@ -267,6 +269,7 @@ describe('setAlertsToUntracked()', () => {
           failed: 0,
         },
         hits: {
+          max_score: null,
           hits: [],
         },
         aggregations: {
@@ -314,6 +317,7 @@ describe('setAlertsToUntracked()', () => {
         failed: 0,
       },
       hits: {
+        max_score: null,
         hits: [],
       },
       aggregations: {
@@ -375,6 +379,7 @@ describe('setAlertsToUntracked()', () => {
         failed: 0,
       },
       hits: {
+        max_score: null,
         hits: [],
       },
       aggregations: {
@@ -401,10 +406,12 @@ describe('setAlertsToUntracked()', () => {
         failed: 0,
       },
       hits: {
+        max_score: 1,
         hits: [
           {
             _index: 'test-alert-index',
             _id: 'test-alert-id-1',
+            _score: 1,
             _source: {
               [ALERT_RULE_UUID]: 'test-alert-rule-id-1',
               [ALERT_UUID]: 'test-alert-id-1',
@@ -413,6 +420,7 @@ describe('setAlertsToUntracked()', () => {
           {
             _index: 'test-alert-index',
             _id: 'test-alert-id-2',
+            _score: 1,
             _source: {
               [ALERT_RULE_UUID]: 'test-alert-rule-id-2',
               [ALERT_UUID]: 'test-alert-id-2',
@@ -541,6 +549,7 @@ describe('setAlertsToUntracked()', () => {
         failed: 0,
       },
       hits: {
+        max_score: null,
         hits: [],
       },
       aggregations: {

--- a/x-pack/platform/plugins/shared/alerting/server/lib/get_execution_log_aggregation.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/get_execution_log_aggregation.test.ts
@@ -762,7 +762,7 @@ describe('formatExecutionLogResult', () => {
     expect(
       formatExecutionLogResult({
         aggregations: undefined,
-        hits: { total: { value: 0, relation: 'eq' }, hits: [] },
+        hits: { total: { value: 0, relation: 'eq' }, max_score: null, hits: [] },
       })
     ).toEqual({
       total: 0,
@@ -773,7 +773,7 @@ describe('formatExecutionLogResult', () => {
     expect(
       formatExecutionLogResult({
         aggregations: { excludeExecuteStart: undefined as unknown as ExecutionUuidAggResult },
-        hits: { total: { value: 0, relation: 'eq' }, hits: [] },
+        hits: { total: { value: 0, relation: 'eq' }, max_score: null, hits: [] },
       })
     ).toEqual({
       total: 0,
@@ -977,6 +977,7 @@ describe('formatExecutionLogResult', () => {
       },
       hits: {
         total: { value: 875, relation: 'eq' },
+        max_score: null,
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
     };
@@ -1235,6 +1236,7 @@ describe('formatExecutionLogResult', () => {
       },
       hits: {
         total: { value: 875, relation: 'eq' },
+        max_score: null,
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
     };
@@ -1485,6 +1487,7 @@ describe('formatExecutionLogResult', () => {
       },
       hits: {
         total: { value: 875, relation: 'eq' },
+        max_score: null,
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
     };
@@ -1740,6 +1743,7 @@ describe('formatExecutionLogResult', () => {
       },
       hits: {
         total: { value: 875, relation: 'eq' },
+        max_score: null,
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
     };
@@ -1995,6 +1999,7 @@ describe('formatExecutionLogResult', () => {
       },
       hits: {
         total: { value: 10000, relation: 'gte' },
+        max_score: null,
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
     };
@@ -2508,6 +2513,7 @@ describe('formatExecutionKPIAggBuckets', () => {
         aggregations: undefined,
         hits: {
           total: { value: 875, relation: 'eq' },
+          max_score: null,
           hits: [],
         } as estypes.SearchHitsMetadata<unknown>,
       })
@@ -2633,6 +2639,7 @@ describe('formatExecutionKPIAggBuckets', () => {
       },
       hits: {
         total: { value: 875, relation: 'eq' },
+        max_score: null,
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
     };
@@ -2759,6 +2766,7 @@ describe('formatExecutionKPIAggBuckets', () => {
       },
       hits: {
         total: { value: 875, relation: 'eq' },
+        max_score: null,
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
     };
@@ -2973,6 +2981,7 @@ describe('formatExecutionKPIAggBuckets', () => {
       },
       hits: {
         total: { value: 10000, relation: 'gte' },
+        max_score: null,
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
     };
@@ -3034,6 +3043,7 @@ describe('formatExecutionSummary', () => {
       },
       hits: {
         total: { value: 36, relation: 'eq' },
+        max_score: null,
         hits: [],
       } as estypes.SearchHitsMetadata<unknown>,
     };

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_execution_log.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_execution_log.test.ts
@@ -353,6 +353,7 @@ const aggregateResults = {
   },
   hits: {
     total: { value: 875, relation: 'eq' },
+    max_score: null,
     hits: [],
   } as estypes.SearchHitsMetadata<unknown>,
 };

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
@@ -400,6 +400,7 @@ describe('Ad Hoc Task Runner', () => {
       timed_out: false,
       _shards: { failed: 0, successful: 1, total: 0, skipped: 0 },
       hits: {
+        max_score: null,
         total: { relation: 'eq', value: 0 },
         hits: [],
       },

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_alerts_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_alerts_client.test.ts
@@ -291,6 +291,7 @@ describe('Task Runner', () => {
           timed_out: false,
           _shards: { failed: 0, successful: 1, total: 0, skipped: 0 },
           hits: {
+            max_score: null,
             total: { relation: 'eq', value: 0 },
             hits: [],
           },

--- a/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.test.ts
@@ -748,6 +748,7 @@ describe('queryEventsBySavedObject', () => {
   test('should call cluster with correct options', async () => {
     clusterClient.search.mockResponse({
       hits: {
+        max_score: 1,
         hits: [
           {
             _index: 'index-name-00001',
@@ -755,6 +756,7 @@ describe('queryEventsBySavedObject', () => {
             _source: { foo: 'bar' },
             _seq_no: 1,
             _primary_term: 1,
+            _score: 1,
           },
         ],
         total: { relation: 'eq', value: 1 },
@@ -838,6 +840,7 @@ describe('aggregateEventsBySavedObject', () => {
         },
       },
       hits: {
+        max_score: null,
         hits: [],
         total: { relation: 'eq', value: 0 },
       },
@@ -941,6 +944,7 @@ describe('aggregateEventsWithAuthFilter', () => {
         },
       },
       hits: {
+        max_score: null,
         hits: [],
         total: { relation: 'eq', value: 0 },
       },
@@ -1030,6 +1034,7 @@ describe('aggregateEventsWithAuthFilter', () => {
         },
       },
       hits: {
+        max_score: null,
         hits: [],
         total: { relation: 'eq', value: 0 },
       },

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/action.mock.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/action.mock.ts
@@ -15,6 +15,7 @@ export function createClientMock() {
   const agentInHostedDoc = {
     _id: 'agent-in-hosted-policy',
     _index: 'index',
+    _score: 1,
     _source: {
       active: true,
       policy_id: 'hosted-agent-policy',
@@ -27,6 +28,7 @@ export function createClientMock() {
   const agentInHostedDoc2 = {
     _id: 'agent-in-hosted-policy2',
     _index: 'index',
+    _score: 1,
     _source: {
       active: true,
       policy_id: 'hosted-agent-policy',
@@ -39,6 +41,7 @@ export function createClientMock() {
   const agentInRegularDoc = {
     _id: 'agent-in-regular-policy',
     _index: 'index',
+    _score: 1,
     _source: {
       active: true,
       policy_id: 'regular-agent-policy',
@@ -51,6 +54,7 @@ export function createClientMock() {
   const agentInRegularDoc2 = {
     _id: 'agent-in-regular-policy2',
     _index: 'index',
+    _score: 1,
     _source: {
       active: true,
       policy_id: 'regular-agent-policy',
@@ -63,6 +67,7 @@ export function createClientMock() {
   const agentInRegularDocNewer = {
     _id: 'agent-in-regular-policy-newer',
     _index: 'index',
+    _score: 1,
     _source: {
       active: true,
       policy_id: 'regular-agent-policy',
@@ -75,6 +80,7 @@ export function createClientMock() {
   const agentInRegularDocNewer2 = {
     _id: 'agent-in-regular-policy-newer2',
     _index: 'index',
+    _score: 1,
     _source: {
       active: true,
       policy_id: 'regular-agent-policy',
@@ -207,6 +213,7 @@ export function createClientMock() {
           value: 5,
           relation: 'eq',
         },
+        max_score: 1,
       },
     })
   );

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/update_agent_tags.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/update_agent_tags.test.ts
@@ -256,6 +256,7 @@ describe('update_agent_tags', () => {
     esClient.search.mockResolvedValue({
       hits: {
         total: 3,
+        max_score: 1,
         hits: [
           {
             _id: 'agent1',

--- a/x-pack/platform/plugins/shared/fleet/server/services/files/client_from_host.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/files/client_from_host.test.ts
@@ -84,8 +84,8 @@ describe('FleetFromHostFilesClient', () => {
           value: 1,
           relation: 'eq',
         },
-        max_score: 0,
-        hits: [{ _index: '', _id: '' }],
+        max_score: 1,
+        hits: [{ _index: '', _id: '', _score: 1 }],
       },
     };
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/files/client_to_host.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/files/client_to_host.test.ts
@@ -95,8 +95,8 @@ describe('FleetToHostFilesClient', () => {
           value: 1,
           relation: 'eq',
         },
-        max_score: 0,
-        hits: [{ _index: '', _id: '' }],
+        max_score: 1,
+        hits: [{ _index: '', _id: '', _score: 1 }],
       },
     };
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/files/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/files/index.test.ts
@@ -52,14 +52,17 @@ describe('files service', () => {
           failed: 0,
         },
         hits: {
+          max_score: 1,
           hits: [
             {
               _index: ENDPOINT_FILE_METADATA_BACKING_INDEX,
               _id: 'someid1',
+              _score: 1,
             },
             {
               _index: ENDPOINT_FILE_METADATA_BACKING_INDEX,
               _id: 'someid2',
+              _score: 1,
             },
           ],
         },
@@ -100,10 +103,12 @@ describe('files service', () => {
           failed: 0,
         },
         hits: {
+          max_score: 1,
           hits: [
             {
               _index: ENDPOINT_FILE_BACKING_INDEX,
               _id: 'keep1',
+              _score: 1,
               _source: {
                 bid: 'keep1',
               },
@@ -111,6 +116,7 @@ describe('files service', () => {
             {
               _index: ENDPOINT_FILE_BACKING_INDEX,
               _id: 'keep2',
+              _score: 1,
               _source: {
                 bid: 'keep2',
               },
@@ -120,10 +126,10 @@ describe('files service', () => {
       });
 
       const files = [
-        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'keep1' },
-        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'keep2' },
-        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'delete1' },
-        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'delete2' },
+        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'keep1', _score: 1, },
+        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'keep2', _score: 1, },
+        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'delete1', _score: 1, },
+        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'delete2', _score: 1, },
       ];
       const { fileIdsByIndex: deletedFileIdsByIndex, allFileIds: allDeletedFileIds } =
         await fileIdsWithoutChunksByIndex(esClientMock, abortController, files);

--- a/x-pack/platform/plugins/shared/fleet/server/services/files/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/files/index.test.ts
@@ -126,10 +126,10 @@ describe('files service', () => {
       });
 
       const files = [
-        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'keep1', _score: 1, },
-        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'keep2', _score: 1, },
-        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'delete1', _score: 1, },
-        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'delete2', _score: 1, },
+        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'keep1', _score: 1 },
+        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'keep2', _score: 1 },
+        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'delete1', _score: 1 },
+        { _index: ENDPOINT_FILE_METADATA_BACKING_INDEX, _id: 'delete2', _score: 1 },
       ];
       const { fileIdsByIndex: deletedFileIdsByIndex, allFileIds: allDeletedFileIds } =
         await fileIdsWithoutChunksByIndex(esClientMock, abortController, files);

--- a/x-pack/platform/plugins/shared/fleet/server/services/metrics/fetch_agent_metrics.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/metrics/fetch_agent_metrics.test.ts
@@ -52,6 +52,7 @@ describe('fetchAgentMetrics', () => {
           value: 0,
           relation: 'eq',
         },
+        max_score: null,
         hits: [],
       },
       aggregations: {

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/check_deleted_files_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/check_deleted_files_task.test.ts
@@ -116,6 +116,7 @@ describe('check deleted files task', () => {
             value: 0,
             relation: 'eq',
           },
+          max_score: null,
           hits: [],
         },
       });
@@ -147,15 +148,18 @@ describe('check deleted files task', () => {
               value: 1,
               relation: 'eq',
             },
+            max_score: 1,
             hits: [
               {
                 _id: 'metadata-testid1',
                 _index: MOCK_FILE_METADATA_INDEX,
+                _score: 1,
                 _source: { file: { status: 'READY' } },
               },
               {
                 _id: 'metadata-testid2',
                 _index: MOCK_FILE_METADATA_INDEX,
+                _score: 1,
                 _source: { file: { status: 'READY' } },
               },
             ],
@@ -176,10 +180,12 @@ describe('check deleted files task', () => {
               value: 0,
               relation: 'eq',
             },
+            max_score: 1,
             hits: [
               {
                 _id: 'data-testid1',
                 _index: MOCK_FILE_DATA_INDEX,
+                _score: 1,
                 _source: {
                   bid: 'metadata-testid1',
                 },

--- a/x-pack/platform/plugins/shared/osquery/public/shared_components/osquery_results/osquery_results.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/shared_components/osquery_results/osquery_results.test.tsx
@@ -37,6 +37,7 @@ const defaultProps: OsqueryActionResultsProps = {
     {
       _id: 'test',
       _index: 'test',
+      _score: 1,
       fields: {
         action_id: ['testActionId'],
         'queries.action_id': ['queriesActionId'],

--- a/x-pack/platform/plugins/shared/rule_registry/server/alert_data_client/tests/bulk_update.test.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/alert_data_client/tests/bulk_update.test.ts
@@ -266,6 +266,7 @@ describe('bulkUpdate()', () => {
               {
                 _id: fakeAlertId,
                 _index: '.alerts-observability.apm.alerts',
+                _score: 999,
                 _source: {
                   [ALERT_RULE_TYPE_ID]: 'apm.error_rate',
                   [ALERT_RULE_CONSUMER]: 'apm',
@@ -318,6 +319,7 @@ describe('bulkUpdate()', () => {
               {
                 _id: fakeAlertId,
                 _index: '.alerts-observability.apm.alerts',
+                _score: 999,
                 _source: {
                   [ALERT_RULE_TYPE_ID]: fakeRuleTypeId,
                   [ALERT_RULE_CONSUMER]: 'apm',
@@ -375,6 +377,7 @@ describe('bulkUpdate()', () => {
               {
                 _id: successfulAuthzHit,
                 _index: '.alerts-observability.apm.alerts',
+                _score: 100,
                 _source: {
                   [ALERT_RULE_TYPE_ID]: 'apm.error_rate',
                   [ALERT_RULE_CONSUMER]: 'apm',
@@ -385,6 +388,7 @@ describe('bulkUpdate()', () => {
               {
                 _id: unsuccessfulAuthzHit,
                 _index: '.alerts-observability.apm.alerts',
+                _score: 999,
                 _source: {
                   [ALERT_RULE_TYPE_ID]: fakeRuleTypeId,
                   [ALERT_RULE_CONSUMER]: 'apm',

--- a/x-pack/platform/plugins/shared/rule_registry/server/utils/create_persistence_rule_type_wrapper.test.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/utils/create_persistence_rule_type_wrapper.test.ts
@@ -176,7 +176,7 @@ describe('isExistingDateGtEqThanAlert', () => {
   it('should return false if existing alert source is undefined', () => {
     expect(
       isExistingDateGtEqThanAlert(
-        { _source: undefined, _id: 'a1', _index: 'test-index' },
+        { _source: undefined, _id: 'a1', _score: 1, _index: 'test-index' },
         {
           _id: 'alert-a',
           _source: {

--- a/x-pack/platform/plugins/shared/streams/server/lib/significant_events/helpers/verify_queries.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/significant_events/helpers/verify_queries.test.ts
@@ -40,7 +40,7 @@ describe('verifyQueries', () => {
       took: 10,
       timed_out: false,
       _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
-      hits: { total: { value: 42, relation: 'eq' }, hits: [] },
+      hits: { total: { value: 42, relation: 'eq' }, max_score: null, hits: [] },
     });
     const esClient = createTracedEsClient({ client: esClientMock, logger: loggerMock });
 

--- a/x-pack/platform/plugins/shared/task_manager/server/removed_tasks/mark_removed_tasks_as_unrecognized.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/removed_tasks/mark_removed_tasks_as_unrecognized.test.ts
@@ -99,7 +99,11 @@ describe('markRemovedTasksAsUnrecognizedTask', () => {
     ]);
     // @ts-expect-error
     esClient.client.asInternalUser.search.mockResponse({
-      hits: { hits: [createTaskDoc('123'), createTaskDoc('456'), createTaskDoc('789')], total: 3, max_score: 1 },
+      hits: {
+        hits: [createTaskDoc('123'), createTaskDoc('456'), createTaskDoc('789')],
+        total: 3,
+        max_score: 1,
+      },
     });
 
     const runner = taskRunner(logger, coreSetup.getStartServices)();
@@ -234,7 +238,11 @@ describe('markRemovedTasksAsUnrecognizedTask', () => {
     ]);
     // @ts-expect-error
     esClient.client.asInternalUser.search.mockResponse({
-      hits: { hits: [createTaskDoc('123'), createTaskDoc('456'), createTaskDoc('789')], total: 3, max_score: 1 },
+      hits: {
+        hits: [createTaskDoc('123'), createTaskDoc('456'), createTaskDoc('789')],
+        total: 3,
+        max_score: 1,
+      },
     });
 
     const runner = taskRunner(logger, coreSetup.getStartServices)();

--- a/x-pack/platform/plugins/shared/task_manager/server/removed_tasks/mark_removed_tasks_as_unrecognized.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/removed_tasks/mark_removed_tasks_as_unrecognized.test.ts
@@ -99,7 +99,7 @@ describe('markRemovedTasksAsUnrecognizedTask', () => {
     ]);
     // @ts-expect-error
     esClient.client.asInternalUser.search.mockResponse({
-      hits: { hits: [createTaskDoc('123'), createTaskDoc('456'), createTaskDoc('789')], total: 3 },
+      hits: { hits: [createTaskDoc('123'), createTaskDoc('456'), createTaskDoc('789')], total: 3, max_score: 1 },
     });
 
     const runner = taskRunner(logger, coreSetup.getStartServices)();
@@ -137,7 +137,7 @@ describe('markRemovedTasksAsUnrecognizedTask', () => {
     ]);
     // @ts-expect-error
     esClient.client.asInternalUser.search.mockResponse({
-      hits: { hits: [], total: 0 },
+      hits: { hits: [], total: 0, max_score: null },
     });
 
     const runner = taskRunner(logger, coreSetup.getStartServices)();
@@ -234,7 +234,7 @@ describe('markRemovedTasksAsUnrecognizedTask', () => {
     ]);
     // @ts-expect-error
     esClient.client.asInternalUser.search.mockResponse({
-      hits: { hits: [createTaskDoc('123'), createTaskDoc('456'), createTaskDoc('789')], total: 3 },
+      hits: { hits: [createTaskDoc('123'), createTaskDoc('456'), createTaskDoc('789')], total: 3, max_score: 1 },
     });
 
     const runner = taskRunner(logger, coreSetup.getStartServices)();

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
@@ -769,9 +769,11 @@ describe('TaskStore', () => {
         [{}],
         [
           {
+            max_score: 1,
             hits: [
               {
                 _index: '.kibana_task_manager_8.16.0_001',
+                _score: 1,
                 _source: {
                   task: { ...mockTask, apiKey: 'encryptedKey' },
                 },

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/common/data/lib/parse_aggregation_results.test.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/common/data/lib/parse_aggregation_results.test.ts
@@ -95,6 +95,7 @@ const sampleAggregations = {
 const sampleEsqlSourceFieldsHit = {
   _id: 'esql_query_document',
   _index: '',
+  _score: 1,
   _source: {
     '@timestamp': '2023-11-27T10:00:00.000Z',
     'host.hostname': 'host-1',
@@ -1205,6 +1206,7 @@ describe('parseAggregationResults', () => {
           _shards: { total: 0, successful: 0, skipped: 0, failed: 0 },
           hits: {
             total: 4,
+            max_score: 1,
             hits: [
               sampleEsqlSourceFieldsHit,
               sampleEsqlSourceFieldsHit,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/server/data/lib/time_series_query.test.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/server/data/lib/time_series_query.test.ts
@@ -812,7 +812,7 @@ describe('getResultFromEs', () => {
           timed_out: false,
           _shards: { total: 0, successful: 0, skipped: 0, failed: 0 },
           _clusters: { total: 1, successful: 1, skipped: 0 } as estypes.ClusterStatistics,
-          hits: { total: { value: 0, relation: 'eq' }, hits: [] },
+          hits: { total: { value: 0, relation: 'eq' }, max_score: null, hits: [] },
         },
       })
     ).toEqual({
@@ -830,7 +830,7 @@ describe('getResultFromEs', () => {
           timed_out: false,
           _shards: { total: 0, successful: 0, skipped: 0, failed: 0 },
           _clusters: { total: 1, successful: 1, skipped: 0 } as estypes.ClusterStatistics,
-          hits: { total: { value: 0, relation: 'eq' }, hits: [] },
+          hits: { total: { value: 0, relation: 'eq' }, max_score: null, hits: [] },
         },
       })
     ).toEqual({
@@ -1268,7 +1268,7 @@ describe('getResultFromEs', () => {
           timed_out: false,
           _shards: { total: 0, successful: 0, skipped: 0, failed: 0 },
           _clusters: { total: 1, successful: 1, skipped: 0 } as estypes.ClusterStatistics,
-          hits: { total: { value: 0, relation: 'eq' }, hits: [] },
+          hits: { total: { value: 0, relation: 'eq' }, max_score: null, hits: [] },
         },
       })
     ).toEqual({
@@ -1286,7 +1286,7 @@ describe('getResultFromEs', () => {
           timed_out: false,
           _shards: { total: 0, successful: 0, skipped: 0, failed: 0 },
           _clusters: { total: 1, successful: 1, skipped: 0 } as estypes.ClusterStatistics,
-          hits: { total: { value: 0, relation: 'eq' }, hits: [] },
+          hits: { total: { value: 0, relation: 'eq' }, max_score: null, hits: [] },
         },
       })
     ).toEqual({

--- a/x-pack/solutions/observability/plugins/apm/server/lib/helpers/transactions/get_is_using_transaction_events.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/helpers/transactions/get_is_using_transaction_events.test.ts
@@ -23,8 +23,8 @@ const mockResponseNoHits = {
     total: {
       value: 0,
       relation: 'gte' as const,
-      max_score: 0,
     },
+    max_score: 0,
     hits: [],
   },
 };
@@ -43,6 +43,7 @@ const mockResponseSomeHits = {
       value: 3,
       relation: 'gte' as const,
     },
+    max_score: 1,
     hits: [],
   },
 };

--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.test.ts
@@ -249,6 +249,7 @@ describe('Error count alert', () => {
 
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
+        max_score: null,
         hits: [],
         total: {
           relation: 'eq',
@@ -423,6 +424,7 @@ describe('Error count alert', () => {
 
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
+        max_score: null,
         hits: [],
         total: {
           relation: 'eq',
@@ -595,6 +597,7 @@ describe('Error count alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -753,6 +756,7 @@ describe('Error count alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -914,6 +918,7 @@ describe('Error count alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -1101,6 +1106,7 @@ describe('Error count alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -1183,6 +1189,7 @@ describe('Error count alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 1,

--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.test.ts
@@ -17,6 +17,7 @@ describe('registerTransactionDurationRuleType', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -105,6 +106,7 @@ describe('registerTransactionDurationRuleType', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -194,6 +196,7 @@ describe('registerTransactionDurationRuleType', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -283,6 +286,7 @@ describe('registerTransactionDurationRuleType', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -371,6 +375,7 @@ describe('registerTransactionDurationRuleType', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -460,6 +465,7 @@ describe('registerTransactionDurationRuleType', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -554,6 +560,7 @@ describe('registerTransactionDurationRuleType', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 0,

--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.test.ts
@@ -21,6 +21,7 @@ describe('Transaction error rate alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 0,
@@ -55,6 +56,7 @@ describe('Transaction error rate alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 0,
@@ -176,6 +178,7 @@ describe('Transaction error rate alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -299,6 +302,7 @@ describe('Transaction error rate alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -421,6 +425,7 @@ describe('Transaction error rate alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 2,
@@ -543,6 +548,7 @@ describe('Transaction error rate alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 1,
@@ -652,6 +658,7 @@ describe('Transaction error rate alert', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResponse({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 1,

--- a/x-pack/solutions/observability/plugins/apm_data_access/server/lib/helpers/create_es_client/create_apm_event_client/index.test.ts
+++ b/x-pack/solutions/observability/plugins/apm_data_access/server/lib/helpers/create_es_client/create_apm_event_client/index.test.ts
@@ -117,7 +117,7 @@ describe('APMEventClient', () => {
     const esResponse: estypes.SearchResponse = {
       hits: {
         total: { value: 1, relation: 'eq' },
-        hits: [{ _source: {}, _index: '' }],
+        hits: [{ _source: {}, _index: '', _score: 1 }],
         max_score: 1,
       },
       took: 1,

--- a/x-pack/solutions/observability/plugins/slo/server/lib/rules/slo_burn_rate/executor.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/rules/slo_burn_rate/executor.test.ts
@@ -85,6 +85,7 @@ const commonEsResponse = {
     failed: 0,
   },
   hits: {
+    max_score: null,
     hits: [],
   },
 };
@@ -926,10 +927,12 @@ function generateEsSummaryResponse() {
   return {
     ...commonEsResponse,
     hits: {
+      max_score: 1,
       hits: [
         {
           _index: '.slo-observability.summary-v3.2',
           _id: 'X19fX19fJWJbqiqq1WN9x1e_kHkXpwAA',
+          _score: 1,
           _source: {
             sliValue: 0.9,
             status: 'HEALTHY',

--- a/x-pack/solutions/observability/plugins/slo/server/services/burn_rates_client.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/burn_rates_client.test.ts
@@ -23,6 +23,7 @@ const commonEsResponse = {
     failed: 0,
   },
   hits: {
+    max_score: null,
     hits: [],
   },
 };

--- a/x-pack/solutions/observability/plugins/slo/server/services/historical_summary_client.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/historical_summary_client.test.ts
@@ -27,6 +27,7 @@ const commonEsResponse = {
     failed: 0,
   },
   hits: {
+    max_score: null,
     hits: [],
   },
 };

--- a/x-pack/solutions/observability/plugins/slo/server/services/management/clean_up_temp_summary.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/management/clean_up_temp_summary.test.ts
@@ -19,6 +19,7 @@ const commonEsResponse = {
     failed: 0,
   },
   hits: {
+    max_score: null,
     hits: [],
   },
 };

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_definition_client.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_definition_client.test.ts
@@ -61,7 +61,8 @@ describe('SLODefinitionClient', () => {
           failed: 0,
         },
         hits: {
-          hits: [{ _source: summaryDoc, _index: '', _id: '' }],
+          max_score: 1,
+          hits: [{ _source: summaryDoc, _index: '', _id: '', _score: 1 }],
         },
       });
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_client.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_client.test.ts
@@ -26,6 +26,7 @@ const createEsResponse = (good: number = 90, total: number = 100) => ({
     failed: 0,
   },
   hits: {
+    max_score: null,
     hits: [],
   },
   aggregations: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.test.ts
@@ -799,6 +799,7 @@ function getEsResponse({ buckets, after }: { buckets: any[]; after?: any }) {
       failed: 0,
     },
     hits: {
+      max_score: null,
       hits: [],
     },
     aggregations: {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.test.ts
@@ -14,10 +14,12 @@ const mockClusterBuckets: ClusterBucket[] = [
     doc_count: 10,
     latestFindingTopHit: {
       hits: {
+        max_score: 1,
         hits: [
           {
             _id: '123',
             _index: '123',
+            _score: 1,
             _source: {
               orchestrator: {
                 cluster: {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/alert_summary.mock.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/alert_summary.mock.ts
@@ -47,11 +47,12 @@ export const getAlertSummarySearchEsMock = () => {
         value: 1,
         relation: 'eq',
       },
-      max_score: 0,
+      max_score: 1,
       hits: [
         {
           _index: 'foo',
           _id: '04128c15-0d1b-4716-a4c5-46997ac7f3bd',
+          _score: 1,
           _source: mockEsAlertSummarySchema,
         },
       ],

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/anonymization_fields_schema.mock.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/anonymization_fields_schema.mock.ts
@@ -29,11 +29,12 @@ export const getAnonymizationFieldsSearchEsMock = () => {
         value: 1,
         relation: 'eq',
       },
-      max_score: 0,
+      max_score: 1,
       hits: [
         {
           _index: 'foo',
           _id: '04128c15-0d1b-4716-a4c5-46997ac7f3bd',
+          _score: 1,
           _source: {
             '@timestamp': '2019-12-13T16:40:33.400Z',
             created_at: '2019-12-13T16:40:33.400Z',

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/attack_discovery_schema.mock.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/attack_discovery_schema.mock.ts
@@ -23,11 +23,12 @@ export const getAttackDiscoverySearchEsMock = () => {
         value: 1,
         relation: 'eq',
       },
-      max_score: 0,
+      max_score: 1,
       hits: [
         {
           _index: 'foo',
           _id: '04128c15-0d1b-4716-a4c5-46997ac7f3bd',
+          _score: 1,
           _source: {
             id: '04128c15-0d1b-4716-a4c5-46997ac7f3bd',
             '@timestamp': '2024-06-07T18:56:17.357Z',

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/conversations_schema.mock.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/conversations_schema.mock.ts
@@ -35,11 +35,12 @@ export const getConversationSearchEsMock = () => {
         value: 1,
         relation: 'eq',
       },
-      max_score: 0,
+      max_score: 1,
       hits: [
         {
           _index: 'foo',
           _id: '04128c15-0d1b-4716-a4c5-46997ac7f3bd',
+          _score: 1,
           _source: {
             category: 'assistant',
             '@timestamp': '2019-12-13T16:40:33.400Z',

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/prompts_schema.mock.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/prompts_schema.mock.ts
@@ -29,11 +29,12 @@ export const getPromptsSearchEsMock = () => {
         value: 1,
         relation: 'eq',
       },
-      max_score: 0,
+      max_score: 1,
       hits: [
         {
           _index: 'foo',
           _id: '04128c15-0d1b-4716-a4c5-46997ac7f3bd',
+          _score: 1,
           _source: {
             '@timestamp': '2019-12-13T16:40:33.400Z',
             created_at: '2019-12-13T16:40:33.400Z',

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_search_response_to_alerts/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_search_response_to_alerts/index.test.ts
@@ -176,11 +176,13 @@ describe('transformSearchResponseToAlerts', () => {
       {
         _id: '1',
         _index: 'foo',
+        _score: 1,
         _source: undefined,
       },
       {
         _id: '2',
         _index: 'foo',
+        _score: 1,
         _source: undefined,
       },
     ];

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/persistence/get_defend_insight.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/persistence/get_defend_insight.test.ts
@@ -48,7 +48,10 @@ describe('getDefendInsight', () => {
   });
 
   it('should return null if no defend insights found', async () => {
-    mockEsClient.search.mockResolvedValueOnce({ ...mockResponse, hits: { max_score: null, hits: [] } });
+    mockEsClient.search.mockResolvedValueOnce({
+      ...mockResponse,
+      hits: { max_score: null, hits: [] },
+    });
 
     const response = await getDefendInsight(mockRequest);
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/persistence/get_defend_insight.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/persistence/get_defend_insight.test.ts
@@ -48,7 +48,7 @@ describe('getDefendInsight', () => {
   });
 
   it('should return null if no defend insights found', async () => {
-    mockEsClient.search.mockResolvedValueOnce({ ...mockResponse, hits: { hits: [] } });
+    mockEsClient.search.mockResolvedValueOnce({ ...mockResponse, hits: { max_score: null, hits: [] } });
 
     const response = await getDefendInsight(mockRequest);
 

--- a/x-pack/solutions/security/plugins/lists/server/services/utils/transform_elastic_to_list_item.test.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/utils/transform_elastic_to_list_item.test.ts
@@ -89,7 +89,13 @@ describe('transform_elastic_to_list_item', () => {
     });
 
     test('converts timestamp from number format to ISO string', () => {
-      const hits = [{ _index: 'test', _source: { ...getSearchEsListItemMock(), '@timestamp': 0 } }];
+      const hits = [
+        {
+          _index: 'test',
+          _score: 1,
+          _source: { ...getSearchEsListItemMock(), '@timestamp': 0 },
+        },
+      ];
 
       const result = transformElasticHitsToListItem({
         hits,
@@ -103,6 +109,7 @@ describe('transform_elastic_to_list_item', () => {
       const hits = [
         {
           _index: 'test',
+          _score: 1,
           _source: { ...getSearchEsListItemMock(), '@timestamp': -63549289600000 },
         },
       ];

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details_alerts_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details_alerts_table.test.tsx
@@ -49,6 +49,7 @@ describe('CorrelationsDetailsAlertsTable', () => {
         {
           _id: '1',
           _index: 'index',
+          _score: 1,
           fields: {
             '@timestamp': ['2022-01-01'],
             'kibana.alert.rule.name': ['Rule1'],
@@ -60,6 +61,7 @@ describe('CorrelationsDetailsAlertsTable', () => {
         {
           _id: '1',
           _index: 'index',
+          _score: 1,
           fields: {
             '@timestamp': ['2022-01-02'],
             'kibana.alert.rule.name': ['Rule2'],

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/mocks/mock_search_hit.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/mocks/mock_search_hit.ts
@@ -13,6 +13,7 @@ import type { SearchHit } from '../../../../../common/search_strategy';
 export const mockSearchHit: SearchHit = {
   _index: 'index',
   _id: 'id',
+  _score: 1,
   fields: {
     'kibana.alert.rule.parameters': [
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/crowdstrike/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/crowdstrike/mocks.ts
@@ -79,9 +79,11 @@ const createConstructorOptionsMock = (): CrowdstrikeActionsClientOptionsMock => 
   crowdstrikeIndexDoc.inner_hits = {
     most_recent: {
       hits: {
+        max_score: 1,
         hits: [
           {
             _index: '',
+            _score: 1,
             _source: {
               agent: { id: 'fleet-agent-id-123' },
               device: { id: '1-2-3' },
@@ -102,9 +104,11 @@ const createConstructorOptionsMock = (): CrowdstrikeActionsClientOptionsMock => 
 
 interface CrowdstrikeEventSearchResponseMock {
   hits: {
+    max_score: number | null;
     hits: Array<{
       _id: string;
       _index: string;
+      _score: number | null;
       _source: Record<string, unknown>;
     }>;
   };
@@ -115,10 +119,12 @@ interface CrowdstrikeEventSearchResponseMock {
 
 const createEventSearchResponseMock = (): CrowdstrikeEventSearchResponseMock => ({
   hits: {
+    max_score: 1,
     hits: [
       {
         _id: '1-2-3',
         _index: 'logs-crowdstrike.fdr-default',
+        _score: 1,
         _source: {
           host: {
             name: 'Crowdstrike-1460',

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/microsoft/defender/endpoint/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/microsoft/defender/endpoint/mocks.ts
@@ -47,9 +47,11 @@ const createMsDefenderClientConstructorOptionsMock = () => {
   msLogIndexEsHit.inner_hits = {
     most_recent: {
       hits: {
+        max_score: 1,
         hits: [
           {
             _index: '',
+            _score: 1,
             _source: {
               agent: {
                 id: '1-2-3',

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.test.ts
@@ -2605,9 +2605,11 @@ describe('SentinelOneActionsClient class', () => {
       agentSearchHit.inner_hits = {
         most_recent: {
           hits: {
+            max_score: 1,
             hits: [
               {
                 _index: '',
+                _score: 1,
                 _source: {
                   agent: {
                     id: 'elastic-agent-id-1',

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/agent/clients/crowdstrike/crowdstrike_agent_status_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/agent/clients/crowdstrike/crowdstrike_agent_status_client.test.ts
@@ -37,18 +37,22 @@ const getMockSearchResponse = (
 ) => ({
   ...baseResponse,
   hits: {
+    max_score: 1,
     hits: [
       {
         _id: '1',
         _index: 'index',
+        _score: 1,
         fields: { 'device.id': [agentName] },
         inner_hits: {
           most_recent: {
             hits: {
+              max_score: 1,
               hits: [
                 {
                   _id: '1',
                   _index: 'index',
+                  _score: 1,
                   _source: {
                     crowdstrike: {
                       host: {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/notifications/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/notifications/utils.test.ts
@@ -45,6 +45,7 @@ describe('utils', () => {
         {
           _id: 'id-123',
           _index: 'index-123',
+          _score: 1,
           _source: {
             test: '123',
           },
@@ -60,6 +61,7 @@ describe('utils', () => {
         {
           _id: 'id-123',
           _index: 'index-123',
+          _score: 1,
           _source: {
             test: '123',
           },
@@ -75,6 +77,7 @@ describe('utils', () => {
         {
           _id: 'id-123',
           _index: 'index-123',
+          _score: 1,
           _source: {
             test: '123',
           },
@@ -84,6 +87,7 @@ describe('utils', () => {
         {
           _id: 'id-789',
           _index: 'index-456',
+          _score: 1,
           _source: {
             test: '456',
           },
@@ -100,6 +104,7 @@ describe('utils', () => {
         {
           _id: 'id-123',
           _index: 'index-123', // This should only show up once and not be duplicated twice
+          _score: 1,
           _source: {
             test: '123',
           },
@@ -107,6 +112,7 @@ describe('utils', () => {
         {
           _index: 'index-890',
           _id: 'id-890',
+          _score: 1,
           _source: {
             test: '890',
           },
@@ -116,6 +122,7 @@ describe('utils', () => {
         {
           _id: 'id-123', // This should only show up once and not be duplicated twice
           _index: 'index-123',
+          _score: 1,
           _source: {
             test: '123',
           },
@@ -123,6 +130,7 @@ describe('utils', () => {
         {
           _id: 'id-789',
           _index: 'index-456',
+          _score: 1,
           _source: {
             test: '456',
           },
@@ -158,6 +166,7 @@ describe('utils', () => {
         {
           _id: 'id-123',
           _index: 'index-123', // This should only show up once and not be duplicated twice
+          _score: 1,
           _source: {
             test: '123',
           },
@@ -165,6 +174,7 @@ describe('utils', () => {
         {
           _index: 'index-890',
           _id: 'id-890',
+          _score: 1,
           _source: {
             test: '890',
           },
@@ -174,6 +184,7 @@ describe('utils', () => {
         {
           _id: 'id-123', // This should only show up once and not be duplicated twice
           _index: 'index-123',
+          _score: 1,
           _source: {
             test: '123',
           },
@@ -181,6 +192,7 @@ describe('utils', () => {
         {
           _id: 'id-789',
           _index: 'index-456',
+          _score: 1,
           _source: {
             test: '456',
           },
@@ -210,6 +222,7 @@ describe('utils', () => {
         {
           _id: 'id-123',
           _index: 'index-123-a', // This is only different by index
+          _score: 1,
           _source: {
             test: '123',
           },
@@ -217,6 +230,7 @@ describe('utils', () => {
         {
           _index: 'index-890',
           _id: 'id-890',
+          _score: 1,
           _source: {
             test: '890',
           },
@@ -226,6 +240,7 @@ describe('utils', () => {
         {
           _id: 'id-123', // This is only different by index
           _index: 'index-123-b',
+          _score: 1,
           _source: {
             test: '123',
           },
@@ -233,6 +248,7 @@ describe('utils', () => {
         {
           _id: 'id-789',
           _index: 'index-456',
+          _score: 1,
           _source: {
             test: '456',
           },
@@ -249,6 +265,7 @@ describe('utils', () => {
         {
           _id: 'id-123',
           _index: 'index-123',
+          _score: 1,
           _source: {
             test: '123',
           },
@@ -258,6 +275,7 @@ describe('utils', () => {
         {
           _id: 'id-123',
           _index: 'index-123',
+          _score: 1,
           _source: {
             test: '456',
           },
@@ -282,6 +300,7 @@ describe('utils', () => {
         {
           _id: 'id-123',
           _index: 'index-123',
+          _score: 1,
           _source: {
             test: '123',
           },
@@ -309,6 +328,7 @@ describe('utils', () => {
         {
           _id: 'id-123',
           _index: 'index-123',
+          _score: 1,
           _source: {
             test: '123',
           },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/__mocks__/empty_signal_source_hit.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/__mocks__/empty_signal_source_hit.ts
@@ -13,5 +13,6 @@ import type { SignalSourceHit } from '../types';
  */
 export const emptyEsResult = (): SignalSourceHit => ({
   _index: 'index',
+  _score: 1,
   _id: '123',
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/__mocks__/threshold.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/__mocks__/threshold.ts
@@ -42,6 +42,7 @@ import { getThresholdTermsHash } from '../threshold/utils';
 export const sampleThresholdAlert = {
   _id: 'b3ad77a4-65bd-4c4e-89cf-13c46f54bc4d',
   _index: 'some-index',
+  _score: 1,
   _source: {
     '@timestamp': '2020-04-20T21:26:30.000Z',
     [SPACE_IDS]: ['default'],

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/esql/utils/generate_alert_id.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/esql/utils/generate_alert_id.test.ts
@@ -15,6 +15,7 @@ import { cloneDeep } from 'lodash';
 const mockEvent: estypes.SearchHit<SignalSource> = {
   _id: 'test_id',
   _version: 2,
+  _score: 1,
   _index: 'test_index',
   _source: {
     'agent.name': 'test-0',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/factories/utils/transform_hit_to_alert.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/factories/utils/transform_hit_to_alert.test.ts
@@ -88,6 +88,7 @@ describe('transformHitToAlert', () => {
     const doc = {
       _index: 'testindex',
       _id: 'myId',
+      _score: 1,
       _source: {
         event: {
           kind: 'test-value',
@@ -121,6 +122,7 @@ describe('transformHitToAlert', () => {
     const doc = {
       _index: 'testindex',
       _id: 'myId',
+      _score: 1,
       _source: {
         'event.kind': 'test-value',
       },
@@ -152,6 +154,7 @@ describe('transformHitToAlert', () => {
     const doc = {
       _index: 'testindex',
       _id: 'myId',
+      _score: 1,
       _source: {
         testField: 'testValue',
       },
@@ -183,6 +186,7 @@ describe('transformHitToAlert', () => {
     const doc = {
       _index: 'testindex',
       _id: 'myId',
+      _score: 1,
       _source: {
         'event.action': ['process', { objectSubfield: 'test' }],
       },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/get_signal_id_to_matched_queries_map.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/get_signal_id_to_matched_queries_map.test.ts
@@ -68,6 +68,7 @@ describe('getSignalIdToMatchedQueriesMap', () => {
       signals: [
         {
           _index: 'test-index',
+          _score: 1,
           _source: { 'source.ip': ['127.0.0.1'] },
           fields: { 'source.ip': ['127.0.0.1'] },
         },
@@ -93,6 +94,7 @@ describe('getSignalIdToMatchedQueriesMap', () => {
       signals: [
         {
           _index: 'test-index',
+          _score: 1,
           _source: { 'user.name': ['test-user'] },
           fields: { 'user.name': ['test-user'] },
         },
@@ -118,6 +120,7 @@ describe('getSignalIdToMatchedQueriesMap', () => {
       signals: [
         {
           _index: 'test-index',
+          _score: 1,
           _source: { 'source.ip': ['127.0.0.1'] },
           fields: { 'source.ip': ['127.0.0.1'] },
         },
@@ -167,6 +170,7 @@ describe('getSignalIdToMatchedQueriesMap', () => {
       signals: [
         {
           _index: 'test-index',
+          _score: 1,
           _source: { 'source.ip': ['127.0.0.1'] },
           fields: { 'source.ip': ['127.0.0.1'] },
         },
@@ -236,6 +240,7 @@ describe('getSignalIdToMatchedQueriesMap', () => {
       signals: [
         {
           _index: 'test-index',
+          _score: 1,
           _source: { 'source.ip': ['127.0.0.1'] },
           fields: { 'source.ip': ['127.0.0.1'] },
         },
@@ -273,6 +278,7 @@ describe('getSignalIdToMatchedQueriesMap', () => {
       signals: [
         {
           _index: 'test-index',
+          _score: 1,
           _source: { 'source.ip': ['127.0.0.1'] },
           fields: { 'source.ip': ['127.0.0.1'] },
         },
@@ -316,12 +322,14 @@ describe('getSignalIdToMatchedQueriesMap', () => {
         {
           _index: 'test-index',
           _id: 'signalId1',
+          _score: 1,
           _source: { 'source.ip': ['127.0.0.1'] },
           fields: { 'source.ip': ['127.0.0.1'] },
         },
         {
           _index: 'test-index',
           _id: 'signalId2',
+          _score: 1,
           _source: { 'source.ip': ['127.0.0.1'] },
           fields: { 'source.ip': ['127.0.0.1'] },
         },
@@ -374,12 +382,14 @@ describe('getSignalIdToMatchedQueriesMap', () => {
         {
           _index: 'test-index',
           _id: 'signalId1',
+          _score: 1,
           _source: { 'source.ip': ['127.0.0.1'] },
           fields: { 'source.ip': ['127.0.0.1'] },
         },
         {
           _index: 'test-index',
           _id: 'signalId2',
+          _score: 1,
           _source: { 'source.ip': ['127.0.0.2'] },
           fields: { 'source.ip': ['127.0.0.2'] },
         },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/utils.test.ts
@@ -1006,6 +1006,7 @@ describe('utils', () => {
           {
             _id: '1',
             _index: 'index-1',
+            _score: 1,
             fields: {
               'host.name': ['host-1'],
             },
@@ -1022,6 +1023,7 @@ describe('utils', () => {
       const createEvent = (id: string, fields: Record<string, unknown>) => ({
         _id: id,
         _index: `index`,
+        _score: 1,
         fields,
       });
       const valueMap = getFieldAndValueToDocIdsMap({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
@@ -93,6 +93,7 @@ describe('Custom Query Alerts', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResolvedValue({
       hits: {
         hits: [],
+        max_score: null,
         total: {
           relation: 'eq',
           value: 0,
@@ -132,6 +133,7 @@ describe('Custom Query Alerts', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResolvedValue({
       hits: {
         hits: [sampleDocNoSortId()],
+        max_score: 100,
         total: {
           relation: 'eq',
           value: 1,
@@ -195,6 +197,7 @@ describe('Custom Query Alerts', () => {
     services.scopedClusterClient.asCurrentUser.search.mockResolvedValue({
       hits: {
         hits: [sampleDocNoSortId()],
+        max_score: 100,
         total: {
           relation: 'eq',
           value: 1,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/partition_missing_fields_events.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/partition_missing_fields_events.test.ts
@@ -20,6 +20,7 @@ describe('partitionMissingFieldsEvents', () => {
             },
             _id: '1',
             _index: 'index-0',
+            _score: 1,
           },
           {
             fields: {
@@ -28,6 +29,7 @@ describe('partitionMissingFieldsEvents', () => {
             },
             _id: '1',
             _index: 'index-0',
+            _score: 1,
           },
         ],
         ['agent.host', 'agent.type', 'agent.version'],
@@ -70,6 +72,7 @@ describe('partitionMissingFieldsEvents', () => {
               },
               _id: '1',
               _index: 'index-0',
+              _score: 1,
             },
           },
           {
@@ -80,6 +83,7 @@ describe('partitionMissingFieldsEvents', () => {
               },
               _id: '1',
               _index: 'index-0',
+              _score: 1,
             },
           },
         ],
@@ -97,6 +101,7 @@ describe('partitionMissingFieldsEvents', () => {
             },
             _id: '1',
             _index: 'index-0',
+            _score: 1,
           },
         },
       ],
@@ -109,6 +114,7 @@ describe('partitionMissingFieldsEvents', () => {
             },
             _id: '1',
             _index: 'index-0',
+            _score: 1,
           },
         },
       ],

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/reason_formatter.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/reason_formatter.test.ts
@@ -10,6 +10,7 @@ import { buildReasonMessageForThresholdAlert, buildReasonMessageUtil } from './r
 const mergedDoc = {
   _index: 'index-1',
   _id: 'id-1',
+  _score: 1,
   fields: {
     'destination.ip': ['9.99.99.9'],
     'destination.port': ['6789'],
@@ -28,6 +29,7 @@ const mergedDoc = {
 const genThresholdMergedDoc = (groupedKeys: Record<string, string>) => ({
   _index: 'index-1',
   _id: 'some-id',
+  _score: 1,
   _source: {
     '@timestamp': '2022-08-16T11:01:09.848Z',
     threshold_result: [Object],

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/wrap_suppressed_alerts.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/wrap_suppressed_alerts.test.ts
@@ -141,6 +141,7 @@ describe('wrapSuppressedAlerts', () => {
           },
           _id: '1',
           _index: 'test*',
+          _score: 1,
         },
       ],
       sharedParams,
@@ -194,6 +195,7 @@ describe('wrapSuppressedAlerts', () => {
           },
           _id: '1',
           _index: 'test*',
+          _score: 1,
         },
         {
           fields: {
@@ -203,6 +205,7 @@ describe('wrapSuppressedAlerts', () => {
           },
           _id: '1',
           _index: 'test*',
+          _score: 1,
         },
       ],
       sharedParams,
@@ -225,6 +228,7 @@ describe('wrapSuppressedAlerts', () => {
           },
           _id: '1',
           _index: 'test*',
+          _score: 1,
         },
       ],
       sharedParams,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_migration_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_migration_client.test.ts
@@ -17,7 +17,7 @@ const emptySearchResponse = {
   took: 1,
   timed_out: false,
   _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
-  hits: { hits: [] },
+  hits: { max_score: null, hits: [] },
 };
 
 describe('AssetCriticalityMigrationClient', () => {
@@ -74,7 +74,7 @@ describe('AssetCriticalityMigrationClient', () => {
     it('should return true if there are documents without asset.criticality field', async () => {
       assetCriticalityDataClient.search.mockResolvedValue({
         ...emptySearchResponse,
-        hits: { hits: [{ _index: 'test-index' }] },
+        hits: { max_score: 1, hits: [{ _index: 'test-index', _score: 1 }] },
       });
 
       const result = await migrationClient.isEcsDataMigrationRequired();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_service.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_service.test.ts
@@ -20,6 +20,7 @@ const buildMockCriticalityHit = (
 ): SearchHit<AssetCriticalityRecord> => ({
   _id: 'host.name:not-found',
   _index: '.asset-criticality-default',
+  _score: 1,
   _source: {
     '@timestamp': '2021-09-16T15:00:00.000Z',
     id_field: 'host.name',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.test.ts
@@ -165,6 +165,7 @@ describe('EntityStoreDataClient', () => {
     },
     hits: {
       total: 0,
+      max_score: null,
       hits: [],
     },
   };
@@ -258,9 +259,11 @@ describe('EntityStoreDataClient', () => {
         ...emptySearchResponse,
         hits: {
           total: 1,
+          max_score: 1,
           hits: [
             {
               _index: '.entities.v1.latest.security_host_default',
+              _score: 1,
               _source: fakeEntityRecord,
             },
           ],
@@ -279,9 +282,11 @@ describe('EntityStoreDataClient', () => {
         ...emptySearchResponse,
         hits: {
           total: 1,
+          max_score: 1,
           hits: [
             {
               _index: '.entities.v1.latest.security_host_default',
+              _score: 1,
               _source: { asset: { criticality: 'deleted' }, ...fakeEntityRecord },
             },
           ],

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/helpers.test.ts
@@ -71,12 +71,12 @@ describe('getTotalCount', () => {
 
 describe('buildIndicatorEnrichments', () => {
   it('returns nothing if hits have no matched queries', () => {
-    const hits = [{ _id: '_id', _index: '_index', matched_queries: [] }];
+    const hits = [{ _id: '_id', _index: '_index', _score: 1, matched_queries: [] }];
     expect(buildIndicatorEnrichments(hits)).toEqual([]);
   });
 
   it("returns nothing if hits' matched queries are not valid", () => {
-    const hits = [{ _id: '_id', _index: '_index', matched_queries: ['invalid.field'] }];
+    const hits = [{ _id: '_id', _index: '_index', _score: 1, matched_queries: ['invalid.field'] }];
     expect(buildIndicatorEnrichments(hits)).toEqual([]);
   });
 
@@ -85,6 +85,7 @@ describe('buildIndicatorEnrichments', () => {
       {
         _id: '_id',
         _index: '_index',
+        _score: 1,
         matched_queries: ['file.hash.md5'],
         fields: {
           'threat.indicator.file.hash.md5': ['indicator_value'],
@@ -108,6 +109,7 @@ describe('buildIndicatorEnrichments', () => {
       {
         _id: '_id',
         _index: '_index',
+        _score: 1,
         matched_queries: ['file.hash.md5', 'source.ip'],
         fields: {
           'threat.indicator.file.hash.md5': ['indicator_value'],
@@ -141,6 +143,7 @@ describe('buildIndicatorEnrichments', () => {
       {
         _id: '_id',
         _index: '_index',
+        _score: 1,
         matched_queries: ['file.hash.md5'],
         fields: {
           'threat.indicator.file.hash.md5': ['indicator_value'],
@@ -149,6 +152,7 @@ describe('buildIndicatorEnrichments', () => {
       {
         _id: '_id2',
         _index: '_index2',
+        _score: 1,
         matched_queries: ['source.ip'],
         fields: {
           'threat.indicator.ip': ['127.0.0.1'],

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/related_entities/related_hosts/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/related_entities/related_hosts/index.test.ts
@@ -42,10 +42,12 @@ describe('usersRelatedHosts search strategy', () => {
 
       mockedDeps.esClient.asCurrentUser.search.mockResponse({
         hits: {
+          max_score: 1,
           hits: [
             {
               _id: 'id',
               _index: 'index',
+              _score: 1,
               _source: {
                 risk,
                 host: {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/related_entities/related_users/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/related_entities/related_users/index.test.ts
@@ -46,6 +46,7 @@ describe('hostsRelatedUsers search strategy', () => {
             {
               _id: 'id',
               _index: 'index',
+              _score: 1,
               _source: {
                 risk,
                 user: {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.test.ts
@@ -33,11 +33,12 @@ export const mockSearchStrategyResponse: IEsSearchResponse<HostRiskScore> = {
       failed: 0,
     },
     hits: {
-      max_score: null,
+      max_score: 1,
       hits: [
         {
           _id: '4',
           _index: 'index',
+          _score: 1,
           _source: {
             '@timestamp': '1234567899',
             host: {


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-specification/pull/1144 was opened in 2021 and just merged last week. It turns out that Elasticsearch search endpoint always returns `response.hits.hits._score` and `response.hit.max_score`, so they are now required. It causes failures in Kibana type checks.  This affects a lot of tests that have mock search responses. 

Since `_score` and `max_score` are already allowed today, the goal of this PR is to add them to the relevant tests so that making them actually required is less tedious.

For example, an issue that I don't know how to fix is:

```
proc [tsc] x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/extract_documentation.ts:103:33 - error TS2345: Argument of type '(hit: SearchHit<any>) => ExtractedDocument' is not assignable to parameter of type '(value: SearchHit<unknown>, index: number, array: SearchHit<unknown>[]) => ExtractedDocument'.
proc [tsc]   Types of parameters 'hit' and 'value' are incompatible.
proc [tsc]     Type 'SearchHit<unknown>' is not assignable to type 'SearchHit<any>'.
proc [tsc]       Types of property '_score' are incompatible.
proc [tsc]         Type 'number \| null \| undefined' is not assignable to type 'number \| null'.
proc [tsc]           Type 'undefined' is not assignable to type 'number \| null'.
proc [tsc]
proc [tsc] 103   return response.hits.hits.map(convertHit);
```

The affected lines:

https://github.com/elastic/kibana/blob/3e02d886bb3978780c5e008665a242e08647c7fb/x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/extract_documentation.ts#L43-L58

I tried using `unknown` instead of `any`, but then all accesses to `source` fail.