### PR TITLE
[Fleet] Only create logs-* index pattern in Logs Essentials projects

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install.ts
@@ -24,7 +24,7 @@ import { KibanaAssetType, KibanaSavedObjectType } from '../../../../types';
 import type { AssetReference, Installation, PackageSpecTags } from '../../../../types';
 import type { KibanaAssetReference, PackageInstallContext } from '../../../../../common/types';
 import {
-  indexPatternTypes,
+  getIndexPatternTypes,
   getIndexPatternSavedObjects,
   makeManagedIndexPatternsGlobal,
 } from '../index_pattern/install';
@@ -615,7 +615,7 @@ async function installKibanaSavedObjectsChunk({
 
 // Filter out any reserved index patterns
 function removeReservedIndexPatterns(kibanaAssets: ArchiveAsset[]) {
-  const reservedPatterns = indexPatternTypes.map((pattern) => `${pattern}-*`);
+  const reservedPatterns = getIndexPatternTypes().map((pattern) => `${pattern}-*`);
 
   return kibanaAssets.filter((asset) => !reservedPatterns.includes(asset.id));
 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_synced_integrations.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_synced_integrations.ts
@@ -17,7 +17,7 @@ import { FleetSetupError } from '../../errors';
 import { appContextService } from '../app_context';
 import {
   INDEX_PATTERN_SAVED_OBJECT_TYPE,
-  indexPatternTypes,
+  getIndexPatternTypes,
 } from '../epm/kibana/index_pattern/install';
 import { SO_SEARCH_LIMIT } from '../../constants';
 import { licenseService } from '../license';
@@ -153,7 +153,7 @@ export async function createCCSIndexPatterns(
   const indexPatternSavedObjectsWithRemoteCluster: SavedObject[] = [];
 
   for (const clusterName of remoteClusterNames) {
-    for (const indexPatternType of indexPatternTypes) {
+    for (const indexPatternType of getIndexPatternTypes()) {
       indexPatternSavedObjectsWithRemoteCluster.push({
         id: `${clusterName}:${indexPatternType}-*`,
         type: INDEX_PATTERN_SAVED_OBJECT_TYPE,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/231181

This PR adds logic to the index patterns created by Fleet:
* For Logs Essentials serverless projects, Fleet will only create `logs-*`
* In all other cases, Fleet will create `logs-*` and `metrics-*` (existing behaviour)

NB: the order in which the dataviews are listed in Discover will not change for existing projects.

### Testing

1. Create or edit your `serverless.dev.yml` config file:
   ```
   xpack.cloud.serverless.project_id: test-123

   pricing.tiers.products:
     - name: observability
       tier: logs_essentials # Accepted values for this tier are: complete, logs_essentials
   ```
2. Run kibana in serverless observability mode:
   ```
   yarn es serverless --projectType=oblt --kill
   yarn serverless-oblt
   ```
3. Install the `system` integration.
4. Go to Discover and check that the `logs-*` data view is selected by default and that there is no `metrics-*` data view.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

There are unknowns, such as the possibility that some integrations would create metrics data even on Logs Essentials projects.