### PR TITLE
[8.19] Feature/default llm setting ai settings (#233874)

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "@kbn/advanced-settings-plugin": "link:src/platform/plugins/private/advanced_settings",
     "@kbn/ai-assistant": "link:x-pack/platform/packages/shared/kbn-ai-assistant",
     "@kbn/ai-assistant-common": "link:x-pack/platform/packages/shared/ai-assistant/common",
+    "@kbn/ai-assistant-default-llm-setting": "link:x-pack/platform/packages/shared/ai-assistant-default-llm-setting",
     "@kbn/ai-assistant-icon": "link:x-pack/platform/packages/shared/ai-assistant/icon",
     "@kbn/ai-assistant-management-plugin": "link:src/platform/plugins/shared/ai_assistant_management/selection",
     "@kbn/ai-security-labs-content": "link:x-pack/solutions/security/packages/ai-security-labs-content",

--- a/src/platform/packages/shared/kbn-management/settings/setting_ids/index.ts
+++ b/src/platform/packages/shared/kbn-management/settings/setting_ids/index.ts
@@ -127,6 +127,9 @@ export const OBSERVABILITY_AI_ASSISTANT_SIMULATED_FUNCTION_CALLING =
   'observability:aiAssistantSimulatedFunctionCalling';
 export const OBSERVABILITY_AI_ASSISTANT_SEARCH_CONNECTOR_INDEX_PATTERN =
   'observability:aiAssistantSearchConnectorIndexPattern';
+export const GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR = 'genAiSettings:defaultAIConnector';
+export const GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY =
+  'genAiSettings:defaultAIConnectorOnly';
 export const AI_ANONYMIZATION_SETTINGS = 'ai:anonymizationSettings';
 export const OBSERVABILITY_SEARCH_EXCLUDED_DATA_TIERS = 'observability:searchExcludedDataTiers';
 export const AI_ASSISTANT_PREFERRED_AI_ASSISTANT_TYPE = 'aiAssistant:preferredAIAssistantType';

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
@@ -650,6 +650,18 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'keyword',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'genAiSettings:defaultAIConnector': {
+    type: 'keyword',
+    _meta: {
+      description: 'Default AI connector',
+    },
+  },
+  'genAiSettings:defaultAIConnectorOnly': {
+    type: 'boolean',
+    _meta: {
+      description: 'Restrict to default AI connector only',
+    },
+  },
   'observability:searchExcludedDataTiers': {
     type: 'array',
     items: {

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
@@ -169,6 +169,8 @@ export interface UsageStats {
   'observability:apmEnableTransactionProfiling': boolean;
   'devTools:enablePersistentConsole': boolean;
   'aiAssistant:preferredAIAssistantType': string;
+  'genAiSettings:defaultAIConnector': string;
+  'genAiSettings:defaultAIConnectorOnly': boolean;
   'securitySolution:excludedDataTiersForRuleExecution': string[];
   'securitySolution:maxUnassociatedNotes': number;
   'observability:searchExcludedDataTiers': string[];

--- a/src/platform/plugins/shared/ai_assistant_management/selection/common/constants.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/common/constants.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const NO_DEFAULT_CONNECTOR = 'NO_DEFAULT_CONNECTOR';

--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.test.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.test.ts
@@ -15,6 +15,11 @@ import { classicSetting } from './src/settings/classic_setting';
 import { observabilitySolutionSetting } from './src/settings/observability_setting';
 import { securitySolutionSetting } from './src/settings/security_setting';
 import { AIAssistantManagementSelectionPlugin } from './plugin';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
+import { NO_DEFAULT_CONNECTOR } from '../common/constants';
 
 describe('plugin', () => {
   beforeEach(() => {
@@ -73,7 +78,7 @@ describe('plugin', () => {
         },
       } as unknown as AIAssistantManagementSelectionPluginServerDependenciesSetup);
 
-      expect(coreSetup.uiSettings.register).toHaveBeenCalledTimes(1);
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledTimes(3);
 
       expect(coreSetup.uiSettings.register).toHaveBeenCalledWith({
         [PREFERRED_AI_ASSISTANT_TYPE_SETTING_KEY]: {
@@ -81,6 +86,25 @@ describe('plugin', () => {
           value: AIAssistantType.Observability,
         },
       });
+
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: expect.objectContaining({
+            readonlyMode: 'ui',
+            readonly: false,
+            value: NO_DEFAULT_CONNECTOR,
+          }),
+        })
+      );
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: expect.objectContaining({
+            readonlyMode: 'ui',
+            readonly: false,
+            value: false,
+          }),
+        })
+      );
     });
 
     it('registers correct uiSettings for serverless security', () => {
@@ -99,7 +123,7 @@ describe('plugin', () => {
         },
       } as unknown as AIAssistantManagementSelectionPluginServerDependenciesSetup);
 
-      expect(coreSetup.uiSettings.register).toHaveBeenCalledTimes(1);
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledTimes(3);
 
       expect(coreSetup.uiSettings.register).toHaveBeenCalledWith({
         [PREFERRED_AI_ASSISTANT_TYPE_SETTING_KEY]: {
@@ -107,6 +131,25 @@ describe('plugin', () => {
           value: AIAssistantType.Security,
         },
       });
+
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: expect.objectContaining({
+            readonlyMode: 'ui',
+            readonly: false,
+            value: NO_DEFAULT_CONNECTOR,
+          }),
+        })
+      );
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: expect.objectContaining({
+            readonlyMode: 'ui',
+            readonly: false,
+            value: false,
+          }),
+        })
+      );
     });
 
     it('registers correct uiSettings for serverless search', () => {
@@ -125,13 +168,31 @@ describe('plugin', () => {
         },
       } as unknown as AIAssistantManagementSelectionPluginServerDependenciesSetup);
 
-      expect(coreSetup.uiSettings.register).toHaveBeenCalledTimes(1);
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledTimes(3);
       expect(coreSetup.uiSettings.register).toHaveBeenCalledWith({
         [PREFERRED_AI_ASSISTANT_TYPE_SETTING_KEY]: {
           ...classicSetting,
           value: AIAssistantType.Default,
         },
       });
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: expect.objectContaining({
+            readonlyMode: 'ui',
+            readonly: false,
+            value: NO_DEFAULT_CONNECTOR,
+          }),
+        })
+      );
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: expect.objectContaining({
+            readonlyMode: 'ui',
+            readonly: false,
+            value: false,
+          }),
+        })
+      );
     });
   });
 
@@ -177,13 +238,32 @@ describe('plugin', () => {
 
       aiAssistantManagementSelectionPlugin.setup(coreSetup, setupDeps);
 
-      expect(coreSetup.uiSettings.register).toHaveBeenCalledTimes(1);
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledTimes(3);
       expect(coreSetup.uiSettings.register).toHaveBeenCalledWith({
         [PREFERRED_AI_ASSISTANT_TYPE_SETTING_KEY]: {
           ...classicSetting,
           value: AIAssistantType.Observability,
         },
       });
+
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: expect.objectContaining({
+            readonlyMode: 'ui',
+            readonly: false,
+            value: NO_DEFAULT_CONNECTOR,
+          }),
+        })
+      );
+      expect(coreSetup.uiSettings.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: expect.objectContaining({
+            readonlyMode: 'ui',
+            readonly: false,
+            value: false,
+          }),
+        })
+      );
     });
   });
 });

--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.ts
@@ -17,6 +17,11 @@ import {
   DEFAULT_APP_CATEGORIES,
 } from '@kbn/core/server';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
+import { schema } from '@kbn/config-schema';
 import type { AIAssistantManagementSelectionConfig } from './config';
 import type {
   AIAssistantManagementSelectionPluginServerDependenciesSetup,
@@ -25,6 +30,7 @@ import type {
   AIAssistantManagementSelectionPluginServerStart,
 } from './types';
 import { PREFERRED_AI_ASSISTANT_TYPE_SETTING_KEY } from '../common/ui_setting_keys';
+import { NO_DEFAULT_CONNECTOR } from '../common/constants';
 import { classicSetting } from './src/settings/classic_setting';
 import { observabilitySolutionSetting } from './src/settings/observability_setting';
 import { securitySolutionSetting } from './src/settings/security_setting';
@@ -49,18 +55,6 @@ export class AIAssistantManagementSelectionPlugin
     core: CoreSetup,
     plugins: AIAssistantManagementSelectionPluginServerDependenciesSetup
   ) {
-    core.capabilities.registerProvider(() => {
-      return {
-        management: {
-          kibana: {
-            aiAssistantManagementSelection: true,
-            observabilityAiAssistantManagement: true,
-            securityAiAssistantManagement: true,
-          },
-        },
-      };
-    });
-
     plugins.features?.registerKibanaFeature({
       id: 'aiAssistantManagementSelection',
       name: i18n.translate('aiAssistantManagementSelection.featureRegistry.featureName', {
@@ -119,6 +113,36 @@ export class AIAssistantManagementSelectionPlugin
     core: CoreSetup,
     plugins: AIAssistantManagementSelectionPluginServerDependenciesSetup
   ) {
+    core.uiSettings.register({
+      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: {
+        readonlyMode: 'ui',
+        readonly: false,
+        schema: schema.string(),
+        value: NO_DEFAULT_CONNECTOR,
+      },
+    });
+
+    core.uiSettings.register({
+      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: {
+        readonlyMode: 'ui',
+        readonly: false,
+        schema: schema.boolean(),
+        value: false,
+      },
+    });
+
+    core.capabilities.registerProvider(() => {
+      return {
+        management: {
+          kibana: {
+            aiAssistantManagementSelection: true,
+            observabilityAiAssistantManagement: true,
+            securityAiAssistantManagement: true,
+          },
+        },
+      };
+    });
+
     const { cloud } = plugins;
     const serverlessProjectType = cloud?.serverless.projectType;
 

--- a/src/platform/plugins/shared/ai_assistant_management/selection/tsconfig.json
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/tsconfig.json
@@ -21,7 +21,8 @@
     "@kbn/doc-links",
     "@kbn/core-ui-settings-common",
     "@kbn/cloud-plugin",
-    "@kbn/licensing-plugin"
+    "@kbn/licensing-plugin",
+    "@kbn/management-settings-ids"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -11405,6 +11405,18 @@
             "description": "Non-default value of setting."
           }
         },
+        "genAiSettings:defaultAIConnector": {
+          "type": "keyword",
+          "_meta": {
+            "description": "Default AI connector"
+          }
+        },
+        "genAiSettings:defaultAIConnectorOnly": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Restrict to default AI connector only"
+          }
+        },
         "observability:searchExcludedDataTiers": {
           "type": "array",
           "items": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,6 +18,8 @@
       "@kbn/ai-assistant/*": ["x-pack/platform/packages/shared/kbn-ai-assistant/*"],
       "@kbn/ai-assistant-common": ["x-pack/platform/packages/shared/ai-assistant/common"],
       "@kbn/ai-assistant-common/*": ["x-pack/platform/packages/shared/ai-assistant/common/*"],
+      "@kbn/ai-assistant-default-llm-setting": ["x-pack/platform/packages/shared/ai-assistant-default-llm-setting"],
+      "@kbn/ai-assistant-default-llm-setting/*": ["x-pack/platform/packages/shared/ai-assistant-default-llm-setting/*"],
       "@kbn/ai-assistant-icon": ["x-pack/platform/packages/shared/ai-assistant/icon"],
       "@kbn/ai-assistant-icon/*": ["x-pack/platform/packages/shared/ai-assistant/icon/*"],
       "@kbn/ai-assistant-management-plugin": ["src/platform/plugins/shared/ai_assistant_management/selection"],

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/README.md
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/README.md
@@ -1,0 +1,3 @@
+# @kbn/ai-assistant-default-llm-setting
+
+UI components for setting to configure default LLM.

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/index.ts
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { DefaultAIConnector } from './src/components/default_ai_connector';
+export {
+  DefaultAiConnectorSettingsContextProvider,
+  useDefaultAiConnectorSettingContext,
+} from './src/context/default_ai_connector_context';

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/jest.config.js
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/jest.config.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  coverageDirectory: '<rootDir>/target/kibana-coverage/jest/x-pack/packages/kbn_ai_assistant_src',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: [
+    '<rootDir>/x-pack/platform/packages/shared/kbn-ai-assistant/src/**/*.{ts,tsx}',
+    '!<rootDir>/x-pack/platform/packages/shared/kbn-ai-assistant/src/*.test.{ts,tsx}',
+  ],
+  preset: '@kbn/test',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/x-pack/platform/packages/shared/ai-assistant-default-llm-setting'],
+};

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/kibana.jsonc
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/kibana.jsonc
@@ -1,0 +1,7 @@
+{
+  "type": "shared-browser",
+  "id": "@kbn/ai-assistant-default-llm-setting",
+  "owner": ["@elastic/security-generative-ai"],
+  "group": "platform",
+  "visibility": "shared"
+}

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/package.json
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@kbn/ai-assistant-default-llm-setting",
+  "description": "Default LLM settings for AI Assistant",
+  "private": true,
+  "version": "1.0.0",
+  "license": "Elastic License 2.0"
+}

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/setup_tests.ts
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/setup_tests.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@testing-library/jest-dom';

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/components/default_ai_connector.test.tsx
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/components/default_ai_connector.test.tsx
@@ -1,0 +1,226 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import {
+  AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED,
+  DefaultAIConnector,
+} from './default_ai_connector';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nProvider } from '@kbn/i18n-react';
+import userEvent from '@testing-library/user-event';
+import { FieldDefinition, UnsavedFieldChange } from '@kbn/management-settings-types';
+import { UiSettingsType } from '@kbn/core-ui-settings-common';
+import { IToasts } from '@kbn/core-notifications-browser';
+import { ApplicationStart } from '@kbn/core-application-browser';
+import { DocLinksStart } from '@kbn/core-doc-links-browser';
+import React from 'react';
+import { DefaultAiConnectorSettingsContextProvider } from '../context/default_ai_connector_context';
+import { FeatureFlagsStart } from '@kbn/core/public';
+
+const mockConnectors = {
+  loading: false,
+  reload: jest.fn(),
+  connectors: [
+    {
+      actionTypeId: 'pre-configured.1',
+      id: 'pre-configured1',
+      isDeprecated: false,
+      isPreconfigured: true,
+      isSystemAction: false,
+      name: 'Pre configured Connector',
+      referencedByCount: 0,
+    },
+    {
+      actionTypeId: 'custom.1',
+      id: 'custom1',
+      isDeprecated: false,
+      isPreconfigured: false,
+      isSystemAction: false,
+      name: 'Custom Connector 1',
+      referencedByCount: 0,
+    },
+  ],
+};
+
+function setupTest({
+  fields,
+  unsavedChanges,
+  enabled = true,
+}: {
+  fields: Record<
+    string,
+    FieldDefinition<
+      UiSettingsType,
+      string | number | boolean | (string | number)[] | null | undefined
+    >
+  >;
+  unsavedChanges: Record<string, UnsavedFieldChange<UiSettingsType>>;
+  enabled?: boolean;
+}) {
+  const queryClient = new QueryClient();
+  const handleFieldChange = jest.fn();
+
+  const settings = {
+    handleFieldChange,
+    fields,
+    unsavedChanges,
+  };
+
+  const utils = render(
+    <>
+      <DefaultAIConnector connectors={mockConnectors} settings={settings} />
+    </>,
+    {
+      wrapper: ({ children }) => (
+        <I18nProvider>
+          <QueryClientProvider client={queryClient}>
+            <DefaultAiConnectorSettingsContextProvider
+              application={
+                {
+                  getUrlForApp: jest.fn(),
+                } as unknown as ApplicationStart
+              }
+              docLinks={{} as DocLinksStart}
+              featureFlags={
+                {
+                  getBooleanValue: jest.fn().mockImplementation((flag) => {
+                    if (flag === AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED && enabled) {
+                      return true;
+                    }
+                    return false;
+                  }),
+                } as unknown as FeatureFlagsStart
+              }
+              toast={{} as IToasts}
+            >
+              {children}
+            </DefaultAiConnectorSettingsContextProvider>
+          </QueryClientProvider>
+        </I18nProvider>
+      ),
+    }
+  );
+
+  return {
+    ...utils,
+    handleFieldChange,
+  };
+}
+
+describe('DefaultAIConnector', () => {
+  describe('rendering', () => {
+    it('renders all component elements correctly', () => {
+      const { container } = setupTest({
+        fields: {},
+        unsavedChanges: {},
+      });
+
+      expect(screen.getByText('genAiSettings:defaultAIConnector')).toBeInTheDocument();
+      expect(screen.getByText('Disallow all other connectors')).toBeInTheDocument();
+      expect(screen.getByTestId('defaultAiConnectorComboBox')).toBeInTheDocument();
+      expect(screen.getByTestId('defaultAiConnectorCheckbox')).toBeInTheDocument();
+
+      expect(screen.getByTestId('comboBoxSearchInput')).toHaveAttribute(
+        'value',
+        'No default connector'
+      );
+      expect(container.querySelector('[class$="square-unselected"]')).not.toBeNull();
+    });
+
+    it('does not render when feature flag is off', () => {
+      setupTest({
+        fields: {},
+        unsavedChanges: {},
+        enabled: false,
+      });
+
+      expect(screen.queryByText('genAiSettings:defaultAIConnector')).not.toBeInTheDocument();
+      expect(screen.queryByText('Disallow all other connectors')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('defaultAiConnectorComboBox')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('defaultAiConnectorCheckbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('combobox interaction', () => {
+    it('shows connector options when clicked', async () => {
+      setupTest({
+        fields: {},
+        unsavedChanges: {},
+      });
+
+      act(() => {
+        screen.getByTestId('comboBoxSearchInput').click();
+      });
+
+      await userEvent.click(screen.getByTestId('comboBoxSearchInput'));
+
+      expect(screen.getByText('Pre configured Connector')).toBeVisible();
+      expect(screen.getByText('Custom Connector 1')).toBeVisible();
+
+      expect(
+        // eslint-disable-next-line no-bitwise
+        screen
+          .getByText('Pre-configured')
+          .compareDocumentPosition(screen.getByText('Pre configured Connector')) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+      expect(
+        // eslint-disable-next-line no-bitwise
+        screen
+          .getByText('Custom connectors')
+          .compareDocumentPosition(screen.getByText('Custom Connector 1')) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+
+      expect(
+        // eslint-disable-next-line no-bitwise
+        screen
+          .getByText('Pre configured Connector')
+          .compareDocumentPosition(screen.getByText('Custom connectors')) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+
+    it('updates selection when connector is chosen', async () => {
+      const { handleFieldChange } = setupTest({
+        fields: {},
+        unsavedChanges: {},
+      });
+
+      act(() => {
+        screen.getByTestId('comboBoxSearchInput').click();
+      });
+
+      await userEvent.click(screen.getByTestId('comboBoxSearchInput'));
+      await userEvent.click(screen.getByText('Custom Connector 1'));
+
+      expect(handleFieldChange).toHaveBeenCalledWith('genAiSettings:defaultAIConnector', {
+        type: 'string',
+        unsavedValue: 'custom1',
+      });
+    });
+  });
+
+  describe('checkbox interaction', () => {
+    it('updates checkbox state when clicked', async () => {
+      const { handleFieldChange, container } = setupTest({
+        fields: {},
+        unsavedChanges: {},
+      });
+
+      expect(container.querySelector('[class$="square-unselected"]')).not.toBeNull();
+
+      await userEvent.click(screen.getByTestId('defaultAiConnectorCheckbox'));
+
+      expect(handleFieldChange).toHaveBeenCalledWith('genAiSettings:defaultAIConnectorOnly', {
+        type: 'boolean',
+        unsavedValue: true,
+      });
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/components/default_ai_connector.tsx
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/components/default_ai_connector.tsx
@@ -1,0 +1,404 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiComboBoxOptionOption } from '@elastic/eui';
+import {
+  EuiCheckbox,
+  EuiComboBox,
+  EuiDescribedFormGroup,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiIconTip,
+  EuiLink,
+  EuiTitle,
+} from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
+import type {
+  FieldDefinition,
+  OnFieldChangeFn,
+  UnsavedFieldChange,
+} from '@kbn/management-settings-types';
+import type { UiSettingsType } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+import { NO_DEFAULT_CONNECTOR } from '../lib/constants';
+import { useDefaultAiConnectorSettingContext } from '../context/default_ai_connector_context';
+
+export const AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED =
+  'aiAssistant.defaultLlmSettingEnabled' as const;
+
+interface ConnectorData {
+  connectors?: Array<{
+    id: string;
+    name: string;
+    isPreconfigured: boolean;
+    actionTypeId: string;
+    config?: Record<string, any>;
+  }>;
+  loading: boolean;
+}
+
+const hasElasticManagedLlm = (connectors: ConnectorData['connectors'] | undefined) => {
+  if (!Array.isArray(connectors) || connectors.length === 0) {
+    return false;
+  }
+
+  return connectors.find(
+    (connector) =>
+      connector.actionTypeId === '.inference' &&
+      connector.isPreconfigured &&
+      connector.config?.provider === 'elastic'
+  );
+};
+
+interface Props {
+  settings: {
+    unsavedChanges: Record<string, UnsavedFieldChange<UiSettingsType>>;
+    handleFieldChange: OnFieldChangeFn;
+    fields: Record<
+      string,
+      FieldDefinition<
+        UiSettingsType,
+        string | number | boolean | (string | number)[] | null | undefined
+      >
+    >;
+  };
+  connectors: ConnectorData;
+}
+
+const NoDefaultOption: EuiComboBoxOptionOption<string> = {
+  label: i18n.translate(
+    'xpack.gen_ai_settings.settings.defaultLLm.select.option.noDefaultConnector',
+    { defaultMessage: 'No default connector' }
+  ),
+  value: NO_DEFAULT_CONNECTOR,
+};
+
+const getOptions = (connectors: ConnectorData): EuiComboBoxOptionOption<string>[] => {
+  const preconfigured =
+    connectors.connectors
+      ?.filter((connector) => connector.isPreconfigured)
+      .map((connector) => ({
+        label: connector.name,
+        value: connector.id,
+      })) ?? [];
+
+  const custom =
+    connectors.connectors
+      ?.filter((connector) => !connector.isPreconfigured)
+      .map((connector) => ({
+        label: connector.name,
+        value: connector.id,
+      })) ?? [];
+
+  return [
+    NoDefaultOption,
+    {
+      label: i18n.translate(
+        'xpack.gen_ai_settings.settings.defaultLLm.select.group.preconfigured.label',
+        { defaultMessage: 'Pre-configured' }
+      ),
+      value: 'preconfigured',
+      options: preconfigured,
+    },
+    {
+      label: i18n.translate('xpack.gen_ai_settings.settings.defaultLLm.select.group.custom.label', {
+        defaultMessage: 'Custom connectors',
+      }),
+      value: 'custom',
+      options: custom,
+    },
+  ];
+};
+
+const getOptionsByValues = (
+  value: string,
+  options: EuiComboBoxOptionOption<string>[]
+): EuiComboBoxOptionOption<string>[] => {
+  const getOptionsByValuesHelper = (
+    option: EuiComboBoxOptionOption<string>
+  ): EuiComboBoxOptionOption<string>[] => {
+    if (option.options === undefined && option.value === value) {
+      // If the option has no sub-options and its value is in the selected values, include it
+      return [option];
+    }
+    if (option.options) {
+      // If the option has sub-options, recursively get their options
+      return option.options.flatMap(getOptionsByValuesHelper);
+    }
+    return [];
+  };
+
+  return options.flatMap(getOptionsByValuesHelper);
+};
+
+export const DefaultAIConnector: React.FC<Props> = ({ connectors, settings }) => {
+  const { toast, application, docLinks, featureFlags } = useDefaultAiConnectorSettingContext();
+  const options = useMemo(() => getOptions(connectors), [connectors]);
+  const { handleFieldChange, fields, unsavedChanges } = settings;
+
+  const onChangeDefaultLlm = (selectedOptions: EuiComboBoxOptionOption<string>[]) => {
+    const values = selectedOptions.map((option) => option.value);
+    if (values.length > 1) {
+      toast?.addDanger({
+        title: i18n.translate(
+          'xpack.observabilityAiAssistantManagement.defaultLlm.onChange.error.multipleSelected.title',
+          {
+            defaultMessage: 'An error occurred while changing the setting',
+          }
+        ),
+        text: i18n.translate(
+          'xpack.observabilityAiAssistantManagement.defaultLlm.onChange.error.multipleSelected.text',
+          {
+            defaultMessage: 'Only one default AI connector can be selected',
+          }
+        ),
+      });
+      throw new Error('Only one default AI connector can be selected');
+    }
+    const value = values[0] ?? NO_DEFAULT_CONNECTOR;
+
+    if (value === fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]?.savedValue) {
+      handleFieldChange(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR);
+      return;
+    }
+
+    handleFieldChange(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR, {
+      type: 'string',
+      unsavedValue: value,
+    });
+  };
+
+  const onChangeDefaultOnly = (checked: boolean) => {
+    if (checked === fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]?.savedValue) {
+      handleFieldChange(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY);
+      return;
+    }
+
+    handleFieldChange(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY, {
+      type: 'boolean',
+      unsavedValue: checked,
+    });
+  };
+
+  const defaultLlmValues = getDefaultLlmValue(unsavedChanges, fields);
+
+  const selectedOptions = useMemo(
+    () => getOptionsByValues(defaultLlmValues, options),
+    [defaultLlmValues, options]
+  );
+
+  const defaultLlmOnlyValue = getDefaultLlmOnlyValue(unsavedChanges, fields);
+
+  const elasticManagedLlmExists = hasElasticManagedLlm(connectors.connectors);
+
+  const connectorDescription = useMemo(() => {
+    if (!elasticManagedLlmExists) {
+      return (
+        <p>
+          <FormattedMessage
+            id="genAiSettings.aiConnectorDescription"
+            defaultMessage={`A large language model (LLM) is required to power the AI Assistant and AI-driven features in Elastic. In order to use the AI Assistant you must have a Generative AI connector. {manageConnectors}`}
+            values={{
+              manageConnectors: (
+                <EuiLink
+                  href={application.getUrlForApp('management', {
+                    path: 'insightsAndAlerting/triggersActionsConnectors/connectors',
+                  })}
+                  target="_blank"
+                >
+                  <FormattedMessage
+                    id="genAiSettings.manage.connectors"
+                    defaultMessage={'View connectors'}
+                  />
+                </EuiLink>
+              ),
+            }}
+          />
+        </p>
+      );
+    }
+
+    return (
+      <p>
+        <FormattedMessage
+          id="genAiSettings.aiConnectorDescriptionWithLink"
+          defaultMessage={`A large language model (LLM) is required to power the AI Assistant and AI-powered features. By default, Elastic uses its {elasticManagedLlm} connector ({link}) when no custom connectors are available. When available, Elastic uses the last used custom connector. {manageConnectors}`}
+          values={{
+            link: (
+              <EuiLink
+                href={docLinks?.links?.observability?.elasticManagedLlmUsageCost}
+                target="_blank"
+              >
+                <FormattedMessage
+                  id="genAiSettings.additionalCostsLink"
+                  defaultMessage="additional costs incur"
+                />
+              </EuiLink>
+            ),
+            manageConnectors: (
+              <EuiLink
+                href={application.getUrlForApp('management', {
+                  path: 'insightsAndAlerting/triggersActionsConnectors/connectors',
+                })}
+                target="_blank"
+              >
+                <FormattedMessage
+                  id="genAiSettings.manage.connectors"
+                  defaultMessage="Manage connectors"
+                />
+              </EuiLink>
+            ),
+            elasticManagedLlm: (
+              <strong>
+                <FormattedMessage
+                  id="genAiSettings.elasticManagedLlm"
+                  defaultMessage="Elastic Managed LLM"
+                />
+              </strong>
+            ),
+          }}
+        />
+      </p>
+    );
+  }, [elasticManagedLlmExists, application, docLinks]);
+
+  if (!featureFlags.getBooleanValue(AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED, false)) {
+    return null;
+  }
+
+  return (
+    <>
+      <EuiDescribedFormGroup
+        data-test-subj="connectorsSection"
+        fullWidth
+        title={
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem>
+              <EuiTitle size="xs">
+                <h3 data-test-subj="connectorsTitle">
+                  <FormattedMessage
+                    id="genAiSettings.aiConnectorLabel"
+                    defaultMessage="Default AI Connector"
+                  />
+                </h3>
+              </EuiTitle>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        description={connectorDescription}
+      >
+        <EuiFormRow fullWidth>
+          <EuiFlexGroup gutterSize="m" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiFormRow label={GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR}>
+                <EuiComboBox
+                  data-test-subj="defaultAiConnectorComboBox"
+                  placeholder={i18n.translate(
+                    'xpack.gen_ai_settings.settings.defaultLLm.select.placeholder',
+                    { defaultMessage: 'Select a single option' }
+                  )}
+                  singleSelection={{ asPlainText: true }}
+                  options={options}
+                  selectedOptions={selectedOptions}
+                  onChange={onChangeDefaultLlm}
+                  isDisabled={fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]?.isReadOnly}
+                  isLoading={connectors.loading}
+                  isInvalid={selectedOptions.length === 0 && !connectors.loading}
+                />
+              </EuiFormRow>
+
+              <EuiFormRow>
+                <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                  <EuiFlexItem grow={false}>
+                    <EuiCheckbox
+                      id="defaultAiConnectorCheckbox"
+                      data-test-subj="defaultAiConnectorCheckbox"
+                      disabled={
+                        fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]?.isReadOnly
+                      }
+                      label={
+                        <FormattedMessage
+                          id="genAiSettings.gen_ai_settings.settings.defaultLlmOnly.checkbox.label"
+                          defaultMessage="Disallow all other connectors"
+                        />
+                      }
+                      checked={defaultLlmOnlyValue}
+                      onChange={(e) => onChangeDefaultOnly(e.target.checked)}
+                    />
+                  </EuiFlexItem>
+
+                  <EuiFlexItem grow={false}>
+                    <EuiIconTip
+                      content={i18n.translate(
+                        'xpack.gen_ai_settings.settings.defaultLLmOnly.checkbox.tooltip',
+                        {
+                          defaultMessage:
+                            'Only the chosen default connector will be shown to users of this space.',
+                        }
+                      )}
+                      position="top"
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+    </>
+  );
+};
+
+/**
+ * Gets current value for the default LLM connector. First checks for unsaved changes, then saved, then default.
+ */
+function getDefaultLlmValue(
+  unsavedChanges: Record<string, UnsavedFieldChange<UiSettingsType>>,
+  fields: Record<string, FieldDefinition<UiSettingsType>>
+) {
+  const defaultLlmUnsavedValue = unsavedChanges[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]
+    ?.unsavedValue as string | undefined;
+  const defaultLlmSavedValue = fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]?.savedValue as
+    | string
+    | undefined;
+  const defaultLlmDefaultValue = fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]?.defaultValue as
+    | string
+    | undefined;
+
+  const defaultLlmValue =
+    defaultLlmUnsavedValue ??
+    defaultLlmSavedValue ??
+    defaultLlmDefaultValue ??
+    NO_DEFAULT_CONNECTOR;
+  return defaultLlmValue;
+}
+
+/**
+ * Gets current value for the default LLM only setting. First checks for unsaved changes, then saved, then default.
+ */
+function getDefaultLlmOnlyValue(
+  unsavedChanges: Record<string, UnsavedFieldChange<UiSettingsType>>,
+  fields: Record<string, FieldDefinition<UiSettingsType>>
+): boolean {
+  const defaultLlmOnlyUnsavedValue = unsavedChanges[
+    GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY
+  ]?.unsavedValue as boolean | undefined;
+  const defaultLlmOnlySavedValue = fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]
+    ?.savedValue as boolean | undefined;
+  const defaultLlmOnlyDefaultValue = fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]
+    ?.defaultValue as boolean | undefined;
+
+  const defaultLlmOnlyValue =
+    defaultLlmOnlyUnsavedValue ?? defaultLlmOnlySavedValue ?? defaultLlmOnlyDefaultValue ?? false;
+  return defaultLlmOnlyValue;
+}

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/context/default_ai_connector_context.tsx
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/context/default_ai_connector_context.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useContext } from 'react';
+import type { ApplicationStart, DocLinksStart, FeatureFlagsStart, IToasts } from '@kbn/core/public';
+
+type DefaultAiConnectorSettingContext = ReturnType<typeof DefaultAiConnector>;
+
+const DefaultAiConnectorSettingContext = createContext<null | DefaultAiConnectorSettingContext>(
+  null
+);
+
+export const useDefaultAiConnectorSettingContext = () => {
+  const context = useContext(DefaultAiConnectorSettingContext);
+  if (!context) {
+    throw new Error(
+      'useDefaultAiConnectorContext must be inside of a SettingsContextProvider.Provider.'
+    );
+  }
+  return context;
+};
+
+export const DefaultAiConnectorSettingsContextProvider = ({
+  children,
+  toast,
+  application,
+  docLinks,
+  featureFlags,
+}: {
+  children: React.ReactNode;
+  toast: IToasts | undefined;
+  application: ApplicationStart;
+  docLinks: DocLinksStart;
+  featureFlags: FeatureFlagsStart;
+}) => {
+  const value = DefaultAiConnector({
+    toast,
+    application,
+    docLinks,
+    featureFlags,
+  });
+  return (
+    <DefaultAiConnectorSettingContext.Provider value={value}>
+      {children}
+    </DefaultAiConnectorSettingContext.Provider>
+  );
+};
+
+const DefaultAiConnector = ({
+  toast,
+  application,
+  docLinks,
+  featureFlags,
+}: {
+  toast: IToasts | undefined;
+  application: ApplicationStart;
+  docLinks: DocLinksStart;
+  featureFlags: FeatureFlagsStart;
+}) => {
+  return {
+    toast,
+    application,
+    docLinks,
+    featureFlags,
+  };
+};
+
+export {
+  DefaultAiConnectorSettingContext as SettingsContext,
+  useDefaultAiConnectorSettingContext as useSettingsContext,
+};

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/lib/constants.ts
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/lib/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const NO_DEFAULT_CONNECTOR = 'NO_DEFAULT_CONNECTOR';

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/tsconfig.json
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": [
+      "jest",
+      "node",
+      "react",
+      "@emotion/react/types/css-prop"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".storybook/**/*.ts",
+    ".storybook/**/*.tsx",
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/i18n-react",
+    "@kbn/management-settings-types",
+    "@kbn/core-ui-settings-common",
+    "@kbn/core-notifications-browser",
+    "@kbn/core-application-browser",
+    "@kbn/core-doc-links-browser",
+    "@kbn/management-settings-ids",
+    "@kbn/core",
+    "@kbn/i18n",
+  ]
+}

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
@@ -25,6 +25,7 @@ import {
   SYSTEM_PROMPTS_TAB,
 } from './const';
 import { DataViewsContract } from '@kbn/data-views-plugin/public';
+import { SettingsStart } from '@kbn/core-ui-settings-browser';
 
 const mockContext = {
   basePromptContexts: MOCK_QUICK_PROMPTS,
@@ -48,6 +49,7 @@ const testProps = {
   dataViews: mockDataViews,
   onTabChange,
   currentTab: CONNECTORS_TAB,
+  settings: {} as SettingsStart,
 };
 jest.mock('../../assistant_context');
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useMemo } from 'react';
 import { EuiAvatar, EuiPageTemplate, EuiTitle, useEuiShadow, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { DataViewsContract } from '@kbn/data-views-plugin/public';
+import { SettingsStart } from '@kbn/core-ui-settings-browser';
 import * as i18n from './translations';
 import { useAssistantContext } from '../../assistant_context';
 import { useLoadConnectors } from '../../connectorland/use_load_connectors';
@@ -34,6 +35,7 @@ import { ManagementSettingsTabs } from './types';
 
 interface Props {
   dataViews: DataViewsContract;
+  settings: SettingsStart;
   onTabChange?: (tabId: string) => void;
   currentTab: ManagementSettingsTabs;
 }
@@ -43,7 +45,7 @@ interface Props {
  * anonymization, knowledge base, and evaluation via the `isModelEvaluationEnabled` feature flag.
  */
 export const AssistantSettingsManagement: React.FC<Props> = React.memo(
-  ({ dataViews, onTabChange, currentTab: selectedSettingsTab }) => {
+  ({ dataViews, onTabChange, currentTab: selectedSettingsTab, settings }) => {
     const {
       assistantFeatures: { assistantModelEvaluation: modelEvaluatorEnabled },
       http,
@@ -154,7 +156,9 @@ export const AssistantSettingsManagement: React.FC<Props> = React.memo(
           `}
           data-test-subj={`tab-${selectedSettingsTab}`}
         >
-          {selectedSettingsTab === CONNECTORS_TAB && <ConnectorsSettingsManagement />}
+          {selectedSettingsTab === CONNECTORS_TAB && (
+            <ConnectorsSettingsManagement connectors={connectors} settings={settings} />
+          )}
           {selectedSettingsTab === CONVERSATIONS_TAB && (
             <ConversationSettingsManagement
               connectors={connectors}

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.test.tsx
@@ -24,6 +24,7 @@ import {
   SYSTEM_PROMPTS_TAB,
 } from './const';
 import { DataViewsContract } from '@kbn/data-views-plugin/public';
+import { SettingsStart } from '@kbn/core-ui-settings-browser';
 
 const mockContext = {
   basePromptContexts: MOCK_QUICK_PROMPTS,
@@ -46,6 +47,7 @@ const testProps = {
   dataViews: mockDataViews,
   onTabChange,
   currentTab: CONNECTORS_TAB,
+  settings: {} as SettingsStart,
 };
 jest.mock('../../assistant_context');
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.tsx
@@ -15,6 +15,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { DataViewsContract } from '@kbn/data-views-plugin/public';
+import { SettingsStart } from '@kbn/core-ui-settings-browser';
 import { AIForSOCConnectorSettingsManagement } from '../../connectorland/ai_for_soc_connector_settings_management';
 import * as i18n from './translations';
 import { useAssistantContext } from '../../assistant_context';
@@ -42,6 +43,7 @@ interface Props {
   dataViews: DataViewsContract;
   onTabChange?: (tabId: string) => void;
   currentTab: ManagementSettingsTabs;
+  settings: SettingsStart;
 }
 
 /**
@@ -49,7 +51,7 @@ interface Props {
  * anonymization, knowledge base, and evaluation via the `isModelEvaluationEnabled` feature flag.
  */
 export const SearchAILakeConfigurationsSettingsManagement: React.FC<Props> = React.memo(
-  ({ dataViews, onTabChange, currentTab }) => {
+  ({ dataViews, onTabChange, currentTab, settings }) => {
     const {
       assistantFeatures: { assistantModelEvaluation: modelEvaluatorEnabled },
       http,
@@ -122,7 +124,9 @@ export const SearchAILakeConfigurationsSettingsManagement: React.FC<Props> = Rea
     const renderTabBody = useCallback(() => {
       switch (currentTab) {
         case CONNECTORS_TAB:
-          return <AIForSOCConnectorSettingsManagement />;
+          return (
+            <AIForSOCConnectorSettingsManagement connectors={connectors} settings={settings} />
+          );
         case SYSTEM_PROMPTS_TAB:
           return (
             <SystemPromptSettingsManagement
@@ -154,7 +158,7 @@ export const SearchAILakeConfigurationsSettingsManagement: React.FC<Props> = Rea
             />
           );
       }
-    }, [connectors, currentTab, dataViews, defaultConnector, modelEvaluatorEnabled]);
+    }, [connectors, currentTab, dataViews, defaultConnector, modelEvaluatorEnabled, settings]);
     return (
       <EuiFlexGroup
         data-test-subj="SearchAILakeConfigurationsSettingsManagement"

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/ai_for_soc_connector_settings_management/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/ai_for_soc_connector_settings_management/index.tsx
@@ -7,13 +7,20 @@
 
 import React from 'react';
 import { EuiSpacer } from '@elastic/eui';
+import { SettingsStart } from '@kbn/core-ui-settings-browser';
 import { SearchConnectorSettingsManagement } from './search_connector_settings_management';
 import { ConnectorsSettingsManagement } from '../connector_settings_management';
+import { AIConnector } from '../connector_selector';
 
-export const AIForSOCConnectorSettingsManagement = () => {
+interface Props {
+  connectors: AIConnector[] | undefined;
+  settings: SettingsStart;
+}
+
+export const AIForSOCConnectorSettingsManagement = ({ connectors, settings }: Props) => {
   return (
     <>
-      <ConnectorsSettingsManagement />
+      <ConnectorsSettingsManagement connectors={connectors} settings={settings} />
       <EuiSpacer size="m" />
       <SearchConnectorSettingsManagement />
     </>

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_settings_management/bottom_bar_actions/bottom_bar_actions.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_settings_management/bottom_bar_actions/bottom_bar_actions.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { BottomBarActions } from './bottom_bar_actions';
+import React from 'react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+describe('bottom_bar_actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function Providers({ children }: { children: React.ReactNode }) {
+    return (
+      <IntlProvider locale="en" messages={{}}>
+        {children}
+      </IntlProvider>
+    );
+  }
+
+  it('renders correctly', () => {
+    const onDiscardChanges = jest.fn();
+    const onSave = jest.fn();
+    render(
+      <BottomBarActions
+        isLoading={true}
+        onDiscardChanges={onDiscardChanges}
+        onSave={onSave}
+        unsavedChangesCount={5}
+        saveLabel="Save Changes"
+        appTestSubj="genAiSettings"
+      />,
+      { wrapper: Providers }
+    );
+
+    expect(screen.getByTestId('genAiSettingsBottomBar')).toBeInTheDocument();
+    expect(screen.getByText('5 unsaved changes')).toBeInTheDocument();
+    expect(screen.getByText('Save Changes')).toBeInTheDocument();
+    expect(screen.getByText('Discard changes')).toBeInTheDocument();
+
+    expect(onDiscardChanges).not.toHaveBeenCalled();
+    screen.getByText('Discard changes').click();
+    expect(onDiscardChanges).toHaveBeenCalled();
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_settings_management/bottom_bar_actions/bottom_bar_actions.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_settings_management/bottom_bar_actions/bottom_bar_actions.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import {
+  EuiBottomBar,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHealth,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+interface Props {
+  unsavedChangesCount: number;
+  isLoading: boolean;
+  onDiscardChanges: () => void;
+  onSave: () => void;
+  saveLabel: string;
+  appTestSubj: string;
+  areChangesInvalid?: boolean;
+}
+
+export const BottomBarActions = ({
+  isLoading,
+  onDiscardChanges,
+  onSave,
+  unsavedChangesCount,
+  saveLabel,
+  appTestSubj,
+  areChangesInvalid = false,
+}: Props) => {
+  return (
+    <EuiBottomBar paddingSize="s" data-test-subj={`${appTestSubj}BottomBar`}>
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+        <EuiFlexItem
+          grow={false}
+          css={{
+            flexDirection: 'row',
+            alignItems: 'center',
+          }}
+        >
+          <EuiHealth color="warning" />
+          <EuiText>
+            <FormattedMessage
+              id="xpack.elasticAssistant.bottomBarActions.unsavedChanges"
+              defaultMessage="{unsavedChangesCount, plural, =0{0 unsaved changes} one {1 unsaved change} other {# unsaved changes}}"
+              values={{ unsavedChangesCount }}
+            />
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                data-test-subj={`${appTestSubj}BottomBarActionsDiscardChangesButton`}
+                color="text"
+                onClick={onDiscardChanges}
+              >
+                <FormattedMessage
+                  id="xpack.elasticAssistant.bottomBarActions.discardChangesButtonAriaLabel"
+                  defaultMessage="Discard changes"
+                />
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip
+                content={
+                  areChangesInvalid &&
+                  i18n.translate(
+                    'xpack.elasticAssistant.bottomBarActions.saveButtonTooltipWithInvalidChanges',
+                    {
+                      defaultMessage: 'Fix invalid settings before saving.',
+                    }
+                  )
+                }
+              >
+                <EuiButton
+                  disabled={areChangesInvalid}
+                  data-test-subj={`${appTestSubj}BottomBarActionsButton`}
+                  onClick={onSave}
+                  fill
+                  isLoading={isLoading}
+                  color="success"
+                  iconType="check"
+                >
+                  {saveLabel}
+                </EuiButton>
+              </EuiToolTip>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiBottomBar>
+  );
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_settings_management/context/settings_context.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_settings_management/context/settings_context.test.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { SettingsContextProvider, useSettingsContext } from './settings_context';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PublicUiSettingsParams, UserProvidedValues } from '@kbn/core/public';
+import { Subject } from 'rxjs';
+import { SettingsStart } from '@kbn/core-ui-settings-browser';
+
+describe('settings_context', () => {
+  const setupSettingsContext = () => {
+    const queryClient = new QueryClient();
+    const set = jest.fn().mockResolvedValue(undefined);
+
+    const rendered = renderHook(() => useSettingsContext(), {
+      wrapper: ({ children }) => {
+        return (
+          <QueryClientProvider client={queryClient}>
+            <SettingsContextProvider
+              settings={
+                {
+                  client: {
+                    getUpdateErrors$: () => new Subject(),
+                    isOverridden: () => false,
+                    isCustom: () => false,
+                    set,
+                    getAll: jest.fn().mockReturnValue({
+                      'genAiSettings:defaultAIConnector': {
+                        readonlyMode: 'ui',
+                        value: 'NO_DEFAULT_CONNECTOR',
+                        userValue: 'pmeClaudeV37SonnetUsEast1',
+                      },
+                      'genAiSettings:defaultAIConnectorOnly': {
+                        readonlyMode: 'ui',
+                        value: false,
+                        userValue: true,
+                      },
+                    } as Record<string, PublicUiSettingsParams & UserProvidedValues>),
+                  },
+                } as unknown as SettingsStart
+              }
+            >
+              {children}
+            </SettingsContextProvider>
+          </QueryClientProvider>
+        );
+      },
+    });
+
+    return { result: rendered.result, set };
+  };
+
+  it('should provide the correct initial state', async () => {
+    const { result } = setupSettingsContext();
+
+    await waitFor(() => {
+      expect(result.current.fields).toEqual(
+        expect.objectContaining({
+          'genAiSettings:defaultAIConnector': expect.anything(),
+          'genAiSettings:defaultAIConnectorOnly': expect.anything(),
+        })
+      );
+    });
+
+    expect(result.current.unsavedChanges).toEqual({});
+    expect(result.current.handleFieldChange).toBeInstanceOf(Function);
+    expect(result.current.saveAll).toBeInstanceOf(Function);
+    expect(result.current.cleanUnsavedChanges).toBeInstanceOf(Function);
+    expect(result.current.saveSingleSetting).toBeInstanceOf(Function);
+  });
+
+  it('should handle updating unsaved changes', async () => {
+    const { result } = setupSettingsContext();
+
+    await waitFor(() => {
+      expect(result.current.fields).toBeDefined();
+    });
+
+    expect(result.current.unsavedChanges).toEqual({});
+
+    act(() => {
+      result.current.handleFieldChange('test', {
+        type: 'string',
+        unsavedValue: 'testValue',
+      });
+    });
+
+    expect(result.current.unsavedChanges).toEqual({
+      test: {
+        type: 'string',
+        unsavedValue: 'testValue',
+      },
+    });
+  });
+
+  it('should save unsaved changes', async () => {
+    const { result, set } = setupSettingsContext();
+
+    await waitFor(() => {
+      expect(result.current.fields).toBeDefined();
+    });
+
+    act(() => {
+      result.current.handleFieldChange('test', {
+        type: 'string',
+        unsavedValue: 'testValue',
+      });
+    });
+
+    expect(set).toHaveBeenCalledTimes(0);
+
+    await act(async () => {
+      await result.current.saveAll();
+    });
+
+    expect(set).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(result.current.unsavedChanges).toEqual({});
+    });
+  });
+
+  it('should save single setting', async () => {
+    const { result, set } = setupSettingsContext();
+
+    await waitFor(() => {
+      expect(result.current.fields).toBeDefined();
+    });
+
+    expect(set).toHaveBeenCalledTimes(0);
+
+    await act(async () => {
+      await result.current.saveSingleSetting({
+        id: 'foo',
+        change: 'bar',
+      });
+    });
+
+    expect(set).toHaveBeenCalledTimes(1);
+  });
+
+  it('should revert unsaved changes', async () => {
+    const { result } = setupSettingsContext();
+
+    await waitFor(() => {
+      expect(result.current.fields).toBeDefined();
+    });
+
+    act(() => {
+      result.current.handleFieldChange('test', {
+        type: 'string',
+        unsavedValue: 'testValue',
+      });
+    });
+
+    expect(result.current.unsavedChanges).toEqual({
+      test: {
+        type: 'string',
+        unsavedValue: 'testValue',
+      },
+    });
+
+    act(() => {
+      result.current.cleanUnsavedChanges();
+    });
+
+    expect(result.current.unsavedChanges).toEqual({});
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_settings_management/context/settings_context.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_settings_management/context/settings_context.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useContext } from 'react';
+import type {
+  FieldDefinition,
+  OnFieldChangeFn,
+  UiSettingMetadata,
+  UnsavedFieldChange,
+} from '@kbn/management-settings-types';
+import { isEmpty } from 'lodash';
+import type { IUiSettingsClient, UiSettingsType } from '@kbn/core/public';
+import { normalizeSettings } from '@kbn/management-settings-utilities';
+import { getFieldDefinition } from '@kbn/management-settings-field-definition';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
+import { SettingsStart } from '@kbn/core-ui-settings-browser';
+
+type SettingsContext = ReturnType<typeof Settings>;
+
+const SettingsContext = createContext<null | SettingsContext>(null);
+
+const useSettingsContext = () => {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error('useSettingsContext must be inside of a SettingsContextProvider.Provider.');
+  }
+  return context;
+};
+
+const SETTING_KEYS = [
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+];
+
+export const SettingsContextProvider = ({
+  children,
+  settings,
+}: {
+  children: React.ReactNode;
+  settings: SettingsStart;
+}) => {
+  const value = Settings({ settingsKeys: SETTING_KEYS, settings });
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+};
+
+function combineErrors(errors: Error[]): Error {
+  const message = errors.map((err) => err.message || String(err)).join('; ');
+  return new Error(message);
+}
+
+function getSettingsFields({
+  settingsKeys,
+  uiSettings,
+}: {
+  settingsKeys: string[];
+  uiSettings?: IUiSettingsClient;
+}) {
+  if (!uiSettings) {
+    return {};
+  }
+
+  const uiSettingsDefinition = uiSettings.getAll();
+  const normalizedSettings = normalizeSettings(uiSettingsDefinition);
+
+  return settingsKeys.reduce<Record<string, FieldDefinition>>((acc, key) => {
+    const setting: UiSettingMetadata = normalizedSettings[key];
+    if (setting) {
+      const field = getFieldDefinition({
+        id: key,
+        setting,
+        params: { isCustom: uiSettings.isCustom(key), isOverridden: uiSettings.isOverridden(key) },
+      });
+      acc[key] = field;
+    }
+    return acc;
+  }, {});
+}
+
+const Settings = ({
+  settingsKeys,
+  settings,
+}: {
+  settingsKeys: string[];
+  settings: SettingsStart;
+}) => {
+  const [unsavedChanges, setUnsavedChanges] = React.useState<Record<string, UnsavedFieldChange>>(
+    {}
+  );
+
+  const queryClient = useQueryClient();
+
+  const fieldsQuery = useQuery({
+    queryKey: ['settingsFields', settingsKeys],
+    queryFn: async () => {
+      return getSettingsFields({ settingsKeys, uiSettings: settings?.client });
+    },
+    refetchOnWindowFocus: true,
+  });
+
+  const saveSingleSettingMutation = useMutation({
+    mutationFn: async ({
+      id,
+      change,
+    }: {
+      id: string;
+      change: UnsavedFieldChange<UiSettingsType>['unsavedValue'];
+    }) => {
+      await settings.client.set(id, change);
+      queryClient.invalidateQueries({ queryKey: ['settingsFields', settingsKeys] });
+    },
+  });
+
+  const saveAllMutation = useMutation({
+    mutationFn: async () => {
+      if (settings && !isEmpty(unsavedChanges)) {
+        const updateErrors: Error[] = [];
+        const subscription = settings.client.getUpdateErrors$().subscribe((error) => {
+          updateErrors.push(error);
+        });
+        try {
+          await Promise.all(
+            Object.entries(unsavedChanges).map(([key, value]) => {
+              return settings.client.set(key, value.unsavedValue);
+            })
+          );
+          queryClient.invalidateQueries({ queryKey: ['settingsFields', settingsKeys] });
+          cleanUnsavedChanges();
+          if (updateErrors.length > 0) {
+            throw combineErrors(updateErrors);
+          }
+        } finally {
+          if (subscription) {
+            subscription.unsubscribe();
+          }
+        }
+      }
+    },
+  });
+
+  const handleFieldChange: OnFieldChangeFn = (id, change) => {
+    if (!change) {
+      const { [id]: unsavedChange, ...rest } = unsavedChanges;
+      setUnsavedChanges(rest);
+      return;
+    }
+    setUnsavedChanges((changes) => ({ ...changes, [id]: change }));
+  };
+
+  function cleanUnsavedChanges() {
+    setUnsavedChanges({});
+  }
+
+  return {
+    fields: fieldsQuery.data ?? {},
+    unsavedChanges,
+    handleFieldChange,
+    saveAll: saveAllMutation.mutateAsync,
+    isSaving: saveAllMutation.isLoading || saveSingleSettingMutation.isLoading,
+    cleanUnsavedChanges,
+    saveSingleSetting: saveSingleSettingMutation.mutateAsync,
+  };
+};
+
+export { SettingsContext, useSettingsContext };

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_settings_management/translations.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_settings_management/translations.ts
@@ -28,3 +28,17 @@ export const CONNECTOR_MANAGEMENT_BUTTON_TITLE = i18n.translate(
     defaultMessage: 'Manage Connectors',
   }
 );
+
+export const BOTTOM_BAR_ACTIONS_SAVE_LABEL = i18n.translate(
+  'xpack.elasticAssistant.settings.bottomBar.action.saveButton',
+  {
+    defaultMessage: 'Save changes',
+  }
+);
+
+export const BOTTOM_BAR_ACTIONS_SAVE_ERROR = i18n.translate(
+  'xpack.elasticAssistant.settings.bottomBar.action.save.error',
+  {
+    defaultMessage: 'An error occurred while saving the settings',
+  }
+);

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/tsconfig.json
@@ -44,5 +44,11 @@
     "@kbn/alerts-ui-shared",
     "@kbn/deeplinks-security",
     "@kbn/inference-common",
+    "@kbn/core-ui-settings-browser",
+    "@kbn/ai-assistant-default-llm-setting",
+    "@kbn/management-settings-types",
+    "@kbn/management-settings-utilities",
+    "@kbn/management-settings-field-definition",
+    "@kbn/management-settings-ids",
   ]
 }

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.test.tsx
@@ -46,6 +46,14 @@ describe('SettingsTab', () => {
     });
     useKibanaMock.mockReturnValue({
       services: {
+        featureFlags: {
+          getBooleanValue: jest.fn().mockImplementation((flag) => {
+            if (flag === 'aiAssistant.defaultLlmSettingEnabled') {
+              return true;
+            }
+            return false;
+          }),
+        },
         application: {
           getUrlForApp: getUrlForAppMock,
           capabilities: {
@@ -75,7 +83,17 @@ describe('SettingsTab', () => {
       installProductDoc: jest.fn().mockResolvedValue({}),
       uninstallProductDoc: jest.fn().mockResolvedValue({}),
     });
-    useGenAIConnectorsMock.mockReturnValue({ connectors: [{ id: 'test-connector' }] });
+    useGenAIConnectorsMock.mockReturnValue({
+      connectors: [
+        {
+          id: 'test-connector',
+          name: 'Test Connector',
+          isPreconfigured: false,
+          actionTypeId: 'test-action-type',
+        },
+      ],
+      loading: false,
+    });
     useInferenceEndpointsMock.mockReturnValue({
       inferenceEndpoints: [{ id: 'test-endpoint', inference_id: 'test-inference-id' }],
       isLoading: false,
@@ -120,7 +138,7 @@ describe('SettingsTab', () => {
   });
 
   it('should not show knowledge base model section when no connectors exist', () => {
-    useGenAIConnectorsMock.mockReturnValue({ connectors: [] });
+    useGenAIConnectorsMock.mockReturnValue({ connectors: [], loading: false });
 
     const { queryByTestId } = render(<SettingsTab />, {
       coreStart: {

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_management/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_management/tsconfig.json
@@ -31,7 +31,9 @@
     "@kbn/ml-plugin",
     "@kbn/test-jest-helpers",
     "@kbn/inference-common",
-    "@kbn/licensing-plugin"
+    "@kbn/licensing-plugin",
+    "@kbn/management-settings-ids",
+    "@kbn/ai-assistant-default-llm-setting"
   ],
   "exclude": [
     "target/**/*"

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
@@ -96,6 +96,13 @@ describe('ManagementSettings', () => {
             getCurrent: jest.fn().mockResolvedValue({ data: { color: 'blue', initials: 'P' } }),
           },
         },
+        notifications: {
+          toasts: {
+            addError: jest.fn(),
+            addSuccess: jest.fn(),
+            addWarning: jest.fn(),
+          },
+        },
       },
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
@@ -14,21 +14,27 @@ import { CONVERSATIONS_TAB } from '@kbn/elastic-assistant/impl/assistant/setting
 import type { ManagementSettingsTabs } from '@kbn/elastic-assistant/impl/assistant/settings/types';
 
 import { AssistantSpaceIdProvider } from '@kbn/elastic-assistant/impl/assistant/use_space_aware_context';
+import { DefaultAiConnectorSettingsContextProvider } from '@kbn/ai-assistant-default-llm-setting/src/context/default_ai_connector_context';
 import { useKibana } from '../../common/lib/kibana';
 import { useSpaceId } from '../../common/hooks/use_space_id';
 
 export const ManagementSettings = React.memo(() => {
   const {
-    application: {
-      navigateToApp,
-      capabilities: {
-        securitySolutionAssistant: { 'ai-assistant': securityAIAssistantEnabled },
-      },
-    },
+    application,
     data: { dataViews },
     chrome: { docTitle, setBreadcrumbs },
     serverless,
+    settings,
+    docLinks,
+    featureFlags,
+    notifications,
   } = useKibana().services;
+  const {
+    navigateToApp,
+    capabilities: {
+      securitySolutionAssistant: { 'ai-assistant': securityAIAssistantEnabled },
+    },
+  } = application;
   const spaceId = useSpaceId();
 
   docTitle.change(SECURITY_AI_SETTINGS);
@@ -98,11 +104,19 @@ export const ManagementSettings = React.memo(() => {
 
   return spaceId ? (
     <AssistantSpaceIdProvider spaceId={spaceId}>
-      <AssistantSettingsManagement
-        dataViews={dataViews}
-        onTabChange={handleTabChange}
-        currentTab={currentTab}
-      />
+      <DefaultAiConnectorSettingsContextProvider
+        toast={notifications.toasts}
+        application={application}
+        docLinks={docLinks}
+        featureFlags={featureFlags}
+      >
+        <AssistantSettingsManagement
+          settings={settings}
+          dataViews={dataViews}
+          onTabChange={handleTabChange}
+          currentTab={currentTab}
+        />
+      </DefaultAiConnectorSettingsContextProvider>
     </AssistantSpaceIdProvider>
   ) : null;
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/ai_settings.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/ai_settings.test.tsx
@@ -31,6 +31,13 @@ describe('AISettings', () => {
             securitySolutionAssistant: { 'ai-assistant': true },
           },
         },
+        notifications: {
+          toasts: {
+            addError: jest.fn(),
+            addSuccess: jest.fn(),
+            addWarning: jest.fn(),
+          },
+        },
         data: { dataViews: {} },
       },
     });
@@ -74,6 +81,13 @@ describe('AISettings', () => {
           navigateToApp: mockNavigateToApp,
           capabilities: {
             securitySolutionAssistant: { 'ai-assistant': false },
+          },
+        },
+        notifications: {
+          toasts: {
+            addError: jest.fn(),
+            addSuccess: jest.fn(),
+            addWarning: jest.fn(),
           },
         },
         data: { dataViews: {} },

--- a/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/ai_settings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/ai_settings.tsx
@@ -13,6 +13,7 @@ import {
   AssistantSpaceIdProvider,
 } from '@kbn/elastic-assistant';
 import { useSearchParams } from 'react-router-dom-v5-compat';
+import { DefaultAiConnectorSettingsContextProvider } from '@kbn/ai-assistant-default-llm-setting';
 import { SecurityPageName } from '../../../common/constants';
 import { useKibana, useNavigation } from '../../common/lib/kibana';
 import { useSpaceId } from '../../common/hooks/use_space_id';
@@ -20,14 +21,20 @@ import { useSpaceId } from '../../common/hooks/use_space_id';
 export const AISettings: React.FC = () => {
   const { navigateTo } = useNavigation();
   const {
-    application: {
-      navigateToApp,
-      capabilities: {
-        securitySolutionAssistant: { 'ai-assistant': securityAIAssistantEnabled },
-      },
-    },
+    application,
     data: { dataViews },
+    settings,
+    docLinks,
+    notifications: { toasts },
+    featureFlags,
   } = useKibana().services;
+
+  const {
+    navigateToApp,
+    capabilities: {
+      securitySolutionAssistant: { 'ai-assistant': securityAIAssistantEnabled },
+    },
+  } = application;
   const spaceId = useSpaceId();
   const onTabChange = useCallback(
     (tab: string) => {
@@ -49,11 +56,19 @@ export const AISettings: React.FC = () => {
   }
   return spaceId ? (
     <AssistantSpaceIdProvider spaceId={spaceId}>
-      <SearchAILakeConfigurationsSettingsManagement
-        dataViews={dataViews}
-        onTabChange={onTabChange}
-        currentTab={currentTab}
-      />
+      <DefaultAiConnectorSettingsContextProvider
+        application={application}
+        docLinks={docLinks}
+        toast={toasts}
+        featureFlags={featureFlags}
+      >
+        <SearchAILakeConfigurationsSettingsManagement
+          dataViews={dataViews}
+          onTabChange={onTabChange}
+          currentTab={currentTab}
+          settings={settings}
+        />
+      </DefaultAiConnectorSettingsContextProvider>
     </AssistantSpaceIdProvider>
   ) : null;
 };

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -259,5 +259,6 @@
     "@kbn/elastic-assistant-shared-state",
     "@kbn/elastic-assistant-shared-state-plugin",
     "@kbn/core-metrics-server",
+    "@kbn/ai-assistant-default-llm-setting",
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,9 +3758,12 @@
   version "0.0.0"
   uid ""
 
-"@kbn/ai-assistant-icon@link:x-pack/platform/packages/shared/ai-assistant/icon":
+"@kbn/ai-assistant-default-llm-setting@link:x-pack/platform/packages/shared/ai-assistant-default-llm-setting":
   version "0.0.0"
   uid ""
+
+"@kbn/ai-assistant-icon@link:x-pack/platform/packages/shared/ai-assistant/icon":
+  version "0.0.0"
 
 "@kbn/ai-assistant-management-plugin@link:src/platform/plugins/shared/ai_assistant_management/selection":
   version "0.0.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.1` to `8.19`:
 - [Feature/default llm setting ai settings (#233874)](https://github.com/elastic/kibana/pull/233874)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kenneth Kreindler","email":"42113355+KDKHD@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-09-09T08:09:02Z","message":"Feature/default llm setting ai settings (#233874)\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\nFollow-up to this change: https://github.com/elastic/kibana/pull/231940\n\nThe PR linked above could not be backported to 8.18, 9.19, 9.1 because\nthe GenAi settings page where the setting was added to does not exist in\nthe versions just listed. As this setting is needed on these version,\nthis PR is required. This PR adds the Default LLM setting to the\nSecurity, Obs & ES AI settings pages.\n\n<img width=\"1855\" height=\"1171\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ab09be60-97b6-40d4-bcfc-5e9859360502\"\n/>\n\n<img width=\"1855\" height=\"1171\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b8c1ae43-e1ee-4f42-bbcb-d7f67be6a598\"\n/>\n\n<img width=\"1855\" height=\"1171\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5647de7f-d1de-4e46-9940-f165b1ef8b7b\"\n/>\n\n<img width=\"1855\" height=\"1171\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/791c953e-a321-419c-a121-66974a6f8b34\"\n/>\n\n### How to test:\n- Enable the feature flag. Add\n`feature_flags.overrides.aiAssistant.defaultLlmSettingEnabled: true` to\nkibana.dev.yml\n- Start Kibana and go to\nhttp://localhost:5601/app/management/kibana/securityAiAssistantManagement?tab=connectors\nor\nhttp://localhost:5601/app/management/kibana/observabilityAiAssistantManagement\n- You should see the `genAiSettings:defaultAIConnector` setting.\nChanging the setting won't do anything just yet as changes within the\nassistants still need to be configured.\n\nTODO:\nWhen the feature flag is lifted, we should remove the following Kibana\nadvanced setting as this one will rpelace it:\n<img width=\"2412\" height=\"198\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f3d1c421-f7c5-42b9-b5dc-85c29b8ef3eb\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [X] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"6141299372af19ca322fb9d90c05d8b775954e48","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","ci:project-deploy-observability","Team:Security Generative AI","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"Feature/default llm setting ai settings","number":233874,"url":"https://github.com/elastic/kibana/pull/233874","mergeCommit":{"message":"Feature/default llm setting ai settings (#233874)\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\nFollow-up to this change: https://github.com/elastic/kibana/pull/231940\n\nThe PR linked above could not be backported to 8.18, 9.19, 9.1 because\nthe GenAi settings page where the setting was added to does not exist in\nthe versions just listed. As this setting is needed on these version,\nthis PR is required. This PR adds the Default LLM setting to the\nSecurity, Obs & ES AI settings pages.\n\n<img width=\"1855\" height=\"1171\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ab09be60-97b6-40d4-bcfc-5e9859360502\"\n/>\n\n<img width=\"1855\" height=\"1171\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b8c1ae43-e1ee-4f42-bbcb-d7f67be6a598\"\n/>\n\n<img width=\"1855\" height=\"1171\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5647de7f-d1de-4e46-9940-f165b1ef8b7b\"\n/>\n\n<img width=\"1855\" height=\"1171\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/791c953e-a321-419c-a121-66974a6f8b34\"\n/>\n\n### How to test:\n- Enable the feature flag. Add\n`feature_flags.overrides.aiAssistant.defaultLlmSettingEnabled: true` to\nkibana.dev.yml\n- Start Kibana and go to\nhttp://localhost:5601/app/management/kibana/securityAiAssistantManagement?tab=connectors\nor\nhttp://localhost:5601/app/management/kibana/observabilityAiAssistantManagement\n- You should see the `genAiSettings:defaultAIConnector` setting.\nChanging the setting won't do anything just yet as changes within the\nassistants still need to be configured.\n\nTODO:\nWhen the feature flag is lifted, we should remove the following Kibana\nadvanced setting as this one will rpelace it:\n<img width=\"2412\" height=\"198\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f3d1c421-f7c5-42b9-b5dc-85c29b8ef3eb\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [X] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"6141299372af19ca322fb9d90c05d8b775954e48"}},"sourceBranch":"9.1","suggestedTargetBranches":["8.18","8.19"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->