### PR TITLE
[OneChat] .search tool will handle subtool-level errors more clearly

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/run_search_tool.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/run_search_tool.ts
@@ -52,14 +52,14 @@ export const runSearchTool = async ({
 
       // handle errors that come from the search tool itself
       if (ToolResultType.error) {
-        let allErrorDetails = [];
+        const allErrorDetails = [];
         for (const msg of outState.messages) {
           if (msg.getType() == 'tool' && msg.name) {
             allErrorDetails.push({
               innerTool: msg.name,
               errorMessage: msg.content,
             });
-          };
+          }
         }
         return [
           {
@@ -67,7 +67,7 @@ export const runSearchTool = async ({
             data: {
               message: `An error occurred within the .search tool`,
               error_details: allErrorDetails,
-           },
+            },
           },
         ];
       }

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/run_search_tool.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/run_search_tool.ts
@@ -54,7 +54,7 @@ export const runSearchTool = async ({
       if (ToolResultType.error) {
         const allErrorDetails = [];
         for (const msg of outState.messages) {
-          if (msg.getType() == 'tool' && msg.name) {
+          if (msg.getType() === 'tool' && msg.name) {
             allErrorDetails.push({
               innerTool: msg.name,
               errorMessage: msg.content,

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/run_search_tool.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/run_search_tool.ts
@@ -50,6 +50,28 @@ export const runSearchTool = async ({
         ];
       }
 
+      // handle errors that come from the search tool itself
+      if (ToolResultType.error) {
+        let allErrorDetails = [];
+        console.log(outState.messages)
+        for (const msg of outState.messages) {
+          if (msg.getType() == 'tool' && msg.name) {
+            allErrorDetails.push({
+              innerTool: msg.name,
+              errorMessage: msg.content,
+            });
+          };
+        }
+        return [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `An error occurred within the .search tool`,
+              error_details: allErrorDetails,
+           },
+          },
+        ];
+      }
       return outState.results;
     }
   );

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/run_search_tool.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/run_search_tool.ts
@@ -53,7 +53,6 @@ export const runSearchTool = async ({
       // handle errors that come from the search tool itself
       if (ToolResultType.error) {
         let allErrorDetails = [];
-        console.log(outState.messages)
         for (const msg of outState.messages) {
           if (msg.getType() == 'tool' && msg.name) {
             allErrorDetails.push({


### PR DESCRIPTION
## Summary

This PR aims to add some clearer subtool error handling for the `.search` tool.

The `.search` tool encapsulates two subtools - `.nl_search` and `.relevance_search`. Previously, we were simply passing errors from those subtools  up directly. 

With the proposed changes, we are still passing the errors up, but with more organization to help better understand which subtool is actually having an 

Example output with the proposed changes in this PR:

```JSON
{
  "results": [
    {
      "type": "error",
      "data": {
        "message": "An error occurred within the .search tool",
        "error_details": [
          {
            "innerTool": "relevance_search",
            "errorMessage": """Error: action_request_validation_exception
	Root causes:
		action_request_validation_exception: Validation Failed: 1: [rrf] must provide [retrievers] or [query];
 Please fix your mistakes."""
          }
        ]
      }
    }
  ]
}
```

`error_details` contains an array of JSON objects, with each object containing the name and error message of a single tool.

Closes https://github.com/elastic/search-team/issues/10912

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



