### PR TITLE
Add tests to new evaluation framework for knowledge base

### DIFF
--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/evaluate_knowledge_base.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/evaluate_knowledge_base.ts
@@ -14,7 +14,6 @@ import { KnowledgeBaseClient } from '@kbn/evals-suite-obs-ai-assistant/src/knowl
 interface KnowledgeBaseExample extends Example {
   input: {
     question: string;
-    conversationId: string | undefined;
   };
   output: {
     criteria?: string[];
@@ -66,7 +65,6 @@ export function createEvaluateKnowledgeBase({
         dataset,
         task: async ({ input }) => {
           const response = await chatClient.complete({
-            conversationId: input.conversationId,
             messages: input.question,
           });
 

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/evaluate_knowledge_base.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/evaluate_knowledge_base.ts
@@ -9,7 +9,7 @@ import type { Example } from '@arizeai/phoenix-client/dist/esm/types/datasets';
 import type { DefaultEvaluators, KibanaPhoenixClient } from '@kbn/evals';
 import type { EvaluationDataset } from '@kbn/evals/src/types';
 import type { ObservabilityAIAssistantEvaluationChatClient } from '../../src/chat_client';
-import { KnowledgeBaseClient } from '../../src/knowledge_base_client';
+import type { KnowledgeBaseClient } from '../../src/knowledge_base_client';
 
 interface KnowledgeBaseExample extends Example {
   input: {

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/evaluate_knowledge_base.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/evaluate_knowledge_base.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Example } from '@arizeai/phoenix-client/dist/esm/types/datasets';
+import type { DefaultEvaluators, KibanaPhoenixClient } from '@kbn/evals';
+import type { EvaluationDataset } from '@kbn/evals/src/types';
+import type { ObservabilityAIAssistantEvaluationChatClient } from '../../src/chat_client';
+import { KnowledgeBaseClient } from '@kbn/evals-suite-obs-ai-assistant/src/knowledge_base_client';
+
+interface KnowledgeBaseExample extends Example {
+  input: {
+    question: string;
+    conversationId: string | undefined;
+  };
+  output: {
+    criteria?: string[];
+  };
+}
+
+export type EvaluateKnowledgeBase = ({
+  dataset: { name, description, examples },
+}: {
+  dataset: {
+    name: string;
+    description: string;
+    examples: KnowledgeBaseExample[];
+  };
+}) => Promise<void>;
+
+export function createEvaluateKnowledgeBase({
+  evaluators,
+  phoenixClient,
+  chatClient,
+  knowledgeBaseClient,
+}: {
+  evaluators: DefaultEvaluators;
+  phoenixClient: KibanaPhoenixClient;
+  chatClient: ObservabilityAIAssistantEvaluationChatClient;
+  knowledgeBaseClient: KnowledgeBaseClient;
+}): EvaluateKnowledgeBase {
+  return async function evaluateEsqlDataset({
+    dataset: { name, description, examples },
+  }: {
+    dataset: {
+      name: string;
+      description: string;
+      examples: KnowledgeBaseExample[];
+    };
+  }) {
+    await knowledgeBaseClient.ensureInstalled().catch((e) => {
+      throw new Error(`Failed to install knowledge base: ${e.message}`);
+    });
+
+    const dataset = {
+      name,
+      description,
+      examples,
+    } satisfies EvaluationDataset;
+
+    await phoenixClient.runExperiment(
+      {
+        dataset,
+        task: async ({ input }) => {
+          const response = await chatClient.complete({
+            conversationId: input.conversationId,
+            messages: input.question,
+          });
+
+          return {
+            errors: response.errors,
+            messages: response.messages,
+          };
+        },
+      },
+      [
+        {
+          name: 'kb-evaluator',
+          kind: 'LLM',
+          evaluate: async ({ input, output, expected, metadata }) => {
+            const result = await evaluators.criteria([...(expected.criteria ?? [])]).evaluate({
+              input,
+              expected,
+              output,
+              metadata,
+            });
+
+            return result;
+          },
+        },
+      ]
+    );
+  };
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/evaluate_knowledge_base.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/evaluate_knowledge_base.ts
@@ -9,7 +9,7 @@ import type { Example } from '@arizeai/phoenix-client/dist/esm/types/datasets';
 import type { DefaultEvaluators, KibanaPhoenixClient } from '@kbn/evals';
 import type { EvaluationDataset } from '@kbn/evals/src/types';
 import type { ObservabilityAIAssistantEvaluationChatClient } from '../../src/chat_client';
-import { KnowledgeBaseClient } from '@kbn/evals-suite-obs-ai-assistant/src/knowledge_base_client';
+import { KnowledgeBaseClient } from '../../src/knowledge_base_client';
 
 interface KnowledgeBaseExample extends Example {
   input: {

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
@@ -110,7 +110,6 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
       },
     ];
 
-    // Ported from the original `before` block
     evaluate.beforeAll(async ({ knowledgeBaseClient, esClient }) => {
       await knowledgeBaseClient.importEntries({ entries: testDocs });
     });
@@ -131,7 +130,6 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
     evaluate(
       'retrieves and describes DevOps teams and on-call info',
       async ({ evaluateKnowledgeBase }) => {
-        // This combines the original two "DevOps" tests into a single, comprehensive evaluation.
         await evaluateKnowledgeBase({
           dataset: {
             name: 'kb_retrieval_devops',

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
@@ -105,6 +105,31 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
       await clearConversations(esClient);
     });
 
+    evaluate('retrieves one entry from the KB without LLM', async ({ chatClient }) => {
+      const conversation = await chatClient.complete({
+        messages: 'What DevOps teams do we have and how is the on-call rotation managed?',
+      });
+      const contextResponseMessage = conversation.messages.find((msg) => msg.name === 'context');
+      if (!contextResponseMessage) {
+        throw new Error('No context function message returned');
+      }
+
+      const { learnings } = JSON.parse(contextResponseMessage.content!);
+      const firstLearning = learnings[0];
+
+      if (learnings.length !== 1) {
+        throw new Error(`Expected 1 learning, got ${learnings.length}`);
+      }
+
+      if (!(firstLearning.llmScore > 4)) {
+        throw new Error(`Expected LLM score > 4, got ${firstLearning.llmScore}`);
+      }
+
+      if (firstLearning.id !== 'acme_teams') {
+        throw new Error(`Expected first learning id "acme_teams", got "${firstLearning.id}"`);
+      }
+    });
+
     evaluate(
       'retrieves and describes DevOps teams and on-call info',
       async ({ evaluateKnowledgeBase }) => {

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
@@ -8,7 +8,7 @@
 import type { EvaluateKnowledgeBase } from './evaluate_knowledge_base';
 import { createEvaluateKnowledgeBase } from './evaluate_knowledge_base';
 import { evaluate as base } from '../../src/evaluate';
-import { clearConversations, clearKnowledgeBase } from './knowledge_base_helpers';
+import { clearConversations, clearKnowledgeBase, testDocs } from './knowledge_base_helpers';
 
 const evaluate = base.extend<{
   evaluateKnowledgeBase: EvaluateKnowledgeBase;
@@ -95,25 +95,7 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
 
   // --- Tests for kb retrieval ---
   evaluate.describe('kb retrieval', () => {
-    const testDocs = [
-      {
-        id: 'acme_teams',
-        title: 'ACME DevOps Team Structure',
-        text: 'ACME maintains three primary DevOps teams: Platform Infrastructure (responsible for cloud infrastructure and Kubernetes clusters), Application Operations (responsible for application deployments and monitoring), and Security Operations (responsible for security monitoring and compliance). Each team maintains a separate on-call rotation accessible via PagerDuty. The current on-call schedule is available in the #oncall Slack channel or through the PagerDuty integration in Kibana.',
-      },
-      {
-        id: 'acme_monitoring',
-        title: 'Alert Thresholds',
-        text: 'Standard alert thresholds for ACME services are: API response time > 500ms (warning) or > 1s (critical), error rate > 1% (warning) or > 5% (critical), CPU usage > 80% (warning) or > 90% (critical), memory usage > 85% (warning) or > 95% (critical). Custom thresholds for specific services are documented in the service runbooks stored in Confluence under the "Service Specifications" space.',
-      },
-      {
-        id: 'acme_infra',
-        title: 'Database Infrastructure',
-        text: 'Primary transactional data is stored in PostgreSQL clusters with read replicas in each region. Customer metadata is stored in MongoDB with M40 clusters in each region. Caching layer uses Redis Enterprise Cloud with 15GB instances. All database metrics are collected via Metricbeat with custom dashboards available under "ACME Databases" in Kibana. Database performance alerts are configured to notify the DBA team via the #db-alerts Slack channel.',
-      },
-    ];
-
-    evaluate.beforeAll(async ({ knowledgeBaseClient, esClient }) => {
+    evaluate.beforeAll(async ({ knowledgeBaseClient }) => {
       await knowledgeBaseClient.importEntries({ entries: testDocs });
     });
 

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
@@ -45,7 +45,6 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
               input: {
                 question:
                   'Remember that this cluster is used to test the AI Assistant using the Observability AI Evaluation Framework',
-                conversationId: undefined,
               },
               output: {
                 criteria: [
@@ -60,11 +59,15 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
         },
       });
     });
-    evaluate('recalls information', async ({ chatClient, evaluateKnowledgeBase }) => {
-      let conversation = await chatClient.complete({
-        messages:
-          'Remember that this cluster is used to test the AI Assistant using the Observability AI Evaluation Framework',
-        persist: true,
+    evaluate('recalls information', async ({ knowledgeBaseClient, evaluateKnowledgeBase }) => {
+      await knowledgeBaseClient.importEntries({
+        entries: [
+          {
+            id: 'cluster_purpose',
+            title: 'Cluster Purpose',
+            text: 'This cluster is used to test the AI Assistant using the Observability AI Evaluation Framework.',
+          },
+        ],
       });
       await evaluateKnowledgeBase({
         dataset: {
@@ -73,7 +76,6 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
           examples: [
             {
               input: {
-                conversationId: conversation.conversationId! || undefined,
                 question: `What is this cluster used for?`,
               },
               output: {
@@ -138,7 +140,6 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
             examples: [
               {
                 input: {
-                  conversationId: undefined,
                   question: 'What DevOps teams do we have and how is the on-call rotation managed?',
                 },
                 output: {
@@ -168,7 +169,6 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
             examples: [
               {
                 input: {
-                  conversationId: undefined,
                   question:
                     'What are our standard alert thresholds for services and what database technologies do we use?',
                 },

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
@@ -8,6 +8,7 @@
 import type { EvaluateKnowledgeBase } from './evaluate_knowledge_base';
 import { createEvaluateKnowledgeBase } from './evaluate_knowledge_base';
 import { evaluate as base } from '../../src/evaluate';
+import { clearConversations, clearKnowledgeBase } from './knowledge_base_helpers';
 
 const evaluate = base.extend<{
   evaluateKnowledgeBase: EvaluateKnowledgeBase;
@@ -31,18 +32,10 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
   // --- Tests for kb functions ---
   evaluate.describe('kb functions', () => {
     evaluate.afterEach(async ({ esClient }) => {
-      await esClient.deleteByQuery({
-        index: '.kibana-observability-ai-assistant-kb-*',
-        ignore_unavailable: true,
-        query: {
-          match: {
-            text: {
-              query: '*Observability AI Evaluation Framework*',
-            },
-          },
-        },
-      });
+      await clearKnowledgeBase(esClient);
+      await clearConversations(esClient);
     });
+
     evaluate('summarizes information', async ({ evaluateKnowledgeBase }) => {
       await evaluateKnowledgeBase({
         dataset: {
@@ -125,16 +118,8 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
     });
 
     evaluate.afterAll(async ({ esClient }) => {
-      await esClient.deleteByQuery({
-        index: '.kibana-observability-ai-assistant-kb-*',
-        ignore_unavailable: true,
-        query: {
-          match: {
-            text: 'ACME',
-          },
-        },
-        refresh: true,
-      });
+      await clearKnowledgeBase(esClient);
+      await clearConversations(esClient);
     });
 
     evaluate(

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
@@ -1,4 +1,12 @@
-import { createEvaluateKnowledgeBase, EvaluateKnowledgeBase } from './evaluate_knowledge_base';
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EvaluateKnowledgeBase } from './evaluate_knowledge_base';
+import { createEvaluateKnowledgeBase } from './evaluate_knowledge_base';
 import { evaluate as base } from '../../src/evaluate';
 
 const evaluate = base.extend<{

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
@@ -1,0 +1,193 @@
+import { createEvaluateKnowledgeBase, EvaluateKnowledgeBase } from './evaluate_knowledge_base';
+import { evaluate as base } from '../../src/evaluate';
+
+const evaluate = base.extend<{
+  evaluateKnowledgeBase: EvaluateKnowledgeBase;
+}>({
+  evaluateKnowledgeBase: [
+    ({ knowledgeBaseClient, chatClient, evaluators, phoenixClient }, use) => {
+      use(
+        createEvaluateKnowledgeBase({
+          chatClient,
+          evaluators,
+          phoenixClient,
+          knowledgeBaseClient,
+        })
+      );
+    },
+    { scope: 'test' },
+  ],
+});
+
+evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
+  // --- Tests for kb functions ---
+  evaluate.describe('kb functions', () => {
+    evaluate.afterEach(async ({ esClient }) => {
+      await esClient.deleteByQuery({
+        index: '.kibana-observability-ai-assistant-kb-*',
+        ignore_unavailable: true,
+        query: {
+          match: {
+            text: {
+              query: '*Observability AI Evaluation Framework*',
+            },
+          },
+        },
+      });
+    });
+    evaluate('summarizes information', async ({ evaluateKnowledgeBase }) => {
+      await evaluateKnowledgeBase({
+        dataset: {
+          name: 'kb_functions_summarize',
+          description: 'Tests the summarize function of the knowledge base',
+          examples: [
+            {
+              input: {
+                question:
+                  'Remember that this cluster is used to test the AI Assistant using the Observability AI Evaluation Framework',
+                conversationId: undefined,
+              },
+              output: {
+                criteria: [
+                  'Calls the summarize function',
+                  'Effectively summarizes that this cluster is used to test the AI Assistant using the Observability AI Evaluation Framework',
+                  'The answer states that the information has been remembered',
+                ],
+              },
+              metadata: {},
+            },
+          ],
+        },
+      });
+    });
+    evaluate('recalls information', async ({ chatClient, evaluateKnowledgeBase }) => {
+      let conversation = await chatClient.complete({
+        messages:
+          'Remember that this cluster is used to test the AI Assistant using the Observability AI Evaluation Framework',
+        persist: true,
+      });
+      await evaluateKnowledgeBase({
+        dataset: {
+          name: 'kb_functions_recall',
+          description: 'Tests the recall functions of the knowledge base',
+          examples: [
+            {
+              input: {
+                conversationId: conversation.conversationId! || undefined,
+                question: `What is this cluster used for?`,
+              },
+              output: {
+                criteria: [
+                  'Calls the "context" function to respond to What is this cluster used for?',
+                  'Effectively recalls that this cluster is used to test the AI Assistant using the Observability AI Evaluation Framework',
+                ],
+              },
+              metadata: {},
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  // --- Tests for kb retrieval ---
+  evaluate.describe('kb retrieval', () => {
+    const testDocs = [
+      {
+        id: 'acme_teams',
+        title: 'ACME DevOps Team Structure',
+        text: 'ACME maintains three primary DevOps teams: Platform Infrastructure (responsible for cloud infrastructure and Kubernetes clusters), Application Operations (responsible for application deployments and monitoring), and Security Operations (responsible for security monitoring and compliance). Each team maintains a separate on-call rotation accessible via PagerDuty. The current on-call schedule is available in the #oncall Slack channel or through the PagerDuty integration in Kibana.',
+      },
+      {
+        id: 'acme_monitoring',
+        title: 'Alert Thresholds',
+        text: 'Standard alert thresholds for ACME services are: API response time > 500ms (warning) or > 1s (critical), error rate > 1% (warning) or > 5% (critical), CPU usage > 80% (warning) or > 90% (critical), memory usage > 85% (warning) or > 95% (critical). Custom thresholds for specific services are documented in the service runbooks stored in Confluence under the "Service Specifications" space.',
+      },
+      {
+        id: 'acme_infra',
+        title: 'Database Infrastructure',
+        text: 'Primary transactional data is stored in PostgreSQL clusters with read replicas in each region. Customer metadata is stored in MongoDB with M40 clusters in each region. Caching layer uses Redis Enterprise Cloud with 15GB instances. All database metrics are collected via Metricbeat with custom dashboards available under "ACME Databases" in Kibana. Database performance alerts are configured to notify the DBA team via the #db-alerts Slack channel.',
+      },
+    ];
+
+    // Ported from the original `before` block
+    evaluate.beforeAll(async ({ knowledgeBaseClient, esClient }) => {
+      await knowledgeBaseClient.importEntries({ entries: testDocs });
+    });
+
+    evaluate.afterAll(async ({ esClient }) => {
+      await esClient.deleteByQuery({
+        index: '.kibana-observability-ai-assistant-kb-*',
+        ignore_unavailable: true,
+        query: {
+          match: {
+            text: 'ACME',
+          },
+        },
+        refresh: true,
+      });
+    });
+
+    evaluate(
+      'retrieves and describes DevOps teams and on-call info',
+      async ({ evaluateKnowledgeBase }) => {
+        // This combines the original two "DevOps" tests into a single, comprehensive evaluation.
+        await evaluateKnowledgeBase({
+          dataset: {
+            name: 'kb_retrieval_devops',
+            description:
+              'Tests retrieval of DevOps team and on-call information from the knowledge base.',
+            examples: [
+              {
+                input: {
+                  conversationId: undefined,
+                  question: 'What DevOps teams do we have and how is the on-call rotation managed?',
+                },
+                output: {
+                  criteria: [
+                    'Uses context function response to find information about ACME DevOps team structure',
+                    "Correctly identifies all three teams: Platform Infrastructure, Application Operations, and Security Operations and describes each team's responsibilities",
+                    'Mentions that on-call rotations are managed through PagerDuty and includes information about accessing the on-call schedule via Slack or Kibana',
+                    'Does not invent unrelated or hallucinated details not present in the KB',
+                  ],
+                },
+                metadata: {},
+              },
+            ],
+          },
+        });
+      }
+    );
+
+    evaluate(
+      'retrieves monitoring thresholds and database infrastructure details',
+      async ({ evaluateKnowledgeBase }) => {
+        await evaluateKnowledgeBase({
+          dataset: {
+            name: 'kb_retrieval_monitoring_db',
+            description:
+              'Tests retrieval of monitoring thresholds and database infrastructure details.',
+            examples: [
+              {
+                input: {
+                  conversationId: undefined,
+                  question:
+                    'What are our standard alert thresholds for services and what database technologies do we use?',
+                },
+                output: {
+                  criteria: [
+                    'Uses context function response to find the correct documents about alert thresholds and database infrastructure',
+                    'Mentions the specific alert thresholds for API response time, error rate, CPU usage, and memory usage',
+                    'Identifies the primary database technologies: PostgreSQL, MongoDB, and Redis and mentions that database metrics are collected via Metricbeat',
+                    'Does not combine information incorrectly or hallucinate details not present in the KB',
+                  ],
+                },
+                metadata: {},
+              },
+            ],
+          },
+        });
+      }
+    );
+  });
+});

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
@@ -11,6 +11,12 @@ import { evaluate as base } from '../../src/evaluate';
 import { clearConversations } from '../utils/conversation';
 import { clearKnowledgeBase, testDocs } from '../utils/knowledge_base';
 
+/**
+ * NOTE: This scenario has been migrated from the legacy evaluation framework.
+ * - x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/kb/index.spec.ts
+ * Any changes should be made in both places until the legacy evaluation framework is removed.
+ */
+
 const evaluate = base.extend<{
   evaluateKnowledgeBase: EvaluateKnowledgeBase;
 }>({
@@ -30,7 +36,6 @@ const evaluate = base.extend<{
 });
 
 evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
-  // --- Tests for kb functions ---
   evaluate.describe('kb functions', () => {
     evaluate.afterEach(async ({ esClient }) => {
       await clearKnowledgeBase(esClient);
@@ -94,7 +99,6 @@ evaluate.describe('Knowledge base', { tag: '@svlOblt' }, () => {
     });
   });
 
-  // --- Tests for kb retrieval ---
   evaluate.describe('kb retrieval', () => {
     evaluate.beforeAll(async ({ knowledgeBaseClient }) => {
       await knowledgeBaseClient.importEntries({ entries: testDocs });

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
@@ -8,7 +8,8 @@
 import type { EvaluateKnowledgeBase } from './evaluate_knowledge_base';
 import { createEvaluateKnowledgeBase } from './evaluate_knowledge_base';
 import { evaluate as base } from '../../src/evaluate';
-import { clearConversations, clearKnowledgeBase, testDocs } from './knowledge_base_helpers';
+import { clearConversations } from '../utils/conversation';
+import { clearKnowledgeBase, testDocs } from '../utils/knowledge_base';
 
 const evaluate = base.extend<{
   evaluateKnowledgeBase: EvaluateKnowledgeBase;

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base_helpers.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base_helpers.ts
@@ -1,4 +1,4 @@
-import { EsClient } from '@kbn/scout';
+import { EsClient } from '@kbn/scout-oblt';
 import pRetry from 'p-retry';
 
 export async function clearKnowledgeBase(esClient: EsClient) {

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base_helpers.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base_helpers.ts
@@ -1,0 +1,32 @@
+import { EsClient } from '@kbn/scout';
+import pRetry from 'p-retry';
+
+export async function clearKnowledgeBase(esClient: EsClient) {
+  const KB_INDEX = '.kibana-observability-ai-assistant-kb-*';
+  return pRetry(
+    () => {
+      return esClient.deleteByQuery({
+        index: KB_INDEX,
+        conflicts: 'proceed',
+        query: { match_all: {} },
+        refresh: true,
+      });
+    },
+    { retries: 5 }
+  );
+}
+
+export async function clearConversations(esClient: EsClient) {
+  const CONV_INDEX = '.kibana-observability-ai-assistant-conversations-*';
+  return pRetry(
+    () => {
+      return esClient.deleteByQuery({
+        index: CONV_INDEX,
+        conflicts: 'proceed',
+        query: { match_all: {} },
+        refresh: true,
+      });
+    },
+    { retries: 5 }
+  );
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base_helpers.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base_helpers.ts
@@ -1,4 +1,11 @@
-import { EsClient } from '@kbn/scout-oblt';
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsClient } from '@kbn/scout-oblt';
 import pRetry from 'p-retry';
 
 export async function clearKnowledgeBase(esClient: EsClient) {

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base_helpers.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base_helpers.ts
@@ -30,3 +30,81 @@ export async function clearConversations(esClient: EsClient) {
     { retries: 5 }
   );
 }
+
+export const testDocs = [
+  {
+    id: 'acme_teams',
+    title: 'ACME DevOps Team Structure',
+    text: 'ACME maintains three primary DevOps teams: Platform Infrastructure (responsible for cloud infrastructure and Kubernetes clusters), Application Operations (responsible for application deployments and monitoring), and Security Operations (responsible for security monitoring and compliance). Each team maintains a separate on-call rotation accessible via PagerDuty. The current on-call schedule is available in the #oncall Slack channel or through the PagerDuty integration in Kibana.',
+  },
+  {
+    id: 'acme_monitoring',
+    title: 'Alert Thresholds',
+    text: 'Standard alert thresholds for ACME services are: API response time > 500ms (warning) or > 1s (critical), error rate > 1% (warning) or > 5% (critical), CPU usage > 80% (warning) or > 90% (critical), memory usage > 85% (warning) or > 95% (critical). Custom thresholds for specific services are documented in the service runbooks stored in Confluence under the "Service Specifications" space.',
+  },
+  {
+    id: 'acme_infra',
+    title: 'Database Infrastructure',
+    text: 'Primary transactional data is stored in PostgreSQL clusters with read replicas in each region. Customer metadata is stored in MongoDB with M40 clusters in each region. Caching layer uses Redis Enterprise Cloud with 15GB instances. All database metrics are collected via Metricbeat with custom dashboards available under "ACME Databases" in Kibana. Database performance alerts are configured to notify the DBA team via the #db-alerts Slack channel.',
+  },
+  {
+    id: 'acme_security',
+    title: 'Security Practices',
+    text: 'ACME follows strict security guidelines including regular audits, monitoring via Security Operations team, and compliance with internal policies.',
+  },
+  {
+    id: 'acme_network',
+    title: 'Network Architecture',
+    text: 'ACME network consists of segmented VLANs for production, staging, and development. Firewalls, VPNs, and secure ingress/egress policies are applied.',
+  },
+  {
+    id: 'acme_backup',
+    title: 'Backup Policies',
+    text: 'Databases are backed up daily with weekly full snapshots and retained for 30 days. Backups are tested monthly for integrity and recoverability.',
+  },
+  {
+    id: 'acme_deploy',
+    title: 'Deployment Procedures',
+    text: 'Applications are deployed via CI/CD pipelines using GitHub Actions. Rollbacks are automated in case of failures, and deployments require approvals from the responsible team.',
+  },
+  {
+    id: 'acme_logging',
+    title: 'Logging Practices',
+    text: 'Logs from all services are centralized in Elasticsearch via Filebeat and Logstash, with dashboards available in Kibana for monitoring and troubleshooting.',
+  },
+  {
+    id: 'acme_alerting',
+    title: 'Alerting Policies',
+    text: 'Critical alerts are sent via Slack and PagerDuty to the on-call team. Alerts are categorized by severity and handled according to the runbook instructions.',
+  },
+  {
+    id: 'acme_api',
+    title: 'API Guidelines',
+    text: 'APIs follow REST principles, with versioning and authentication via OAuth2. Rate limits are enforced, and all endpoints are documented in the internal API portal.',
+  },
+  {
+    id: 'acme_compliance',
+    title: 'Compliance Requirements',
+    text: 'ACME adheres to GDPR and SOC 2 compliance requirements. All user data is encrypted at rest and in transit.',
+  },
+  {
+    id: 'acme_ci_cd',
+    title: 'CI/CD Pipeline Details',
+    text: 'ACME uses Jenkins and GitHub Actions for continuous integration and deployment. Pipelines include automated testing, linting, and deployment to staging before production release.',
+  },
+  {
+    id: 'acme_incidents',
+    title: 'Incident Management',
+    text: 'All incidents are logged in Jira and tracked by severity. The on-call engineer is responsible for initial response, with postmortems conducted for P1/P2 incidents.',
+  },
+  {
+    id: 'acme_storage',
+    title: 'Storage Infrastructure',
+    text: 'ACME storage includes AWS S3 buckets for object storage, EBS volumes for block storage, and replicated snapshots for disaster recovery.',
+  },
+  {
+    id: 'acme_monitoring_tools',
+    title: 'Monitoring Tools',
+    text: 'ACME uses Prometheus for metrics collection, Grafana for dashboards, and Alertmanager for alerting. All monitoring data is centralized and available to relevant teams.',
+  },
+];

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/utils/conversation.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/utils/conversation.ts
@@ -1,0 +1,17 @@
+import { EsClient } from '@kbn/scout-oblt';
+import pRetry from 'p-retry';
+
+export async function clearConversations(esClient: EsClient) {
+  const CONV_INDEX = '.kibana-observability-ai-assistant-conversations-*';
+  return pRetry(
+    () => {
+      return esClient.deleteByQuery({
+        index: CONV_INDEX,
+        conflicts: 'proceed',
+        query: { match_all: {} },
+        refresh: true,
+      });
+    },
+    { retries: 5 }
+  );
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/utils/conversation.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/utils/conversation.ts
@@ -1,4 +1,11 @@
-import { EsClient } from '@kbn/scout-oblt';
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsClient } from '@kbn/scout-oblt';
 import pRetry from 'p-retry';
 
 export async function clearConversations(esClient: EsClient) {

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/utils/knowledge_base.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/utils/knowledge_base.ts
@@ -23,21 +23,6 @@ export async function clearKnowledgeBase(esClient: EsClient) {
   );
 }
 
-export async function clearConversations(esClient: EsClient) {
-  const CONV_INDEX = '.kibana-observability-ai-assistant-conversations-*';
-  return pRetry(
-    () => {
-      return esClient.deleteByQuery({
-        index: CONV_INDEX,
-        conflicts: 'proceed',
-        query: { match_all: {} },
-        refresh: true,
-      });
-    },
-    { retries: 5 }
-  );
-}
-
 export const testDocs = [
   {
     id: 'acme_teams',

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/chat_client.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/chat_client.ts
@@ -58,7 +58,6 @@ interface CompleteFunctionParams {
   conversationId?: string;
   options?: Options;
   scope?: AssistantScope;
-  persist?: boolean;
 }
 
 type CompleteFunction = (params: CompleteFunctionParams) => Promise<{
@@ -161,7 +160,6 @@ export class ObservabilityAIAssistantEvaluationChatClient {
   complete: CompleteFunction = async ({
     messages: messagesArg,
     conversationId,
-    persist = false,
     options = {},
     scope,
   }) => {
@@ -184,7 +182,7 @@ export class ObservabilityAIAssistantEvaluationChatClient {
             conversationId,
             messages,
             connectorId: this.connectorId,
-            persist,
+            persist: false,
             scopes: scope ? [scope] : ['observability'],
           }),
           asResponse: true,

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/chat_client.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/chat_client.ts
@@ -58,6 +58,7 @@ interface CompleteFunctionParams {
   conversationId?: string;
   options?: Options;
   scope?: AssistantScope;
+  persist?: boolean;
 }
 
 type CompleteFunction = (params: CompleteFunctionParams) => Promise<{
@@ -160,6 +161,7 @@ export class ObservabilityAIAssistantEvaluationChatClient {
   complete: CompleteFunction = async ({
     messages: messagesArg,
     conversationId,
+    persist = false,
     options = {},
     scope,
   }) => {
@@ -182,7 +184,7 @@ export class ObservabilityAIAssistantEvaluationChatClient {
             conversationId,
             messages,
             connectorId: this.connectorId,
-            persist: false,
+            persist,
             scopes: scope ? [scope] : ['observability'],
           }),
           asResponse: true,

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/knowledge_base_client.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/knowledge_base_client.ts
@@ -27,16 +27,13 @@ export class KnowledgeBaseClient {
 
     await pRetry(
       async () => {
+        this.log.info('Waiting for knowledge base to be ready...');
         const response = await this.fetch<{}>('/internal/observability_ai_assistant/kb/setup', {
           method: 'POST',
           query: {
             wait_until_complete: true,
+            inference_id: '.elser-2-elasticsearch',
           },
-          body: JSON.stringify({
-            query: {
-              inference_id: '.elser-2-elasticsearch',
-            },
-          }),
         });
 
         this.log.info('Knowledge base is ready');
@@ -46,5 +43,12 @@ export class KnowledgeBaseClient {
     );
 
     this.log.success('Knowledge base installed');
+  }
+
+  async importEntries({ entries }: { entries: unknown[] }): Promise<void> {
+    await this.fetch<{}>('/internal/observability_ai_assistant/kb/entries/import', {
+      method: 'POST',
+      body: JSON.stringify({ entries }),
+    });
   }
 }

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
@@ -2,17 +2,10 @@
   "extends": "../../../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "target/types",
-    "types": [
-      "jest",
-      "node"
-    ]
+    "types": ["jest", "node"]
   },
-  "include": [
-    "**/*.ts",
-  ],
-  "exclude": [
-    "target/**/*"
-  ],
+  "include": ["**/*.ts"],
+  "exclude": ["target/**/*"],
   "kbn_references": [
     "@kbn/apm-synthtrace-client",
     "@kbn/evals",
@@ -21,6 +14,6 @@
     "@kbn/ai-assistant-common",
     "@kbn/core",
     "@kbn/core-http-browser",
-    "@kbn/scout-oblt",
+    "@kbn/scout-oblt"
   ]
 }

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
@@ -14,6 +14,7 @@
     "@kbn/ai-assistant-common",
     "@kbn/core",
     "@kbn/core-http-browser",
-    "@kbn/scout-oblt"
+    "@kbn/scout-oblt",
+    "@kbn/scout"
   ]
 }

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
@@ -14,7 +14,6 @@
     "@kbn/ai-assistant-common",
     "@kbn/core",
     "@kbn/core-http-browser",
-    "@kbn/scout-oblt",
-    "@kbn/evals-suite-obs-ai-assistant"
+    "@kbn/scout-oblt"
   ]
 }

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
@@ -14,6 +14,7 @@
     "@kbn/ai-assistant-common",
     "@kbn/core",
     "@kbn/core-http-browser",
-    "@kbn/scout-oblt"
+    "@kbn/scout-oblt",
+    "@kbn/evals-suite-obs-ai-assistant"
   ]
 }

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
@@ -14,7 +14,6 @@
     "@kbn/ai-assistant-common",
     "@kbn/core",
     "@kbn/core-http-browser",
-    "@kbn/scout-oblt",
-    "@kbn/scout"
+    "@kbn/scout-oblt"
   ]
 }

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/kb/index.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/kb/index.spec.ts
@@ -17,7 +17,6 @@ describe('Knowledge base', () => {
   describe('kb functions', () => {
     // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
     // Any new improvements should be made in both frameworks.
-    // This scenario will be deleted when all legacy scenarios have been migrated.
     it('summarizes and recalls information', async () => {
       let conversation = await chatClient.complete({
         messages:
@@ -107,7 +106,6 @@ describe('Knowledge base', () => {
       });
       // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
       // Any new improvements should be made in both frameworks.
-      // This scenario will be deleted when all legacy scenarios have been migrated.
       it('retrieves one entry from the KB', async () => {
         const contextResponseMessage = conversation.messages.find(
           (msg) => msg.name === CONTEXT_FUNCTION_NAME
@@ -121,7 +119,6 @@ describe('Knowledge base', () => {
       });
       // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
       // Any new improvements should be made in both frameworks.
-      // This scenario will be deleted when all legacy scenarios have been migrated.
       it('retrieves DevOps team structure and on-call information', async () => {
         const result = await chatClient.evaluate(conversation, [
           'Uses context function response to find information about ACME DevOps team structure',
@@ -135,7 +132,6 @@ describe('Knowledge base', () => {
     });
     // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
     // Any new improvements should be made in both frameworks.
-    // This scenario will be deleted when all legacy scenarios have been migrated.
     it('retrieves monitoring thresholds and database infrastructure details', async () => {
       const prompt =
         'What are our standard alert thresholds for services and what database technologies do we use?';

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/kb/index.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/kb/index.spec.ts
@@ -15,6 +15,9 @@ const KB_INDEX = '.kibana-observability-ai-assistant-kb-*';
 
 describe('Knowledge base', () => {
   describe('kb functions', () => {
+    // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
+    // Any new improvements should be made in both frameworks.
+    // This scenario will be deleted when all legacy scenarios have been migrated.
     it('summarizes and recalls information', async () => {
       let conversation = await chatClient.complete({
         messages:
@@ -102,7 +105,9 @@ describe('Knowledge base', () => {
         const prompt = 'What DevOps teams does we have and how is the on-call rotation managed?';
         conversation = await chatClient.complete({ messages: prompt });
       });
-
+      // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
+      // Any new improvements should be made in both frameworks.
+      // This scenario will be deleted when all legacy scenarios have been migrated.
       it('retrieves one entry from the KB', async () => {
         const contextResponseMessage = conversation.messages.find(
           (msg) => msg.name === CONTEXT_FUNCTION_NAME
@@ -114,7 +119,9 @@ describe('Knowledge base', () => {
         expect(firstLearning.llmScore).to.be.greaterThan(4);
         expect(firstLearning.id).to.be('acme_teams');
       });
-
+      // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
+      // Any new improvements should be made in both frameworks.
+      // This scenario will be deleted when all legacy scenarios have been migrated.
       it('retrieves DevOps team structure and on-call information', async () => {
         const result = await chatClient.evaluate(conversation, [
           'Uses context function response to find information about ACME DevOps team structure',
@@ -126,7 +133,9 @@ describe('Knowledge base', () => {
         expect(result.passed).to.be(true);
       });
     });
-
+    // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
+    // Any new improvements should be made in both frameworks.
+    // This scenario will be deleted when all legacy scenarios have been migrated.
     it('retrieves monitoring thresholds and database infrastructure details', async () => {
       const prompt =
         'What are our standard alert thresholds for services and what database technologies do we use?';

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/kb/index.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/kb/index.spec.ts
@@ -11,12 +11,16 @@ import expect from '@kbn/expect';
 import { CONTEXT_FUNCTION_NAME, MessageRole } from '@kbn/observability-ai-assistant-plugin/common';
 import { chatClient, esClient, kibanaClient } from '../../services';
 
+/**
+ * NOTE: This scenario has been migrated from the legacy evaluation framework.
+ * - x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts
+ * Any changes should be made in both places until the legacy evaluation framework is removed.
+ */
+
 const KB_INDEX = '.kibana-observability-ai-assistant-kb-*';
 
 describe('Knowledge base', () => {
   describe('kb functions', () => {
-    // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
-    // Any new improvements should be made in both frameworks.
     it('summarizes and recalls information', async () => {
       let conversation = await chatClient.complete({
         messages:
@@ -104,8 +108,7 @@ describe('Knowledge base', () => {
         const prompt = 'What DevOps teams does we have and how is the on-call rotation managed?';
         conversation = await chatClient.complete({ messages: prompt });
       });
-      // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
-      // Any new improvements should be made in both frameworks.
+
       it('retrieves one entry from the KB', async () => {
         const contextResponseMessage = conversation.messages.find(
           (msg) => msg.name === CONTEXT_FUNCTION_NAME
@@ -117,8 +120,7 @@ describe('Knowledge base', () => {
         expect(firstLearning.llmScore).to.be.greaterThan(4);
         expect(firstLearning.id).to.be('acme_teams');
       });
-      // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
-      // Any new improvements should be made in both frameworks.
+
       it('retrieves DevOps team structure and on-call information', async () => {
         const result = await chatClient.evaluate(conversation, [
           'Uses context function response to find information about ACME DevOps team structure',
@@ -130,8 +132,7 @@ describe('Knowledge base', () => {
         expect(result.passed).to.be(true);
       });
     });
-    // This scenario has been migrated to x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/knowledge_base/knowledge_base.spec.ts.
-    // Any new improvements should be made in both frameworks.
+
     it('retrieves monitoring thresholds and database infrastructure details', async () => {
       const prompt =
         'What are our standard alert thresholds for services and what database technologies do we use?';


### PR DESCRIPTION
## Summary

Migrate knowledge base scenarios to new evaluation framework.


### Results
#### Model: anthropic.claude-3-5-sonnet-20241022-v2:0 (Claude/Anthropic)
| Dataset                    | # Examples | kb-evaluator | mean  | median | std   | min   | max   |
|-----------------------------|------------|--------------|-------|--------|-------|-------|-------|
| kb_functions_summarize      | 1          | 100.0%       | 1.000 | 1.000  | 0.000 | 1.000 | 1.000 |
| kb_functions_recall         | 1          | 100.0%       | 1.000 | 1.000  | 0.000 | 1.000 | 1.000 |
| kb_retrieval_devops         | 1          | 100.0%       | 1.000 | 1.000  | 0.000 | 1.000 | 1.000 |
| kb_retrieval_monitoring_db  | 1          | 100.0%       | 1.000 | 1.000  | 0.000 | 1.000 | 1.000 |
| **Overall**                 | **4**      | **100.0%**   | 1.000 | 1.000  | 0.000 | 1.000 | 1.000 |

#### Model: gpt-4o (GPT/OpenAI)
| Dataset                    | # Examples | kb-evaluator | mean  | median | std   | min   | max   |
|-----------------------------|------------|--------------|-------|--------|-------|-------|-------|
| kb_functions_summarize      | 1          | 100.0%       | 1.000 | 1.000  | 0.000 | 1.000 | 1.000 |
| kb_functions_recall         | 1          | 100.0%       | 1.000 | 1.000  | 0.000 | 1.000 | 1.000 |
| kb_retrieval_devops         | 1          | 100.0%       | 1.000 | 1.000  | 0.000 | 1.000 | 1.000 |
| kb_retrieval_monitoring_db  | 1          | 100.0%       | 1.000 | 1.000  | 0.000 | 1.000 | 1.000 |
| **Overall**                 | **4**      | **100.0%**   | 1.000 | 1.000  | 0.000 | 1.000 | 1.000 |
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


## Release notes

Migrate knowledge base scenarios to new evaluation framework.

