### PR TITLE
[Fleet] Fix typo for agent logging file rotation interval

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/settings/agent_policy_settings.tsx
+++ b/x-pack/platform/plugins/shared/fleet/common/settings/agent_policy_settings.tsx
@@ -191,7 +191,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     title: i18n.translate(
       'xpack.fleet.settings.agentPolicyAdvanced.agentLoggingFileIntervalTitle',
       {
-        defaultMessage: 'Agent logging number of files',
+        defaultMessage: 'Agent logging file rotation interval',
       }
     ),
     description: (


### PR DESCRIPTION
## Summary

Fix duplicated title `Agent logging number of files` 

Before 

<img width="1237" height="592" alt="386396615-8de9023c-29a0-4ecf-803a-d8c0c4b87616" src="https://github.com/user-attachments/assets/ef72226a-70fe-49a7-92af-50d2a80b2fef" />


After

<img width="824" height="444" alt="Screenshot 2025-09-04 at 10 06 03 AM" src="https://github.com/user-attachments/assets/fe48b05f-7d97-4d81-9fcf-48ca19bfef1f" />



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->