### PR TITLE
[Metrics][Discover] Add copy to dashboard action

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_extra_actions.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_extra_actions.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useLensExtraActions } from './use_lens_extra_actions';
+import type { ActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+
+describe('useLensExtraActions', () => {
+  it('should return an empty array when no config is provided', () => {
+    const { result } = renderHook(() => useLensExtraActions({}));
+    expect(result.current).toEqual([]);
+  });
+
+  describe('copyToDashboard', () => {
+    it('should return copyToDashboard action when config is provided', () => {
+      const onClick = jest.fn();
+      const { result } = renderHook(() => useLensExtraActions({ copyToDashboard: { onClick } }));
+
+      expect(result.current).toHaveLength(1);
+      const action = result.current[0];
+
+      expect(action).toEqual(
+        expect.objectContaining({
+          id: 'copyToDashboard',
+          order: 1,
+          type: 'actionButton',
+        })
+      );
+
+      expect(action.getIconType({} as ActionExecutionContext)).toBe('dashboardApp');
+    });
+
+    it('should call onClick when execute is invoked', async () => {
+      const onClick = jest.fn();
+      const { result } = renderHook(() => useLensExtraActions({ copyToDashboard: { onClick } }));
+
+      const action = result.current[0];
+
+      await act(async () => {
+        await action.execute({} as ActionExecutionContext);
+      });
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_extra_actions.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_extra_actions.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { i18n } from '@kbn/i18n';
+import type { Action } from '@kbn/ui-actions-plugin/public';
+import { useMemo } from 'react';
+
+interface CopyToDashboardActionConfig {
+  onClick: () => void;
+}
+
+interface UseLensExtraActions {
+  copyToDashboard?: CopyToDashboardActionConfig;
+}
+export const useLensExtraActions = (config: UseLensExtraActions): Action[] => {
+  const extraActions = useMemo(() => {
+    const actions: Action[] = [];
+
+    if (config.copyToDashboard) {
+      actions.push(getCopyToDashboardAction(config.copyToDashboard.onClick));
+    }
+
+    return actions;
+  }, [config.copyToDashboard]);
+
+  return extraActions;
+};
+
+const getCopyToDashboardAction = (onExecute: () => void): Action => {
+  return {
+    id: 'copyToDashboard',
+    order: 1,
+    type: 'actionButton',
+    getDisplayName() {
+      return i18n.translate('metricsExperience.lens.actions.copyToDashboard', {
+        defaultMessage: 'Copy to dashboard',
+      });
+    },
+    getIconType() {
+      return 'dashboardApp';
+    },
+    async isCompatible() {
+      return true;
+    },
+    async execute() {
+      onExecute();
+    },
+  };
+};

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
@@ -98,13 +98,15 @@ export const Chart: React.FC<ChartProps> = ({
         border-radius: ${euiTheme.border.radius.medium};
       `}
     >
-      <LensWrapperMemo
-        lensProps={lensProps}
-        services={services}
-        onBrushEnd={onBrushEnd}
-        onFilter={onFilter}
-        abortController={abortController}
-      />
+      {lensProps && (
+        <LensWrapperMemo
+          lensProps={lensProps}
+          services={services}
+          onBrushEnd={onBrushEnd}
+          onFilter={onFilter}
+          abortController={abortController}
+        />
+      )}
     </div>
   );
 };

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/lens_wrapper.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/lens_wrapper.tsx
@@ -18,7 +18,12 @@ export type LensWrapperProps = {
   lensProps: LensProps;
 } & Pick<ChartSectionProps, 'services' | 'onBrushEnd' | 'onFilter' | 'abortController'>;
 
-const DEFAULT_DISABLED_ACTIONS = ['ACTION_CUSTOMIZE_PANEL', 'ACTION_EXPORT_CSV'];
+const DEFAULT_DISABLED_ACTIONS = [
+  'ACTION_CUSTOMIZE_PANEL',
+  'ACTION_EXPORT_CSV',
+  // temporarily disabiling it until we figure out this action
+  'ACTION_OPEN_IN_DISCOVER',
+];
 
 export function LensWrapper({
   lensProps,

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/tsconfig.json
@@ -26,5 +26,7 @@
     "@kbn/lens-plugin",
     "@kbn/esql-composer",
     "@kbn/shared-ux-toolbar-selector",
+    "@kbn/ui-actions-plugin",
+    "@kbn/react-hooks",
   ]
 }


### PR DESCRIPTION
closes [#234200](https://github.com/elastic/kibana/issues/234200)

## Summary

Adds an action to copy a visualization in the metrics explorer grid to a dashboard


**Copy to dashboard**
![copy_to_dashboard](https://github.com/user-attachments/assets/8e5a740c-3fac-4ee6-aa02-f749741b6ea8)

**Copy a visualization with dimensions to a dashboard**
![copy_to_dashboard_dimensions](https://github.com/user-attachments/assets/3f098e33-cb78-44a1-89a1-bc604702a856)

**Copy a visualization to an existing dashboard**
![add_to_existing_dashboard](https://github.com/user-attachments/assets/29763ca1-bc5f-43bd-bab1-5f340fcfac3b)



## How to test
- Clone https://github.com/simianhacker/simian-forge/tree/main
- Run ` ./forge --dataset hosts --count 25 --interval 30s`
- Set the following config to `kibana.dev.yml`
```yml
discover.experimental.enabledProfiles:
  - observability-metrics-data-source-profile
metricsExperience.enabled: true
 ```
- Navigate to Discover and Switch to ESQL mode
- Hover the mouse over a visualization, and click on the triple dots icon to copy a visualization to a dashboard
