### PR TITLE
[Cases] Fix case list refetch on window focus

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/all_cases_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/all_cases_list.tsx
@@ -192,24 +192,23 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       filterOptions
     );
 
+    const cssStyling = useMemo(
+      () =>
+        isLoading || isLoadingCases || isLoadingColumns
+          ? css`
+              top: ${euiTheme.size.xxs};
+              border-radius: ${euiTheme.border.radius};
+              z-index: ${euiTheme.levels.header};
+            `
+          : css`
+              display: none;
+            `,
+      [isLoading, isLoadingCases, isLoadingColumns, euiTheme]
+    );
+
     return (
       <>
-        <EuiProgress
-          size="xs"
-          color="accent"
-          className="essentialAnimation"
-          css={
-            isLoading || isLoadingCases || isLoadingColumns
-              ? css`
-                  top: ${euiTheme.size.xxs};
-                  border-radius: ${euiTheme.border.radius};
-                  z-index: ${euiTheme.levels.header};
-                `
-              : css`
-                  display: none;
-                `
-          }
-        />
+        <EuiProgress size="xs" color="accent" className="essentialAnimation" css={cssStyling} />
 
         {!isSelectorView ? <CasesMetrics /> : null}
         <CasesTableFilters

--- a/x-pack/platform/plugins/shared/cases/public/containers/configure/use_get_case_configurations_query.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/configure/use_get_case_configurations_query.tsx
@@ -30,6 +30,7 @@ export const useGetCaseConfigurationsQuery = <T,>({
         showErrorToast(error, { title: i18n.ERROR_TITLE });
       },
       initialData: [initialConfiguration],
+      refetchOnWindowFocus: false,
     }
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_get_cases.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_get_cases.tsx
@@ -63,6 +63,7 @@ export const useGetCases = (
     },
     {
       keepPreviousData: true,
+      refetchOnWindowFocus: false,
       onError: (error: ServerError) => {
         if (error.name !== 'AbortError') {
           toasts.addError(


### PR DESCRIPTION
## Summary

This PR fixes an unnecessary refresh when user has cases page open, go to another tab in the browser and come back to cases. 

Before

https://github.com/user-attachments/assets/e20c3baf-bbd8-4d55-908d-b10059e8a022



After

https://github.com/user-attachments/assets/8089abcb-7a3f-420d-aa5a-cd840475981c



### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
