### PR TITLE
POC: Numeric font style overrides

### DIFF
--- a/src/core/packages/rendering/server-internal/src/views/fonts.tsx
+++ b/src/core/packages/rendering/server-internal/src/views/fonts.tsx
@@ -224,11 +224,14 @@ export const Fonts: FunctionComponent<Props> = ({ url }) => {
   return (
     <style
       dangerouslySetInnerHTML={{
-        __html: `@font-face {
-  font-family: 'InterWOFF2';
-  src: url('https://rsms.me/inter/font-files/Inter-Regular.woff2?v=4.1') format('woff2');
-  font-weight: normal;
-  font-style: normal;
+        __html: `
+body {
+  @font-face {
+    font-family: 'Inter' !important;
+    src: url('https://rsms.me/inter/font-files/Inter-Regular.woff2?v=4.1') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+  }
 }`,
       }}
     />

--- a/src/core/packages/rendering/server-internal/src/views/fonts.tsx
+++ b/src/core/packages/rendering/server-internal/src/views/fonts.tsx
@@ -220,41 +220,16 @@ const getRoboto = (url: string): FontFace => {
 };
 
 export const Fonts: FunctionComponent<Props> = ({ url }) => {
-  const sansFont = getInter(url);
-  const codeFont = getRoboto(url);
-
   /* eslint-disable react/no-danger */
   return (
     <style
       dangerouslySetInnerHTML={{
-        __html: `
-        ${[sansFont, codeFont]
-          .flatMap(({ family, variants }) =>
-            variants.map(({ style, weight, format, sources, unicodeRange }) => {
-              const src = sources
-                .map((source) =>
-                  source.startsWith(url)
-                    ? `url('${source}') format('${format || source.split('.').pop()}')`
-                    : `local('${source}')`
-                )
-                .join(', ');
-
-              return `
-        @font-face {
-          font-family: '${family}';
-          font-style: ${style};
-          font-weight: ${weight};
-          src: ${src};${
-                unicodeRange
-                  ? `
-          unicode-range: ${unicodeRange};`
-                  : ''
-              }
-        }`;
-            })
-          )
-          .join('\n')}
-      `,
+        __html: `@font-face {
+  font-family: 'InterWOFF2';
+  src: url('https://rsms.me/inter/font-files/Inter-Regular.woff2?v=4.1') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}`,
       }}
     />
   );

--- a/src/core/public/styles/_base.scss
+++ b/src/core/public/styles/_base.scss
@@ -30,5 +30,5 @@
 // POC: Numeric font style overrides
 body {
   font-variant-numeric: tabular-nums slashed-zero !important;
-  font-feature-settings: 'ss01','ss07' !important;
+  font-feature-settings: 'ss07', 'cv02', 'cv09' !important;
 }

--- a/src/core/public/styles/_base.scss
+++ b/src/core/public/styles/_base.scss
@@ -28,7 +28,7 @@
 }
 
 // POC: Numeric font style overrides
-body {
+body, .euiDataGrid__content {
   font-variant-numeric: tabular-nums slashed-zero !important;
   font-feature-settings: 'ss07', 'cv02', 'cv09' !important;
 }

--- a/src/core/public/styles/_base.scss
+++ b/src/core/public/styles/_base.scss
@@ -26,3 +26,9 @@
 .euiBody--hasFlyout .euiBottomBar--fixed {
   margin-left: var(--euiCollapsibleNavOffset, 0);
 }
+
+// POC: Numeric font style overrides
+body {
+  font-variant-numeric: tabular-nums slashed-zero !important;
+  font-feature-settings: 'ss01','ss07' !important;
+}


### PR DESCRIPTION
## Summary

### Variant 1: 118fce4ee0f612913d6c35f5516f79d80e06fb2b

```
body {
  font-variant-numeric: tabular-nums slashed-zero !important;
  font-feature-settings: 'ss01','ss07' !important;
}
```

<img width="1922" height="728" alt="image" src="https://github.com/user-attachments/assets/a18e68d4-973d-48ee-9a6a-324833ed16ad" />

### Variant 2: 15d3ce846230d24295543c84c26e28dae6b373a8

```
@font-face {
  font-family: 'InterWOFF2';
  src: url('https://rsms.me/inter/font-files/Inter-Regular.woff2?v=4.1') format('woff2');
  font-weight: normal;
  font-style: normal;
}

font-variant-numeric: tabular-nums slashed-zero;
font-feature-settings: "ss07", "cv02", "cv09"
```

<img width="1368" height="730" alt="CleanShot 2025-09-05 at 14 03 54@2x" src="https://github.com/user-attachments/assets/c192cccb-706b-4107-b56e-f9e21d7c96c1" />

### Overrides

In the following screenshots I replaced the styles where the server side `Fonts` styles (https://github.com/elastic/kibana/blob/main/src/core/packages/rendering/server-internal/src/views/fonts.tsx) would be rendered with `body { color: red !important; font-family: serif !important }`.

This documents that the font-family gets overwritten in a lot of places. 

<img width="3838" height="1866" alt="CleanShot 2025-09-09 at 11 45 26@2x" src="https://github.com/user-attachments/assets/452b45ab-9dc1-4b14-8701-800865201f53" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



