### PR TITLE
[ResponseOps][MW] Fix flaky maintenance window pagination test

### DIFF
--- a/x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/maintenance_windows/maintenance_windows_table.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/maintenance_windows/maintenance_windows_table.ts
@@ -278,9 +278,6 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       await pageObjects.maintenanceWindows.getMaintenanceWindowsList();
 
       await testSubjects.click('tablePaginationPopoverButton');
-      await testSubjects.click('tablePagination-25-rows');
-      await testSubjects.missingOrFail('pagination-button-1');
-      await testSubjects.click('tablePaginationPopoverButton');
       await testSubjects.click('tablePagination-10-rows');
       const listedOnFirstPageMWs = await testSubjects.findAll('list-item');
       expect(listedOnFirstPageMWs.length).to.be(10);
@@ -288,8 +285,11 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       await testSubjects.isEnabled('pagination-button-1');
       await testSubjects.click('pagination-button-1');
       await testSubjects.isEnabled('pagination-button-0');
-      const listedOnSecondPageMWs = await testSubjects.findAll('list-item');
-      expect(listedOnSecondPageMWs.length).to.be(2);
+
+      await retry.try(async () => {
+        const listedOnSecondPageMWs = await testSubjects.findAll('list-item');
+        expect(listedOnSecondPageMWs.length).to.be(2);
+      });
     });
 
     it('should delete a maintenance window', async () => {


### PR DESCRIPTION
Closes #205269

## Summary

I removed some unnecessary logic and wrapped the failing portion in a retry.

