### PR TITLE
[9.1] Add overlay for Fleet remote synced integrations API (#233493)

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -103,6 +103,13 @@ tags:
   - name: Fleet package policies
   - name: Fleet proxies
   - name: Fleet remote synced integrations
+    description: |
+      Use the Fleet remote synced integrations API to check the status of the automatic integrations synchronization on a remote cluster:
+      * Use the `/api/fleet/remote_synced_integrations/{outputId}/remote_status` endpoint on the management cluster to query the synchronization status of the integrations installed on the remote cluster by the ID of the configured remote Elasticsearch output.
+      * Use the `/api/fleet/remote_synced_integrations/status` endpoint on the remote cluster to query the synchronization status of the installed integrations.
+    externalDocs:
+      description: Automatic integrations synchronization documentation
+      url: https://www.elastic.co/docs/reference/fleet/automatic-integrations-synchronization
   - name: Fleet Server hosts
   - name: Fleet service tokens
   - name: Fleet uninstall tokens

--- a/oas_docs/overlays/kibana.overlays.shared.yaml
+++ b/oas_docs/overlays/kibana.overlays.shared.yaml
@@ -1,7 +1,7 @@
 # overlays.yaml
 overlay: 1.0.0
 info:
-  title: Overlays that are applicable to both serverless and non-serverless documentas
+  title: Overlays that are applicable to both serverless and non-serverless documents
   version: 0.0.1
 actions:
   # Add some tag descriptions and displayNames

--- a/oas_docs/overlays/kibana.overlays.yaml
+++ b/oas_docs/overlays/kibana.overlays.yaml
@@ -102,6 +102,18 @@ actions:
         externalDocs:
           description: Synthetic monitoring
           url: https://www.elastic.co/docs/solutions/observability/synthetics
+  - target: '$.tags[?(@.name=="Fleet remote synced integrations")]'
+    description: Change tag description and add external docs link
+    update:
+      description: >
+        Use the Fleet remote synced integrations API to check the status of the automatic integrations synchronization on a remote cluster:
+
+        * Use the `/api/fleet/remote_synced_integrations/{outputId}/remote_status` endpoint on the management cluster to query the synchronization status of the integrations installed on the remote cluster by the ID of the configured remote Elasticsearch output.
+        
+        * Use the `/api/fleet/remote_synced_integrations/status` endpoint on the remote cluster to query the synchronization status of the installed integrations.
+      externalDocs:
+        description: Automatic integrations synchronization documentation
+        url: https://www.elastic.co/docs/reference/fleet/automatic-integrations-synchronization
 # Remove extra tags from operations
   - target: "$.paths[*][*].tags[1:]"
     description: Remove all but first tag from operations


### PR DESCRIPTION
This PR is a manual backport of https://github.com/elastic/kibana/pull/233493 and includes:

- A commit with the changes from [the backported PR](https://github.com/elastic/kibana/pull/233493)
- A commit by the CI which updates the `oas_docs/output/kibana.yaml`

---

This PR adds an overlay for the Fleet remote synced integrations API, adding a description for the API and an external link to the relevant documentation.

Closes https://github.com/elastic/docs-content/issues/1691