### PR TITLE
[8.18] [DOCS][ResponseOps][8.x] Clarify untracked alerts  (#232790)

### DIFF
--- a/docs/user/alerting/view-alerts.asciidoc
+++ b/docs/user/alerting/view-alerts.asciidoc
@@ -62,22 +62,28 @@ There are three common alert statuses:
 `recovered`:: The conditions for the rule are no longer met and recovery actions should be generated.
 `untracked`:: Actions are no longer generated. For example, you can choose to move active alerts to this state when you disable or delete rules.
 
-[NOTE]
-====
-An alert can also be in a "flapping" state when it is switching repeatedly between active and recovered states.
-This state is possible only if you have enabled alert flapping detection in *{stack-manage-app} > {rules-ui} > Settings*.
-For each space, you can choose a look back window and threshold that are used to determine whether alerts are flapping.
-For example, you can specify that the alert must change status at least 6 times in the last 10 runs.
-If the rule has actions that run when the alert status changes, those actions are suppressed while the alert is flapping.
-====
+NOTE: Alert flapping is turned on by default. You can modify the criteria for changing an alert's status to the flapping state by configuring the **Alert flapping detection** settings. To do this, navigate to the **Alerts** page in the main menu, or use the {kibana-ref}/introduction.html#kibana-navigation-search[global search field]. Next, click **Manage Rules**, then **Settings** to open the global rule settings for the space. In the **Alert flapping detection** section, modify the rules' look back window and threshold for alert status changes. For example, you can specify that the alert must change its status at least 6 times in the last 10 runs for it to become a flapping alert. 
 
+`recovered`::
+The conditions for the rule are no longer met. If the rule has  <<defining-rules-actions-details, recovery actions>>, {kib} generates notifications based on the actions' notification settings. Recovery actions only run if the rule's conditions aren't met during the current rule execution, but were in the previous one. 
++
+An active alert changes to recovered if the conditions for the rule that generated it are no longer met. 
++
+A flapping alert changes to recovered when the rule's conditions are unmet for a specific number of consecutive runs. This number is determined by the **Alert status change threshold** setting, which you can configure under the **Alert flapping detection** settings.
++    
+For example, if the threshold requires an alert to change status at least 6 times in the last 10 runs to be considered flapping, then to recover, the rule's conditions must remain unmet for 6 consecutive runs. If the rule's conditions are met at any point during this recovery period, the count of consecutive unmet runs will reset, requiring the alert to remain unmet for an additional 6 consecutive runs to finally be reported as recovered.
++
+Once a flapping alert is recovered, it cannot be changed to flapping again. Only new alerts with repeated status changes are candidates for the flapping status. 
+
+`untracked`::
+The rule is disabled, or you've marked the alert as untracked. To mark the alert as untracked, go to the **Alerts** table, click the actions icon (…) to expand the **More actions** menu, and click **Mark as untracked**. When an alert is marked as untracked, actions are no longer generated and the alert's status can no longer be changed. You can choose to move active alerts to this state when you disable or delete rules.
 
 [discrete]
 [[mute-alerts]]
 === Mute alerts
 
-If an alert is active or flapping, you can mute it to temporarily suppress future actions.
-In both *{stack-manage-app} > Alerts* and *{rules-ui}*, you can open the action menu (…) for the appropriate alert and select *Mute*.
-To permanently suppress actions for an alert, open the actions menu and select *Mark as untracked*.
+If an alert is active or flapping, you can mute it to temporarily suppress future actions. In *{stack-manage-app} > Alerts*, open the action menu (…) for the appropriate alert, then select **Mute**. While muted, the alert's status will continue to update but rule actions won't run. All future alerts with the same alert ID will also be muted.
+
+To permanently suppress an alert's actions, open the actions menu for the appropriate alert, then select *Mark as untracked*. In this case, the alert's status is no longer updated and actions are no longer run. These changes are only applied to the alert that you untracked and cannot be reverted. Future alerts with the same alert ID are unaffected.
 
 To affect the behavior of the rule rather than individual alerts, check out <<controlling-rules>>.


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.18`:
 - [[DOCS][ResponseOps][8.x] Clarify untracked alerts  (#232790)](https://github.com/elastic/kibana/pull/232790)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nastasha Solomon","email":"79124755+nastasha-solomon@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-09-09T02:56:01Z","message":"[DOCS][ResponseOps][8.x] Clarify untracked alerts  (#232790)\n\nContributes to https://github.com/elastic/platform-docs-team/issues/641\nby adding that untracked alerts can no longer have their status updated.\n\n**Corresponding 9.x/Serverless and 8.x updates** \n- 9.x/Serverless: https://github.com/elastic/docs-content/pull/2690\n- Observability: https://github.com/elastic/observability-docs/pull/4952\n\nPreviews\n-\nhttps://kibana_bk_232790.docs-preview.app.elstc.co/guide/en/kibana/8.19/view-alerts.html#alert-status\n-\nhttps://kibana_bk_232790.docs-preview.app.elstc.co/guide/en/kibana/current/view-alerts.html#alert-status\n\n---------\n\nCo-authored-by: Lisa Cawley <lcawley@elastic.co>","sha":"9d7c6425105d77b5e64cdadf60a4ad6ae4f980b2","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","Team:ResponseOps","docs","backport:version","v8.18.0","v8.19.0"],"title":"[DOCS][ResponseOps][8.x] Clarify untracked alerts ","number":232790,"url":"https://github.com/elastic/kibana/pull/232790","mergeCommit":{"message":"[DOCS][ResponseOps][8.x] Clarify untracked alerts  (#232790)\n\nContributes to https://github.com/elastic/platform-docs-team/issues/641\nby adding that untracked alerts can no longer have their status updated.\n\n**Corresponding 9.x/Serverless and 8.x updates** \n- 9.x/Serverless: https://github.com/elastic/docs-content/pull/2690\n- Observability: https://github.com/elastic/observability-docs/pull/4952\n\nPreviews\n-\nhttps://kibana_bk_232790.docs-preview.app.elstc.co/guide/en/kibana/8.19/view-alerts.html#alert-status\n-\nhttps://kibana_bk_232790.docs-preview.app.elstc.co/guide/en/kibana/current/view-alerts.html#alert-status\n\n---------\n\nCo-authored-by: Lisa Cawley <lcawley@elastic.co>","sha":"9d7c6425105d77b5e64cdadf60a4ad6ae4f980b2"}},"sourceBranch":"8.19","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232790","number":232790,"mergeCommit":{"message":"[DOCS][ResponseOps][8.x] Clarify untracked alerts  (#232790)\n\nContributes to https://github.com/elastic/platform-docs-team/issues/641\nby adding that untracked alerts can no longer have their status updated.\n\n**Corresponding 9.x/Serverless and 8.x updates** \n- 9.x/Serverless: https://github.com/elastic/docs-content/pull/2690\n- Observability: https://github.com/elastic/observability-docs/pull/4952\n\nPreviews\n-\nhttps://kibana_bk_232790.docs-preview.app.elstc.co/guide/en/kibana/8.19/view-alerts.html#alert-status\n-\nhttps://kibana_bk_232790.docs-preview.app.elstc.co/guide/en/kibana/current/view-alerts.html#alert-status\n\n---------\n\nCo-authored-by: Lisa Cawley <lcawley@elastic.co>","sha":"9d7c6425105d77b5e64cdadf60a4ad6ae4f980b2"}}]}] BACKPORT-->