### PR TITLE
🌊 [Group streams] Allow Group streams without Wired streams being enabled

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/route.ts
@@ -106,10 +106,10 @@ export const editStreamRoute = createServerRoute({
     const { streamsClient } = await getScopedClients({ request });
 
     if (
-      !Streams.ClassicStream.UpsertRequest.is(params.body) &&
+      Streams.WiredStream.UpsertRequest.is(params.body) &&
       !(await streamsClient.isStreamsEnabled())
     ) {
-      throw badData('Streams are not enabled for Wired and Group streams.');
+      throw badData('Streams are not enabled for Wired streams.');
     }
 
     const core = await context.core;

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/group/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/group/route.ts
@@ -81,10 +81,6 @@ const upsertGroupRoute = createServerRoute({
       request,
     });
 
-    if (!(await streamsClient.isStreamsEnabled())) {
-      throw badData('Streams are not enabled for Group streams.');
-    }
-
     const core = await context.core;
     const groupStreamsEnabled = await core.uiSettings.client.get(
       OBSERVABILITY_STREAMS_ENABLE_GROUP_STREAMS


### PR DESCRIPTION
## Summary

This PR changes the feature flag checks in the Group streams APIs to allow creation of Group streams even if Wired streams aren't enabled.

The UI (Streams and Group streams) can be enabled with an Advanced Setting, but since the API still expected Wired streams to be enabled it caused some confusion.

Since Group streams can work with only Classic streams, rather than binding the UI to the `_enable` status, I'm instead removing the checks from the APIs.