### PR TITLE
[Vega] Lazy load inspector and vegaVisType modules

### DIFF
--- a/src/platform/plugins/private/vis_types/vega/public/async_services.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/async_services.ts
@@ -13,3 +13,5 @@ export { VegaVisComponent } from './components/vega_vis_component';
 export { VegaParser } from './data_model/vega_parser';
 export { getServiceSettings } from './vega_view/vega_map_view/service_settings/get_service_settings';
 export { VegaView } from './vega_view/vega_view';
+export { getVegaInspectorView } from './vega_inspector';
+export { vegaVisType } from './vega_type';

--- a/src/platform/plugins/private/vis_types/vega/public/plugin.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/plugin.ts
@@ -30,15 +30,9 @@ import {
   setUsageCollectionStart,
 } from './services';
 
-import { createVegaFn } from './vega_fn';
-import { vegaVisType } from './vega_type';
 import type { IServiceSettings } from './vega_view/vega_map_view/service_settings/service_settings_types';
-
 import type { ConfigSchema } from '../server/config';
-
-import { getVegaInspectorView } from './vega_inspector';
-import { getVegaVisRenderer } from './vega_vis_renderer';
-import { getServiceSettingsLazy } from './vega_view/vega_map_view/service_settings/get_service_settings_lazy';
+import { registerVegaVis } from './register_vis';
 
 /** @internal */
 export interface VegaVisualizationDependencies {
@@ -75,28 +69,11 @@ export class VegaPlugin implements Plugin<void, void> {
     this.initializerContext = initializerContext;
   }
 
-  public setup(
-    core: CoreSetup,
-    { inspector, data, expressions, visualizations }: VegaPluginSetupDependencies
-  ) {
+  public setup(core: CoreSetup, deps: VegaPluginSetupDependencies) {
     setInjectedVars({
       enableExternalUrls: this.initializerContext.config.get().enableExternalUrls,
     });
-
-    const visualizationDependencies: Readonly<VegaVisualizationDependencies> = {
-      core,
-      plugins: {
-        data,
-      },
-      getServiceSettings: getServiceSettingsLazy,
-    };
-
-    inspector.registerView(getVegaInspectorView({ uiSettings: core.uiSettings }));
-
-    expressions.registerFunction(() => createVegaFn(visualizationDependencies));
-    expressions.registerRenderer(getVegaVisRenderer(visualizationDependencies));
-
-    visualizations.createBaseVisualization(vegaVisType);
+    registerVegaVis(core, deps);
   }
 
   public start(core: CoreStart, deps: VegaPluginStartDependencies) {

--- a/src/platform/plugins/private/vis_types/vega/public/register_vis.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/register_vis.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CoreSetup } from '@kbn/core/public';
+import type { VegaPluginSetupDependencies, VegaVisualizationDependencies } from './plugin';
+import { getServiceSettingsLazy } from './vega_view/vega_map_view/service_settings/get_service_settings_lazy';
+import { createVegaFn } from './vega_fn';
+import { getVegaVisRenderer } from './vega_vis_renderer';
+
+export const registerVegaVis = async (
+  core: CoreSetup,
+  { data, expressions, inspector, visualizations }: VegaPluginSetupDependencies
+) => {
+  const visualizationDependencies: Readonly<VegaVisualizationDependencies> = {
+    core,
+    plugins: {
+      data,
+    },
+    getServiceSettings: getServiceSettingsLazy,
+  };
+  const [{ getVegaInspectorView }, { vegaVisType }] = await Promise.all([
+    import('./vega_inspector'),
+    import('./vega_type'),
+  ]);
+  inspector.registerView(getVegaInspectorView({ uiSettings: core.uiSettings }));
+
+  expressions.registerFunction(() => createVegaFn(visualizationDependencies));
+  expressions.registerRenderer(getVegaVisRenderer(visualizationDependencies));
+
+  visualizations.createBaseVisualization(vegaVisType);
+};

--- a/src/platform/plugins/private/vis_types/vega/public/register_vis.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/register_vis.ts
@@ -24,10 +24,8 @@ export const registerVegaVis = async (
     },
     getServiceSettings: getServiceSettingsLazy,
   };
-  const [{ getVegaInspectorView }, { vegaVisType }] = await Promise.all([
-    import('./vega_inspector'),
-    import('./vega_type'),
-  ]);
+  const { getVegaInspectorView, vegaVisType } = await import('./async_services');
+
   inspector.registerView(getVegaInspectorView({ uiSettings: core.uiSettings }));
 
   expressions.registerFunction(() => createVegaFn(visualizationDependencies));


### PR DESCRIPTION
## Summary

Lazy loads the inspector and vegaVisType modules.

I noticed the entrypoint bundle size increasing beyond the limits when I was [moving static code from the inspector plugin to packages](https://github.com/elastic/kibana/pull/232694). With this PR we can shave of several kb by lazy loading the vega inspector and vega vistypes. 


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



