### PR TITLE
[9.1] [ska] remove kbn/test-suites-xpack imports (#233427)

### DIFF
--- a/x-pack/performance/configs/apm_config.ts
+++ b/x-pack/performance/configs/apm_config.ts
@@ -11,7 +11,7 @@ import { CA_CERT_PATH } from '@kbn/dev-utils';
 // eslint-disable-next-line import/no-default-export
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xpackFunctionalConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   return {

--- a/x-pack/performance/configs/cloud_security_posture_config.ts
+++ b/x-pack/performance/configs/cloud_security_posture_config.ts
@@ -10,7 +10,7 @@ import type { FtrConfigProviderContext } from '@kbn/test';
 // eslint-disable-next-line import/no-default-export
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xpackFunctionalConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   return {

--- a/x-pack/performance/configs/http2_config.ts
+++ b/x-pack/performance/configs/http2_config.ts
@@ -11,7 +11,7 @@ import { configureHTTP2 } from '@kbn/test-suites-src/common/configure_http2';
 // eslint-disable-next-line import/no-default-export
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xpackFunctionalConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   return configureHTTP2({

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/config.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/config.ts
@@ -21,7 +21,7 @@ async function config({ readConfigFile }: FtrConfigProviderContext) {
     require.resolve('@kbn/test-suites-src/common/config')
   );
   const xpackFunctionalTestsConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   const kibanaConfig = readKibanaConfig();

--- a/x-pack/solutions/observability/plugins/uptime/e2e/config.ts
+++ b/x-pack/solutions/observability/plugins/uptime/e2e/config.ts
@@ -19,7 +19,7 @@ async function config({ readConfigFile }: FtrConfigProviderContext) {
     require.resolve('@kbn/test-suites-src/common/config')
   );
   const xpackFunctionalTestsConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   const kibanaConfig = readKibanaConfig();

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/config.cloud.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/config.cloud.ts
@@ -11,7 +11,7 @@ import { pageObjects } from './page_objects';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xpackFunctionalConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
   // FTR configuration for cloud testing
   return {

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/config.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/config.ts
@@ -12,7 +12,7 @@ import {
   KibanaEBTServerProvider,
   KibanaEBTUIProvider,
 } from '@kbn/test-suites-src/analytics/services/kibana_ebt';
-import type { services as inheritedServices } from '@kbn/test-suites-xpack/functional/services';
+import type { services as inheritedServices } from '@kbn/test-suites-xpack-platform/functional/services';
 import { pageObjects } from './page_objects';
 import { services } from './services';
 
@@ -28,7 +28,7 @@ export type SecurityTelemetryFtrProviderContext = GenericFtrProviderContext<
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xpackFunctionalConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   return {

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/data_views/config.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/data_views/config.ts
@@ -12,7 +12,7 @@ import { services } from '../services';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xpackFunctionalConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   return {

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/alerts_page.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/alerts_page.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrService } from '@kbn/test-suites-xpack/functional/ftr_provider_context';
+import { FtrService } from '@kbn/test-suites-xpack-platform/functional/ftr_provider_context';
 import { testSubjectIds } from '../constants/test_subject_ids';
 
 const {

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/index.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { pageObjects as xpackFunctionalPageObjects } from '@kbn/test-suites-xpack/functional/page_objects';
+import { pageObjects as xpackFunctionalPageObjects } from '@kbn/test-suites-xpack-platform/functional/page_objects';
 import { FindingsPageProvider } from './findings_page';
 import { CspDashboardPageProvider } from './csp_dashboard_page';
 import { AddCisIntegrationFormPageProvider } from './add_cis_integration_form_page';

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/network_events_page.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/network_events_page.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrService } from '@kbn/test-suites-xpack/functional/ftr_provider_context';
+import { FtrService } from '@kbn/test-suites-xpack-platform/functional/ftr_provider_context';
 import { testSubjectIds } from '../constants/test_subject_ids';
 
 const {

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/timeline_page.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/timeline_page.ts
@@ -6,7 +6,7 @@
  */
 
 import { subj as testSubjSelector } from '@kbn/test-subj-selector';
-import { FtrService } from '@kbn/test-suites-xpack/functional/ftr_provider_context';
+import { FtrService } from '@kbn/test-suites-xpack-platform/functional/ftr_provider_context';
 
 const TIMELINE_CLOSE_BUTTON_TEST_SUBJ = 'timeline-modal-header-close-button';
 const TIMELINE_MODAL_PAGE_TEST_SUBJ = 'timeline';

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/services/query_bar_provider.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/services/query_bar_provider.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrService } from '@kbn/test-suites-xpack/functional/ftr_provider_context';
+import { FtrService } from '@kbn/test-suites-xpack-platform/functional/ftr_provider_context';
 
 export class QueryBarProvider extends FtrService {
   private readonly testSubjects = this.ctx.getService('testSubjects');

--- a/x-pack/solutions/security/test/security_solution_cypress/runner.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/runner.ts
@@ -8,12 +8,13 @@
 import Url from 'url';
 
 import { createEsClientForFtrConfig } from '@kbn/test';
-import { TransportResult } from '@elastic/elasticsearch';
-export type { FtrProviderContext } from '@kbn/test-suites-xpack/common/ftr_provider_context';
-import { FtrProviderContext } from '@kbn/test-suites-xpack/common/ftr_provider_context';
+import type { TransportResult } from '@elastic/elasticsearch';
+import type { FtrProviderContext } from '../api_integration/ftr_provider_context';
 import { tiAbusechMalware } from './pipelines/ti_abusech_malware';
 import { tiAbusechMalwareBazaar } from './pipelines/ti_abusech_malware_bazaar';
 import { tiAbusechUrl } from './pipelines/ti_abusech_url';
+
+export type { FtrProviderContext } from '../api_integration/ftr_provider_context';
 
 export async function SecuritySolutionConfigurableCypressTestRunner({
   getService,

--- a/x-pack/solutions/security/test/tsconfig.json
+++ b/x-pack/solutions/security/test/tsconfig.json
@@ -36,7 +36,6 @@
     "@kbn/tooling-log",
     "@kbn/cloud-security-posture-plugin",
     "@kbn/cloud-security-posture-common",
-    "@kbn/test-suites-xpack",
     "@kbn/security-solution-plugin",
     "@kbn/dev-utils",
     "@kbn/test-suites-src",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ska] remove kbn/test-suites-xpack imports (#233427)](https://github.com/elastic/kibana/pull/233427)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-09-01T13:13:42Z","message":"[ska] remove kbn/test-suites-xpack imports (#233427)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR removes any imports from `@kbn/test-suites-xpack` before we\ndelete `x-pack/test` directory completely. Doing it separately to make\nsure we don't break any tests and there is no more connections to the\nold directory.","sha":"61f6690fb3fd735da29dcfc8fa426c2a4ba398f2","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:obs-ux-management","backport:version","v9.2.0","v9.1.3","v8.19.3"],"title":"[ska] remove kbn/test-suites-xpack imports","number":233427,"url":"https://github.com/elastic/kibana/pull/233427","mergeCommit":{"message":"[ska] remove kbn/test-suites-xpack imports (#233427)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR removes any imports from `@kbn/test-suites-xpack` before we\ndelete `x-pack/test` directory completely. Doing it separately to make\nsure we don't break any tests and there is no more connections to the\nold directory.","sha":"61f6690fb3fd735da29dcfc8fa426c2a4ba398f2"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/233427","number":233427,"mergeCommit":{"message":"[ska] remove kbn/test-suites-xpack imports (#233427)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR removes any imports from `@kbn/test-suites-xpack` before we\ndelete `x-pack/test` directory completely. Doing it separately to make\nsure we don't break any tests and there is no more connections to the\nold directory.","sha":"61f6690fb3fd735da29dcfc8fa426c2a4ba398f2"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->