### PR TITLE
🌊 POC: Client side routing

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/ingest_pipelines/generate_reroute_pipeline.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/ingest_pipelines/generate_reroute_pipeline.ts
@@ -17,14 +17,28 @@ interface GenerateReroutePipelineParams {
 export function generateReroutePipeline({ definition }: GenerateReroutePipelineParams) {
   return {
     id: getReroutePipelineName(definition.name),
-    processors: definition.ingest.wired.routing.map((child) => {
-      return {
-        reroute: {
-          destination: child.destination,
-          if: conditionToPainless(child.where),
-        },
-      };
-    }),
+    processors: [
+      // client side routing
+      ...definition.ingest.wired.routing.map((child) => {
+        return {
+          reroute: {
+            destination: child.destination,
+            if: `$("attributes.elastic.stream", "") == "${child.destination}" || $("attributes.elastic.stream", "").startsWith("${child.destination}" + ".")`,
+          },
+        };
+      }),
+      // server side routing
+      ...definition.ingest.wired.routing
+        .filter((child) => child.status !== 'disabled')
+        .map((child) => {
+          return {
+            reroute: {
+              destination: child.destination,
+              if: conditionToPainless(child.where),
+            },
+          };
+        }),
+    ],
     _meta: {
       description: `Reroute pipeline for the ${definition.name} stream`,
       managed: true,


### PR DESCRIPTION
Allow client side routing via special `attributes.elastic.stream` attribute