### PR TITLE
[Discover] [Unified Tabs] Add default value for max items count

### DIFF
--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabbed_content/tabbed_content.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabbed_content/tabbed_content.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../utils/manage_tabs';
 import type { TabItem, TabsServices, TabPreviewData } from '../../types';
 import { getNextTabNumber } from '../../utils/get_next_tab_number';
+import { MAX_ITEMS_COUNT } from '../../constants';
 
 export interface TabbedContentProps extends Pick<TabsBarProps, 'maxItemsCount'> {
   items: TabItem[];
@@ -49,7 +50,7 @@ export const TabbedContent: React.FC<TabbedContentProps> = ({
   items: managedItems,
   selectedItemId: managedSelectedItemId,
   recentlyClosedItems,
-  maxItemsCount,
+  maxItemsCount = MAX_ITEMS_COUNT,
   services,
   hideTabsBar = false,
   renderContent,

--- a/src/platform/packages/shared/kbn-unified-tabs/src/constants.ts
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/constants.ts
@@ -13,3 +13,5 @@ export const MAX_TAB_WIDTH = 280;
 export const MIN_TAB_WIDTH = 112;
 
 export const PREVIEW_WIDTH = 280;
+
+export const MAX_ITEMS_COUNT = 25;


### PR DESCRIPTION
Closes #234436

This pull request introduces a default limit for the number of tabs that can be displayed in the `TabbedContent` component, improving consistency and preventing excessive tabs from being shown. The main change is the addition of a new constant for the maximum number of items, which is now used as the default value in the component.

Lack of prop on a consumer side mentioned in issue was already resolved in a meantime with [#227159 [Discover] Save and load Discover session tabs](https://github.com/elastic/kibana/pull/227159), so this PR is limited only to a guard on a provider side.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



