### PR TITLE
🌊 Streams: Per-level breadcrumbs

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_root/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_root/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { getAncestorsAndSelf, getSegments } from '@kbn/streams-schema';
 import { StreamDetailContextProvider } from '../../hooks/use_stream_detail';
 import { useStreamsAppBreadcrumbs } from '../../hooks/use_streams_app_breadcrumbs';
 import { useStreamsAppParams } from '../../hooks/use_streams_app_params';
@@ -19,13 +20,14 @@ export function StreamDetailRoot({ children }: { children: React.ReactNode }) {
   } = useStreamsAppParams('/{key}', true);
 
   useStreamsAppBreadcrumbs(() => {
-    return [
-      {
-        title: key,
-        path: `/{key}`,
-        params: { path: { key } },
-      },
-    ];
+    // Build breadcrumbs for each segment in the hierarchy
+    const ids = getAncestorsAndSelf(key);
+    const segments = getSegments(key);
+    return ids.map((id, idx) => ({
+      title: segments[idx],
+      path: `/{key}`,
+      params: { path: { key: id } },
+    }));
   }, [key]);
 
   return (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_root/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_root/index.tsx
@@ -6,9 +6,7 @@
  */
 
 import React from 'react';
-import { getAncestorsAndSelf, getSegments } from '@kbn/streams-schema';
 import { StreamDetailContextProvider } from '../../hooks/use_stream_detail';
-import { useStreamsAppBreadcrumbs } from '../../hooks/use_streams_app_breadcrumbs';
 import { useStreamsAppParams } from '../../hooks/use_streams_app_params';
 import { useKibana } from '../../hooks/use_kibana';
 
@@ -18,17 +16,6 @@ export function StreamDetailRoot({ children }: { children: React.ReactNode }) {
   const {
     path: { key },
   } = useStreamsAppParams('/{key}', true);
-
-  useStreamsAppBreadcrumbs(() => {
-    // Build breadcrumbs for each segment in the hierarchy
-    const ids = getAncestorsAndSelf(key);
-    const segments = getSegments(key);
-    return ids.map((id, idx) => ({
-      title: segments[idx],
-      path: `/{key}`,
-      params: { path: { key: id } },
-    }));
-  }, [key]);
 
   return (
     <StreamDetailContextProvider name={key} streamsRepositoryClient={streamsRepositoryClient}>

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_stream_detail.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_stream_detail.tsx
@@ -10,7 +10,10 @@ import type { StreamsRepositoryClient } from '@kbn/streams-plugin/public/api';
 import { EuiFlexGroup, EuiLoadingSpinner } from '@elastic/eui';
 import { Streams } from '@kbn/streams-schema';
 import { STREAMS_UI_PRIVILEGES } from '@kbn/streams-plugin/public';
+import { getAncestorsAndSelf, getSegments } from '@kbn/streams-schema';
 import { useStreamsAppFetch } from './use_streams_app_fetch';
+import { useStreamsAppBreadcrumbs } from './use_streams_app_breadcrumbs';
+import { useStreamsAppParams } from './use_streams_app_params';
 import { useKibana } from './use_kibana';
 
 export interface StreamDetailContextProviderProps {
@@ -77,6 +80,24 @@ export function StreamDetailContextProvider({
     },
     [streamsRepositoryClient, name, canManage]
   );
+
+  const {
+    path: { key },
+  } = useStreamsAppParams('/{key}', true);
+
+  useStreamsAppBreadcrumbs(() => {
+    if (!definition || !Streams.WiredStream.Definition.is(definition.stream)) {
+      return [{ title: key, path: `/{key}`, params: { path: { key } } }];
+    }
+    // Build breadcrumbs for each segment in the hierarchy for wired streams
+    const ids = getAncestorsAndSelf(key);
+    const segments = getSegments(key);
+    return ids.map((id, idx) => ({
+      title: segments[idx],
+      path: `/{key}`,
+      params: { path: { key: id } },
+    }));
+  }, [key, definition]);
 
   const context = React.useMemo(
     // useMemo cannot be used conditionally after the definition narrowing, the assertion is to narrow correctly the context value


### PR DESCRIPTION
Fixes https://github.com/elastic/streams-program/issues/358

<img width="968" height="369" alt="Screenshot 2025-09-09 at 11 59 31" src="https://github.com/user-attachments/assets/231bbca8-3a64-44de-ab5a-4a22a3f56272" />

Only applies to wired streams:

<img width="1304" height="452" alt="Screenshot 2025-09-09 at 11 59 40" src="https://github.com/user-attachments/assets/3dfbbba1-b433-47f6-b082-1f3675a42cad" />
