### PR TITLE
[onboarding] k8s e2e stop relying on panel id

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/README.md
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/README.md
@@ -21,5 +21,10 @@ ARTIFACTS_FOLDER = ./.playwright
 # Assuming the working directory is the root of the Kibana repo
 npx playwright test -c ./x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/playwright.config.ts --project stateful --reporter list --headed
 ```
-1. Once the test reaches one of the required manual steps, like executing auto-detect command snippet, do the step manually.
-2. The test will proceed once the manual step is done.
+For running a specific test, use the following command
+```
+npx playwright test -c ./x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/playwright.config.ts --reporter list --headed x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/$
+```
+
+2. Once the test reaches one of the required manual steps, like executing auto-detect command snippet, do the step manually.
+3. The test will proceed once the manual step is done.

--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
@@ -12,6 +12,11 @@ import { assertEnv } from '../lib/assert_env';
 import { OtelKubernetesOverviewDashboardPage } from './pom/pages/otel_kubernetes_overview_dashboard.page';
 import { ApmServiceInventoryPage } from './pom/pages/apm_service_inventory.page';
 
+/**
+ * In case you need to run this test locally, you can use https://github.com/elastic/oblt-reference-stack
+ * to spin up a local k8s cluster with the required resources.
+ */
+
 test.beforeEach(async ({ page }) => {
   await page.goto(`${process.env.KIBANA_BASE_URL}/app/observabilityOnboarding`);
 });

--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/pom/pages/otel_kubernetes_overview_dashboard.page.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/pom/pages/otel_kubernetes_overview_dashboard.page.ts
@@ -15,13 +15,11 @@ export class OtelKubernetesOverviewDashboardPage {
   constructor(page: Page) {
     this.page = page;
 
-    this.nodesPanelValue = this.page.locator(
-      `#panel-6119419c-1899-4765-aed4-c050cde4c30a .echMetricText__value`
-    );
+    this.nodesPanelValue = this.page.locator(`[id^=panel] .echMetricText__value`);
   }
 
   async assertNodesPanelNotEmpty() {
-    await expect(this.nodesPanelValue).toBeVisible();
-    expect(await this.nodesPanelValue.textContent()).toMatch(/\d+/);
+    await expect(this.nodesPanelValue.first()).toBeVisible();
+    expect(await this.nodesPanelValue.first().textContent()).toMatch(/\d+/);
   }
 }

--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/pom/pages/otel_kubernetes_overview_dashboard.page.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/pom/pages/otel_kubernetes_overview_dashboard.page.ts
@@ -10,16 +10,16 @@ import { expect, type Page, type Locator } from '@playwright/test';
 export class OtelKubernetesOverviewDashboardPage {
   page: Page;
 
-  private readonly nodesPanelValue: Locator;
+  private readonly metricPanelValues: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
-    this.nodesPanelValue = this.page.locator(`[id^=panel] .echMetricText__value`);
+    this.metricPanelValues = this.page.locator(`[id^=panel] .echMetricText__value`);
   }
 
   async assertNodesPanelNotEmpty() {
-    await expect(this.nodesPanelValue.first()).toBeVisible();
-    expect(await this.nodesPanelValue.first().textContent()).toMatch(/\d+/);
+    await expect(this.metricPanelValues.first()).toBeVisible();
+    expect(await this.metricPanelValues.first().textContent()).toMatch(/\d+/);
   }
 }


### PR DESCRIPTION
onboarding ensemble test [were failing](https://github.com/elastic/ensemble/actions/runs/17572338291/attempts/1) due to us relying in the id panel of the dashboard to assert data was ingested.

This PR aims to make the test more robust by localising the specific panel using css selectors.
In addition I improved the `README` and added some hints for local runs in `x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts`