### PR TITLE
[embeddable] remove EmbeddableRenderer from embeddable factory tests

### DIFF
--- a/src/platform/plugins/private/links/public/embeddable/links_embeddable.test.tsx
+++ b/src/platform/plugins/private/links/public/embeddable/links_embeddable.test.tsx
@@ -121,7 +121,7 @@ async function buildLinksEmbeddable(state: LinksEmbeddableState) {
   const uuid = '1234';
   return await factory.buildEmbeddable({
     initialState: {
-      rawState: state
+      rawState: state,
     },
     finalizeApi: (api) => {
       return {
@@ -129,12 +129,12 @@ async function buildLinksEmbeddable(state: LinksEmbeddableState) {
         uuid,
         parentApi,
         type: LINKS_EMBEDDABLE_TYPE,
-      } as LinksApi
+      } as LinksApi;
     },
     parentApi,
-    uuid
+    uuid,
   });
-};
+}
 
 describe('getLinksEmbeddableFactory', () => {
   describe('by reference embeddable', () => {
@@ -151,7 +151,7 @@ describe('getLinksEmbeddableFactory', () => {
         <EuiThemeProvider>
           <Component />
         </EuiThemeProvider>
-      )
+      );
       expect(await screen.findByTestId('links--component')).toBeInTheDocument();
     });
 
@@ -199,7 +199,7 @@ describe('getLinksEmbeddableFactory', () => {
         <EuiThemeProvider>
           <Component />
         </EuiThemeProvider>
-      )
+      );
 
       expect(await screen.findByTestId('links--component')).toBeInTheDocument();
     });

--- a/src/platform/plugins/private/links/public/embeddable/links_embeddable.test.tsx
+++ b/src/platform/plugins/private/links/public/embeddable/links_embeddable.test.tsx
@@ -8,16 +8,13 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import { embeddablePluginMock } from '@kbn/embeddable-plugin/public/mocks';
-import { setStubKibanaServices } from '@kbn/presentation-panel-plugin/public/mocks';
+import { render, screen } from '@testing-library/react';
 import { EuiThemeProvider } from '@elastic/eui';
 import { getLinksEmbeddableFactory } from './links_embeddable';
 import type { LinksEmbeddableState } from '../../common';
 import { LINKS_EMBEDDABLE_TYPE } from '../../common';
 import type { Link } from '../../server';
-import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
-import type { LinksApi, LinksParentApi, ResolvedLink } from '../types';
+import type { LinksApi, ResolvedLink } from '../types';
 import { linksClient } from '../content_management';
 import { getMockLinksParentApi } from '../mocks';
 
@@ -118,144 +115,128 @@ jest.mock('../content_management/load_from_library', () => {
   };
 });
 
-const renderEmbeddable = (
-  parent: LinksParentApi,
-  overrides?: {
-    onApiAvailable: (api: LinksApi) => void;
-  }
-) => {
-  return render(
-    <EuiThemeProvider>
-      <EmbeddableRenderer<LinksEmbeddableState, LinksApi>
-        type={LINKS_EMBEDDABLE_TYPE}
-        onApiAvailable={jest.fn()}
-        getParentApi={jest.fn().mockReturnValue(parent)}
-        {...overrides}
-      />
-    </EuiThemeProvider>
-  );
+async function buildLinksEmbeddable(state: LinksEmbeddableState) {
+  const factory = getLinksEmbeddableFactory();
+  const parentApi = getMockLinksParentApi(state);
+  const uuid = '1234';
+  return await factory.buildEmbeddable({
+    initialState: {
+      rawState: state
+    },
+    finalizeApi: (api) => {
+      return {
+        ...api,
+        uuid,
+        parentApi,
+        type: LINKS_EMBEDDABLE_TYPE,
+      } as LinksApi
+    },
+    parentApi,
+    uuid
+  });
 };
 
 describe('getLinksEmbeddableFactory', () => {
-  const factory = getLinksEmbeddableFactory();
-
-  beforeAll(() => {
-    const embeddable = embeddablePluginMock.createSetupContract();
-    embeddable.registerReactEmbeddableFactory(LINKS_EMBEDDABLE_TYPE, async () => {
-      return factory;
-    });
-    setStubKibanaServices();
-  });
-
   describe('by reference embeddable', () => {
-    const parent = getMockLinksParentApi({
+    const byRefState = {
       title: 'my links',
       description: 'just a few links',
       hidePanelTitles: false,
       savedObjectId: '123',
-    });
+    } as LinksEmbeddableState;
 
     test('component renders', async () => {
-      renderEmbeddable(parent);
+      const { Component } = await buildLinksEmbeddable(byRefState);
+      render(
+        <EuiThemeProvider>
+          <Component />
+        </EuiThemeProvider>
+      )
       expect(await screen.findByTestId('links--component')).toBeInTheDocument();
     });
 
     test('api methods', async () => {
-      const onApiAvailable = jest.fn() as jest.MockedFunction<(api: LinksApi) => void>;
-      renderEmbeddable(parent, { onApiAvailable });
-
-      await waitFor(async () => {
-        const api = onApiAvailable.mock.calls[0][0];
-        expect(api.serializeState()).toEqual({
-          rawState: {
-            title: 'my links',
-            description: 'just a few links',
-            hidePanelTitles: false,
-            savedObjectId: '123',
-          },
-        });
-        expect(await api.canUnlinkFromLibrary()).toBe(true);
-        expect(api.defaultTitle$?.value).toBe('links 001');
-        expect(api.defaultDescription$?.value).toBe('some links');
+      const { api } = await buildLinksEmbeddable(byRefState);
+      expect(api.serializeState()).toEqual({
+        rawState: {
+          title: 'my links',
+          description: 'just a few links',
+          hidePanelTitles: false,
+          savedObjectId: '123',
+        },
       });
+      expect(await api.canUnlinkFromLibrary()).toBe(true);
+      expect(api.defaultTitle$?.value).toBe('links 001');
+      expect(api.defaultDescription$?.value).toBe('some links');
     });
 
     test('unlink from library', async () => {
-      const onApiAvailable = jest.fn() as jest.MockedFunction<(api: LinksApi) => void>;
-      renderEmbeddable(parent, { onApiAvailable });
-
-      await waitFor(async () => {
-        const api = onApiAvailable.mock.calls[0][0];
-        expect(api.getSerializedStateByValue()).toEqual({
-          rawState: {
-            title: 'my links',
-            description: 'just a few links',
-            hidePanelTitles: false,
-            links: getLinks(),
-            layout: 'vertical',
-          },
-        });
+      const { api } = await buildLinksEmbeddable(byRefState);
+      expect(api.getSerializedStateByValue()).toEqual({
+        rawState: {
+          title: 'my links',
+          description: 'just a few links',
+          hidePanelTitles: false,
+          links: getLinks(),
+          layout: 'vertical',
+        },
       });
     });
   });
 
   describe('by value embeddable', () => {
-    const parent = getMockLinksParentApi({
+    const byValueState = {
       description: 'just a few links',
       title: 'my links',
       hidePanelTitles: true,
       links: getLinks(),
       layout: 'horizontal',
-    });
+    } as LinksEmbeddableState;
 
     test('component renders', async () => {
-      renderEmbeddable(parent);
+      const { Component } = await buildLinksEmbeddable(byValueState);
+      render(
+        <EuiThemeProvider>
+          <Component />
+        </EuiThemeProvider>
+      )
 
       expect(await screen.findByTestId('links--component')).toBeInTheDocument();
     });
 
     test('api methods', async () => {
-      const onApiAvailable = jest.fn() as jest.MockedFunction<(api: LinksApi) => void>;
-      renderEmbeddable(parent, { onApiAvailable });
-
-      await waitFor(async () => {
-        const api = onApiAvailable.mock.calls[0][0];
-        expect(api.serializeState()).toEqual({
-          rawState: {
-            title: 'my links',
-            description: 'just a few links',
-            hidePanelTitles: true,
-            links: getLinks(),
-            layout: 'horizontal',
-          },
-        });
-
-        expect(await api.canLinkToLibrary()).toBe(true);
+      const { api } = await buildLinksEmbeddable(byValueState);
+      expect(api.serializeState()).toEqual({
+        rawState: {
+          title: 'my links',
+          description: 'just a few links',
+          hidePanelTitles: true,
+          links: getLinks(),
+          layout: 'horizontal',
+        },
       });
-    });
-    test('save to library', async () => {
-      const onApiAvailable = jest.fn() as jest.MockedFunction<(api: LinksApi) => void>;
-      renderEmbeddable(parent, { onApiAvailable });
 
-      await waitFor(async () => {
-        const api = onApiAvailable.mock.calls[0][0];
-        const newId = await api.saveToLibrary('some new title');
-        expect(linksClient.create).toHaveBeenCalledWith({
-          data: {
-            title: 'some new title',
-            links: getLinks(),
-            layout: 'horizontal',
-          },
-        });
-        expect(newId).toBe('333');
-        expect(api.getSerializedStateByReference(newId)).toEqual({
-          rawState: {
-            title: 'my links',
-            description: 'just a few links',
-            hidePanelTitles: true,
-            savedObjectId: '333',
-          },
-        });
+      expect(await api.canLinkToLibrary()).toBe(true);
+    });
+
+    test('save to library', async () => {
+      const { api } = await buildLinksEmbeddable(byValueState);
+      const newId = await api.saveToLibrary('some new title');
+      expect(linksClient.create).toHaveBeenCalledWith({
+        data: {
+          title: 'some new title',
+          links: getLinks(),
+          layout: 'horizontal',
+        },
+      });
+      expect(newId).toBe('333');
+      expect(api.getSerializedStateByReference(newId)).toEqual({
+        rawState: {
+          title: 'my links',
+          description: 'just a few links',
+          hidePanelTitles: true,
+          savedObjectId: '333',
+        },
       });
     });
   });

--- a/src/platform/plugins/private/links/public/embeddable/links_embeddable.test.tsx
+++ b/src/platform/plugins/private/links/public/embeddable/links_embeddable.test.tsx
@@ -138,12 +138,12 @@ async function buildLinksEmbeddable(state: LinksEmbeddableState) {
 
 describe('getLinksEmbeddableFactory', () => {
   describe('by reference embeddable', () => {
-    const byRefState = {
+    const byRefState: LinksEmbeddableState = {
       title: 'my links',
       description: 'just a few links',
       hidePanelTitles: false,
       savedObjectId: '123',
-    } as LinksEmbeddableState;
+    };
 
     test('component renders', async () => {
       const { Component } = await buildLinksEmbeddable(byRefState);
@@ -185,13 +185,13 @@ describe('getLinksEmbeddableFactory', () => {
   });
 
   describe('by value embeddable', () => {
-    const byValueState = {
+    const byValueState: LinksEmbeddableState = {
       description: 'just a few links',
       title: 'my links',
       hidePanelTitles: true,
       links: getLinks(),
       layout: 'horizontal',
-    } as LinksEmbeddableState;
+    };
 
     test('component renders', async () => {
       const { Component } = await buildLinksEmbeddable(byValueState);

--- a/src/platform/plugins/private/links/tsconfig.json
+++ b/src/platform/plugins/private/links/tsconfig.json
@@ -36,7 +36,6 @@
     "@kbn/presentation-containers",
     "@kbn/presentation-publishing",
     "@kbn/react-kibana-context-render",
-    "@kbn/presentation-panel-plugin",
     "@kbn/share-plugin",
     "@kbn/es-query",
     "@kbn/presentation-util"

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable_factory.test.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable_factory.test.tsx
@@ -8,15 +8,12 @@
 import { coreMock } from '@kbn/core/public/mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
-import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
-import { setStubKibanaServices } from '@kbn/presentation-panel-plugin/public/mocks';
 import { render, waitFor, screen } from '@testing-library/react';
 import React from 'react';
 import { of } from 'rxjs';
 import { ANOMALY_SWIMLANE_EMBEDDABLE_TYPE } from '../constants';
 import { getAnomalySwimLaneEmbeddableFactory } from './anomaly_swimlane_embeddable_factory';
 import type { AnomalySwimLaneEmbeddableApi, AnomalySwimLaneEmbeddableState } from './types';
-import { embeddablePluginMock } from '@kbn/embeddable-plugin/public/mocks';
 
 // Mock dependencies
 const pluginStartDeps = {
@@ -81,44 +78,38 @@ jest.mock('../../application/services/anomaly_timeline_service', () => {
 describe('getAnomalySwimLaneEmbeddableFactory', () => {
   const factory = getAnomalySwimLaneEmbeddableFactory(getStartServices);
 
-  beforeAll(() => {
-    const embeddable = embeddablePluginMock.createSetupContract();
-    embeddable.registerReactEmbeddableFactory(ANOMALY_SWIMLANE_EMBEDDABLE_TYPE, async () => {
-      return factory;
-    });
-    setStubKibanaServices();
-  });
-
   it('should init embeddable api based on provided state', async () => {
-    const rawState = { jobIds: ['my-job'], viewBy: 'overall' } as AnomalySwimLaneEmbeddableState;
+    const uuid = '1234';
+    const parentApi = {
+      executionContext: {
+        type: 'dashboard',
+        id: 'dashboard-id',
+      },
+    };
+    const { api, Component } = await factory.buildEmbeddable({
+      initialState: {
+        rawState: { jobIds: ['my-job'], viewBy: 'overall' } as AnomalySwimLaneEmbeddableState,
+      },
+      finalizeApi: (preFinalizeApi) => {
+        return {
+          ...preFinalizeApi,
+          uuid,
+          parentApi,
+          type: ANOMALY_SWIMLANE_EMBEDDABLE_TYPE,
+        } as AnomalySwimLaneEmbeddableApi;
+      },
+      parentApi,
+      uuid,
+    });
 
-    const onApiAvailable = jest.fn() as jest.MockedFunction<
-      (api: AnomalySwimLaneEmbeddableApi) => void
-    >;
-
-    render(
-      <EmbeddableRenderer<AnomalySwimLaneEmbeddableState, AnomalySwimLaneEmbeddableApi>
-        maybeId={'maybe_id'}
-        type={ANOMALY_SWIMLANE_EMBEDDABLE_TYPE}
-        onApiAvailable={onApiAvailable}
-        getParentApi={() => ({
-          getSerializedStateForChild: () => ({ rawState }),
-          executionContext: {
-            type: 'dashboard',
-            id: 'dashboard-id',
-          },
-        })}
-      />
-    );
+    render(<Component />);
 
     await waitFor(() => {
-      const resultApi = onApiAvailable.mock.calls[0][0];
+      expect(api.dataLoading$?.value).toEqual(false);
+      expect(api.jobIds.value).toEqual(['my-job']);
+      expect(api.viewBy.value).toEqual('overall');
 
-      expect(resultApi.dataLoading$?.value).toEqual(false);
-      expect(resultApi.jobIds.value).toEqual(['my-job']);
-      expect(resultApi.viewBy.value).toEqual('overall');
-
-      expect(screen.getByTestId<HTMLElement>('mlSwimLaneEmbeddable_maybe_id')).toBeInTheDocument();
+      expect(screen.getByTestId<HTMLElement>('mlSwimLaneEmbeddable_1234')).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/ml/tsconfig.json
+++ b/x-pack/platform/plugins/shared/ml/tsconfig.json
@@ -100,7 +100,6 @@
     "@kbn/monaco",
     "@kbn/observability-ai-assistant-plugin",
     "@kbn/presentation-containers",
-    "@kbn/presentation-panel-plugin",
     "@kbn/presentation-publishing",
     "@kbn/presentation-util-plugin",
     "@kbn/react-kibana-context-render",


### PR DESCRIPTION
Part of effort to merge `presentationPanel` plugin into `embeddable` plugin

Embeddable factory tests should not use `EmbeddableRenderer` and as a by product, need to call `setStubKibanaServices`. Instead, these tests should just call `buildEmbeddable` directly to better test the embeddable factory without other dependencies.