### PR TITLE
[8.19] skip failing test suite (#233044)

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/diagnostics/index_pattern_settings.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/diagnostics/index_pattern_settings.spec.ts
@@ -18,7 +18,8 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const start = new Date('2021-01-01T00:00:00.000Z').getTime();
   const end = new Date('2021-01-01T00:15:00.000Z').getTime() - 1;
 
-  describe('Diagnostics: Index pattern settings', () => {
+  // Failing: See https://github.com/elastic/kibana/issues/233044
+  describe.skip('Diagnostics: Index pattern settings', () => {
     describe('When data is ingested', () => {
       let apmSynthtraceEsClient: ApmSynthtraceEsClient;
 


### PR DESCRIPTION
## Summary

This PR backports the skip commit fb4ecd7800f321f11e8b84fa72e3fb7153b255a0 to 8.19 in order to address the failing forward camptibility tests as well, see #233044.
