### PR TITLE
[Stream] Fix matched rate percentage rounding

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/preview_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/preview_panel.tsx
@@ -183,7 +183,7 @@ const SamplePreviewPanel = () => {
         <DocumentMatchFilterControls
           initialFilter={samplesSnapshot.context.documentMatchFilter}
           onFilterChange={setDocumentMatchFilter}
-          matchedDocumentPercentage={Math.round(matchedDocumentPercentage)}
+          matchedDocumentPercentage={Math.ceil(matchedDocumentPercentage)}
           isDisabled={!!documentsError || !condition}
         />
         {content}


### PR DESCRIPTION
## Summary

This fixes a rounding issue. In the image below we have matched rate of 0.25% but because of the rounding it comes down to 0% which might not be best visualisation to the user when we say 0% and still show documents.

<img width="1482" height="696" alt="Screenshot 2025-09-09 at 15 49 00" src="https://github.com/user-attachments/assets/8f8e6f58-7dd2-49ab-86a8-60fbfa82f113" />
