### PR TITLE
[onechat] add id attribute to conversation rounds

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/chat/conversation.ts
@@ -117,6 +117,8 @@ export type ConversationRoundStep = ToolCallStep | ReasoningStep;
  * related to this particular round.
  */
 export interface ConversationRound {
+  /** unique id for this round */
+  id: string;
   /** The user input that initiated the round */
   input: RoundInput;
   /** List of intermediate steps before the end result, such as tool calls */

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation_actions.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation_actions.ts
@@ -19,6 +19,8 @@ import { queryKeys } from '../query_keys';
 import { useNavigation } from './use_navigation';
 import { appPaths } from '../utils/app_paths';
 
+const pendingRoundId = '__pending__';
+
 export const useConversationActions = () => {
   const queryClient = useQueryClient();
   const conversationId = useConversationId();
@@ -63,6 +65,7 @@ export const useConversationActions = () => {
       setConversation(
         produce((draft) => {
           const nextRound: ConversationRound = {
+            id: pendingRoundId,
             input: { message: userMessage },
             response: { message: '' },
             steps: [],

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/add_round_complete_event.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/add_round_complete_event.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { v4 as uuidv4 } from 'uuid';
 import type { OperatorFunction } from 'rxjs';
 import { map, merge, share, toArray } from 'rxjs';
 import type {
@@ -108,6 +109,7 @@ const createRoundFromEvents = ({
   };
 
   const round: ConversationRound = {
+    id: uuidv4(),
     input,
     steps: stepEvents.map(eventToStep),
     trace_id: getCurrentTraceId(),

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/to_langchain_messages.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/to_langchain_messages.test.ts
@@ -44,6 +44,7 @@ describe('conversationLangchainMessages', () => {
   it('handles a round with only user and assistant messages', () => {
     const previousRounds: ConversationRound[] = [
       {
+        id: 'round-1',
         input: makeRoundInput('hi'),
         steps: [],
         response: makeAssistantResponse('hello!'),
@@ -74,6 +75,7 @@ describe('conversationLangchainMessages', () => {
     ]);
     const previousRounds: ConversationRound[] = [
       {
+        id: 'round-1',
         input: makeRoundInput('find foo'),
         steps: [makeToolCallStep(toolCall)],
         response: makeAssistantResponse('done!'),
@@ -118,11 +120,13 @@ describe('conversationLangchainMessages', () => {
   it('handles multiple rounds', () => {
     const previousRounds: ConversationRound[] = [
       {
+        id: 'round-1',
         input: makeRoundInput('hi'),
         steps: [],
         response: makeAssistantResponse('hello!'),
       },
       {
+        id: 'round-2',
         input: makeRoundInput('search for bar'),
         steps: [
           makeToolCallStep(
@@ -177,6 +181,7 @@ describe('conversationLangchainMessages', () => {
     ]);
     const previousRounds: ConversationRound[] = [
       {
+        id: 'round-1',
         input: makeRoundInput('find foo'),
         steps: [makeToolCallStep(toolCall)],
         response: makeAssistantResponse('done!'),

--- a/x-pack/platform/plugins/shared/onechat/server/services/conversation/converters.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/conversation/converters.test.ts
@@ -25,6 +25,7 @@ describe('conversation model converters', () => {
           user_name: 'user_name',
           rounds: [
             {
+              id: 'round-1',
               input: {
                 message: 'some message',
               },
@@ -58,6 +59,7 @@ describe('conversation model converters', () => {
 
         rounds: [
           {
+            id: 'round-1',
             input: {
               message: 'some message',
             },
@@ -125,6 +127,7 @@ describe('conversation model converters', () => {
         updated_at: updateDate,
         rounds: [
           {
+            id: 'round-1',
             input: {
               message: 'some message',
             },
@@ -148,6 +151,7 @@ describe('conversation model converters', () => {
         user_name: 'user_name',
         rounds: [
           {
+            id: 'round-1',
             input: {
               message: 'some message',
             },


### PR DESCRIPTION
## Summary

It's not used for now, but we will likely need to be able to identify rounds for future features (e.g. to fork a conversation on a given round, or restart a conversation from a given round).

Because backfilling such unique ID fields later can be challenging, especially on serverless, let's keep it save and future-proof, and add that field before the initial release. 


