### PR TITLE
[9.1] [Security Solution][EDR] Fix import of endpoint exceptions (#233142)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/handlers/exceptions_pre_import_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/handlers/exceptions_pre_import_handler.ts
@@ -6,26 +6,64 @@
  */
 
 import type { ExceptionsListPreImportServerExtension } from '@kbn/lists-plugin/server';
+import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
+import type { PromiseFromStreams } from '@kbn/lists-plugin/server/services/exception_lists/import_exception_list_and_items';
+import { stringify } from '../../../endpoint/utils/stringify';
+import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_context_services';
+import {
+  ALL_ENDPOINT_ARTIFACT_LIST_IDS,
+  GLOBAL_ARTIFACT_TAG,
+} from '../../../../common/endpoint/service/artifacts/constants';
 import { EndpointArtifactExceptionValidationError } from '../validators/errors';
-import { ALL_ENDPOINT_ARTIFACT_LIST_IDS } from '../../../../common/endpoint/service/artifacts/constants';
 
-export const getExceptionsPreImportHandler =
-  (): ExceptionsListPreImportServerExtension['callback'] => {
-    return async ({ data }) => {
-      const hasEndpointArtifactListOrListItems = [...data.lists, ...data.items].some((item) => {
-        if ('list_id' in item) {
-          return (ALL_ENDPOINT_ARTIFACT_LIST_IDS as string[]).includes(item.list_id);
-        }
+export const getExceptionsPreImportHandler = (
+  endpointAppContextService: EndpointAppContextService
+): ExceptionsListPreImportServerExtension['callback'] => {
+  const logger = endpointAppContextService.createLogger('listsPreImportExtensionPoint');
 
-        return false;
-      });
+  return async ({ data }) => {
+    const hasEndpointArtifactListOrListItems = [...data.lists, ...data.items].some((item) => {
+      if ('list_id' in item) {
+        const NON_IMPORTABLE_ENDPOINT_ARTIFACT_IDS = ALL_ENDPOINT_ARTIFACT_LIST_IDS.filter(
+          (listId) => listId !== ENDPOINT_ARTIFACT_LISTS.endpointExceptions.id
+        ) as string[];
 
-      if (hasEndpointArtifactListOrListItems) {
-        throw new EndpointArtifactExceptionValidationError(
-          'Import is not supported for Endpoint artifact exceptions'
-        );
+        return NON_IMPORTABLE_ENDPOINT_ARTIFACT_IDS.includes(item.list_id);
       }
 
-      return data;
-    };
+      return false;
+    });
+
+    if (hasEndpointArtifactListOrListItems) {
+      throw new EndpointArtifactExceptionValidationError(
+        'Import is not supported for Endpoint artifact exceptions'
+      );
+    }
+
+    // Temporary Work-around:
+    // v9.1.0 introduced support for spaces, which also now requires that each endpoint exception
+    // have the `global` tag, or else they will not be returned via API. Since Endpoint
+    // Exceptions continue to be global only in v9.1, we add the global tag to them here if it is
+    // missing
+    const adjustedImportItems: PromiseFromStreams['items'] = [];
+
+    for (const item of data.items) {
+      if (
+        !(item instanceof Error) &&
+        item.list_id === ENDPOINT_ARTIFACT_LISTS.endpointExceptions.id &&
+        item.tags?.includes(GLOBAL_ARTIFACT_TAG) === false
+      ) {
+        item.tags = item.tags ?? [];
+        item.tags.push(GLOBAL_ARTIFACT_TAG);
+        adjustedImportItems.push(item);
+      }
+    }
+
+    if (adjustedImportItems.length > 0) {
+      logger.debug(`The following Endpoint Exceptions item imports were adjusted to include the Global artifact tag:
+${stringify(adjustedImportItems)}`);
+    }
+
+    return data;
   };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/handlers/exceptions_pre_import_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/handlers/exceptions_pre_import_handler.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ExceptionsListPreImportServerExtension } from '@kbn/lists-plugin/server';
-import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
+import { ENDPOINT_LIST_ID } from '@kbn/securitysolution-list-constants';
 import type { PromiseFromStreams } from '@kbn/lists-plugin/server/services/exception_lists/import_exception_list_and_items';
 import { stringify } from '../../../endpoint/utils/stringify';
 import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_context_services';
@@ -24,11 +24,7 @@ export const getExceptionsPreImportHandler = (
   return async ({ data }) => {
     const hasEndpointArtifactListOrListItems = [...data.lists, ...data.items].some((item) => {
       if ('list_id' in item) {
-        const NON_IMPORTABLE_ENDPOINT_ARTIFACT_IDS = ALL_ENDPOINT_ARTIFACT_LIST_IDS.filter(
-          (listId) => listId !== ENDPOINT_ARTIFACT_LISTS.endpointExceptions.id
-        ) as string[];
-
-        return NON_IMPORTABLE_ENDPOINT_ARTIFACT_IDS.includes(item.list_id);
+        return (ALL_ENDPOINT_ARTIFACT_LIST_IDS as string[]).includes(item.list_id);
       }
 
       return false;
@@ -50,7 +46,7 @@ export const getExceptionsPreImportHandler = (
     for (const item of data.items) {
       if (
         !(item instanceof Error) &&
-        item.list_id === ENDPOINT_ARTIFACT_LISTS.endpointExceptions.id &&
+        item.list_id === ENDPOINT_LIST_ID &&
         item.tags?.includes(GLOBAL_ARTIFACT_TAG) === false
       ) {
         item.tags = item.tags ?? [];

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/register_endpoint_extension_points.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/register_endpoint_extension_points.ts
@@ -72,6 +72,6 @@ export const registerListsPluginEndpointExtensionPoints = (
   // PRE-IMPORT
   registerListsExtensionPoint({
     type: 'exceptionsListPreImport',
-    callback: getExceptionsPreImportHandler(),
+    callback: getExceptionsPreImportHandler(endpointAppContextService),
   });
 };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/endpoint_exceptions.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/endpoint_exceptions.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type TestAgent from 'supertest/lib/agent';
+import expect from '@kbn/expect';
+import {
+  ENDPOINT_ARTIFACT_LISTS,
+  EXCEPTION_LIST_ITEM_URL,
+  EXCEPTION_LIST_URL,
+} from '@kbn/securitysolution-list-constants';
+import {
+  ALL_ENDPOINT_ARTIFACT_LIST_IDS,
+  GLOBAL_ARTIFACT_TAG,
+} from '@kbn/security-solution-plugin/common/endpoint/service/artifacts/constants';
+import { ExceptionsListItemGenerator } from '@kbn/security-solution-plugin/common/endpoint/data_generators/exceptions_list_item_generator';
+import { ROLE } from '../../../../config/services/security_solution_edr_workflows_roles_users';
+import { createSupertestErrorLogger } from '../../utils';
+import type { FtrProviderContext } from '../../../../ftr_provider_context_edr_workflows';
+
+export default function ({ getService }: FtrProviderContext) {
+  const endpointArtifactTestResources = getService('endpointArtifactTestResources');
+  const utils = getService('securitySolutionUtils');
+  const log = getService('log');
+
+  describe('@ess @serverless Endpoint artifacts (via lists plugin): Endpoint Exceptions', function () {
+    let endpointOpsAnalystSupertest: TestAgent;
+
+    before(async () => {
+      endpointOpsAnalystSupertest = await utils.createSuperTest(ROLE.endpoint_operations_analyst);
+    });
+
+    describe(`and using Import API`, function () {
+      const buildImportBuffer = (
+        listId: (typeof ALL_ENDPOINT_ARTIFACT_LIST_IDS)[number]
+      ): Buffer => {
+        const generator = new ExceptionsListItemGenerator();
+        const listInfo = Object.values(ENDPOINT_ARTIFACT_LISTS).find((listDefinition) => {
+          return listDefinition.id === listId;
+        });
+
+        if (!listInfo) {
+          throw new Error(`Unknown listId: ${listId}. Unable to generate exception list item.`);
+        }
+
+        const createItem = () => {
+          switch (listId) {
+            case ENDPOINT_ARTIFACT_LISTS.endpointExceptions.id:
+              return generator.generateEndpointException();
+
+            case ENDPOINT_ARTIFACT_LISTS.blocklists.id:
+              return generator.generateBlocklist();
+
+            case ENDPOINT_ARTIFACT_LISTS.eventFilters.id:
+              return generator.generateEventFilter();
+
+            case ENDPOINT_ARTIFACT_LISTS.hostIsolationExceptions.id:
+              return generator.generateHostIsolationException();
+
+            case ENDPOINT_ARTIFACT_LISTS.trustedApps.id:
+              return generator.generateTrustedApp();
+
+            case ENDPOINT_ARTIFACT_LISTS.trustedDevices.id:
+              return generator.generateTrustedDevice();
+
+            default:
+              throw new Error(`Unknown listId: ${listId}. Unable to generate exception list item.`);
+          }
+        };
+
+        return Buffer.from(
+          `
+{"_version":"WzEsMV0=","created_at":"2025-08-21T14:20:07.012Z","created_by":"kibana","description":"${
+            listInfo!.description
+          }","id":"${listId}","immutable":false,"list_id":"${listId}","name":"${
+            listInfo!.name
+          }","namespace_type":"agnostic","os_types":[],"tags":[],"tie_breaker_id":"034d07f4-fa33-43bb-adfa-6f6bda7921ce","type":"endpoint","updated_at":"2025-08-21T14:20:07.012Z","updated_by":"kibana","version":1}
+${JSON.stringify(createItem())}
+${JSON.stringify(createItem())}
+${JSON.stringify(createItem())}
+{"exported_exception_list_count":1,"exported_exception_list_item_count":3,"missing_exception_list_item_count":0,"missing_exception_list_items":[],"missing_exception_lists":[],"missing_exception_lists_count":0}
+`,
+          'utf8'
+        );
+      };
+
+      // All non-Endpoint exceptions artifacts are not allowed to import
+      ALL_ENDPOINT_ARTIFACT_LIST_IDS.filter(
+        (listId) => listId !== ENDPOINT_ARTIFACT_LISTS.endpointExceptions.id
+      ).forEach((listId) => {
+        it(`should error when importing ${listId} artifacts`, async () => {
+          await endpointArtifactTestResources.deleteList(listId);
+
+          const { body } = await endpointOpsAnalystSupertest
+            .post(`${EXCEPTION_LIST_URL}/_import`)
+            .set('kbn-xsrf', 'true')
+            .on('error', createSupertestErrorLogger(log).ignoreCodes([400]))
+            .attach('file', buildImportBuffer(listId), 'import_data.ndjson')
+            .expect(400);
+
+          expect(body.message).to.eql(
+            'EndpointArtifactError: Import is not supported for Endpoint artifact exceptions'
+          );
+        });
+      });
+
+      it('should import endpoint exceptions and add global artifact tag if missing', async () => {
+        await endpointArtifactTestResources.deleteList(
+          ENDPOINT_ARTIFACT_LISTS.endpointExceptions.id
+        );
+
+        await endpointOpsAnalystSupertest
+          .post(`${EXCEPTION_LIST_URL}/_import`)
+          .set('kbn-xsrf', 'true')
+          .on('error', createSupertestErrorLogger(log))
+          .attach(
+            'file',
+            buildImportBuffer(ENDPOINT_ARTIFACT_LISTS.endpointExceptions.id),
+            'import_exceptions.ndjson'
+          )
+          .expect(200);
+
+        const { body } = await endpointOpsAnalystSupertest
+          .get(`${EXCEPTION_LIST_ITEM_URL}/_find`)
+          .set('kbn-xsrf', 'true')
+          .on('error', createSupertestErrorLogger(log))
+          .query({
+            list_id: 'endpoint_list',
+            namespace_type: 'agnostic',
+            per_page: 50,
+          })
+          .send()
+          .expect(200);
+
+        // After import - all items should be returned on a GET `find` request.
+        expect(body.data.length).to.eql(3);
+
+        for (const endpointException of body.data) {
+          expect(endpointException.tags).to.include.string(GLOBAL_ARTIFACT_TAG);
+        }
+      });
+    });
+  });
+}

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/endpoint_exceptions.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/endpoint_exceptions.ts
@@ -9,7 +9,9 @@ import type TestAgent from 'supertest/lib/agent';
 import expect from '@kbn/expect';
 import {
   ENDPOINT_ARTIFACT_LISTS,
+  ENDPOINT_LIST_DESCRIPTION,
   ENDPOINT_LIST_ID,
+  ENDPOINT_LIST_NAME,
   EXCEPTION_LIST_ITEM_URL,
   EXCEPTION_LIST_URL,
 } from '@kbn/securitysolution-list-constants';
@@ -39,12 +41,22 @@ export default function ({ getService }: FtrProviderContext) {
         listId: (typeof ALL_ENDPOINT_ARTIFACT_LIST_IDS)[number] | typeof ENDPOINT_LIST_ID
       ): Buffer => {
         const generator = new ExceptionsListItemGenerator();
-        const listInfo = Object.values(ENDPOINT_ARTIFACT_LISTS).find((listDefinition) => {
+        let listInfo: { id: string; name: string; description: string } | undefined = Object.values(
+          ENDPOINT_ARTIFACT_LISTS
+        ).find((listDefinition) => {
           return listDefinition.id === listId;
         });
 
         if (!listInfo) {
-          throw new Error(`Unknown listId: ${listId}. Unable to generate exception list item.`);
+          if (listId === ENDPOINT_LIST_ID) {
+            listInfo = {
+              id: listId,
+              name: ENDPOINT_LIST_NAME,
+              description: ENDPOINT_LIST_DESCRIPTION,
+            };
+          } else {
+            throw new Error(`Unknown listId: ${listId}. Unable to generate exception list item.`);
+          }
         }
 
         const createItem = () => {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/index.ts
@@ -56,5 +56,6 @@ export default function endpointAPIIntegrationTests(providerContext: FtrProvider
     loadTestFile(require.resolve('./event_filters'));
     loadTestFile(require.resolve('./host_isolation_exceptions'));
     loadTestFile(require.resolve('./blocklists'));
+    loadTestFile(require.resolve('./endpoint_exceptions'));
   });
 }

--- a/x-pack/solutions/security/test/security_solution_endpoint/services/endpoint_artifacts.ts
+++ b/x-pack/solutions/security/test/security_solution_endpoint/services/endpoint_artifacts.ts
@@ -67,6 +67,22 @@ export function EndpointArtifactsTestResourcesProvider({ getService }: FtrProvid
       };
     }
 
+    /**
+     * Deletes an artifact list along with all of its items (if any).
+     * @param listId
+     * @param supertest
+     */
+    async deleteList(
+      listId: (typeof ENDPOINT_ARTIFACT_LIST_IDS)[number],
+      supertest: TestAgent = this.supertest
+    ): Promise<void> {
+      await supertest
+        .delete(`${EXCEPTION_LIST_URL}?list_id=${listId}&namespace_type=agnostic`)
+        .set('kbn-xsrf', 'true')
+        .send()
+        .then(this.getHttpResponseFailureHandler([404]));
+    }
+
     async ensureListExists(
       listDefinition: CreateExceptionListSchema,
       { supertest = this.supertest, spaceId = DEFAULT_SPACE_ID }: ArtifactCreateOptions = {}

--- a/x-pack/solutions/security/test/security_solution_endpoint/services/endpoint_artifacts.ts
+++ b/x-pack/solutions/security/test/security_solution_endpoint/services/endpoint_artifacts.ts
@@ -73,7 +73,7 @@ export function EndpointArtifactsTestResourcesProvider({ getService }: FtrProvid
      * @param supertest
      */
     async deleteList(
-      listId: (typeof ENDPOINT_ARTIFACT_LIST_IDS)[number],
+      listId: (typeof ENDPOINT_ARTIFACT_LIST_IDS)[number] | typeof ENDPOINT_LIST_ID,
       supertest: TestAgent = this.supertest
     ): Promise<void> {
       await supertest


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution][EDR] Fix import of endpoint exceptions (#233142)](https://github.com/elastic/kibana/pull/233142)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-09-02T21:02:24Z","message":"[Security Solution][EDR] Fix import of endpoint exceptions (#233142)\n\n## Summary\n\n- Fix import of Endpoint Exceptions to ensure they are made visible and\naccessible via API\n- A bug was introduced with `v9.1.0`, as part of support for Spaces,\nthat made imported endpoint exceptions unaccessible after import. Items\nwere imported into the index, but they did not include a `tag`\nindicating that the exception is Global. This was a new requirement with\n`v9.1.0`","sha":"5be7a8f4c914eea310ca137407403a67fcb923e5","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Defend Workflows","backport:version","v9.1.0","v9.2.0"],"title":"[Security Solution][EDR] Fix import of endpoint exceptions","number":233142,"url":"https://github.com/elastic/kibana/pull/233142","mergeCommit":{"message":"[Security Solution][EDR] Fix import of endpoint exceptions (#233142)\n\n## Summary\n\n- Fix import of Endpoint Exceptions to ensure they are made visible and\naccessible via API\n- A bug was introduced with `v9.1.0`, as part of support for Spaces,\nthat made imported endpoint exceptions unaccessible after import. Items\nwere imported into the index, but they did not include a `tag`\nindicating that the exception is Global. This was a new requirement with\n`v9.1.0`","sha":"5be7a8f4c914eea310ca137407403a67fcb923e5"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/233142","number":233142,"mergeCommit":{"message":"[Security Solution][EDR] Fix import of endpoint exceptions (#233142)\n\n## Summary\n\n- Fix import of Endpoint Exceptions to ensure they are made visible and\naccessible via API\n- A bug was introduced with `v9.1.0`, as part of support for Spaces,\nthat made imported endpoint exceptions unaccessible after import. Items\nwere imported into the index, but they did not include a `tag`\nindicating that the exception is Global. This was a new requirement with\n`v9.1.0`","sha":"5be7a8f4c914eea310ca137407403a67fcb923e5"}}]}] BACKPORT-->