### PR TITLE
[One Workflow] fix: decorations not appearing in workflow editor

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { I18nProviderMock } from '@kbn/core-i18n-browser-mocks/src/i18n_context_mock';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
+import type { WorkflowYAMLEditorProps } from './workflow_yaml_editor';
+import { WorkflowYAMLEditor } from './workflow_yaml_editor';
+
+// Mock the YamlEditor component to avoid Monaco complexity in tests
+jest.mock('../../../shared/ui/yaml_editor', () => ({
+  YamlEditor: ({ value, onChange, ...props }: any) => (
+    <div data-testid="yaml-editor">
+      <textarea
+        value={value || ''}
+        onChange={(e: any) => onChange?.(e.target.value)}
+        data-testid="yaml-textarea"
+      />
+    </div>
+  ),
+}));
+
+// Mock the validation hook
+jest.mock('../lib/use_yaml_validation', () => ({
+  useYamlValidation: () => ({
+    error: null,
+    validationErrors: [],
+    validateVariables: jest.fn(),
+    handleMarkersChanged: jest.fn(),
+  }),
+}));
+
+// Mock the completion provider
+jest.mock('../lib/get_completion_item_provider', () => ({
+  getCompletionItemProvider: () => ({}),
+}));
+
+// Mock the UnsavedChangesPrompt
+jest.mock('../../../shared/ui/unsaved_changes_prompt', () => ({
+  UnsavedChangesPrompt: () => null,
+}));
+
+// Mock the validation errors component
+jest.mock('./workflow_yaml_validation_errors', () => ({
+  WorkflowYAMLValidationErrors: () => null,
+}));
+
+describe('WorkflowYAMLEditor', () => {
+  const defaultProps: WorkflowYAMLEditorProps = {
+    value: '',
+    workflowId: 'test-workflow',
+  };
+
+  const renderWithI18n = (component: React.ReactElement) => {
+    return render(<I18nProviderMock>{component}</I18nProviderMock>);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    renderWithI18n(<WorkflowYAMLEditor {...defaultProps} />);
+    expect(document.querySelector('[data-testid="yaml-editor"]')).toBeInTheDocument();
+  });
+
+  it('shows saved status when no changes', () => {
+    const { getByText } = renderWithI18n(
+      <WorkflowYAMLEditor {...defaultProps} hasChanges={false} />
+    );
+    expect(getByText('Saved')).toBeInTheDocument();
+  });
+
+  it('shows unsaved changes when there are changes', () => {
+    const { getByText } = renderWithI18n(
+      <WorkflowYAMLEditor {...defaultProps} hasChanges={true} />
+    );
+    expect(getByText('Unsaved changes')).toBeInTheDocument();
+  });
+
+  it('calls onChange when editor content changes', async () => {
+    const onChangeMock = jest.fn();
+    renderWithI18n(<WorkflowYAMLEditor {...defaultProps} onChange={onChangeMock} />);
+
+    const textarea = document.querySelector('[data-testid="yaml-textarea"]') as HTMLTextAreaElement;
+    const newValue = 'version: "1"\nname: "test"';
+
+    // Simulate typing using React Testing Library
+    fireEvent.change(textarea, { target: { value: newValue } });
+
+    await waitFor(() => {
+      expect(onChangeMock).toHaveBeenCalledWith(newValue);
+    });
+  });
+
+  describe('alert trigger decorations', () => {
+    const yamlWithAlertTrigger = `
+version: "1"
+name: "test workflow"
+triggers:
+  - type: alert
+    with:
+      rule_id: "test-rule"
+steps:
+  - name: step1
+    type: console.log
+    with:
+      message: "Alert triggered!"
+`.trim();
+
+    it('renders without crashing with alert trigger YAML', () => {
+      renderWithI18n(
+        <WorkflowYAMLEditor {...defaultProps} value={yamlWithAlertTrigger} readOnly={false} />
+      );
+
+      expect(document.querySelector('[data-testid="yaml-editor"]')).toBeInTheDocument();
+    });
+
+    it('renders in readOnly mode', () => {
+      renderWithI18n(
+        <WorkflowYAMLEditor {...defaultProps} value={yamlWithAlertTrigger} readOnly={true} />
+      );
+
+      expect(document.querySelector('[data-testid="yaml-editor"]')).toBeInTheDocument();
+    });
+
+    it('handles invalid YAML gracefully', () => {
+      const invalidYaml = `
+version: "1"
+name: "test workflow"
+triggers:
+  - type: alert
+    with:
+      rule_id: "test-rule"
+      invalid: [ unclosed array
+steps:
+  - name: step1
+`.trim();
+
+      // Should not throw an error
+      expect(() => {
+        renderWithI18n(
+          <WorkflowYAMLEditor {...defaultProps} value={invalidYaml} readOnly={false} />
+        );
+      }).not.toThrow();
+
+      expect(document.querySelector('[data-testid="yaml-editor"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('editor initialization', () => {
+    it('renders correctly when editor mounts with content', () => {
+      const yamlContent = 'version: "1"\nname: "test"';
+
+      renderWithI18n(<WorkflowYAMLEditor {...defaultProps} value={yamlContent} />);
+
+      expect(document.querySelector('[data-testid="yaml-editor"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-testid="yaml-textarea"]')).toBeInTheDocument();
+
+      const textarea = document.querySelector(
+        '[data-testid="yaml-textarea"]'
+      ) as HTMLTextAreaElement;
+      expect(textarea?.value).toBe(yamlContent);
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -18,6 +18,7 @@ import type { EsWorkflowStepExecution } from '@kbn/workflows';
 import { getJsonSchemaFromYamlSchema } from '@kbn/workflows';
 import type { SchemasSettings } from 'monaco-yaml';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import YAML, { isPair, isScalar, visit } from 'yaml';
 import { getStepNode } from '../../../../common/lib/yaml_utils';
 import { WORKFLOW_ZOD_SCHEMA, WORKFLOW_ZOD_SCHEMA_LOOSE } from '../../../../common/schema';
@@ -184,13 +185,41 @@ export const WorkflowYAMLEditor = ({
 
     onMount?.(editor, monaco);
 
-    setIsEditorMounted(true);
+    // Parse initial YAML content immediately if available
+    const model = editor.getModel();
+    if (model) {
+      const value = model.getValue();
+      if (value && value.trim() !== '') {
+        validateVariables(editor);
+        try {
+          const parsedDocument = YAML.parseDocument(value);
+          // Use flushSync to ensure yamlDocument is set synchronously
+          // before isEditorMounted is set, preventing race conditions
+          flushSync(() => {
+            setYamlDocument(parsedDocument);
+          });
+        } catch (error) {
+          flushSync(() => {
+            setYamlDocument(null);
+          });
+        }
+      }
+    }
+
+    // Use flushSync here too to ensure isEditorMounted is set synchronously
+    // after yamlDocument, guaranteeing the decoration effect has both values
+    flushSync(() => {
+      setIsEditorMounted(true);
+    });
   };
 
   useEffect(() => {
     // After editor is mounted or workflowId changes, validate the initial content
-    if (isEditorMounted && editorRef.current && editorRef.current.getModel()?.getValue() !== '') {
-      changeSideEffects();
+    if (isEditorMounted && editorRef.current) {
+      const model = editorRef.current.getModel();
+      if (model && model.getValue() !== '') {
+        changeSideEffects();
+      }
     }
   }, [changeSideEffects, isEditorMounted, workflowId]);
 
@@ -287,8 +316,8 @@ export const WorkflowYAMLEditor = ({
       alertTriggerDecorationCollectionRef.current.clear();
     }
 
-    // Don't show alert dots when in executions view
-    if (!model || !yamlDocument || !isEditorMounted || readOnly) {
+    // Don't show alert dots when in executions view or when prerequisites aren't met
+    if (!model || !yamlDocument || !isEditorMounted || readOnly || !editorRef.current) {
       return;
     }
 
@@ -373,8 +402,24 @@ export const WorkflowYAMLEditor = ({
       .flat()
       .filter((d) => d !== null) as monaco.editor.IModelDeltaDecoration[];
 
-    alertTriggerDecorationCollectionRef.current =
-      editorRef.current?.createDecorationsCollection(decorations) ?? null;
+    // Ensure we have a valid editor reference before creating decorations
+    if (decorations.length > 0 && editorRef.current) {
+      // Small delay to ensure Monaco editor is fully ready for decorations
+      // This addresses race conditions where the editor is mounted but not fully initialized
+      const createDecorations = () => {
+        if (editorRef.current) {
+          alertTriggerDecorationCollectionRef.current =
+            editorRef.current.createDecorationsCollection(decorations);
+        }
+      };
+
+      // Try immediately, and if that fails, try again with a small delay
+      try {
+        createDecorations();
+      } catch (error) {
+        setTimeout(createDecorations, 10);
+      }
+    }
   }, [isEditorMounted, yamlDocument, readOnly]);
 
   const completionProvider = useMemo(() => {

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -45,7 +45,8 @@
     "@kbn/react-kibana-context-theme",
     "@kbn/core-chrome-layout",
     "@kbn/core-security-browser",
-    "@kbn/react-kibana-context-theme"
+    "@kbn/react-kibana-context-theme",
+    "@kbn/core-i18n-browser-mocks"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
**Fix race condition in WorkflowYAMLEditor alert trigger decorations**

**Problem**: Alert trigger decorations (warning dots) didn't appear on first load after hard refresh due to timing issue between editor mount and YAML parsing.

https://github.com/user-attachments/assets/56732af8-249b-49d7-918b-f8d342d13515

**Solution**: Use flushSync() to ensure synchronous state updates - yamlDocument is set before isEditorMounted, guaranteeing decoration effect has required data when it runs.

https://github.com/user-attachments/assets/8f6765a1-5ea3-4e9b-9313-eec621eed240

_AI generated description ^_