### PR TITLE
Fleet changes to add opentelemetry category

### DIFF
--- a/src/platform/plugins/shared/custom_integrations/common/index.ts
+++ b/src/platform/plugins/shared/custom_integrations/common/index.ts
@@ -60,6 +60,7 @@ export const INTEGRATION_CATEGORY_DISPLAY: {
   network: { title: 'Network', parent_id: undefined },
   network_security: { title: 'Network', parent_id: 'security' },
   notification: { title: 'Notification', parent_id: 'observability' },
+  opentelemetry: { title: 'OpenTelemetry', parent_id: undefined },
   observability: { title: 'Observability', parent_id: undefined },
   os_system: { title: 'Operating Systems', parent_id: undefined },
   process_manager: { title: 'Process Manager', parent_id: 'observability' },

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
@@ -101,6 +101,7 @@ export type PackageSpecCategory =
   | 'network'
   | 'network_security'
   | 'notification'
+  | 'opentelemetry'
   | 'observability'
   | 'os_system'
   | 'process_manager'


### PR DESCRIPTION
This change adds new category opentelemetry to the UI. 

Relates: https://github.com/elastic/package-spec/issues/939

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->