### PR TITLE
[Search] 1st pass for updated v2 navigation

### DIFF
--- a/src/platform/test/functional/page_objects/solution_navigation.ts
+++ b/src/platform/test/functional/page_objects/solution_navigation.ts
@@ -199,7 +199,9 @@ export function SolutionNavigationProvider(ctx: Pick<FtrProviderContext, 'getSer
         }
         expect(foundNavItemIds).to.have.length(
           navItemIds.length,
-          `Found nav item list length (${foundNavItemIds.length}) does not match expected length (${navItemIds.length}) of side nav items`
+          `Found nav item list length (${foundNavItemIds.length}) does not match expected length (${
+            navItemIds.length
+          }) of side nav items.\nFound items with nav ids:${JSON.stringify(foundNavItemIds)}`
         );
         if (options?.checkOrder !== false) {
           for (let i = 0; i < foundNavItemIds.length; i++) {

--- a/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
@@ -104,7 +104,8 @@ export const getNavigationTreeDefinition = ({
                   getIsActive: ({ pathNameSerialized, prepend }) => {
                     return (
                       pathNameSerialized.startsWith(prepend('/app/elasticsearch/overview')) ||
-                      pathNameSerialized.startsWith(prepend('/app/elasticsearch/start'))
+                      pathNameSerialized.startsWith(prepend('/app/elasticsearch/start')) ||
+                      pathNameSerialized.startsWith(prepend('/app/elasticsearch/home'))
                     );
                   },
                   link: SEARCH_HOMEPAGE,
@@ -112,18 +113,6 @@ export const getNavigationTreeDefinition = ({
                     defaultMessage: 'Home',
                   }),
                   sideNavVersion: 'v1',
-                },
-                {
-                  children: [
-                    { link: 'agent_builder:conversations' },
-                    { link: 'agent_builder:tools' },
-                    { link: 'agent_builder:agents' },
-                  ],
-                  iconV2: 'comment',
-                  id: 'chat',
-                  renderAs: 'panelOpener',
-                  sideNavVersion: 'v2',
-                  title: AGENTS_TITLE,
                 },
                 {
                   link: 'discover',
@@ -144,6 +133,18 @@ export const getNavigationTreeDefinition = ({
                   title: AGENTS_TITLE,
                   renderAs: 'accordion',
                   sideNavVersion: 'v1',
+                },
+                {
+                  children: [
+                    { link: 'agent_builder:conversations' },
+                    { link: 'agent_builder:tools' },
+                    { link: 'agent_builder:agents' },
+                  ],
+                  iconV2: 'comment',
+                  id: 'agent_builder',
+                  renderAs: 'panelOpener',
+                  sideNavVersion: 'v2',
+                  title: AGENTS_TITLE,
                 },
                 {
                   children: [
@@ -326,18 +327,6 @@ export const getNavigationTreeDefinition = ({
                   children: [
                     {
                       children: [
-                        { link: 'management:ingest_pipelines' },
-                        { link: 'management:pipelines' },
-                      ],
-                      title: i18n.translate(
-                        'xpack.enterpriseSearch.searchNav.ingest.pipelines.title',
-                        {
-                          defaultMessage: 'Ingest',
-                        }
-                      ),
-                    },
-                    {
-                      children: [
                         {
                           getIsActive: ({ pathNameSerialized, prepend }) => {
                             return (
@@ -358,6 +347,18 @@ export const getNavigationTreeDefinition = ({
                         'xpack.enterpriseSearch.searchNav.ingest.indices.title',
                         {
                           defaultMessage: 'Indices, data streams and roll ups',
+                        }
+                      ),
+                    },
+                    {
+                      children: [
+                        { link: 'management:ingest_pipelines' },
+                        { link: 'management:pipelines' },
+                      ],
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.searchNav.ingest.pipelines.title',
+                        {
+                          defaultMessage: 'Ingest',
                         }
                       ),
                     },

--- a/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
@@ -116,7 +116,7 @@ export const getNavigationTreeDefinition = ({
                     { link: 'onechat:tools' },
                     { link: 'onechat:agents' },
                   ],
-                  iconV2: 'comment' /* TODO: review icon */,
+                  iconV2: 'comment',
                   id: 'chat',
                   renderAs: 'panelOpener',
                   sideNavVersion: 'v2',

--- a/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
@@ -32,6 +32,9 @@ const title = i18n.translate(
     defaultMessage: 'Elasticsearch',
   }
 );
+const AGENTS_TITLE = i18n.translate('xpack.enterpriseSearch.searchNav.agents', {
+  defaultMessage: 'Agents',
+});
 const icon = 'logoElasticsearch';
 
 const euiItemTypeToNodeDefinition = ({
@@ -112,17 +115,15 @@ export const getNavigationTreeDefinition = ({
                 },
                 {
                   children: [
-                    { link: 'onechat:conversations' },
-                    { link: 'onechat:tools' },
-                    { link: 'onechat:agents' },
+                    { link: 'agent_builder:conversations' },
+                    { link: 'agent_builder:tools' },
+                    { link: 'agent_builder:agents' },
                   ],
                   iconV2: 'comment',
                   id: 'chat',
                   renderAs: 'panelOpener',
                   sideNavVersion: 'v2',
-                  title: i18n.translate('xpack.enterpriseSearch.searchNav.chat', {
-                    defaultMessage: 'Chat',
-                  }),
+                  title: AGENTS_TITLE,
                 },
                 {
                   link: 'discover',
@@ -140,9 +141,7 @@ export const getNavigationTreeDefinition = ({
                     { link: 'agent_builder:agents' },
                   ],
                   id: 'agent_builder',
-                  title: i18n.translate('xpack.enterpriseSearch.searchNav.chat', {
-                    defaultMessage: 'Agents',
-                  }),
+                  title: AGENTS_TITLE,
                   renderAs: 'accordion',
                   sideNavVersion: 'v1',
                 },

--- a/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
@@ -111,6 +111,20 @@ export const getNavigationTreeDefinition = ({
                   sideNavVersion: 'v1',
                 },
                 {
+                  children: [
+                    { link: 'onechat:conversations' },
+                    { link: 'onechat:tools' },
+                    { link: 'onechat:agents' },
+                  ],
+                  iconV2: 'comment' /* TODO: review icon */,
+                  id: 'chat',
+                  renderAs: 'panelOpener',
+                  sideNavVersion: 'v2',
+                  title: i18n.translate('xpack.enterpriseSearch.searchNav.chat', {
+                    defaultMessage: 'Chat',
+                  }),
+                },
+                {
                   link: 'discover',
                 },
                 {
@@ -130,6 +144,7 @@ export const getNavigationTreeDefinition = ({
                     defaultMessage: 'Agents',
                   }),
                   renderAs: 'accordion',
+                  sideNavVersion: 'v1',
                 },
                 {
                   children: [
@@ -142,10 +157,11 @@ export const getNavigationTreeDefinition = ({
                         );
                       },
                       link: 'elasticsearchIndexManagement',
-                      iconV2: 'indexManagementApp',
+                      sideNavVersion: 'v1',
                     },
                     {
                       breadcrumbStatus: 'hidden',
+                      iconV2: 'broom' /* TODO: review icon */,
                       link: 'searchPlayground',
                     },
                     {
@@ -162,7 +178,6 @@ export const getNavigationTreeDefinition = ({
                         );
                       },
                       link: 'enterpriseSearchApplications:searchApplications',
-                      iconV2: 'searchProfilerApp' /* TODO: review icon */,
                       renderAs: 'item',
                       ...(searchApps
                         ? {
@@ -171,6 +186,7 @@ export const getNavigationTreeDefinition = ({
                             renderAs: 'accordion',
                           }
                         : {}),
+                      sideNavVersion: 'v1',
                     },
                     {
                       getIsActive: ({ pathNameSerialized, prepend }) => {
@@ -197,6 +213,7 @@ export const getNavigationTreeDefinition = ({
                             renderAs: 'accordion',
                           }
                         : {}),
+                      sideNavVersion: 'v1',
                     },
                   ],
                   id: 'build',
@@ -208,12 +225,80 @@ export const getNavigationTreeDefinition = ({
                   children: [
                     { link: 'searchSynonyms:synonyms' },
                     { link: 'searchQueryRules' },
-                    { link: 'searchInferenceEndpoints:inferenceEndpoints' },
+                    { link: 'searchInferenceEndpoints:inferenceEndpoints', sideNavVersion: 'v1' },
                   ],
                   id: 'relevance',
                   title: i18n.translate('xpack.enterpriseSearch.searchNav.relevance', {
                     defaultMessage: 'Relevance',
                   }),
+                },
+                {
+                  children: [
+                    {
+                      id: 'ml_overview',
+                      title: '',
+                      children: [{ link: 'ml:overview' }, { link: 'ml:dataVisualizer' }],
+                    },
+                    {
+                      id: 'category-anomaly_detection',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.searchNav.machineLearning.anomalyDetection',
+                        {
+                          defaultMessage: 'Anomaly detection',
+                        }
+                      ),
+                      breadcrumbStatus: 'hidden',
+                      children: [{ link: 'ml:anomalyExplorer' }, { link: 'ml:singleMetricViewer' }],
+                    },
+                    {
+                      id: 'category-data_frame analytics',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.searchNav.machineLearning.dataFrameAnalytics',
+                        {
+                          defaultMessage: 'Data frame analytics',
+                        }
+                      ),
+                      breadcrumbStatus: 'hidden',
+                      children: [{ link: 'ml:resultExplorer' }, { link: 'ml:analyticsMap' }],
+                    },
+                    {
+                      id: 'category-aiops_labs',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.searchNav.machineLearning.aiops_labs',
+                        {
+                          defaultMessage: 'AIOps labs',
+                        }
+                      ),
+                      breadcrumbStatus: 'hidden',
+                      children: [
+                        { link: 'ml:logRateAnalysis' },
+                        { link: 'ml:logPatternAnalysis' },
+                        { link: 'ml:changePointDetections' },
+                      ],
+                    },
+                  ],
+                  iconV2: 'machineLearningApp',
+                  id: 'machine_learning',
+                  renderAs: 'panelOpener',
+                  sideNavVersion: 'v2',
+                  title: i18n.translate('xpack.enterpriseSearch.searchNav.machineLearning', {
+                    defaultMessage: 'Machine Learning',
+                  }),
+                },
+                {
+                  iconV2: 'globe' /* TODO: review icon */,
+                  link: 'maps',
+                  sideNavVersion: 'v2',
+                },
+                {
+                  iconV2: 'graphApp',
+                  link: 'graph',
+                  sideNavVersion: 'v2',
+                },
+                {
+                  iconV2: 'visualizeApp',
+                  link: 'visualize',
+                  sideNavVersion: 'v2',
                 },
               ],
               defaultIsCollapsed: false,
@@ -231,11 +316,64 @@ export const getNavigationTreeDefinition = ({
                   getIsActive: ({ pathNameSerialized, prepend }) => {
                     return pathNameSerialized.startsWith(prepend('/app/dev_tools'));
                   },
+                  iconV2: 'code',
                   id: 'dev_tools',
                   link: 'dev_tools',
                   title: i18n.translate('xpack.enterpriseSearch.searchNav.devTools', {
-                    defaultMessage: 'Dev Tools',
+                    defaultMessage: 'Developer Tools',
                   }),
+                },
+                {
+                  children: [
+                    {
+                      children: [
+                        { link: 'management:ingest_pipelines' },
+                        { link: 'management:pipelines' },
+                      ],
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.searchNav.ingest.pipelines.title',
+                        {
+                          defaultMessage: 'Ingest',
+                        }
+                      ),
+                    },
+                    {
+                      children: [
+                        {
+                          getIsActive: ({ pathNameSerialized, prepend }) => {
+                            return (
+                              pathNameSerialized.startsWith(
+                                prepend('/app/elasticsearch/index_management/indices')
+                              ) ||
+                              pathNameSerialized.startsWith(prepend('/app/elasticsearch/indices'))
+                            );
+                          },
+                          link: 'elasticsearchIndexManagement',
+                        },
+                        { link: 'management:index_lifecycle_management' },
+                        { link: 'management:snapshot_restore' },
+                        { link: 'management:transform' },
+                        { link: 'management:rollup_jobs' },
+                      ],
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.searchNav.ingest.indices.title',
+                        {
+                          defaultMessage: 'Indices, data streams and roll ups',
+                        }
+                      ),
+                    },
+                  ],
+                  iconV2: 'database',
+                  id: 'ingest_and_data',
+                  sideNavVersion: 'v2',
+                  renderAs: 'panelOpener',
+                  title: i18n.translate('xpack.enterpriseSearch.searchNav.ingestAndData', {
+                    defaultMessage: 'Ingest and manage data',
+                  }),
+                },
+                {
+                  id: 'monitoring',
+                  link: 'monitoring',
                 },
                 {
                   breadcrumbStatus: 'hidden',
@@ -248,6 +386,7 @@ export const getNavigationTreeDefinition = ({
                           defaultMessage: 'Trained Models',
                         }
                       ),
+                      sideNavVersion: 'v1',
                     },
                     {
                       iconV2: 'managementApp',
@@ -257,7 +396,13 @@ export const getNavigationTreeDefinition = ({
                             { link: 'management:ingest_pipelines' },
                             { link: 'management:pipelines' },
                           ],
-                          title: 'Ingest',
+                          title: i18n.translate(
+                            'xpack.enterpriseSearch.searchNav.management.ingest',
+                            {
+                              defaultMessage: 'Ingest',
+                            }
+                          ),
+                          sideNavVersion: 'v1',
                         },
                         {
                           children: [
@@ -270,7 +415,13 @@ export const getNavigationTreeDefinition = ({
                             { link: 'management:remote_clusters' },
                             { link: 'management:migrate_data' },
                           ],
-                          title: 'Data',
+                          title: i18n.translate(
+                            'xpack.enterpriseSearch.searchNav.management.data',
+                            {
+                              defaultMessage: 'Data',
+                            }
+                          ),
+                          sideNavVersion: 'v1',
                         },
                         {
                           children: [
@@ -282,11 +433,27 @@ export const getNavigationTreeDefinition = ({
                             { link: 'management:watcher' },
                             { link: 'management:maintenanceWindows' },
                           ],
-                          title: 'Alerts and Insights',
+                          title: i18n.translate(
+                            'xpack.enterpriseSearch.searchNav.management.alerts',
+                            {
+                              defaultMessage: 'Alerts and Insights',
+                            }
+                          ),
                         },
                         {
-                          children: [{ link: 'management:trained_models' }],
-                          title: 'Machine Learning',
+                          children: [
+                            { link: 'management:trained_models' },
+                            {
+                              link: 'searchInferenceEndpoints:inferenceEndpoints',
+                              sideNavVersion: 'v2',
+                            },
+                          ],
+                          title: i18n.translate(
+                            'xpack.enterpriseSearch.searchNav.management.machineLearning',
+                            {
+                              defaultMessage: 'Machine Learning',
+                            }
+                          ),
                         },
                         {
                           children: [
@@ -295,19 +462,63 @@ export const getNavigationTreeDefinition = ({
                             { link: 'management:api_keys' },
                             { link: 'management:role_mappings' },
                           ],
-                          title: 'Security',
+                          title: i18n.translate(
+                            'xpack.enterpriseSearch.searchNav.management.security',
+                            {
+                              defaultMessage: 'Security',
+                            }
+                          ),
+                        },
+                        {
+                          children: [
+                            { link: 'management:cross_cluster_replication' },
+                            { link: 'management:remote_clusters' },
+                            { link: 'management:migrate_data' },
+                          ],
+                          title: i18n.translate(
+                            'xpack.enterpriseSearch.searchNav.management.dataV2',
+                            {
+                              defaultMessage: 'Data',
+                            }
+                          ),
+                          sideNavVersion: 'v2',
                         },
                         {
                           children: [
                             { link: 'management:dataViews' },
                             { link: 'management:filesManagement' },
                             { link: 'management:objects' },
+                            {
+                              getIsActive: ({ pathNameSerialized, prepend }) => {
+                                const someSubItemSelected = searchApps?.some((app) =>
+                                  app.items?.some((item) => item.isSelected)
+                                );
+
+                                if (someSubItemSelected) return false;
+
+                                return (
+                                  pathNameSerialized ===
+                                  prepend(
+                                    `/app/elasticsearch/applications${SEARCH_APPLICATIONS_PATH}`
+                                  )
+                                );
+                              },
+                              iconV2: 'searchProfilerApp' /* TODO: review icon */,
+                              link: 'enterpriseSearchApplications:searchApplications',
+                              renderAs: 'item',
+                              sideNavVersion: 'v2',
+                            },
                             { link: 'management:tags' },
                             { link: 'management:search_sessions' },
                             { link: 'management:spaces' },
                             { link: 'management:settings' },
                           ],
-                          title: 'Kibana',
+                          title: i18n.translate(
+                            'xpack.enterpriseSearch.searchNav.management.kibana',
+                            {
+                              defaultMessage: 'Kibana',
+                            }
+                          ),
                         },
                         {
                           children: [
@@ -315,14 +526,21 @@ export const getNavigationTreeDefinition = ({
                             { link: 'management:agentBuilder' },
                             { link: 'management:aiAssistantManagementSelection' },
                           ],
-                          title: 'AI',
+                          title: i18n.translate('xpack.enterpriseSearch.searchNav.management.ai', {
+                            defaultMessage: 'AI',
+                          }),
                         },
                         {
                           children: [
                             { link: 'management:license_management' },
                             { link: 'management:upgrade_assistant' },
                           ],
-                          title: 'Stack',
+                          title: i18n.translate(
+                            'xpack.enterpriseSearch.searchNav.management.stack',
+                            {
+                              defaultMessage: 'Stack',
+                            }
+                          ),
                         },
                       ],
                       id: 'stack_management', // This id can't be changed as we use it to open the panel programmatically
@@ -331,10 +549,6 @@ export const getNavigationTreeDefinition = ({
                       title: i18n.translate('xpack.enterpriseSearch.searchNav.mngt', {
                         defaultMessage: 'Stack Management',
                       }),
-                    },
-                    {
-                      id: 'monitoring',
-                      link: 'monitoring',
                     },
                   ],
                   icon: 'gear',

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage.tsx
@@ -8,6 +8,7 @@
 import React, { useEffect, useMemo } from 'react';
 import { EuiHorizontalRule, EuiLoadingSpinner } from '@elastic/eui';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+import { i18n } from '@kbn/i18n';
 import { useKibana } from '../hooks/use_kibana';
 import { useSearchHomePageRedirect } from '../hooks/use_search_home_page_redirect';
 import { SearchHomepageBody } from './search_homepage_body';
@@ -19,7 +20,11 @@ export const SearchHomepagePage = () => {
   } = useKibana();
   useEffect(() => {
     if (searchNavigation) {
-      searchNavigation.breadcrumbs.setSearchBreadCrumbs([]);
+      searchNavigation.breadcrumbs.setSearchBreadCrumbs([
+        {
+          text: i18n.translate('xpack.searchHomepage.breadcrumbs.home', { defaultMessage: 'Home' }),
+        },
+      ]);
     }
   }, [searchNavigation]);
   const { isLoading } = useSearchHomePageRedirect();

--- a/x-pack/solutions/search/test/functional_search/config.ts
+++ b/x-pack/solutions/search/test/functional_search/config.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { resolve } from 'path';
 import type { FtrConfigProviderContext } from '@kbn/test';
 import { services } from './services';
 import { pageObjects } from './page_objects';
@@ -41,5 +42,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       ],
     },
     testFiles: [require.resolve('.')],
+    screenshots: { directory: resolve(__dirname, 'screenshots') },
   };
 }

--- a/x-pack/solutions/search/test/functional_search/config/config.nav_v2.ts
+++ b/x-pack/solutions/search/test/functional_search/config/config.nav_v2.ts
@@ -17,6 +17,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       serverArgs: [
         ...baseConfig.get('kbnTestServer.serverArgs'),
         '--feature_flags.overrides.core.chrome.projectSideNav=v2',
+        '--uiSettings.overrides.agentBuilder:enabled=true',
       ],
     },
     testFiles: [require.resolve('../tests/solution_navigation')],

--- a/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
@@ -197,46 +197,38 @@ export default function searchSolutionNavigation({
     });
 
     it('renders only expected items', async () => {
-      await solutionNavigation.sidenav.openSection(
-        'search_project_nav_footer.project_settings_project_nav'
-      );
-      await solutionNavigation.sidenav.expectSectionOpen(
-        'search_project_nav_footer.project_settings_project_nav'
-      );
       const isV2 = await solutionNavigation.sidenav.isV2();
 
       if (isV2) {
         // in v2 we don't have "sections" and order is different because items under "more" are in the end
         await solutionNavigation.sidenav.expectOnlyDefinedLinks(
           [
-            // home:
             'searchHomepage',
-
-            // main;
             'discover',
             'dashboards',
             'searchPlayground',
             'searchSynonyms:synonyms',
             'searchQueryRules',
-
-            // more:
             'machine_learning',
-            'maps',
-            'graph',
-            'visualize',
-
-            // footer:
             'dev_tools',
             'ingest_and_data',
             'monitoring',
             'stack_management',
+            // more:
+            'maps',
+            'graph',
+            'visualize',
           ],
-          {
-            // don't check order because of "more" menu
-            checkOrder: false,
-          }
+          { checkOrder: false }
         );
       } else {
+        await solutionNavigation.sidenav.openSection(
+          'search_project_nav_footer.project_settings_project_nav'
+        );
+        await solutionNavigation.sidenav.expectSectionOpen(
+          'search_project_nav_footer.project_settings_project_nav'
+        );
+
         await solutionNavigation.sidenav.expectOnlyDefinedLinks([
           'search_project_nav',
           'searchHomepage',

--- a/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
@@ -46,18 +46,34 @@ export default function searchSolutionNavigation({
 
     it('renders expected side nav items', async () => {
       // Verify all expected top-level links exist
+      const isV2 = await solutionNavigation.sidenav.isV2();
+
+      // Items in both v1 & v2 navigation
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Discover' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dashboards' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Index Management' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Search applications' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Synonyms' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Query rules' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Inference endpoints' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Dev Tools' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Developer Tools' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Stack Monitoring' });
+
+      if (isV2) {
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Machine Learning' });
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Maps' });
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Graph' });
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Visualize library' });
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Ingest and manage data' });
+      } else {
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Index Management' });
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Search applications' });
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Inference endpoints' });
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Management' });
+      }
     });
 
     it('has expected navigation', async () => {
+      const isV2 = await solutionNavigation.sidenav.isV2();
+
       const expectNoPageReload = await solutionNavigation.createNoPageReloadCheck();
 
       // check side nav links
@@ -73,48 +89,96 @@ export default function searchSolutionNavigation({
         deepLinkId: AppDeepLinkId;
         breadcrumbs: string[];
         pageTestSubject: string;
-      }> = [
-        {
-          deepLinkId: 'discover',
-          breadcrumbs: ['Discover'],
-          pageTestSubject: 'kbnNoDataPage',
-        },
-        {
-          deepLinkId: 'dashboards',
-          breadcrumbs: ['Dashboards'],
-          pageTestSubject: 'kbnNoDataPage',
-        },
-        {
-          deepLinkId: 'elasticsearchIndexManagement',
-          breadcrumbs: ['Build', 'Index Management', 'Indices'],
-          pageTestSubject: 'elasticsearchIndexManagement',
-        },
-        {
-          deepLinkId: 'searchPlayground',
-          breadcrumbs: ['Build', 'Playground'],
-          pageTestSubject: 'playgroundsListPage',
-        },
-        {
-          deepLinkId: 'enterpriseSearchApplications:searchApplications',
-          breadcrumbs: ['Build', 'Search applications'],
-          pageTestSubject: 'searchApplicationsListPage',
-        },
-        {
-          deepLinkId: 'searchSynonyms:synonyms',
-          breadcrumbs: ['Relevance', 'Synonyms'],
-          pageTestSubject: 'searchSynonymsOverviewPage',
-        },
-        {
-          deepLinkId: 'searchInferenceEndpoints:inferenceEndpoints',
-          breadcrumbs: ['Relevance', 'Inference endpoints'],
-          pageTestSubject: 'inferenceEndpointsPage',
-        },
-        {
-          deepLinkId: 'dev_tools',
-          breadcrumbs: ['Dev Tools'],
-          pageTestSubject: 'console',
-        },
-      ];
+      }> = isV2
+        ? [
+            {
+              deepLinkId: 'discover',
+              breadcrumbs: ['Discover'],
+              pageTestSubject: 'kbnNoDataPage',
+            },
+            {
+              deepLinkId: 'dashboards',
+              breadcrumbs: ['Dashboards'],
+              pageTestSubject: 'kbnNoDataPage',
+            },
+            {
+              deepLinkId: 'searchPlayground',
+              breadcrumbs: ['Build', 'Playground'],
+              pageTestSubject: 'playgroundsListPage',
+            },
+            {
+              deepLinkId: 'searchSynonyms:synonyms',
+              breadcrumbs: ['Relevance', 'Synonyms'],
+              pageTestSubject: 'searchSynonymsOverviewPage',
+            },
+            {
+              deepLinkId: 'searchQueryRules',
+              breadcrumbs: ['Relevance', 'Query rules'],
+              pageTestSubject: 'queryRulesBasePage',
+            },
+            {
+              deepLinkId: 'graph',
+              breadcrumbs: ['Graph'],
+              pageTestSubject: 'graphCreateGraphPromptButton',
+            },
+            {
+              deepLinkId: 'visualize',
+              breadcrumbs: ['Visualize library'],
+              pageTestSubject: 'kbnNoDataPage',
+            },
+            {
+              deepLinkId: 'dev_tools',
+              breadcrumbs: ['Developer Tools'],
+              pageTestSubject: 'console',
+            },
+          ]
+        : [
+            {
+              deepLinkId: 'discover',
+              breadcrumbs: ['Discover'],
+              pageTestSubject: 'kbnNoDataPage',
+            },
+            {
+              deepLinkId: 'dashboards',
+              breadcrumbs: ['Dashboards'],
+              pageTestSubject: 'kbnNoDataPage',
+            },
+            {
+              deepLinkId: 'elasticsearchIndexManagement',
+              breadcrumbs: ['Build', 'Index Management', 'Indices'],
+              pageTestSubject: 'elasticsearchIndexManagement',
+            },
+            {
+              deepLinkId: 'searchPlayground',
+              breadcrumbs: ['Build', 'Playground'],
+              pageTestSubject: 'playgroundsListPage',
+            },
+            {
+              deepLinkId: 'enterpriseSearchApplications:searchApplications',
+              breadcrumbs: ['Build', 'Search applications'],
+              pageTestSubject: 'searchApplicationsListPage',
+            },
+            {
+              deepLinkId: 'searchSynonyms:synonyms',
+              breadcrumbs: ['Relevance', 'Synonyms'],
+              pageTestSubject: 'searchSynonymsOverviewPage',
+            },
+            {
+              deepLinkId: 'searchQueryRules',
+              breadcrumbs: ['Relevance', 'Query rules'],
+              pageTestSubject: 'queryRulesBasePage',
+            },
+            {
+              deepLinkId: 'searchInferenceEndpoints:inferenceEndpoints',
+              breadcrumbs: ['Relevance', 'Inference endpoints'],
+              pageTestSubject: 'inferenceEndpointsPage',
+            },
+            {
+              deepLinkId: 'dev_tools',
+              breadcrumbs: ['Developer Tools'],
+              pageTestSubject: 'console',
+            },
+          ];
 
       for (const testCase of sideNavTestCases) {
         await solutionNavigation.sidenav.clickLink({
@@ -151,20 +215,21 @@ export default function searchSolutionNavigation({
             // main;
             'discover',
             'dashboards',
-            'elasticsearchIndexManagement',
             'searchPlayground',
-            'enterpriseSearchApplications:searchApplications',
-
-            // more:
             'searchSynonyms:synonyms',
             'searchQueryRules',
-            'searchInferenceEndpoints:inferenceEndpoints',
+
+            // more:
+            'machine_learning',
+            'maps',
+            'graph',
+            'visualize',
 
             // footer:
             'dev_tools',
-            'management:trained_models',
-            'stack_management',
+            'ingest_and_data',
             'monitoring',
+            'stack_management',
           ],
           {
             // don't check order because of "more" menu
@@ -187,10 +252,10 @@ export default function searchSolutionNavigation({
           'searchInferenceEndpoints:inferenceEndpoints',
           'search_project_nav_footer',
           'dev_tools',
+          'monitoring',
           'project_settings_project_nav',
           'management:trained_models',
           'stack_management',
-          'monitoring',
         ]);
       }
     });

--- a/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
@@ -8,6 +8,9 @@
 import type { AppDeepLinkId } from '@kbn/core-chrome-browser';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
+const archiveEmptyIndex =
+  'x-pack/solutions/search/test/functional_search/fixtures/search-empty-index';
+
 export default function searchSolutionNavigation({
   getPageObjects,
   getService,
@@ -20,12 +23,14 @@ export default function searchSolutionNavigation({
   const spaces = getService('spaces');
   const browser = getService('browser');
   const testSubjects = getService('testSubjects');
+  const esArchiver = getService('esArchiver');
 
   describe('Search Solution Navigation', () => {
     let cleanUp: () => Promise<unknown>;
     let spaceCreated: { id: string } = { id: '' };
 
     before(async () => {
+      await esArchiver.load(archiveEmptyIndex);
       // Navigate to the spaces management page which will log us in Kibana
       await common.navigateToUrl('management', 'kibana/spaces', {
         shouldUseHashForSubUrl: false,
@@ -42,6 +47,7 @@ export default function searchSolutionNavigation({
     after(async () => {
       // Clean up space created
       await cleanUp();
+      await esArchiver.unload(archiveEmptyIndex);
     });
 
     it('renders expected side nav items', async () => {
@@ -58,6 +64,7 @@ export default function searchSolutionNavigation({
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Stack Monitoring' });
 
       if (isV2) {
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Agents' });
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Machine Learning' });
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Maps' });
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Graph' });
@@ -81,113 +88,126 @@ export default function searchSolutionNavigation({
       await solutionNavigation.sidenav.expectLinkActive({
         deepLinkId: 'searchHomepage',
       });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-        text: 'Create your first index',
-      });
 
       const sideNavTestCases: Array<{
-        deepLinkId: AppDeepLinkId;
+        link: { deepLinkId: AppDeepLinkId } | { navId: string } | { text: string };
         breadcrumbs: string[];
         pageTestSubject: string;
       }> = isV2
         ? [
             {
-              deepLinkId: 'discover',
+              link: { navId: 'agent_builder' },
+              breadcrumbs: ['Agent Chat'],
+              pageTestSubject: 'onechatPageConversations',
+            },
+            {
+              link: { deepLinkId: 'agent_builder:tools' },
+              breadcrumbs: ['Tools'],
+              pageTestSubject: 'kbnAppWrapper visibleChrome',
+            },
+            {
+              link: { deepLinkId: 'agent_builder:agents' },
+              breadcrumbs: ['Agents'],
+              pageTestSubject: 'kbnAppWrapper visibleChrome',
+            },
+            {
+              link: { deepLinkId: 'discover' },
               breadcrumbs: ['Discover'],
-              pageTestSubject: 'kbnNoDataPage',
+              pageTestSubject: 'noDataViewsPrompt',
             },
             {
-              deepLinkId: 'dashboards',
+              link: { deepLinkId: 'dashboards' },
               breadcrumbs: ['Dashboards'],
-              pageTestSubject: 'kbnNoDataPage',
+              pageTestSubject: 'noDataViewsPrompt',
             },
             {
-              deepLinkId: 'searchPlayground',
+              link: { deepLinkId: 'searchPlayground' },
               breadcrumbs: ['Build', 'Playground'],
               pageTestSubject: 'playgroundsListPage',
             },
             {
-              deepLinkId: 'searchSynonyms:synonyms',
+              link: { deepLinkId: 'searchSynonyms:synonyms' },
               breadcrumbs: ['Relevance', 'Synonyms'],
               pageTestSubject: 'searchSynonymsOverviewPage',
             },
             {
-              deepLinkId: 'searchQueryRules',
+              link: { deepLinkId: 'searchQueryRules' },
               breadcrumbs: ['Relevance', 'Query rules'],
               pageTestSubject: 'queryRulesBasePage',
             },
             {
-              deepLinkId: 'graph',
+              link: { deepLinkId: 'graph' },
               breadcrumbs: ['Graph'],
               pageTestSubject: 'graphCreateGraphPromptButton',
             },
             {
-              deepLinkId: 'visualize',
+              link: { deepLinkId: 'visualize' },
               breadcrumbs: ['Visualize library'],
-              pageTestSubject: 'kbnNoDataPage',
+              pageTestSubject: 'noDataViewsPrompt',
             },
             {
-              deepLinkId: 'dev_tools',
+              link: { deepLinkId: 'dev_tools' },
               breadcrumbs: ['Developer Tools'],
               pageTestSubject: 'console',
             },
           ]
         : [
             {
-              deepLinkId: 'discover',
+              link: { deepLinkId: 'searchHomepage' },
+              breadcrumbs: ['Home'],
+              pageTestSubject: 'search-homepage',
+            },
+            {
+              link: { deepLinkId: 'discover' },
               breadcrumbs: ['Discover'],
-              pageTestSubject: 'kbnNoDataPage',
+              pageTestSubject: 'noDataViewsPrompt',
             },
             {
-              deepLinkId: 'dashboards',
+              link: { deepLinkId: 'dashboards' },
               breadcrumbs: ['Dashboards'],
-              pageTestSubject: 'kbnNoDataPage',
+              pageTestSubject: 'noDataViewsPrompt',
             },
             {
-              deepLinkId: 'elasticsearchIndexManagement',
+              link: { deepLinkId: 'elasticsearchIndexManagement' },
               breadcrumbs: ['Build', 'Index Management', 'Indices'],
               pageTestSubject: 'elasticsearchIndexManagement',
             },
             {
-              deepLinkId: 'searchPlayground',
+              link: { deepLinkId: 'searchPlayground' },
               breadcrumbs: ['Build', 'Playground'],
               pageTestSubject: 'playgroundsListPage',
             },
             {
-              deepLinkId: 'enterpriseSearchApplications:searchApplications',
+              link: { deepLinkId: 'enterpriseSearchApplications:searchApplications' },
               breadcrumbs: ['Build', 'Search applications'],
               pageTestSubject: 'searchApplicationsListPage',
             },
             {
-              deepLinkId: 'searchSynonyms:synonyms',
+              link: { deepLinkId: 'searchSynonyms:synonyms' },
               breadcrumbs: ['Relevance', 'Synonyms'],
               pageTestSubject: 'searchSynonymsOverviewPage',
             },
             {
-              deepLinkId: 'searchQueryRules',
+              link: { deepLinkId: 'searchQueryRules' },
               breadcrumbs: ['Relevance', 'Query rules'],
               pageTestSubject: 'queryRulesBasePage',
             },
             {
-              deepLinkId: 'searchInferenceEndpoints:inferenceEndpoints',
+              link: { deepLinkId: 'searchInferenceEndpoints:inferenceEndpoints' },
               breadcrumbs: ['Relevance', 'Inference endpoints'],
               pageTestSubject: 'inferenceEndpointsPage',
             },
             {
-              deepLinkId: 'dev_tools',
+              link: { deepLinkId: 'dev_tools' },
               breadcrumbs: ['Developer Tools'],
               pageTestSubject: 'console',
             },
           ];
 
       for (const testCase of sideNavTestCases) {
-        await solutionNavigation.sidenav.clickLink({
-          deepLinkId: testCase.deepLinkId,
-        });
+        await solutionNavigation.sidenav.clickLink(testCase.link);
         await testSubjects.existOrFail(testCase.pageTestSubject);
-        await solutionNavigation.sidenav.expectLinkActive({
-          deepLinkId: testCase.deepLinkId,
-        });
+        await solutionNavigation.sidenav.expectLinkActive(testCase.link);
         for (const breadcrumb of testCase.breadcrumbs) {
           await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: breadcrumb });
         }
@@ -197,6 +217,7 @@ export default function searchSolutionNavigation({
     });
 
     it('renders only expected items', async () => {
+      await solutionNavigation.sidenav.clickLink({ deepLinkId: 'searchHomepage' });
       const isV2 = await solutionNavigation.sidenav.isV2();
 
       if (isV2) {
@@ -204,6 +225,7 @@ export default function searchSolutionNavigation({
         await solutionNavigation.sidenav.expectOnlyDefinedLinks(
           [
             'searchHomepage',
+            'agent_builder',
             'discover',
             'dashboards',
             'searchPlayground',

--- a/x-pack/solutions/search/test/functional_solution_sidenav/tests/search_sidenav.ts
+++ b/x-pack/solutions/search/test/functional_solution_sidenav/tests/search_sidenav.ts
@@ -34,34 +34,56 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
     describe('sidenav & breadcrumbs', () => {
       it('renders the correct nav and navigate to links', async () => {
+        const isV2 = await solutionNavigation.sidenav.isV2();
         const expectNoPageReload = await solutionNavigation.createNoPageReloadCheck();
 
         await solutionNavigation.expectExists();
         await solutionNavigation.breadcrumbs.expectExists();
 
         // check side nav links
-        await solutionNavigation.sidenav.expectSectionExists('search_project_nav');
         await solutionNavigation.sidenav.expectLinkActive({
           deepLinkId: 'searchHomepage',
         });
 
-        // check the Data > Indices section
-        await solutionNavigation.sidenav.clickLink({
-          deepLinkId: 'elasticsearchIndexManagement',
-        });
-        await solutionNavigation.sidenav.expectLinkActive({
-          deepLinkId: 'elasticsearchIndexManagement',
-        });
-        await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Build' });
-        await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Index Management' });
-        await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-          text: 'Indices',
-        });
+        if (isV2) {
+          await solutionNavigation.sidenav.clickLink({
+            deepLinkId: 'discover',
+          });
+          await solutionNavigation.sidenav.expectLinkActive({
+            deepLinkId: 'discover',
+          });
 
-        // navigate to a different section
-        await solutionNavigation.sidenav.openSection(
-          'search_project_nav_footer.project_settings_project_nav'
-        );
+          await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Discover' });
+
+          // navigate to a different section
+          await solutionNavigation.sidenav.clickLink({
+            deepLinkId: 'searchSynonyms:synonyms',
+          });
+          await solutionNavigation.sidenav.expectLinkActive({
+            deepLinkId: 'searchSynonyms:synonyms',
+          });
+          await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Relevance' });
+          await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Synonyms' });
+        } else {
+          // check the Data > Indices section
+          await solutionNavigation.sidenav.clickLink({
+            deepLinkId: 'elasticsearchIndexManagement',
+          });
+          await solutionNavigation.sidenav.expectLinkActive({
+            deepLinkId: 'elasticsearchIndexManagement',
+          });
+          await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Build' });
+          await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Index Management' });
+          await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
+            text: 'Indices',
+          });
+
+          // navigate to a different section
+          await solutionNavigation.sidenav.openSection(
+            'search_project_nav_footer.project_settings_project_nav'
+          );
+        }
+
         await solutionNavigation.sidenav.clickLink({ navId: 'stack_management' });
         await solutionNavigation.sidenav.expectLinkActive({ navId: 'stack_management' });
 


### PR DESCRIPTION
## Summary

This is the 1st pass of updates for the v2 navigation to align with the current items. There will be another series of updates once all icons are finalized and for any desired tweaks.

### Testing

To enabled v2 solution nav override the feature flag for you local development env:

```yaml
# config/kibana.dev.yml
feature_flags.overrides:
  core.chrome.projectSideNav: "v2"
```

You should also make the solution navigation default for the default space with:
```
xpack.spaces.defaultSolution: es
```

### Screenshots
<img width="372" height="1133" alt="image" src="https://github.com/user-attachments/assets/54ba571c-9593-4e8d-8c8c-89d134d25d53" />
Ingest and manage data
<img width="372" height="1133" alt="image" src="https://github.com/user-attachments/assets/2b42dec4-8987-43a3-9a9a-ef886092172a" />
Stack Management
<img width="372" height="1133" alt="image" src="https://github.com/user-attachments/assets/f6936b42-fa46-42e4-b512-2db1dc17549b" />

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
