### PR TITLE
[ResponseOps][Docs][8.x]: Update pager duty connector doc

### DIFF
--- a/docs/management/connectors/action-types/pagerduty.asciidoc
+++ b/docs/management/connectors/action-types/pagerduty.asciidoc
@@ -109,7 +109,7 @@ An optional list of links to add to the event.
 You must provide a URL and plain text description for each link.
 Severity::
 The perceived severity of on the affected system.
-This can be one of `Critical`, `Error`, `Warning` or `Info`(default).
+This can be one of `critical`, `error`, `warning` or `info`(default).
 Source::
 An optional value indicating the affected system, preferably a hostname or fully qualified domain name.
 Defaults to the {kib} saved object id of the action.


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/2777 by fixing the casing for values in the `Severity` property.

Corresponding 9.x udpates: https://github.com/elastic/kibana/pull/234314

Preview: https://kibana_bk_234315.docs-preview.app.elstc.co/guide/en/kibana/8.19/pagerduty-action-type.html

