### PR TITLE
trying to get input type from schema

### DIFF
--- a/src/platform/packages/shared/kbn-config-schema/src/types/array_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/array_type.ts
@@ -48,6 +48,22 @@ export class ArrayType<T> extends Type<T[]> {
     return new ArrayType(this.arrayType.extendsDeep(options), this.arrayOptions);
   }
 
+  public getInputSchema(): ArrayType<T> | import('./maybe_type').MaybeType<T[]> {
+    // For arrays, create a new array with the input schema of the item type
+    const inputItemType = this.arrayType.getInputSchema();
+    
+    // Create new options without defaultValue to avoid circular default handling
+    const { defaultValue, ...optionsWithoutDefault } = this.arrayOptions;
+    const inputArrayType = new ArrayType(inputItemType as Type<T>, optionsWithoutDefault);
+    
+    // If this array has a default value, wrap it in MaybeType
+    if (defaultValue !== undefined) {
+      return new (require('./maybe_type').MaybeType)(inputArrayType);
+    }
+    
+    return inputArrayType;
+  }
+
   protected handleError(type: string, { limit, reason, value }: Record<string, any>) {
     switch (type) {
       case 'any.required':

--- a/src/platform/packages/shared/kbn-config-schema/src/types/intersection_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/intersection_type.ts
@@ -9,6 +9,7 @@
 
 import type { Props, ObjectTypeOptions } from './object_type';
 import { ObjectType } from './object_type';
+import { Type } from './type';
 
 export type IntersectionTypeOptions<T extends Props = any> = ObjectTypeOptions<T>;
 
@@ -16,6 +17,9 @@ export class IntersectionType<
   RTS extends Array<ObjectType<any>>,
   T extends Props
 > extends ObjectType<T> {
+  private readonly intersectionTypes: RTS;
+  private readonly intersectionOptions?: IntersectionTypeOptions<T>;
+
   constructor(types: RTS, options?: IntersectionTypeOptions<T>) {
     const props = types.reduce((mergedProps, type) => {
       Object.entries(type.getPropSchemas() as Record<string, any>).forEach(([key, value]) => {
@@ -29,5 +33,13 @@ export class IntersectionType<
     }, {} as T);
 
     super(props, options);
+    this.intersectionTypes = types;
+    this.intersectionOptions = options;
+  }
+
+  public getInputSchema() {    
+    const newIntersectonTypes = this.intersectionTypes.map(type => type.getInputSchema());
+    console.log('Getting input schema for IntersectionType with types:', newIntersectonTypes);
+    return new IntersectionType(newIntersectonTypes as RTS, this.intersectionOptions);
   }
 }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/map_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/map_type.ts
@@ -57,6 +57,27 @@ export class MapOfType<K, V> extends Type<Map<K, V>> {
     );
   }
 
+  public getInputSchema(): MapOfType<K, V> | import('./maybe_type').MaybeType<Map<K, V>> {
+    // For maps, create a new map with the input schemas of key and value types
+    const inputKeyType = this.keyType.getInputSchema();
+    const inputValueType = this.valueType.getInputSchema();
+    
+    // Create new options without defaultValue to avoid circular default handling
+    const { defaultValue, ...optionsWithoutDefault } = this.mapOptions;
+    const inputMapType = new MapOfType(
+      inputKeyType as Type<K>, 
+      inputValueType as Type<V>, 
+      optionsWithoutDefault
+    );
+    
+    // If this map has a default value, wrap it in MaybeType
+    if (defaultValue !== undefined) {
+      return new (require('./maybe_type').MaybeType)(inputMapType);
+    }
+    
+    return inputMapType;
+  }
+
   protected handleError(
     type: string,
     { entryKey, reason, value }: Record<string, any>,

--- a/src/platform/packages/shared/kbn-config-schema/src/types/maybe_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/maybe_type.ts
@@ -28,4 +28,10 @@ export class MaybeType<V> extends Type<V | undefined> {
   public extendsDeep(options: ExtendsDeepOptions) {
     return new MaybeType(this.maybeType.extendsDeep(options));
   }
+
+  public getInputSchema(): MaybeType<V> {
+    // For maybe types, create a new maybe with the input schema of the wrapped type
+    const inputType = this.maybeType.getInputSchema();
+    return new MaybeType(inputType as Type<V>);
+  }
 }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/object_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/object_type.ts
@@ -13,6 +13,7 @@ import { internals } from '../internals';
 import type { TypeOptions, ExtendsDeepOptions, UnknownOptions } from './type';
 import { Type } from './type';
 import { ValidationError } from '../errors';
+import { MaybeType } from './maybe_type';
 
 export type Props = Record<string, Type<any>>;
 
@@ -110,6 +111,29 @@ export class ObjectType<P extends Props = any> extends Type<ObjectResultType<P>>
     this.props = props;
     this.propSchemas = schemaKeys;
     this.options = options;
+  }
+
+  public getInputSchema() {
+    // Transform each property to its input schema version
+    console.log('Getting input schema for ObjectType with props:', this.props);
+    const inputProps = Object.entries(this.props).reduce((memo, [key, value]) => {
+      return {
+        ...memo,
+        [key]: value.getInputSchema(),
+      };
+    }, {} as P);
+
+    console.log('Transformed input props:', inputProps);
+
+    // Remove defaultValue from options to avoid circular default handling
+    const inputObjectType = new ObjectType(inputProps, this.options);
+
+    // // If this object has a default value, wrap it in MaybeType
+    // if (this.options.defaultValue !== undefined) {
+    //   return new MaybeType(inputObjectType);
+    // }
+
+    return inputObjectType;
   }
 
   /**

--- a/src/platform/packages/shared/kbn-config-schema/src/types/record_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/record_type.ts
@@ -49,6 +49,27 @@ export class RecordOfType<K extends string, V> extends Type<Record<K, V>> {
     );
   }
 
+  public getInputSchema(): RecordOfType<K, V> | import('./maybe_type').MaybeType<Record<K, V>> {
+    // For records, create a new record with the input schemas of key and value types
+    const inputKeyType = this.keyType.getInputSchema();
+    const inputValueType = this.valueType.getInputSchema();
+    
+    // Create new options without defaultValue to avoid circular default handling
+    const { defaultValue, ...optionsWithoutDefault } = this.options;
+    const inputRecordType = new RecordOfType(
+      inputKeyType as Type<K>, 
+      inputValueType as Type<V>, 
+      optionsWithoutDefault
+    );
+    
+    // If this record has a default value, wrap it in MaybeType
+    if (defaultValue !== undefined) {
+      return new (require('./maybe_type').MaybeType)(inputRecordType);
+    }
+    
+    return inputRecordType;
+  }
+
   protected handleError(
     type: string,
     { entryKey, reason, value }: Record<string, any>,

--- a/src/platform/packages/shared/kbn-config-schema/src/types/union_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/union_type.ts
@@ -36,6 +36,10 @@ export class UnionType<RTS extends Array<Type<any>>, T> extends Type<T> {
     );
   }
 
+  public getInputSchema() {
+    return new UnionType(this.unionTypes.map((type) => type.getInputSchema()), this.typeOptions);
+  }
+
   protected handleError(type: string, { value, details }: Record<string, any>, path: string[]) {
     switch (type) {
       case 'any.required':

--- a/src/platform/packages/shared/kbn-config-schema/test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/test.ts
@@ -1,0 +1,31 @@
+import { TypeOf, schema } from '@kbn/config-schema';
+import _ from 'lodash';
+
+const testSchemaObject = schema.object({
+    a: schema.string(),
+    b: schema.number({ defaultValue: 5 }),
+    c: schema.maybe(schema.boolean()),
+});
+
+const testSchemaAllOf = schema.allOf([
+    testSchemaObject,
+    schema.object({
+        d: schema.string(),
+        e: schema.number({ defaultValue: 3 }),
+        f: schema.maybe(schema.boolean()) 
+    }),
+])
+
+const testSchemaObjectInput = testSchemaObject.getInputSchema();
+const testSchemaAllOfInput = testSchemaAllOf.getInputSchema();
+
+type TestSchemaObjectInputType = typeof testSchemaObjectInput.type;
+type TestSchemaAllOfInputType = typeof testSchemaAllOfInput.type;
+
+const testObject: TestSchemaObjectInputType = {
+    a: 'hello',
+    // b is optional because it has a default value
+    // c is optional because it's maybe
+};
+
+// complains that b is missing


### PR DESCRIPTION
## Summary

This PR tries to implement getInputSchemas() function on the schema, which should return same schema, but with every property that has default defined being wrapped in schema.maybe.

this part seems to work, but the types inferred from the function call are not correct. (which is the goal)
