### PR TITLE
[9.1] [Security Solution][Alert details] fix mitre attack not showing up (#233805)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/mitre_attack.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/mitre_attack.tsx
@@ -8,7 +8,7 @@
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
-import type { Threats } from '@kbn/securitysolution-io-ts-alerting-types';
+import type { Threat, Threats } from '@kbn/securitysolution-io-ts-alerting-types';
 import type { SearchHit } from '../../../../../common/search_strategy';
 import { buildThreatDescription } from '../../../../detection_engine/rule_creation_ui/components/description_step/helpers';
 import { useDocumentDetailsContext } from '../../shared/context';
@@ -21,13 +21,16 @@ const getMitreComponentParts = (searchHit?: SearchHit) => {
   const ruleParameters = searchHit?.fields
     ? searchHit?.fields['kibana.alert.rule.parameters']
     : null;
-  const threat = ruleParameters ? (ruleParameters[0]?.threat as Threats) : null;
-  return threat && threat.length > 0
-    ? buildThreatDescription({
-        label: threat[0].framework,
-        threat,
-      })
-    : null;
+  const threat: Threat = ruleParameters ? ruleParameters[0]?.threat : null;
+  if (!threat) {
+    return null;
+  }
+
+  const threats: Threats = Array.isArray(threat) ? (threat as Threats) : ([threat] as Threats);
+  return buildThreatDescription({
+    label: threats[0].framework,
+    threat: threats,
+  });
 };
 
 export const MitreAttack: FC = () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution][Alert details] fix mitre attack not showing up (#233805)](https://github.com/elastic/kibana/pull/233805)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-09-04T09:41:44Z","message":"[Security Solution][Alert details] fix mitre attack not showing up (#233805)\n\n## Summary\n\nThis PR fixes an issue where the mitre attack component is not rendered\nin the About section of the Alert details flyout.\nIt seems that this has been an issue for a few releases. I went back as\nfar as `8.17` and the issue is there.\n\nWe've always assumed that the information to populate the mitre attack\ncomponent was under the `kibana.alert.rule.parameters` field, and more\nspecifically under its `threat` nested field. The code was also assuming\nthat the data was structured as an array. This has been the case for\nmany years. A (somewhat) recent change broke that logic, and we now have\na plain object when there is only a single tactic, and an array when we\nhave multiple.\n\nThe PR makes a very simple change to handle both an array and an object.\nI tested the following combinations:\n\n### No tactic or technique\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"681\" height=\"194\" alt=\"no-main\"\nsrc=\"https://github.com/user-attachments/assets/58d08188-71fa-41c3-bc9f-e36a17691ca1\"\n/> | <img width=\"682\" height=\"187\" alt=\"no-branch\"\nsrc=\"https://github.com/user-attachments/assets/bb4c49f6-a102-464c-ba1c-9f452adf8d28\"\n/> |\n\n### One tactic only\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"689\" height=\"193\" alt=\"tactic-main\"\nsrc=\"https://github.com/user-attachments/assets/39f7c940-466b-4442-901a-15c5213ebafb\"\n/> | <img width=\"688\" height=\"276\" alt=\"tactic-branch\"\nsrc=\"https://github.com/user-attachments/assets/696fdee2-81a8-4e34-be8f-720162676c50\"\n/> |\n\n### One tactic with one technique\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"681\" height=\"190\" alt=\"tactic+technique-main\"\nsrc=\"https://github.com/user-attachments/assets/583531a2-5ad7-43c9-bbb5-52471b7bf66f\"\n/> | <img width=\"686\" height=\"287\" alt=\"tactic+technique-branch\"\nsrc=\"https://github.com/user-attachments/assets/d3a4b0d2-d77a-4ad0-bf11-f48f49eea353\"\n/> |\n\n### Multiple tactics and techniques\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"689\" height=\"339\" alt=\"multiple-main\"\nsrc=\"https://github.com/user-attachments/assets/78fbec85-0275-4068-9086-fcc19aa437cf\"\n/> | <img width=\"690\" height=\"333\" alt=\"multiple-branch\"\nsrc=\"https://github.com/user-attachments/assets/be61c2da-60cc-473f-a8d7-8b57e0b29557\"\n/> |\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nhttps://github.com/elastic/kibana/issues/233819\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"15a698a8fd81cce3593275a54fbbdf4f47336e36","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","backport:version","v9.2.0","v9.1.4","v9.0.7","v8.18.7","v8.19.4"],"title":"[Security Solution][Alert details] fix mitre attack not showing up","number":233805,"url":"https://github.com/elastic/kibana/pull/233805","mergeCommit":{"message":"[Security Solution][Alert details] fix mitre attack not showing up (#233805)\n\n## Summary\n\nThis PR fixes an issue where the mitre attack component is not rendered\nin the About section of the Alert details flyout.\nIt seems that this has been an issue for a few releases. I went back as\nfar as `8.17` and the issue is there.\n\nWe've always assumed that the information to populate the mitre attack\ncomponent was under the `kibana.alert.rule.parameters` field, and more\nspecifically under its `threat` nested field. The code was also assuming\nthat the data was structured as an array. This has been the case for\nmany years. A (somewhat) recent change broke that logic, and we now have\na plain object when there is only a single tactic, and an array when we\nhave multiple.\n\nThe PR makes a very simple change to handle both an array and an object.\nI tested the following combinations:\n\n### No tactic or technique\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"681\" height=\"194\" alt=\"no-main\"\nsrc=\"https://github.com/user-attachments/assets/58d08188-71fa-41c3-bc9f-e36a17691ca1\"\n/> | <img width=\"682\" height=\"187\" alt=\"no-branch\"\nsrc=\"https://github.com/user-attachments/assets/bb4c49f6-a102-464c-ba1c-9f452adf8d28\"\n/> |\n\n### One tactic only\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"689\" height=\"193\" alt=\"tactic-main\"\nsrc=\"https://github.com/user-attachments/assets/39f7c940-466b-4442-901a-15c5213ebafb\"\n/> | <img width=\"688\" height=\"276\" alt=\"tactic-branch\"\nsrc=\"https://github.com/user-attachments/assets/696fdee2-81a8-4e34-be8f-720162676c50\"\n/> |\n\n### One tactic with one technique\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"681\" height=\"190\" alt=\"tactic+technique-main\"\nsrc=\"https://github.com/user-attachments/assets/583531a2-5ad7-43c9-bbb5-52471b7bf66f\"\n/> | <img width=\"686\" height=\"287\" alt=\"tactic+technique-branch\"\nsrc=\"https://github.com/user-attachments/assets/d3a4b0d2-d77a-4ad0-bf11-f48f49eea353\"\n/> |\n\n### Multiple tactics and techniques\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"689\" height=\"339\" alt=\"multiple-main\"\nsrc=\"https://github.com/user-attachments/assets/78fbec85-0275-4068-9086-fcc19aa437cf\"\n/> | <img width=\"690\" height=\"333\" alt=\"multiple-branch\"\nsrc=\"https://github.com/user-attachments/assets/be61c2da-60cc-473f-a8d7-8b57e0b29557\"\n/> |\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nhttps://github.com/elastic/kibana/issues/233819\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"15a698a8fd81cce3593275a54fbbdf4f47336e36"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.0","8.18","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/233805","number":233805,"mergeCommit":{"message":"[Security Solution][Alert details] fix mitre attack not showing up (#233805)\n\n## Summary\n\nThis PR fixes an issue where the mitre attack component is not rendered\nin the About section of the Alert details flyout.\nIt seems that this has been an issue for a few releases. I went back as\nfar as `8.17` and the issue is there.\n\nWe've always assumed that the information to populate the mitre attack\ncomponent was under the `kibana.alert.rule.parameters` field, and more\nspecifically under its `threat` nested field. The code was also assuming\nthat the data was structured as an array. This has been the case for\nmany years. A (somewhat) recent change broke that logic, and we now have\na plain object when there is only a single tactic, and an array when we\nhave multiple.\n\nThe PR makes a very simple change to handle both an array and an object.\nI tested the following combinations:\n\n### No tactic or technique\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"681\" height=\"194\" alt=\"no-main\"\nsrc=\"https://github.com/user-attachments/assets/58d08188-71fa-41c3-bc9f-e36a17691ca1\"\n/> | <img width=\"682\" height=\"187\" alt=\"no-branch\"\nsrc=\"https://github.com/user-attachments/assets/bb4c49f6-a102-464c-ba1c-9f452adf8d28\"\n/> |\n\n### One tactic only\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"689\" height=\"193\" alt=\"tactic-main\"\nsrc=\"https://github.com/user-attachments/assets/39f7c940-466b-4442-901a-15c5213ebafb\"\n/> | <img width=\"688\" height=\"276\" alt=\"tactic-branch\"\nsrc=\"https://github.com/user-attachments/assets/696fdee2-81a8-4e34-be8f-720162676c50\"\n/> |\n\n### One tactic with one technique\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"681\" height=\"190\" alt=\"tactic+technique-main\"\nsrc=\"https://github.com/user-attachments/assets/583531a2-5ad7-43c9-bbb5-52471b7bf66f\"\n/> | <img width=\"686\" height=\"287\" alt=\"tactic+technique-branch\"\nsrc=\"https://github.com/user-attachments/assets/d3a4b0d2-d77a-4ad0-bf11-f48f49eea353\"\n/> |\n\n### Multiple tactics and techniques\n\n| Before fix  | After fix |\n| ------------- | ------------- |\n| <img width=\"689\" height=\"339\" alt=\"multiple-main\"\nsrc=\"https://github.com/user-attachments/assets/78fbec85-0275-4068-9086-fcc19aa437cf\"\n/> | <img width=\"690\" height=\"333\" alt=\"multiple-branch\"\nsrc=\"https://github.com/user-attachments/assets/be61c2da-60cc-473f-a8d7-8b57e0b29557\"\n/> |\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nhttps://github.com/elastic/kibana/issues/233819\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"15a698a8fd81cce3593275a54fbbdf4f47336e36"}},{"branch":"9.1","label":"v9.1.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->