### PR TITLE
[dashboard] fix cannot see full viz title if its truncated

### DIFF
--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
@@ -107,36 +107,36 @@ export const PresentationPanelTitle = ({
             align-items: center;
           `}
         >
-          {!hideTitle ? (
-            <h2
-              // styles necessary for applying ellipsis and showing the info icon if description is present
-              css={css`
-                overflow: hidden;
-              `}
-            >
-              <EuiScreenReaderOnly>
-                <span id={headerId}>
-                  {panelTitle
-                    ? i18n.translate('presentationPanel.ariaLabel', {
-                        defaultMessage: 'Panel: {title}',
-                        values: {
-                          title: panelTitle,
-                        },
-                      })
-                    : i18n.translate('presentationPanel.untitledPanelAriaLabel', {
-                        defaultMessage: 'Untitled panel',
-                      })}
-                </span>
-              </EuiScreenReaderOnly>
-              {panelTitleElement}
-            </h2>
+          <h2
+            // styles necessary for applying ellipsis and showing the info icon if description is present
+            css={css`
+              overflow: hidden;
+            `}
+          >
+            <EuiScreenReaderOnly>
+              <span id={headerId}>
+                {panelTitle
+                  ? i18n.translate('presentationPanel.ariaLabel', {
+                      defaultMessage: 'Panel: {title}',
+                      values: {
+                        title: panelTitle,
+                      },
+                    })
+                  : i18n.translate('presentationPanel.untitledPanelAriaLabel', {
+                      defaultMessage: 'Untitled panel',
+                    })}
+              </span>
+            </EuiScreenReaderOnly>
+            {panelTitleElement}
+          </h2>
+          {panelDescription ? (
+            <EuiIcon
+              type="info"
+              color="subdued"
+              data-test-subj="embeddablePanelTitleDescriptionIcon"
+              tabIndex={0}
+            />
           ) : null}
-          <EuiIcon
-            type="info"
-            color="subdued"
-            data-test-subj="embeddablePanelTitleDescriptionIcon"
-            tabIndex={0}
-          />
         </div>
       </EuiToolTip>
     );

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
@@ -87,13 +87,10 @@ export const PresentationPanelTitle = ({
   const describedPanelTitleElement = useMemo(() => {
     if (hideTitle) return null;
 
-    if (!panelDescription) {
-      return panelTitleElement;
-    }
     return (
       <EuiToolTip
         title={panelTitle}
-        content={panelDescription}
+        content={panelDescription ?? ''}
         delay="regular"
         position="top"
         anchorProps={{

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
@@ -84,7 +84,7 @@ export const PresentationPanelTitle = ({
     );
   }, [onClick, hideTitle, panelTitle, viewMode, api, euiTheme]);
 
-  const describedPanelTitleElement = useMemo(() => {
+  const tooltipElement = useMemo(() => {
     if (hideTitle) return null;
 
     return (
@@ -143,5 +143,5 @@ export const PresentationPanelTitle = ({
     );
   }, [hideTitle, panelDescription, panelTitle, panelTitleElement, headerId, euiTheme.size.xs]);
 
-  return describedPanelTitleElement;
+  return tooltipElement;
 };

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
@@ -110,6 +110,7 @@ export const PresentationPanelTitle = ({
           <h2
             // styles necessary for applying ellipsis and showing the info icon if description is present
             css={css`
+               ${euiTextTruncate()};
               overflow: hidden;
             `}
           >


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/232587

Always show title tooltip so that truncated titles can be viewed

<img width="295" height="538" alt="Screenshot 2025-09-03 at 11 42 41 AM" src="https://github.com/user-attachments/assets/4b93ebf0-2960-4cad-8736-4300967748bf" />

