### PR TITLE
Agentic search tool OneChat

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/i18n.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/i18n.ts
@@ -26,6 +26,12 @@ export const progressMessages = {
       defaultMessage: 'Thinking about the search strategy to use',
     });
   },
+  searchAttempt: ({ attempt, max }: { attempt: number; max: number }) => {
+    return i18n.translate('xpack.onechat.tools.search.progress.searchAttempt', {
+      defaultMessage: 'Executing search attempt {attempt} of {max}',
+      values: { attempt, max },
+    });
+  },
   performingRelevanceSearch: ({ term }: { term: string }) => {
     return i18n.translate('xpack.onechat.tools.search.progress.performingRelevanceSearch', {
       defaultMessage: 'Searching documents for "{term}"',
@@ -40,6 +46,11 @@ export const progressMessages = {
       values: {
         query,
       },
+    });
+  },
+  exhaustedAttempts: () => {
+    return i18n.translate('xpack.onechat.tools.search.progress.exhaustedAttempts', {
+      defaultMessage: 'Maximum search attempts reached without results',
     });
   },
 };

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/convert_graph_events.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/convert_graph_events.ts
@@ -69,7 +69,7 @@ export const convertGraphEvents = ({
         }
 
         // emit tool calls or full message on each agent step
-        if (matchEvent(event, 'on_chain_end') && matchName(event, 'agent')) {
+  if (matchEvent(event, 'on_chain_end') && (matchName(event, 'agent') || matchName(event, 'finalize'))) {
           const addedMessages: BaseMessage[] = event.data.output.addedMessages ?? [];
           const lastMessage = addedMessages[addedMessages.length - 1];
 
@@ -101,7 +101,7 @@ export const convertGraphEvents = ({
         }
 
         // emit tool result events
-        if (matchEvent(event, 'on_chain_end') && matchName(event, 'tools')) {
+  if (matchEvent(event, 'on_chain_end') && matchName(event, 'tools')) {
           const toolMessages = ((event.data.output as StateType).addedMessages ?? []).filter(
             isToolMessage
           );

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/convert_graph_events.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/convert_graph_events.ts
@@ -69,12 +69,13 @@ export const convertGraphEvents = ({
         }
 
         // emit tool calls or full message on each agent step
-  if (matchEvent(event, 'on_chain_end') && (matchName(event, 'agent') || matchName(event, 'finalize'))) {
+        if (matchEvent(event, 'on_chain_end') && (matchName(event, 'agent') || matchName(event, 'finalize'))) {
           const addedMessages: BaseMessage[] = event.data.output.addedMessages ?? [];
           const lastMessage = addedMessages[addedMessages.length - 1];
 
           const toolCalls = extractToolCalls(lastMessage);
-          if (toolCalls.length > 0) {
+          // If this is a finalize step we intentionally ignore any tool calls (should have been stripped)
+          if (toolCalls.length > 0 && matchName(event, 'agent')) {
             const toolCallEvents: ToolCallEvent[] = [];
 
             for (const toolCall of toolCalls) {

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/graph.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/graph.ts
@@ -105,15 +105,11 @@ export const createAgentGraph = ({
     const last = added[added.length - 1] as AIMessage | undefined;
     if (last && last.tool_calls && last.tool_calls.length > 0) {
       const textOnly = extractTextContent(last).trim();
-      // If there is no meaningful textual content besides tool calls, drop the message entirely.
       if (!textOnly) {
         added.pop();
       } else {
-        const sanitized: any = { ...last, tool_calls: [], content: textOnly };
-        // remove provider-specific transient fields that might reference pending tool calls
-        delete sanitized.tool_call_chunks;
-        delete sanitized.invalid_tool_calls;
-        added[added.length - 1] = sanitized;
+        // Replace with a simple assistant tuple to avoid lingering provider metadata/tool_call chunks
+        (added as any)[added.length - 1] = ['assistant', textOnly];
       }
     }
     const used = state.toolCallCount;

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
@@ -20,14 +20,25 @@ const tools = {
 export const getActPrompt = ({
   customInstructions,
   messages,
+  toolBudget,
 }: {
   customInstructions?: string;
   messages: BaseMessageLike[];
+  toolBudget?: { used: number; max: number; remaining: number };
 }): BaseMessageLike[] => {
+  const budgetLine = toolBudget
+    ? `\nTOOL CALL BUDGET STATUS: used ${toolBudget.used} / ${toolBudget.max} (remaining ${toolBudget.remaining}).$${
+        toolBudget.remaining === 0
+          ? ' When remaining is 0 you MUST NOT call tools again; synthesize the best grounded answer only.'
+          : ' Use remaining calls only if they are likely to retrieve clearly missing evidence; otherwise synthesize now.'
+      }\n`
+    : '';
   return [
     [
       'system',
       `You are an expert enterprise AI assistant from Elastic, the company behind Elasticsearch.
+
+        ${budgetLine}
 
         PRIORITY ORDER (read first)
         1) NON-NEGOTIABLE RULES (highest priority)
@@ -125,7 +136,7 @@ export const getActPrompt = ({
         ${customInstructionsBlock(customInstructions)}
 
         ADDITIONAL INFO
-        - Current date: ${formatDate()}`,
+  - Current date: ${formatDate()}`,
     ],
     ...messages,
   ];


### PR DESCRIPTION
## Summary

This pull request introduces support for iterative search attempts and tool call budgeting in the OneChat search and agent graphs. The changes enable agents and search tools to track and limit the number of attempts or tool calls, provide progress updates, and summarize failures when no useful results are found. Prompts are updated to guide the models in using budgets efficiently and avoiding redundant actions.

### Iterative Search and Failure Handling Improvements

* Added state tracking for search attempts, including `maxAttempts`, `attempt`, `attemptSummaries`, and `hadAnyResult` in the search tool graph (`graph.ts`). The graph now loops until a result is found or the attempt budget is exhausted, and summarizes failure if no usable results are obtained. [[1]](diffhunk://#diff-7bb66f28786f0180e9687fae3d3f122514577482be60d02edb6ba3300656b951R28-R48) [[2]](diffhunk://#diff-7bb66f28786f0180e9687fae3d3f122514577482be60d02edb6ba3300656b951R107-R222) [[3]](diffhunk://#diff-7bb66f28786f0180e9687fae3d3f122514577482be60d02edb6ba3300656b951R232-R235)
* Updated `runSearchTool` to accept a configurable `maxAttempts` parameter and return a failure summary as an error result when no useful results are found after all attempts. [[1]](diffhunk://#diff-e4a6351ce52ad0ddaa2962bd2d22ed7e95491338e6170945513dc88e39ec7389R24-R32) [[2]](diffhunk://#diff-e4a6351ce52ad0ddaa2962bd2d22ed7e95491338e6170945513dc88e39ec7389L43-R45) [[3]](diffhunk://#diff-e4a6351ce52ad0ddaa2962bd2d22ed7e95491338e6170945513dc88e39ec7389R58-R67)

### Enhanced Progress and Failure Messaging

* Added new progress messages for search attempts and exhausted attempts to the i18n module (`i18n.ts`). [[1]](diffhunk://#diff-404cb2b397decd7232370df79f76388a79516134ffc7e916d12c0a9474679606R29-R34) [[2]](diffhunk://#diff-404cb2b397decd7232370df79f76388a79516134ffc7e916d12c0a9474679606R51-R55)

### Prompt Refinement for Budget Awareness

* Updated prompts for both search tools and agents to include attempt/tool call budget status and histories, and added explicit instructions to avoid repeating identical tool calls and to synthesize answers when the budget is exhausted. [[1]](diffhunk://#diff-d23cf11c8f2d7ef8d0e4e97b84840b8ffec7cfc67ae5d9e9f8a1ee274aff104cR19-R48) [[2]](diffhunk://#diff-d23cf11c8f2d7ef8d0e4e97b84840b8ffec7cfc67ae5d9e9f8a1ee274aff104cL45-R73) [[3]](diffhunk://#diff-a2e20361b72bf39b781e9a92dcd430afaf5d29405d7c93f0bad998874b1ba5ceR23-R42)

### Agent Graph Tool Call Budgeting

* Added `maxToolCalls` and `toolCallCount` state to the agent graph, enforcing a limit on tool calls per session. The agent graph now finalizes the answer when the tool call budget is exhausted, sanitizing messages to remove unexecuted tool calls. [[1]](diffhunk://#diff-80b9c183538a23d8dbb0365437249a262d48ee444fbc4d2db61890a058e235b5R25-R31) [[2]](diffhunk://#diff-80b9c183538a23d8dbb0365437249a262d48ee444fbc4d2db61890a058e235b5R42-R49) [[3]](diffhunk://#diff-80b9c183538a23d8dbb0365437249a262d48ee444fbc4d2db61890a058e235b5R58-R67) [[4]](diffhunk://#diff-80b9c183538a23d8dbb0365437249a262d48ee444fbc4d2db61890a058e235b5R79-R145)

### Event Conversion Logic Update

* Modified event conversion logic to handle new `finalize` steps in the agent graph, ensuring tool calls are only emitted for actual agent steps and not for finalization.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



