### PR TITLE
Scout events report: more efficient event persistence

### DIFF
--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/report.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/report.ts
@@ -18,10 +18,15 @@ import { ScoutReport, ScoutReportError } from '../base';
  *
  */
 export class ScoutEventsReport extends ScoutReport {
+  private readonly eventLogFileDescriptor: number;
+
   constructor(log?: ToolingLog) {
     super('Scout Events report', log);
     this.log = log || new ToolingLog();
     this.workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-report-'));
+
+    // Create a reusable event log file handle to reduce overhead with file open/close whenever an event is logged
+    this.eventLogFileDescriptor = fs.openSync(this.eventLogPath, 'w');
   }
 
   public get eventLogPath(): string {
@@ -40,7 +45,7 @@ export class ScoutEventsReport extends ScoutReport {
       event['@timestamp'] = new Date();
     }
 
-    fs.appendFileSync(this.eventLogPath, JSON.stringify(event) + '\n');
+    fs.appendFileSync(this.eventLogFileDescriptor, JSON.stringify(event) + '\n');
   }
 
   /**
@@ -50,6 +55,10 @@ export class ScoutEventsReport extends ScoutReport {
    */
   save(destination: string) {
     this.raiseIfConcluded('nothing to save because workdir has been cleared');
+
+    // Flush & close the event log file
+    fs.fsyncSync(this.eventLogFileDescriptor);
+    fs.closeSync(this.eventLogFileDescriptor);
 
     if (fs.existsSync(destination)) {
       throw new ScoutReportError(`Save destination path '${destination}' already exists`);


### PR DESCRIPTION
Appending to the event log file is now done using a single file handle created when the reporter is initialised rather than opening/closing the file with every logged event.

This can reduce the time to it takes for the reporter to log an event by up to ~20x. In the context of an usual test run in CI on a pull request, that's bringing down the total time spent with persistence from _~20s_ down to _~1s_.




<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->