### PR TITLE
[8.19] fix issue with reporting user prompt choice selection (#232745)

### DIFF
--- a/x-pack/platform/plugins/private/product_intercept/public/intercept_registration_config.tsx
+++ b/x-pack/platform/plugins/private/product_intercept/public/intercept_registration_config.tsx
@@ -138,14 +138,14 @@ export const productInterceptRegistrationConfig = ({
       });
     },
     onFinish: ({ response: feedbackResponse, runId }) => {
-      eventReporter.reportInterceptInteraction({
+      eventReporter.reportInterceptInteractionTermination({
         interactionType: 'completion',
         interceptRunId: runId,
       });
     },
     onDismiss: ({ runId }) => {
       // still update user profile run count, a dismissal is still an interaction
-      eventReporter.reportInterceptInteraction({
+      eventReporter.reportInterceptInteractionTermination({
         interactionType: 'dismissal',
         interceptRunId: runId,
       });

--- a/x-pack/platform/plugins/private/product_intercept/public/telemetry/event_reporter.test.ts
+++ b/x-pack/platform/plugins/private/product_intercept/public/telemetry/event_reporter.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PromptTelemetry } from './event_reporter';
+import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
+
+describe('event reporter', () => {
+  it('exports a setup and start function', () => {
+    // Test implementation
+    const eventReporter = new PromptTelemetry();
+
+    expect(eventReporter).toHaveProperty('setup', expect.any(Function));
+    expect(eventReporter).toHaveProperty('start', expect.any(Function));
+  });
+
+  it('should register events types for intercept', () => {
+    const eventReporter = new PromptTelemetry();
+
+    const analyticsSetup = analyticsServiceMock.createAnalyticsServiceSetup();
+
+    eventReporter.setup({
+      analytics: analyticsSetup,
+    });
+
+    expect(analyticsSetup.registerEventType).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return reporting functions on start', () => {
+    const eventReporter = new PromptTelemetry();
+
+    const analyticsSetup = analyticsServiceMock.createAnalyticsServiceSetup();
+    const analyticsStart = analyticsServiceMock.createAnalyticsServiceStart();
+
+    eventReporter.setup({
+      analytics: analyticsSetup,
+    });
+
+    const reportingFunctions = eventReporter.start({ analytics: analyticsStart });
+
+    expect(reportingFunctions).toHaveProperty(
+      'reportInterceptInteractionTermination',
+      expect.any(Function)
+    );
+    expect(reportingFunctions).toHaveProperty(
+      'reportInterceptInteractionProgress',
+      expect.any(Function)
+    );
+    expect(reportingFunctions).toHaveProperty('reportTriggerFetchError', expect.any(Function));
+  });
+
+  describe('reportInterceptInteractionTermination', () => {
+    it('should report the interaction', () => {
+      const eventReporter = new PromptTelemetry();
+
+      const analyticsSetup = analyticsServiceMock.createAnalyticsServiceSetup();
+      const analyticsStart = analyticsServiceMock.createAnalyticsServiceStart();
+
+      eventReporter.setup({
+        analytics: analyticsSetup,
+      });
+
+      const reportingFunctions = eventReporter.start({ analytics: analyticsStart });
+
+      reportingFunctions.reportInterceptInteractionTermination({
+        interceptRunId: 1,
+        interactionType: 'dismissal',
+      });
+
+      expect(analyticsStart.reportEvent).toHaveBeenCalledWith(
+        'product_intercept_termination_interaction',
+        {
+          interaction_run_id: String(1),
+          interaction_type: 'dismissal',
+        }
+      );
+    });
+  });
+
+  describe('reportInterceptInteractionProgress', () => {
+    it('should report the interaction', () => {
+      const eventReporter = new PromptTelemetry();
+
+      const analyticsSetup = analyticsServiceMock.createAnalyticsServiceSetup();
+      const analyticsStart = analyticsServiceMock.createAnalyticsServiceStart();
+
+      eventReporter.setup({
+        analytics: analyticsSetup,
+      });
+
+      const reportingFunctions = eventReporter.start({ analytics: analyticsStart });
+
+      reportingFunctions.reportInterceptInteractionProgress({
+        interceptRunId: 1,
+        metricId: 'satisfaction',
+        value: 5,
+      });
+
+      expect(analyticsStart.reportEvent).toHaveBeenCalledWith(
+        'product_intercept_interaction_progress',
+        {
+          interaction_run_id: String(1),
+          interaction_metric: 'satisfaction',
+          interaction_metric_value: 5,
+        }
+      );
+    });
+  });
+
+  describe('reportTriggerFetchError', () => {
+    it('should report the error', () => {
+      const eventReporter = new PromptTelemetry();
+
+      const analyticsSetup = analyticsServiceMock.createAnalyticsServiceSetup();
+      const analyticsStart = analyticsServiceMock.createAnalyticsServiceStart();
+
+      eventReporter.setup({
+        analytics: analyticsSetup,
+      });
+
+      const reportingFunctions = eventReporter.start({ analytics: analyticsStart });
+
+      reportingFunctions.reportTriggerFetchError({
+        errorMessage: 'Fetch failed',
+      });
+
+      expect(analyticsStart.reportEvent).toHaveBeenCalledWith(
+        'product_intercept_trigger_fetch_error',
+        {
+          trigger_fetch_error_message: 'Fetch failed',
+        }
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/private/product_intercept/public/telemetry/event_reporter.ts
+++ b/x-pack/platform/plugins/private/product_intercept/public/telemetry/event_reporter.ts
@@ -23,9 +23,9 @@ export class PromptTelemetry {
     this.reportEvent = analytics.reportEvent;
 
     return {
-      reportInterceptInteraction: this.reportInterceptTermination,
-      reportInterceptInteractionProgress: this.reportInterceptInteractionProgress,
-      reportTriggerFetchError: this.reportTriggerFetchError,
+      reportInterceptInteractionTermination: this.reportInterceptTermination.bind(this),
+      reportInterceptInteractionProgress: this.reportInterceptInteractionProgress.bind(this),
+      reportTriggerFetchError: this.reportTriggerFetchError.bind(this),
     };
   }
 

--- a/x-pack/platform/plugins/private/product_intercept/tsconfig.json
+++ b/x-pack/platform/plugins/private/product_intercept/tsconfig.json
@@ -19,7 +19,8 @@
     "@kbn/i18n",
     "@kbn/intercepts-plugin",
     "@kbn/i18n-react",
-    "@kbn/cloud-plugin"
+    "@kbn/cloud-plugin",
+    "@kbn/core-analytics-browser-mocks"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [fix issue with reporting user prompt choice selection (#232745)](https://github.com/elastic/kibana/pull/232745)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-26T10:27:18Z","message":"fix issue with reporting user prompt choice selection (#232745)\n\n## Summary\n\nThis PR fixes an issue that caused selections for input provided by the\nuser not to be transmitted.\n\n### How to test\n\n- Add the following config to your `kibana.dev.yml` file\n\n\t```\n\t xpack.product_intercept.interval: '10s'\n\t```\n\tSo you have intercepts show up frequently.\n- participate in the survey presented, on participating when a score is\nselected, verify that a request is made that includes the payload for\nthe selected option, by examining the `kibana-browser` request path, the\nproperty to look for is `properties`. You'd be presented with a payload\nsimilar to the screenshot below;\n\t\n<img width=\"1546\" height=\"717\" alt=\"Screenshot 2025-08-26 at 11 57 59\"\nsrc=\"https://github.com/user-attachments/assets/0825e5e0-a1e5-411b-bcfd-268ea3a489bd\"\n/>\n\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e1cb3fd9f4aeb8719484c095c18ebcc381fbeba1","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","backport:prev-minor","v9.2.0","v9.1.3"],"title":"fix issue with reporting user prompt choice selection","number":232745,"url":"https://github.com/elastic/kibana/pull/232745","mergeCommit":{"message":"fix issue with reporting user prompt choice selection (#232745)\n\n## Summary\n\nThis PR fixes an issue that caused selections for input provided by the\nuser not to be transmitted.\n\n### How to test\n\n- Add the following config to your `kibana.dev.yml` file\n\n\t```\n\t xpack.product_intercept.interval: '10s'\n\t```\n\tSo you have intercepts show up frequently.\n- participate in the survey presented, on participating when a score is\nselected, verify that a request is made that includes the payload for\nthe selected option, by examining the `kibana-browser` request path, the\nproperty to look for is `properties`. You'd be presented with a payload\nsimilar to the screenshot below;\n\t\n<img width=\"1546\" height=\"717\" alt=\"Screenshot 2025-08-26 at 11 57 59\"\nsrc=\"https://github.com/user-attachments/assets/0825e5e0-a1e5-411b-bcfd-268ea3a489bd\"\n/>\n\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e1cb3fd9f4aeb8719484c095c18ebcc381fbeba1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232745","number":232745,"mergeCommit":{"message":"fix issue with reporting user prompt choice selection (#232745)\n\n## Summary\n\nThis PR fixes an issue that caused selections for input provided by the\nuser not to be transmitted.\n\n### How to test\n\n- Add the following config to your `kibana.dev.yml` file\n\n\t```\n\t xpack.product_intercept.interval: '10s'\n\t```\n\tSo you have intercepts show up frequently.\n- participate in the survey presented, on participating when a score is\nselected, verify that a request is made that includes the payload for\nthe selected option, by examining the `kibana-browser` request path, the\nproperty to look for is `properties`. You'd be presented with a payload\nsimilar to the screenshot below;\n\t\n<img width=\"1546\" height=\"717\" alt=\"Screenshot 2025-08-26 at 11 57 59\"\nsrc=\"https://github.com/user-attachments/assets/0825e5e0-a1e5-411b-bcfd-268ea3a489bd\"\n/>\n\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e1cb3fd9f4aeb8719484c095c18ebcc381fbeba1"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/232926","number":232926,"state":"MERGED","mergeCommit":{"sha":"7cc3773df245650977847600f3f2c59d2f26ddcc","message":"[9.1] fix issue with reporting user prompt choice selection (#232745) (#232926)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [fix issue with reporting user prompt choice selection\n(#232745)](https://github.com/elastic/kibana/pull/232745)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Eyo O. Eyo <7893459+eokoneyo@users.noreply.github.com>"}}]}] BACKPORT-->