### PR TITLE
[Synthetics] Import Synthetics e2e tests

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/index.ts
@@ -5,27 +5,27 @@
  * 2.0.
  */
 
-// export * from './data_retention.journey'; // it is flaky
-export type * from './project_api_keys.journey';
-export type * from './getting_started.journey';
-export type * from './add_monitor.journey';
-export type * from './monitor_selector.journey';
-export type * from './management_list.journey';
-export type * from './overview_sorting.journey';
-// export * from './overview_scrolling.journey';
-// export * from './overview_search.journey';
-export type * from './private_locations.journey';
-export type * from './alerting_default.journey';
-export type * from './global_parameters.journey';
-export type * from './detail_flyout';
-export type * from './alert_rules/default_status_alert.journey';
-export type * from './alert_rules/custom_status_alert.journey';
-export type * from './alert_rules/custom_tls_alert.journey';
-export type * from './test_now_mode.journey';
-export type * from './monitor_details_page/monitor_summary.journey';
-export type * from './test_run_details.journey';
-export type * from './step_details.journey';
-export type * from './project_monitor_read_only.journey';
-export type * from './overview_save_lens_visualization.journey';
-export type * from './filter_monitors.journey';
-export type * from './overview_compact_view.journey';
+// import './data_retention.journey'; // it is flaky
+import './project_api_keys.journey';
+import './getting_started.journey';
+import './add_monitor.journey';
+import './monitor_selector.journey';
+import './management_list.journey';
+import './overview_sorting.journey';
+// import './overview_scrolling.journey';
+// import './overview_search.journey';
+import './private_locations.journey';
+import './alerting_default.journey';
+import './global_parameters.journey';
+import './detail_flyout';
+import './alert_rules/default_status_alert.journey';
+import './alert_rules/custom_status_alert.journey';
+import './alert_rules/custom_tls_alert.journey';
+import './test_now_mode.journey';
+import './monitor_details_page/monitor_summary.journey';
+import './test_run_details.journey';
+import './step_details.journey';
+import './project_monitor_read_only.journey';
+import './overview_save_lens_visualization.journey';
+import './filter_monitors.journey';
+import './overview_compact_view.journey';


### PR DESCRIPTION
Synthetics e2e tests were mistakenly disabled in this PR: https://github.com/elastic/kibana/pull/227746

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->