### PR TITLE
[Fleet] Handle Fleet unreachable error from agentless API

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts
@@ -37,6 +37,7 @@ export const AGENTLESS_ALLOWED_OUTPUT_TYPES = [outputType.Elasticsearch];
 
 export const AGENTLESS_API_ERROR_CODES = {
   OVER_PROVISIONED: 'OVER_PROVISIONED',
+  FLEET_UNREACHABLE: 'FLEET_UNREACHABLE',
 };
 
 // Input types to disable for agentless integrations

--- a/x-pack/platform/plugins/shared/fleet/common/errors.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/errors.ts
@@ -32,6 +32,12 @@ export class UninstallTokenError extends FleetError {}
 export class AgentRequestInvalidError extends FleetError {}
 export class OutputInvalidError extends FleetError {}
 
+export class AgentlessAgentCreateFleetUnreachableError extends FleetError {
+  constructor(message: string) {
+    super(`Error creating agentless agent in Fleet, ${message}`);
+  }
+}
+
 export class AgentlessAgentCreateOverProvisionedError extends FleetError<{ limit?: number }> {
   constructor(message: string, limit?: number) {
     super(`Error creating agentless agent in Fleet, ${message}`, { limit });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -14,7 +14,10 @@ import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiLink } from '@elastic/eui';
 
-import { AgentlessAgentCreateOverProvisionedError } from '../../../../../../../../common/errors';
+import {
+  AgentlessAgentCreateFleetUnreachableError,
+  AgentlessAgentCreateOverProvisionedError,
+} from '../../../../../../../../common/errors';
 import { useSpaceSettingsContext } from '../../../../../../../hooks/use_space_settings_context';
 import {
   type AgentPolicy,
@@ -499,6 +502,33 @@ export function useOnSubmit({
                     defaultMessage="You've reached the maximum number of {limit} agentless deployments. To add more, either remove or change some to Elastic Agent-based integrations. {docLink}"
                     values={{
                       limit: <b>{e?.attributes?.limit ?? DEFAULT_AGENTLESS_LIMIT}</b>,
+                      docLink: (
+                        <EuiLink href={docLinks.links.fleet.agentlessIntegrations} target="_blank">
+                          <FormattedMessage
+                            id="xpack.fleet.createAgentlessPolicy.seeDocLink"
+                            defaultMessage="See agentless documentation."
+                          />
+                        </EuiLink>
+                      ),
+                    }}
+                  />
+                </>
+              ),
+            });
+          }
+          if (e?.attributes?.type === AgentlessAgentCreateFleetUnreachableError.name) {
+            notifications.toasts.addError(e, {
+              title: i18n.translate('xpack.fleet.createAgentlessPolicy.errorNotificationTitle', {
+                defaultMessage: 'Unable to create integration',
+              }),
+              // @ts-expect-error
+              toastMessage: (
+                <>
+                  <FormattedMessage
+                    id="xpack.fleet.createAgentlessPolicy.FleetUnreachableErrorMessage"
+                    defaultMessage="Fleet is not reachable and required to create agentless policy. Error: {errorMessage}. {docLink}"
+                    values={{
+                      errorMessage: e?.message ?? '',
                       docLink: (
                         <EuiLink href={docLinks.links.fleet.agentlessIntegrations} target="_blank">
                           <FormattedMessage

--- a/x-pack/platform/plugins/shared/fleet/server/errors/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/errors/handlers.ts
@@ -15,7 +15,10 @@ import type {
 } from '@kbn/core/server';
 import type { KibanaRequest } from '@kbn/core/server';
 
-import { UninstallTokenError } from '../../common/errors';
+import {
+  AgentlessAgentCreateFleetUnreachableError,
+  UninstallTokenError,
+} from '../../common/errors';
 
 import { appContextService } from '../services';
 
@@ -173,6 +176,8 @@ function shouldRespondWithErrorType(error: FleetError) {
   if (error instanceof OutputInvalidError) {
     return true;
   } else if (error instanceof AgentlessAgentCreateOverProvisionnedError) {
+    return true;
+  } else if (error instanceof AgentlessAgentCreateFleetUnreachableError) {
     return true;
   }
   return false;

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
@@ -16,7 +16,10 @@ import axios from 'axios';
 
 import apm from 'elastic-apm-node';
 
-import { AgentlessAgentCreateOverProvisionedError } from '../../../common/errors';
+import {
+  AgentlessAgentCreateOverProvisionedError,
+  AgentlessAgentCreateFleetUnreachableError,
+} from '../../../common/errors';
 import { SO_SEARCH_LIMIT } from '../../constants';
 import type { AgentPolicy } from '../../types';
 import type { AgentlessApiDeploymentResponse, FleetServerHost } from '../../../common/types';
@@ -591,7 +594,12 @@ class AgentlessAgentService {
           this.withRequestIdMessage(userMessage, traceId),
           limit
         );
+      } else if (responseData?.code === AGENTLESS_API_ERROR_CODES.FLEET_UNREACHABLE) {
+        return new AgentlessAgentCreateFleetUnreachableError(
+          this.withRequestIdMessage(userMessage, traceId)
+        );
       }
+
       return new AgentlessAgentCreateError(this.withRequestIdMessage(userMessage, traceId));
     }
     if (action === 'delete') {


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/232433

Handle Fleet unreachable errors from agentless API, 

Agentless-API now detect if Fleet is not reachable, that PR handle that error to:
* return a 400 server side
* display an error message to the user client side

## UI Changes


<img width="1501" height="732" alt="Screenshot 2025-09-02 at 5 36 53 PM" src="https://github.com/user-attachments/assets/749a7dae-a03d-4068-a4b1-e370c9aab479" />





<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->