### PR TITLE
[Security Solution][Notes] prevent users who don't have crud privilege to delete notes

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/delete_note_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/delete_note_button.test.tsx
@@ -12,6 +12,7 @@ import { createMockStore, mockGlobalState, TestProviders } from '../../common/mo
 import type { Note } from '../../../common/api/timeline';
 import { DELETE_NOTE_BUTTON_TEST_ID } from './test_ids';
 import { ReqStatus } from '..';
+import { useUserPrivileges } from '../../common/components/user_privileges';
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
@@ -29,6 +30,8 @@ jest.mock('../../common/hooks/use_app_toasts', () => ({
   }),
 }));
 
+jest.mock('../../common/components/user_privileges');
+
 const note: Note = {
   eventId: '1',
   noteId: '1',
@@ -43,6 +46,13 @@ const note: Note = {
 const index = 0;
 
 describe('DeleteNoteButtonIcon', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useUserPrivileges as jest.Mock).mockReturnValue({
+      notesPrivileges: { crud: true },
+    });
+  });
+
   it('should render the delete icon', () => {
     const { getByTestId } = render(
       <TestProviders>
@@ -116,5 +126,19 @@ describe('DeleteNoteButtonIcon', () => {
     expect(mockAddError).toHaveBeenCalledWith(null, {
       title: DELETE_NOTE_ERROR,
     });
+  });
+
+  it('should not render the icon if user does not have crud privileges', () => {
+    (useUserPrivileges as jest.Mock).mockReturnValue({
+      notesPrivileges: { crud: false },
+    });
+
+    const { container } = render(
+      <TestProviders>
+        <DeleteNoteButtonIcon note={note} index={index} />
+      </TestProviders>
+    );
+
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/delete_note_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/delete_note_button.tsx
@@ -9,6 +9,7 @@ import React, { memo, useCallback, useEffect, useState } from 'react';
 import { EuiButtonIcon } from '@elastic/eui';
 import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@kbn/i18n';
+import { useUserPrivileges } from '../../common/components/user_privileges';
 import { DELETE_NOTE_BUTTON_TEST_ID } from './test_ids';
 import type { State } from '../../common/store';
 import type { Note } from '../../../common/api/timeline';
@@ -49,6 +50,9 @@ export const DeleteNoteButtonIcon = memo(({ note, index }: DeleteNoteButtonIconP
   const dispatch = useDispatch();
   const { addError: addErrorToast } = useAppToasts();
 
+  const { notesPrivileges } = useUserPrivileges();
+  const canDeleteNotes = notesPrivileges.crud;
+
   const deleteStatus = useSelector((state: State) => selectDeleteNotesStatus(state));
   const deleteError = useSelector((state: State) => selectDeleteNotesError(state));
   const [deletingNoteId, setDeletingNoteId] = useState('');
@@ -68,6 +72,10 @@ export const DeleteNoteButtonIcon = memo(({ note, index }: DeleteNoteButtonIconP
       });
     }
   }, [addErrorToast, deleteError, deleteStatus]);
+
+  if (!canDeleteNotes) {
+    return null;
+  }
 
   return (
     <EuiButtonIcon

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/notes_list.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/notes_list.tsx
@@ -23,7 +23,6 @@ import {
   selectCreateNoteStatus,
   selectNotesTablePendingDeleteIds,
 } from '../store/notes.slice';
-import { useUserPrivileges } from '../../common/components/user_privileges';
 
 export const ADDED_A_NOTE = i18n.translate('xpack.securitySolution.notes.addedANoteLabel', {
   defaultMessage: 'added a note',
@@ -59,9 +58,6 @@ export interface NotesListProps {
  * When a note is being created, the component renders a loading spinner when the new note is about to be added.
  */
 export const NotesList = memo(({ notes, options }: NotesListProps) => {
-  const { notesPrivileges } = useUserPrivileges();
-  const canDeleteNotes = notesPrivileges.crud;
-
   const createStatus = useSelector((state: State) => selectCreateNoteStatus(state));
 
   const pendingDeleteIds = useSelector(selectNotesTablePendingDeleteIds);
@@ -89,7 +85,7 @@ export const NotesList = memo(({ notes, options }: NotesListProps) => {
                 {note.timelineId && note.timelineId.length > 0 && !options?.hideTimelineIcon && (
                   <OpenTimelineButtonIcon note={note} index={index} />
                 )}
-                {canDeleteNotes && <DeleteNoteButtonIcon note={note} index={index} />}
+                <DeleteNoteButtonIcon note={note} index={index} />
               </>
             }
             timelineAvatar={


### PR DESCRIPTION
## Summary

This PR fixes a small but important bug where the delete note icon on the Notes management page was accessible even by users who did not have the correct privileges.
While on the Alert details flyout Notes's tab we were correctly hiding the delete note icon, we were not doing so on the Notes management page.

The fix consist of having the privilege check and logic within the `DeleteNoteButtonIcon` component directly, to make sure that every current and future usage will automatically have the privileges check.

Alert details flyout

| With crud privileges  | Without crud privileges |
| ------------- | ------------- |
| <img width="1173" height="618" alt="Screenshot 2025-09-04 at 8 52 30 AM" src="https://github.com/user-attachments/assets/798ec170-c838-4f8c-942f-ef9a588ee756" />  | <img width="1166" height="361" alt="Screenshot 2025-09-04 at 8 55 33 AM" src="https://github.com/user-attachments/assets/8c55591a-ac8f-4f64-80b5-622ca910ea3d" /> |

Notes management page

| With crud privileges  | Without crud privileges |
| ------------- | ------------- |
| <img width="968" height="283" alt="Screenshot 2025-09-04 at 8 53 11 AM" src="https://github.com/user-attachments/assets/dd60149e-62f9-4653-8e37-60a022619b12" /> | <img width="962" height="311" alt="Screenshot 2025-09-04 at 8 55 44 AM" src="https://github.com/user-attachments/assets/2e1c5128-99e7-4401-a8d9-233c1208c432" /> |

### How to test

- generate some alerts or events and add at least one note to one of the documents
- verify that a user with Notes crud privileges can see the delete icon shows up everywhere
- create a new role that has either Read or None privileges for Notes and verify it can't see the delete icon anywhere

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/222152

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->