### PR TITLE
multi-hop search tool

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/prompts.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/prompts.ts
@@ -16,14 +16,44 @@ import {
 export const getSearchPrompt = ({
   nlQuery,
   searchTarget,
+  attempt,
+  previousAttemptSummaries,
+  maxAttempts,
 }: {
   nlQuery: string;
   searchTarget: SearchTarget;
+  attempt?: number; // 0-based
+  previousAttemptSummaries?: string[];
+  maxAttempts?: number;
 }): BaseMessageLike[] => {
-  const systemPrompt = `You are an expert search dispatcher. Your sole task is to analyze a user's request and call the single most appropriate tool to answer it.
-You **must** call **one** of the available tools. Do not answer the user directly or ask clarifying questions.
+  const attemptNumber = (attempt ?? 0) + 1; // human readable 1-based
+  const remaining = maxAttempts ? Math.max(maxAttempts - attemptNumber, 0) : undefined;
+  const hasHistory = (previousAttemptSummaries?.length ?? 0) > 0;
 
-## Available Tools
+  const historySection = hasHistory
+    ? `\n\nPrevious attempts (${previousAttemptSummaries!.length}):\n- ${previousAttemptSummaries!
+        .map((s) => s.replace(/\n+/g, ' '))
+        .join('\n- ')}\n\nIf a previous attempt produced only errors or no meaningful results, you MUST adjust your strategy: choose the alternative tool or modify the parameters (shorter / more specific term for relevance search; clearer analytical intent for natural language analytic tool).`
+    : '';
+
+  const retryGuidance = maxAttempts
+    ? `\nYou are on attempt ${attemptNumber} of up to ${maxAttempts}. ${
+        remaining && remaining > 0
+          ? `If this attempt fails to produce a non-error result, you will still have ${remaining} more attempt$${
+              remaining === 1 ? '' : 's'
+            }.`
+          : 'This is the final attempt, so produce the best possible tool call.'
+      }`
+    : '';
+
+  const systemPrompt = `You are an expert search dispatcher. Your sole task is to analyze a user's request and call the single most appropriate tool to answer it.
+You operate in a lightweight ReAct style (Think -> Tool). You MUST always:
+1. Think: silently decide the best strategy (keep reasoning ultra concise)
+2. Call exactly ONE tool with well-formed, non-redundant arguments
+
+CRITICAL: Do NOT answer the user directly. Do NOT ask clarifying questions. Never fabricate results. If unsure, still pick the most plausible tool and adjust parameters.
+
+## Available Tools (choose EXACTLY ONE per attempt)
 
 ### 1. Relevance Search Tool ('${relevanceTool}')
 - **Purpose**: For full-text, relevance-based searches. Use this when the user is looking for documents based on topics, concepts, or matching unstructured text. The results are ranked by a relevance score.
@@ -40,9 +70,17 @@ You **must** call **one** of the available tools. Do not answer the user directl
   - "list all products where status is 'in_stock' and price is less than 50"
   - "how many errors were logged in the past hour?"
 
-## Additional instructions
+## Execution Rules
 
-- The search will be performed against the \`${searchTarget.name}\` ${searchTarget.type}, so you should use that value for the \`index\` parameters of the tool you will call.`;
+- Target: use \`${searchTarget.name}\` (${searchTarget.type}) for any index-related parameter.
+- Format your response so the model emits a tool call (not plain text output to user).
+- Provide at most one short reasoning line BEFORE the tool call (<= 40 words). Avoid lists, markdown, or restating the query.
+- Adapt: if prior attempts failed or were empty, CHANGE something (tool choice, query terms, filters, aggregation focus). Never repeat an identical call.
+- Prefer relevance search for unstructured semantic / conceptual queries; prefer natural language analytic tool for structured, filter, sort, aggregate, count, or top-N style tasks.
+- If this is the final allowed attempt, be decisive and broaden or strategically narrow to maximize useful signal.
+- Never include raw previous attempt summaries verbatim in parameters—derive improvements from them.
+- Absolutely no multiple tool calls in a single response.
+${historySection}${retryGuidance}`;
 
   const userPrompt = `Execute the following user query: "${nlQuery}"`;
 

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/convert_graph_events.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/convert_graph_events.ts
@@ -68,8 +68,9 @@ export const convertGraphEvents = ({
           }
         }
 
-        // emit tool calls or full message on each agent step
-        if (matchEvent(event, 'on_chain_end') && matchName(event, 'agent')) {
+  // emit tool calls or full message on each agent step
+  // also handle the guidance fallback node 'ask_user' which behaves like an agent message without tool calls
+  if (matchEvent(event, 'on_chain_end') && (matchName(event, 'agent') || matchName(event, 'ask_user'))) {
           const addedMessages: BaseMessage[] = event.data.output.addedMessages ?? [];
           const lastMessage = addedMessages[addedMessages.length - 1];
 


### PR DESCRIPTION
## Summary


This pull request enhances the search and agent graph logic for OneChat, introducing more robust retry and guidance mechanisms when tool calls fail or are exhausted. The changes focus on improving agent resilience, user guidance, and providing clearer context for each search attempt.

**Search Tool Graph Improvements**

* Added tracking for search attempts, summaries, and a configurable maximum number of attempts (`maxAttempts`, `attempt`, `attemptSummaries`) to `graph.ts`, allowing the agent to retry intelligently and record outcomes.
* Enhanced the agent's decision-making: after each tool execution, the agent checks for non-error results, retries up to `maxAttempts`, and provides final guidance if all attempts fail.
* Incorporated attempt history and retry guidance into the search prompt, ensuring the agent adapts its strategy after failed attempts and never repeats identical tool calls. [[1]](diffhunk://#diff-d23cf11c8f2d7ef8d0e4e97b84840b8ffec7cfc67ae5d9e9f8a1ee274aff104cR19-R56) [[2]](diffhunk://#diff-d23cf11c8f2d7ef8d0e4e97b84840b8ffec7cfc67ae5d9e9f8a1ee274aff104cL43-R83)

**Agent Graph Improvements**

* Introduced `maxToolCalls` and `toolCallCount` to the agent graph, limiting the number of tool calls and routing to a guidance node (`ask_user`) when the limit is reached. [[1]](diffhunk://#diff-80b9c183538a23d8dbb0365437249a262d48ee444fbc4d2db61890a058e235b5R23-R30) [[2]](diffhunk://#diff-80b9c183538a23d8dbb0365437249a262d48ee444fbc4d2db61890a058e235b5L67-R122)
* Added a new node (`ask_user`) that synthesizes an assistant message requesting more details from the user if the agent cannot answer after exhausting tool calls.

**Integration and Event Handling**

* Updated event conversion logic to handle the new `ask_user` node, emitting its messages as agent responses when guidance is needed.

These changes collectively make the agent more robust, user-friendly, and capable of handling ambiguous or difficult queries by providing clear feedback and guidance.

**References:**  
[[1]](diffhunk://#diff-7bb66f28786f0180e9687fae3d3f122514577482be60d02edb6ba3300656b951R27-R46) [[2]](diffhunk://#diff-7bb66f28786f0180e9687fae3d3f122514577482be60d02edb6ba3300656b951L88-R184) [[3]](diffhunk://#diff-d23cf11c8f2d7ef8d0e4e97b84840b8ffec7cfc67ae5d9e9f8a1ee274aff104cR19-R56) [[4]](diffhunk://#diff-d23cf11c8f2d7ef8d0e4e97b84840b8ffec7cfc67ae5d9e9f8a1ee274aff104cL43-R83) [[5]](diffhunk://#diff-80b9c183538a23d8dbb0365437249a262d48ee444fbc4d2db61890a058e235b5R23-R30) [[6]](diffhunk://#diff-80b9c183538a23d8dbb0365437249a262d48ee444fbc4d2db61890a058e235b5L67-R122) [[7]](diffhunk://#diff-d411767049b5c51146ced53f857d0ff9565ab4d927e8bf40feb63f025d6ae8e8L72-R73)


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



