### PR TITLE
Update ownership of the @elastic/ecs package for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1169,7 +1169,7 @@
         "@elastic/ecs"
       ],
       "reviewers": [
-        "team:kibana-core"
+        "team:obs-ux-logs-team"
       ],
       "matchBaseBranches": [
         "main"
@@ -1177,7 +1177,7 @@
       "labels": [
         "release_note:skip",
         "backport:all-open",
-        "Team:Core"
+        "Team:obs-ux-logs"
       ],
       "enabled": true
     },


### PR DESCRIPTION
Transfers ownership of the `@elastic/ecs` package for renovate to the Observability team.

The automation for new npm package releases will be fixed in a follow-up.

Addresses part of https://github.com/elastic/observability-dev/issues/4814