### PR TITLE
[Security Solution][EASE] fix alert details flyout not showing the integration icon

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.test.tsx
@@ -10,14 +10,14 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { AiForSOCAlertsTab, CONTENT_TEST_ID, ERROR_TEST_ID, SKELETON_TEST_ID } from './wrapper';
 import { TestProviders } from '../../../../../../../common/mock';
 import { useFetchIntegrations } from '../../../../../../../detections/hooks/alert_summary/use_fetch_integrations';
-import { useCreateDataView } from '../../../../../../../common/hooks/use_create_data_view';
+import { useCreateEaseAlertsDataView } from '../../../../../../../detections/hooks/alert_summary/use_create_data_view';
 
 jest.mock('./table', () => ({
   Table: () => <div />,
 }));
 jest.mock('../../../../../../../common/lib/kibana');
 jest.mock('../../../../../../../detections/hooks/alert_summary/use_fetch_integrations');
-jest.mock('../../../../../../../common/hooks/use_create_data_view');
+jest.mock('../../../../../../../detections/hooks/alert_summary/use_create_data_view');
 
 const id = 'id';
 const query = { ids: { values: ['abcdef'] } };
@@ -33,7 +33,7 @@ describe('<AiForSOCAlertsTab />', () => {
   });
 
   it('should render a loading skeleton while fetching packages (integrations)', async () => {
-    (useCreateDataView as jest.Mock).mockReturnValue({
+    (useCreateEaseAlertsDataView as jest.Mock).mockReturnValue({
       dataView: undefined,
       loading: false,
     });
@@ -48,7 +48,7 @@ describe('<AiForSOCAlertsTab />', () => {
   });
 
   it('should render a loading skeleton while creating the dataView', async () => {
-    (useCreateDataView as jest.Mock).mockReturnValue({
+    (useCreateEaseAlertsDataView as jest.Mock).mockReturnValue({
       dataView: undefined,
       loading: true,
     });
@@ -61,7 +61,7 @@ describe('<AiForSOCAlertsTab />', () => {
   });
 
   it('should render an error if the dataView fail to be created correctly', async () => {
-    (useCreateDataView as jest.Mock).mockReturnValue({
+    (useCreateEaseAlertsDataView as jest.Mock).mockReturnValue({
       dataView: undefined,
       loading: false,
     });
@@ -79,7 +79,7 @@ describe('<AiForSOCAlertsTab />', () => {
   });
 
   it('should render the content', async () => {
-    (useCreateDataView as jest.Mock).mockReturnValue({
+    (useCreateEaseAlertsDataView as jest.Mock).mockReturnValue({
       dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
       loading: false,
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.tsx
@@ -5,16 +5,13 @@
  * 2.0.
  */
 
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import { EuiEmptyPrompt, EuiSkeletonRectangle } from '@elastic/eui';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { i18n } from '@kbn/i18n';
-import { RUNTIME_FIELD_MAP } from '../../../../../../../detections/components/alert_summary/wrapper';
+import { useCreateEaseAlertsDataView } from '../../../../../../../detections/hooks/alert_summary/use_create_data_view';
 import { Table } from './table';
-import { useSpaceId } from '../../../../../../../common/hooks/use_space_id';
 import { useFetchIntegrations } from '../../../../../../../detections/hooks/alert_summary/use_fetch_integrations';
-import { useCreateDataView } from '../../../../../../../common/hooks/use_create_data_view';
-import { DEFAULT_ALERTS_INDEX } from '../../../../../../../../common/constants';
 
 const DATAVIEW_ERROR = i18n.translate(
   'xpack.securitySolution.attackDiscovery.aiForSocTableTab.dataViewError',
@@ -44,18 +41,8 @@ interface AiForSOCAlertsTabProps {
  * It renders a loading skeleton while packages are being fetched and while the dataView is being created.
  */
 export const AiForSOCAlertsTab = memo(({ id, query }: AiForSOCAlertsTabProps) => {
-  const spaceId = useSpaceId();
-  const dataViewSpec = useMemo(
-    () => ({
-      title: `${DEFAULT_ALERTS_INDEX}-${spaceId}`,
-      runtimeFieldMap: RUNTIME_FIELD_MAP,
-    }),
-    [spaceId]
-  );
+  const { dataView, loading: dataViewLoading } = useCreateEaseAlertsDataView();
 
-  const { dataView, loading: dataViewLoading } = useCreateDataView({ dataViewSpec });
-
-  // Fetch all integrations
   const { installedPackages, isLoading: integrationIsLoading } = useFetchIntegrations();
 
   return (
@@ -66,7 +53,7 @@ export const AiForSOCAlertsTab = memo(({ id, query }: AiForSOCAlertsTabProps) =>
       width="100%"
     >
       <>
-        {!dataView || !dataView.id ? (
+        {!dataView ? (
           <EuiEmptyPrompt
             color="danger"
             data-test-subj={ERROR_TEST_ID}

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/wrapper.test.tsx
@@ -10,13 +10,13 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { AiForSOCAlertsTable, CONTENT_TEST_ID, ERROR_TEST_ID, SKELETON_TEST_ID } from './wrapper';
 import { TestProviders } from '../../../common/mock';
 import { useFetchIntegrations } from '../../../detections/hooks/alert_summary/use_fetch_integrations';
-import { useCreateDataView } from '../../../common/hooks/use_create_data_view';
+import { useCreateEaseAlertsDataView } from '../../../detections/hooks/alert_summary/use_create_data_view';
 
 jest.mock('./table', () => ({
   Table: () => <div />,
 }));
 jest.mock('../../../detections/hooks/alert_summary/use_fetch_integrations');
-jest.mock('../../../common/hooks/use_create_data_view');
+jest.mock('../../../detections/hooks/alert_summary/use_create_data_view');
 
 const id = 'id';
 const query = { ids: { values: ['abcdef'] } };
@@ -33,7 +33,7 @@ describe('<AiForSOCAlertsTab />', () => {
   });
 
   it('should render a loading skeleton while fetching packages (integrations)', async () => {
-    (useCreateDataView as jest.Mock).mockReturnValue({
+    (useCreateEaseAlertsDataView as jest.Mock).mockReturnValue({
       dataView: undefined,
       loading: false,
     });
@@ -48,7 +48,7 @@ describe('<AiForSOCAlertsTab />', () => {
   });
 
   it('should render a loading skeleton while creating the dataView', async () => {
-    (useCreateDataView as jest.Mock).mockReturnValue({
+    (useCreateEaseAlertsDataView as jest.Mock).mockReturnValue({
       dataView: undefined,
       loading: true,
     });
@@ -61,7 +61,7 @@ describe('<AiForSOCAlertsTab />', () => {
   });
 
   it('should render an error if the dataView fail to be created correctly', async () => {
-    (useCreateDataView as jest.Mock).mockReturnValue({
+    (useCreateEaseAlertsDataView as jest.Mock).mockReturnValue({
       dataView: undefined,
       loading: false,
     });
@@ -79,7 +79,7 @@ describe('<AiForSOCAlertsTab />', () => {
   });
 
   it('should render the content', async () => {
-    (useCreateDataView as jest.Mock).mockReturnValue({
+    (useCreateEaseAlertsDataView as jest.Mock).mockReturnValue({
       dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
       loading: false,
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/wrapper.tsx
@@ -9,11 +9,8 @@ import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/type
 import { EuiEmptyPrompt, EuiSkeletonRectangle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { AlertsTableOnLoadedProps } from '@kbn/response-ops-alerts-table/types';
-import React, { memo, useMemo } from 'react';
-import { RUNTIME_FIELD_MAP } from '../../../detections/components/alert_summary/wrapper';
-import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
-import { useCreateDataView } from '../../../common/hooks/use_create_data_view';
-import { useSpaceId } from '../../../common/hooks/use_space_id';
+import React, { memo } from 'react';
+import { useCreateEaseAlertsDataView } from '../../../detections/hooks/alert_summary/use_create_data_view';
 import { useFetchIntegrations } from '../../../detections/hooks/alert_summary/use_fetch_integrations';
 import { Table } from './table';
 
@@ -49,18 +46,8 @@ interface AiForSOCAlertsTableProps {
  * It renders a loading skeleton while packages are being fetched and while the dataView is being created.
  */
 export const AiForSOCAlertsTable = memo(({ id, onLoaded, query }: AiForSOCAlertsTableProps) => {
-  const spaceId = useSpaceId();
-  const dataViewSpec = useMemo(
-    () => ({
-      title: `${DEFAULT_ALERTS_INDEX}-${spaceId}`,
-      runtimeFieldMap: RUNTIME_FIELD_MAP,
-    }),
-    [spaceId]
-  );
+  const { dataView, loading: dataViewLoading } = useCreateEaseAlertsDataView();
 
-  const { dataView, loading: dataViewLoading } = useCreateDataView({ dataViewSpec });
-
-  // Fetch all integrations
   const { installedPackages, isLoading: integrationIsLoading } = useFetchIntegrations();
 
   return (
@@ -71,7 +58,7 @@ export const AiForSOCAlertsTable = memo(({ id, onLoaded, query }: AiForSOCAlerts
       width="100%"
     >
       <>
-        {!dataView || !dataView.id ? (
+        {!dataView ? (
           <EuiEmptyPrompt
             color="danger"
             data-test-subj={ERROR_TEST_ID}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.test.tsx
@@ -23,8 +23,8 @@ import { SEARCH_BAR_TEST_ID } from './search_bar/search_bar_section';
 import { KPIS_SECTION } from './kpis/kpis_section';
 import { GROUPED_TABLE_TEST_ID } from './table/table_section';
 import { useNavigateToIntegrationsPage } from '../../hooks/alert_summary/use_navigate_to_integrations_page';
-import { useCreateDataView } from '../../../common/hooks/use_create_data_view';
 import { useKibana } from '../../../common/lib/kibana';
+import { useCreateEaseAlertsDataView } from '../../hooks/alert_summary/use_create_data_view';
 
 jest.mock('../../../common/components/search_bar', () => ({
   // The module factory of `jest.mock()` is not allowed to reference any out-of-scope variables so we can't use SEARCH_BAR_TEST_ID
@@ -36,7 +36,7 @@ jest.mock('../alerts_table/alerts_grouping', () => ({
 jest.mock('../../../common/lib/kibana');
 jest.mock('../../hooks/alert_summary/use_navigate_to_integrations_page');
 jest.mock('../../hooks/alert_summary/use_integration_last_alert_ingested');
-jest.mock('../../../common/hooks/use_create_data_view');
+jest.mock('../../hooks/alert_summary/use_create_data_view');
 
 const packages: PackageListItem[] = [
   {
@@ -50,7 +50,7 @@ const packages: PackageListItem[] = [
 
 describe('<Wrapper />', () => {
   it('should render a loading skeleton while creating the dataView', async () => {
-    (useCreateDataView as jest.Mock).mockReturnValue({
+    (useCreateEaseAlertsDataView as jest.Mock).mockReturnValue({
       dataView: undefined,
       loading: true,
     });
@@ -64,7 +64,7 @@ describe('<Wrapper />', () => {
   });
 
   it('should render an error if the dataView fail to be created correctly', async () => {
-    (useCreateDataView as jest.Mock).mockReturnValue({
+    (useCreateEaseAlertsDataView as jest.Mock).mockReturnValue({
       dataView: undefined,
       loading: false,
     });
@@ -93,7 +93,7 @@ describe('<Wrapper />', () => {
       isLoading: true,
       lastAlertIngested: {},
     });
-    (useCreateDataView as jest.Mock).mockReturnValue({
+    (useCreateEaseAlertsDataView as jest.Mock).mockReturnValue({
       dataView: { getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() },
       loading: false,
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.tsx
@@ -15,15 +15,11 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { PackageListItem } from '@kbn/fleet-plugin/common';
-import type { DataViewSpec, RuntimeFieldSpec } from '@kbn/data-views-plugin/common';
-import { RELATED_INTEGRATION } from '../../constants';
+import { useCreateEaseAlertsDataView } from '../../hooks/alert_summary/use_create_data_view';
 import { KPIsSection } from './kpis/kpis_section';
 import { IntegrationSection } from './integrations/integration_section';
 import { SearchBarSection } from './search_bar/search_bar_section';
 import { TableSection } from './table/table_section';
-import { useCreateDataView } from '../../../common/hooks/use_create_data_view';
-import { useSpaceId } from '../../../common/hooks/use_space_id';
-import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
 
 const DATAVIEW_ERROR = i18n.translate('xpack.securitySolution.alertSummary.dataViewError', {
   defaultMessage: 'Unable to create data view',
@@ -33,15 +29,6 @@ export const DATA_VIEW_LOADING_PROMPT_TEST_ID = 'alert-summary-data-view-loading
 export const DATA_VIEW_ERROR_TEST_ID = 'alert-summary-data-view-error';
 export const SKELETON_TEST_ID = 'alert-summary-skeleton';
 export const CONTENT_TEST_ID = 'alert-summary-content';
-
-export const RUNTIME_FIELD_MAP: Record<string, RuntimeFieldSpec> = {
-  [RELATED_INTEGRATION]: {
-    type: 'keyword',
-    script: {
-      source: `if (params._source.containsKey('kibana.alert.rule.parameters') && params._source['kibana.alert.rule.parameters'].containsKey('related_integrations')) { def integrations = params._source['kibana.alert.rule.parameters']['related_integrations']; if (integrations != null && integrations.size() > 0 && integrations[0].containsKey('package')) { emit(integrations[0]['package']); } }`,
-    },
-  },
-};
 
 export interface WrapperProps {
   /**
@@ -57,17 +44,8 @@ export interface WrapperProps {
  * If the creation fails, we show an error message.
  */
 export const Wrapper = memo(({ packages }: WrapperProps) => {
-  const spaceId = useSpaceId();
-  const signalIndexName = `${DEFAULT_ALERTS_INDEX}-${spaceId}`;
-  const dataViewSpec: DataViewSpec = useMemo(
-    () => ({
-      title: signalIndexName,
-      runtimeFieldMap: RUNTIME_FIELD_MAP,
-    }),
-    [signalIndexName]
-  );
-
-  const { dataView, loading } = useCreateDataView({ dataViewSpec });
+  const { dataView, loading } = useCreateEaseAlertsDataView();
+  const signalIndexName = useMemo(() => (dataView ? dataView.getIndexPattern() : ''), [dataView]);
 
   return (
     <EuiSkeletonLoading
@@ -86,7 +64,7 @@ export const Wrapper = memo(({ packages }: WrapperProps) => {
       }
       loadedContent={
         <>
-          {!dataView || !dataView.id ? (
+          {!dataView ? (
             <EuiEmptyPrompt
               color="danger"
               data-test-subj={DATA_VIEW_ERROR_TEST_ID}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_create_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_create_data_view.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useCreateEaseAlertsDataView } from './use_create_data_view';
+import { useSpaceId } from '../../../common/hooks/use_space_id';
+import { useCreateDataView } from '../../../common/hooks/use_create_data_view';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+
+jest.mock('../../../common/hooks/use_space_id');
+jest.mock('../../../common/hooks/use_create_data_view');
+
+const dataView: DataView = createStubDataView({ spec: {} });
+
+describe('useCreateEaseAlertsDataView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return undefined and loading true while spaceId is undefined', () => {
+    (useSpaceId as jest.Mock).mockReturnValue(undefined);
+    (useCreateDataView as jest.Mock).mockReturnValue({ dataView: undefined, loading: true });
+
+    const { result } = renderHook(() => useCreateEaseAlertsDataView());
+
+    expect(result.current.dataView).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('should return undefined and loading true while dataView is being created', () => {
+    (useSpaceId as jest.Mock).mockReturnValue('spaceId');
+    (useCreateDataView as jest.Mock).mockReturnValue({ dataView: undefined, loading: true });
+
+    const { result } = renderHook(() => useCreateEaseAlertsDataView());
+
+    expect(result.current.dataView).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('should return dataView and loading false when ready', () => {
+    (useSpaceId as jest.Mock).mockReturnValue('spaceId');
+    (useCreateDataView as jest.Mock).mockReturnValue({ dataView, loading: false });
+
+    const { result } = renderHook(() => useCreateEaseAlertsDataView());
+
+    expect(result.current.dataView).toBe(dataView);
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_create_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_create_data_view.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { DataView, DataViewSpec, RuntimeFieldSpec } from '@kbn/data-views-plugin/common';
+import { RELATED_INTEGRATION } from '../../constants';
+import { useSpaceId } from '../../../common/hooks/use_space_id';
+import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
+import { useCreateDataView } from '../../../common/hooks/use_create_data_view';
+
+// Unique id for the ad-hoc dataView created for the alert summary page (used so we can retrieve the DataView from the flyout)
+export const DATA_VIEW_ID = 'alert-summary-data-view-id';
+
+// Runtime field to extract the related integration package name from the alert rule parameters field
+export const RUNTIME_FIELD_MAP: Record<string, RuntimeFieldSpec> = {
+  [RELATED_INTEGRATION]: {
+    type: 'keyword',
+    script: {
+      source: `if (params._source.containsKey('kibana.alert.rule.parameters') && params._source['kibana.alert.rule.parameters'].containsKey('related_integrations')) { def integrations = params._source['kibana.alert.rule.parameters']['related_integrations']; if (integrations != null && integrations.size() > 0 && integrations[0].containsKey('package')) { emit(integrations[0]['package']); } }`,
+    },
+  },
+};
+
+export interface UseCreateDataViewResult {
+  /**
+   * DataView created for the alert summary page
+   */
+  dataView: DataView | undefined;
+  /**
+   * Loading state while creating the dataView
+   */
+  loading: boolean;
+}
+
+/**
+ * Hook that creates a DataView for the EASE pages (alert summary, attack discovery and case pages as well as for the alert details flyout.
+ * - it takes into account the current space.
+ * - it uses the DEFAULT_ALERTS_INDEX as the index pattern.
+ * - it adds a runtime field to extract the related integration package name from the alert rule parameters field.
+ * - we pass a constant id, to prevent recreating the same dataView on other pages or in the flyout. For this we rely on the cache built in the DataViewService.
+ *
+ * It returns a null dataView if the space is undefined, to prevent unnecessary renders of the components.
+ */
+export const useCreateEaseAlertsDataView = (): UseCreateDataViewResult => {
+  const spaceId = useSpaceId();
+
+  const signalIndexName: string = useMemo(
+    () => (spaceId ? `${DEFAULT_ALERTS_INDEX}-${spaceId}` : ''),
+    [spaceId]
+  );
+  const dataViewId: string = useMemo(
+    () => (spaceId ? `${DATA_VIEW_ID}-${spaceId}` : ''),
+    [spaceId]
+  );
+
+  const dataViewSpec: DataViewSpec = useMemo(
+    () => ({
+      id: dataViewId,
+      runtimeFieldMap: RUNTIME_FIELD_MAP,
+      title: signalIndexName,
+    }),
+    [dataViewId, signalIndexName]
+  );
+
+  // If the spaceId is undefined, we skip creating the dataView
+  const { dataView, loading } = useCreateDataView({ dataViewSpec, skip: !spaceId });
+  return {
+    dataView,
+    loading,
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/header_title.tsx
@@ -8,6 +8,7 @@
 import React, { memo, useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { RELATED_INTEGRATION } from '../../../detections/constants';
 import { IntegrationIcon } from './integration_icon';
 import { DocumentSeverity } from '../../document_details/right/components/severity';
 import { useBasicDataFromDetailsData } from '../../document_details/shared/hooks/use_basic_data_from_details_data';
@@ -30,7 +31,11 @@ export const HEADER_INTEGRATION_TITLE_TEST_ID = 'ai-for-soc-alert-flyout-header-
 export const HeaderTitle = memo(() => {
   const { dataFormattedForFieldBrowser, getFieldsData } = useAIForSOCDetailsContext();
   const { ruleName, timestamp } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
-  const integrationName = getField(getFieldsData('relatedIntegrationPackage')) || '';
+
+  const integrationName = useMemo(
+    () => getField(getFieldsData(RELATED_INTEGRATION)) || '',
+    [getFieldsData]
+  );
 
   const title = useMemo(() => getAlertTitle({ ruleName }), [ruleName]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/hooks/use_document_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/hooks/use_document_details.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useTimelineEventsDetails } from '../../../timelines/containers/details';
+import { useDocumentDetails } from './use_document_details';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+import { mockDataFormattedForFieldBrowser } from '../../document_details/shared/mocks/mock_data_formatted_for_field_browser';
+import { mockSearchHit } from '../../document_details/shared/mocks/mock_search_hit';
+import { mockDataAsNestedObject } from '../../document_details/shared/mocks/mock_data_as_nested_object';
+import { useGetFieldsData } from '../../document_details/shared/hooks/use_get_fields_data';
+
+jest.mock('../../../timelines/containers/details');
+jest.mock('../../document_details/shared/hooks/use_get_fields_data');
+
+const dataView: DataView = createStubDataView({ spec: {} });
+const documentId = 'documentId';
+
+describe('useDocumentDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return all properties', () => {
+    (useTimelineEventsDetails as jest.Mock).mockReturnValue([
+      true,
+      mockDataFormattedForFieldBrowser,
+      mockSearchHit,
+      mockDataAsNestedObject,
+    ]);
+    const getFieldsData = jest.fn();
+    (useGetFieldsData as jest.Mock).mockReturnValue({ getFieldsData });
+
+    const { result } = renderHook(() =>
+      useDocumentDetails({
+        dataView,
+        documentId,
+      })
+    );
+
+    expect(result.current.dataAsNestedObject).toBe(mockDataAsNestedObject);
+    expect(result.current.dataFormattedForFieldBrowser).toBe(mockDataFormattedForFieldBrowser);
+    expect(result.current.getFieldsData).toBe(getFieldsData);
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/hooks/use_document_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/hooks/use_document_details.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
+import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import {
+  type GetFieldsData,
+  useGetFieldsData,
+} from '../../document_details/shared/hooks/use_get_fields_data';
+import type { RunTimeMappings } from '../../../../common/api/search_strategy';
+import { useTimelineEventsDetails } from '../../../timelines/containers/details';
+
+export interface UseDocumentDetailsParams {
+  /**
+   * DataView created for the alert summary page
+   */
+  dataView: DataView | undefined;
+  /**
+   * Id of the document
+   */
+  documentId: string | undefined;
+}
+
+export interface UseDocumentDetailsResult {
+  /**
+   * An object with top level fields from the ECS object
+   */
+  dataAsNestedObject: Ecs | null;
+  /**
+   * An array of field objects with category and value
+   */
+  dataFormattedForFieldBrowser: TimelineEventsDetailsItem[] | null;
+  /**
+   * Retrieves searchHit values for the provided field
+   */
+  getFieldsData: GetFieldsData;
+  /**
+   * Whether the data is loading
+   */
+  loading: boolean;
+}
+
+/**
+ * Hook to retrieve event details for EASE alert details flyout context
+ */
+export const useDocumentDetails = ({
+  dataView,
+  documentId,
+}: UseDocumentDetailsParams): UseDocumentDetailsResult => {
+  const indexName = useMemo(() => (dataView ? dataView.getIndexPattern() : ''), [dataView]);
+  const runtimeMappings = dataView?.getRuntimeMappings() as RunTimeMappings;
+
+  const [loading, dataFormattedForFieldBrowser, searchHit, dataAsNestedObject] =
+    useTimelineEventsDetails({
+      indexName,
+      eventId: documentId || '',
+      runtimeMappings,
+      skip: !documentId || !dataView,
+    });
+
+  const { getFieldsData } = useGetFieldsData({ fieldsData: searchHit?.fields });
+
+  return {
+    dataAsNestedObject,
+    dataFormattedForFieldBrowser,
+    getFieldsData,
+    loading,
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/types.ts
@@ -12,6 +12,5 @@ export interface AIForSOCDetailsProps extends FlyoutPanelProps {
   key: typeof IOCPanelKey;
   params?: {
     id: string;
-    indexName: string;
   };
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue that was introduced by [this previous PR](https://github.com/elastic/kibana/pull/231436) which changed the logic to render the integration icon in the table. The integration icon stopped being rendered in the alert detail flyout, because the flyout did not have the same dataView and therefore the same runTime mappings.

### Approach

I considered a few solutions
- the first one was to modify the existing [useEventDetails](https://github.com/elastic/kibana/tree/main/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts) hook that we use to retrieve the alert related objects used in the flyout. But this was a bit of a risky approach, as the hook is used in many other places. Also, we would have had to have even more if/else conditions in the code and this is not desired...
- the second one was to pass the runTime mappings to the flyout (I thought about passing the `dataView` directly but we should not do that as it's not serializable and shouldn't be placed in the url
- the third and final option was suggested by @michaelolo24 and consists of creating the same `dataView` in the flyout

### Implementation details

I decided to create a hook to take care of this `dataView` creation. That way, we can share the hook between all the places where we were previously creating the dataView:
- case details page alerts tab
- attack discovery page alerts tab
- alerts summary page
- and now flyout

This also allows us to better prevent any renders of the components while the `spaceId` is `undefined`, or while the `dataView` is being created.

Finally, recommended by @michaelolo24, we're passing an constant `id` to the dataView creation.
- This allows easy reusability on the flyout (which is on a different level of the DOM and does not have access to the dataView created on the page) as we can just fetch the `dataViewService` and retrieve the `dataView`.
- Also as we're relying on the caching mechanism, the dataView is not longer recreated every time we change page. It's a welcome performance improvement.

-----------------

The flyout was not showing the integration icon:

<img width="1380" height="886" alt="Screenshot 2025-09-09 at 10 54 28 AM" src="https://github.com/user-attachments/assets/73e62f50-ff4f-4d70-82aa-d37ff700f706" />

And it is now fixed (tested from all pages) and after a refresh:

https://github.com/user-attachments/assets/443ec958-8452-4cb3-beec-647026e562d0

## How to test

**_You might need to clear localStorage as the table columns are saved in there and this PR changes the Integration column to the new runTime field._**

This needs to be ran in Serverless:
- `yarn es serverless --projectType security`
- `yarn serverless-security --no-base-path`

You also need to enable the AI for SOC tier, by adding the following to your `serverless.security.dev.yaml` file:
```
xpack.securitySolutionServerless.productTypes:
  [
    { product_line: 'ai_soc', product_tier: 'search_ai_lake' },
  ]
```

Use one of these Serverless users:
- `platform_engineer`
- `endpoint_operations_analyst`
- `endpoint_policy_manager`
- `admin`
- `system_indices_superuser`

Then:
- generate data: `yarn test:generate:serverless-dev`
- create multiple catch all rules, each with a name of a AI for SOC integration (`google_secops`, `microsoft_sentinel`,, `sentinel_one` and `crowdstrike`) and make sure to add the related integration (with the same names) => to do that you'll need to temporary comment the `serverless.security.dev.yaml` config changes as the rules page is not accessible in AI for SOC.
-  change [this line](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_fetch_integrations.ts#L73) to `installedPackages: availablePackages` to force having some packages installed


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/234354