### PR TITLE
[8.19] [ska] remove kbn/test-suites-xpack imports (#233427)

### DIFF
--- a/x-pack/performance/configs/apm_config.ts
+++ b/x-pack/performance/configs/apm_config.ts
@@ -11,7 +11,7 @@ import { CA_CERT_PATH } from '@kbn/dev-utils';
 // eslint-disable-next-line import/no-default-export
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xpackFunctionalConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   return {

--- a/x-pack/performance/configs/cloud_security_posture_config.ts
+++ b/x-pack/performance/configs/cloud_security_posture_config.ts
@@ -10,7 +10,7 @@ import type { FtrConfigProviderContext } from '@kbn/test';
 // eslint-disable-next-line import/no-default-export
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xpackFunctionalConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   return {

--- a/x-pack/performance/configs/http2_config.ts
+++ b/x-pack/performance/configs/http2_config.ts
@@ -11,7 +11,7 @@ import { configureHTTP2 } from '@kbn/test-suites-src/common/configure_http2';
 // eslint-disable-next-line import/no-default-export
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xpackFunctionalConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   return configureHTTP2({

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/config.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/config.ts
@@ -21,7 +21,7 @@ async function config({ readConfigFile }: FtrConfigProviderContext) {
     require.resolve('@kbn/test-suites-src/common/config')
   );
   const xpackFunctionalTestsConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   const kibanaConfig = readKibanaConfig();

--- a/x-pack/solutions/observability/plugins/uptime/e2e/config.ts
+++ b/x-pack/solutions/observability/plugins/uptime/e2e/config.ts
@@ -19,7 +19,7 @@ async function config({ readConfigFile }: FtrConfigProviderContext) {
     require.resolve('@kbn/test-suites-src/common/config')
   );
   const xpackFunctionalTestsConfig = await readConfigFile(
-    require.resolve('@kbn/test-suites-xpack/functional/config.base')
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
   );
 
   const kibanaConfig = readKibanaConfig();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ska] remove kbn/test-suites-xpack imports (#233427)](https://github.com/elastic/kibana/pull/233427)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-09-01T13:13:42Z","message":"[ska] remove kbn/test-suites-xpack imports (#233427)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR removes any imports from `@kbn/test-suites-xpack` before we\ndelete `x-pack/test` directory completely. Doing it separately to make\nsure we don't break any tests and there is no more connections to the\nold directory.","sha":"61f6690fb3fd735da29dcfc8fa426c2a4ba398f2","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-management","v9.2.0","v9.1.3","v9.1.4","v8.19.4"],"title":"[ska] remove kbn/test-suites-xpack imports","number":233427,"url":"https://github.com/elastic/kibana/pull/233427","mergeCommit":{"message":"[ska] remove kbn/test-suites-xpack imports (#233427)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR removes any imports from `@kbn/test-suites-xpack` before we\ndelete `x-pack/test` directory completely. Doing it separately to make\nsure we don't break any tests and there is no more connections to the\nold directory.","sha":"61f6690fb3fd735da29dcfc8fa426c2a4ba398f2"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/233427","number":233427,"mergeCommit":{"message":"[ska] remove kbn/test-suites-xpack imports (#233427)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR removes any imports from `@kbn/test-suites-xpack` before we\ndelete `x-pack/test` directory completely. Doing it separately to make\nsure we don't break any tests and there is no more connections to the\nold directory.","sha":"61f6690fb3fd735da29dcfc8fa426c2a4ba398f2"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/234428","number":234428,"state":"MERGED","mergeCommit":{"sha":"d02d36d1f61fb99572fd3235bb5b5e26e23717f4","message":"[9.1] [ska] remove kbn/test-suites-xpack imports (#233427) (#234428)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[ska] remove kbn/test-suites-xpack imports\n(#233427)](https://github.com/elastic/kibana/pull/233427)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"8.19","label":"v8.19.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->