### PR TITLE
[Security Solution][Alert details] fix mitre attack not showing up

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/mitre_attack.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/mitre_attack.test.tsx
@@ -20,8 +20,45 @@ const renderMitreAttack = (contextValue: DocumentDetailsContext) =>
   );
 
 describe('<MitreAttack />', () => {
-  it('should render mitre attack information', async () => {
+  it('should render mitre attack information (in array form)', async () => {
     const contextValue = { searchHit: mockSearchHit } as unknown as DocumentDetailsContext;
+
+    const { getByTestId } = renderMitreAttack(contextValue);
+
+    await act(async () => {
+      expect(getByTestId(MITRE_ATTACK_TITLE_TEST_ID)).toBeInTheDocument();
+      expect(getByTestId(MITRE_ATTACK_DETAILS_TEST_ID)).toBeInTheDocument();
+    });
+  });
+
+  it('should render mitre attack information (in object form)', async () => {
+    const contextValue = {
+      searchHit: {
+        _index: 'index',
+        _id: 'id',
+        fields: {
+          'kibana.alert.rule.parameters': [
+            {
+              threat: {
+                framework: 'MITRE ATT&CK',
+                tactic: {
+                  id: '123',
+                  reference: 'https://attack.mitre.org/tactics/123',
+                  name: 'Tactic',
+                },
+                technique: [
+                  {
+                    id: '456',
+                    reference: 'https://attack.mitre.org/techniques/456',
+                    name: 'Technique',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as DocumentDetailsContext;
 
     const { getByTestId } = renderMitreAttack(contextValue);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/mitre_attack.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/mitre_attack.tsx
@@ -10,9 +10,7 @@ import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import type { Threat, Threats } from '@kbn/securitysolution-io-ts-alerting-types';
 import type { SearchHit } from '../../../../../common/search_strategy';
-import {
-  buildThreatDescription
-} from '../../../../detection_engine/rule_creation_ui/components/description_step/helpers';
+import { buildThreatDescription } from '../../../../detection_engine/rule_creation_ui/components/description_step/helpers';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { MITRE_ATTACK_DETAILS_TEST_ID, MITRE_ATTACK_TITLE_TEST_ID } from './test_ids';
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/mitre_attack.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/mitre_attack.tsx
@@ -8,9 +8,11 @@
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
-import type { Threats } from '@kbn/securitysolution-io-ts-alerting-types';
+import type { Threat, Threats } from '@kbn/securitysolution-io-ts-alerting-types';
 import type { SearchHit } from '../../../../../common/search_strategy';
-import { buildThreatDescription } from '../../../../detection_engine/rule_creation_ui/components/description_step/helpers';
+import {
+  buildThreatDescription
+} from '../../../../detection_engine/rule_creation_ui/components/description_step/helpers';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { MITRE_ATTACK_DETAILS_TEST_ID, MITRE_ATTACK_TITLE_TEST_ID } from './test_ids';
 
@@ -21,13 +23,16 @@ const getMitreComponentParts = (searchHit?: SearchHit) => {
   const ruleParameters = searchHit?.fields
     ? searchHit?.fields['kibana.alert.rule.parameters']
     : null;
-  const threat = ruleParameters ? (ruleParameters[0]?.threat as Threats) : null;
-  return threat && threat.length > 0
-    ? buildThreatDescription({
-        label: threat[0].framework,
-        threat,
-      })
-    : null;
+  const threat: Threat = ruleParameters ? ruleParameters[0]?.threat : null;
+  if (!threat) {
+    return null;
+  }
+
+  const threats: Threats = Array.isArray(threat) ? (threat as Threats) : ([threat] as Threats);
+  return buildThreatDescription({
+    label: threats[0].framework,
+    threat: threats,
+  });
 };
 
 export const MitreAttack: FC = () => {


### PR DESCRIPTION
## Summary

This PR fixes an issue where the mitre attack component is not rendered in the About section of the Alert details flyout.
It seems that this has been an issue for a few releases. I went back as far as `8.17` and the issue is there.

We've always assumed that the information to populate the mitre attack component was under the `kibana.alert.rule.parameters` field, and more specifically under its `threat` nested field. The code was also assuming that the data was structured as an array. This has been the case for many years. A (somewhat) recent change broke that logic, and we now have a plain object when there is only a single tactic, and an array when we have multiple.

The PR makes a very simple change to handle both an array and an object.
I tested the following combinations:

### No tactic or technique

| Before fix  | After fix |
| ------------- | ------------- |
| <img width="681" height="194" alt="no-main" src="https://github.com/user-attachments/assets/58d08188-71fa-41c3-bc9f-e36a17691ca1" /> | <img width="682" height="187" alt="no-branch" src="https://github.com/user-attachments/assets/bb4c49f6-a102-464c-ba1c-9f452adf8d28" /> |

### One tactic only

| Before fix  | After fix |
| ------------- | ------------- |
| <img width="689" height="193" alt="tactic-main" src="https://github.com/user-attachments/assets/39f7c940-466b-4442-901a-15c5213ebafb" /> | <img width="688" height="276" alt="tactic-branch" src="https://github.com/user-attachments/assets/696fdee2-81a8-4e34-be8f-720162676c50" /> |

### One tactic with one technique

| Before fix  | After fix |
| ------------- | ------------- |
| <img width="681" height="190" alt="tactic+technique-main" src="https://github.com/user-attachments/assets/583531a2-5ad7-43c9-bbb5-52471b7bf66f" /> | <img width="686" height="287" alt="tactic+technique-branch" src="https://github.com/user-attachments/assets/d3a4b0d2-d77a-4ad0-bf11-f48f49eea353" /> |

### Multiple tactics and techniques

| Before fix  | After fix |
| ------------- | ------------- |
| <img width="689" height="339" alt="multiple-main" src="https://github.com/user-attachments/assets/78fbec85-0275-4068-9086-fcc19aa437cf" /> | <img width="690" height="333" alt="multiple-branch" src="https://github.com/user-attachments/assets/be61c2da-60cc-473f-a8d7-8b57e0b29557" /> |

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/233819

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->