### PR TITLE
[8.19] Fixes Failing test: Plugin Functional Tests.x-pack/platform/test/plugin_api_integration/test_suites/task_manager/migrations·ts - task_manager migrations 8.8.0 adds UUIDs to all alerts (#234189)

### DIFF
--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/migrations.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/migrations.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect/expect';
+import expect from '@kbn/expect';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { TransportResult } from '@elastic/elasticsearch';
 import {

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/migrations.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/migrations.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
+import expect from '@kbn/expect/expect';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { TransportResult } from '@elastic/elasticsearch';
 import {
@@ -19,6 +19,7 @@ import type { RuleTaskState, WrappedLifecycleRuleState } from '@kbn/alerting-sta
 import { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 export default function createGetTests({ getService }: FtrProviderContext) {
+  const retry = getService('retry');
   const es = getService('es');
   const esArchiver = getService('esArchiver');
   const ALERT_ID = '0359d7fcc04da9878ee9aadbda38ba55';
@@ -195,35 +196,37 @@ export default function createGetTests({ getService }: FtrProviderContext) {
 
     describe('8.8.0', () => {
       it('adds UUIDs to all alerts', async () => {
-        const response = await es.search<{ task: SerializedConcreteTaskInstance }>(
-          {
-            index: '.kibana_task_manager',
-            size: 100,
-            body: { query: { match_all: {} } },
-          },
-          { meta: true }
-        );
-        expect(response.statusCode).to.eql(200);
-        const tasks = response.body.hits.hits;
-        tasks.forEach((task) => {
-          const stateString = task._source?.task.state;
-          expect(stateString).to.be.ok();
-          const state: RuleTaskState = JSON.parse(stateString!);
-          const uuids = new Set<string>();
+        await retry.try(async () => {
+          const response = await es.search<{ task: SerializedConcreteTaskInstance }>(
+            {
+              index: '.kibana_task_manager',
+              size: 100,
+              query: { match_all: {} },
+            },
+            { meta: true }
+          );
+          expect(response.statusCode).to.eql(200);
+          const tasks = response.body.hits.hits;
+          tasks.forEach((task) => {
+            const stateString = task._source?.task.state;
+            expect(stateString).to.be.ok();
+            const state: RuleTaskState = JSON.parse(stateString!);
+            const uuids = new Set<string>();
 
-          for (const alert of Object.values(state.alertInstances || {})) {
-            const uuid = alert?.meta?.uuid || 'uuid-is-missing';
-            expect(uuid).to.match(/^.{8}-.{4}-.{4}-.{4}-.{12}$/);
-            expect(uuids.has(uuid)).to.be(false);
-            uuids.add(uuid);
-          }
+            for (const alert of Object.values(state.alertInstances || {})) {
+              const uuid = alert?.meta?.uuid || 'uuid-is-missing';
+              expect(uuid).to.match(/^.{8}-.{4}-.{4}-.{4}-.{12}$/);
+              expect(uuids.has(uuid)).to.be(false);
+              uuids.add(uuid);
+            }
 
-          for (const alert of Object.values(state.alertRecoveredInstances || {})) {
-            const uuid = alert?.meta?.uuid || 'uuid-is-missing';
-            expect(uuid).to.match(/^.{8}-.{4}-.{4}-.{4}-.{12}$/);
-            expect(uuids.has(uuid)).to.be(false);
-            uuids.add(uuid);
-          }
+            for (const alert of Object.values(state.alertRecoveredInstances || {})) {
+              const uuid = alert?.meta?.uuid || 'uuid-is-missing';
+              expect(uuid).to.match(/^.{8}-.{4}-.{4}-.{4}-.{12}$/);
+              expect(uuids.has(uuid)).to.be(false);
+              uuids.add(uuid);
+            }
+          });
         });
       });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fixes Failing test: Plugin Functional Tests.x-pack/platform/test/plugin_api_integration/test_suites/task_manager/migrations·ts - task_manager migrations 8.8.0 adds UUIDs to all alerts (#234189)](https://github.com/elastic/kibana/pull/234189)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-09-08T15:07:18Z","message":"Fixes Failing test: Plugin Functional Tests.x-pack/platform/test/plugin_api_integration/test_suites/task_manager/migrations·ts - task_manager migrations 8.8.0 adds UUIDs to all alerts (#234189)\n\nFixes https://github.com/elastic/kibana/issues/233770\n\n## Summary\n\nAdded some debug logging to the task manager migrations to verify that\nthe 8.8.0 migrations are being applied. Added a retry so the test will\nwait a little longer for the migration to be complete and the task\ninstance to be updated with the UUID.\n\nFlaky test runner:\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9299\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9298\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0552314bd6734ac51a6c5431ee66fddf58b44688","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Task Manager","Team:ResponseOps","backport:version","v9.2.0","v9.1.4","v8.19.4"],"title":"Fixes Failing test: Plugin Functional Tests.x-pack/platform/test/plugin_api_integration/test_suites/task_manager/migrations·ts - task_manager migrations 8.8.0 adds UUIDs to all alerts","number":234189,"url":"https://github.com/elastic/kibana/pull/234189","mergeCommit":{"message":"Fixes Failing test: Plugin Functional Tests.x-pack/platform/test/plugin_api_integration/test_suites/task_manager/migrations·ts - task_manager migrations 8.8.0 adds UUIDs to all alerts (#234189)\n\nFixes https://github.com/elastic/kibana/issues/233770\n\n## Summary\n\nAdded some debug logging to the task manager migrations to verify that\nthe 8.8.0 migrations are being applied. Added a retry so the test will\nwait a little longer for the migration to be complete and the task\ninstance to be updated with the UUID.\n\nFlaky test runner:\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9299\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9298\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0552314bd6734ac51a6c5431ee66fddf58b44688"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/234189","number":234189,"mergeCommit":{"message":"Fixes Failing test: Plugin Functional Tests.x-pack/platform/test/plugin_api_integration/test_suites/task_manager/migrations·ts - task_manager migrations 8.8.0 adds UUIDs to all alerts (#234189)\n\nFixes https://github.com/elastic/kibana/issues/233770\n\n## Summary\n\nAdded some debug logging to the task manager migrations to verify that\nthe 8.8.0 migrations are being applied. Added a retry so the test will\nwait a little longer for the migration to be complete and the task\ninstance to be updated with the UUID.\n\nFlaky test runner:\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9299\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9298\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0552314bd6734ac51a6c5431ee66fddf58b44688"}},{"branch":"9.1","label":"v9.1.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/234329","number":234329,"state":"OPEN"},{"branch":"8.19","label":"v8.19.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->