### PR TITLE
Streams 🌊: removing manual pipeline from sample_logs scenario

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/sample_logs.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/sample_logs.ts
@@ -55,42 +55,7 @@ const scenario: Scenario<LogDocument> = async (runOptions) => {
           ingest: {
             lifecycle: { inherit: {} },
             processing: {
-              steps: [
-                {
-                  customIdentifier: 'synth-step-0',
-                  action: 'dissect',
-                  where: {
-                    always: {},
-                  },
-                  from: 'attributes.user.name',
-                  pattern: 'user%{attributes.user.id}',
-                  ignore_failure: false,
-                  ignore_missing: false,
-                },
-                {
-                  customIdentifier: 'synth-step-1',
-                  action: 'manual_ingest_pipeline',
-                  where: {
-                    always: {},
-                  },
-                  processors: [
-                    {
-                      convert: {
-                        field: 'attributes.user.id',
-                        type: 'long',
-                        ignore_missing: true,
-                      },
-                    },
-                    {
-                      fail: {
-                        if: 'ctx.attributes?.user?.id != null && ctx.attributes.user.id > 2',
-                        message: 'User is not allowed',
-                      },
-                    },
-                  ],
-                  ignore_failure: false,
-                },
-              ],
+              steps: [],
             },
             wired: {
               fields: {

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/sample_logs.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/sample_logs.ts
@@ -59,7 +59,6 @@ const scenario: Scenario<LogDocument> = async (runOptions) => {
             },
             wired: {
               fields: {
-                'attributes.user.id': { type: 'keyword' },
                 'attributes.process.name': { type: 'keyword', ignore_above: 18 },
               },
               routing: [],


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/233902 `manual_ingest_pipeline` are not supported in wired streams.
This PR removes steps when configuring child streams in `sample_logs` scenario