### PR TITLE
[FTR] Moved superuser tests to stateful-only configs

### DIFF
--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/create.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/create.ts
@@ -26,7 +26,6 @@ export default function createSpacesOnlySuite(context: DeploymentAgnosticFtrProv
         spaceId: SPACES.DEFAULT.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace: AUTHENTICATION.KIBANA_RBAC_DEFAULT_SPACE_ALL_USER,
@@ -39,7 +38,6 @@ export default function createSpacesOnlySuite(context: DeploymentAgnosticFtrProv
         spaceId: SPACES.SPACE_1.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace: AUTHENTICATION.KIBANA_RBAC_SPACE_1_ALL_USER,
@@ -72,28 +70,6 @@ export default function createSpacesOnlySuite(context: DeploymentAgnosticFtrProv
         },
       });
 
-      createTest(`superuser from the ${scenario.spaceId} space`, {
-        spaceId: scenario.spaceId,
-        user: scenario.users.superuser,
-        tests: {
-          newSpace: {
-            statusCode: 200,
-            response: expectNewSpaceResult,
-          },
-          alreadyExists: {
-            statusCode: 409,
-            response: expectConflictResponse,
-          },
-          reservedSpecified: {
-            statusCode: 200,
-            response: expectReservedSpecifiedResult,
-          },
-          solutionSpecified: {
-            statusCode: 200,
-            response: expectSolutionSpecifiedResult,
-          },
-        },
-      });
       createTest(`rbac user with all globally from the ${scenario.spaceId} space`, {
         spaceId: scenario.spaceId,
         user: scenario.users.allGlobally,

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/delete.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/delete.ts
@@ -25,7 +25,6 @@ export default function deleteSpaceTestSuite(context: DeploymentAgnosticFtrProvi
         spaceId: SPACES.DEFAULT.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace: AUTHENTICATION.KIBANA_RBAC_DEFAULT_SPACE_ALL_USER,
@@ -38,7 +37,6 @@ export default function deleteSpaceTestSuite(context: DeploymentAgnosticFtrProvi
         spaceId: SPACES.SPACE_1.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace: AUTHENTICATION.KIBANA_RBAC_SPACE_1_ALL_USER,
@@ -63,25 +61,6 @@ export default function deleteSpaceTestSuite(context: DeploymentAgnosticFtrProvi
           doesntExist: {
             statusCode: 403,
             response: expectRbacForbidden,
-          },
-        },
-      });
-
-      deleteTest(`superuser from the ${scenario.spaceId} space`, {
-        spaceId: scenario.spaceId,
-        user: scenario.users.superuser,
-        tests: {
-          exists: {
-            statusCode: 204,
-            response: expectEmptyResult,
-          },
-          reservedSpace: {
-            statusCode: 400,
-            response: expectReservedSpaceResult,
-          },
-          doesntExist: {
-            statusCode: 404,
-            response: expectNotFound,
           },
         },
       });

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/get.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/get.ts
@@ -26,7 +26,6 @@ export default function getSpaceTestSuite(context: DeploymentAgnosticFtrProvider
         otherSpaceId: SPACES.SPACE_1.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace: AUTHENTICATION.KIBANA_RBAC_DEFAULT_SPACE_ALL_USER,
@@ -42,7 +41,6 @@ export default function getSpaceTestSuite(context: DeploymentAgnosticFtrProvider
         otherSpaceId: SPACES.DEFAULT.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace: AUTHENTICATION.KIBANA_RBAC_SPACE_1_ALL_USER,
@@ -58,7 +56,6 @@ export default function getSpaceTestSuite(context: DeploymentAgnosticFtrProvider
         otherSpaceId: SPACES.DEFAULT.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace: AUTHENTICATION.KIBANA_RBAC_SPACE_3_ALL_USER,
@@ -78,18 +75,6 @@ export default function getSpaceTestSuite(context: DeploymentAgnosticFtrProvider
           default: {
             statusCode: 403,
             response: createExpectRbacForbidden(scenario.spaceId),
-          },
-        },
-      });
-
-      getTest(`superuser`, {
-        currentSpaceId: scenario.spaceId,
-        spaceId: scenario.spaceId,
-        user: scenario.users.superuser,
-        tests: {
-          default: {
-            statusCode: 200,
-            response: createExpectResults(scenario.spaceId),
           },
         },
       });

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/get_all.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/get_all.ts
@@ -37,7 +37,6 @@ export default function getAllSpacesTestSuite(context: DeploymentAgnosticFtrProv
         spaceId: SPACES.DEFAULT.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace_1: AUTHENTICATION.KIBANA_RBAC_SPACE_1_ALL_USER,
@@ -59,7 +58,6 @@ export default function getAllSpacesTestSuite(context: DeploymentAgnosticFtrProv
         spaceId: SPACES.SPACE_1.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace_1: AUTHENTICATION.KIBANA_RBAC_SPACE_1_ALL_USER,
@@ -98,29 +96,6 @@ export default function getAllSpacesTestSuite(context: DeploymentAgnosticFtrProv
           includeAuthorizedPurposes: {
             statusCode: 403,
             response: expectRbacForbidden,
-          },
-        },
-      });
-
-      getAllTest(`superuser can access all spaces from ${scenario.spaceId}`, {
-        spaceId: scenario.spaceId,
-        user: scenario.users.superuser,
-        tests: {
-          exists: {
-            statusCode: 200,
-            response: createExpectResults(...spaces),
-          },
-          copySavedObjectsPurpose: {
-            statusCode: 200,
-            response: createExpectResults(...spaces),
-          },
-          shareSavedObjectsPurpose: {
-            statusCode: 200,
-            response: createExpectResults(...spaces),
-          },
-          includeAuthorizedPurposes: {
-            statusCode: 200,
-            response: createExpectAllPurposesResults(authorizedAll, ...spaces),
           },
         },
       });

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/index_basic.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/index_basic.ts
@@ -25,5 +25,12 @@ export default function ({ loadTestFile, getService }: DeploymentAgnosticFtrProv
     loadTestFile(require.resolve('./get_all'));
     loadTestFile(require.resolve('./get'));
     loadTestFile(require.resolve('./update'));
+
+    loadTestFile(require.resolve('./superuser/resolve_copy_to_space_conflicts'));
+    loadTestFile(require.resolve('./superuser/create'));
+    loadTestFile(require.resolve('./superuser/delete'));
+    loadTestFile(require.resolve('./superuser/get_all'));
+    loadTestFile(require.resolve('./superuser/get'));
+    loadTestFile(require.resolve('./superuser/update'));
   });
 }

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/index_trial.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/index_trial.ts
@@ -17,5 +17,12 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./get_all'));
     loadTestFile(require.resolve('./get'));
     loadTestFile(require.resolve('./update'));
+
+    loadTestFile(require.resolve('./superuser/resolve_copy_to_space_conflicts'));
+    loadTestFile(require.resolve('./superuser/create'));
+    loadTestFile(require.resolve('./superuser/delete'));
+    loadTestFile(require.resolve('./superuser/get_all'));
+    loadTestFile(require.resolve('./superuser/get'));
+    loadTestFile(require.resolve('./superuser/update'));
   });
 }

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/resolve_copy_to_space_conflicts.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/resolve_copy_to_space_conflicts.ts
@@ -38,7 +38,6 @@ export default function resolveCopyToSpaceConflictsTestSuite(
         spaceId: SPACES.DEFAULT.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace: AUTHENTICATION.KIBANA_RBAC_DEFAULT_SPACE_ALL_USER,
@@ -51,7 +50,6 @@ export default function resolveCopyToSpaceConflictsTestSuite(
         spaceId: SPACES.SPACE_1.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace: AUTHENTICATION.KIBANA_RBAC_SPACE_1_ALL_USER,
@@ -182,10 +180,6 @@ export default function resolveCopyToSpaceConflictsTestSuite(
       resolveCopyToSpaceConflictsTest(
         `user with no access from the ${spaceId} space`,
         definitionNoAccess(scenario.users.noAccess)
-      );
-      resolveCopyToSpaceConflictsTest(
-        `superuser from the ${spaceId} space`,
-        definitionAuthorized(scenario.users.superuser)
       );
       resolveCopyToSpaceConflictsTest(
         `rbac user with all globally from the ${spaceId} space`,

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/create.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/create.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AUTHENTICATION } from '../../../../common/lib/authentication';
+import { SPACES } from '../../../../common/lib/spaces';
+import { createTestSuiteFactory } from '../../../../common/suites/create.agnostic';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
+
+export default function createSpacesOnlySuite(context: DeploymentAgnosticFtrProviderContext) {
+  const {
+    createTest,
+    expectNewSpaceResult,
+    expectReservedSpecifiedResult,
+    expectConflictResponse,
+    expectSolutionSpecifiedResult,
+  } = createTestSuiteFactory(context);
+
+  describe('create', () => {
+    [
+      {
+        spaceId: SPACES.DEFAULT.spaceId,
+      },
+      {
+        spaceId: SPACES.SPACE_1.spaceId,
+      },
+    ].forEach((scenario) => {
+      createTest(`superuser from the ${scenario.spaceId} space`, {
+        spaceId: scenario.spaceId,
+        user: AUTHENTICATION.SUPERUSER,
+        tests: {
+          newSpace: {
+            statusCode: 200,
+            response: expectNewSpaceResult,
+          },
+          alreadyExists: {
+            statusCode: 409,
+            response: expectConflictResponse,
+          },
+          reservedSpecified: {
+            statusCode: 200,
+            response: expectReservedSpecifiedResult,
+          },
+          solutionSpecified: {
+            statusCode: 200,
+            response: expectSolutionSpecifiedResult,
+          },
+        },
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/delete.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/delete.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AUTHENTICATION } from '../../../../common/lib/authentication';
+import { SPACES } from '../../../../common/lib/spaces';
+import { deleteTestSuiteFactory } from '../../../../common/suites/delete.agnostic';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
+
+export default function deleteSpaceTestSuite(context: DeploymentAgnosticFtrProviderContext) {
+  const { deleteTest, expectEmptyResult, expectNotFound, expectReservedSpaceResult } =
+    deleteTestSuiteFactory(context);
+
+  describe('delete', () => {
+    [
+      {
+        spaceId: SPACES.DEFAULT.spaceId,
+      },
+      {
+        spaceId: SPACES.SPACE_1.spaceId,
+      },
+    ].forEach((scenario) => {
+      deleteTest(`superuser from the ${scenario.spaceId} space`, {
+        spaceId: scenario.spaceId,
+        user: AUTHENTICATION.SUPERUSER,
+        tests: {
+          exists: {
+            statusCode: 204,
+            response: expectEmptyResult,
+          },
+          reservedSpace: {
+            statusCode: 400,
+            response: expectReservedSpaceResult,
+          },
+          doesntExist: {
+            statusCode: 404,
+            response: expectNotFound,
+          },
+        },
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/get.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/get.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AUTHENTICATION } from '../../../../common/lib/authentication';
+import { SPACES } from '../../../../common/lib/spaces';
+import { getTestSuiteFactory } from '../../../../common/suites/get.agnostic';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
+
+export default function getSpaceTestSuite(context: DeploymentAgnosticFtrProviderContext) {
+  const { getTest, createExpectResults } = getTestSuiteFactory(context);
+
+  describe('get', () => {
+    [
+      {
+        spaceId: SPACES.DEFAULT.spaceId,
+        otherSpaceId: SPACES.SPACE_1.spaceId,
+      },
+      {
+        spaceId: SPACES.SPACE_1.spaceId,
+        otherSpaceId: SPACES.DEFAULT.spaceId,
+      },
+      {
+        spaceId: SPACES.SPACE_3.spaceId, // This space has a solution set and we expect disabledFeatures to be automatically set
+        otherSpaceId: SPACES.DEFAULT.spaceId,
+      },
+    ].forEach((scenario) => {
+      getTest(`superuser`, {
+        currentSpaceId: scenario.spaceId,
+        spaceId: scenario.spaceId,
+        user: AUTHENTICATION.SUPERUSER,
+        tests: {
+          default: {
+            statusCode: 200,
+            response: createExpectResults(scenario.spaceId),
+          },
+        },
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/get_all.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/get_all.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AUTHENTICATION } from '../../../../common/lib/authentication';
+import { SPACES } from '../../../../common/lib/spaces';
+import { getAllTestSuiteFactory } from '../../../../common/suites/get_all.agnostic';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
+
+export default function getAllSpacesTestSuite(context: DeploymentAgnosticFtrProviderContext) {
+  const { getAllTest, createExpectResults, createExpectAllPurposesResults } =
+    getAllTestSuiteFactory(context);
+
+  const spaces = ['default', 'space_1', 'space_2', 'space_3'];
+
+  // these are used to determine expected results for tests where the `include_authorized_purposes` option is enabled
+  const authorizedAll = {
+    any: true,
+    copySavedObjectsIntoSpace: true,
+    findSavedObjects: true,
+    shareSavedObjectsIntoSpace: true,
+  };
+
+  describe('get all', () => {
+    [
+      {
+        spaceId: SPACES.DEFAULT.spaceId,
+      },
+      {
+        spaceId: SPACES.SPACE_1.spaceId,
+      },
+    ].forEach((scenario) => {
+      getAllTest(`superuser can access all spaces from ${scenario.spaceId}`, {
+        spaceId: scenario.spaceId,
+        user: AUTHENTICATION.SUPERUSER,
+        tests: {
+          exists: {
+            statusCode: 200,
+            response: createExpectResults(...spaces),
+          },
+          copySavedObjectsPurpose: {
+            statusCode: 200,
+            response: createExpectResults(...spaces),
+          },
+          shareSavedObjectsPurpose: {
+            statusCode: 200,
+            response: createExpectResults(...spaces),
+          },
+          includeAuthorizedPurposes: {
+            statusCode: 200,
+            response: createExpectAllPurposesResults(authorizedAll, ...spaces),
+          },
+        },
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/resolve_copy_to_space_conflicts.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/resolve_copy_to_space_conflicts.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AUTHENTICATION } from '../../../../common/lib/authentication';
+import { SPACES } from '../../../../common/lib/spaces';
+import { resolveCopyToSpaceConflictsSuite } from '../../../../common/suites/resolve_copy_to_space_conflicts.agnostic';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
+
+interface TestUser {
+  username: string;
+  password: string;
+  role: string;
+}
+
+export default function resolveCopyToSpaceConflictsTestSuite(
+  context: DeploymentAgnosticFtrProviderContext
+) {
+  const {
+    resolveCopyToSpaceConflictsTest,
+    createExpectNonOverriddenResponseWithReferences,
+    createExpectNonOverriddenResponseWithoutReferences,
+    createExpectOverriddenResponseWithReferences,
+    createExpectOverriddenResponseWithoutReferences,
+    createMultiNamespaceTestCases,
+    NON_EXISTENT_SPACE_ID,
+  } = resolveCopyToSpaceConflictsSuite(context);
+
+  describe('resolve copy to spaces conflicts', () => {
+    [
+      {
+        spaceId: SPACES.DEFAULT.spaceId,
+      },
+      {
+        spaceId: SPACES.SPACE_1.spaceId,
+      },
+    ].forEach(({ spaceId }) => {
+      const definitionAuthorized = (user: TestUser) => ({
+        spaceId,
+        user,
+        tests: {
+          withReferencesNotOverwriting: {
+            statusCode: 200,
+            response: createExpectNonOverriddenResponseWithReferences(spaceId),
+          },
+          withReferencesOverwriting: {
+            statusCode: 200,
+            response: createExpectOverriddenResponseWithReferences(spaceId),
+          },
+          withoutReferencesOverwriting: {
+            statusCode: 200,
+            response: createExpectOverriddenResponseWithoutReferences(spaceId),
+          },
+          withoutReferencesNotOverwriting: {
+            statusCode: 200,
+            response: createExpectNonOverriddenResponseWithoutReferences(spaceId),
+          },
+          nonExistentSpace: {
+            statusCode: 200,
+            response: createExpectOverriddenResponseWithoutReferences(
+              spaceId,
+              NON_EXISTENT_SPACE_ID
+            ),
+          },
+          multiNamespaceTestCases: createMultiNamespaceTestCases(spaceId, 'authorized'),
+        },
+      });
+
+      resolveCopyToSpaceConflictsTest(
+        `superuser from the ${spaceId} space`,
+        definitionAuthorized(AUTHENTICATION.SUPERUSER)
+      );
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/update.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/superuser/update.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AUTHENTICATION } from '../../../../common/lib/authentication';
+import { SPACES } from '../../../../common/lib/spaces';
+import { updateTestSuiteFactory } from '../../../../common/suites/update.agnostic';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
+
+export default function updateSpaceTestSuite(context: DeploymentAgnosticFtrProviderContext) {
+  const { updateTest, expectNotFound, expectAlreadyExistsResult, expectDefaultSpaceResult } =
+    updateTestSuiteFactory(context);
+
+  describe('update', () => {
+    [
+      {
+        spaceId: SPACES.DEFAULT.spaceId,
+      },
+      {
+        spaceId: SPACES.SPACE_1.spaceId,
+      },
+    ].forEach((scenario) => {
+      updateTest(`superuser from the ${scenario.spaceId} space`, {
+        spaceId: scenario.spaceId,
+        user: AUTHENTICATION.SUPERUSER,
+        tests: {
+          alreadyExists: {
+            statusCode: 200,
+            response: expectAlreadyExistsResult,
+          },
+          defaultSpace: {
+            statusCode: 200,
+            response: expectDefaultSpaceResult,
+          },
+          newSpace: {
+            statusCode: 404,
+            response: expectNotFound,
+          },
+        },
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/update.ts
+++ b/x-pack/platform/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/update.ts
@@ -25,7 +25,6 @@ export default function updateSpaceTestSuite(context: DeploymentAgnosticFtrProvi
         spaceId: SPACES.DEFAULT.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace: AUTHENTICATION.KIBANA_RBAC_SPACE_1_ALL_USER,
@@ -39,7 +38,6 @@ export default function updateSpaceTestSuite(context: DeploymentAgnosticFtrProvi
         spaceId: SPACES.SPACE_1.spaceId,
         users: {
           noAccess: AUTHENTICATION.NOT_A_KIBANA_USER,
-          superuser: AUTHENTICATION.SUPERUSER,
           allGlobally: AUTHENTICATION.KIBANA_RBAC_USER,
           readGlobally: AUTHENTICATION.KIBANA_RBAC_DASHBOARD_ONLY_USER,
           allAtSpace: AUTHENTICATION.KIBANA_RBAC_SPACE_1_ALL_USER,
@@ -65,25 +63,6 @@ export default function updateSpaceTestSuite(context: DeploymentAgnosticFtrProvi
           newSpace: {
             statusCode: 403,
             response: expectRbacForbidden,
-          },
-        },
-      });
-
-      updateTest(`superuser from the ${scenario.spaceId} space`, {
-        spaceId: scenario.spaceId,
-        user: scenario.users.superuser,
-        tests: {
-          alreadyExists: {
-            statusCode: 200,
-            response: expectAlreadyExistsResult,
-          },
-          defaultSpace: {
-            statusCode: 200,
-            response: expectDefaultSpaceResult,
-          },
-          newSpace: {
-            statusCode: 404,
-            response: expectNotFound,
           },
         },
       });


### PR DESCRIPTION
## Summary

Moved superuser tests to stateful-only configs,

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




