### PR TITLE
[Background search] Disable IN_PROGRESS background search links

### DIFF
--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.test.tsx
@@ -43,19 +43,36 @@ const setup = ({
 };
 
 describe('name column', () => {
-  describe('when the session name is clicked', () => {
-    it('should call onBackgroundSearchOpened', async () => {
+  describe('when the session is in progress', () => {
+    it('should render the name as plain text', () => {
       // Given
-      const mockSession = getUiSessionMock();
+      const mockSession = getUiSessionMock({ status: SearchSessionStatus.IN_PROGRESS });
 
       // When
-      const { user, onBackgroundSearchOpened } = setup({ uiSession: mockSession });
-      await user.click(screen.getByText(mockSession.name));
+      setup({ uiSession: mockSession });
 
       // Then
-      expect(onBackgroundSearchOpened).toHaveBeenCalledWith({
-        event: expect.any(Object),
-        session: mockSession,
+      expect(screen.getByTestId('sessionManagementNameText')).toBeVisible();
+      expect(screen.getByText(mockSession.name)).toBeVisible();
+    });
+  });
+
+  describe('when the session is NOT in progress', () => {
+    describe('when the session name is clicked', () => {
+      it('should call onBackgroundSearchOpened', async () => {
+        // Given
+        const mockSession = getUiSessionMock({ status: SearchSessionStatus.COMPLETE });
+
+        // When
+        const { user, onBackgroundSearchOpened } = setup({ uiSession: mockSession });
+        await user.click(screen.getByText(mockSession.name));
+
+        // Then
+        expect(screen.getByTestId('sessionManagementNameLink')).toBeVisible();
+        expect(onBackgroundSearchOpened).toHaveBeenCalledWith({
+          event: expect.any(Object),
+          session: mockSession,
+        });
       });
     });
   });

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
@@ -8,7 +8,7 @@
  */
 
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiIconTip, EuiLink } from '@elastic/eui';
+import { EuiIconTip, EuiLink, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -22,6 +22,34 @@ import { TableText } from '../..';
 function isSessionRestorable(status: SearchSessionStatus) {
   return status === SearchSessionStatus.IN_PROGRESS || status === SearchSessionStatus.COMPLETE;
 }
+
+const NameColumnText = ({
+  status,
+  children,
+  href,
+  onClick,
+}: {
+  status: SearchSessionStatus;
+  children: React.ReactNode;
+  href: string;
+  onClick: (event: React.MouseEvent<HTMLAnchorElement>) => void;
+}) => {
+  const hideLink = status === SearchSessionStatus.IN_PROGRESS;
+
+  if (hideLink)
+    return (
+      <EuiText data-test-subj="sessionManagementNameText" color="subdued">
+        {children}
+      </EuiText>
+    );
+
+  return (
+    // eslint-disable-next-line @elastic/eui/href-or-on-click
+    <EuiLink href={href} onClick={onClick} data-test-subj="sessionManagementNameLink">
+      {children}
+    </EuiLink>
+  );
+};
 
 export const nameColumn = ({
   core,
@@ -88,21 +116,20 @@ export const nameColumn = ({
           application: core.application,
         }}
       >
-        {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
-        <EuiLink
+        <NameColumnText
+          status={status}
           href={href}
           onClick={(event) => {
             trackAction?.();
             onBackgroundSearchOpened?.({ session, event });
           }}
-          data-test-subj="sessionManagementNameCol"
         >
-          <TableText>
+          <TableText data-test-subj="sessionManagementNameCol">
             {name}
             {notRestorableWarning}
             {versionIncompatibleWarning}
           </TableText>
-        </EuiLink>
+        </NameColumnText>
       </RedirectAppLinks>
     );
   },

--- a/x-pack/platform/test/functional/page_objects/search_sessions_management_page.ts
+++ b/x-pack/platform/test/functional/page_objects/search_sessions_management_page.ts
@@ -37,7 +37,7 @@ export function SearchSessionsPageProvider({ getService, getPageObjects }: FtrPr
             id: ((await row.getAttribute('data-test-search-session-id')) ?? '').split('id-')[1],
             name: $.findTestSubject('sessionManagementNameCol').text().trim(),
             status: $.findTestSubject('sessionManagementStatusLabel').attr('data-test-status'),
-            mainUrl: $.findTestSubject('sessionManagementNameCol').attr('href'),
+            mainUrl: $.findTestSubject('sessionManagementNameLink').attr('href'),
             created: $.findTestSubject('sessionManagementCreatedCol').text(),
             expires: $.findTestSubject('sessionManagementExpiresCol').text(),
             searchesCount: Number($.findTestSubject('sessionManagementNumSearchesCol').text()),

--- a/x-pack/platform/test/search_sessions_integration/tests/apps/dashboard/async_search/session_searches_integration.ts
+++ b/x-pack/platform/test/search_sessions_integration/tests/apps/dashboard/async_search/session_searches_integration.ts
@@ -172,7 +172,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         let searchSessionList = await searchSessionsManagement.getList();
         let searchSessionItem = searchSessionList.find((session) => session.id === savedSessionId)!;
         expect(searchSessionItem.searchesCount).to.be(1);
-        await new Promise((resolve) => setTimeout(resolve, 10000));
+
+        await new Promise((resolve) => setTimeout(resolve, 10_000));
+        await retry.waitFor('session should be in a completed status', async () => {
+          searchSessionList = await searchSessionsManagement.getList();
+          searchSessionItem = searchSessionList.find((session) => session.id === savedSessionId)!;
+          return searchSessionItem.status === 'complete';
+        });
 
         await searchSessionItem.view();
 
@@ -190,6 +196,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         searchSessionList = await searchSessionsManagement.getList();
         searchSessionItem = searchSessionList.find((session) => session.id === savedSessionId)!;
         expect(searchSessionItem.searchesCount).to.be(2);
+
+        await new Promise((resolve) => setTimeout(resolve, 10_000));
+        await retry.waitFor('session should be in a completed status', async () => {
+          searchSessionList = await searchSessionsManagement.getList();
+          searchSessionItem = searchSessionList.find((session) => session.id === savedSessionId)!;
+          return searchSessionItem.status === 'complete';
+        });
 
         await searchSessionItem.view();
         expect(await toasts.getCount()).to.be(0); // there should be no warnings


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/233475

When a background search is "IN_PROGRESS" right now it is rendered as a link in the management table, with this task it is just rendered as plain text.

| Before | After |
|--------|------|
| <img width="1226" height="382" alt="image" src="https://github.com/user-attachments/assets/531381c2-83f7-4056-b297-ab8257e8f0ad" /> | <img width="1230" height="354" alt="image" src="https://github.com/user-attachments/assets/38270b66-ed03-4a1f-90e4-9b623397a2c9" /> |


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

