### PR TITLE
[9.0] [kbn-eslint-plugin-eslint] add scout_no_describe_configure rule (#234390)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2170,6 +2170,17 @@ module.exports = {
         'no-console': 'off',
       },
     },
+    {
+      // Custom rules for scout tests
+      files: [
+        'src/platform/plugins/**/test/scout/**/*.ts',
+        'x-pack/platform/**/plugins/**/test/scout/**/*.ts',
+        'x-pack/solutions/**/plugins/test/scout/**/*.ts',
+      ],
+      rules: {
+        '@kbn/eslint/scout_no_describe_configure': 'error',
+      },
+    },
   ],
 };
 

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -22,5 +22,6 @@ module.exports = {
     no_unsafe_hash: require('./rules/no_unsafe_hash'),
     no_deprecated_authz_config: require('./rules/no_deprecated_authz_config'),
     require_kibana_feature_privileges_naming: require('./rules/require_kibana_feature_privileges_naming'),
+    scout_no_describe_configure: require('./rules/scout_no_describe_configure'),
   },
 };

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_describe_configure.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_describe_configure.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+/** @typedef {import("@typescript-eslint/typescript-estree").TSESTree.CallExpression} CallExpression */
+/** @typedef {import("@typescript-eslint/typescript-estree").TSESTree.MemberExpression} MemberExpression */
+
+const ERROR_MSG = 'Using describe.configure is not allowed in Scout tests.';
+
+/**
+ * Checks if a node represents *.describe.configure()
+ * @param {CallExpression} node
+ * @returns {boolean}
+ */
+const isDescribeConfigure = (node) => {
+  // Check for *.describe.configure()
+  return (
+    node.callee.type === 'MemberExpression' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'configure' &&
+    node.callee.object.type === 'MemberExpression' &&
+    node.callee.object.property.type === 'Identifier' &&
+    node.callee.object.property.name === 'describe'
+  );
+};
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow describe.configure in Scout tests',
+      category: 'Best Practices',
+    },
+    fixable: null,
+    schema: [],
+  },
+  create: (context) => ({
+    CallExpression(node) {
+      if (isDescribeConfigure(node)) {
+        context.report({
+          node,
+          message: ERROR_MSG,
+        });
+      }
+    },
+  }),
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_describe_configure.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_describe_configure.test.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { RuleTester } = require('eslint');
+const rule = require('./scout_no_describe_configure');
+const dedent = require('dedent');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('@kbn/eslint/scout_no_describe_configure', rule, {
+  valid: [
+    {
+      code: dedent`
+        test('should work', () => {
+          expect(true).toBe(true);
+        });
+      `,
+    },
+    {
+      code: dedent`
+        test.describe('my test suite', () => {
+          test('should work', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+    },
+    {
+      code: dedent`
+        spaceTest.describe('my space-aware test suite', () => {
+          spaceTest('should work', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+    },
+    {
+      code: dedent`
+        describe('my test suite', () => {
+          test('should work', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+    },
+    {
+      code: dedent`
+        const describeBlock = test.describe;
+        describeBlock('my test suite', () => {
+          test('should work', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+    },
+  ],
+
+  invalid: [
+    {
+      code: dedent`
+        test.describe.configure({ mode: 'parallel' });
+      `,
+      errors: [
+        {
+          message: 'Using describe.configure is not allowed in Scout tests.',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        test.describe.configure({ 
+          mode: 'parallel',
+          retries: 2 
+        });
+      `,
+      errors: [
+        {
+          message: 'Using describe.configure is not allowed in Scout tests.',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        test.describe('my suite', () => {
+          test.describe.configure({ mode: 'serial' });
+          
+          test('should work', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+      errors: [
+        {
+          message: 'Using describe.configure is not allowed in Scout tests.',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const myTest = test;
+        myTest.describe.configure({ mode: 'parallel' });
+      `,
+      errors: [
+        {
+          message: 'Using describe.configure is not allowed in Scout tests.',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        // Different object with describe.configure should also be caught
+        spaceTest.describe.configure({});
+      `,
+      errors: [
+        {
+          message: 'Using describe.configure is not allowed in Scout tests.',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[kbn-eslint-plugin-eslint] add scout_no_describe_configure rule (#234390)](https://github.com/elastic/kibana/pull/234390)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-09-10T06:07:51Z","message":"[kbn-eslint-plugin-eslint] add scout_no_describe_configure rule (#234390)\n\n## Summary\n\nAdding new rule to prevent playwright runner configuration overrides in\nspec files. It is important to keep runner functionality unified across\nall the Scout tests and having custom logic may lead to unexpected CI\nbehavior or wrong test results ingestion.\nWe already have unified functionality in place:\n- retrying failure is handled on CI script level\n- parallel test execution is limited to test spec level (we don't allow\nconcurrent run of tests within the same file)\n- explicit timeouts for test execution is not recommended, but can be\naccepted for individual cases\n\nAdding smth like:\n\n```\nspaceTest.describe('Discover app - errors', { tag: tags.ESS_ONLY }, () => {\n  spaceTest.describe.configure({\n    retries: 2,\n    timeout: 120000,\n  });\n```\n\nwill be blocked by pre-commit hook:\n\n```\n*[scout/scout_no_describe_configure][~/github/kibana]$ gc \"add configure\"\nERROR\n      /Users/dmle/github/kibana/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/error_handling.spec.ts\n        12:3  error  Using describe.configure is not allowed in Scout tests  @kbn/eslint/scout_no_describe_configure\n```","sha":"1d540a7216fbd5ad2ab305572e56dffce8adc619","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","test:scout","v9.2.0","v9.1.3","v9.0.6","v8.19.4"],"title":"[kbn-eslint-plugin-eslint] add scout_no_describe_configure rule","number":234390,"url":"https://github.com/elastic/kibana/pull/234390","mergeCommit":{"message":"[kbn-eslint-plugin-eslint] add scout_no_describe_configure rule (#234390)\n\n## Summary\n\nAdding new rule to prevent playwright runner configuration overrides in\nspec files. It is important to keep runner functionality unified across\nall the Scout tests and having custom logic may lead to unexpected CI\nbehavior or wrong test results ingestion.\nWe already have unified functionality in place:\n- retrying failure is handled on CI script level\n- parallel test execution is limited to test spec level (we don't allow\nconcurrent run of tests within the same file)\n- explicit timeouts for test execution is not recommended, but can be\naccepted for individual cases\n\nAdding smth like:\n\n```\nspaceTest.describe('Discover app - errors', { tag: tags.ESS_ONLY }, () => {\n  spaceTest.describe.configure({\n    retries: 2,\n    timeout: 120000,\n  });\n```\n\nwill be blocked by pre-commit hook:\n\n```\n*[scout/scout_no_describe_configure][~/github/kibana]$ gc \"add configure\"\nERROR\n      /Users/dmle/github/kibana/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/error_handling.spec.ts\n        12:3  error  Using describe.configure is not allowed in Scout tests  @kbn/eslint/scout_no_describe_configure\n```","sha":"1d540a7216fbd5ad2ab305572e56dffce8adc619"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/234390","number":234390,"mergeCommit":{"message":"[kbn-eslint-plugin-eslint] add scout_no_describe_configure rule (#234390)\n\n## Summary\n\nAdding new rule to prevent playwright runner configuration overrides in\nspec files. It is important to keep runner functionality unified across\nall the Scout tests and having custom logic may lead to unexpected CI\nbehavior or wrong test results ingestion.\nWe already have unified functionality in place:\n- retrying failure is handled on CI script level\n- parallel test execution is limited to test spec level (we don't allow\nconcurrent run of tests within the same file)\n- explicit timeouts for test execution is not recommended, but can be\naccepted for individual cases\n\nAdding smth like:\n\n```\nspaceTest.describe('Discover app - errors', { tag: tags.ESS_ONLY }, () => {\n  spaceTest.describe.configure({\n    retries: 2,\n    timeout: 120000,\n  });\n```\n\nwill be blocked by pre-commit hook:\n\n```\n*[scout/scout_no_describe_configure][~/github/kibana]$ gc \"add configure\"\nERROR\n      /Users/dmle/github/kibana/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/error_handling.spec.ts\n        12:3  error  Using describe.configure is not allowed in Scout tests  @kbn/eslint/scout_no_describe_configure\n```","sha":"1d540a7216fbd5ad2ab305572e56dffce8adc619"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/234519","number":234519,"state":"OPEN"},{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->