### PR TITLE
[ES|QL][Discover] Removes the default limit 10 added on the query

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.test.ts
@@ -122,8 +122,8 @@ describe('getInitialESQLQuery', () => {
       },
     ] as DataView['fields'];
     const dataView = getDataView('logs*', fields, '@custom_timestamp');
-    expect(getInitialESQLQuery(dataView, { language: 'kuery', query: 'error' })).toBe(
-      'FROM logs* | WHERE @custom_timestamp >= ?_tstart AND @custom_timestamp <= ?_tend AND KQL("""error""") | LIMIT 10'
+    expect(getInitialESQLQuery(dataView, true, { language: 'kuery', query: 'error' })).toBe(
+      'FROM logs* | WHERE @custom_timestamp >= ?_tstart AND @custom_timestamp <= ?_tend AND KQL("""error""")'
     );
   });
 
@@ -147,7 +147,7 @@ describe('getInitialESQLQuery', () => {
       },
     ] as DataView['fields'];
     const dataView = getDataView('logs*', fields, 'timestamp');
-    expect(getInitialESQLQuery(dataView, { language: 'lucene', query: 'error' })).toBe(
+    expect(getInitialESQLQuery(dataView, false, { language: 'lucene', query: 'error' })).toBe(
       'FROM logs* | WHERE QSTR("""error""") | LIMIT 10'
     );
   });
@@ -172,8 +172,8 @@ describe('getInitialESQLQuery', () => {
       },
     ] as DataView['fields'];
     const dataView = getDataView('logs*', fields, 'timestamp');
-    expect(getInitialESQLQuery(dataView, { language: 'unknown', query: 'error' })).toBe(
-      'FROM logs* | LIMIT 10'
+    expect(getInitialESQLQuery(dataView, true, { language: 'unknown', query: 'error' })).toBe(
+      'FROM logs*'
     );
   });
 });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.ts
@@ -40,7 +40,11 @@ const getFinalWhereClause = (timeFilter?: string, queryFilter?: string) => {
  * If there is no @timestamp and there is a dataView timeFieldName, we add the WHERE clause with the timeFieldName
  * @param dataView
  */
-export function getInitialESQLQuery(dataView: DataView, query?: Query): string {
+export function getInitialESQLQuery(
+  dataView: DataView,
+  removeLimit?: boolean,
+  query?: Query
+): string {
   const hasAtTimestampField = dataView?.fields?.getByName?.('@timestamp')?.type === 'date';
   const timeFieldName = dataView?.timeFieldName;
   const filterByTimeParams =
@@ -51,5 +55,5 @@ export function getInitialESQLQuery(dataView: DataView, query?: Query): string {
   const filterBySearchText = getFilterBySearchText(query);
 
   const whereClause = getFinalWhereClause(filterByTimeParams, filterBySearchText);
-  return `FROM ${dataView.getIndexPattern()}${whereClause} | LIMIT 10`;
+  return `FROM ${dataView.getIndexPattern()}${whereClause}${removeLimit ? '' : ' | LIMIT 10'}`;
 }

--- a/src/platform/plugins/shared/discover/common/esql_locator_get_location.ts
+++ b/src/platform/plugins/shared/discover/common/esql_locator_get_location.ts
@@ -22,7 +22,7 @@ export const esqlLocatorGetLocation = async ({
 }): ReturnType<DiscoverESQLLocatorGetLocation> => {
   const indexName = (await getIndexForESQLQuery({ dataViews })) ?? '*';
   const dataView = await getESQLAdHocDataview(`from ${indexName}`, dataViews);
-  const esql = getInitialESQLQuery(dataView);
+  const esql = getInitialESQLQuery(dataView, true);
 
   const params = {
     query: { esql },

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -127,7 +127,7 @@ export const useTopNavLinks = ({
       if (!defaultMenu?.newItem?.disabled) {
         const defaultEsqlState: Pick<DiscoverAppState, 'query'> | undefined =
           isEsqlMode && currentDataView.type === ESQL_TYPE
-            ? { query: { esql: getInitialESQLQuery(currentDataView) } }
+            ? { query: { esql: getInitialESQLQuery(currentDataView, true) } }
             : undefined;
         const locatorParams: DiscoverAppLocatorParams = defaultEsqlState
           ? defaultEsqlState

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
@@ -1046,7 +1046,7 @@ describe('Discover state', () => {
       state.appState.set({ query });
       await state.actions.transitionFromDataViewToESQL(dataViewMock);
       expect(state.appState.getState().query).toStrictEqual({
-        esql: 'FROM the-data-view-title | WHERE KQL("""foo: \'bar\'""") | LIMIT 10',
+        esql: 'FROM the-data-view-title | WHERE KQL("""foo: \'bar\'""")',
       });
       expect(state.getCurrentTab().globalState.filters).toStrictEqual([]);
       expect(state.appState.getState().filters).toStrictEqual([]);
@@ -1055,7 +1055,7 @@ describe('Discover state', () => {
     test('transitionFromESQLToDataView', async () => {
       const savedSearchWithQuery = copySavedSearch(savedSearchMock);
       const query = {
-        esql: 'FROM the-data-view-title | LIMIT 10',
+        esql: 'FROM the-data-view-title',
       };
       savedSearchWithQuery.searchSource.setField('query', query);
       const { state } = await getState('/', { savedSearch: savedSearchWithQuery });

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
@@ -361,7 +361,7 @@ export function getDiscoverStateContainer({
     const appState = appStateContainer.get();
     const { query } = appState;
     const filterQuery = query && isOfQueryType(query) ? query : undefined;
-    const queryString = getInitialESQLQuery(dataView, filterQuery);
+    const queryString = getInitialESQLQuery(dataView, true, filterQuery);
 
     appStateContainer.update({
       query: { esql: queryString },

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -144,7 +144,9 @@ export const updateTabs: InternalStateThunkActionCreator<[TabbedContentState], P
           const isCurrentModeESQL = isOfAggregateQueryType(currentQuery);
 
           tab.initialAppState = {
-            query: isCurrentModeESQL ? { esql: getInitialESQLQuery(currentDataView) } : undefined,
+            query: isCurrentModeESQL
+              ? { esql: getInitialESQLQuery(currentDataView, true) }
+              : undefined,
             dataSource: createDataSource({
               dataView: currentDataView,
               query: currentQuery,

--- a/src/platform/plugins/shared/discover/public/plugin_imports/search_provider_find.ts
+++ b/src/platform/plugins/shared/discover/public/plugin_imports/search_provider_find.ts
@@ -50,7 +50,7 @@ export const searchProviderFind: (
 
   const params = {
     query: {
-      esql: getInitialESQLQuery(defaultDataView),
+      esql: getInitialESQLQuery(defaultDataView, true),
     },
     dataViewSpec: defaultDataView?.toSpec(),
   };

--- a/src/platform/test/functional/apps/discover/esql/_esql_view.ts
+++ b/src/platform/test/functional/apps/discover/esql/_esql_view.ts
@@ -457,7 +457,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await testSubjects.click('ESQLEditor-toggle-query-history-button');
         const historyItems = await esql.getHistoryItems();
-        await esql.isQueryPresentInTable('FROM logstash-* | LIMIT 10', historyItems);
+        await esql.isQueryPresentInTable('FROM logstash-*', historyItems);
       });
 
       it('updating the query should add this to the history', async () => {

--- a/src/platform/test/functional/apps/discover/group10/_lens_vis.ts
+++ b/src/platform/test/functional/apps/discover/group10/_lens_vis.ts
@@ -217,7 +217,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await discover.selectTextBaseLang();
       await header.waitUntilLoadingHasFinished();
       await discover.waitUntilSearchingHasFinished();
-      await checkNoVis('10');
+      await checkNoVis('50');
     });
 
     it('should show ESQL histogram for ES|QL query', async () => {

--- a/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_field_tokens.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_field_tokens.ts
@@ -142,7 +142,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should render field tokens correctly for ES|QL', async function () {
       await discover.selectTextBaseLang();
-      expect(await discover.getHitCount()).to.be('10');
+      expect(await discover.getHitCount()).to.be('1000');
       await unifiedFieldList.clickFieldListItemAdd('@timestamp');
       await unifiedFieldList.clickFieldListItemAdd('bytes');
       await unifiedFieldList.clickFieldListItemAdd('extension');

--- a/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_field_tokens.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_field_tokens.ts
@@ -142,7 +142,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should render field tokens correctly for ES|QL', async function () {
       await discover.selectTextBaseLang();
-      expect(await discover.getHitCount()).to.be('1000');
+      expect(await discover.getHitCount()).to.be('1,000');
       await unifiedFieldList.clickFieldListItemAdd('@timestamp');
       await unifiedFieldList.clickFieldListItemAdd('bytes');
       await unifiedFieldList.clickFieldListItemAdd('extension');

--- a/src/platform/test/functional/apps/discover/group7/_new_search.ts
+++ b/src/platform/test/functional/apps/discover/group7/_new_search.ts
@@ -113,9 +113,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await discover.clickNewSearchButton();
       await discover.waitUntilSearchingHasFinished();
-      expect(await monacoEditor.getCodeEditorValue()).to.be('FROM logstash-* | LIMIT 10');
+      expect(await monacoEditor.getCodeEditorValue()).to.be('FROM logstash-*');
       expect(await discover.getVisContextSuggestionType()).to.be('histogramForESQL');
-      expect(await discover.getHitCount()).to.be('10');
+      expect(await discover.getHitCount()).to.be('1000');
     });
 
     it('should work correctly for a saved search in ESQL mode', async () => {

--- a/src/platform/test/functional/apps/discover/group7/_new_search.ts
+++ b/src/platform/test/functional/apps/discover/group7/_new_search.ts
@@ -135,7 +135,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await discover.clickNewSearchButton();
       await discover.waitUntilSearchingHasFinished();
       expect(await monacoEditor.getCodeEditorValue()).to.be('FROM logstash-*');
-      expect(await discover.getHitCount()).to.be('10');
+      expect(await discover.getHitCount()).to.be('1,000');
     });
   });
 }

--- a/src/platform/test/functional/apps/discover/group7/_new_search.ts
+++ b/src/platform/test/functional/apps/discover/group7/_new_search.ts
@@ -134,7 +134,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await discover.clickNewSearchButton();
       await discover.waitUntilSearchingHasFinished();
-      expect(await monacoEditor.getCodeEditorValue()).to.be('FROM logstash-* | LIMIT 10');
+      expect(await monacoEditor.getCodeEditorValue()).to.be('FROM logstash-*');
       expect(await discover.getHitCount()).to.be('10');
     });
   });

--- a/src/platform/test/functional/apps/discover/group7/_new_search.ts
+++ b/src/platform/test/functional/apps/discover/group7/_new_search.ts
@@ -115,7 +115,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await discover.waitUntilSearchingHasFinished();
       expect(await monacoEditor.getCodeEditorValue()).to.be('FROM logstash-*');
       expect(await discover.getVisContextSuggestionType()).to.be('histogramForESQL');
-      expect(await discover.getHitCount()).to.be('1000');
+      expect(await discover.getHitCount()).to.be('1,000');
     });
 
     it('should work correctly for a saved search in ESQL mode', async () => {

--- a/src/platform/test/functional/apps/discover/group9/_panels_toggle.ts
+++ b/src/platform/test/functional/apps/discover/group9/_panels_toggle.ts
@@ -234,7 +234,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await unifiedFieldList.waitUntilSidebarHasLoaded();
       });
 
-      checkPanelsToggle({ isChartAvailable: true, totalHits: '1000' });
+      checkPanelsToggle({ isChartAvailable: true, totalHits: '1,000' });
     });
 
     describe('ES|QL with aggs chart', function () {
@@ -271,7 +271,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await unifiedFieldList.waitUntilSidebarHasLoaded();
       });
 
-      checkPanelsToggle({ isChartAvailable: false, totalHits: '1000' });
+      checkPanelsToggle({ isChartAvailable: false, totalHits: '1,000' });
     });
   });
 }

--- a/src/platform/test/functional/apps/discover/group9/_panels_toggle.ts
+++ b/src/platform/test/functional/apps/discover/group9/_panels_toggle.ts
@@ -234,7 +234,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await unifiedFieldList.waitUntilSidebarHasLoaded();
       });
 
-      checkPanelsToggle({ isChartAvailable: true, totalHits: '10' });
+      checkPanelsToggle({ isChartAvailable: true, totalHits: '1000' });
     });
 
     describe('ES|QL with aggs chart', function () {
@@ -271,7 +271,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await unifiedFieldList.waitUntilSidebarHasLoaded();
       });
 
-      checkPanelsToggle({ isChartAvailable: false, totalHits: '10' });
+      checkPanelsToggle({ isChartAvailable: false, totalHits: '1000' });
     });
   });
 }

--- a/src/platform/test/functional/apps/discover/tabs/_new_tab.ts
+++ b/src/platform/test/functional/apps/discover/tabs/_new_tab.ts
@@ -42,7 +42,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await discover.waitUntilTabIsLoaded();
       await discover.selectTextBaseLang();
       await discover.waitUntilTabIsLoaded();
-      expect(await esql.getEsqlEditorQuery()).to.be('FROM logsta* | LIMIT 10');
+      expect(await esql.getEsqlEditorQuery()).to.be('FROM logsta*');
 
       await unifiedTabs.selectTab(0);
       await discover.waitUntilTabIsLoaded();
@@ -71,7 +71,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       // tab 1 - create another new tab in ES|QL mode
-      const defaultQuery = 'FROM logst* | LIMIT 10';
+      const defaultQuery = 'FROM logst*';
       await unifiedTabs.createNewTab();
       await discover.waitUntilTabIsLoaded();
       await discover.selectTextBaseLang();

--- a/src/platform/test/functional/apps/discover/tabs/_no_data.ts
+++ b/src/platform/test/functional/apps/discover/tabs/_no_data.ts
@@ -76,7 +76,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(await unifiedTabs.isTabsBarVisible()).to.be(false);
         await testSubjects.click('tryESQLLink');
         await discover.waitUntilTabIsLoaded();
-        expect(await monacoEditor.getCodeEditorValue()).to.be('FROM logs* | LIMIT 10');
+        expect(await monacoEditor.getCodeEditorValue()).to.be('FROM logs*');
         expect((await dataGrid.getDocTableRows()).length).to.be.above(0);
         expect(await unifiedTabs.isTabsBarVisible()).to.be(true);
       });

--- a/src/platform/test/functional/apps/discover/tabs/_restorable_state.ts
+++ b/src/platform/test/functional/apps/discover/tabs/_restorable_state.ts
@@ -333,7 +333,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should restore the search bar state in ES|QL mode', async () => {
         await discover.selectTextBaseLang();
         await discover.waitUntilTabIsLoaded();
-        const defaultQuery = 'FROM logstash-* | LIMIT 10';
+        const defaultQuery = 'FROM logstash-*';
 
         const expectState = async (query: string, isDirty: boolean) => {
           await retry.try(async () => {
@@ -363,7 +363,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await unifiedTabs.selectTab(0);
         await discover.waitUntilTabIsLoaded();
         await expectState(draftQuery0, true);
-        expect(await discover.getHitCount()).to.be('10');
+        expect(await discover.getHitCount()).to.be('1,000');
         await queryBar.clickQuerySubmitButton();
         await discover.waitUntilTabIsLoaded();
         await expectState(draftQuery0, false);
@@ -372,12 +372,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await unifiedTabs.selectTab(1);
         await discover.waitUntilTabIsLoaded();
         await expectState(defaultQuery, false);
-        expect(await discover.getHitCount()).to.be('10');
+        expect(await discover.getHitCount()).to.be('1,000');
 
         await unifiedTabs.selectTab(2);
         await discover.waitUntilTabIsLoaded();
         await expectState(draftQuery2, true);
-        expect(await discover.getHitCount()).to.be('10');
+        expect(await discover.getHitCount()).to.be('1,000');
         await queryBar.clickQuerySubmitButton();
         await discover.waitUntilTabIsLoaded();
         await expectState(draftQuery2, false);

--- a/src/platform/test/functional/apps/management/data_views/_try_esql.ts
+++ b/src/platform/test/functional/apps/management/data_views/_try_esql.ts
@@ -28,7 +28,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.click('tryESQLLink');
 
       await PageObjects.discover.expectOnDiscover();
-      await esql.expectEsqlStatement('FROM logs* | LIMIT 10');
+      await esql.expectEsqlStatement('FROM logs*');
     });
   });
 }

--- a/x-pack/platform/test/functional/apps/discover/group3/esql_starred.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/esql_starred.ts
@@ -89,7 +89,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.click('starred-queries-tab');
 
       const starredItems = await esql.getStarredItems();
-      await esql.isQueryPresentInTable('FROM logstash-* | LIMIT 10', starredItems);
+      await esql.isQueryPresentInTable('FROM logstash-*', starredItems);
     });
 
     it('should persist the starred query after a browser refresh', async () => {

--- a/x-pack/platform/test/functional/apps/discover/group3/esql_starred.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/esql_starred.ts
@@ -101,7 +101,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.click('ESQLEditor-toggle-query-history-button');
       await testSubjects.click('starred-queries-tab');
       const starredItems = await esql.getStarredItems();
-      await esql.isQueryPresentInTable('FROM logstash-* | LIMIT 10', starredItems);
+      await esql.isQueryPresentInTable('FROM logstash-*', starredItems);
     });
 
     it('should select a query from the starred and submit it', async () => {
@@ -118,7 +118,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await header.waitUntilLoadingHasFinished();
 
       const editorValue = await monacoEditor.getCodeEditorValue();
-      expect(editorValue).to.eql(`FROM logstash-* | LIMIT 10`);
+      expect(editorValue).to.eql(`FROM logstash-*`);
     });
 
     it('should delete a query from the starred queries tab', async () => {

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/esql/_esql_view.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/esql/_esql_view.ts
@@ -397,7 +397,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await testSubjects.click('ESQLEditor-toggle-query-history-button');
         const historyItems = await esql.getHistoryItems();
-        await esql.isQueryPresentInTable('FROM logstash-* | LIMIT 10', historyItems);
+        await esql.isQueryPresentInTable('FROM logstash-*', historyItems);
       });
 
       it('updating the query should add this to the history', async () => {


### PR DESCRIPTION
## Summary

This PR removes the limit 10 from Discover ES|QL default query.

We think that ES is more performant to do this change atm. The maximum default in ES is 10K (thanx Matthias who discovered this) so we must be safe without pagination

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




