### PR TITLE
scripts/kbn_dependency_tree

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2244,6 +2244,7 @@ module.exports = {
         'src/platform/plugins/**/{server,public,common}/index.ts',
         'x-pack/platform/plugins/**/{server,public,common}/index.ts',
         'x-pack/solutions/*/plugins/**/{server,public,common}/index.ts',
+        'packages/kbn-dependency-tree/index.ts',
       ],
       rules: {
         '@kbn/eslint/no_export_all': 'error',

--- a/package.json
+++ b/package.json
@@ -1553,6 +1553,7 @@
     "@kbn/cypress-config": "link:src/platform/packages/shared/kbn-cypress-config",
     "@kbn/cypress-test-helper": "link:src/platform/packages/shared/kbn-cypress-test-helper",
     "@kbn/dependency-ownership": "link:packages/kbn-dependency-ownership",
+    "@kbn/dependency-tree": "link:packages/kbn-dependency-tree",
     "@kbn/dependency-usage": "link:packages/kbn-dependency-usage",
     "@kbn/dev-cli-errors": "link:src/platform/packages/shared/kbn-dev-cli-errors",
     "@kbn/dev-cli-runner": "link:src/platform/packages/shared/kbn-dev-cli-runner",

--- a/packages/kbn-dependency-tree/README.md
+++ b/packages/kbn-dependency-tree/README.md
@@ -1,0 +1,110 @@
+# @kbn/dependency-tree
+
+A CLI tool for visualizing TypeScript dependency trees using `tsconfig.json` files with `kbn_references`.
+
+## Usage
+
+### Command Line Interface
+
+```bash
+node scripts/kbn_dependency_tree <tsconfig.json> [options]
+```
+
+#### Basic Examples
+
+```bash
+# Analyze ML plugin dependencies
+node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json
+
+# Self-referential example - analyze this package's own dependencies
+node scripts/kbn_dependency_tree packages/kbn-dependency-tree/tsconfig.json
+
+# Limit depth to avoid deep traversal
+node scripts/kbn_dependency_tree packages/some-package/tsconfig.json --depth 2
+
+# Filter to only show ML-related dependencies
+node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json --filter "@kbn/ml-"
+
+# Show package paths in output
+node scripts/kbn_dependency_tree packages/some-package/tsconfig.json --paths
+
+# Output as JSON for further processing
+node scripts/kbn_dependency_tree packages/some-package/tsconfig.json --json
+```
+
+#### Command Line Options
+
+| Option               | Description                             | Default |
+| -------------------- | --------------------------------------- | ------- |
+| `--depth <n>`        | Maximum depth to traverse               | `3`     |
+| `--paths`            | Show package paths in parentheses       | `false` |
+| `--filter <pattern>` | Show only dependencies matching pattern | none    |
+| `--json`             | Output as JSON instead of tree format   | `false` |
+
+#### Example Output
+
+**Tree Format:**
+
+```
+└─ @kbn/dependency-tree
+   ├─ @kbn/dev-cli-runner
+   │  ├─ @kbn/dev-cli-errors
+   │  ├─ @kbn/ci-stats-reporter
+   │  │  ├─ @kbn/tooling-log
+   │  │  └─ @kbn/ci-stats-core
+   │  └─ @kbn/tooling-log
+   ├─ @kbn/dev-cli-errors
+   └─ @kbn/repo-packages
+      └─ @kbn/projects-solutions-groups
+
+Legend:
+  [EXTERNAL]     - Package not found in root package.json dependencies
+  [CIRCULAR]     - Circular dependency detected
+  [NO-TSCONFIG]  - Package found but no tsconfig.json
+```
+
+**JSON Format:**
+
+```json
+{
+  "id": "@kbn/dependency-tree",
+  "tsconfigPath": "packages/kbn-dependency-tree/tsconfig.json",
+  "packagePath": "packages/kbn-dependency-tree",
+  "dependencies": [
+    {
+      "id": "@kbn/dev-cli-runner",
+      "tsconfigPath": "packages/kbn-dev-cli-runner/tsconfig.json",
+      "packagePath": "packages/kbn-dev-cli-runner",
+      "dependencies": [...]
+    }
+  ]
+}
+```
+
+## How It Works
+
+1. **Reads tsconfig.json** files and extracts `kbn_references` arrays
+2. **Maps package names** to file paths using the root `package.json` dependencies
+3. **Builds dependency tree** by recursively following references
+4. **Detects issues** like circular dependencies, external packages, and missing tsconfigs
+5. **Formats output** as visual tree or structured JSON
+
+## Dependency Issue Detection
+
+The tool automatically detects and labels various dependency issues:
+
+- **`[CIRCULAR]`** - Circular dependency detected in the dependency chain
+- **`[EXTERNAL]`** - Package referenced but not found in root package.json dependencies
+- **`[NO-TSCONFIG]`** - Package found but has no tsconfig.json file
+
+## Development
+
+### Running Tests
+
+```bash
+# Run all tests for this package
+yarn test:jest packages/kbn-dependency-tree
+
+# Run with coverage
+yarn test:jest packages/kbn-dependency-tree --coverage
+```

--- a/packages/kbn-dependency-tree/index.ts
+++ b/packages/kbn-dependency-tree/index.ts
@@ -7,5 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-require('../src/setup_node_env');
-require('@kbn/dependency-tree').runCli();
+export * from './src/cli';

--- a/packages/kbn-dependency-tree/index.ts
+++ b/packages/kbn-dependency-tree/index.ts
@@ -7,4 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './src/cli';
+export { runCli } from './src/cli';
+export { buildDependencyTree, printTree, printJson } from './src/dependency_tree';

--- a/packages/kbn-dependency-tree/jest.config.js
+++ b/packages/kbn-dependency-tree/jest.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../..',
+  roots: ['<rootDir>/packages/kbn-dependency-tree'],
+};

--- a/packages/kbn-dependency-tree/kibana.jsonc
+++ b/packages/kbn-dependency-tree/kibana.jsonc
@@ -1,0 +1,6 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/dependency-tree",
+  "devOnly": true,
+  "owner": "@elastic/kibana-operations"
+}

--- a/packages/kbn-dependency-tree/package.json
+++ b/packages/kbn-dependency-tree/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/dependency-tree",
+  "version": "1.0.0",
+  "private": true,
+  "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0"
+}

--- a/packages/kbn-dependency-tree/src/cli.test.ts
+++ b/packages/kbn-dependency-tree/src/cli.test.ts
@@ -1,0 +1,279 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ToolingLog } from '@kbn/tooling-log';
+
+// Mock the dependencies first
+jest.mock('@kbn/dev-cli-runner', () => ({
+  run: jest.fn(),
+}));
+
+jest.mock('@kbn/dev-cli-errors', () => ({
+  createFlagError: jest.fn((message: string) => new Error(message)),
+}));
+
+jest.mock('./dependency_tree', () => ({
+  buildDependencyTree: jest.fn(),
+  printTree: jest.fn(),
+  printJson: jest.fn(),
+}));
+
+// Import after mocks are set up
+import { runCli } from './cli';
+import { buildDependencyTree, printTree, printJson } from './dependency_tree';
+import { run as mockRun } from '@kbn/dev-cli-runner';
+
+const mockBuildDependencyTree = buildDependencyTree as jest.MockedFunction<
+  typeof buildDependencyTree
+>;
+const mockPrintTree = printTree as jest.MockedFunction<typeof printTree>;
+const mockPrintJson = printJson as jest.MockedFunction<typeof printJson>;
+
+describe('cli', () => {
+  let mockLogger: jest.Mocked<ToolingLog>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLogger = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warning: jest.fn(),
+      write: jest.fn(),
+    } as any;
+  });
+
+  describe('runCli', () => {
+    it('should configure the CLI runner with correct options', () => {
+      runCli();
+
+      expect(mockRun).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          description:
+            'CLI dependency tree visualization using tsconfig.json files with kbn_references',
+          usage: 'node scripts/kbn_dependency_tree <tsconfig.json> [options]',
+          flags: expect.objectContaining({
+            boolean: ['paths', 'json'],
+            string: ['filter'],
+            number: ['depth'],
+            default: {
+              depth: 3,
+            },
+          }),
+        })
+      );
+    });
+
+    it('should include help text with examples', () => {
+      runCli();
+
+      const [, config] = mockRun.mock.calls[0];
+      expect(config.flags.help).toContain('Examples:');
+      expect(config.flags.help).toContain(
+        'node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json'
+      );
+      expect(config.flags.help).toContain('--depth <n>');
+      expect(config.flags.help).toContain('--paths');
+      expect(config.flags.help).toContain('--filter <pattern>');
+      expect(config.flags.help).toContain('--json');
+    });
+  });
+
+  describe('CLI handler', () => {
+    let cliHandler: (params: any) => Promise<void>;
+
+    beforeEach(() => {
+      runCli();
+      cliHandler = mockRun.mock.calls[0][0];
+    });
+
+    it('should throw error when no tsconfig path provided', async () => {
+      await expect(
+        cliHandler({
+          log: mockLogger,
+          flags: { _: [] },
+        })
+      ).rejects.toThrow('Please provide a tsconfig.json file path as the first argument');
+    });
+
+    it('should throw error when tsconfig path is not a string', async () => {
+      await expect(
+        cliHandler({
+          log: mockLogger,
+          flags: { _: [123] },
+        })
+      ).rejects.toThrow('Please provide a tsconfig.json file path as the first argument');
+    });
+
+    it('should build dependency tree with default options', async () => {
+      const mockTree = { id: '@kbn/test-package', dependencies: [] };
+      mockBuildDependencyTree.mockReturnValue(mockTree);
+
+      await cliHandler({
+        log: mockLogger,
+        flags: { _: ['test/tsconfig.json'] },
+      });
+
+      expect(mockBuildDependencyTree).toHaveBeenCalledWith('test/tsconfig.json', {
+        maxDepth: 3,
+        filter: undefined,
+        logger: mockLogger,
+      });
+
+      expect(mockLogger.info).toHaveBeenCalledWith('@kbn dependency tree for test/tsconfig.json');
+      expect(mockPrintTree).toHaveBeenCalledWith(mockTree, '', true, false, mockLogger);
+    });
+
+    it('should use custom depth when provided', async () => {
+      const mockTree = { id: '@kbn/test-package', dependencies: [] };
+      mockBuildDependencyTree.mockReturnValue(mockTree);
+
+      await cliHandler({
+        log: mockLogger,
+        flags: { _: ['test/tsconfig.json'], depth: 5 },
+      });
+
+      expect(mockBuildDependencyTree).toHaveBeenCalledWith('test/tsconfig.json', {
+        maxDepth: 5,
+        filter: undefined,
+        logger: mockLogger,
+      });
+    });
+
+    it('should use filter when provided', async () => {
+      const mockTree = { id: '@kbn/test-package', dependencies: [] };
+      mockBuildDependencyTree.mockReturnValue(mockTree);
+
+      await cliHandler({
+        log: mockLogger,
+        flags: { _: ['test/tsconfig.json'], filter: '@kbn/ml-' },
+      });
+
+      expect(mockBuildDependencyTree).toHaveBeenCalledWith('test/tsconfig.json', {
+        maxDepth: 3,
+        filter: '@kbn/ml-',
+        logger: mockLogger,
+      });
+
+      expect(mockLogger.info).toHaveBeenCalledWith('(filtered to packages containing: "@kbn/ml-")');
+    });
+
+    it('should show paths when paths flag is true', async () => {
+      const mockTree = { id: '@kbn/test-package', dependencies: [] };
+      mockBuildDependencyTree.mockReturnValue(mockTree);
+
+      await cliHandler({
+        log: mockLogger,
+        flags: { _: ['test/tsconfig.json'], paths: true },
+      });
+
+      expect(mockPrintTree).toHaveBeenCalledWith(mockTree, '', true, true, mockLogger);
+    });
+
+    it('should output JSON when json flag is true', async () => {
+      const mockTree = { id: '@kbn/test-package', dependencies: [] };
+      mockBuildDependencyTree.mockReturnValue(mockTree);
+
+      await cliHandler({
+        log: mockLogger,
+        flags: { _: ['test/tsconfig.json'], json: true },
+      });
+
+      expect(mockPrintJson).toHaveBeenCalledWith(mockTree, mockLogger);
+      expect(mockLogger.info).not.toHaveBeenCalledWith(
+        '@kbn dependency tree for test/tsconfig.json'
+      );
+    });
+
+    it('should not show legend in JSON mode', async () => {
+      const mockTree = { id: '@kbn/test-package', dependencies: [] };
+      mockBuildDependencyTree.mockReturnValue(mockTree);
+
+      await cliHandler({
+        log: mockLogger,
+        flags: { _: ['test/tsconfig.json'], json: true },
+      });
+
+      expect(mockLogger.info).not.toHaveBeenCalledWith('Legend:');
+    });
+
+    it('should show legend in normal mode', async () => {
+      const mockTree = { id: '@kbn/test-package', dependencies: [] };
+      mockBuildDependencyTree.mockReturnValue(mockTree);
+
+      await cliHandler({
+        log: mockLogger,
+        flags: { _: ['test/tsconfig.json'] },
+      });
+
+      expect(mockLogger.info).toHaveBeenCalledWith('Legend:');
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '  [EXTERNAL]     - Package not found in root package.json dependencies'
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '  [CIRCULAR]     - Circular dependency detected'
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '  [NO-TSCONFIG]  - Package found but no tsconfig.json'
+      );
+    });
+
+    it('should handle null dependency tree', async () => {
+      mockBuildDependencyTree.mockReturnValue(null);
+
+      await cliHandler({
+        log: mockLogger,
+        flags: { _: ['test/tsconfig.json'] },
+      });
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'No dependencies found or unable to build dependency tree.'
+      );
+      expect(mockPrintTree).not.toHaveBeenCalled();
+    });
+
+    it('should show filter info in legend when filter is applied', async () => {
+      const mockTree = { id: '@kbn/test-package', dependencies: [] };
+      mockBuildDependencyTree.mockReturnValue(mockTree);
+
+      await cliHandler({
+        log: mockLogger,
+        flags: { _: ['test/tsconfig.json'], filter: '@kbn/ml-' },
+      });
+
+      expect(mockLogger.info).toHaveBeenCalledWith('  Filtered to packages containing: "@kbn/ml-"');
+    });
+
+    it('should handle combination of flags', async () => {
+      const mockTree = { id: '@kbn/test-package', dependencies: [] };
+      mockBuildDependencyTree.mockReturnValue(mockTree);
+
+      await cliHandler({
+        log: mockLogger,
+        flags: {
+          _: ['test/tsconfig.json'],
+          depth: 2,
+          filter: '@kbn/test',
+          paths: true,
+        },
+      });
+
+      expect(mockBuildDependencyTree).toHaveBeenCalledWith('test/tsconfig.json', {
+        maxDepth: 2,
+        filter: '@kbn/test',
+        logger: mockLogger,
+      });
+
+      expect(mockPrintTree).toHaveBeenCalledWith(mockTree, '', true, true, mockLogger);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '(filtered to packages containing: "@kbn/test")'
+      );
+    });
+  });
+});

--- a/packages/kbn-dependency-tree/src/cli.test.ts
+++ b/packages/kbn-dependency-tree/src/cli.test.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ToolingLog } from '@kbn/tooling-log';
+import { createMockLogger, simpleTestTree } from './fixtures';
 
 // Mock the dependencies first
 jest.mock('@kbn/dev-cli-runner', () => ({
@@ -40,12 +41,7 @@ describe('cli', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockLogger = {
-      info: jest.fn(),
-      error: jest.fn(),
-      warning: jest.fn(),
-      write: jest.fn(),
-    } as any;
+    mockLogger = createMockLogger();
   });
 
   describe('runCli', () => {
@@ -112,8 +108,7 @@ describe('cli', () => {
     });
 
     it('should build dependency tree with default options', async () => {
-      const mockTree = { id: '@kbn/test-package', dependencies: [] };
-      mockBuildDependencyTree.mockReturnValue(mockTree);
+      mockBuildDependencyTree.mockReturnValue(simpleTestTree);
 
       await cliHandler({
         log: mockLogger,
@@ -127,12 +122,11 @@ describe('cli', () => {
       });
 
       expect(mockLogger.info).toHaveBeenCalledWith('@kbn dependency tree for test/tsconfig.json');
-      expect(mockPrintTree).toHaveBeenCalledWith(mockTree, '', true, false, mockLogger);
+      expect(mockPrintTree).toHaveBeenCalledWith(simpleTestTree, '', true, false, mockLogger);
     });
 
     it('should use custom depth when provided', async () => {
-      const mockTree = { id: '@kbn/test-package', dependencies: [] };
-      mockBuildDependencyTree.mockReturnValue(mockTree);
+      mockBuildDependencyTree.mockReturnValue(simpleTestTree);
 
       await cliHandler({
         log: mockLogger,
@@ -147,8 +141,7 @@ describe('cli', () => {
     });
 
     it('should use filter when provided', async () => {
-      const mockTree = { id: '@kbn/test-package', dependencies: [] };
-      mockBuildDependencyTree.mockReturnValue(mockTree);
+      mockBuildDependencyTree.mockReturnValue(simpleTestTree);
 
       await cliHandler({
         log: mockLogger,
@@ -165,35 +158,32 @@ describe('cli', () => {
     });
 
     it('should show paths when paths flag is true', async () => {
-      const mockTree = { id: '@kbn/test-package', dependencies: [] };
-      mockBuildDependencyTree.mockReturnValue(mockTree);
+      mockBuildDependencyTree.mockReturnValue(simpleTestTree);
 
       await cliHandler({
         log: mockLogger,
         flags: { _: ['test/tsconfig.json'], paths: true },
       });
 
-      expect(mockPrintTree).toHaveBeenCalledWith(mockTree, '', true, true, mockLogger);
+      expect(mockPrintTree).toHaveBeenCalledWith(simpleTestTree, '', true, true, mockLogger);
     });
 
     it('should output JSON when json flag is true', async () => {
-      const mockTree = { id: '@kbn/test-package', dependencies: [] };
-      mockBuildDependencyTree.mockReturnValue(mockTree);
+      mockBuildDependencyTree.mockReturnValue(simpleTestTree);
 
       await cliHandler({
         log: mockLogger,
         flags: { _: ['test/tsconfig.json'], json: true },
       });
 
-      expect(mockPrintJson).toHaveBeenCalledWith(mockTree, mockLogger);
+      expect(mockPrintJson).toHaveBeenCalledWith(simpleTestTree, mockLogger);
       expect(mockLogger.info).not.toHaveBeenCalledWith(
         '@kbn dependency tree for test/tsconfig.json'
       );
     });
 
     it('should not show legend in JSON mode', async () => {
-      const mockTree = { id: '@kbn/test-package', dependencies: [] };
-      mockBuildDependencyTree.mockReturnValue(mockTree);
+      mockBuildDependencyTree.mockReturnValue(simpleTestTree);
 
       await cliHandler({
         log: mockLogger,
@@ -204,8 +194,7 @@ describe('cli', () => {
     });
 
     it('should show legend in normal mode', async () => {
-      const mockTree = { id: '@kbn/test-package', dependencies: [] };
-      mockBuildDependencyTree.mockReturnValue(mockTree);
+      mockBuildDependencyTree.mockReturnValue(simpleTestTree);
 
       await cliHandler({
         log: mockLogger,
@@ -239,8 +228,7 @@ describe('cli', () => {
     });
 
     it('should show filter info in legend when filter is applied', async () => {
-      const mockTree = { id: '@kbn/test-package', dependencies: [] };
-      mockBuildDependencyTree.mockReturnValue(mockTree);
+      mockBuildDependencyTree.mockReturnValue(simpleTestTree);
 
       await cliHandler({
         log: mockLogger,
@@ -251,8 +239,7 @@ describe('cli', () => {
     });
 
     it('should handle combination of flags', async () => {
-      const mockTree = { id: '@kbn/test-package', dependencies: [] };
-      mockBuildDependencyTree.mockReturnValue(mockTree);
+      mockBuildDependencyTree.mockReturnValue(simpleTestTree);
 
       await cliHandler({
         log: mockLogger,
@@ -270,7 +257,7 @@ describe('cli', () => {
         logger: mockLogger,
       });
 
-      expect(mockPrintTree).toHaveBeenCalledWith(mockTree, '', true, true, mockLogger);
+      expect(mockPrintTree).toHaveBeenCalledWith(simpleTestTree, '', true, true, mockLogger);
       expect(mockLogger.info).toHaveBeenCalledWith(
         '(filtered to packages containing: "@kbn/test")'
       );

--- a/packages/kbn-dependency-tree/src/cli.ts
+++ b/packages/kbn-dependency-tree/src/cli.ts
@@ -31,6 +31,7 @@ export function runCli() {
       const treeOptions = {
         maxDepth,
         filter,
+        logger: log,
       };
 
       if (!jsonOutput) {
@@ -44,10 +45,10 @@ export function runCli() {
       const tree = buildDependencyTree(tsconfigPath, treeOptions);
 
       if (jsonOutput) {
-        printJson(tree);
+        printJson(tree, log);
       } else {
         if (tree) {
-          printTree(tree, '', true, showPaths);
+          printTree(tree, '', true, showPaths, log);
         } else {
           log.info('No dependencies found or unable to build dependency tree.');
         }

--- a/packages/kbn-dependency-tree/src/cli.ts
+++ b/packages/kbn-dependency-tree/src/cli.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { run } from '@kbn/dev-cli-runner';
+import { createFlagError } from '@kbn/dev-cli-errors';
+import { buildDependencyTree, printTree, printJson } from './dependency_tree';
+
+const DEFAULT_MAX_DEPTH = 3;
+
+export function runCli() {
+  run(
+    async ({ log, flags }) => {
+      const tsconfigPath = flags._?.[0];
+      if (!tsconfigPath || typeof tsconfigPath !== 'string') {
+        throw createFlagError('Please provide a tsconfig.json file path as the first argument');
+      }
+
+      const maxDepth = typeof flags.depth === 'number' ? flags.depth : DEFAULT_MAX_DEPTH;
+
+      const filter = typeof flags.filter === 'string' ? flags.filter : undefined;
+
+      const showPaths = !!flags.paths;
+      const jsonOutput = !!flags.json;
+
+      const treeOptions = {
+        maxDepth,
+        filter,
+      };
+
+      if (!jsonOutput) {
+        log.info(`@kbn dependency tree for ${tsconfigPath}`);
+        if (filter) {
+          log.info(`(filtered to packages containing: "${filter}")`);
+        }
+        log.info('');
+      }
+
+      const tree = buildDependencyTree(tsconfigPath, treeOptions);
+
+      if (jsonOutput) {
+        printJson(tree);
+      } else {
+        if (tree) {
+          printTree(tree, '', true, showPaths);
+        } else {
+          log.info('No dependencies found or unable to build dependency tree.');
+        }
+
+        log.info('');
+        log.info('Legend:');
+        log.info('  [EXTERNAL]     - Package not found in root package.json dependencies');
+        log.info('  [CIRCULAR]     - Circular dependency detected');
+        log.info('  [NO-TSCONFIG]  - Package found but no tsconfig.json');
+
+        if (filter) {
+          log.info(`  Filtered to packages containing: "${filter}"`);
+        }
+      }
+    },
+    {
+      description:
+        'CLI dependency tree visualization using tsconfig.json files with kbn_references',
+      usage: 'node scripts/kbn_dependency_tree <tsconfig.json> [options]',
+      flags: {
+        boolean: ['paths', 'json'],
+        string: ['filter'],
+        number: ['depth'],
+        default: {
+          depth: DEFAULT_MAX_DEPTH,
+        },
+        help: `
+Examples:
+  node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json
+  node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json --depth 2
+  node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json --filter "@kbn/ml-"
+
+Options:
+  --depth <n>      Maximum depth to traverse (default: ${DEFAULT_MAX_DEPTH})
+  --paths          Show package paths in parentheses
+  --filter <pattern>  Show only dependencies matching pattern (e.g., "@kbn/ml-", "core")
+  --json           Output as JSON
+        `,
+      },
+    }
+  );
+}

--- a/packages/kbn-dependency-tree/src/dependency_tree.test.ts
+++ b/packages/kbn-dependency-tree/src/dependency_tree.test.ts
@@ -1,0 +1,390 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as fs from 'fs';
+import type { ToolingLog } from '@kbn/tooling-log';
+import { buildDependencyTree, printTree, printJson } from './dependency_tree';
+
+// Mock fs module
+jest.mock('fs');
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+// Mock @kbn/repo-packages/utils/jsonc
+jest.mock('@kbn/repo-packages/utils/jsonc', () => ({
+  parse: jest.fn(),
+}));
+
+const { parse: mockParseJsonc } = jest.requireMock('@kbn/repo-packages/utils/jsonc');
+
+describe('dependency_tree', () => {
+  let mockLogger: jest.Mocked<ToolingLog>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLogger = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warning: jest.fn(),
+      write: jest.fn(),
+    } as any;
+  });
+
+  describe('buildDependencyTree', () => {
+    beforeEach(() => {
+      // Mock root package.json
+      mockFs.readFileSync.mockImplementation((filePath) => {
+        if (filePath === 'package.json') {
+          return JSON.stringify({
+            dependencies: {
+              '@kbn/test-package': 'link:packages/kbn-test-package',
+              '@kbn/another-package': 'link:packages/kbn-another-package',
+            },
+            devDependencies: {
+              '@kbn/dev-package': 'link:packages/kbn-dev-package',
+            },
+          });
+        }
+        if (typeof filePath === 'string' && filePath.includes('tsconfig.json')) {
+          if (filePath.includes('kbn-test-package')) {
+            return '{"kbn_references": ["@kbn/another-package"]}';
+          }
+          if (filePath.includes('kbn-another-package')) {
+            return '{"kbn_references": []}';
+          }
+          if (filePath.includes('kbn-dev-package')) {
+            return '{"kbn_references": []}';
+          }
+        }
+        return '{}';
+      });
+
+      mockFs.existsSync.mockReturnValue(true);
+    });
+
+    it('should build a simple dependency tree', () => {
+      const tsconfigPath = 'packages/kbn-test-package/tsconfig.json';
+
+      mockParseJsonc.mockImplementation((content) => {
+        return JSON.parse(content);
+      });
+
+      const result = buildDependencyTree(tsconfigPath, { logger: mockLogger });
+
+      expect(result).toBeDefined();
+      expect(result?.id).toBe('@kbn/test-package');
+      expect(result?.dependencies).toHaveLength(1);
+      expect(result?.dependencies?.[0]?.id).toBe('@kbn/another-package');
+    });
+
+    it('should handle circular dependencies', () => {
+      const tsconfigPath = 'packages/kbn-test-package/tsconfig.json';
+
+      // Override the default mock to simulate circular dependency
+      mockFs.readFileSync.mockImplementation((filePath) => {
+        if (filePath === 'package.json') {
+          return JSON.stringify({
+            dependencies: {
+              '@kbn/test-package': 'link:packages/kbn-test-package',
+              '@kbn/another-package': 'link:packages/kbn-another-package',
+            },
+          });
+        }
+        if (typeof filePath === 'string' && filePath.includes('tsconfig.json')) {
+          if (filePath.includes('kbn-test-package')) {
+            return '{"kbn_references": ["@kbn/another-package"]}';
+          }
+          if (filePath.includes('kbn-another-package')) {
+            return '{"kbn_references": ["@kbn/test-package"]}';
+          }
+        }
+        return '{}';
+      });
+
+      mockParseJsonc.mockImplementation((content) => {
+        return JSON.parse(content);
+      });
+
+      const result = buildDependencyTree(tsconfigPath, { logger: mockLogger });
+
+      expect(result).toBeDefined();
+      expect(result?.id).toBe('@kbn/test-package');
+      expect(result?.dependencies).toHaveLength(1);
+      expect(result?.dependencies?.[0]?.id).toBe('@kbn/another-package');
+      // The second level should detect the circular reference
+      expect(result?.dependencies?.[0]?.dependencies?.[0]?.circular).toBe(true);
+    });
+
+    it('should handle external dependencies', () => {
+      const tsconfigPath = 'packages/kbn-test-package/tsconfig.json';
+
+      // Override the default mock to include external package reference
+      mockFs.readFileSync.mockImplementation((filePath) => {
+        if (filePath === 'package.json') {
+          return JSON.stringify({
+            dependencies: {
+              '@kbn/test-package': 'link:packages/kbn-test-package',
+              // Note: @kbn/external-package is NOT included here, making it external
+            },
+          });
+        }
+        if (typeof filePath === 'string' && filePath.includes('kbn-test-package/tsconfig.json')) {
+          return '{"kbn_references": ["@kbn/external-package"]}';
+        }
+        return '{}';
+      });
+
+      mockParseJsonc.mockImplementation((content) => {
+        return JSON.parse(content);
+      });
+
+      const result = buildDependencyTree(tsconfigPath, { logger: mockLogger });
+
+      expect(result).toBeDefined();
+      expect(result?.dependencies).toHaveLength(1);
+      expect(result?.dependencies?.[0]?.id).toBe('@kbn/external-package');
+      expect(result?.dependencies?.[0]?.external).toBe(true);
+    });
+
+    it('should handle packages with no tsconfig', () => {
+      const tsconfigPath = 'packages/kbn-test-package/tsconfig.json';
+
+      mockFs.readFileSync.mockImplementation((filePath) => {
+        if (filePath === 'package.json') {
+          return JSON.stringify({
+            dependencies: {
+              '@kbn/test-package': 'link:packages/kbn-test-package',
+              '@kbn/another-package': 'link:packages/kbn-another-package',
+            },
+          });
+        }
+        if (typeof filePath === 'string' && filePath.includes('kbn-test-package/tsconfig.json')) {
+          return '{"kbn_references": ["@kbn/another-package"]}';
+        }
+        return '{}';
+      });
+
+      mockFs.existsSync.mockImplementation((filePath) => {
+        if (
+          typeof filePath === 'string' &&
+          filePath.includes('kbn-another-package/tsconfig.json')
+        ) {
+          return false;
+        }
+        return true;
+      });
+
+      mockParseJsonc.mockImplementation((content) => {
+        return JSON.parse(content);
+      });
+
+      const result = buildDependencyTree(tsconfigPath, { logger: mockLogger });
+
+      expect(result).toBeDefined();
+      expect(result?.dependencies).toHaveLength(1);
+      expect(result?.dependencies?.[0]?.id).toBe('@kbn/another-package');
+      expect(result?.dependencies?.[0]?.noTsconfig).toBe(true);
+    });
+
+    it('should respect maxDepth option', () => {
+      const tsconfigPath = 'packages/kbn-test-package/tsconfig.json';
+
+      mockFs.readFileSync.mockImplementation((filePath) => {
+        if (filePath === 'package.json') {
+          return JSON.stringify({
+            dependencies: {
+              '@kbn/test-package': 'link:packages/kbn-test-package',
+              '@kbn/another-package': 'link:packages/kbn-another-package',
+              '@kbn/dev-package': 'link:packages/kbn-dev-package',
+            },
+          });
+        }
+        if (typeof filePath === 'string' && filePath.includes('tsconfig.json')) {
+          if (filePath.includes('kbn-test-package')) {
+            return '{"kbn_references": ["@kbn/another-package"]}';
+          }
+          if (filePath.includes('kbn-another-package')) {
+            return '{"kbn_references": ["@kbn/dev-package"]}';
+          }
+          if (filePath.includes('kbn-dev-package')) {
+            return '{"kbn_references": []}';
+          }
+        }
+        return '{}';
+      });
+
+      mockParseJsonc.mockImplementation((content) => {
+        return JSON.parse(content);
+      });
+
+      const resultDepth1 = buildDependencyTree(tsconfigPath, { maxDepth: 1, logger: mockLogger });
+      const resultDepth2 = buildDependencyTree(tsconfigPath, { maxDepth: 2, logger: mockLogger });
+
+      // At depth 1, we should see fewer nested dependencies
+      expect(resultDepth1?.dependencies).toHaveLength(1);
+      expect(resultDepth2?.dependencies).toHaveLength(1);
+
+      // The key difference is in nested dependency resolution
+      const depth1Nested = resultDepth1?.dependencies?.[0]?.dependencies?.length || 0;
+      const depth2Nested = resultDepth2?.dependencies?.[0]?.dependencies?.length || 0;
+      expect(depth1Nested).toBeLessThanOrEqual(depth2Nested);
+    });
+
+    it('should apply filter option', () => {
+      const tsconfigPath = 'packages/kbn-test-package/tsconfig.json';
+
+      mockFs.readFileSync.mockImplementation((filePath) => {
+        if (filePath === 'package.json') {
+          return JSON.stringify({
+            dependencies: {
+              '@kbn/test-package': 'link:packages/kbn-test-package',
+              '@kbn/another-package': 'link:packages/kbn-another-package',
+              '@kbn/dev-package': 'link:packages/kbn-dev-package',
+              '@kbn/filtered-out': 'link:packages/kbn-filtered-out',
+            },
+          });
+        }
+        if (typeof filePath === 'string' && filePath.includes('kbn-test-package/tsconfig.json')) {
+          return '{"kbn_references": ["@kbn/another-package", "@kbn/dev-package", "@kbn/filtered-out"]}';
+        }
+        return '{}';
+      });
+
+      mockParseJsonc.mockImplementation((content) => {
+        return JSON.parse(content);
+      });
+
+      const result = buildDependencyTree(tsconfigPath, {
+        filter: 'dev',
+        logger: mockLogger,
+      });
+
+      expect(result?.dependencies).toHaveLength(1);
+      expect(result?.dependencies?.[0]?.id).toBe('@kbn/dev-package');
+    });
+
+    it('should handle missing tsconfig file', () => {
+      const tsconfigPath = 'non-existent/tsconfig.json';
+      mockFs.existsSync.mockReturnValue(false);
+
+      expect(() => buildDependencyTree(tsconfigPath, { logger: mockLogger })).toThrow(
+        'Package name not found for tsconfig at non-existent/tsconfig.json'
+      );
+    });
+
+    it('should handle malformed tsconfig file', () => {
+      const tsconfigPath = 'packages/kbn-test-package/tsconfig.json';
+
+      mockParseJsonc.mockImplementation(() => {
+        throw new Error('Invalid JSON');
+      });
+
+      const result = buildDependencyTree(tsconfigPath, { logger: mockLogger });
+
+      expect(result?.dependencies).toHaveLength(0);
+      expect(mockLogger.warning).toHaveBeenCalled();
+    });
+  });
+
+  describe('printTree', () => {
+    it('should print simple tree structure', () => {
+      const node = {
+        id: '@kbn/test-package',
+        dependencies: [{ id: '@kbn/child-package' }],
+      };
+
+      printTree(node, '', true, false, mockLogger);
+
+      expect(mockLogger.write).toHaveBeenCalledWith('└─ @kbn/test-package');
+      expect(mockLogger.write).toHaveBeenCalledWith('   └─ @kbn/child-package');
+    });
+
+    it('should print tree with paths when showPaths is true', () => {
+      const node = {
+        id: '@kbn/test-package',
+        packagePath: 'packages/kbn-test-package',
+        dependencies: [
+          {
+            id: '@kbn/child-package',
+            packagePath: 'packages/kbn-child-package',
+          },
+        ],
+      };
+
+      printTree(node, '', true, true, mockLogger);
+
+      expect(mockLogger.write).toHaveBeenCalledWith(
+        '└─ @kbn/test-package (packages/kbn-test-package)'
+      );
+      expect(mockLogger.write).toHaveBeenCalledWith(
+        '   └─ @kbn/child-package (packages/kbn-child-package)'
+      );
+    });
+
+    it('should print circular dependencies', () => {
+      const node = {
+        id: '@kbn/test-package',
+        dependencies: [{ id: '@kbn/circular-package', circular: true }],
+      };
+
+      printTree(node, '', true, false, mockLogger);
+
+      expect(mockLogger.write).toHaveBeenCalledWith('   └─ @kbn/circular-package [CIRCULAR]');
+    });
+
+    it('should print external dependencies', () => {
+      const node = {
+        id: '@kbn/test-package',
+        dependencies: [{ id: '@kbn/external-package', external: true }],
+      };
+
+      printTree(node, '', true, false, mockLogger);
+
+      expect(mockLogger.write).toHaveBeenCalledWith('   └─ @kbn/external-package [EXTERNAL]');
+    });
+
+    it('should print packages with no tsconfig', () => {
+      const node = {
+        id: '@kbn/test-package',
+        dependencies: [{ id: '@kbn/no-tsconfig-package', noTsconfig: true }],
+      };
+
+      printTree(node, '', true, false, mockLogger);
+
+      expect(mockLogger.write).toHaveBeenCalledWith('   └─ @kbn/no-tsconfig-package [NO-TSCONFIG]');
+    });
+
+    it('should handle null node', () => {
+      printTree(null, '', true, false, mockLogger);
+      expect(mockLogger.write).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('printJson', () => {
+    it('should print tree as JSON', () => {
+      const tree = {
+        id: '@kbn/test-package',
+        dependencies: [{ id: '@kbn/child-package' }],
+      };
+
+      printJson(tree, mockLogger);
+
+      expect(mockLogger.write).toHaveBeenCalledWith(JSON.stringify(tree, null, 2));
+    });
+
+    it('should handle null tree', () => {
+      printJson(null, mockLogger);
+      expect(mockLogger.write).toHaveBeenCalledWith('null');
+    });
+
+    it('should work without logger', () => {
+      const tree = { id: '@kbn/test-package' };
+      expect(() => printJson(tree)).not.toThrow();
+    });
+  });
+});

--- a/packages/kbn-dependency-tree/src/dependency_tree.ts
+++ b/packages/kbn-dependency-tree/src/dependency_tree.ts
@@ -53,7 +53,7 @@ interface BuildOptions {
 }
 
 /**
- * Loads and caches the package map from the root package.json dependencies
+ * Loads and caches the package map from the root package.json dependencies and devDependencies
  */
 function loadPackageMap(): Map<string, string> {
   if (state.packageMap) return state.packageMap;
@@ -65,9 +65,11 @@ function loadPackageMap(): Map<string, string> {
     state.packageMap = new Map();
     state.reversePackageMap = new Map();
 
-    // Parse dependencies for @kbn packages with "link:" prefix
-    if (packageJson.dependencies) {
-      Object.entries(packageJson.dependencies).forEach(([packageName, packageSpec]) => {
+    // Helper function to process dependencies
+    const processDependencies = (deps: Record<string, string> | undefined, depType: string) => {
+      if (!deps) return;
+
+      Object.entries(deps).forEach(([packageName, packageSpec]) => {
         if (
           packageName.startsWith('@kbn/') &&
           typeof packageSpec === 'string' &&
@@ -78,7 +80,11 @@ function loadPackageMap(): Map<string, string> {
           state.reversePackageMap!.set(packagePath, packageName);
         }
       });
-    }
+    };
+
+    // Parse both dependencies and devDependencies for @kbn packages with "link:" prefix
+    processDependencies(packageJson.dependencies, 'dependencies');
+    processDependencies(packageJson.devDependencies, 'devDependencies');
 
     return state.packageMap;
   } catch (error) {

--- a/packages/kbn-dependency-tree/src/dependency_tree.ts
+++ b/packages/kbn-dependency-tree/src/dependency_tree.ts
@@ -1,0 +1,342 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { parse as parseJsonc } from '@kbn/repo-packages/utils/jsonc';
+
+// Constants
+const TREE_CHARS = {
+  branch: '├─ ',
+  last: '└─ ',
+  pipe: '│  ',
+  space: '   ',
+};
+
+const DEFAULT_MAX_DEPTH = 3;
+const ROOT_PACKAGE_JSON_PATH = 'package.json';
+
+// Global state
+interface State {
+  packageMap: Map<string, string> | null;
+  reversePackageMap: Map<string, string> | null;
+}
+
+const state: State = {
+  packageMap: null,
+  reversePackageMap: null,
+};
+
+interface DependencyNode {
+  id: string;
+  tsconfigPath?: string;
+  packagePath?: string;
+  dependencies?: DependencyNode[];
+  circular?: boolean;
+  external?: boolean;
+  noTsconfig?: boolean;
+}
+
+interface BuildOptions {
+  maxDepth?: number;
+  filter?: string;
+}
+
+/**
+ * Loads and caches the package map from the root package.json dependencies
+ */
+function loadPackageMap(): Map<string, string> {
+  if (state.packageMap) return state.packageMap;
+
+  try {
+    const packageJsonContent = fs.readFileSync(ROOT_PACKAGE_JSON_PATH, 'utf8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    state.packageMap = new Map();
+    state.reversePackageMap = new Map();
+
+    // Parse dependencies for @kbn packages with "link:" prefix
+    if (packageJson.dependencies) {
+      Object.entries(packageJson.dependencies).forEach(([packageName, packageSpec]) => {
+        if (
+          packageName.startsWith('@kbn/') &&
+          typeof packageSpec === 'string' &&
+          packageSpec.startsWith('link:')
+        ) {
+          const packagePath = packageSpec.replace('link:', '');
+          state.packageMap!.set(packageName, packagePath);
+          state.reversePackageMap!.set(packagePath, packageName);
+        }
+      });
+    }
+
+    return state.packageMap;
+  } catch (error) {
+    // TODO: Use logger instead of console.error - need to pass logger down from CLI context
+    // eslint-disable-next-line no-console
+    console.error('Failed to load package map from root package.json:', (error as Error).message);
+    return new Map();
+  }
+}
+
+/**
+ * Extracts kbn_references from a tsconfig.json file
+ */
+function readTsconfigReferences(tsconfigPath: string): string[] {
+  try {
+    if (!fs.existsSync(tsconfigPath)) {
+      // TODO: Use logger instead of console.warn - need to pass logger down from CLI context
+      // eslint-disable-next-line no-console
+      console.warn(`Warning: File does not exist at ${tsconfigPath}`);
+      return [];
+    }
+
+    const tsconfigContent = fs.readFileSync(tsconfigPath, 'utf8');
+    const tsconfig = parseJsonc(tsconfigContent);
+
+    if (!tsconfig.kbn_references || !Array.isArray(tsconfig.kbn_references)) {
+      return [];
+    }
+
+    return tsconfig.kbn_references.filter((ref: unknown): ref is string => {
+      // Handle string references
+      if (typeof ref === 'string') {
+        return ref.startsWith('@kbn/');
+      }
+      // Skip object references (like { "path": "..." })
+      return false;
+    });
+  } catch (error) {
+    // TODO: Use logger instead of console.warn - need to pass logger down from CLI context
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Warning: Could not read tsconfig at ${tsconfigPath}: ${(error as Error).message}`
+    );
+    return [];
+  }
+}
+
+/**
+ * Gets the file path for a given package name
+ */
+function getPackagePath(packageName: string): string | null {
+  const pkgMap = loadPackageMap();
+  return pkgMap.get(packageName) || null;
+}
+
+/**
+ * Gets the package name for a given package path using reverse lookup
+ */
+function getPackageNameFromPath(packagePath: string): string | null {
+  loadPackageMap(); // Ensure maps are loaded
+  return state.reversePackageMap?.get(packagePath) || null;
+}
+
+/**
+ * Finds the tsconfig.json file for a given package path
+ */
+function findTsconfigForPackage(packagePath: string): string | null {
+  const tsconfigPath = path.join(packagePath, 'tsconfig.json');
+  return fs.existsSync(tsconfigPath) ? tsconfigPath : null;
+}
+
+/**
+ * Gets the package name from a tsconfig.json path using reverse lookup
+ */
+function getPackageNameFromTsconfig(tsconfigPath: string): string {
+  const packagePath = path.dirname(tsconfigPath);
+
+  // First try exact path lookup
+  const packageName = getPackageNameFromPath(packagePath);
+  if (packageName) {
+    return packageName;
+  } else {
+    throw new Error(`Package name not found for tsconfig at ${tsconfigPath}`);
+  }
+}
+
+/**
+ * Applies filters to the list of references
+ */
+function applyFilters(references: string[], filter?: string): string[] {
+  if (!filter) {
+    return references;
+  }
+
+  return references.filter((ref) => ref.includes(filter));
+}
+
+/**
+ * Creates a dependency node structure
+ */
+function createDependencyNode(packageName: string, tsconfigPath: string): DependencyNode {
+  return {
+    id: packageName,
+    tsconfigPath,
+    packagePath: path.dirname(tsconfigPath),
+    dependencies: [],
+  };
+}
+
+/**
+ * Processes a single dependency reference
+ */
+function processDependency(
+  refPackageName: string,
+  depth: number,
+  currentPath: string[],
+  packageName: string,
+  maxDepth: number,
+  traverse: (tsconfigPath: string, depth: number, currentPath?: string[]) => DependencyNode | null
+): DependencyNode | null {
+  if (currentPath.includes(refPackageName)) {
+    return { id: refPackageName, circular: true };
+  }
+
+  const refPackagePath = getPackagePath(refPackageName);
+  if (!refPackagePath) {
+    return { id: refPackageName, external: true };
+  }
+
+  const refTsconfigPath = findTsconfigForPackage(refPackagePath);
+  if (!refTsconfigPath) {
+    return { id: refPackageName, packagePath: refPackagePath, noTsconfig: true };
+  }
+
+  if (depth < maxDepth) {
+    const newPath = [...currentPath, packageName];
+    const childNode = traverse(refTsconfigPath, depth + 1, newPath);
+    if (childNode) {
+      return childNode;
+    }
+  }
+
+  return {
+    id: refPackageName,
+    packagePath: refPackagePath,
+    tsconfigPath: refTsconfigPath,
+  };
+}
+
+/**
+ * Builds a dependency tree from a tsconfig.json file
+ */
+export function buildDependencyTree(
+  tsconfigPath: string,
+  options: BuildOptions = {}
+): DependencyNode | null {
+  const maxDepth = options.maxDepth || DEFAULT_MAX_DEPTH;
+  const filter = options.filter;
+  const nodeCache = new Map<string, DependencyNode>(); // Cache complete dependency nodes
+  const processing = new Set<string>();
+
+  function traverse(
+    currentTsconfigPath: string,
+    depth: number,
+    currentPath: string[] = []
+  ): DependencyNode | null {
+    if (depth > maxDepth) return null;
+
+    const packageName = getPackageNameFromTsconfig(currentTsconfigPath);
+
+    if (processing.has(packageName)) {
+      return { id: packageName, circular: true };
+    }
+
+    // Return cached node if already processed
+    if (nodeCache.has(packageName)) {
+      return nodeCache.get(packageName)!;
+    }
+
+    if (currentPath.includes(packageName)) {
+      return { id: packageName, circular: true };
+    }
+
+    processing.add(packageName);
+    const references = readTsconfigReferences(currentTsconfigPath);
+    const filteredRefs = applyFilters(references, filter);
+
+    const node = createDependencyNode(packageName, currentTsconfigPath);
+
+    for (const refPackageName of filteredRefs) {
+      const dependency = processDependency(
+        refPackageName,
+        depth,
+        currentPath,
+        packageName,
+        maxDepth,
+        traverse
+      );
+      if (dependency) {
+        node.dependencies!.push(dependency);
+      }
+    }
+
+    processing.delete(packageName);
+    nodeCache.set(packageName, node); // Cache the complete node
+    return node;
+  }
+
+  return traverse(tsconfigPath, 0);
+}
+
+/**
+ * Prints the dependency tree in a visual format
+ */
+export function printTree(
+  node: DependencyNode | null,
+  prefix = '',
+  isLast = true,
+  showPaths = false
+): void {
+  if (!node) return;
+
+  const connector = isLast ? TREE_CHARS.last : TREE_CHARS.branch;
+  let info = '';
+
+  if (showPaths && !node.circular && !node.external) {
+    if (node.packagePath) {
+      info = ` (${node.packagePath})`;
+    } else if (node.tsconfigPath) {
+      info = ` (${path.dirname(node.tsconfigPath)})`;
+    }
+  }
+
+  let label = node.id;
+  if (node.circular) {
+    label += ' [CIRCULAR]';
+  } else if (node.external) {
+    label += ' [EXTERNAL]';
+  } else if (node.noTsconfig) {
+    label += ' [NO-TSCONFIG]';
+  }
+
+  // TODO: Use logger instead of console.log - need to pass logger down from CLI context
+  // eslint-disable-next-line no-console
+  console.log(prefix + connector + label + info);
+
+  if (node.dependencies && node.dependencies.length > 0) {
+    const newPrefix = prefix + (isLast ? TREE_CHARS.space : TREE_CHARS.pipe);
+
+    for (let i = 0; i < node.dependencies.length; i++) {
+      const child = node.dependencies[i];
+      const isLastChild = i === node.dependencies.length - 1;
+      printTree(child, newPrefix, isLastChild, showPaths);
+    }
+  }
+}
+
+/**
+ * Prints the dependency tree as JSON
+ */
+export function printJson(tree: DependencyNode | null): void {
+  // TODO: Use logger instead of console.log - need to pass logger down from CLI context
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(tree, null, 2));
+}

--- a/packages/kbn-dependency-tree/src/fixtures/dependency_tree_fixtures.ts
+++ b/packages/kbn-dependency-tree/src/fixtures/dependency_tree_fixtures.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+interface DependencyNode {
+  id: string;
+  tsconfigPath?: string;
+  packagePath?: string;
+  dependencies?: DependencyNode[];
+  circular?: boolean;
+  external?: boolean;
+  noTsconfig?: boolean;
+}
+
+export const simpleTestTree: DependencyNode = {
+  id: '@kbn/test-package',
+  dependencies: [],
+};
+
+export const simpleTreeWithChild: DependencyNode = {
+  id: '@kbn/test-package',
+  dependencies: [{ id: '@kbn/child-package' }],
+};
+
+export const treeWithPaths: DependencyNode = {
+  id: '@kbn/test-package',
+  packagePath: 'packages/kbn-test-package',
+  dependencies: [
+    {
+      id: '@kbn/child-package',
+      packagePath: 'packages/kbn-child-package',
+    },
+  ],
+};
+
+export const circularTree: DependencyNode = {
+  id: '@kbn/test-package',
+  dependencies: [{ id: '@kbn/circular-package', circular: true }],
+};
+
+export const externalTree: DependencyNode = {
+  id: '@kbn/test-package',
+  dependencies: [{ id: '@kbn/external-package', external: true }],
+};
+
+export const noTsconfigTree: DependencyNode = {
+  id: '@kbn/test-package',
+  dependencies: [{ id: '@kbn/no-tsconfig-package', noTsconfig: true }],
+};

--- a/packages/kbn-dependency-tree/src/fixtures/file_system_fixtures.ts
+++ b/packages/kbn-dependency-tree/src/fixtures/file_system_fixtures.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as fs from 'fs';
+
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+export interface FileSystemScenario {
+  rootPackageJson: any;
+  tsconfigFiles: Record<string, string>;
+  existingFiles?: string[];
+}
+
+export function setupFileSystemMocks(scenario: FileSystemScenario) {
+  mockFs.readFileSync.mockImplementation((filePath) => {
+    if (filePath === 'package.json') {
+      return JSON.stringify(scenario.rootPackageJson);
+    }
+
+    if (typeof filePath === 'string' && filePath.includes('tsconfig.json')) {
+      for (const [packageName, content] of Object.entries(scenario.tsconfigFiles)) {
+        if (filePath.includes(packageName)) {
+          return content;
+        }
+      }
+    }
+    return '{}';
+  });
+
+  if (scenario.existingFiles) {
+    mockFs.existsSync.mockImplementation((filePath) => {
+      if (typeof filePath === 'string') {
+        return scenario.existingFiles!.some((existingFile) => filePath.includes(existingFile));
+      }
+      return true;
+    });
+  } else {
+    mockFs.existsSync.mockReturnValue(true);
+  }
+}

--- a/packages/kbn-dependency-tree/src/fixtures/index.ts
+++ b/packages/kbn-dependency-tree/src/fixtures/index.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Logger utilities
+export { createMockLogger } from './logger_fixtures';
+
+// File system mocking utilities
+export { setupFileSystemMocks } from './file_system_fixtures';
+export type { FileSystemScenario } from './file_system_fixtures';
+
+// Package.json test data
+export {
+  rootPackageJsonStandard,
+  rootPackageJsonCircular,
+  rootPackageJsonExternal,
+  rootPackageJsonFiltered,
+  rootPackageJsonNoTsconfig,
+  rootPackageJsonDepth,
+} from './package_json_fixtures';
+
+// Tsconfig.json test data and helpers
+export {
+  tsconfigStandard,
+  tsconfigCircular,
+  tsconfigExternal,
+  tsconfigFiltered,
+  tsconfigDepth,
+  defaultTsconfig,
+  createTsconfigMockImplementation,
+} from './tsconfig_fixtures';
+
+// Dependency tree test data
+export {
+  simpleTestTree,
+  simpleTreeWithChild,
+  treeWithPaths,
+  circularTree,
+  externalTree,
+  noTsconfigTree,
+} from './dependency_tree_fixtures';

--- a/packages/kbn-dependency-tree/src/fixtures/logger_fixtures.ts
+++ b/packages/kbn-dependency-tree/src/fixtures/logger_fixtures.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ToolingLog } from '@kbn/tooling-log';
+
+export function createMockLogger(): jest.Mocked<ToolingLog> {
+  return {
+    info: jest.fn(),
+    error: jest.fn(),
+    warning: jest.fn(),
+    write: jest.fn(),
+  } as any;
+}

--- a/packages/kbn-dependency-tree/src/fixtures/package_json_fixtures.ts
+++ b/packages/kbn-dependency-tree/src/fixtures/package_json_fixtures.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const rootPackageJsonStandard = {
+  dependencies: {
+    '@kbn/test-package': 'link:packages/kbn-test-package',
+    '@kbn/another-package': 'link:packages/kbn-another-package',
+  },
+  devDependencies: {
+    '@kbn/dev-package': 'link:packages/kbn-dev-package',
+  },
+};
+
+export const rootPackageJsonCircular = {
+  dependencies: {
+    '@kbn/test-package': 'link:packages/kbn-test-package',
+    '@kbn/another-package': 'link:packages/kbn-another-package',
+  },
+};
+
+export const rootPackageJsonExternal = {
+  dependencies: {
+    '@kbn/test-package': 'link:packages/kbn-test-package',
+    // Note: @kbn/external-package is NOT included here, making it external
+  },
+};
+
+export const rootPackageJsonFiltered = {
+  dependencies: {
+    '@kbn/test-package': 'link:packages/kbn-test-package',
+    '@kbn/another-package': 'link:packages/kbn-another-package',
+    '@kbn/dev-package': 'link:packages/kbn-dev-package',
+    '@kbn/filtered-out': 'link:packages/kbn-filtered-out',
+  },
+};
+
+export const rootPackageJsonNoTsconfig = {
+  dependencies: {
+    '@kbn/test-package': 'link:packages/kbn-test-package',
+    '@kbn/another-package': 'link:packages/kbn-another-package',
+  },
+};
+
+export const rootPackageJsonDepth = {
+  dependencies: {
+    '@kbn/test-package': 'link:packages/kbn-test-package',
+    '@kbn/another-package': 'link:packages/kbn-another-package',
+    '@kbn/dev-package': 'link:packages/kbn-dev-package',
+  },
+};

--- a/packages/kbn-dependency-tree/src/fixtures/tsconfig_fixtures.ts
+++ b/packages/kbn-dependency-tree/src/fixtures/tsconfig_fixtures.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const tsconfigStandard = {
+  'kbn-test-package': '{"kbn_references": ["@kbn/another-package"]}',
+  'kbn-another-package': '{"kbn_references": []}',
+  'kbn-dev-package': '{"kbn_references": []}',
+};
+
+export const tsconfigCircular = {
+  'kbn-test-package': '{"kbn_references": ["@kbn/another-package"]}',
+  'kbn-another-package': '{"kbn_references": ["@kbn/test-package"]}',
+};
+
+export const tsconfigExternal = {
+  'kbn-test-package': '{"kbn_references": ["@kbn/external-package"]}',
+};
+
+export const tsconfigFiltered = {
+  'kbn-test-package':
+    '{"kbn_references": ["@kbn/another-package", "@kbn/dev-package", "@kbn/filtered-out"]}',
+};
+
+export const tsconfigDepth = {
+  'kbn-test-package': '{"kbn_references": ["@kbn/another-package"]}',
+  'kbn-another-package': '{"kbn_references": ["@kbn/dev-package"]}',
+  'kbn-dev-package': '{"kbn_references": []}',
+};
+
+export const defaultTsconfig = '{}';
+
+export function createTsconfigMockImplementation(scenario: typeof tsconfigStandard) {
+  return (filePath: string | number | Buffer | URL) => {
+    if (filePath === 'package.json') {
+      throw new Error('This function is only for tsconfig.json files');
+    }
+
+    if (typeof filePath === 'string' && filePath.includes('tsconfig.json')) {
+      for (const [packageName, content] of Object.entries(scenario)) {
+        if (filePath.includes(packageName)) {
+          return content;
+        }
+      }
+    }
+    return defaultTsconfig;
+  };
+}

--- a/packages/kbn-dependency-tree/tsconfig.json
+++ b/packages/kbn-dependency-tree/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.bazel.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "target_types"
+  },
+  "include": [
+    "**/*"
+  ],
+  "exclude": [
+    "target_types/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/dev-cli-runner",
+    "@kbn/dev-cli-errors",
+    "@kbn/repo-packages"
+  ]
+}

--- a/scripts/kbn_dependency_tree.js
+++ b/scripts/kbn_dependency_tree.js
@@ -1,0 +1,464 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Kibana Package Dependency Tree
+ *
+ * CLI dependency tree visualization using tsconfig.json files with kbn_references.
+ *
+ * Usage:
+ *   node scripts/kbn_dependency_tree <tsconfig.json> [options]
+ *
+ * Examples:
+ *   node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json
+ *   node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json --depth 2
+ *   node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json --filter "@kbn/ml-"
+ *
+ * Options:
+ *   --depth <n>     Maximum depth to traverse (default: 3)
+ *   --paths         Show package paths in parentheses
+ *   --filter <pattern>  Show only dependencies matching pattern (e.g., "@kbn/ml-", "core")
+ *   --json          Output as JSON
+ */
+
+var fs = require('fs');
+var path = require('path');
+var parseJsonc = require('@kbn/repo-packages/utils/jsonc').parse;
+
+// Constants
+var TREE_CHARS = {
+  branch: '├─ ',
+  last: '└─ ',
+  pipe: '│  ',
+  space: '   ',
+};
+
+var DEFAULT_MAX_DEPTH = 3;
+var ROOT_PACKAGE_JSON_PATH = 'package.json';
+
+// Global state
+var state = {
+  packageMap: null,
+  reversePackageMap: null,
+};
+
+/**
+ * Loads and caches the package map from the root package.json dependencies
+ * @returns {Map<string, string>} Map of package names to their paths
+ */
+function loadPackageMap() {
+  if (state.packageMap) return state.packageMap;
+
+  try {
+    var packageJsonContent = fs.readFileSync(ROOT_PACKAGE_JSON_PATH, 'utf8');
+    var packageJson = JSON.parse(packageJsonContent);
+
+    state.packageMap = new Map();
+    state.reversePackageMap = new Map();
+
+    // Parse dependencies for @kbn packages with "link:" prefix
+    if (packageJson.dependencies) {
+      Object.entries(packageJson.dependencies).forEach(function ([packageName, packageSpec]) {
+        if (packageName.startsWith('@kbn/') && packageSpec.startsWith('link:')) {
+          var packagePath = packageSpec.replace('link:', '');
+          state.packageMap.set(packageName, packagePath);
+          state.reversePackageMap.set(packagePath, packageName);
+        }
+      });
+    }
+
+    return state.packageMap;
+  } catch (error) {
+    console.error('Failed to load package map from root package.json:', error.message);
+    return new Map();
+  }
+}
+
+/**
+ * Extracts kbn_references from a tsconfig.json file
+ * @param {string} tsconfigPath - Path to the tsconfig.json file
+ * @returns {string[]} Array of @kbn package references
+ */
+function readTsconfigReferences(tsconfigPath) {
+  try {
+    if (!fs.existsSync(tsconfigPath)) {
+      console.warn(`Warning: File does not exist at ${tsconfigPath}`);
+      return [];
+    }
+
+    var tsconfigContent = fs.readFileSync(tsconfigPath, 'utf8');
+    var tsconfig = parseJsonc(tsconfigContent);
+
+    if (!tsconfig.kbn_references || !Array.isArray(tsconfig.kbn_references)) {
+      return [];
+    }
+
+    return tsconfig.kbn_references.filter(function (ref) {
+      // Handle string references
+      if (typeof ref === 'string') {
+        return ref.startsWith('@kbn/');
+      }
+      // Skip object references (like { "path": "..." })
+      return false;
+    });
+  } catch (error) {
+    console.warn(`Warning: Could not read tsconfig at ${tsconfigPath}: ${error.message}`);
+    return [];
+  }
+}
+
+/**
+ * Gets the file path for a given package name
+ * @param {string} packageName - The @kbn package name
+ * @returns {string|null} The package path or null if not found
+ */
+function getPackagePath(packageName) {
+  var pkgMap = loadPackageMap();
+  return pkgMap.get(packageName) || null;
+}
+
+/**
+ * Gets the package name for a given package path using reverse lookup
+ * @param {string} packagePath - The path to the package directory
+ * @returns {string|null} The package name or null if not found
+ */
+function getPackageNameFromPath(packagePath) {
+  loadPackageMap(); // Ensure maps are loaded
+  return state.reversePackageMap.get(packagePath) || null;
+}
+
+/**
+ * Finds the tsconfig.json file for a given package path
+ * @param {string} packagePath - The path to the package directory
+ * @returns {string|null} The path to tsconfig.json or null if not found
+ */
+function findTsconfigForPackage(packagePath) {
+  var tsconfigPath = path.join(packagePath, 'tsconfig.json');
+  return fs.existsSync(tsconfigPath) ? tsconfigPath : null;
+}
+
+/**
+ * Gets the package name from a tsconfig.json path using reverse lookup
+ * @param {string} tsconfigPath - Path to the tsconfig.json file
+ * @returns {string} The package name, or a fallback based on directory name
+ */
+function getPackageNameFromTsconfig(tsconfigPath) {
+  var packagePath = path.dirname(tsconfigPath);
+
+  // First try exact path lookup
+  var packageName = getPackageNameFromPath(packagePath);
+  if (packageName) {
+    return packageName;
+  } else {
+    throw new Error(`Package name not found for tsconfig at ${tsconfigPath}`);
+  }
+}
+
+/**
+ * Builds a dependency tree from a tsconfig.json file
+ * @param {string} tsconfigPath - Path to the root tsconfig.json
+ * @param {Object} options - Configuration options
+ * @returns {Object|null} The dependency tree
+ */
+function buildDependencyTree(tsconfigPath, options) {
+  options = options || {};
+  var maxDepth = options.maxDepth || DEFAULT_MAX_DEPTH;
+  var filter = options.filter || null;
+  var nodeCache = new Map(); // Cache complete dependency nodes
+  var processing = new Set();
+
+  function traverse(currentTsconfigPath, depth, currentPath) {
+    currentPath = currentPath || [];
+    if (depth > maxDepth) return null;
+
+    var packageName = getPackageNameFromTsconfig(currentTsconfigPath);
+
+    if (processing.has(packageName)) {
+      return { id: packageName, circular: true };
+    }
+
+    // Return cached node if already processed
+    if (nodeCache.has(packageName)) {
+      return nodeCache.get(packageName);
+    }
+
+    if (currentPath.includes(packageName)) {
+      return { id: packageName, circular: true };
+    }
+
+    processing.add(packageName);
+    var references = readTsconfigReferences(currentTsconfigPath);
+    var filteredRefs = applyFilters(references, filter);
+
+    var node = createDependencyNode(packageName, currentTsconfigPath);
+
+    for (var i = 0; i < filteredRefs.length; i++) {
+      var refPackageName = filteredRefs[i];
+      var dependency = processDependency(
+        refPackageName,
+        depth,
+        currentPath,
+        packageName,
+        maxDepth,
+        traverse
+      );
+      if (dependency) {
+        node.dependencies.push(dependency);
+      }
+    }
+
+    processing.delete(packageName);
+    nodeCache.set(packageName, node); // Cache the complete node
+    return node;
+  }
+
+  return traverse(tsconfigPath, 0);
+}
+
+/**
+ * Applies filters to the list of references
+ * @param {string[]} references - The original references
+ * @param {string|null} filter - Filter pattern to match package names
+ * @returns {string[]} Filtered references
+ */
+function applyFilters(references, filter) {
+  if (!filter) {
+    return references;
+  }
+
+  return references.filter(function (ref) {
+    return ref.includes(filter);
+  });
+}
+
+/**
+ * Creates a dependency node structure
+ * @param {string} packageName - The package name
+ * @param {string} tsconfigPath - Path to tsconfig
+ * @returns {Object} Dependency node
+ */
+function createDependencyNode(packageName, tsconfigPath) {
+  return {
+    id: packageName,
+    tsconfigPath: tsconfigPath,
+    packagePath: path.dirname(tsconfigPath),
+    dependencies: [],
+  };
+}
+
+/**
+ * Processes a single dependency reference
+ * @param {string} refPackageName - The dependency package name
+ * @param {number} depth - Current traversal depth
+ * @param {string[]} currentPath - Current path to detect cycles
+ * @param {string} packageName - Current package name
+ * @param {number} maxDepth - Maximum traversal depth
+ * @param {Function} traverse - Recursive traversal function
+ * @returns {Object|null} Processed dependency node
+ */
+function processDependency(refPackageName, depth, currentPath, packageName, maxDepth, traverse) {
+  if (currentPath.includes(refPackageName)) {
+    return { id: refPackageName, circular: true };
+  }
+
+  var refPackagePath = getPackagePath(refPackageName);
+  if (!refPackagePath) {
+    return { id: refPackageName, external: true };
+  }
+
+  var refTsconfigPath = findTsconfigForPackage(refPackagePath);
+  if (!refTsconfigPath) {
+    return { id: refPackageName, packagePath: refPackagePath, noTsconfig: true };
+  }
+
+  if (depth < maxDepth) {
+    var newPath = currentPath.slice();
+    newPath.push(packageName);
+    var childNode = traverse(refTsconfigPath, depth + 1, newPath);
+    if (childNode) {
+      return childNode;
+    }
+  }
+
+  return {
+    id: refPackageName,
+    packagePath: refPackagePath,
+    tsconfigPath: refTsconfigPath,
+  };
+}
+
+function printTree(node, prefix, isLast, showPaths) {
+  prefix = prefix || '';
+  isLast = isLast !== false;
+  showPaths = showPaths || false;
+  if (!node) return;
+
+  var connector = isLast ? TREE_CHARS.last : TREE_CHARS.branch;
+  var info = '';
+
+  if (showPaths && !node.circular && !node.external) {
+    if (node.packagePath) {
+      info = ' (' + node.packagePath + ')';
+    } else if (node.tsconfigPath) {
+      info = ' (' + path.dirname(node.tsconfigPath) + ')';
+    }
+  }
+
+  var label = node.id;
+  if (node.circular) {
+    label += ' [CIRCULAR]';
+  } else if (node.external) {
+    label += ' [EXTERNAL]';
+  } else if (node.noTsconfig) {
+    label += ' [NO-TSCONFIG]';
+  }
+
+  console.log(prefix + connector + label + info);
+
+  if (node.dependencies && node.dependencies.length > 0) {
+    var newPrefix = prefix + (isLast ? TREE_CHARS.space : TREE_CHARS.pipe);
+
+    for (var i = 0; i < node.dependencies.length; i++) {
+      var child = node.dependencies[i];
+      var isLastChild = i === node.dependencies.length - 1;
+      printTree(child, newPrefix, isLastChild, showPaths);
+    }
+  }
+}
+
+function printJson(tree) {
+  console.log(JSON.stringify(tree, null, 2));
+}
+
+/**
+ * Prints usage information and exits
+ */
+function printUsage() {
+  console.log('Usage: node scripts/kbn_dependency_tree <tsconfig.json> [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --depth <n>     Maximum depth to traverse (default: ' + DEFAULT_MAX_DEPTH + ')');
+  console.log('  --paths         Show package paths in parentheses');
+  console.log('  --filter <pattern>  Show only dependencies matching pattern');
+  console.log('  --json          Output as JSON');
+  console.log('  --help          Show this help message');
+  console.log('');
+  console.log('Examples:');
+  console.log('  node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json');
+  console.log(
+    '  node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json --depth 2'
+  );
+  console.log(
+    '  node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json --filter "@kbn/ml-"'
+  );
+  process.exit(0);
+}
+
+/**
+ * Parses command line arguments into structured options
+ * @param {string[]} args - Command line arguments
+ * @returns {Object} Parsed options
+ */
+function parseArgs(args) {
+  var flags = args.filter(function (arg) {
+    return arg.startsWith('--');
+  });
+  var params = args.filter(function (arg) {
+    return !arg.startsWith('--');
+  });
+
+  if (params.length < 1 || args.includes('--help')) {
+    printUsage();
+  }
+
+  function getArgValue(flag) {
+    var index = args.indexOf(flag);
+    return index >= 0 && args[index + 1] ? args[index + 1] : null;
+  }
+
+  return {
+    tsconfigPath: params[0],
+    maxDepth: parseInt(getArgValue('--depth')) || DEFAULT_MAX_DEPTH,
+    filterPattern: getArgValue('--filter'),
+    showPaths: flags.includes('--paths'),
+    jsonOutput: flags.includes('--json'),
+  };
+}
+
+/**
+ * Prints header information for non-JSON output
+ * @param {string} tsconfigPath - Path to tsconfig
+ * @param {string|null} filterPattern - Filter pattern
+ */
+function printHeader(tsconfigPath, filterPattern) {
+  console.log('@kbn dependency tree for ' + tsconfigPath);
+  if (filterPattern) {
+    console.log('(filtered to packages containing: "' + filterPattern + '")');
+  }
+  console.log('');
+}
+
+/**
+ * Prints legend information
+ * @param {string|null} filterPattern - Filter pattern
+ */
+function printLegend(filterPattern) {
+  console.log('');
+  console.log('Legend:');
+  console.log('  [EXTERNAL]     - Package not found in root package.json dependencies');
+  console.log('  [CIRCULAR]     - Circular dependency detected');
+  console.log('  [NO-TSCONFIG]  - Package found but no tsconfig.json');
+
+  if (filterPattern) {
+    console.log('  Filtered to packages containing: "' + filterPattern + '"');
+  }
+}
+
+function main() {
+  var args = process.argv.slice(2);
+  var options = parseArgs(args);
+  var tsconfigPath = options.tsconfigPath;
+  var maxDepth = options.maxDepth;
+  var filterPattern = options.filterPattern;
+  var showPaths = options.showPaths;
+  var jsonOutput = options.jsonOutput;
+
+  if (!fs.existsSync(tsconfigPath)) {
+    console.error('Error: tsconfig.json file "' + tsconfigPath + '" does not exist');
+    process.exit(1);
+  }
+
+  if (!jsonOutput) {
+    printHeader(tsconfigPath, filterPattern);
+  }
+
+  var treeOptions = {
+    maxDepth: maxDepth,
+    filter: filterPattern,
+  };
+
+  var tree = buildDependencyTree(tsconfigPath, treeOptions);
+
+  if (jsonOutput) {
+    printJson(tree);
+  } else {
+    if (tree) {
+      printTree(tree, '', true, showPaths);
+    } else {
+      console.log('No dependencies found or unable to build dependency tree.');
+    }
+    printLegend(filterPattern);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -856,6 +856,8 @@
       "@kbn/dependency-injection-example-plugin/*": ["examples/dependency_injection/*"],
       "@kbn/dependency-ownership": ["packages/kbn-dependency-ownership"],
       "@kbn/dependency-ownership/*": ["packages/kbn-dependency-ownership/*"],
+      "@kbn/dependency-tree": ["packages/kbn-dependency-tree"],
+      "@kbn/dependency-tree/*": ["packages/kbn-dependency-tree/*"],
       "@kbn/dependency-usage": ["packages/kbn-dependency-usage"],
       "@kbn/dependency-usage/*": ["packages/kbn-dependency-usage/*"],
       "@kbn/dev-cli-errors": ["src/platform/packages/shared/kbn-dev-cli-errors"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5685,6 +5685,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/dependency-tree@link:packages/kbn-dependency-tree":
+  version "0.0.0"
+  uid ""
+
 "@kbn/dependency-usage@link:packages/kbn-dependency-usage":
   version "0.0.0"
   uid ""
@@ -30841,7 +30845,7 @@ string-replace-loader@^3.1.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -30858,15 +30862,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -30960,7 +30955,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -30973,13 +30968,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -33796,7 +33784,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -33817,15 +33805,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -33941,7 +33920,7 @@ xpath@^0.0.33:
   resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.33.tgz#5136b6094227c5df92002e7c3a13516a5074eb07"
   integrity sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==
 
-"xstate5@npm:xstate@^5.19.2":
+"xstate5@npm:xstate@^5.19.2", xstate@^5.19.2:
   version "5.19.2"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.19.2.tgz#db3f1ee614bbb6a49ad3f0c96ddbf98562d456ba"
   integrity sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==
@@ -33950,11 +33929,6 @@ xstate@^4.38.3:
   version "4.38.3"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.38.3.tgz#4e15e7ad3aa0ca1eea2010548a5379966d8f1075"
   integrity sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==
-
-xstate@^5.19.2:
-  version "5.19.2"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.19.2.tgz#db3f1ee614bbb6a49ad3f0c96ddbf98562d456ba"
-  integrity sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Summary

```bash
  node scripts/kbn_dependency_tree <tsconfig.json> [options]

  CLI dependency tree visualization using tsconfig.json files with kbn_references

  Options:
    Examples:
    node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json
    node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json --depth 2
    node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json --filter "@kbn/ml-"
    Options:
    --depth <n>      Maximum depth to traverse (default: 3)
    --paths          Show package paths in parentheses
    --filter <pattern>  Show only dependencies matching pattern (e.g., "@kbn/ml-", "core")
    --json           Output as JSON
    --verbose, -v      Log verbosely
    --debug            Log debug messages (less than verbose)
    --quiet            Only log errors
    --silent           Don't log anything
    --help             Show this message
```

Example output running

`node scripts/kbn_dependency_tree x-pack/platform/plugins/shared/ml/tsconfig.json --filter "@kbn/ml-"`:

```bash
 info @kbn dependency tree for x-pack/platform/plugins/shared/ml/tsconfig.json
 info (filtered to packages containing: "@kbn/ml-")
 info 
└─ @kbn/ml-plugin
   ├─ @kbn/ml-agg-utils
   │  ├─ @kbn/ml-is-populated-object
   │  ├─ @kbn/ml-string-hash
   │  └─ @kbn/ml-random-sampler-utils
   │     └─ @kbn/ml-is-populated-object
   ├─ @kbn/ml-anomaly-utils
   │  └─ @kbn/ml-is-populated-object
   ├─ @kbn/ml-category-validator
   │  └─ @kbn/ml-runtime-field-utils
   │     └─ @kbn/ml-is-populated-object
   ├─ @kbn/ml-creation-wizard-utils
   ├─ @kbn/ml-data-frame-analytics-utils
   │  ├─ @kbn/ml-is-populated-object
   │  ├─ @kbn/ml-error-utils
   │  │  └─ @kbn/ml-is-populated-object
   │  └─ @kbn/ml-anomaly-utils
   │     └─ @kbn/ml-is-populated-object
   ├─ @kbn/ml-data-grid
   │  ├─ @kbn/ml-nested-property
   │  ├─ @kbn/ml-agg-utils
   │  │  ├─ @kbn/ml-is-populated-object
   │  │  ├─ @kbn/ml-string-hash
   │  │  └─ @kbn/ml-random-sampler-utils
   │  │     └─ @kbn/ml-is-populated-object
   │  ├─ @kbn/ml-error-utils
   │  │  └─ @kbn/ml-is-populated-object
   │  ├─ @kbn/ml-data-frame-analytics-utils
   │  │  ├─ @kbn/ml-is-populated-object
   │  │  ├─ @kbn/ml-error-utils
   │  │  │  └─ @kbn/ml-is-populated-object
   │  │  └─ @kbn/ml-anomaly-utils
   │  │     └─ @kbn/ml-is-populated-object
   │  ├─ @kbn/ml-is-populated-object
   │  ├─ @kbn/ml-date-picker
   │  │  ├─ @kbn/ml-url-state
   │  │  │  ├─ @kbn/ml-nested-property
   │  │  │  └─ @kbn/ml-is-populated-object
   │  │  ├─ @kbn/ml-is-populated-object
   │  │  └─ @kbn/ml-query-utils
   │  │     └─ @kbn/ml-is-populated-object
   │  ├─ @kbn/ml-query-utils
   │  │  └─ @kbn/ml-is-populated-object
   │  └─ @kbn/ml-date-utils
...
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



