### PR TITLE
[Inspector] Make Inspector View registry async

### DIFF
--- a/src/platform/plugins/private/presentation_panel/public/panel_actions/inspect_panel_action/inspect_panel_action.ts
+++ b/src/platform/plugins/private/presentation_panel/public/panel_actions/inspect_panel_action/inspect_panel_action.ts
@@ -43,7 +43,7 @@ export class InspectPanelAction implements Action<EmbeddableApiContext> {
 
   public async isCompatible({ embeddable }: EmbeddableApiContext) {
     if (!isApiCompatible(embeddable)) return false;
-    return inspector.isAvailable(embeddable.getInspectorAdapters());
+    return await inspector.isAvailable(embeddable.getInspectorAdapters());
   }
 
   public async execute({ embeddable }: EmbeddableApiContext) {

--- a/src/platform/plugins/private/vis_types/vega/public/async_services.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/async_services.ts
@@ -13,3 +13,4 @@ export { VegaVisComponent } from './components/vega_vis_component';
 export { VegaParser } from './data_model/vega_parser';
 export { getServiceSettings } from './vega_view/vega_map_view/service_settings/get_service_settings';
 export { VegaView } from './vega_view/vega_view';
+export { getVegaInspectorView } from './vega_inspector/vega_inspector';

--- a/src/platform/plugins/private/vis_types/vega/public/plugin.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/plugin.ts
@@ -36,7 +36,6 @@ import type { IServiceSettings } from './vega_view/vega_map_view/service_setting
 
 import type { ConfigSchema } from '../server/config';
 
-import { getVegaInspectorView } from './vega_inspector';
 import { getVegaVisRenderer } from './vega_vis_renderer';
 import { getServiceSettingsLazy } from './vega_view/vega_map_view/service_settings/get_service_settings_lazy';
 
@@ -91,7 +90,12 @@ export class VegaPlugin implements Plugin<void, void> {
       getServiceSettings: getServiceSettingsLazy,
     };
 
-    inspector.registerView(getVegaInspectorView({ uiSettings: core.uiSettings }));
+    inspector.registerViewAsync(async () => {
+      const { getVegaInspectorView } = await import('./async_services');
+      return getVegaInspectorView({
+        uiSettings: core.uiSettings,
+      });
+    });
 
     expressions.registerFunction(() => createVegaFn(visualizationDependencies));
     expressions.registerRenderer(getVegaVisRenderer(visualizationDependencies));

--- a/src/platform/plugins/private/vis_types/vega/public/vega_inspector/create_vega_adapters.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/vega_inspector/create_vega_adapters.ts
@@ -7,5 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { VegaInspectorAdapters } from './types';
-export { createInspectorAdapters } from './create_vega_adapters';
+import { RequestAdapter } from '@kbn/inspector-plugin/public';
+import type { VegaInspectorAdapters } from './types';
+import { VegaAdapter } from './vega_adapter';
+
+export const createInspectorAdapters = (): VegaInspectorAdapters => ({
+  requests: new RequestAdapter(),
+  vega: new VegaAdapter(),
+});

--- a/src/platform/plugins/private/vis_types/vega/public/vega_inspector/types.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/vega_inspector/types.ts
@@ -7,5 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { VegaInspectorAdapters } from './types';
-export { createInspectorAdapters } from './create_vega_adapters';
+import type { IUiSettingsClient } from '@kbn/core/public';
+import type { Adapters, RequestAdapter } from '@kbn/inspector-plugin/public';
+import type { VegaAdapter } from './vega_adapter';
+
+export interface VegaInspectorViewDependencies {
+  uiSettings: IUiSettingsClient;
+}
+
+export interface VegaInspectorAdapters extends Adapters {
+  requests: RequestAdapter;
+  vega: VegaAdapter;
+}

--- a/src/platform/plugins/private/vis_types/vega/public/vega_inspector/vega_data_inspector.tsx
+++ b/src/platform/plugins/private/vis_types/vega/public/vega_inspector/vega_data_inspector.tsx
@@ -13,7 +13,7 @@ import { EuiTabbedContent, EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { InspectorViewProps } from '@kbn/inspector-plugin/public';
 import { css } from '@emotion/react';
-import type { VegaInspectorAdapters } from './vega_inspector';
+import type { VegaInspectorAdapters } from './types';
 import { DataViewer, SignalViewer, SpecViewer } from './components';
 
 export type VegaDataInspectorProps = InspectorViewProps<VegaInspectorAdapters>;

--- a/src/platform/plugins/private/vis_types/vega/public/vega_inspector/vega_inspector.tsx
+++ b/src/platform/plugins/private/vis_types/vega/public/vega_inspector/vega_inspector.tsx
@@ -11,27 +11,16 @@ import React, { lazy, Suspense } from 'react';
 import { EuiLoadingSpinner } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
-import type { IUiSettingsClient } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import type { Adapters, InspectorViewDescription } from '@kbn/inspector-plugin/public';
-import { RequestAdapter } from '@kbn/inspector-plugin/public';
-import { VegaAdapter } from './vega_adapter';
+import type { InspectorViewDescription } from '@kbn/inspector-plugin/public';
 import type { VegaDataInspectorProps } from './vega_data_inspector';
+import type { VegaInspectorViewDependencies } from './types';
 
 const VegaDataInspector = lazy(() => import('./vega_data_inspector'));
-
-export interface VegaInspectorAdapters extends Adapters {
-  requests: RequestAdapter;
-  vega: VegaAdapter;
-}
 
 const vegaDebugLabel = i18n.translate('visTypeVega.inspector.vegaDebugLabel', {
   defaultMessage: 'Vega debug',
 });
-
-interface VegaInspectorViewDependencies {
-  uiSettings: IUiSettingsClient;
-}
 
 export const getVegaInspectorView = (dependencies: VegaInspectorViewDependencies) =>
   ({
@@ -47,8 +36,3 @@ export const getVegaInspectorView = (dependencies: VegaInspectorViewDependencies
       </KibanaContextProvider>
     ),
   } as InspectorViewDescription);
-
-export const createInspectorAdapters = (): VegaInspectorAdapters => ({
-  requests: new RequestAdapter(),
-  vega: new VegaAdapter(),
-});

--- a/src/platform/plugins/shared/inspector/public/async_services.ts
+++ b/src/platform/plugins/shared/inspector/public/async_services.ts
@@ -8,4 +8,5 @@
  */
 
 export { RequestsViewComponent } from './views/requests/components/requests_view';
+export { getRequestsViewDescription } from './views/requests';
 export { InspectorPanel } from './ui/inspector_panel';

--- a/src/platform/plugins/shared/inspector/public/mocks.ts
+++ b/src/platform/plugins/shared/inspector/public/mocks.ts
@@ -38,8 +38,8 @@ const createStartContract = (): Start => {
   const openResult = {
     onClose: Promise.resolve(undefined),
     close: jest.fn(() => Promise.resolve(undefined)),
-  } as ReturnType<Start['open']>;
-  startContract.open.mockImplementation(() => openResult);
+  };
+  startContract.open.mockImplementation(() => Promise.resolve(openResult));
 
   return startContract;
 };

--- a/src/platform/plugins/shared/inspector/public/mocks.ts
+++ b/src/platform/plugins/shared/inspector/public/mocks.ts
@@ -25,6 +25,7 @@ const createSetupContract = (): Setup => {
 
   const setupContract: Setup = {
     registerView: jest.fn(views.register.bind(views)),
+    registerViewAsync: jest.fn(views.registerAsync.bind(views)),
   };
   return setupContract;
 };

--- a/src/platform/plugins/shared/inspector/public/view_registry.test.ts
+++ b/src/platform/plugins/shared/inspector/public/view_registry.test.ts
@@ -43,49 +43,62 @@ describe('InspectorViewRegistry', () => {
     expect(listener).toHaveBeenCalled();
   });
 
-  it('should return views ordered by their order property', () => {
+  it('should return views ordered by their order property', async () => {
     const view1 = createMockView({ title: 'view1', order: 2000 });
     const view2 = createMockView({ title: 'view2', order: 1000 });
     registry.register(view1);
     registry.register(view2);
-    const views = registry.getAll();
+    const views = await registry.getAll();
+    expect(views.map((v) => v.title)).toEqual(['view2', 'view1']);
+  });
+
+  it('should register async views', async () => {
+    const view1 = createMockView({ title: 'view1', order: 2000 });
+    const view2 = createMockView({ title: 'view2', order: 1000 });
+    registry.registerAsync(async () => {
+      return Promise.resolve(view1);
+    });
+    registry.registerAsync(async () => {
+      return Promise.resolve(view2);
+    });
+    const views = await registry.getAll();
     expect(views.map((v) => v.title)).toEqual(['view2', 'view1']);
   });
 
   describe('getVisible()', () => {
-    it('should return empty array on passing undefined to the registry', () => {
+    it('should return empty array on passing undefined to the registry', async () => {
       const view1 = createMockView({ title: 'view1', shouldShow: () => true });
       const view2 = createMockView({ title: 'view2', shouldShow: () => false });
       registry.register(view1);
       registry.register(view2);
-      const views = registry.getVisible();
+      const views = await registry.getVisible();
       expect(views).toEqual([]);
     });
 
-    it('should only return matching views', () => {
+    it('should only return matching views', async () => {
       const view1 = createMockView({ title: 'view1', shouldShow: () => true });
       const view2 = createMockView({ title: 'view2', shouldShow: () => false });
       registry.register(view1);
       registry.register(view2);
-      const views = registry.getVisible({});
+      const views = await registry.getVisible({});
       expect(views.map((v) => v.title)).toEqual(['view1']);
     });
 
-    it('views without shouldShow should be included', () => {
+    it('views without shouldShow should be included', async () => {
       const view1 = createMockView({ title: 'view1', shouldShow: () => true });
       const view2 = createMockView({ title: 'view2' });
       registry.register(view1);
       registry.register(view2);
-      const views = registry.getVisible({});
+      const views = await registry.getVisible({});
       expect(views.map((v) => v.title)).toEqual(['view1', 'view2']);
     });
 
-    it('should pass the adapters to the callbacks', () => {
+    it('should pass the adapters to the callbacks', async () => {
       const shouldShow = jest.fn();
       const view1 = createMockView({ shouldShow });
       registry.register(view1);
       const adapter = { foo: () => null };
-      registry.getVisible(adapter);
+      await registry.getVisible(adapter);
       expect(shouldShow).toHaveBeenCalledWith(adapter);
     });
   });

--- a/src/platform/plugins/shared/visualizations/public/embeddable/types.ts
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/types.ts
@@ -83,5 +83,5 @@ export type VisualizeApi = Partial<HasEditCapabilities> &
   HasLibraryTransforms &
   DefaultEmbeddableApi<VisualizeSerializedState> & {
     updateVis: (vis: DeepPartial<SerializedVis<VisParams>>) => void;
-    openInspector: () => OverlayRef | undefined;
+    openInspector: () => Promise<OverlayRef | undefined>;
   };

--- a/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
@@ -275,12 +275,12 @@ export const getVisualizeEmbeddableFactory: (deps: {
           titleManager.api.setTitle(visUpdates.title);
         }
       },
-      openInspector: () => {
+      openInspector: async () => {
         const adapters = inspectorAdapters$.getValue();
         if (!adapters) return;
         const inspector = getInspector();
-        if (!inspector.isAvailable(adapters)) return;
-        return getInspector().open(adapters, {
+        if (!(await inspector.isAvailable(adapters))) return;
+        return await inspector.open(adapters, {
           title:
             titleManager.api.title$?.getValue() ||
             i18n.translate('visualizations.embeddable.inspectorTitle', {

--- a/src/platform/plugins/shared/visualizations/public/visualize_app/components/visualize_top_nav.tsx
+++ b/src/platform/plugins/shared/visualizations/public/visualize_app/components/visualize_top_nav.tsx
@@ -115,8 +115,8 @@ const TopNav = ({
     setHideTryInLensBadge(true);
   }, [setHideTryInLensBadge]);
 
-  const openInspector = useCallback(() => {
-    const session = embeddableHandler.openInspector();
+  const openInspector = useCallback(async () => {
+    const session = await embeddableHandler.openInspector();
     setInspectorSession(session);
   }, [embeddableHandler]);
 


### PR DESCRIPTION
## Summary

Makes the Inspector View registry async and adds a `registerViewAsync` method. This allows plugins to lazy load their inspector views. 

As an example, the Vega plugin was updated to lazy load its inspector view using the async registry.

This is part of the larger effort to move static code from plugins into packages that is blocking parts of the Dashboards as Code project. 



