### PR TITLE
[9.1][Fleet] remove sync integrations APIs in serverless 

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -41657,10 +41657,11 @@
             }
           }
         },
-        "summary": "Get CCR Remote synced integrations status",
+        "summary": "Get remote synced integrations status",
         "tags": [
-          "CCR Remote synced integrations"
-        ]
+          "Fleet remote synced integrations"
+        ],
+        "x-state": "Generally available; added in 9.1.0"
       }
     },
     "/api/fleet/remote_synced_integrations/{outputId}/remote_status": {
@@ -41852,10 +41853,11 @@
             }
           }
         },
-        "summary": "Get CCR Remote synced integrations status by outputId",
+        "summary": "Get remote synced integrations status by outputId",
         "tags": [
-          "CCR Remote synced integrations"
-        ]
+          "Fleet remote synced integrations"
+        ],
+        "x-state": "Generally available; added in 9.1.0"
       }
     },
     "/api/fleet/service_tokens": {
@@ -59070,9 +59072,6 @@
       "name": "alerting"
     },
     {
-      "name": "CCR Remote synced integrations"
-    },
-    {
       "name": "connectors"
     },
     {
@@ -59110,6 +59109,9 @@
     },
     {
       "name": "Fleet proxies"
+    },
+    {
+      "name": "Fleet remote synced integrations"
     },
     {
       "name": "Fleet Server hosts"

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -58661,9 +58661,6 @@
       "name": "alerting"
     },
     {
-      "name": "CCR Remote synced integrations"
-    },
-    {
       "name": "connectors"
     },
     {

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -66,7 +66,6 @@ tags:
       Configure APM source maps. A source map allows minified files to be mapped back to original source code--allowing you to maintain the speed advantage of minified code, without losing the ability to quickly and easily debug your application.
       For best results, uploading source maps should become a part of your deployment procedure, and not something you only do when you see unhelpful errors. That's because uploading source maps after errors happen won't make old errors magically readable--errors must occur again for source mapping to occur.
     name: APM sourcemaps
-  - name: CCR Remote synced integrations
   - name: connectors
     description: |
       Connectors provide a central place to store connection information for services and integrations with Elastic or third party systems. Alerting rules can use connectors to run actions when rule conditions are met.
@@ -37520,6 +37519,9 @@ paths:
       summary: Create a service token
       tags:
         - Fleet service tokens
+      x-metaTags:
+        - content: Kibana, Elastic Cloud Serverless
+          name: product_name
   /api/fleet/settings:
     get:
       description: '[Required authorization] Route required privileges: fleet-settings-read.'

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -37519,9 +37519,6 @@ paths:
       summary: Create a service token
       tags:
         - Fleet service tokens
-      x-metaTags:
-        - content: Kibana, Elastic Cloud Serverless
-          name: product_name
   /api/fleet/settings:
     get:
       description: '[Required authorization] Route required privileges: fleet-settings-read.'

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -39575,9 +39575,6 @@ paths:
       tags:
         - Fleet remote synced integrations
       x-state: Generally available; added in 9.1.0
-      x-metaTags:
-        - content: Kibana
-          name: product_name
   /api/fleet/remote_synced_integrations/status:
     get:
       description: '[Required authorization] Route required privileges: fleet-settings-read AND integrations-read.'
@@ -39706,9 +39703,6 @@ paths:
       tags:
         - Fleet remote synced integrations
       x-state: Generally available; added in 9.1.0
-      x-metaTags:
-        - content: Kibana
-          name: product_name
   /api/fleet/service_tokens:
     post:
       description: '[Required authorization] Route required privileges: fleet-agents-all.'

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -39704,15 +39704,11 @@ paths:
                   - attributes
       summary: Get remote synced integrations status
       tags:
-<<<<<<< HEAD
-        - CCR Remote synced integrations
-=======
         - Fleet remote synced integrations
       x-state: Generally available; added in 9.1.0
       x-metaTags:
         - content: Kibana
           name: product_name
->>>>>>> ebb81fc8cbc ([Fleet] remove sync integrations APIs in serverless (#233482))
   /api/fleet/service_tokens:
     post:
       description: '[Required authorization] Route required privileges: fleet-agents-all.'

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -80,7 +80,6 @@ tags:
       description: Cases documentation
       url: https://www.elastic.co/docs/explore-analyze/alerts-cases/cases
     x-displayName: Cases
-  - name: CCR Remote synced integrations
   - name: connectors
     description: |
       Connectors provide a central place to store connection information for services and integrations with Elastic or third party systems. Alerting rules can use connectors to run actions when rule conditions are met.
@@ -103,6 +102,7 @@ tags:
   - name: Fleet outputs
   - name: Fleet package policies
   - name: Fleet proxies
+  - name: Fleet remote synced integrations
   - name: Fleet Server hosts
   - name: Fleet service tokens
   - name: Fleet uninstall tokens
@@ -39571,9 +39571,13 @@ paths:
                 required:
                   - message
                   - attributes
-      summary: Get CCR Remote synced integrations status by outputId
+      summary: Get remote synced integrations status by outputId
       tags:
-        - CCR Remote synced integrations
+        - Fleet remote synced integrations
+      x-state: Generally available; added in 9.1.0
+      x-metaTags:
+        - content: Kibana
+          name: product_name
   /api/fleet/remote_synced_integrations/status:
     get:
       description: '[Required authorization] Route required privileges: fleet-settings-read AND integrations-read.'
@@ -39698,9 +39702,17 @@ paths:
                 required:
                   - message
                   - attributes
-      summary: Get CCR Remote synced integrations status
+      summary: Get remote synced integrations status
       tags:
+<<<<<<< HEAD
         - CCR Remote synced integrations
+=======
+        - Fleet remote synced integrations
+      x-state: Generally available; added in 9.1.0
+      x-metaTags:
+        - content: Kibana
+          name: product_name
+>>>>>>> ebb81fc8cbc ([Fleet] remove sync integrations APIs in serverless (#233482))
   /api/fleet/service_tokens:
     post:
       description: '[Required authorization] Route required privileges: fleet-agents-all.'

--- a/x-pack/platform/plugins/shared/fleet/server/routes/remote_synced_integrations/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/remote_synced_integrations/index.ts
@@ -32,9 +32,13 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
           ],
         },
       },
-      summary: `Get CCR Remote synced integrations status`,
+      summary: `Get remote synced integrations status`,
       options: {
-        tags: ['oas-tag:CCR Remote synced integrations'],
+        tags: ['oas-tag:Fleet remote synced integrations'],
+        availability: {
+          since: '9.1.0',
+          stability: 'stable',
+        },
       },
     })
     .addVersion(
@@ -66,9 +70,13 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
           ],
         },
       },
-      summary: `Get CCR Remote synced integrations status by outputId`,
+      summary: `Get remote synced integrations status by outputId`,
       options: {
-        tags: ['oas-tag:CCR Remote synced integrations'],
+        tags: ['oas-tag:Fleet remote synced integrations'],
+        availability: {
+          since: '9.1.0',
+          stability: 'stable',
+        },
       },
     })
     .addVersion(


### PR DESCRIPTION
## Summary

Backport https://github.com/elastic/kibana/pull/233482 to 9.1
