### PR TITLE
[ES|QL] Fix duplicated suggestions in JOIN command

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/autocomplete.test.ts
@@ -16,6 +16,7 @@ import { expectSuggestions, getFieldNamesByType } from '../../../__tests__/autoc
 import type { ICommandCallbacks } from '../../types';
 import { correctQuerySyntax, findAstPosition } from '../../../definitions/utils/ast';
 import { parse } from '../../../parser';
+import { uniq } from 'lodash';
 
 const joinExpectSuggestions = (
   query: string,
@@ -126,7 +127,7 @@ describe('JOIN Autocomplete', () => {
 
       expected.sort();
 
-      expect(labels).toEqual(expected);
+      expect(labels).toEqual(uniq(expected));
     });
 
     test('more field suggestions after comma', async () => {
@@ -142,7 +143,7 @@ describe('JOIN Autocomplete', () => {
 
       expected.sort();
 
-      expect(labels).toEqual(expected);
+      expect(labels).toEqual(uniq(expected));
     });
 
     test('supports field prefixes', async () => {
@@ -158,7 +159,7 @@ describe('JOIN Autocomplete', () => {
 
       expected.sort();
 
-      expect(labels).toEqual(expected);
+      expect(labels).toEqual(uniq(expected));
     });
 
     test('suggests comma and pipe on complete field name', async () => {

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/utils.ts
@@ -111,11 +111,10 @@ export const getFieldSuggestions = async (
     }),
   ]);
 
-  const supportsControls = context?.supportsControls ?? false;
   const joinFields = buildFieldsDefinitionsWithMetadata(
     lookupIndexFields.filter((f) => !ignoredFields.includes(f.name)),
     [],
-    { supportsControls },
+    { supportsControls: false }, // Controls are being added as part of the sourceFields, no need to add them again as joinFields.
     context?.variables
   );
 
@@ -123,9 +122,6 @@ export const getFieldSuggestions = async (
   const union = suggestionUnion(sourceFields, joinFields);
 
   for (const commonField of intersection) {
-    if (commonField.command?.id === 'esql.control.fields.create') {
-      continue;
-    }
     commonField.sortText = '1';
     commonField.documentation = {
       value: i18n.translate('kbn-esql-ast.esql.autocomplete.join.sharedField', {

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/utils.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { i18n } from '@kbn/i18n';
+import { uniqBy } from 'lodash';
 import { handleFragment, columnExists } from '../../../definitions/utils/autocomplete/helpers';
 import { unescapeColumnName } from '../../../definitions/utils/shared';
 import * as mutate from '../../../mutate';
@@ -122,6 +123,9 @@ export const getFieldSuggestions = async (
   const union = suggestionUnion(sourceFields, joinFields);
 
   for (const commonField of intersection) {
+    if (commonField.command?.id === 'esql.control.fields.create') {
+      continue;
+    }
     commonField.sortText = '1';
     commonField.documentation = {
       value: i18n.translate('kbn-esql-ast.esql.autocomplete.join.sharedField', {
@@ -143,7 +147,7 @@ export const getFieldSuggestions = async (
   }
 
   return {
-    suggestions: [...intersection, ...union],
+    suggestions: uniqBy([...intersection, ...union], 'label'),
     lookupIndexFieldExists: (field: string) =>
       lookupIndexFieldSet.set.has(unescapeColumnName(field)),
   };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/233958
## Summary
`Create control` and overlapping index fields were being suggested twice.
Also `(common field)` documentation was being added to `Create control` suggestion. 

<img width="499" height="186" alt="image" src="https://github.com/user-attachments/assets/d0a8e88f-23b9-499c-8e1b-abe770cef2ac" />

------

<img width="794" height="254" alt="image" src="https://github.com/user-attachments/assets/6943f353-3082-42bf-9402-61a3e24630c2" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



