### PR TITLE
[Dashboard] Fix resize bug

### DIFF
--- a/src/platform/packages/private/kbn-grid-layout/grid/use_grid_layout_events/panel/state_manager_actions.ts
+++ b/src/platform/packages/private/kbn-grid-layout/grid/use_grid_layout_events/panel/state_manager_actions.ts
@@ -76,11 +76,15 @@ export const moveAction = (
   const previewRect = (() => {
     if (isResize) {
       const { resizeOptions } = currentPanelData;
+      const maxRight = gridLayoutElement
+        ? gridLayoutElement.getBoundingClientRect().right
+        : window.innerWidth;
       return getResizePreviewRect({
         activePanel,
         pointerPixel,
         runtimeSettings,
         resizeOptions,
+        maxRight,
       });
     } else {
       return getDragPreviewRect({ activePanel, pointerPixel });

--- a/src/platform/packages/private/kbn-grid-layout/grid/use_grid_layout_events/panel/utils.ts
+++ b/src/platform/packages/private/kbn-grid-layout/grid/use_grid_layout_events/panel/utils.ts
@@ -46,11 +46,13 @@ export const getResizePreviewRect = ({
   pointerPixel,
   runtimeSettings,
   resizeOptions,
+  maxRight,
 }: {
   pointerPixel: PointerPosition;
   activePanel: ActivePanelEvent;
   runtimeSettings: RuntimeGridSettings;
   resizeOptions: GridPanelData['resizeOptions'];
+  maxRight: number;
 }) => {
   const panelRect = activePanel.panelDiv.getBoundingClientRect();
   const { minWidth, maxWidth, minHeight, maxHeight } = {
@@ -72,8 +74,7 @@ export const getResizePreviewRect = ({
         pointerPixel.clientX - activePanel.sensorOffsets.right, // actual width based on mouse position
         panelRect.left + getColumnCountInPixels({ columnCount: maxWidth, runtimeSettings }), // max width of panel
         // cannot extend width past the right edge of the grid layout
-        getColumnCountInPixels({ columnCount: runtimeSettings.columnCount, runtimeSettings }) +
-          runtimeSettings.gutterSize
+        maxRight
       ),
       panelRect.left + getColumnCountInPixels({ columnCount: minWidth, runtimeSettings }) // min width of panel
     ),


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/233517

## Summary

This fixes a bug where panels could not be resized to the max width when using a serverless / solution view.


Essentially, when calculating the "max right" position of the panel on resize, we were not accounting for the left navigation. Rather than using the **panel** element to determine what the maximum right pixel is, we must use the layout element instead since it takes into account the left offset. 

| Before (no left nav) | After (no left nav) |
|--------|--------|
| ![Sep-02-2025 09-52-00](https://github.com/user-attachments/assets/77c9a2c3-b93f-488e-b1c1-b4ee3ab1f06f) | ![Sep-02-2025 09-42-17](https://github.com/user-attachments/assets/05bdc446-9266-480c-a615-7d5d452a50a9) | 

| Before (left nav) | After (left nav) |
|--------|--------|
| ![Sep-02-2025 09-53-07](https://github.com/user-attachments/assets/11bff577-973d-42df-9035-e00038d86aeb) | ![Sep-02-2025 09-45-18](https://github.com/user-attachments/assets/02ad582e-6b4c-4525-a522-330a3f7b7ea0) | 


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
