### PR TITLE
[8.19] [ES|QL] Fixes the history component failure when on read indexes permission

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -603,17 +603,25 @@ export const ESQLEditor = memo(function ESQLEditor({
   useEffect(() => {
     const setQueryToTheCache = async () => {
       if (editor1?.current) {
-        const parserMessages = await parseMessages();
-        const clientParserStatus = parserMessages.errors?.length
-          ? 'error'
-          : parserMessages.warnings.length
-          ? 'warning'
-          : 'success';
+        try {
+          const parserMessages = await parseMessages();
+          const clientParserStatus = parserMessages.errors?.length
+            ? 'error'
+            : parserMessages.warnings.length
+            ? 'warning'
+            : 'success';
 
-        addQueriesToCache({
-          queryString: code,
-          status: clientParserStatus,
-        });
+          addQueriesToCache({
+            queryString: code,
+            status: clientParserStatus,
+          });
+        } catch (error) {
+          // Default to warning when parseMessages fails
+          addQueriesToCache({
+            queryString: code,
+            status: 'warning',
+          });
+        }
       }
     };
     if (isQueryLoading || isLoading) {


### PR DESCRIPTION
## Summary

I could not backport https://github.com/elastic/kibana/pull/233282 as the ES api is different but I am backporting the most important part of the fix which is allowing the history component to work properly when there is a 500 error in the lookup index route

