### PR TITLE
[Background search] Integrate background search button in unified search

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -75,6 +75,7 @@ enabled:
   - src/platform/test/functional/apps/discover/ccs_compatibility/config.ts
   - src/platform/test/functional/apps/discover/embeddable/config.ts
   - src/platform/test/functional/apps/discover/esql/config.ts
+  - src/platform/test/functional/apps/discover/background_search/config.ts
   - src/platform/test/functional/apps/discover/group1/config.ts
   - src/platform/test/functional/apps/discover/group2_data_grid1/config.ts
   - src/platform/test/functional/apps/discover/group2_data_grid2/config.ts

--- a/src/platform/packages/private/kbn-split-button/src/split_button.tsx
+++ b/src/platform/packages/private/kbn-split-button/src/split_button.tsx
@@ -14,9 +14,11 @@ import React from 'react';
 
 type SplitButtonProps = React.ComponentProps<typeof EuiButton> & {
   isMainButtonLoading?: boolean;
+  isMainButtonDisabled?: boolean;
   iconOnly?: boolean;
 
   isSecondaryButtonLoading?: boolean;
+  isSecondaryButtonDisabled?: boolean;
   secondaryButtonIcon: string;
   secondaryButtonAriaLabel?: string;
   onSecondaryButtonClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -32,12 +34,14 @@ export const SplitButton = ({
 
   // Secondary button props
   isSecondaryButtonLoading = false,
+  isSecondaryButtonDisabled = false,
   secondaryButtonIcon,
   secondaryButtonAriaLabel,
   onSecondaryButtonClick,
 
   // Primary button props
   isMainButtonLoading = false,
+  isMainButtonDisabled = false,
   iconOnly = false,
   iconType,
   ...mainButtonProps
@@ -57,7 +61,7 @@ export const SplitButton = ({
     },
     color,
     size,
-    isDisabled: areButtonsDisabled,
+    isDisabled: areButtonsDisabled || isMainButtonDisabled,
     isLoading: isLoading || isMainButtonLoading,
     'data-icon': iconType,
     ...mainButtonProps,
@@ -84,7 +88,7 @@ export const SplitButton = ({
         size={size}
         iconType={secondaryButtonIcon}
         onClick={onSecondaryButtonClick}
-        isDisabled={areButtonsDisabled}
+        isDisabled={areButtonsDisabled || isSecondaryButtonDisabled}
         isLoading={isLoading || isSecondaryButtonLoading}
       />
     </div>

--- a/src/platform/packages/private/kbn-split-button/src/split_button.tsx
+++ b/src/platform/packages/private/kbn-split-button/src/split_button.tsx
@@ -21,6 +21,7 @@ type SplitButtonProps = React.ComponentProps<typeof EuiButton> & {
   isSecondaryButtonDisabled?: boolean;
   secondaryButtonIcon: string;
   secondaryButtonAriaLabel?: string;
+  secondaryButtonTitle?: string;
   onSecondaryButtonClick?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
@@ -37,6 +38,7 @@ export const SplitButton = ({
   isSecondaryButtonDisabled = false,
   secondaryButtonIcon,
   secondaryButtonAriaLabel,
+  secondaryButtonTitle,
   onSecondaryButtonClick,
 
   // Primary button props
@@ -83,6 +85,7 @@ export const SplitButton = ({
         data-test-subj={mainButtonProps['data-test-subj'] + `-secondary-button`}
         data-icon={secondaryButtonIcon}
         aria-label={secondaryButtonAriaLabel}
+        title={secondaryButtonTitle}
         display="base"
         color={color}
         size={size}

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -386,6 +386,7 @@ export function InternalDashboardTopNav({
           }
         }}
         onSavedQueryIdChange={setSavedQueryId}
+        useBackgroundSearchButton={dataService.search.isBackgroundSearchEnabled}
       />
       {viewMode !== 'print' && isLabsEnabled && isLabsShown ? (
         <LabsFlyout solutions={['dashboard']} onClose={() => setIsLabsShown(false)} />

--- a/src/platform/plugins/shared/data/public/search/mocks.ts
+++ b/src/platform/plugins/shared/data/public/search/mocks.ts
@@ -22,7 +22,9 @@ function createSetupContract(): jest.Mocked<ISearchSetup> {
   };
 }
 
-function createStartContract(): jest.Mocked<ISearchStart> {
+function createStartContract(
+  overrides: Partial<jest.Mocked<ISearchStart>> = {}
+): jest.Mocked<ISearchStart> {
   return {
     aggs: searchAggsStartMock(),
     search: jest.fn(),
@@ -33,6 +35,7 @@ function createStartContract(): jest.Mocked<ISearchStart> {
     session: getSessionServiceMock(),
     sessionsClient: getSessionsClientMock(),
     searchSource: searchSourceMock.createStartContract(),
+    ...overrides,
   };
 }
 

--- a/src/platform/plugins/shared/data/public/search/search_service.test.ts
+++ b/src/platform/plugins/shared/data/public/search/search_service.test.ts
@@ -73,6 +73,7 @@ describe('Search service', () => {
       expect(data).toHaveProperty('aggs');
       expect(data).toHaveProperty('search');
       expect(data).toHaveProperty('showSearchSessionsFlyout');
+      expect(data).toHaveProperty('isBackgroundSearchEnabled');
       expect(data).toHaveProperty('showWarnings');
       expect(data).toHaveProperty('showError');
       expect(data).toHaveProperty('searchSource');

--- a/src/platform/plugins/shared/data/public/search/session/mocks.ts
+++ b/src/platform/plugins/shared/data/public/search/session/mocks.ts
@@ -26,7 +26,9 @@ export function getSessionsClientMock(): jest.Mocked<ISessionsClient> {
   };
 }
 
-export function getSessionServiceMock(): jest.Mocked<ISessionService> {
+export function getSessionServiceMock(
+  overrides: Partial<jest.Mocked<ISessionService>> = {}
+): jest.Mocked<ISessionService> {
   return {
     clear: jest.fn(),
     start: jest.fn(),
@@ -59,6 +61,7 @@ export function getSessionServiceMock(): jest.Mocked<ISessionService> {
     getSearchSessionIndicatorUiConfig: jest.fn(() => ({ isDisabled: () => ({ disabled: false }) })),
     hasAccess: jest.fn(() => true),
     continue: jest.fn(),
+    ...overrides,
   };
 }
 

--- a/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
@@ -462,7 +462,7 @@ describe('Session service', () => {
     expect(onSavingSession).toHaveBeenCalledTimes(1);
   });
 
-  test('save() return a formattedName', async () => {
+  test('save() return a search session', async () => {
     sessionService.enableStorage({
       getName: async () => 'Name',
       getLocatorData: async () => ({
@@ -472,6 +472,7 @@ describe('Session service', () => {
       }),
       appendSessionStartTimeToName: false,
     });
+    sessionsClient.create.mockResolvedValue(mockSavedObject);
 
     sessionService.start();
     const abort = jest.fn();
@@ -482,9 +483,9 @@ describe('Session service', () => {
 
     expect(onSavingSession).toHaveBeenCalledTimes(0);
 
-    const { formattedName } = await sessionService.save();
+    const searchSession = await sessionService.save();
 
-    expect(formattedName).toBe('Name');
+    expect(searchSession.attributes.name).toBe(mockSavedObject.attributes.name);
   });
 
   describe("user doesn't have access to search session", () => {

--- a/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
@@ -462,6 +462,31 @@ describe('Session service', () => {
     expect(onSavingSession).toHaveBeenCalledTimes(1);
   });
 
+  test('save() return a formattedName', async () => {
+    sessionService.enableStorage({
+      getName: async () => 'Name',
+      getLocatorData: async () => ({
+        id: 'id',
+        initialState: {},
+        restoreState: {},
+      }),
+      appendSessionStartTimeToName: false,
+    });
+
+    sessionService.start();
+    const abort = jest.fn();
+    const poll = jest.fn(() => Promise.resolve());
+    const onSavingSession = jest.fn(() => Promise.resolve());
+
+    sessionService.trackSearch({ poll, abort, onSavingSession });
+
+    expect(onSavingSession).toHaveBeenCalledTimes(0);
+
+    const { formattedName } = await sessionService.save();
+
+    expect(formattedName).toBe('Name');
+  });
+
   describe("user doesn't have access to search session", () => {
     beforeAll(() => {
       userHasAccessToSearchSessions = false;

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -532,7 +532,7 @@ export class SessionService {
    * Save current session as SO to get back to results later
    * (Send to background)
    */
-  public async save(): Promise<void> {
+  public async save() {
     const sessionId = this.getSessionId();
     if (!sessionId) throw new Error('No current session');
     const currentSessionApp = this.state.get().appName;
@@ -597,6 +597,8 @@ export class SessionService {
 
       await extendSearchesPromise;
     }
+
+    return { formattedName };
   }
 
   /**

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -598,7 +598,7 @@ export class SessionService {
       await extendSearchesPromise;
     }
 
-    return { formattedName };
+    return searchSessionSavedObject;
   }
 
   /**

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
@@ -51,7 +51,10 @@ export function openSearchSessionsFlyout({
           <KibanaReactContextProvider>
             <Flyout
               onClose={() => flyout.close()}
-              onBackgroundSearchOpened={attrs.onBackgroundSearchOpened}
+              onBackgroundSearchOpened={(params) => {
+                attrs.onBackgroundSearchOpened?.(params);
+                flyout.close();
+              }}
               appId={attrs.appId}
               api={api}
               coreStart={coreStart}

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -251,6 +251,7 @@ export const DiscoverTopNav = ({
     <>
       <SearchBar
         {...topNavProps}
+        useBackgroundSearchButton={services.data.search.isBackgroundSearchEnabled}
         appName="discover"
         indexPatterns={[dataView]}
         onQuerySubmit={stateContainer.actions.onUpdateQuery}

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.test.tsx
@@ -12,7 +12,7 @@ import { mockPersistedLogFactory } from './query_string_input.test.mocks';
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { BehaviorSubject } from 'rxjs';
-import { render } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import { EMPTY } from 'rxjs';
 
 import { QueryBarTopRow, SharingMetaFields } from './query_bar_top_row';
@@ -169,7 +169,7 @@ describe('QueryBarTopRowTopRow', () => {
           )
         );
 
-        expect(getByTestId(submitId)).toBeVisible();
+        expect(within(getByTestId(submitId)).getByText('Refresh')).toBeVisible();
       });
     });
 
@@ -185,12 +185,13 @@ describe('QueryBarTopRowTopRow', () => {
               timeHistory: mockTimeHistory,
               isLoading: true,
               onCancel: jest.fn(),
+              submitButtonStyle: 'withText',
             },
             { servicesOverride: { data } }
           )
         );
 
-        expect(getByTestId(cancelId)).toBeVisible();
+        expect(within(getByTestId(cancelId)).getByText('Cancel')).toBeVisible();
       });
     });
   });

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.test.tsx
@@ -151,22 +151,17 @@ describe('QueryBarTopRowTopRow', () => {
       cancelId: 'queryCancelSplitButton',
     },
   ])('when background search is $description', ({ value, submitId, cancelId }) => {
-    const data = dataPluginMock.createStartContract();
-    data.search.isBackgroundSearchEnabled = value;
-
     describe('when it is NOT loading', () => {
       it('should render the submit button', () => {
         const { getByTestId } = render(
-          wrapQueryBarTopRowInContext(
-            {
-              query: kqlQuery,
-              screenTitle: 'Another Screen',
-              isDirty: false,
-              indexPatterns: [stubIndexPattern],
-              timeHistory: mockTimeHistory,
-            },
-            { servicesOverride: { data } }
-          )
+          wrapQueryBarTopRowInContext({
+            query: kqlQuery,
+            screenTitle: 'Another Screen',
+            isDirty: false,
+            indexPatterns: [stubIndexPattern],
+            timeHistory: mockTimeHistory,
+            useBackgroundSearchButton: value,
+          })
         );
 
         expect(within(getByTestId(submitId)).getByText('Refresh')).toBeVisible();
@@ -176,19 +171,17 @@ describe('QueryBarTopRowTopRow', () => {
     describe('when it is loading', () => {
       it('should render the cancel button', () => {
         const { getByTestId } = render(
-          wrapQueryBarTopRowInContext(
-            {
-              query: kqlQuery,
-              screenTitle: 'Another Screen',
-              isDirty: false,
-              indexPatterns: [stubIndexPattern],
-              timeHistory: mockTimeHistory,
-              isLoading: true,
-              onCancel: jest.fn(),
-              submitButtonStyle: 'withText',
-            },
-            { servicesOverride: { data } }
-          )
+          wrapQueryBarTopRowInContext({
+            query: kqlQuery,
+            screenTitle: 'Another Screen',
+            isDirty: false,
+            indexPatterns: [stubIndexPattern],
+            timeHistory: mockTimeHistory,
+            isLoading: true,
+            onCancel: jest.fn(),
+            submitButtonStyle: 'withText',
+            useBackgroundSearchButton: value,
+          })
         );
 
         expect(within(getByTestId(cancelId)).getByText('Cancel')).toBeVisible();
@@ -198,8 +191,6 @@ describe('QueryBarTopRowTopRow', () => {
 
   describe('when background search is enabled', () => {
     const data = dataPluginMock.createStartContract();
-    data.search.isBackgroundSearchEnabled = true;
-
     const session = getSessionServiceMock({
       state$: new BehaviorSubject(SearchSessionState.Completed).asObservable(),
     });
@@ -222,6 +213,7 @@ describe('QueryBarTopRowTopRow', () => {
                 indexPatterns: [stubIndexPattern],
                 timeHistory: mockTimeHistory,
                 onSubmit,
+                useBackgroundSearchButton: true,
               },
               { servicesOverride: { data } }
             )
@@ -249,6 +241,7 @@ describe('QueryBarTopRowTopRow', () => {
                 indexPatterns: [stubIndexPattern],
                 timeHistory: mockTimeHistory,
                 onSendToBackground,
+                useBackgroundSearchButton: true,
               },
               { servicesOverride: { data } }
             )
@@ -281,6 +274,7 @@ describe('QueryBarTopRowTopRow', () => {
                 timeHistory: mockTimeHistory,
                 isLoading,
                 onCancel,
+                useBackgroundSearchButton: true,
               },
               { servicesOverride: { data } }
             )
@@ -310,6 +304,7 @@ describe('QueryBarTopRowTopRow', () => {
                 isLoading,
                 onCancel: jest.fn(),
                 onSendToBackground,
+                useBackgroundSearchButton: true,
               },
               { servicesOverride: { data } }
             )

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -600,6 +600,7 @@ export const QueryBarTopRow = React.memo(
             data-test-subj="queryCancelSplitButton"
             color="text"
             secondaryButtonIcon="clock"
+            secondaryButtonTitle={strings.getSendToBackgroundLabel()}
             secondaryButtonAriaLabel={strings.getSendToBackgroundLabel()}
             isSecondaryButtonDisabled={!canSendToBackground}
           >
@@ -663,6 +664,7 @@ export const QueryBarTopRow = React.memo(
           color={props.isDirty ? 'success' : 'primary'}
           secondaryButtonIcon="clock"
           secondaryButtonAriaLabel={strings.getSendToBackgroundLabel()}
+          secondaryButtonTitle={strings.getSendToBackgroundLabel()}
           isSecondaryButtonDisabled={!canSendToBackground}
         >
           {props.isDirty ? buttonLabelDirty : strings.getRefreshButtonLabel()}

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -194,6 +194,8 @@ export interface QueryBarTopRowProps<QT extends Query | AggregateQuery = Query> 
 
   esqlEditorInitialState?: ESQLEditorProps['initialState'];
   onEsqlEditorInitialStateChange?: ESQLEditorProps['onInitialStateChange'];
+
+  useBackgroundSearchButton?: boolean;
 }
 
 export const SharingMetaFields = React.memo(function SharingMetaFields({
@@ -284,7 +286,6 @@ export const QueryBarTopRow = React.memo(
       dataViews,
     } = kibana.services;
 
-    const isBackgroundSearchEnabled = data.search.isBackgroundSearchEnabled;
     const isQueryLangSelected = props.query && !isOfQueryType(props.query);
 
     const backgroundSearchState = useObservable(data.search.session.state$);
@@ -589,7 +590,7 @@ export const QueryBarTopRow = React.memo(
     function renderCancelButton() {
       const buttonLabelCancel = strings.getCancelQueryLabel();
 
-      if (isBackgroundSearchEnabled) {
+      if (props.useBackgroundSearchButton) {
         return (
           <SplitButton
             aria-label={buttonLabelCancel}
@@ -651,7 +652,7 @@ export const QueryBarTopRow = React.memo(
         ? strings.getRunButtonLabel()
         : strings.getUpdateButtonLabel();
 
-      const updateButton = isBackgroundSearchEnabled ? (
+      const updateButton = props.useBackgroundSearchButton ? (
         <SplitButton
           aria-label={props.isDirty ? labelDirty : strings.getRefreshQueryLabel()}
           color={props.isDirty ? 'success' : 'primary'}

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -592,17 +592,17 @@ export const QueryBarTopRow = React.memo(
       if (isBackgroundSearchEnabled) {
         return (
           <SplitButton
+            aria-label={buttonLabelCancel}
+            color="text"
+            data-test-subj="queryCancelSplitButton"
+            iconType="cross"
+            isSecondaryButtonDisabled={!canSendToBackground}
             onClick={onClickCancelButton}
             onSecondaryButtonClick={onClickSendToBackground}
-            aria-label={buttonLabelCancel}
-            size={shouldShowDatePickerAsBadge() ? 's' : 'm'}
-            iconType="cross"
-            data-test-subj="queryCancelSplitButton"
-            color="text"
+            secondaryButtonAriaLabel={strings.getSendToBackgroundLabel()}
             secondaryButtonIcon="clock"
             secondaryButtonTitle={strings.getSendToBackgroundLabel()}
-            secondaryButtonAriaLabel={strings.getSendToBackgroundLabel()}
-            isSecondaryButtonDisabled={!canSendToBackground}
+            size={shouldShowDatePickerAsBadge() ? 's' : 'm'}
           >
             {buttonLabelCancel}
           </SplitButton>
@@ -653,19 +653,19 @@ export const QueryBarTopRow = React.memo(
 
       const updateButton = isBackgroundSearchEnabled ? (
         <SplitButton
+          aria-label={props.isDirty ? labelDirty : strings.getRefreshQueryLabel()}
+          color={props.isDirty ? 'success' : 'primary'}
           data-test-subj="querySubmitSplitButton"
           iconType={props.isDirty ? iconDirty : 'refresh'}
-          aria-label={props.isDirty ? labelDirty : strings.getRefreshQueryLabel()}
           isDisabled={isDateRangeInvalid || props.isDisabled}
           isLoading={props.isLoading}
+          isSecondaryButtonDisabled={!canSendToBackground}
           onClick={onClickSubmitButton}
           onSecondaryButtonClick={onClickSendToBackground}
-          size={shouldShowDatePickerAsBadge() ? 's' : 'm'}
-          color={props.isDirty ? 'success' : 'primary'}
-          secondaryButtonIcon="clock"
           secondaryButtonAriaLabel={strings.getSendToBackgroundLabel()}
+          secondaryButtonIcon="clock"
           secondaryButtonTitle={strings.getSendToBackgroundLabel()}
-          isSecondaryButtonDisabled={!canSendToBackground}
+          size={shouldShowDatePickerAsBadge() ? 's' : 'm'}
         >
           {props.isDirty ? buttonLabelDirty : strings.getRefreshButtonLabel()}
         </SplitButton>

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -289,6 +289,7 @@ export const QueryBarTopRow = React.memo(
 
     const backgroundSearchState = useObservable(data.search.session.state$);
     const canSendToBackground =
+      props.isDirty ||
       backgroundSearchState === SearchSessionState.Loading ||
       backgroundSearchState === SearchSessionState.Completed;
 

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -596,7 +596,7 @@ export const QueryBarTopRow = React.memo(
             aria-label={buttonLabelCancel}
             size={shouldShowDatePickerAsBadge() ? 's' : 'm'}
             iconType="cross"
-            data-test-subj="queryCancelButton"
+            data-test-subj="queryCancelSplitButton"
             color="text"
             secondaryButtonIcon="clock"
             secondaryButtonAriaLabel={strings.getSendToBackgroundLabel()}
@@ -651,6 +651,7 @@ export const QueryBarTopRow = React.memo(
 
       const updateButton = isBackgroundSearchEnabled ? (
         <SplitButton
+          data-test-subj="querySubmitSplitButton"
           iconType={props.isDirty ? iconDirty : 'refresh'}
           aria-label={props.isDirty ? labelDirty : strings.getRefreshQueryLabel()}
           isDisabled={isDateRangeInvalid || props.isDisabled}

--- a/src/platform/plugins/shared/unified_search/public/search_bar/create_search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/create_search_bar.tsx
@@ -278,6 +278,7 @@ export function createSearchBar({
             onESQLDocsFlyoutVisibilityChanged={props.onESQLDocsFlyoutVisibilityChanged}
             esqlEditorInitialState={props.esqlEditorInitialState}
             onEsqlEditorInitialStateChange={props.onEsqlEditorInitialStateChange}
+            useBackgroundSearchButton={props.useBackgroundSearchButton}
           />
         </core.i18n.Context>
       </KibanaContextProvider>

--- a/src/platform/plugins/shared/unified_search/public/search_bar/mocks.ts
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/mocks.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const createMockTimeHistory = () => ({
+  get: () => {
+    return [];
+  },
+  add: jest.fn(),
+  get$: () => {
+    return {
+      pipe: () => {},
+    };
+  },
+});
+
+export const createMockWebStorage = () => ({
+  clear: jest.fn(),
+  getItem: jest.fn(),
+  key: jest.fn(),
+  removeItem: jest.fn(),
+  setItem: jest.fn(),
+  length: 0,
+});
+
+export const createMockStorage = () => ({
+  storage: createMockWebStorage(),
+  get: jest.fn(),
+  set: jest.fn(),
+  remove: jest.fn(),
+  clear: jest.fn(),
+});

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.bgs.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.bgs.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import { QueryBarTopRow } from '../query_string_input/query_bar_top_row';
+import SearchBar from './search_bar';
+import { coreMock } from '@kbn/core/public/mocks';
+import React from 'react';
+import { EuiThemeProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { createMockStorage } from './mocks';
+import { searchServiceMock } from '@kbn/data-plugin/public/search/mocks';
+import { indexPatternEditorPluginMock as dataViewEditorPluginMock } from '@kbn/data-view-editor-plugin/public/mocks';
+import { getSessionServiceMock } from '@kbn/data-plugin/public/search/session/mocks';
+import { BehaviorSubject } from 'rxjs';
+
+const SAVED_SEARCH_NAME = 'Data discovery search';
+const INITIAL_SESSION_ID = '12345';
+const NEW_SESSION_ID = '67890';
+
+jest.mock('../query_string_input/query_bar_top_row', () => ({
+  QueryBarTopRow: jest.fn(() => <div />),
+}));
+const QueryBarTopRowMock = jest.mocked(QueryBarTopRow);
+
+const setup = ({
+  props,
+}: {
+  props?: Partial<React.ComponentProps<typeof SearchBar.WrappedComponent>>;
+} = {}) => {
+  const startMock = coreMock.createStart();
+
+  const save = jest.fn().mockResolvedValue({ formattedName: SAVED_SEARCH_NAME });
+  const getSessionObservable = new BehaviorSubject<string | undefined>(undefined);
+
+  const search = searchServiceMock.createStartContract({
+    session: getSessionServiceMock({
+      save,
+      getSessionId: jest.fn().mockReturnValue(INITIAL_SESSION_ID),
+      getSession$: jest.fn().mockReturnValue(getSessionObservable.asObservable()),
+    }),
+  });
+
+  const finalServices = {
+    ...startMock,
+    storage: createMockStorage(),
+    data: { query: {}, search },
+    dataViewEditor: dataViewEditorPluginMock.createStartContract(),
+    dataViews: {
+      getIdsWithTitle: jest.fn(() => []),
+    },
+  };
+
+  render(
+    <EuiThemeProvider>
+      <I18nProvider>
+        <KibanaContextProvider services={finalServices}>
+          <SearchBar.WrappedComponent intl={null as any} {...props} />
+        </KibanaContextProvider>
+      </I18nProvider>
+    </EuiThemeProvider>
+  );
+
+  return { save, addSuccess: startMock.notifications.toasts.addSuccess, getSessionObservable };
+};
+
+beforeEach(() => {
+  QueryBarTopRowMock.mockReturnValue(<div />);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('<SearchBarUI />', () => {
+  describe('when the query is NOT dirty', () => {
+    const props = {
+      showDatePicker: false,
+      query: undefined,
+      dateRangeFrom: 'now-15m',
+      dateRangeTo: 'now',
+    };
+
+    describe('when a search is backgrounded', () => {
+      it('should save the session', async () => {
+        // When
+        const { save } = setup({ props });
+        QueryBarTopRowMock.mock.calls[0][0].onSendToBackground({ dateRange: { from: '', to: '' } });
+
+        // Then
+        await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+      });
+
+      it('should add a toast', async () => {
+        const { addSuccess } = setup({ props });
+        QueryBarTopRowMock.mock.calls[0][0].onSendToBackground({ dateRange: { from: '', to: '' } });
+
+        await waitFor(() => expect(addSuccess).toHaveBeenCalledTimes(1));
+      });
+    });
+  });
+
+  describe('when the query is dirty', () => {
+    const props = {
+      showDatePicker: false,
+      query: undefined,
+      dateRangeFrom: 'now-1h',
+      dateRangeTo: 'now-15m',
+    };
+
+    describe('when a search is backgrounded', () => {
+      it('should save the session', async () => {
+        // When
+        const { save, getSessionObservable } = setup({ props });
+        QueryBarTopRowMock.mock.calls[0][0].onSendToBackground({ dateRange: { from: '', to: '' } });
+        getSessionObservable.next(NEW_SESSION_ID); // simulate session being saved
+
+        // Then
+        await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+      });
+
+      it('should add a toast', async () => {
+        // When
+        const { addSuccess, getSessionObservable } = setup({ props });
+        QueryBarTopRowMock.mock.calls[0][0].onSendToBackground({ dateRange: { from: '', to: '' } });
+        getSessionObservable.next(NEW_SESSION_ID); // simulate session being saved
+
+        // Then
+        await waitFor(() => expect(addSuccess).toHaveBeenCalledTimes(1));
+      });
+    });
+  });
+});

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.bgs.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.bgs.test.tsx
@@ -37,7 +37,22 @@ const setup = ({
 } = {}) => {
   const startMock = coreMock.createStart();
 
-  const save = jest.fn().mockResolvedValue({ formattedName: SAVED_SEARCH_NAME });
+  const save = jest.fn().mockResolvedValue({
+    id: 'd7170a35-7e2c-48d6-8dec-9a056721b489',
+    type: 'search-session',
+    attributes: {
+      name: SAVED_SEARCH_NAME,
+      appId: 'my_app_id',
+      locatorId: 'my_locator_id',
+      idMapping: {},
+      sessionId: 'session_id',
+      created: new Date().toISOString(),
+      expires: new Date().toISOString(),
+      version: '8.0.0',
+    },
+    references: [],
+  });
+
   const getSessionObservable = new BehaviorSubject<string | undefined>(undefined);
 
   const search = searchServiceMock.createStartContract({

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.test.tsx
@@ -24,38 +24,10 @@ import { EuiSuperDatePicker, EuiSuperUpdateButton, EuiThemeProvider } from '@ela
 import { FilterItems } from '../filter_bar';
 import { DataViewPicker } from '..';
 import { searchServiceMock } from '@kbn/data-plugin/public/search/mocks';
+import { createMockStorage, createMockTimeHistory } from './mocks';
 import { SearchSessionState } from '@kbn/data-plugin/public';
 
-const mockTimeHistory = {
-  get: () => {
-    return [];
-  },
-  add: jest.fn(),
-  get$: () => {
-    return {
-      pipe: () => {},
-    };
-  },
-};
-
 const noop = jest.fn();
-
-const createMockWebStorage = () => ({
-  clear: jest.fn(),
-  getItem: jest.fn(),
-  key: jest.fn(),
-  removeItem: jest.fn(),
-  setItem: jest.fn(),
-  length: 0,
-});
-
-const createMockStorage = () => ({
-  storage: createMockWebStorage(),
-  get: jest.fn(),
-  set: jest.fn(),
-  remove: jest.fn(),
-  clear: jest.fn(),
-});
 
 const kqlQuery = {
   query: 'response:200',
@@ -77,7 +49,7 @@ function wrapSearchBarInContext(
 ) {
   const defaultOptions = {
     appName: 'test',
-    timeHistory: mockTimeHistory,
+    timeHistory: createMockTimeHistory(),
     intl: null as any,
   };
 

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.test.tsx
@@ -26,6 +26,7 @@ import { DataViewPicker } from '..';
 import { searchServiceMock } from '@kbn/data-plugin/public/search/mocks';
 import { createMockStorage, createMockTimeHistory } from './mocks';
 import { SearchSessionState } from '@kbn/data-plugin/public';
+import { getSessionServiceMock } from '@kbn/data-plugin/public/search/session/mocks';
 
 const noop = jest.fn();
 
@@ -83,11 +84,10 @@ function wrapSearchBarInContext(
     docLinks: startMock.docLinks,
     storage: createMockStorage(),
     data: {
-      search: {
-        ...searchServiceMock.createStartContract(),
+      search: searchServiceMock.createStartContract({
         isBackgroundSearchEnabled: backgroundSearchEnabled,
-        session: { state$: sessionState$ },
-      },
+        session: getSessionServiceMock({ state$: sessionState$ }),
+      }),
       query: {
         savedQueries: {
           findSavedQueries: () =>

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -526,7 +526,9 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
     }
   };
 
-  private showBackgroundSearchCreatedToast(name: string) {
+  private showBackgroundSearchCreatedToast(name: string | undefined) {
+    if (!name) return;
+
     const toast = this.services.notifications.toasts.addSuccess({
       title: i18n.translate('unifiedSearch.search.searchBar.backgroundSearch.toast.title', {
         defaultMessage: 'Background search created',
@@ -561,8 +563,8 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
     query?: QT | Query | undefined;
   }) => {
     if (!this.isDirty()) {
-      const { formattedName } = await this.services.data.search.session.save();
-      this.showBackgroundSearchCreatedToast(formattedName);
+      const searchSession = await this.services.data.search.session.save();
+      this.showBackgroundSearchCreatedToast(searchSession.attributes.name);
       return;
     }
 
@@ -573,8 +575,8 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
       .subscribe(async (newSessionId) => {
         if (currentSessionId === newSessionId) return;
         subscription.unsubscribe();
-        const { formattedName } = await this.services.data.search.session.save();
-        this.showBackgroundSearchCreatedToast(formattedName);
+        const searchSession = await this.services.data.search.session.save();
+        this.showBackgroundSearchCreatedToast(searchSession.attributes.name);
       });
 
     this.onQueryBarSubmit(payload);

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -541,7 +541,9 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
               <EuiLink
                 onClick={() => {
                   this.services.notifications.toasts.remove(toast);
-                  this.services.data.search.showSearchSessionsFlyout();
+                  this.services.data.search.showSearchSessionsFlyout({
+                    appId: this.services.appName,
+                  });
                 }}
               >
                 {chunks}

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -156,6 +156,8 @@ export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
 
   esqlEditorInitialState?: QueryBarTopRowProps['esqlEditorInitialState'];
   onEsqlEditorInitialStateChange?: QueryBarTopRowProps['onEsqlEditorInitialStateChange'];
+
+  useBackgroundSearchButton?: boolean;
 }
 
 export type SearchBarProps<QT extends Query | AggregateQuery = Query> = SearchBarOwnProps<QT> &
@@ -770,6 +772,7 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
           bubbleSubmitEvent={this.props.bubbleSubmitEvent}
           esqlEditorInitialState={this.props.esqlEditorInitialState}
           onEsqlEditorInitialStateChange={this.props.onEsqlEditorInitialStateChange}
+          useBackgroundSearchButton={this.props.useBackgroundSearchButton}
         />
       </div>
     );

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -9,11 +9,11 @@
 
 import { compact } from 'lodash';
 import type { InjectedIntl } from '@kbn/i18n-react';
-import { injectI18n } from '@kbn/i18n-react';
+import { FormattedMessage, injectI18n } from '@kbn/i18n-react';
 import classNames from 'classnames';
 import React, { Component, createRef } from 'react';
 import type { EuiIconProps, WithEuiThemeProps } from '@elastic/eui';
-import { withEuiTheme } from '@elastic/eui';
+import { EuiLink, withEuiTheme } from '@elastic/eui';
 import type { EuiContextMenuClass } from '@elastic/eui/src/components/context_menu/context_menu';
 import { get, isEqual } from 'lodash';
 import memoizeOne from 'memoize-one';
@@ -39,6 +39,7 @@ import type { DataView } from '@kbn/data-views-plugin/public';
 
 import { BackgroundSearchRestoredCallout } from '@kbn/background-search';
 import { i18n } from '@kbn/i18n';
+import { toMountPoint } from '@kbn/react-kibana-mount';
 import type { AdditionalQueryBarMenuItems } from '../query_string_input/query_bar_menu_panels';
 import type { IUnifiedSearchPluginServices, UnifiedSearchDraft } from '../types';
 import type { SavedQueryMeta } from '../saved_query_form';
@@ -525,6 +526,57 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
     }
   };
 
+  private showBackgroundSearchCreatedToast(name: string) {
+    const toast = this.services.notifications.toasts.addSuccess({
+      title: i18n.translate('unifiedSearch.search.searchBar.backgroundSearch.toast.title', {
+        defaultMessage: 'Background search created',
+      }),
+      text: toMountPoint(
+        <FormattedMessage
+          id="unifiedSearch.search.searchBar.backgroundSearch.toast.text"
+          defaultMessage="{name} is running now. <link>Check its progress here</link>"
+          values={{
+            name,
+            link: (chunks: React.ReactNode) => (
+              <EuiLink
+                onClick={() => {
+                  this.services.notifications.toasts.remove(toast);
+                  this.services.data.search.showSearchSessionsFlyout();
+                }}
+              >
+                {chunks}
+              </EuiLink>
+            ),
+          }}
+        />,
+        this.services
+      ),
+    });
+  }
+
+  private onBackgroundSearch = async (payload: {
+    dateRange: TimeRange;
+    query?: QT | Query | undefined;
+  }) => {
+    if (!this.isDirty()) {
+      const { formattedName } = await this.services.data.search.session.save();
+      this.showBackgroundSearchCreatedToast(formattedName);
+    }
+
+    const currentSessionId = this.services.data.search.session.getSessionId();
+
+    const subscription = this.services.data.search.session
+      .getSession$()
+      .subscribe(async (newSessionId) => {
+        if (currentSessionId === newSessionId) return;
+        subscription.unsubscribe();
+        const { formattedName } = await this.services.data.search.session.save();
+        this.showBackgroundSearchCreatedToast(formattedName);
+      });
+
+    this.onQueryBarSubmit(payload);
+  };
+
   private shouldShowDatePickerAsBadge() {
     return this.shouldRenderFilterBar() && !this.props.showQueryInput;
   }
@@ -678,6 +730,7 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
           onCancel={this.props.onCancel}
           onChange={this.onQueryBarChange}
           onDraftChange={this.props.onDraftChange}
+          onSendToBackground={this.onBackgroundSearch}
           isDirty={this.isDirty()}
           customSubmitButton={
             this.props.customSubmitButton ? this.props.customSubmitButton : undefined

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -561,6 +561,7 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
     if (!this.isDirty()) {
       const { formattedName } = await this.services.data.search.session.save();
       this.showBackgroundSearchCreatedToast(formattedName);
+      return;
     }
 
     const currentSessionId = this.services.data.search.session.getSessionId();

--- a/src/platform/plugins/shared/unified_search/tsconfig.json
+++ b/src/platform/plugins/shared/unified_search/tsconfig.json
@@ -1,14 +1,9 @@
 {
   "extends": "../../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "target/types",
+    "outDir": "target/types"
   },
-  "include": [
-    "public/**/*",
-    "public/**/*.json",
-    "server/**/*",
-    "../../../../../typings/**/*",
-  ],
+  "include": ["public/**/*", "public/**/*.json", "server/**/*", "../../../../../typings/**/*"],
   "kbn_references": [
     "@kbn/core",
     "@kbn/data-plugin",
@@ -53,8 +48,7 @@
     "@kbn/aiops-utils",
     "@kbn/esql-ast",
     "@kbn/background-search",
+    "@kbn/split-button"
   ],
-  "exclude": [
-    "target/**/*",
-  ]
+  "exclude": ["target/**/*"]
 }

--- a/src/platform/test/functional/apps/discover/background_search/_classic.ts
+++ b/src/platform/test/functional/apps/discover/background_search/_classic.ts
@@ -18,7 +18,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataViews = getService('dataViews');
   const queryBar = getService('queryBar');
   const retry = getService('retry');
-  const find = getService('find');
+  const toasts = getService('toasts');
 
   const { common, unifiedFieldList, discover } = getPageObjects([
     'common',
@@ -60,8 +60,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await retry.waitFor(
           'the toast appears indicating that the search session is saved',
           async () => {
-            const element = await find.byButtonText('Check its progress here');
-            return !!element;
+            const count = await toasts.getCount();
+            return count > 0;
           }
         );
       });
@@ -80,8 +80,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await retry.waitFor(
           'the toast appears indicating that the search session is saved',
           async () => {
-            const element = await find.byButtonText('Check its progress here');
-            return !!element;
+            const count = await toasts.getCount();
+            return count > 0;
           }
         );
       });

--- a/src/platform/test/functional/apps/discover/background_search/_classic.ts
+++ b/src/platform/test/functional/apps/discover/background_search/_classic.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
+  const security = getService('security');
+  const testSubjects = getService('testSubjects');
+  const dataViews = getService('dataViews');
+  const queryBar = getService('queryBar');
+  const retry = getService('retry');
+  const find = getService('find');
+
+  const { common, unifiedFieldList, discover } = getPageObjects([
+    'common',
+    'unifiedFieldList',
+    'discover',
+  ]);
+
+  describe('Discover background search', function () {
+    before(async () => {
+      await kibanaServer.savedObjects.cleanStandardList();
+
+      await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
+      await kibanaServer.importExport.load(
+        'src/platform/test/functional/fixtures/kbn_archiver/discover'
+      );
+      await esArchiver.load(
+        'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights'
+      );
+      await kibanaServer.importExport.load(
+        'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern'
+      );
+
+      await common.navigateToApp('discover');
+      await unifiedFieldList.waitUntilSidebarHasLoaded();
+      await dataViews.switchToAndValidate('kibana_sample_data_flights');
+      await discover.expandTimeRangeAsSuggestedInNoResultsMessage();
+    });
+
+    describe('Classic view', function () {
+      it('stores a finished search', async () => {
+        const ariaLabel = await testSubjects.getAttribute(
+          'querySubmitSplitButton-primary-button',
+          'aria-label'
+        );
+        expect(ariaLabel).to.eql('Refresh query');
+
+        await testSubjects.click('querySubmitSplitButton-secondary-button');
+
+        await retry.waitFor(
+          'the toast appears indicating that the search session is saved',
+          async () => {
+            const element = await find.byButtonText('Check its progress here');
+            return !!element;
+          }
+        );
+      });
+
+      it('starts and stores a new search', async () => {
+        await queryBar.setQuery('Carrier: "Kibana Airlines"');
+
+        const ariaLabel = await testSubjects.getAttribute(
+          'querySubmitSplitButton-primary-button',
+          'aria-label'
+        );
+        expect(ariaLabel).to.eql('Needs updating');
+
+        await testSubjects.click('querySubmitSplitButton-secondary-button');
+
+        await retry.waitFor(
+          'the toast appears indicating that the search session is saved',
+          async () => {
+            const element = await find.byButtonText('Check its progress here');
+            return !!element;
+          }
+        );
+      });
+    });
+  });
+}

--- a/src/platform/test/functional/apps/discover/background_search/_esql.ts
+++ b/src/platform/test/functional/apps/discover/background_search/_esql.ts
@@ -18,7 +18,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataViews = getService('dataViews');
   const monacoEditor = getService('monacoEditor');
   const retry = getService('retry');
-  const find = getService('find');
+  const toasts = getService('toasts');
 
   const { common, unifiedFieldList, discover } = getPageObjects([
     'common',
@@ -64,8 +64,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await retry.waitFor(
           'the toast appears indicating that the search session is saved',
           async () => {
-            const element = await find.byButtonText('Check its progress here');
-            return !!element;
+            const count = await toasts.getCount();
+            return count > 0;
           }
         );
       });
@@ -83,8 +83,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await retry.waitFor(
           'the toast appears indicating that the search session is saved',
           async () => {
-            const element = await find.byButtonText('Check its progress here');
-            return !!element;
+            const count = await toasts.getCount();
+            return count > 0;
           }
         );
         await discover.waitUntilSearchingHasFinished();
@@ -110,8 +110,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await retry.waitFor(
           'the toast appears indicating that the search session is saved',
           async () => {
-            const element = await find.byButtonText('Check its progress here');
-            return !!element;
+            const count = await toasts.getCount();
+            return count > 0;
           }
         );
       });

--- a/src/platform/test/functional/apps/discover/background_search/_esql.ts
+++ b/src/platform/test/functional/apps/discover/background_search/_esql.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
+  const security = getService('security');
+  const testSubjects = getService('testSubjects');
+  const dataViews = getService('dataViews');
+  const monacoEditor = getService('monacoEditor');
+  const retry = getService('retry');
+  const find = getService('find');
+
+  const { common, unifiedFieldList, discover } = getPageObjects([
+    'common',
+    'unifiedFieldList',
+    'discover',
+  ]);
+
+  const defaultSettings = {
+    defaultIndex: 'logstash-*',
+    enableESQL: true,
+  };
+
+  describe('Discover background search', function () {
+    before(async () => {
+      await kibanaServer.savedObjects.cleanStandardList();
+
+      await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
+      await kibanaServer.importExport.load(
+        'src/platform/test/functional/fixtures/kbn_archiver/discover'
+      );
+      await esArchiver.load(
+        'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights'
+      );
+      await kibanaServer.importExport.load(
+        'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern'
+      );
+
+      await kibanaServer.uiSettings.replace(defaultSettings);
+      await common.navigateToApp('discover');
+      await unifiedFieldList.waitUntilSidebarHasLoaded();
+      await dataViews.switchToAndValidate('kibana_sample_data_flights');
+      await discover.selectTextBaseLang();
+    });
+
+    describe('ESQL view', function () {
+      it('stores a finished search', async () => {
+        const ariaLabel = await testSubjects.getAttribute(
+          'querySubmitSplitButton-primary-button',
+          'aria-label'
+        );
+        expect(ariaLabel).to.eql('Refresh query');
+        await testSubjects.click('querySubmitSplitButton-secondary-button');
+        await retry.waitFor(
+          'the toast appears indicating that the search session is saved',
+          async () => {
+            const element = await find.byButtonText('Check its progress here');
+            return !!element;
+          }
+        );
+      });
+
+      it('runs and stores a new search', async () => {
+        await monacoEditor.setCodeEditorValue('FROM kibana_sample_data_flights | LIMIT 10');
+
+        const ariaLabel = await testSubjects.getAttribute(
+          'querySubmitSplitButton-primary-button',
+          'aria-label'
+        );
+        expect(ariaLabel).to.eql('Run query');
+
+        await testSubjects.click('querySubmitSplitButton-secondary-button');
+        await retry.waitFor(
+          'the toast appears indicating that the search session is saved',
+          async () => {
+            const element = await find.byButtonText('Check its progress here');
+            return !!element;
+          }
+        );
+        await discover.waitUntilSearchingHasFinished();
+      });
+
+      it('stores a running search', async () => {
+        await monacoEditor.setCodeEditorValue(
+          'FROM kibana_sample_data_flights | LIMIT 10 | WHERE DELAY(1000ms)'
+        );
+
+        await testSubjects.click('querySubmitSplitButton-primary-button');
+
+        await retry.waitFor('waits for the Cancel button to appear', async () => {
+          const ariaLabel = await testSubjects.getAttribute(
+            'queryCancelSplitButton-primary-button',
+            'aria-label'
+          );
+          return ariaLabel === 'Cancel';
+        });
+
+        await testSubjects.click('queryCancelSplitButton-secondary-button');
+
+        await retry.waitFor(
+          'the toast appears indicating that the search session is saved',
+          async () => {
+            const element = await find.byButtonText('Check its progress here');
+            return !!element;
+          }
+        );
+      });
+    });
+  });
+}

--- a/src/platform/test/functional/apps/discover/background_search/config.ts
+++ b/src/platform/test/functional/apps/discover/background_search/config.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(require.resolve('../../../config.base.js'));
+
+  return {
+    ...functionalConfig.getAll(),
+    testFiles: [require.resolve('.')],
+    kbnTestServer: {
+      ...functionalConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...functionalConfig.get('kbnTestServer.serverArgs'),
+        '--data.search.sessions.enabled=true',
+        '--feature_flags.overrides.search.backgroundSearchEnabled=true',
+      ],
+    },
+  };
+}

--- a/src/platform/test/functional/apps/discover/background_search/index.ts
+++ b/src/platform/test/functional/apps/discover/background_search/index.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ getService, loadTestFile }: FtrProviderContext) {
+  const esArchiver = getService('esArchiver');
+  const browser = getService('browser');
+
+  describe('discover/background_search', function () {
+    before(async function () {
+      await browser.setWindowSize(1600, 1200);
+    });
+
+    after(async function unloadMakelogs() {
+      await esArchiver.unload(
+        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
+      );
+    });
+
+    loadTestFile(require.resolve('./_classic'));
+    loadTestFile(require.resolve('./_esql'));
+  });
+}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/230908

| Scenario | Without BGS | With BGS |
|----------|--------------|-----------|
| Classic | <img width="1919" height="940" alt="image" src="https://github.com/user-attachments/assets/ca03fbc7-a3cd-42c9-9bf3-634239ef0ac1" /> | <img width="1919" height="938" alt="image" src="https://github.com/user-attachments/assets/c5f7d650-9c71-41d0-a7ea-52d60b4e8a6a" /> |
| ESQL | <img width="1916" height="939" alt="image" src="https://github.com/user-attachments/assets/87309d60-f986-4797-b3b2-85c61324a935" /> | <img width="1917" height="938" alt="image" src="https://github.com/user-attachments/assets/6b75a47b-2d1c-41d1-acc7-f4c1d0755c0f" /> |
| Dashboards | <img width="1909" height="941" alt="image" src="https://github.com/user-attachments/assets/47e88295-b00f-42f7-8345-add256414156" /> | <img width="1909" height="940" alt="image" src="https://github.com/user-attachments/assets/4848c94d-78d1-4a04-880d-203cc9e9dbfe" /> |

---

Video demo

https://github.com/user-attachments/assets/59fb3c22-423c-4466-bb87-9b7c3df85e15

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



