### PR TITLE
[kbn-eslint-plugin-eslint] add scout_no_describe_configure rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2422,6 +2422,17 @@ module.exports = {
       },
     },
     {
+      // Custom rules for scout tests
+      files: [
+        'src/platform/plugins/**/test/scout/**/*.ts',
+        'x-pack/platform/**/plugins/**/test/scout/**/*.ts',
+        'x-pack/solutions/**/plugins/test/scout/**/*.ts',
+      ],
+      rules: {
+        '@kbn/eslint/scout_no_describe_configure': 'error',
+      },
+    },
+    {
       // Deployment-agnostic test files must use proper context and services
       files: [
         'x-pack/platform/test/api_integration_deployment_agnostic/apis/**/*.{js,ts}',

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -23,5 +23,6 @@ module.exports = {
     require_kibana_feature_privileges_naming: require('./rules/require_kibana_feature_privileges_naming'),
     no_deprecated_imports: require('./rules/no_deprecated_imports'),
     deployment_agnostic_test_context: require('./rules/deployment_agnostic_test_context'),
+    scout_no_describe_configure: require('./rules/scout_no_describe_configure'),
   },
 };

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_describe_configure.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_describe_configure.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+/** @typedef {import("@typescript-eslint/typescript-estree").TSESTree.CallExpression} CallExpression */
+/** @typedef {import("@typescript-eslint/typescript-estree").TSESTree.MemberExpression} MemberExpression */
+
+const ERROR_MSG = 'Using describe.configure is not allowed in Scout tests.';
+
+/**
+ * Checks if a node represents *.describe.configure()
+ * @param {CallExpression} node
+ * @returns {boolean}
+ */
+const isDescribeConfigure = (node) => {
+  // Check for *.describe.configure()
+  return (
+    node.callee.type === 'MemberExpression' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'configure' &&
+    node.callee.object.type === 'MemberExpression' &&
+    node.callee.object.property.type === 'Identifier' &&
+    node.callee.object.property.name === 'describe'
+  );
+};
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow describe.configure in Scout tests',
+      category: 'Best Practices',
+    },
+    fixable: null,
+    schema: [],
+  },
+  create: (context) => ({
+    CallExpression(node) {
+      if (isDescribeConfigure(node)) {
+        context.report({
+          node,
+          message: ERROR_MSG,
+        });
+      }
+    },
+  }),
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_describe_configure.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_describe_configure.test.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { RuleTester } = require('eslint');
+const rule = require('./scout_no_describe_configure');
+const dedent = require('dedent');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('@kbn/eslint/scout_no_describe_configure', rule, {
+  valid: [
+    {
+      code: dedent`
+        test('should work', () => {
+          expect(true).toBe(true);
+        });
+      `,
+    },
+    {
+      code: dedent`
+        test.describe('my test suite', () => {
+          test('should work', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+    },
+    {
+      code: dedent`
+        spaceTest.describe('my space-aware test suite', () => {
+          spaceTest('should work', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+    },
+    {
+      code: dedent`
+        describe('my test suite', () => {
+          test('should work', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+    },
+    {
+      code: dedent`
+        const describeBlock = test.describe;
+        describeBlock('my test suite', () => {
+          test('should work', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+    },
+  ],
+
+  invalid: [
+    {
+      code: dedent`
+        test.describe.configure({ mode: 'parallel' });
+      `,
+      errors: [
+        {
+          message: 'Using describe.configure is not allowed in Scout tests.',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        test.describe.configure({ 
+          mode: 'parallel',
+          retries: 2 
+        });
+      `,
+      errors: [
+        {
+          message: 'Using describe.configure is not allowed in Scout tests.',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        test.describe('my suite', () => {
+          test.describe.configure({ mode: 'serial' });
+          
+          test('should work', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+      errors: [
+        {
+          message: 'Using describe.configure is not allowed in Scout tests.',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const myTest = test;
+        myTest.describe.configure({ mode: 'parallel' });
+      `,
+      errors: [
+        {
+          message: 'Using describe.configure is not allowed in Scout tests.',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        // Different object with describe.configure should also be caught
+        spaceTest.describe.configure({});
+      `,
+      errors: [
+        {
+          message: 'Using describe.configure is not allowed in Scout tests.',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Adding new rule to prevent playwright runner configuration overrides in spec files. It is important to keep runner functionality unified across all the Scout tests and having custom logic may lead to unexpected CI behavior or wrong test results ingestion.
We already have unified functionality in place:
- retrying failure is handled on CI script level
- parallel test execution is limited to test spec level (we don't allow concurrent run of tests within the same file)
- explicit timeouts for test execution is not recommended, but can be accepted for individual cases

Adding smth like:

```
spaceTest.describe('Discover app - errors', { tag: tags.ESS_ONLY }, () => {
  spaceTest.describe.configure({
    retries: 2,
    timeout: 120000,
  });
```

will be blocked by pre-commit hook:

```
*[scout/scout_no_describe_configure][~/github/kibana]$ gc "add configure"
ERROR
      /Users/dmle/github/kibana/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/error_handling.spec.ts
        12:3  error  Using describe.configure is not allowed in Scout tests  @kbn/eslint/scout_no_describe_configure
```

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->