### PR TITLE
[ES|QL] fix parser error when index is not provided in lookup join

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/join.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/join.test.ts
@@ -180,4 +180,22 @@ describe('<TYPE> JOIN command', () => {
       expect(query.src.slice(on?.location.min, on?.location.max! + 1)).toBe('ON on_1, on_2');
     });
   });
+
+  describe('malformed', () => {
+    it('can parse JOIN without target', () => {
+      const text = `FROM employees | LOOKUP JOIN `;
+      const query = EsqlQuery.fromSrc(text);
+      expect(query.ast.commands[1].args[0]).toMatchObject({
+        sourceType: 'index',
+        name: '',
+        location: {
+          min: 29,
+          max: 27,
+        },
+        text: '',
+        incomplete: true,
+        type: 'source',
+      });
+    });
+  });
 });

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/cst_to_ast_converter.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/cst_to_ast_converter.ts
@@ -1079,7 +1079,21 @@ export class CstToAstConverter {
   }
 
   private fromJoinTarget(ctx: cst.JoinTargetContext): ast.ESQLSource | ast.ESQLIdentifier {
-    return this.toSource(ctx._index);
+    if (ctx._index) {
+      return this.toSource(ctx._index);
+    } else {
+      return Builder.expression.source.node(
+        {
+          sourceType: 'index',
+          name: '',
+        },
+        {
+          location: getPosition(ctx.start, ctx.stop),
+          incomplete: true,
+          text: ctx?.getText(),
+        }
+      );
+    }
   }
 
   // ------------------------------------------------------------- CHANGE_POINT


### PR DESCRIPTION
## Summary

Since the new LOOKUP JOIN grammar updates, the parser is throwing when parsing querys like
`FROM index LOOKUP JOIN \` , not  being able to find an `indexName`.

```
index.ts:23 TypeError: Cannot read properties of undefined (reading 'getText')
    at CstToAstConverter.sanitizeSourceString (cst_to_ast_converter.ts:1513:1)
    at CstToAstConverter.toSource (cst_to_ast_converter.ts:1465:1)
    at CstToAstConverter.fromJoinTarget (cst_to_ast_converter.ts:864:1)
    at CstToAstConverter.fromJoinCommand (cst_to_ast_converter.ts:847:1)
    at CstToAstConverter.fromProcessingCommand (cst_to_ast_converter.ts:309:1)
    at CstToAstConverter.fromCompositeQuery (cst_to_ast_converter.ts:185:1)
    at CstToAstConverter.fromAnyQuery (cst_to_ast_converter.ts:170:1)
    at CstToAstConverter.fromSingleStatement (cst_to_ast_converter.ts:166:1)
    at Parser.parseTarget (parser.ts:44:1)
    at Parser.parse (parser.ts:70:1)
```


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



