### PR TITLE
[9.1] Fix Save Modal promise chain `onSave` (#233933)

### DIFF
--- a/src/platform/plugins/private/links/public/content_management/save_to_library.tsx
+++ b/src/platform/plugins/private/links/public/content_management/save_to_library.tsx
@@ -12,8 +12,8 @@ import { i18n } from '@kbn/i18n';
 import {
   showSaveModal,
   OnSaveProps,
-  SavedObjectSaveModal,
   SaveResult,
+  SavedObjectSaveModalWithSaveResult,
 } from '@kbn/saved-objects-plugin/public';
 import { CONTENT_ID } from '../../common';
 import { checkForDuplicateTitle } from './duplicate_title_check';
@@ -83,7 +83,7 @@ export const runSaveToLibrary = async (
     };
 
     const saveModal = (
-      <SavedObjectSaveModal
+      <SavedObjectSaveModalWithSaveResult
         onSave={onSave}
         onClose={() => resolve(undefined)}
         title={newState.title ?? ''}

--- a/src/platform/plugins/shared/dashboard/public/dashboard_actions/library_add_action.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_actions/library_add_action.test.tsx
@@ -15,7 +15,12 @@ import { BehaviorSubject } from 'rxjs';
 jest.mock('@kbn/saved-objects-plugin/public', () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { render } = require('@testing-library/react');
-  const MockSavedObjectSaveModal = ({ onSave }: { onSave: (props: OnSaveProps) => void }) => {
+  const MockSavedObjectSaveModal = ({
+    onSave,
+  }: {
+    onSave: (props: OnSaveProps) => Promise<unknown> | unknown;
+  }) => {
+    // invoke onSave synchronously to simulate the user confirming the save
     onSave({
       newTitle: 'Library panel one',
       newCopyOnSave: true,
@@ -26,7 +31,7 @@ jest.mock('@kbn/saved-objects-plugin/public', () => {
     return null;
   };
   return {
-    SavedObjectSaveModal: MockSavedObjectSaveModal,
+    SavedObjectSaveModalWithSaveResult: MockSavedObjectSaveModal,
     showSaveModal: (saveModal: React.ReactElement) => {
       render(saveModal);
     },

--- a/src/platform/plugins/shared/dashboard/public/dashboard_actions/library_add_action.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_actions/library_add_action.tsx
@@ -30,7 +30,7 @@ import {
 import {
   OnSaveProps,
   SaveResult,
-  SavedObjectSaveModal,
+  SavedObjectSaveModalWithSaveResult,
   showSaveModal,
 } from '@kbn/saved-objects-plugin/public';
 import { Action, IncompatibleActionError } from '@kbn/ui-actions-plugin/public';
@@ -113,7 +113,7 @@ export class AddToLibraryAction implements Action<EmbeddableApiContext> {
           }
         };
         showSaveModal(
-          <SavedObjectSaveModal
+          <SavedObjectSaveModalWithSaveResult
             onSave={onSave}
             onClose={() => {}}
             title={lastTitle ?? ''}

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/__snapshots__/save_modal.test.tsx.snap
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/__snapshots__/save_modal.test.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders DashboardSaveModal 1`] = `
-<SavedObjectSaveModal
+<Component
   description="dash description"
   initialCopyOnSave={true}
   objectType="dashboard"
-  onClose={[Function]}
+  onClose={[MockFunction]}
   onSave={[Function]}
   options={
     <React.Fragment>

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/save_modal.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/save_modal.test.tsx
@@ -16,11 +16,14 @@ jest.mock('@kbn/saved-objects-plugin/public', () => ({
 
 import { DashboardSaveModal } from './save_modal';
 
+const mockSave = jest.fn();
+const mockClose = jest.fn();
+
 test('renders DashboardSaveModal', () => {
   const component = shallowWithI18nProvider(
     <DashboardSaveModal
-      onSave={() => {}}
-      onClose={() => {}}
+      onSave={mockSave}
+      onClose={mockClose}
       title="dash title"
       description="dash description"
       timeRestore={true}

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/save_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/save_modal.tsx
@@ -12,7 +12,8 @@ import React, { Fragment, useCallback } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiIconTip, EuiSwitch } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { SavedObjectSaveModal } from '@kbn/saved-objects-plugin/public';
+import type { SaveResult } from '@kbn/saved-objects-plugin/public';
+import { SavedObjectSaveModalWithSaveResult } from '@kbn/saved-objects-plugin/public';
 import { savedObjectsTaggingService } from '../../services/kibana_services';
 import type { DashboardSaveOptions } from './types';
 
@@ -25,7 +26,7 @@ interface DashboardSaveModalProps {
     newTimeRestore,
     isTitleDuplicateConfirmed,
     onTitleDuplicate,
-  }: DashboardSaveOptions) => void;
+  }: DashboardSaveOptions) => Promise<SaveResult>;
   onClose: () => void;
   title: string;
   description: string;
@@ -130,7 +131,7 @@ export const DashboardSaveModal: React.FC<DashboardSaveModalProps> = ({
   }, [persistSelectedTimeInterval, selectedTags, showStoreTimeOnSave]);
 
   return (
-    <SavedObjectSaveModal
+    <SavedObjectSaveModalWithSaveResult
       onSave={saveDashboard}
       onClose={onClose}
       title={title}

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/on_save_search.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/on_save_search.tsx
@@ -11,8 +11,15 @@ import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFormRow, EuiSwitch } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import type { OnSaveProps } from '@kbn/saved-objects-plugin/public';
-import { SavedObjectSaveModal, showSaveModal } from '@kbn/saved-objects-plugin/public';
+import type {
+  OnSaveProps,
+  SaveResult,
+  ShowSaveModalMinimalSaveModalProps,
+} from '@kbn/saved-objects-plugin/public';
+import {
+  SavedObjectSaveModalWithSaveResult,
+  showSaveModal,
+} from '@kbn/saved-objects-plugin/public';
 import type { SavedSearch, SaveSavedSearchOptions } from '@kbn/saved-search-plugin/public';
 import type { DiscoverServices } from '../../../../build_services';
 import type { DiscoverStateContainer } from '../../state_management/discover_state';
@@ -114,7 +121,7 @@ export async function onSaveSearch({
     newTags: string[];
     isTitleDuplicateConfirmed: boolean;
     onTitleDuplicate: () => void;
-  }) => {
+  }): Promise<SaveResult> => {
     const appState = state.appState.getState();
     const currentTitle = savedSearch.title;
     const currentTimeRestore = savedSearch.timeRestore;
@@ -184,10 +191,10 @@ export async function onSaveSearch({
 
     onSaveCb?.();
 
-    return response;
+    return response ?? {};
   };
 
-  const saveModal = (
+  const saveModal: React.ReactElement<ShowSaveModalMinimalSaveModalProps> = (
     <SaveSearchObjectModal
       isTimeBased={dataView?.isTimeBased() ?? false}
       services={services}
@@ -215,7 +222,9 @@ const SaveSearchObjectModal: React.FC<{
   description?: string;
   timeRestore?: boolean;
   tags: string[];
-  onSave: (props: OnSaveProps & { newTimeRestore: boolean; newTags: string[] }) => void;
+  onSave: (
+    props: OnSaveProps & { newTimeRestore: boolean; newTags: string[] }
+  ) => Promise<SaveResult>;
   onClose: () => void;
   managed: boolean;
 }> = ({
@@ -237,8 +246,8 @@ const SaveSearchObjectModal: React.FC<{
   );
   const [currentTags, setCurrentTags] = useState(tags);
 
-  const onModalSave = (params: OnSaveProps) => {
-    onSave({
+  const onModalSave = async (params: OnSaveProps): Promise<SaveResult> => {
+    return onSave({
       ...params,
       newTimeRestore: timeRestore,
       newTags: currentTags,
@@ -287,7 +296,7 @@ const SaveSearchObjectModal: React.FC<{
   );
 
   return (
-    <SavedObjectSaveModal
+    <SavedObjectSaveModalWithSaveResult
       title={title}
       showCopyOnSave={showCopyOnSave}
       initialCopyOnSave={initialCopyOnSave}

--- a/src/platform/plugins/shared/presentation_util/public/components/index.tsx
+++ b/src/platform/plugins/shared/presentation_util/public/components/index.tsx
@@ -39,6 +39,13 @@ export const LazySavedObjectSaveModalDashboard = React.lazy(
   () => import('./saved_object_save_modal_dashboard')
 );
 
+/**
+ * Used with `showSaveModal` to pass `SaveResult` back from `onSave`
+ */
+export const LazySavedObjectSaveModalDashboardWithSaveResult = React.lazy(
+  () => import('./saved_object_save_modal_dashboard_with_save_result')
+);
+
 export const LazyDataViewPicker = React.lazy(() => import('./data_view_picker/data_view_picker'));
 
 export const LazyFieldPicker = React.lazy(() => import('./field_picker/field_picker'));

--- a/src/platform/plugins/shared/presentation_util/public/components/saved_object_save_modal_dashboard.tsx
+++ b/src/platform/plugins/shared/presentation_util/public/components/saved_object_save_modal_dashboard.tsx
@@ -21,7 +21,7 @@ import { SaveModalDashboardProps } from './types';
 import { SaveModalDashboardSelector } from './saved_object_save_modal_dashboard_selector';
 import { getPresentationCapabilities } from '../utils/get_presentation_capabilities';
 
-function SavedObjectSaveModalDashboard(props: SaveModalDashboardProps) {
+function SavedObjectSaveModalDashboard<T = void>(props: SaveModalDashboardProps<T>) {
   const { documentInfo, tagOptions, objectType, onClose, canSaveByReference } = props;
   const { id: documentId } = documentInfo;
   const initialCopyOnSave = !Boolean(documentId);
@@ -75,7 +75,7 @@ function SavedObjectSaveModalDashboard(props: SaveModalDashboardProps) {
     setCopyOnSave(newCopyOnSave);
   };
 
-  const onModalSave = (onSaveProps: OnSaveProps) => {
+  const onModalSave = async (onSaveProps: OnSaveProps): Promise<void> => {
     let dashboardId = null;
 
     // Don't save with a dashboard ID if we're
@@ -88,7 +88,7 @@ function SavedObjectSaveModalDashboard(props: SaveModalDashboardProps) {
       }
     }
 
-    props.onSave({ ...onSaveProps, dashboardId, addToLibrary: isAddToLibrarySelected });
+    await props.onSave({ ...onSaveProps, dashboardId, addToLibrary: isAddToLibrarySelected });
   };
 
   const saveLibraryLabel =

--- a/src/platform/plugins/shared/presentation_util/public/components/saved_object_save_modal_dashboard_with_save_result.tsx
+++ b/src/platform/plugins/shared/presentation_util/public/components/saved_object_save_modal_dashboard_with_save_result.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SaveResult } from '@kbn/saved-objects-plugin/public';
+
+import SavedObjectSaveModalDashboard from './saved_object_save_modal_dashboard';
+
+/**
+ * Used with `showSaveModal` to pass `SaveResult` back from `onSave`
+ */
+const SavedObjectSaveModalDashboardWithSaveResult = SavedObjectSaveModalDashboard<SaveResult>;
+
+// required for dynamic import using React.lazy()
+// eslint-disable-next-line import/no-default-export
+export default SavedObjectSaveModalDashboardWithSaveResult;

--- a/src/platform/plugins/shared/presentation_util/public/components/types.ts
+++ b/src/platform/plugins/shared/presentation_util/public/components/types.ts
@@ -21,12 +21,14 @@ interface SaveModalDocumentInfo {
   description?: string;
 }
 
-export interface SaveModalDashboardProps {
+export interface SaveModalDashboardProps<T = void> {
   documentInfo: SaveModalDocumentInfo;
   canSaveByReference: boolean;
   objectType: string;
   onClose: () => void;
-  onSave: (props: OnSaveProps & { dashboardId: string | null; addToLibrary: boolean }) => void;
+  onSave: (
+    props: OnSaveProps & { dashboardId: string | null; addToLibrary: boolean }
+  ) => Promise<T>;
   tagOptions?: React.ReactNode | ((state: SaveModalState) => React.ReactNode);
   // include a message if the user has to copy on save
   mustCopyOnSaveMessage?: string;

--- a/src/platform/plugins/shared/presentation_util/public/index.ts
+++ b/src/platform/plugins/shared/presentation_util/public/index.ts
@@ -21,6 +21,7 @@ export {
   LazyLabsFlyout,
   LazyDashboardPicker,
   LazySavedObjectSaveModalDashboard,
+  LazySavedObjectSaveModalDashboardWithSaveResult,
   withSuspense,
   LazyDataViewPicker,
   LazyFieldPicker,

--- a/src/platform/plugins/shared/saved_objects/public/index.ts
+++ b/src/platform/plugins/shared/saved_objects/public/index.ts
@@ -10,7 +10,13 @@
 import { SavedObjectsPublicPlugin } from './plugin';
 
 export type { OnSaveProps, OriginSaveModalProps, SaveModalState, SaveResult } from './save_modal';
-export { SavedObjectSaveModal, SavedObjectSaveModalOrigin, showSaveModal } from './save_modal';
+export {
+  SavedObjectSaveModal,
+  SavedObjectSaveModalWithSaveResult,
+  SavedObjectSaveModalOrigin,
+  showSaveModal,
+  type ShowSaveModalMinimalSaveModalProps,
+} from './save_modal';
 export { isErrorNonFatal } from './saved_object';
 export type { SavedObjectSaveOpts, SavedObject, SavedObjectConfig } from './types';
 

--- a/src/platform/plugins/shared/saved_objects/public/save_modal/index.ts
+++ b/src/platform/plugins/shared/saved_objects/public/save_modal/index.ts
@@ -8,8 +8,14 @@
  */
 
 export type { OnSaveProps, SaveModalState } from './saved_object_save_modal';
-export { SavedObjectSaveModal } from './saved_object_save_modal';
+export {
+  SavedObjectSaveModal,
+  SavedObjectSaveModalWithSaveResult,
+} from './saved_object_save_modal';
 export type { OriginSaveModalProps } from './saved_object_save_modal_origin';
 export { SavedObjectSaveModalOrigin } from './saved_object_save_modal_origin';
 export type { SaveResult } from './show_saved_object_save_modal';
-export { showSaveModal } from './show_saved_object_save_modal';
+export {
+  showSaveModal,
+  type ShowSaveModalMinimalSaveModalProps,
+} from './show_saved_object_save_modal';

--- a/src/platform/plugins/shared/saved_objects/public/save_modal/saved_object_save_modal.test.tsx
+++ b/src/platform/plugins/shared/saved_objects/public/save_modal/saved_object_save_modal.test.tsx
@@ -33,13 +33,16 @@ jest.mock('@elastic/eui', () => {
   };
 });
 
+const mockSave = jest.fn();
+const mockClose = jest.fn();
+
 describe('SavedObjectSaveModal', () => {
   it('should render', async () => {
     const { findByTestId, getByText } = render(
       <I18nProvider>
         <SavedObjectSaveModal
-          onSave={() => void 0}
-          onClose={() => void 0}
+          onSave={mockSave}
+          onClose={mockClose}
           title={'Saved Object title'}
           showCopyOnSave={false}
           objectType="visualization"
@@ -56,8 +59,8 @@ describe('SavedObjectSaveModal', () => {
     const { getByText } = render(
       <I18nProvider>
         <SavedObjectSaveModal
-          onSave={() => void 0}
-          onClose={() => void 0}
+          onSave={mockSave}
+          onClose={mockClose}
           title={'Saved Object title'}
           showCopyOnSave={false}
           objectType="visualization"
@@ -75,8 +78,8 @@ describe('SavedObjectSaveModal', () => {
     const { getByText, rerender } = render(
       <I18nProvider>
         <SavedObjectSaveModal
-          onSave={() => void 0}
-          onClose={() => void 0}
+          onSave={mockSave}
+          onClose={mockClose}
           title={'Saved Object title'}
           showCopyOnSave={false}
           objectType="visualization"
@@ -90,8 +93,8 @@ describe('SavedObjectSaveModal', () => {
     rerender(
       <I18nProvider>
         <SavedObjectSaveModal
-          onSave={() => void 0}
-          onClose={() => void 0}
+          onSave={mockSave}
+          onClose={mockClose}
           title={'Saved Object title'}
           showCopyOnSave={false}
           objectType="visualization"
@@ -109,8 +112,8 @@ describe('SavedObjectSaveModal', () => {
     render(
       <I18nProvider>
         <SavedObjectSaveModal
-          onSave={() => void 0}
-          onClose={() => void 0}
+          onSave={mockSave}
+          onClose={mockClose}
           title={'Saved Object title'}
           showCopyOnSave={false}
           objectType="visualization"
@@ -131,7 +134,7 @@ describe('SavedObjectSaveModal', () => {
         <I18nProvider>
           <SavedObjectSaveModal
             onSave={onSave}
-            onClose={() => void 0}
+            onClose={mockClose}
             title={'Saved Object title'}
             objectType="visualization"
             showDescription={true}

--- a/src/platform/plugins/shared/saved_objects/public/save_modal/saved_object_save_modal.tsx
+++ b/src/platform/plugins/shared/saved_objects/public/save_modal/saved_object_save_modal.tsx
@@ -36,6 +36,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
+import type { SaveResult } from './show_saved_object_save_modal';
 
 export interface OnSaveProps {
   newTitle: string;
@@ -58,8 +59,8 @@ export interface SaveDashboardReturn {
   redirectRequired?: boolean;
 }
 
-interface Props {
-  onSave: (props: OnSaveProps) => void;
+interface Props<T = void> {
+  onSave: (props: OnSaveProps) => Promise<T>;
   onClose: () => void;
   title: string;
   showCopyOnSave: boolean;
@@ -82,7 +83,7 @@ export interface SaveModalState {
   copyOnSave: boolean;
   isTitleDuplicateConfirmed: boolean;
   hasTitleDuplicate: boolean;
-  isLoading: boolean;
+  isSaving: boolean;
   visualizationDescription: string;
   hasAttemptedSubmit: boolean;
 }
@@ -93,8 +94,8 @@ const generateId = htmlIdGenerator();
  * @deprecated
  * @removeBy 8.8.0
  */
-class SavedObjectSaveModalComponent extends React.Component<
-  Props,
+class SavedObjectSaveModalComponent<T = void> extends React.Component<
+  Props<T>,
   SaveModalState,
   WithEuiThemeProps
 > {
@@ -106,7 +107,7 @@ class SavedObjectSaveModalComponent extends React.Component<
     copyOnSave: Boolean(this.props.initialCopyOnSave),
     isTitleDuplicateConfirmed: false,
     hasTitleDuplicate: false,
-    isLoading: false,
+    isSaving: false,
     visualizationDescription: this.props.description ? this.props.description : '',
     hasAttemptedSubmit: false,
   };
@@ -258,7 +259,7 @@ class SavedObjectSaveModalComponent extends React.Component<
 
   private onTitleDuplicate = () => {
     this.setState({
-      isLoading: false,
+      isSaving: false,
       isTitleDuplicateConfirmed: true,
       hasTitleDuplicate: true,
     });
@@ -269,18 +270,12 @@ class SavedObjectSaveModalComponent extends React.Component<
   };
 
   private saveSavedObject = async () => {
-    if (this.state.isLoading) {
-      // ignore extra clicks
-      return;
-    }
+    if (this.state.isSaving) return;
 
     this.setState({
-      isLoading: true,
+      isSaving: true,
     });
 
-    // Although `onSave` is an asynchronous function, it is typed as returning `void`
-    // somewhere deeper in the call chain, which causes its asynchronous nature to be lost.
-    // We still need to treat it as async here to properly handle the loading state.
     try {
       await this.props.onSave({
         newTitle: this.state.title,
@@ -290,7 +285,7 @@ class SavedObjectSaveModalComponent extends React.Component<
         newDescription: this.state.visualizationDescription,
       });
     } finally {
-      this.setState({ isLoading: false });
+      this.setState({ isSaving: false });
     }
   };
 
@@ -350,7 +345,7 @@ class SavedObjectSaveModalComponent extends React.Component<
   };
 
   private renderConfirmButton = () => {
-    const { isLoading } = this.state;
+    const { isSaving } = this.state;
 
     let confirmLabel: string | React.ReactNode = i18n.translate(
       'savedObjects.saveModal.saveButtonLabel',
@@ -367,7 +362,7 @@ class SavedObjectSaveModalComponent extends React.Component<
       <EuiButton
         fill
         data-test-subj="confirmSaveSavedObjectButton"
-        isLoading={isLoading}
+        isLoading={isSaving}
         type="submit"
         form={this.formId}
       >
@@ -444,4 +439,19 @@ class SavedObjectSaveModalComponent extends React.Component<
   };
 }
 
-export const SavedObjectSaveModal = withEuiTheme(SavedObjectSaveModalComponent);
+/**
+ * @deprecated
+ */
+export const SavedObjectSaveModal = withEuiTheme(SavedObjectSaveModalComponent<void>);
+
+/**
+ * This is a workaround for using this directly with the `showSaveModal` method.
+ *
+ * The `showSaveModal` method wraps and calls these props from outside but this modal
+ * does not require the `SaveResult` to be returned from `onSave`.
+ *
+ * @deprecated
+ */
+export const SavedObjectSaveModalWithSaveResult = withEuiTheme(
+  SavedObjectSaveModalComponent<SaveResult>
+);

--- a/src/platform/plugins/shared/saved_objects/public/save_modal/saved_object_save_modal_origin.tsx
+++ b/src/platform/plugins/shared/saved_objects/public/save_modal/saved_object_save_modal_origin.tsx
@@ -12,7 +12,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiFormRow, EuiSwitch } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
-import { OnSaveProps, SaveModalState, SavedObjectSaveModal } from '.';
+import { OnSaveProps, SaveModalState, SaveResult, SavedObjectSaveModalWithSaveResult } from '.';
 
 interface SaveModalDocumentInfo {
   id?: string;
@@ -29,7 +29,7 @@ export interface OriginSaveModalProps {
   objectType: string;
   onClose: () => void;
   options?: React.ReactNode | ((state: SaveModalState) => React.ReactNode);
-  onSave: (props: OnSaveProps & { returnToOrigin: boolean }) => void;
+  onSave: (props: OnSaveProps & { returnToOrigin: boolean }) => Promise<SaveResult>;
 }
 
 export function SavedObjectSaveModalOrigin(props: OriginSaveModalProps) {
@@ -88,8 +88,8 @@ export function SavedObjectSaveModalOrigin(props: OriginSaveModalProps) {
     }
   };
 
-  const onModalSave = (onSaveProps: OnSaveProps) => {
-    props.onSave({ ...onSaveProps, returnToOrigin: returnToOriginMode });
+  const onModalSave = async (onSaveProps: OnSaveProps): Promise<SaveResult> => {
+    return props.onSave({ ...onSaveProps, returnToOrigin: returnToOriginMode });
   };
 
   const confirmButtonLabel = returnToOriginMode
@@ -99,7 +99,7 @@ export function SavedObjectSaveModalOrigin(props: OriginSaveModalProps) {
     : null;
 
   return (
-    <SavedObjectSaveModal
+    <SavedObjectSaveModalWithSaveResult
       onSave={onModalSave}
       onClose={props.onClose}
       title={documentInfo.title}

--- a/src/platform/plugins/shared/saved_objects/public/save_modal/show_saved_object_save_modal.tsx
+++ b/src/platform/plugins/shared/saved_objects/public/save_modal/show_saved_object_save_modal.tsx
@@ -25,13 +25,19 @@ function isSuccess(result: SaveResult): result is { id?: string } {
   return 'id' in result;
 }
 
-interface MinimalSaveModalProps {
+/**
+ * Minimum props expected for model components passed to `showSaveModal`
+ */
+export interface ShowSaveModalMinimalSaveModalProps {
   onSave: (...args: any[]) => Promise<SaveResult>;
   onClose: () => void;
 }
 
+/**
+ * @deprecated legacy modal display mechanism
+ */
 export function showSaveModal(
-  saveModal: React.ReactElement<MinimalSaveModalProps>,
+  saveModal: React.ReactElement<ShowSaveModalMinimalSaveModalProps>,
   Wrapper?: FC<PropsWithChildren<unknown>>
 ) {
   // initialize variable that will hold reference for unmount
@@ -50,7 +56,7 @@ export function showSaveModal(
 
       const onSave = saveModal.props.onSave;
 
-      const onSaveConfirmed: MinimalSaveModalProps['onSave'] = async (...args) => {
+      const onSaveConfirmed: ShowSaveModalMinimalSaveModalProps['onSave'] = async (...args) => {
         const response = await onSave(...args);
         // close modal if we either hit an error or the saved object got an id
         if (Boolean(isSuccess(response) ? response.id : response.error)) {

--- a/src/platform/plugins/shared/visualizations/public/legacy/embeddable/attribute_service.tsx
+++ b/src/platform/plugins/shared/visualizations/public/legacy/embeddable/attribute_service.tsx
@@ -11,9 +11,11 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { get, omit } from 'lodash';
 import {
-  SavedObjectSaveModal,
   OnSaveProps,
   SaveResult,
+} from '@kbn/saved-objects-plugin/public';
+import {
+  SavedObjectSaveModalWithSaveResult,
   showSaveModal,
 } from '@kbn/saved-objects-plugin/public';
 import { getNotifications } from '../../services';
@@ -152,7 +154,7 @@ export class AttributeService {
       };
       if (saveOptions && (saveOptions as { showSaveModal: boolean }).showSaveModal) {
         showSaveModal(
-          <SavedObjectSaveModal
+          <SavedObjectSaveModalWithSaveResult
             onSave={onSave}
             onClose={() => {}}
             title={get(

--- a/src/platform/plugins/shared/visualizations/public/legacy/embeddable/attribute_service.tsx
+++ b/src/platform/plugins/shared/visualizations/public/legacy/embeddable/attribute_service.tsx
@@ -10,10 +10,7 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { get, omit } from 'lodash';
-import {
-  OnSaveProps,
-  SaveResult,
-} from '@kbn/saved-objects-plugin/public';
+import { OnSaveProps, SaveResult } from '@kbn/saved-objects-plugin/public';
 import {
   SavedObjectSaveModalWithSaveResult,
   showSaveModal,

--- a/src/platform/plugins/shared/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
+++ b/src/platform/plugins/shared/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
@@ -21,9 +21,11 @@ import {
   SavedObjectSaveModalOrigin,
   SavedObjectSaveOpts,
   OnSaveProps,
+  SaveResult,
+  ShowSaveModalMinimalSaveModalProps,
 } from '@kbn/saved-objects-plugin/public';
 import {
-  LazySavedObjectSaveModalDashboard,
+  LazySavedObjectSaveModalDashboardWithSaveResult,
   withSuspense,
 } from '@kbn/presentation-util-plugin/public';
 import { unhashUrl } from '@kbn/kibana-utils-plugin/public';
@@ -76,7 +78,9 @@ export interface TopNavConfigParams {
   eventEmitter?: EventEmitter;
 }
 
-const SavedObjectSaveModalDashboard = withSuspense(LazySavedObjectSaveModalDashboard);
+const SavedObjectSaveModalDashboardWithSaveResult = withSuspense(
+  LazySavedObjectSaveModalDashboardWithSaveResult
+);
 
 export const showPublicUrlSwitch = (anonymousUserCapabilities: Capabilities) => {
   if (!anonymousUserCapabilities.visualize_v2) return false;
@@ -584,7 +588,7 @@ export const getTopNavConfig = (
               }: OnSaveProps & { returnToOrigin?: boolean } & {
                 dashboardId?: string | null;
                 addToLibrary?: boolean;
-              }) => {
+              }): Promise<SaveResult> => {
                 const currentTitle = savedVis.title;
                 savedVis.title = newTitle;
                 embeddableHandler.updateInput({ title: newTitle });
@@ -629,7 +633,7 @@ export const getTopNavConfig = (
                   });
 
                   // TODO: Saved Object Modal requires `id` to be defined so this is a workaround
-                  return { id: true };
+                  return { id: 'true' };
                 }
 
                 // We're adding the viz to a library so we need to save it and then
@@ -659,7 +663,7 @@ export const getTopNavConfig = (
                 );
               }
 
-              let saveModal;
+              let saveModal: React.ReactElement<ShowSaveModalMinimalSaveModalProps>;
 
               if (originatingApp) {
                 saveModal = (
@@ -690,7 +694,7 @@ export const getTopNavConfig = (
                 );
               } else {
                 saveModal = (
-                  <SavedObjectSaveModalDashboard
+                  <SavedObjectSaveModalDashboardWithSaveResult
                     documentInfo={{
                       id: visualizeCapabilities.save ? savedVis?.id : undefined,
                       title: savedVis?.title || '',

--- a/x-pack/platform/plugins/private/graph/public/components/save_modal.tsx
+++ b/x-pack/platform/plugins/private/graph/public/components/save_modal.tsx
@@ -8,7 +8,8 @@
 import React, { useState } from 'react';
 import { EuiFormRow, EuiTextArea, EuiCallOut, EuiSpacer, EuiSwitch } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { SavedObjectSaveModal, OnSaveProps } from '@kbn/saved-objects-plugin/public';
+import type { OnSaveProps, SaveResult } from '@kbn/saved-objects-plugin/public';
+import { SavedObjectSaveModalWithSaveResult } from '@kbn/saved-objects-plugin/public';
 
 import { GraphSavePolicy } from '../types/config';
 
@@ -26,7 +27,7 @@ export function SaveModal({
   savePolicy,
   hasData,
 }: {
-  onSave: (props: OnSaveGraphProps) => void;
+  onSave: (props: OnSaveGraphProps) => Promise<SaveResult>;
   onClose: () => void;
   title: string;
   description: string;
@@ -37,9 +38,9 @@ export function SaveModal({
   const [newDescription, setDescription] = useState(description);
   const [dataConsent, setDataConsent] = useState(false);
   return (
-    <SavedObjectSaveModal
-      onSave={(props) => {
-        onSave({ ...props, newDescription, dataConsent });
+    <SavedObjectSaveModalWithSaveResult
+      onSave={async (props) => {
+        return onSave({ ...props, newDescription, dataConsent });
       }}
       onClose={onClose}
       title={title}

--- a/x-pack/platform/plugins/private/graph/public/services/save_modal.tsx
+++ b/x-pack/platform/plugins/private/graph/public/services/save_modal.tsx
@@ -43,14 +43,14 @@ export function openSaveModal({
 }) {
   const currentTitle = workspace.title;
   const currentDescription = workspace.description;
-  const onSave = ({
+  const onSave = async ({
     newTitle,
     newDescription,
     newCopyOnSave,
     isTitleDuplicateConfirmed,
     onTitleDuplicate,
     dataConsent,
-  }: OnSaveGraphProps) => {
+  }: OnSaveGraphProps): Promise<SaveResult> => {
     workspace.title = newTitle;
     workspace.description = newDescription;
     workspace.copyOnSave = newCopyOnSave;
@@ -68,6 +68,7 @@ export function openSaveModal({
       return response;
     });
   };
+
   showSaveModal(
     <SaveModal
       savePolicy={savePolicy}

--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/fields_config.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/fields_config.tsx
@@ -479,8 +479,8 @@ const FieldPanel: FC<FieldPanelProps> = ({
     timeRange,
   ]);
 
-  const onSaveCallback: SaveModalDashboardProps['onSave'] = useCallback(
-    ({ dashboardId, newTitle, newDescription }) => {
+  const onSaveCallback = useCallback<SaveModalDashboardProps['onSave']>(
+    async ({ dashboardId, newTitle, newDescription }) => {
       const stateTransfer = embeddable!.getStateTransfer();
 
       const embeddableInput: Partial<ChangePointEmbeddableState> = {

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/attachments_menu.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/attachments_menu.tsx
@@ -81,7 +81,7 @@ export const AttachmentsMenu = ({
   const canEditDashboards = capabilities.dashboard_v2.createNew;
 
   const onSave: SaveModalDashboardProps['onSave'] = useCallback(
-    ({ dashboardId, newTitle, newDescription }) => {
+    async ({ dashboardId, newTitle, newDescription }) => {
       const stateTransfer = embeddable!.getStateTransfer();
 
       const embeddableInput: Partial<PatternAnalysisEmbeddableState> = {

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_attachments_menu.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_attachments_menu.tsx
@@ -80,7 +80,7 @@ export const LogRateAnalysisAttachmentsMenu = ({
   const isCasesAttachmentEnabled = showLogRateAnalysisResults && significantItems.length > 0;
 
   const onSave: SaveModalDashboardProps['onSave'] = useCallback(
-    ({ dashboardId, newTitle, newDescription }) => {
+    async ({ dashboardId, newTitle, newDescription }) => {
       const stateTransfer = embeddable!.getStateTransfer();
 
       const embeddableInput: Partial<LogRateAnalysisEmbeddableState> = {

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal.tsx
@@ -37,7 +37,7 @@ export interface Props {
   returnToOriginSwitchLabel?: string;
   returnToOrigin?: boolean;
   onClose: () => void;
-  onSave: (props: SaveProps, options: { saveToLibrary: boolean }) => void;
+  onSave: (props: SaveProps, options: { saveToLibrary: boolean }) => Promise<void>;
 
   managed: boolean;
 }
@@ -89,9 +89,9 @@ export const SaveModal = (props: Props) => {
       savedObjectsTagging={savedObjectsTagging}
       initialTags={tagsIds}
       canSaveByReference={Boolean(savingToLibraryPermitted)}
-      onSave={(saveProps) => {
+      onSave={async (saveProps) => {
         const saveToLibrary = Boolean(saveProps.addToLibrary);
-        onSave(saveProps, { saveToLibrary });
+        await onSave(saveProps, { saveToLibrary });
       }}
       onClose={onClose}
       documentInfo={{

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container.tsx
@@ -174,8 +174,8 @@ export function SaveModalContainer({
       savingToLibraryPermitted={savingToLibraryPermitted}
       savedObjectsTagging={savedObjectsTagging}
       tagsIds={tagsIds}
-      onSave={(saveProps, options) => {
-        runLensSave(saveProps, options);
+      onSave={async (saveProps, options) => {
+        await runLensSave(saveProps, options);
       }}
       onClose={onClose}
       getAppNameFromId={getAppNameFromId}

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/tags_saved_object_save_modal_dashboard_wrapper.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/tags_saved_object_save_modal_dashboard_wrapper.tsx
@@ -27,7 +27,7 @@ export type TagEnhancedSavedObjectSaveModalDashboardProps = Omit<
 > & {
   initialTags: string[];
   savedObjectsTagging?: SavedObjectTaggingPluginStart;
-  onSave: (props: DashboardSaveProps) => void;
+  onSave: (props: DashboardSaveProps) => Promise<void>;
   getOriginatingPath?: (dashboardId: string) => string;
 };
 
@@ -52,9 +52,9 @@ export const TagEnhancedSavedObjectSaveModalDashboard: FC<
 
   const tagEnhancedOptions = <>{tagSelectorOption}</>;
 
-  const tagEnhancedOnSave: SaveModalDashboardProps['onSave'] = useCallback(
-    (saveOptions) => {
-      onSave({
+  const tagEnhancedOnSave = useCallback<SaveModalDashboardProps['onSave']>(
+    async (saveOptions) => {
+      await onSave({
         ...saveOptions,
         returnToOrigin: false,
         newTags: selectedTags,

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/tags_saved_object_save_modal_origin_wrapper.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/tags_saved_object_save_modal_origin_wrapper.tsx
@@ -19,7 +19,7 @@ export type OriginSaveProps = OnSaveProps & { returnToOrigin: boolean; newTags?:
 export type TagEnhancedSavedObjectSaveModalOriginProps = Omit<OriginSaveModalProps, 'onSave'> & {
   initialTags: string[];
   savedObjectsTagging?: SavedObjectTaggingPluginStart;
-  onSave: (props: OriginSaveProps) => void;
+  onSave: (props: OriginSaveProps) => Promise<void>;
 };
 
 export const TagEnhancedSavedObjectSaveModalOrigin: FC<
@@ -56,11 +56,12 @@ export const TagEnhancedSavedObjectSaveModalOrigin: FC<
     );
 
   const tagEnhancedOnSave: OriginSaveModalProps['onSave'] = useCallback(
-    (saveOptions) => {
-      onSave({
+    async (saveOptions) => {
+      await onSave({
         ...saveOptions,
         newTags: selectedTags,
       });
+      return {}; // SaveResult return type not needed here
     },
     [onSave, selectedTags]
   );

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/annotations/actions/save_action.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/annotations/actions/save_action.test.tsx
@@ -26,6 +26,8 @@ import { taggingApiMock } from '@kbn/saved-objects-tagging-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/public';
 
+const mockSave = jest.fn();
+
 describe('annotation group save action', () => {
   describe('save modal', () => {
     const modalSaveArgs = {
@@ -94,7 +96,7 @@ describe('annotation group save action', () => {
       const wrapper = shallowWithIntl(
         <SaveModal
           domElement={document.createElement('div')}
-          onSave={() => {}}
+          onSave={mockSave}
           savedObjectsTagging={savedObjectsTagging}
           title={title}
           description={description}

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/annotations/actions/save_action.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/annotations/actions/save_action.tsx
@@ -48,7 +48,7 @@ export const SaveModal = ({
 }: {
   domElement: HTMLDivElement;
   savedObjectsTagging: SavedObjectTaggingPluginStart | undefined;
-  onSave: (props: ModalOnSaveProps) => void;
+  onSave: (props: ModalOnSaveProps) => Promise<void>;
   title: string;
   description: string;
   tags: string[];
@@ -60,7 +60,9 @@ export const SaveModal = ({
 
   return (
     <SavedObjectSaveModal
-      onSave={async (props) => onSave({ ...props, closeModal, newTags: selectedTags })}
+      onSave={async (props) => {
+        await onSave({ ...props, closeModal, newTags: selectedTags });
+      }}
       onClose={closeModal}
       title={title}
       description={description}

--- a/x-pack/platform/plugins/shared/maps/public/routes/map_page/top_nav_config.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/routes/map_page/top_nav_config.tsx
@@ -10,11 +10,13 @@ import { i18n } from '@kbn/i18n';
 import { Adapters } from '@kbn/inspector-plugin/public';
 import {
   SavedObjectSaveModalOrigin,
+  ShowSaveModalMinimalSaveModalProps,
   OnSaveProps,
+  SaveResult,
   showSaveModal,
 } from '@kbn/saved-objects-plugin/public';
 import {
-  LazySavedObjectSaveModalDashboard,
+  LazySavedObjectSaveModalDashboardWithSaveResult,
   withSuspense,
 } from '@kbn/presentation-util-plugin/public';
 import { ScopedHistory } from '@kbn/core/public';
@@ -29,7 +31,9 @@ import { MAP_EMBEDDABLE_NAME } from '../../../common/constants';
 import { SavedMap } from './saved_map';
 import { checkForDuplicateTitle } from '../../content_management';
 
-const SavedObjectSaveModalDashboard = withSuspense(LazySavedObjectSaveModalDashboard);
+const SavedObjectSaveModalDashboardWithSaveResult = withSuspense(
+  LazySavedObjectSaveModalDashboardWithSaveResult
+);
 
 export function getTopNavConfig({
   savedMap,
@@ -169,7 +173,7 @@ export function getTopNavConfig({
               dashboardId?: string | null;
               addToLibrary: boolean;
             }
-          ) => {
+          ): Promise<SaveResult> => {
             try {
               await checkForDuplicateTitle(
                 {
@@ -210,7 +214,7 @@ export function getTopNavConfig({
           }),
         };
 
-        let saveModal;
+        let saveModal: React.ReactElement<ShowSaveModalMinimalSaveModalProps>;
 
         if (savedMap.hasOriginatingApp()) {
           saveModal = (
@@ -234,7 +238,7 @@ export function getTopNavConfig({
           );
         } else {
           saveModal = (
-            <SavedObjectSaveModalDashboard
+            <SavedObjectSaveModalDashboardWithSaveResult
               {...saveModalProps}
               canSaveByReference={true} // we know here that we have save capabilities.
               mustCopyOnSaveMessage={

--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_context_menu.tsx
@@ -184,7 +184,7 @@ export const AnomalyContextMenu: FC<AnomalyContextMenuProps> = ({
   );
 
   const onSaveCallback: SaveModalDashboardProps['onSave'] = useCallback(
-    ({ dashboardId, newTitle, newDescription }) => {
+    async ({ dashboardId, newTitle, newDescription }) => {
       const stateTransfer = embeddable!.getStateTransfer();
 
       const embeddableInput: Partial<AnomalyChartsEmbeddableState> = {

--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_timeline.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_timeline.tsx
@@ -387,7 +387,7 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
     }, []);
 
     const onSaveCallback: SaveModalDashboardProps['onSave'] = useCallback(
-      ({ dashboardId, newTitle, newDescription }) => {
+      async ({ dashboardId, newTitle, newDescription }) => {
         if (!selectedJobs) return;
 
         const stateTransfer = embeddable!.getStateTransfer();

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/timeseriesexplorer_controls/timeseriesexplorer_controls.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/timeseriesexplorer_controls/timeseriesexplorer_controls.tsx
@@ -178,7 +178,7 @@ export const TimeSeriesExplorerControls: FC<Props> = ({
   }
 
   const onSaveCallback: SaveModalDashboardProps['onSave'] = useCallback(
-    ({ dashboardId, newTitle, newDescription }) => {
+    async ({ dashboardId, newTitle, newDescription }) => {
       const stateTransfer = embeddable!.getStateTransfer();
       const config = getDefaultEmbeddablePanelConfig(selectedJobId);
 

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/error_budget_chart_panel.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/error_budget_chart_panel.tsx
@@ -43,7 +43,7 @@ export function ErrorBudgetChartPanel({
   const { embeddable } = useKibana().services;
 
   const handleAttachToDashboardSave: SaveModalDashboardProps['onSave'] = useCallback(
-    ({ dashboardId, newTitle, newDescription }) => {
+    async ({ dashboardId, newTitle, newDescription }) => {
       const stateTransfer = embeddable!.getStateTransfer();
       const embeddableInput = {
         title: newTitle,

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/hooks/use_slo_list_actions.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/hooks/use_slo_list_actions.ts
@@ -28,7 +28,7 @@ export function useSloListActions({
   };
 
   const handleAttachToDashboardSave: SaveModalDashboardProps['onSave'] = useCallback(
-    ({ dashboardId, newTitle, newDescription }) => {
+    async ({ dashboardId, newTitle, newDescription }) => {
       const stateTransfer = embeddable!.getStateTransfer();
       const embeddableInput = {
         title: newTitle,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/add_to_dashboard.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/add_to_dashboard.tsx
@@ -59,7 +59,7 @@ export const useAddToDashboard = ({
   const { embeddable } = useKibana<ClientPluginsStart>().services;
 
   const handleAttachToDashboardSave: SaveModalDashboardProps['onSave'] = useCallback(
-    ({ dashboardId }) => {
+    async ({ dashboardId }) => {
       const stateTransfer = embeddable.getStateTransfer();
 
       const state = {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix Save Modal promise chain `onSave` (#233933)](https://github.com/elastic/kibana/pull/233933)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Partridge","email":"nicholas.partridge@elastic.co"},"sourceCommit":{"committedDate":"2025-09-08T21:31:34Z","message":"Fix Save Modal promise chain `onSave` (#233933)\n\n## Summary\n\nThis PR fixes an issue in which the SO save modal in Lens, Dashboard and\nothers, allowed the user to spam the save button, resulting in multiple\nsaved instances.\n\n### Demo\n\n#### Before\n\n\nhttps://github.com/user-attachments/assets/70ddc6c1-b99d-4758-8333-fe9ab47474a4\n\n#### After\n\n\nhttps://github.com/user-attachments/assets/84f016dd-05d9-441c-864c-b06160c9d531\n\n\nFixes #233906\n\n## Details\n\nWhen attempting to save any SO using the\n[`SavedObjectSaveModal`](https://github.com/elastic/kibana/blob/07cc9e9c1a271c37f42c84f57a1600596070fd9c/src/platform/plugins/shared/saved_objects/public/save_modal/saved_object_save_modal.tsx#L95),\nthe logic was attempting to `await` the call to `onSave` and block any\nadditional calls. This was working correctly to set the `isLoading`\nstate, but the `onSave` callback is not expecting a `Promise` to be\nreturned so it has no affect and the `onSave` is immediately resolved,\nunsetting the loading state and thus allowing multiple calls to save.\n\nSo the issue is that `onSave` should expect `() => Promise<void>` not\n`() => void`. A crude fix to this could be to throttle the calls to\n`onSave` and preventing and future clicks until the save is eventually\ncomplete. But if the save takes longer or fails this will enable the\nsave button and allow clicking again, creating other possible issues and\nnot solving the root of the problem.\n\nSo the chain of `onSave` is broken from calling it here to the eventual\nfunction up the call stack that is performing the save. This involves\nupdating the chain of promised from the `onSave` prop all the way up to\nthe root consumer, which is typically calling an async function.\n\nFurther complicating things.... there is this dreadful, I mean\ndeprecated, `showSaveModal` function that wraps a modal component\n(almost like a HOC) and calls `props.onSave` of the passed component to\ndetermine the success state of the call to `onSave`.\n\n\nhttps://github.com/elastic/kibana/blob/07cc9e9c1a271c37f42c84f57a1600596070fd9c/src/platform/plugins/shared/saved_objects/public/save_modal/show_saved_object_save_modal.tsx#L34-L37\n\nHere's a rough example...\n\n```tsx\nimport { showSaveModal } from \"@kbn/saved-objects-plugin/public\";\n\nexport function openSaveModal() {\n  // ...\n\n  showSaveModal(\n    <SavedObjectSaveModal\n      ...\n      onSave={async () => {\n        const response = await doTheSave();\n\n        if(response.success) {\n          return { id: response.id };\n        } else {\n          return { error: 'failed to save' }\n        }\n      }}\n    />\n  );\n}\n```\n\nThe strange thing is that the `SavedObjectSaveModal.onSave` doesn't need\nthe `SaveResult` to be returned and these modal components are used in\nvarious places but only some are passed to `showSaveModal`.\n\nSo I cleaned up this code as well to expect the `SaveResult` when using\n`showSaveModal` and `void` otherwise.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release Notes\n\nFixes issue with save modal allowing duplicate saves of dashboard,\nvisualizations and others.\n\n---------\n\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"8415158b5d487e7dfa58ebbdb5021df160ab4279","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Team:obs-ux-management","backport:version","v9.2.0","v9.1.4","v8.19.4"],"title":"Fixes Save Modal promise chain `onSave`","number":233933,"url":"https://github.com/elastic/kibana/pull/233933","mergeCommit":{"message":"Fix Save Modal promise chain `onSave` (#233933)\n\n## Summary\n\nThis PR fixes an issue in which the SO save modal in Lens, Dashboard and\nothers, allowed the user to spam the save button, resulting in multiple\nsaved instances.\n\n### Demo\n\n#### Before\n\n\nhttps://github.com/user-attachments/assets/70ddc6c1-b99d-4758-8333-fe9ab47474a4\n\n#### After\n\n\nhttps://github.com/user-attachments/assets/84f016dd-05d9-441c-864c-b06160c9d531\n\n\nFixes #233906\n\n## Details\n\nWhen attempting to save any SO using the\n[`SavedObjectSaveModal`](https://github.com/elastic/kibana/blob/07cc9e9c1a271c37f42c84f57a1600596070fd9c/src/platform/plugins/shared/saved_objects/public/save_modal/saved_object_save_modal.tsx#L95),\nthe logic was attempting to `await` the call to `onSave` and block any\nadditional calls. This was working correctly to set the `isLoading`\nstate, but the `onSave` callback is not expecting a `Promise` to be\nreturned so it has no affect and the `onSave` is immediately resolved,\nunsetting the loading state and thus allowing multiple calls to save.\n\nSo the issue is that `onSave` should expect `() => Promise<void>` not\n`() => void`. A crude fix to this could be to throttle the calls to\n`onSave` and preventing and future clicks until the save is eventually\ncomplete. But if the save takes longer or fails this will enable the\nsave button and allow clicking again, creating other possible issues and\nnot solving the root of the problem.\n\nSo the chain of `onSave` is broken from calling it here to the eventual\nfunction up the call stack that is performing the save. This involves\nupdating the chain of promised from the `onSave` prop all the way up to\nthe root consumer, which is typically calling an async function.\n\nFurther complicating things.... there is this dreadful, I mean\ndeprecated, `showSaveModal` function that wraps a modal component\n(almost like a HOC) and calls `props.onSave` of the passed component to\ndetermine the success state of the call to `onSave`.\n\n\nhttps://github.com/elastic/kibana/blob/07cc9e9c1a271c37f42c84f57a1600596070fd9c/src/platform/plugins/shared/saved_objects/public/save_modal/show_saved_object_save_modal.tsx#L34-L37\n\nHere's a rough example...\n\n```tsx\nimport { showSaveModal } from \"@kbn/saved-objects-plugin/public\";\n\nexport function openSaveModal() {\n  // ...\n\n  showSaveModal(\n    <SavedObjectSaveModal\n      ...\n      onSave={async () => {\n        const response = await doTheSave();\n\n        if(response.success) {\n          return { id: response.id };\n        } else {\n          return { error: 'failed to save' }\n        }\n      }}\n    />\n  );\n}\n```\n\nThe strange thing is that the `SavedObjectSaveModal.onSave` doesn't need\nthe `SaveResult` to be returned and these modal components are used in\nvarious places but only some are passed to `showSaveModal`.\n\nSo I cleaned up this code as well to expect the `SaveResult` when using\n`showSaveModal` and `void` otherwise.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release Notes\n\nFixes issue with save modal allowing duplicate saves of dashboard,\nvisualizations and others.\n\n---------\n\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"8415158b5d487e7dfa58ebbdb5021df160ab4279"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/233933","number":233933,"mergeCommit":{"message":"Fix Save Modal promise chain `onSave` (#233933)\n\n## Summary\n\nThis PR fixes an issue in which the SO save modal in Lens, Dashboard and\nothers, allowed the user to spam the save button, resulting in multiple\nsaved instances.\n\n### Demo\n\n#### Before\n\n\nhttps://github.com/user-attachments/assets/70ddc6c1-b99d-4758-8333-fe9ab47474a4\n\n#### After\n\n\nhttps://github.com/user-attachments/assets/84f016dd-05d9-441c-864c-b06160c9d531\n\n\nFixes #233906\n\n## Details\n\nWhen attempting to save any SO using the\n[`SavedObjectSaveModal`](https://github.com/elastic/kibana/blob/07cc9e9c1a271c37f42c84f57a1600596070fd9c/src/platform/plugins/shared/saved_objects/public/save_modal/saved_object_save_modal.tsx#L95),\nthe logic was attempting to `await` the call to `onSave` and block any\nadditional calls. This was working correctly to set the `isLoading`\nstate, but the `onSave` callback is not expecting a `Promise` to be\nreturned so it has no affect and the `onSave` is immediately resolved,\nunsetting the loading state and thus allowing multiple calls to save.\n\nSo the issue is that `onSave` should expect `() => Promise<void>` not\n`() => void`. A crude fix to this could be to throttle the calls to\n`onSave` and preventing and future clicks until the save is eventually\ncomplete. But if the save takes longer or fails this will enable the\nsave button and allow clicking again, creating other possible issues and\nnot solving the root of the problem.\n\nSo the chain of `onSave` is broken from calling it here to the eventual\nfunction up the call stack that is performing the save. This involves\nupdating the chain of promised from the `onSave` prop all the way up to\nthe root consumer, which is typically calling an async function.\n\nFurther complicating things.... there is this dreadful, I mean\ndeprecated, `showSaveModal` function that wraps a modal component\n(almost like a HOC) and calls `props.onSave` of the passed component to\ndetermine the success state of the call to `onSave`.\n\n\nhttps://github.com/elastic/kibana/blob/07cc9e9c1a271c37f42c84f57a1600596070fd9c/src/platform/plugins/shared/saved_objects/public/save_modal/show_saved_object_save_modal.tsx#L34-L37\n\nHere's a rough example...\n\n```tsx\nimport { showSaveModal } from \"@kbn/saved-objects-plugin/public\";\n\nexport function openSaveModal() {\n  // ...\n\n  showSaveModal(\n    <SavedObjectSaveModal\n      ...\n      onSave={async () => {\n        const response = await doTheSave();\n\n        if(response.success) {\n          return { id: response.id };\n        } else {\n          return { error: 'failed to save' }\n        }\n      }}\n    />\n  );\n}\n```\n\nThe strange thing is that the `SavedObjectSaveModal.onSave` doesn't need\nthe `SaveResult` to be returned and these modal components are used in\nvarious places but only some are passed to `showSaveModal`.\n\nSo I cleaned up this code as well to expect the `SaveResult` when using\n`showSaveModal` and `void` otherwise.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release Notes\n\nFixes issue with save modal allowing duplicate saves of dashboard,\nvisualizations and others.\n\n---------\n\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"8415158b5d487e7dfa58ebbdb5021df160ab4279"}},{"branch":"9.1","label":"v9.1.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->