### PR TITLE
[Security Solution] fix page filters not working when newDataViewPickerEnabled ff is on

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
@@ -51,7 +51,7 @@ export const Wrapper = memo(() => {
   const isLoading: boolean = useMemo(
     () =>
       newDataViewPickerEnabled
-        ? experimentalDataViewStatus === 'loading'
+        ? experimentalDataViewStatus === 'loading' || experimentalDataViewStatus === 'pristine'
         : oldSourcererDataViewIsLoading,
     [experimentalDataViewStatus, newDataViewPickerEnabled, oldSourcererDataViewIsLoading]
   );
@@ -67,15 +67,20 @@ export const Wrapper = memo(() => {
     [newDataViewPickerEnabled, experimentalDataView, oldSourcererDataViewSpec?.runtimeFieldMap]
   );
 
-  // TODO check for status ready instead!
   const isDataViewInvalid: boolean = useMemo(
     () =>
       newDataViewPickerEnabled
-        ? experimentalDataViewStatus === 'error'
+        ? experimentalDataViewStatus === 'error' ||
+          (experimentalDataViewStatus === 'ready' && !experimentalDataView.hasMatchedIndices())
         : !oldSourcererDataViewSpec ||
           !oldSourcererDataViewSpec.id ||
           !oldSourcererDataViewSpec.title,
-    [experimentalDataViewStatus, newDataViewPickerEnabled, oldSourcererDataViewSpec]
+    [
+      experimentalDataView,
+      experimentalDataViewStatus,
+      newDataViewPickerEnabled,
+      oldSourcererDataViewSpec,
+    ]
   );
 
   return (


### PR DESCRIPTION
## Summary

This PR fixes a small issue introduced by the merge of this alerts page refactor [PR](https://github.com/elastic/kibana/pull/222457) and this other [PR](https://github.com/elastic/kibana/pull/227422) preparing for the `newDataViewPickerEnabled` to be turned on.

With the alerts page refactor, we were now checking for the dataView to be in `pristine` status, but we should have checked for `ready` status. I noticed that we can have a dataView in `pristine` status while still have its `id`, `title` and all its other fields being `undefined`...

Also, to avoid a split second of a error message being displayed, we're now checking both `loading` and `pristine` statuses to show the loading skeleton on the page.

| Before fix | After fix |
| ------------- | ------------- |
| <img width="932" height="633" alt="Screenshot 2025-09-05 at 9 01 01 AM" src="https://github.com/user-attachments/assets/2d2d40d8-2b12-4e0c-828c-752e5c9757de" /> | <img width="936" height="596" alt="Screenshot 2025-09-05 at 9 00 09 AM" src="https://github.com/user-attachments/assets/ac803b70-d1dc-4c9a-9ad6-d0fa458479fc" /> |  

### How to test

- generate some alerts
- turn on the `newDataViewPickerEnabled` feature flag

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
