### PR TITLE
[9.1] [Upgrade Assistant] Add tests config category (#232210)

### DIFF
--- a/x-pack/platform/test/upgrade_assistant_integration/config.ts
+++ b/x-pack/platform/test/upgrade_assistant_integration/config.ts
@@ -29,6 +29,7 @@ export default async function ({ readConfigFile, log }: FtrConfigProviderContext
   }
 
   return {
+    testConfigCategory: ScoutTestRunConfigCategory.API_TEST,
     testFiles: [require.resolve('./upgrade_assistant')],
     servers: xPackApiTestsConfig.get('servers'),
     services: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Upgrade Assistant] Add tests config category (#232210)](https://github.com/elastic/kibana/pull/232210)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sonia Sanz Vivas","email":"sonia.sanzvivas@elastic.co"},"sourceCommit":{"committedDate":"2025-08-28T13:31:11Z","message":"[Upgrade Assistant] Add tests config category (#232210)\n\n## Summary\n\nSpace time project. I'm trying to improve the test for Kibana Management\nteam. This tests is missing a testConfigCategory. Adding it to ensure QA\nreporting.","sha":"743e6af72c66ad26ce6d6003dfcc2cb1094af67c","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","Feature:Upgrade Assistant","backport missing","backport:all-open","v9.2.0"],"title":"[Upgrade Assistant] Add tests config category","number":232210,"url":"https://github.com/elastic/kibana/pull/232210","mergeCommit":{"message":"[Upgrade Assistant] Add tests config category (#232210)\n\n## Summary\n\nSpace time project. I'm trying to improve the test for Kibana Management\nteam. This tests is missing a testConfigCategory. Adding it to ensure QA\nreporting.","sha":"743e6af72c66ad26ce6d6003dfcc2cb1094af67c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232210","number":232210,"mergeCommit":{"message":"[Upgrade Assistant] Add tests config category (#232210)\n\n## Summary\n\nSpace time project. I'm trying to improve the test for Kibana Management\nteam. This tests is missing a testConfigCategory. Adding it to ensure QA\nreporting.","sha":"743e6af72c66ad26ce6d6003dfcc2cb1094af67c"}}]}] BACKPORT-->