### PR TITLE
[Fleet] Add info when independent agent release version is selected for upgrade

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -906,6 +906,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       httpMonitoring: `${ELASTIC_DOCS}reference/fleet/agent-policy#change-policy-enable-agent-monitoring`,
       agentLevelLogging: `${ELASTIC_DOCS}reference/fleet/monitor-elastic-agent#change-logging-level`,
       remoteESOoutputTroubleshooting: `${ELASTIC_DOCS}reference/fleet/remote-elasticsearch-output#troubleshooting`,
+      agentReleaseProcess: `${ELASTIC_DOCS}reference/fleet/fleet-agent-release-process`,
     },
     integrationDeveloper: {
       upload: `${ELASTIC_DOCS}extend/integrations/upload-new-integration`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -554,6 +554,7 @@ export interface DocLinks {
     httpMonitoring: string;
     agentLevelLogging: string;
     remoteESOoutputTroubleshooting: string;
+    agentReleaseProcess: string;
   }>;
   readonly integrationDeveloper: {
     upload: string;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -209,7 +209,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
       value: option,
       toolTipContent: isIndependentAgentReleaseVersion(option)
         ? i18n.translate('xpack.fleet.upgradeAgents.iarVersionOptionTooltip', {
-            defaultMessage: 'Independent Elastic Agent Release version',
+            defaultMessage: 'Independent Elastic Agent release version',
           })
         : undefined,
     }));
@@ -568,14 +568,14 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
             title={
               <FormattedMessage
                 id="xpack.fleet.settings.editOutputFlyout.iarVersionSelectedCalloutTitle"
-                defaultMessage="Independent Elastic Agent Release version selected"
+                defaultMessage="Independent Elastic Agent release version selected"
               />
             }
             data-test-subj="iarVersionSelectedCallout"
           >
             <FormattedMessage
               id="xpack.fleet.settings.iarVersionSelected.description"
-              defaultMessage="For more information, see the {documentationLink}."
+              defaultMessage="For more information, refer to {documentationLink}."
               values={{
                 documentationLink: (
                   <EuiLink external={true} href={docLinks.links.fleet.agentReleaseProcess}>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -7,21 +7,20 @@
 
 import React, { useState, useMemo, useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
-import { useGeneratedHtmlId } from '@elastic/eui';
 
 import {
   EuiConfirmModal,
   EuiComboBox,
   EuiFormRow,
+  EuiIconTip,
   EuiSpacer,
-  EuiToolTip,
-  EuiIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCallOut,
   EuiDatePicker,
   EuiFieldText,
   EuiLink,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
@@ -180,6 +179,10 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
     fetchFleetServerAgents();
   }, []);
 
+  const isIndependentAgentReleaseVersion = (version: string) => {
+    return version.includes('+build');
+  };
+
   const minVersion = useMemo(() => {
     if (!Array.isArray(agents)) {
       // when agent is a query, don't set minVersion, so the versions are available to select
@@ -204,6 +207,11 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
     const options = displayVersions.map((option) => ({
       label: option,
       value: option,
+      toolTipContent: isIndependentAgentReleaseVersion(option)
+        ? i18n.translate('xpack.fleet.upgradeAgents.iarVersionOptionTooltip', {
+            defaultMessage: 'Independent Elastic Agent Release version',
+          })
+        : undefined,
     }));
     if (options.length === 0) {
       return [EMPTY_VALUE];
@@ -233,6 +241,9 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
     },
   ];
   const [selectedVersion, setSelectedVersion] = useState(preselected);
+  const isSelectedVersionIAR = useMemo(() => {
+    return isIndependentAgentReleaseVersion(selectedVersion[0]?.value || '');
+  }, [selectedVersion]);
 
   // latest agent version might be earlier than kibana version
   const latestAgentVersion = useAgentVersion();
@@ -550,6 +561,36 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
           />
         )}
       </p>
+      {isSelectedVersionIAR ? (
+        <>
+          <EuiCallOut
+            iconType="info"
+            title={
+              <FormattedMessage
+                id="xpack.fleet.settings.editOutputFlyout.iarVersionSelectedCalloutTitle"
+                defaultMessage="Independent Elastic Agent Release version selected"
+              />
+            }
+            data-test-subj="iarVersionSelectedCallout"
+          >
+            <FormattedMessage
+              id="xpack.fleet.settings.iarVersionSelected.description"
+              defaultMessage="For more information, see the {documentationLink}."
+              values={{
+                documentationLink: (
+                  <EuiLink external={true} href={docLinks.links.fleet.agentReleaseProcess}>
+                    <FormattedMessage
+                      id="xpack.fleet.settings.iarVersionSelected.documentationLink"
+                      defaultMessage="Elastic Agent release process"
+                    />
+                  </EuiLink>
+                ),
+              }}
+            />
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+        </>
+      ) : null}
       <EuiFormRow
         label={i18n.translate('xpack.fleet.upgradeAgents.chooseVersionLabel', {
           defaultMessage: 'Upgrade version',
@@ -659,15 +700,14 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
               </EuiFlexItem>
               <EuiSpacer size="xs" />
               <EuiFlexItem grow={false}>
-                <EuiToolTip
+                <EuiIconTip
+                  type="info"
                   position="top"
                   content={i18n.translate('xpack.fleet.upgradeAgents.rolloutPeriodTooltip', {
                     defaultMessage:
                       'Define the rollout period for upgrades to your Elastic Agents. Any agents that are offline during this period will be upgraded when they come back online.',
                   })}
-                >
-                  <EuiIcon type="info" />
-                </EuiToolTip>
+                />
               </EuiFlexItem>
             </EuiFlexGroup>
           }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/228494

This PR adds informational UI elements when an independent agent release (IAR) version is selected when upgrading Fleet managed Elastic Agents in Fleet UI, in the upgrade agents confirm modal:
* Show a tooltip when hovering on an IAR version in the version selection dropdown menu
* Render an info callout with a link to the documentation (new page created in https://github.com/elastic/docs-content/pull/2824) when an IAR version is selected

Screen recording showing affected flows:

https://github.com/user-attachments/assets/9d7e9a39-f4f2-4145-b730-ccc3ff91b94e

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

This change only renders additional informational UI elements, risk is minimal.



