### PR TITLE
[Infra] Use selected schema for alerts creation

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/search_bar/search_bar.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/search_bar/search_bar.tsx
@@ -72,9 +72,16 @@ export const SearchBar = () => {
         <EuiFlexItem>
           <UnifiedSearchBar
             onQuerySubmit={handleRefresh}
-            placeholder={i18n.translate('xpack.infra.hosts.searchPlaceholder', {
-              defaultMessage: 'Search hosts (E.g. cloud.provider:gcp AND system.load.1 > 0.5)',
-            })}
+            placeholder={
+              searchCriteria.preferredSchema === 'ecs'
+                ? i18n.translate('xpack.infra.hosts.searchPlaceholder', {
+                    defaultMessage:
+                      'Search hosts (E.g. cloud.provider:gcp AND system.load.1 > 0.5)',
+                  })
+                : i18n.translate('xpack.infra.hosts.otelSearchPlaceholder', {
+                    defaultMessage: 'Search hosts (E.g. cloud.provider:gcp AND os.type:linux)',
+                  })
+            }
             showDatePicker
             showFilterBar
             showSubmitButton

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/alerts/alerts_tab_content.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/alerts/alerts_tab_content.tsx
@@ -103,6 +103,7 @@ export const AlertsTabContent = () => {
           nodeType="host"
           setVisible={toggleAlertFlyout}
           visible={isAlertFlyoutVisible}
+          schema={searchCriteria.preferredSchema}
         />
       )}
     </HeightRetainer>

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/node_context_menu.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/node_context_menu.tsx
@@ -39,6 +39,7 @@ import type {
   InfraWaffleMapOptions,
 } from '../../../../../common/inventory/types';
 import { getUptimeUrl } from '../../lib/get_uptime_url';
+import { useWaffleOptionsContext } from '../../hooks/use_waffle_options';
 
 interface Props {
   options: InfraWaffleMapOptions;
@@ -52,6 +53,7 @@ export const NodeContextMenu = withEuiTheme(
   ({ options, currentTime, node, nodeType }: PropsWithTheme) => {
     const { getAssetDetailUrl } = useAssetDetailsRedirect();
     const [flyoutVisible, setFlyoutVisible] = useState(false);
+    const { preferredSchema } = useWaffleOptionsContext();
     const inventoryModel = findInventoryModel(nodeType);
     const nodeDetailFrom = currentTime - inventoryModel.metrics.defaultTimeRangeInSeconds * 1000;
     const { services } = useKibanaContextForPlugin();
@@ -230,6 +232,7 @@ export const NodeContextMenu = withEuiTheme(
             nodeType={nodeType}
             setVisible={setFlyoutVisible}
             visible={flyoutVisible}
+            schema={preferredSchema}
           />
         )}
       </>


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/232981
Fixes https://github.com/elastic/kibana/issues/232974

This PR uses the selected schema for alert creation, instead of the default one. It also updates the search bar placeholder copy for the semconv schema.

