### PR TITLE
[ES|QL] Rerank command validation

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.test.ts
@@ -182,20 +182,20 @@ describe('COMPLETION Validation', () => {
 
       it('inference_id is not provided', () => {
         completionExpectErrors(`FROM index | COMPLETION "prompt"`, [
-          '[COMPLETION] inference_id parameter is required',
+          '"inference_id" parameter is required.',
         ]);
         completionExpectErrors(`FROM index | COMPLETION "prompt" WITH`, [
-          '[COMPLETION] inference_id parameter is required',
+          '"inference_id" parameter is required.',
         ]);
         completionExpectErrors(`FROM index | COMPLETION "prompt" WITH {}`, [
-          '[COMPLETION] inference_id parameter is required',
+          '"inference_id" parameter is required.',
         ]);
         completionExpectErrors(`FROM index | COMPLETION "prompt" WITH { "": ""}`, [
-          '[COMPLETION] inference_id parameter is required',
+          '"inference_id" parameter is required.',
         ]);
         completionExpectErrors(
           `FROM index | COMPLETION "prompt" WITH { "some_param": "some_value"}`,
-          ['[COMPLETION] inference_id parameter is required']
+          ['"inference_id" parameter is required.']
         );
       });
     });

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.test.ts
@@ -104,19 +104,19 @@ describe('COMPLETION Validation', () => {
       it('prompt is a constant, but not text', async () => {
         await completionExpectErrors(
           `FROM index | COMPLETION 47 WITH { "inference_id": "inferenceId"}`,
-          ['[COMPLETION] prompt must be of type [text] but is [integer]']
+          ['COMPLETION query must be of type text. Found integer']
         );
 
         await completionExpectErrors(
           `FROM index | COMPLETION true WITH { "inference_id": "inferenceId"}`,
-          ['[COMPLETION] prompt must be of type [text] but is [boolean]']
+          ['COMPLETION query must be of type text. Found boolean']
         );
       });
 
       it('prompt is a function, but does not return text', async () => {
         await completionExpectErrors(
           `FROM index | COMPLETION PI() WITH { "inference_id": "inferenceId"}`,
-          ['[COMPLETION] prompt must be of type [text] but is [double]']
+          ['COMPLETION query must be of type text. Found double']
         );
 
         await completionExpectErrors(
@@ -126,18 +126,18 @@ describe('COMPLETION Validation', () => {
                       var0 == 0, 2,
                       var0 == 1, 1
                     ) WITH { "inference_id": "inferenceId"}`,
-          ['[COMPLETION] prompt must be of type [text] but is [integer]']
+          ['COMPLETION query must be of type text. Found integer']
         );
 
         await completionExpectErrors(
           `FROM index | COMPLETION TO_DATETIME("2023-12-02T11:00:00.000Z") WITH { "inference_id": "inferenceId"}`,
-          ['[COMPLETION] prompt must be of type [text] but is [date]']
+          ['COMPLETION query must be of type text. Found date']
         );
 
         await completionExpectErrors(
           `FROM index | COMPLETION AVG(integerField) WITH { "inference_id": "inferenceId"}`,
           [
-            '[COMPLETION] prompt must be of type [text] but is [double]',
+            'COMPLETION query must be of type text. Found double',
             'Function AVG not allowed in COMPLETION',
           ]
         );
@@ -146,19 +146,19 @@ describe('COMPLETION Validation', () => {
       it('prompt is a column, but not a text one', () => {
         completionExpectErrors(
           `FROM index | EVAL integerPrompt = 47 | COMPLETION integerPrompt WITH { "inference_id": "inferenceId"}`,
-          ['[COMPLETION] prompt must be of type [text] but is [integer]']
+          ['COMPLETION query must be of type text. Found integer']
         );
         completionExpectErrors(
           `FROM index | EVAL ipPrompt = to_ip("1.2.3.4") | COMPLETION ipPrompt WITH { "inference_id": "inferenceId"}`,
-          ['[COMPLETION] prompt must be of type [text] but is [ip]']
+          ['COMPLETION query must be of type text. Found ip']
         );
         completionExpectErrors(
           `FROM index | COMPLETION dateField WITH { "inference_id": "inferenceId"}`,
-          ['[COMPLETION] prompt must be of type [text] but is [date]']
+          ['COMPLETION query must be of type text. Found date']
         );
         completionExpectErrors(
           `FROM index | COMPLETION counterIntegerField WITH { "inference_id": "inferenceId"}`,
-          ['[COMPLETION] prompt must be of type [text] but is [counter_integer]']
+          ['COMPLETION query must be of type text. Found counter_integer']
         );
       });
 
@@ -176,7 +176,7 @@ describe('COMPLETION Validation', () => {
       it('prompt is a parenthesized expression, but not a text one', () => {
         completionExpectErrors(
           `FROM index | COMPLETION (1 > 2) WITH { "inference_id": "inferenceId"}`,
-          ['[COMPLETION] prompt must be of type [text] but is [boolean]']
+          ['COMPLETION query must be of type text. Found boolean']
         );
       });
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.test.ts
@@ -182,20 +182,20 @@ describe('COMPLETION Validation', () => {
 
       it('inference_id is not provided', () => {
         completionExpectErrors(`FROM index | COMPLETION "prompt"`, [
-          '"inference_id" parameter is required.',
+          '"inference_id" parameter is required for COMPLETION.',
         ]);
         completionExpectErrors(`FROM index | COMPLETION "prompt" WITH`, [
-          '"inference_id" parameter is required.',
+          '"inference_id" parameter is required for COMPLETION.',
         ]);
         completionExpectErrors(`FROM index | COMPLETION "prompt" WITH {}`, [
-          '"inference_id" parameter is required.',
+          '"inference_id" parameter is required for COMPLETION.',
         ]);
         completionExpectErrors(`FROM index | COMPLETION "prompt" WITH { "": ""}`, [
-          '"inference_id" parameter is required.',
+          '"inference_id" parameter is required for COMPLETION.',
         ]);
         completionExpectErrors(
           `FROM index | COMPLETION "prompt" WITH { "some_param": "some_value"}`,
-          ['"inference_id" parameter is required.']
+          ['"inference_id" parameter is required for COMPLETION.']
         );
       });
     });

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.ts
@@ -11,6 +11,7 @@ import type { ESQLAst, ESQLAstCompletionCommand, ESQLCommand, ESQLMessage } from
 import type { ICommandContext, ICommandCallbacks } from '../../types';
 import { getExpressionType } from '../../../definitions/utils/expressions';
 import { validateCommandArguments } from '../../../definitions/utils/validation';
+import { errors } from '../../../definitions/utils/errors';
 
 const supportedPromptTypes = ['text', 'keyword', 'unknown', 'param'];
 
@@ -43,15 +44,8 @@ export const validate = (
     });
   }
 
-  if (inferenceId.incomplete) {
-    messages.push({
-      location: command.location,
-      text: i18n.translate('kbn-esql-ast.esql.validation.completionInferenceIdRequired', {
-        defaultMessage: '[COMPLETION] inference_id parameter is required',
-      }),
-      type: 'error',
-      code: 'completionInferenceIdRequired',
-    });
+  if (inferenceId?.incomplete) {
+    messages.push(errors.byId('inferenceIdRequired', command.location, {}));
   }
 
   const targetName = targetField?.name || 'completion';

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.ts
@@ -45,7 +45,7 @@ export const validate = (
   }
 
   if (inferenceId?.incomplete) {
-    messages.push(errors.byId('inferenceIdRequired', command.location, {}));
+    messages.push(errors.byId('inferenceIdRequired', command.location, { command: 'COMPLETION' }));
   }
 
   const targetName = targetField?.name || 'completion';

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.ts
@@ -6,7 +6,6 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { i18n } from '@kbn/i18n';
 import type { ESQLAst, ESQLAstCompletionCommand, ESQLCommand, ESQLMessage } from '../../../types';
 import type { ICommandContext, ICommandCallbacks } from '../../types';
 import { getExpressionType } from '../../../definitions/utils/expressions';
@@ -32,16 +31,12 @@ export const validate = (
   );
 
   if (!supportedPromptTypes.includes(promptExpressionType)) {
-    messages.push({
-      location: 'location' in prompt ? prompt?.location : location,
-      text: i18n.translate('kbn-esql-ast.esql.validation.completionUnsupportedFieldType', {
-        defaultMessage:
-          '[COMPLETION] prompt must be of type [text] but is [{promptExpressionType}]',
-        values: { promptExpressionType },
-      }),
-      type: 'error',
-      code: 'completionUnsupportedFieldType',
-    });
+    messages.push(
+      errors.byId('unsupportedQueryType', 'location' in prompt ? prompt?.location : location, {
+        command: 'COMPLETION',
+        expressionType: promptExpressionType,
+      })
+    );
   }
 
   if (inferenceId?.incomplete) {

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.test.ts
@@ -22,7 +22,7 @@ describe('RERANK Validation', () => {
 
     test('unsupported field type', () => {
       rerankExpectErrors('FROM index | RERANK col0=2 ON keywordField', [
-        '[RERANK] query must be of type [text]. Found [integer]',
+        'RERANK query must be of type text. Found integer',
       ]);
     });
   });

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { validate } from './validate';
+import { expectErrors } from '../../../__tests__/validation';
+import { mockContext } from '../../../__tests__/context_fixtures';
+
+const rerankExpectErrors = (query: string, expected: string[]) =>
+  expectErrors(query, expected, mockContext, 'rerank', validate);
+
+describe('RERANK Validation', () => {
+  describe('Query', () => {
+    test('query as parameter', () => {
+      rerankExpectErrors('FROM index | RERANK ?q ON keywordField', []);
+    });
+
+    test('unsupported field type', () => {
+      const msg = (type: string) => `[RERANK] query must be of type [text] but is [${type}]`;
+
+      rerankExpectErrors('FROM index | RERANK col0=2 ON keywordField', [msg('integer')]);
+    });
+  });
+
+  describe('WITH inference_id', () => {
+    test('inference_id as parameter', () => {
+      rerankExpectErrors(
+        'FROM index | RERANK "q" ON keywordField WITH { "inference_id": ?named_param }',
+        []
+      );
+    });
+
+    const msg = '[RERANK] inference_id parameter is required.';
+
+    test('WITH without map (partial: WITH)', () => {
+      rerankExpectErrors('FROM index | RERANK "q" ON keywordField WITH', [msg]);
+    });
+
+    test('WITH with partial map start (WITH{)', () => {
+      rerankExpectErrors('FROM index | RERANK "q" ON keywordField WITH{', [msg]);
+    });
+
+    test('WITH with empty map (WITH {})', () => {
+      rerankExpectErrors('FROM index | RERANK "q" ON keywordField WITH { }', [msg]);
+    });
+
+    test('WITH map without inference_id key', () => {
+      rerankExpectErrors('FROM index | RERANK "q" ON keywordField WITH { "some_param": "value" }', [
+        msg,
+      ]);
+    });
+
+    test('WITH inference_id with empty string value', () => {
+      rerankExpectErrors('FROM index | RERANK "q" ON keywordField WITH { "inference_id": "" }', [
+        msg,
+      ]);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.test.ts
@@ -21,13 +21,13 @@ describe('RERANK Validation', () => {
     });
 
     test('unsupported field type', () => {
-      const msg = (type: string) => `[RERANK] query must be of type [text] but is [${type}]`;
-
-      rerankExpectErrors('FROM index | RERANK col0=2 ON keywordField', [msg('integer')]);
+      rerankExpectErrors('FROM index | RERANK col0=2 ON keywordField', [
+        '[RERANK] query must be of type [text]. Found [integer]',
+      ]);
     });
   });
 
-  describe('WITH inference_id', () => {
+  describe('Inference_id check', () => {
     test('inference_id as parameter', () => {
       rerankExpectErrors(
         'FROM index | RERANK "q" ON keywordField WITH { "inference_id": ?named_param }',
@@ -35,7 +35,7 @@ describe('RERANK Validation', () => {
       );
     });
 
-    const msg = '[RERANK] inference_id parameter is required.';
+    const msg = '"inference_id" parameter is required.';
 
     test('WITH without map (partial: WITH)', () => {
       rerankExpectErrors('FROM index | RERANK "q" ON keywordField WITH', [msg]);

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.test.ts
@@ -35,7 +35,7 @@ describe('RERANK Validation', () => {
       );
     });
 
-    const msg = '"inference_id" parameter is required.';
+    const msg = '"inference_id" parameter is required for RERANK.';
 
     test('WITH without map (partial: WITH)', () => {
       rerankExpectErrors('FROM index | RERANK "q" ON keywordField WITH', [msg]);

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { i18n } from '@kbn/i18n';
 import type { ESQLCommand, ESQLMessage, ESQLAst, ESQLAstRerankCommand } from '../../../types';
 import type { ICommandContext, ICommandCallbacks } from '../../types';
 import { getExpressionType } from '../../../definitions/utils/expressions';
@@ -33,15 +32,12 @@ export const validate = (
 
   // check for supported query types
   if (!supportedQueryTypes.includes(rerankExpressionType)) {
-    messages.push({
-      location: 'location' in query ? query?.location : location,
-      text: i18n.translate('kbn-esql-ast.esql.validation.rerankUnsupportedFieldType', {
-        defaultMessage: '[RERANK] query must be of type [text]. Found [{rerankExpressionType}]',
-        values: { rerankExpressionType },
-      }),
-      type: 'error',
-      code: 'rerankUnsupportedFieldType',
-    });
+    messages.push(
+      errors.byId('unsupportedQueryType', 'location' in query ? query?.location : location, {
+        command: 'RERANK',
+        expressionType: rerankExpressionType,
+      })
+    );
   }
 
   if (inferenceId?.incomplete) {

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.ts
@@ -8,9 +8,21 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { ESQLCommand, ESQLMessage, ESQLAst, ESQLAstRerankCommand } from '../../../types';
+import type {
+  ESQLCommand,
+  ESQLMessage,
+  ESQLAst,
+  ESQLAstRerankCommand,
+  ESQLCommandOption,
+  ESQLMap,
+} from '../../../types';
 import type { ICommandContext, ICommandCallbacks } from '../../types';
+import { getExpressionType } from '../../../definitions/utils/expressions';
 import { validateCommandArguments } from '../../../definitions/utils/validation';
+import { isOptionNode, isMap, isLiteral } from '../../../ast/is';
+
+const supportedQueryTypes = ['keyword', 'text', 'param'];
+const WITH_OPTION_NAMES = ['inference_id'];
 
 export const validate = (
   command: ESQLCommand,
@@ -20,35 +32,72 @@ export const validate = (
 ): ESQLMessage[] => {
   const messages: ESQLMessage[] = [];
 
-  // Run standard argument validation
+  const { query, targetField, location } = command as ESQLAstRerankCommand;
+
+  // Sets the target field so the column is recognized after the command is applied
+  const targetName = targetField?.name || 'rerank';
+
+  context?.userDefinedColumns.set(targetName, [
+    {
+      name: targetName,
+      location: targetField?.location || location,
+      type: 'keyword',
+    },
+  ]);
+
+  const rerankExpressionType = getExpressionType(
+    query,
+    context?.fields,
+    context?.userDefinedColumns
+  );
+
+  // check for supported query types
+  if (!supportedQueryTypes.includes(rerankExpressionType)) {
+    messages.push({
+      location: 'location' in query ? query?.location : location,
+      text: i18n.translate('kbn-esql-ast.esql.validation.rerankUnsupportedFieldType', {
+        defaultMessage: '[RERANK] query must be of type [text] but is [{rerankExpressionType}]',
+        values: { rerankExpressionType },
+      }),
+      type: 'error',
+      code: 'rerankUnsupportedFieldType',
+    });
+  }
+
+  // check for WITH clause and require inference_id
+  const withOption = command.args.find(
+    (arg): arg is ESQLCommandOption => isOptionNode(arg) && arg.name === 'with'
+  );
+  const hasWith = !!withOption || (command.text || '').toLowerCase().includes('with');
+
+  if (hasWith) {
+    const map = (withOption?.args?.[0] as ESQLMap | undefined) || undefined;
+
+    const key =
+      map && isMap(map) && !map.incomplete
+        ? map.entries?.find((entry) => WITH_OPTION_NAMES.includes(entry.key?.valueUnquoted))?.value
+        : undefined;
+
+    const isEmptyString = !!(
+      key &&
+      isLiteral(key) &&
+      key.literalType === 'keyword' &&
+      (key.valueUnquoted?.length ?? 0) === 0
+    );
+
+    if (!key || key.incomplete || isEmptyString) {
+      messages.push({
+        location: withOption?.location ?? command.location,
+        text: i18n.translate('kbn-esql-ast.esql.validation.rerankInferenceIdRequired', {
+          defaultMessage: '[RERANK] inference_id parameter is required.',
+        }),
+        type: 'error',
+        code: 'rerankInferenceIdRequired',
+      });
+    }
+  }
+
   messages.push(...validateCommandArguments(command, ast, context, callbacks));
-
-  // Cast to RERANK command for type-specific validation
-  const rerankCommand = command as ESQLAstRerankCommand;
-
-  // Validate that query text is provided
-  if (!rerankCommand.query) {
-    messages.push({
-      location: command.location,
-      text: i18n.translate('kbn-esql-ast.esql.validation.rerankMissingQuery', {
-        defaultMessage: '[RERANK] Query text is required.',
-      }),
-      type: 'error',
-      code: 'rerankMissingQuery',
-    });
-  }
-
-  // Validate that at least one field is specified in ON clause
-  if (!rerankCommand.fields || rerankCommand.fields.length === 0) {
-    messages.push({
-      location: command.location,
-      text: i18n.translate('kbn-esql-ast.esql.validation.rerankMissingFields', {
-        defaultMessage: '[RERANK] At least one field must be specified in the ON clause.',
-      }),
-      type: 'error',
-      code: 'rerankMissingFields',
-    });
-  }
 
   return messages;
 };

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.ts
@@ -45,7 +45,7 @@ export const validate = (
   }
 
   if (inferenceId?.incomplete) {
-    messages.push(errors.byId('inferenceIdRequired', command.location, {}));
+    messages.push(errors.byId('inferenceIdRequired', command.location, { command: 'RERANK' }));
   }
 
   const targetName = targetField?.name || 'rerank';

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/types.ts
@@ -214,6 +214,11 @@ export enum Location {
   RENAME = 'rename',
 
   /**
+   * In the RERANK command
+   */
+  RERANK = 'rerank',
+
+  /**
    * In the JOIN command (used only for AS)
    */
   JOIN = 'join',
@@ -244,6 +249,7 @@ const commandOptionNameToLocation: Record<string, Location> = {
   join: Location.JOIN,
   show: Location.SHOW,
   completion: Location.COMPLETION,
+  rerank: Location.RERANK,
 };
 
 /**

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/all_operators.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/all_operators.ts
@@ -95,6 +95,7 @@ const otherDefinitions: FunctionDefinition[] = [
       Location.DISSECT,
       Location.COMPLETION,
       Location.RENAME,
+      Location.RERANK,
     ],
     signatures: [
       {

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/types.ts
@@ -360,6 +360,10 @@ export interface ValidationErrors {
     message: string;
     type: {};
   };
+  unsupportedQueryType: {
+    message: string;
+    type: {};
+  };
 }
 
 export type ErrorTypes = keyof ValidationErrors;

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/types.ts
@@ -356,6 +356,10 @@ export interface ValidationErrors {
     message: string;
     type: {};
   };
+  inferenceIdRequired: {
+    message: string;
+    type: {};
+  };
 }
 
 export type ErrorTypes = keyof ValidationErrors;

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/errors.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/errors.ts
@@ -303,6 +303,15 @@ Expected one of:
         }),
         type: 'error',
       };
+
+    case 'unsupportedQueryType':
+      return {
+        message: i18n.translate('kbn-esql-ast.esql.validation.unsupportedQueryType', {
+          defaultMessage: '{command} query must be of type text. Found {expressionType}',
+          values: { command: out.command.toUpperCase(), expressionType: out.expressionType },
+        }),
+        type: 'error',
+      };
   }
   return { message: '' };
 }

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/errors.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/errors.ts
@@ -294,6 +294,14 @@ Expected one of:
         }),
         type: 'warning',
       };
+
+    case 'inferenceIdRequired':
+      return {
+        message: i18n.translate('kbn-esql-ast.esql.validation.inferenceIdRequired', {
+          defaultMessage: '"inference_id" parameter is required.',
+        }),
+        type: 'error',
+      };
   }
   return { message: '' };
 }

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/errors.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/errors.ts
@@ -298,7 +298,8 @@ Expected one of:
     case 'inferenceIdRequired':
       return {
         message: i18n.translate('kbn-esql-ast.esql.validation.inferenceIdRequired', {
-          defaultMessage: '"inference_id" parameter is required.',
+          defaultMessage: '"inference_id" parameter is required for {command}.',
+          values: { command: out.command.toUpperCase() },
         }),
         type: 'error',
       };

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/rerank.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/rerank.test.ts
@@ -200,7 +200,7 @@ describe('RERANK', () => {
         fields: [{ type: 'column', name: 'title' }],
       });
 
-      expect(rerankCmd).not.toHaveProperty('inferenceId');
+      expect(rerankCmd.inferenceId).toEqual(undefined);
     });
 
     it('should handle missing ON clause', () => {

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/cst_to_ast_converter.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/cst_to_ast_converter.ts
@@ -1338,8 +1338,32 @@ export class CstToAstConverter {
     }
 
     const withOption = this.fromCommandNamedParameters(namedParamsCtx);
-    if (withOption && !withOption.incomplete) {
+
+    if (!withOption) {
+      return;
+    }
+
+    // check the existence of inference_id
+    const namedParameters = withOption.args[0] as ast.ESQLMap | undefined;
+    command.inferenceId = undefined;
+
+    if (namedParameters) {
       command.args.push(withOption);
+
+      command.inferenceId = Builder.expression.literal.string(
+        '',
+        { name: 'inferenceId' },
+        { incomplete: true }
+      );
+
+      const inferenceIdParam = namedParameters?.entries.find(
+        (param) => param.key.valueUnquoted === 'inference_id'
+      )?.value as ast.ESQLStringLiteral;
+
+      if (inferenceIdParam) {
+        command.inferenceId = inferenceIdParam;
+        command.inferenceId.incomplete = inferenceIdParam.valueUnquoted?.length === 0;
+      }
     }
   }
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/types.ts
@@ -133,6 +133,7 @@ export interface ESQLAstRerankCommand extends ESQLCommand<'rerank'> {
   query: ESQLLiteral;
   fields: ESQLAstField[];
   targetField?: ESQLColumn;
+  inferenceId: ESQLLiteral | undefined;
 }
 
 export type ESQLIdentifierOrParam = ESQLIdentifier | ESQLParamLiteral;


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/217285

We enable validation for the RERANK command

Many validations come from parsing errors and are therefore difficult to read.
- The fragment after ON should be standard for other commands and therefore no custom handlers.
- WITH needs to be handled custom, like COMPLETION.
- I have a custom handling for the query string value similar to COMPLETION.

Note: For RERANK, our validation only works after the ON command is recognized, because the grammar requires it to define the input. Until the parser consumes On, the builder has no scope and we can see only syntax errors. 

<img width="1304" height="123" alt="Screenshot 2025-09-02 080759" src="https://github.com/user-attachments/assets/eb03e855-e957-41a0-8dff-4cec6e1ed9f0" />
<img width="916" height="332" alt="Screenshot 2025-09-02 080925" src="https://github.com/user-attachments/assets/859b97f9-054e-4c26-99f3-45ec8c3d8672" />
<img width="719" height="125" alt="Screenshot 2025-09-02 081011" src="https://github.com/user-attachments/assets/28f3ecc3-6d64-4850-b412-2939553faf3a" />

<img width="1301" height="122" alt="Screenshot 2025-09-02 081044" src="https://github.com/user-attachments/assets/145cb625-e9ad-418d-a0bf-fbb0d98b8b1d" />
