### PR TITLE
[Agent Builder] create reasoning from hybrid tool call test responses

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/consts.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/consts.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const openingTag = (tagName: string) => `<${tagName}>`;
+const closingTag = (tagName: string) => `</${tagName}>`;
+
+export const toolReasoningTagName = 'tool_reasoning';
+export const toolReasoningOpeningTag = openingTag(toolReasoningTagName);
+export const toolReasoningClosingTag = closingTag(toolReasoningTagName);

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/convert_graph_events.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/convert_graph_events.ts
@@ -16,6 +16,7 @@ import type {
   MessageCompleteEvent,
   ToolCallEvent,
   ToolResultEvent,
+  ReasoningEvent,
 } from '@kbn/onechat-common';
 import type { ToolIdMapping } from '@kbn/onechat-genai-utils/langchain';
 import {
@@ -26,19 +27,23 @@ import {
   createMessageEvent,
   createToolCallEvent,
   createToolResultEvent,
+  createReasoningEvent,
   extractTextContent,
   extractToolCalls,
   extractToolReturn,
   toolIdentifierFromToolCall,
 } from '@kbn/onechat-genai-utils/langchain';
 import type { Logger } from '@kbn/logging';
+import { ChunkDecisionBuffer, ChunkType } from '../utils/chunk_decision_buffer';
 import type { StateType } from './graph';
+import { toolReasoningOpeningTag } from './consts';
 
 export type ConvertedEvents =
   | MessageChunkEvent
   | MessageCompleteEvent
   | ToolCallEvent
-  | ToolResultEvent;
+  | ToolResultEvent
+  | ReasoningEvent;
 
 export const convertGraphEvents = ({
   graphName,
@@ -53,6 +58,9 @@ export const convertGraphEvents = ({
     const toolCallIdToIdMap = new Map<string, string>();
     const messageId = uuidv4();
 
+    const decisionBuffer = new ChunkDecisionBuffer({ tag: toolReasoningOpeningTag });
+    let thinkingBuffer = '';
+
     return streamEvents$.pipe(
       mergeMap((event) => {
         if (!matchGraphName(event, graphName)) {
@@ -64,12 +72,38 @@ export const convertGraphEvents = ({
           const chunk: AIMessageChunk = event.data.chunk;
           const textContent = extractTextContent(chunk);
           if (textContent) {
-            return of(createTextChunkEvent(textContent, { messageId }));
+            const classifiedChunks = decisionBuffer.process(textContent) ?? [];
+            const textChunks = classifiedChunks
+              .filter((cc) => cc.type === ChunkType.FinalAnswer)
+              .map((cc) => cc.text);
+
+            const thinkingChunks = classifiedChunks
+              .filter((cc) => cc.type === ChunkType.ToolReasoning)
+              .map((cc) => cc.text);
+            if (thinkingChunks.length > 0) {
+              thinkingBuffer += thinkingChunks.join('');
+            }
+
+            return of(
+              ...textChunks.map((textChunk) => createTextChunkEvent(textChunk, { messageId }))
+            );
           }
         }
 
         // emit tool calls or full message on each agent step
         if (matchEvent(event, 'on_chain_end') && matchName(event, 'agent')) {
+          const events: ConvertedEvents[] = [];
+
+          // create reasoning event from thinking if present
+          if (thinkingBuffer.length > 0) {
+            events.push(createReasoningEvent(thinkingBuffer));
+          }
+
+          // reset decision and thinking buffer
+          decisionBuffer.reset();
+          thinkingBuffer = '';
+
+          // process last emitted message
           const addedMessages: BaseMessage[] = event.data.output.addedMessages ?? [];
           const lastMessage = addedMessages[addedMessages.length - 1];
 
@@ -89,15 +123,15 @@ export const convertGraphEvents = ({
                 })
               );
             }
-
-            return of(...toolCallEvents);
+            events.push(...toolCallEvents);
           } else {
             const messageEvent = createMessageEvent(extractTextContent(lastMessage), {
               messageId,
             });
-
-            return of(messageEvent);
+            events.push(messageEvent);
           }
+
+          return of(...events);
         }
 
         // emit tool result events

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
@@ -111,7 +111,7 @@ export const getActPrompt = ({
           - If you are providing a final answer directly to the user without calling a tool, your response should be plain text.
         2. Tool Use Format (Tool calling):
           - When calling a tool, you should generally include a brief reasoning message to keep the user informed.
-          - This message MUST start with the ${toolReasoningOpeningTag} tag.
+          - This message MUST start with the "${toolReasoningOpeningTag}" and end with "${toolReasoningClosingTag}".
           - You may omit the reasoning message only when the user's request is very direct, simple, and transactional.
 
         PRE-RESPONSE COMPLIANCE CHECK

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
@@ -10,6 +10,7 @@ import { platformCoreTools, ToolResultType } from '@kbn/onechat-common';
 import { sanitizeToolId } from '@kbn/onechat-genai-utils/langchain';
 import { visualizationElement } from '@kbn/onechat-common/tools/tool_result';
 import { customInstructionsBlock, formatDate } from '../utils/prompt_helpers';
+import { toolReasoningOpeningTag, toolReasoningClosingTag } from './consts';
 
 const tools = {
   indexExplorer: sanitizeToolId(platformCoreTools.indexExplorer),
@@ -103,6 +104,16 @@ export const getActPrompt = ({
               2) Ask the user to enable/authorize a needed tool.
           - Do NOT provide ungrounded general knowledge answers.
 
+        CRITICAL OUTPUT FORMATTING
+        Your response for each turn MUST follow one of these two formats. Do not deviate.
+
+        1. Final Answer Format (No Tool Required):
+          - If you are providing a final answer directly to the user without calling a tool, your response should be plain text.
+        2. Tool Use Format (Tool calling):
+          - When calling a tool, you should generally include a brief reasoning message to keep the user informed.
+          - This message MUST start with the ${toolReasoningOpeningTag} tag.
+          - You may omit the reasoning message only when the user's request is very direct, simple, and transactional.
+
         PRE-RESPONSE COMPLIANCE CHECK
         - [ ] For information-seeking content, I used at least one tool or answered using conversation history unless the Decision Gateway allowed skipping.
         - [ ] All claims are grounded in tool output or user-provided content.
@@ -115,7 +126,7 @@ export const getActPrompt = ({
         OUTPUT STYLE
         - Clear, direct, and scoped. No extraneous commentary.
         - Use minimal Markdown for readability (short bullets; code blocks for queries/JSON when helpful).
-        - Do not mention internal reasoning or tool names unless user explicitly asks.
+        - For final answers, do not mention internal reasoning or tool names unless user explicitly asks.
 
         CUSTOMIZATION AND PRECEDENCE
         - Apply the organization-specific custom instructions below. If they conflict with the NON-NEGOTIABLE RULES, the NON-NEGOTIABLE RULES take precedence.
@@ -125,7 +136,18 @@ export const getActPrompt = ({
         ${customInstructionsBlock(customInstructions)}
 
         ADDITIONAL INFO
-        - Current date: ${formatDate()}`,
+        - Current date: ${formatDate()}
+
+        ## EXAMPLES
+
+        ### Example of a Tool Call with Reasoning
+        User query: "How many 404 errors did our web server log in the last hour?"
+
+        Your complete output for this turn MUST be structured like this:
+        - Text Component: "${toolReasoningOpeningTag}Of course, I'll search the web server logs for 404 errors from the last hour.${toolReasoningClosingTag}"
+        - Tool Call Component: [The actual tool call to the '${
+          tools.search
+        }' tool with the correct parameters]`,
     ],
     ...messages,
   ];

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/chunk_decision_buffer.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/chunk_decision_buffer.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ClassifiedChunk } from './chunk_decision_buffer';
+import { ChunkDecisionBuffer, ChunkType } from './chunk_decision_buffer';
+
+describe('ChunkDecisionBuffer', () => {
+  let buffer: ChunkDecisionBuffer;
+  const toolReasoningTag = '<tool_reasoning>';
+
+  beforeEach(() => {
+    buffer = new ChunkDecisionBuffer({ tag: toolReasoningTag });
+  });
+
+  // Helper function to process a stream of chunks and collect all outputs
+  const processStream = (chunks: string[]) => {
+    const output: ClassifiedChunk[] = [];
+    for (const chunk of chunks) {
+      const result = buffer.process(chunk);
+      if (result) {
+        output.push(...result);
+      }
+    }
+    // After the stream, flush any remaining text from the internal buffer
+    const finalFlush = buffer.flush();
+    if (finalFlush) {
+      output.push(...finalFlush);
+    }
+    return output;
+  };
+
+  it('should correctly classify and stream a simple final answer', () => {
+    const chunks = ['This ', 'is ', 'a final answer.'];
+    const result = processStream(chunks);
+    expect(result.map((r) => r.text).join('')).toEqual('This is a final answer.');
+    expect(result[0].type).toEqual(ChunkType.FinalAnswer);
+  });
+
+  it('should correctly classify and stream a simple tool reasoning message', () => {
+    const chunks = [toolReasoningTag, 'Searching ', 'for ', 'documents.'];
+    const result = processStream(chunks);
+    expect(result.map((r) => r.text).join('')).toEqual('Searching for documents.');
+    expect(result[0].type).toEqual(ChunkType.ToolReasoning);
+  });
+
+  it('should suppress output while buffering and then flush with correct type', () => {
+    expect(buffer.process('This is')).toBe(null); // Buffering, not enough to decide
+    expect(buffer.process(' a test.')).toBe(null); // Still buffering, should be null
+    const resultFromFlush = buffer.flush(); // Flush now handles the buffered content
+
+    expect(resultFromFlush).toEqual([{ type: ChunkType.FinalAnswer, text: 'This is a test.' }]);
+  });
+
+  it('should handle the opening tag being split across chunks', () => {
+    const chunks = ['<tool_rea', 'soning>', 'Okay, ', 'I will search.'];
+    const result = processStream(chunks);
+    expect(result.map((r) => r.text).join('')).toEqual('Okay, I will search.');
+  });
+
+  it('should handle the closing tag being split across two chunks', () => {
+    const chunks = [toolReasoningTag, 'Searching... ', 'and done.</tool_rea', 'soning>'];
+    const result = processStream(chunks);
+    expect(result.map((r) => r.text).join('')).toEqual('Searching... and done.');
+  });
+
+  it('should handle the closing tag being split across multiple chunks', () => {
+    const chunks = [
+      toolReasoningTag,
+      'Searching... ',
+      'and done.</',
+      'tool_rea',
+      'soning>',
+      ' some trailing text.',
+    ];
+    const result = processStream(chunks);
+    expect(result.map((r) => r.text).join('')).toEqual(
+      'Searching... and done. some trailing text.'
+    );
+  });
+
+  it('should handle a stream that ends mid-tag, flushing the clean part', () => {
+    const chunks = ['<tool_reasoning>', 'Searching...</tool_rea'];
+    const result = processStream(chunks);
+    expect(result.map((r) => r.text).join('')).toEqual('Searching...');
+  });
+
+  it('should correctly reset its state for a new stream', () => {
+    processStream([toolReasoningTag, 'First task.']);
+    buffer.reset();
+    const result2 = processStream(['Second ', 'task is a final answer.']);
+
+    expect(result2.map((r) => r.text).join('')).toEqual('Second task is a final answer.');
+    expect(result2[0].type).toEqual(ChunkType.FinalAnswer);
+  });
+
+  it('should not emit anything if the stream is only an opening tag', () => {
+    const chunks = ['<tool_rea', 'soning>'];
+    const result = processStream(chunks);
+    expect(result).toEqual([]);
+  });
+
+  it('should not emit anything if the stream is only a closing tag', () => {
+    const chunks = ['</tool_rea', 'soning>'];
+    const result = processStream(chunks);
+    expect(result).toEqual([]);
+  });
+
+  it('should flush remaining text that is not a partial tag', () => {
+    const chunks = ['Final chunk of text'];
+    const result = processStream(chunks);
+    expect(result.map((r) => r.text).join('')).toEqual('Final chunk of text');
+  });
+
+  it('should correctly handle a long stream that triggers a decision then continues', () => {
+    const chunks = [
+      'This is the first part of a long message, ',
+      'long enough to make a decision. ',
+      'And this is the second part.',
+    ];
+    const result = processStream(chunks);
+    expect(result.map((r) => r.text).join('')).toEqual(
+      'This is the first part of a long message, long enough to make a decision. And this is the second part.'
+    );
+    expect(result[0].type).toEqual(ChunkType.FinalAnswer);
+  });
+});

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/chunk_decision_buffer.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/chunk_decision_buffer.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Defines the types of content chunks the buffer can classify.
+ */
+export enum ChunkType {
+  FinalAnswer = 'final_answer',
+  ToolReasoning = 'tool_reasoning',
+}
+
+/**
+ * The structured output for a processed chunk.
+ */
+export interface ClassifiedChunk {
+  type: ChunkType;
+  text: string;
+}
+
+/**
+ * A utility to buffer and conditionally classify text chunks from an LLM stream.
+ */
+export class ChunkDecisionBuffer {
+  private readonly openingTag: string;
+  private readonly closingTag: string;
+  private readonly decisionThreshold: number;
+
+  private decisionMade = false;
+  private isToolTurn = false;
+  private buffer: string[] = [];
+  private accumulatedText = '';
+
+  private trailingCleanBuffer = '';
+
+  constructor({ tag }: { tag: string }) {
+    if (!tag.startsWith('<') || !tag.endsWith('>')) {
+      throw new Error('Tag must be a valid XML-like tag, e.g., "<example>"');
+    }
+    this.openingTag = tag;
+    this.closingTag = `</${tag.substring(1)}`;
+    this.decisionThreshold = this.openingTag.length;
+  }
+
+  public reset(): void {
+    this.decisionMade = false;
+    this.isToolTurn = false;
+    this.buffer = [];
+    this.accumulatedText = '';
+    this.trailingCleanBuffer = '';
+  }
+
+  public process(chunkText: string): ClassifiedChunk[] | null {
+    if (this.decisionMade) {
+      const type = this.isToolTurn ? ChunkType.ToolReasoning : ChunkType.FinalAnswer;
+      const cleanedText = this.cleanAndManageBuffer(chunkText);
+      return cleanedText ? [{ type, text: cleanedText }] : null;
+    }
+
+    this.buffer.push(chunkText);
+    this.accumulatedText += chunkText;
+
+    if (this.accumulatedText.trimStart().startsWith(this.openingTag)) {
+      this.decisionMade = true;
+      this.isToolTurn = true;
+      return this.flushAndClassifyBuffer(ChunkType.ToolReasoning);
+    }
+
+    if (this.accumulatedText.length >= this.decisionThreshold) {
+      this.decisionMade = true;
+      this.isToolTurn = false;
+      return this.flushAndClassifyBuffer(ChunkType.FinalAnswer);
+    }
+
+    return null;
+  }
+
+  public flush(): ClassifiedChunk[] | null {
+    if (!this.decisionMade && this.buffer.length > 0) {
+      const fullText = this.buffer.join('');
+      this.buffer = [];
+      if (fullText) {
+        return [{ type: ChunkType.FinalAnswer, text: fullText }];
+      }
+      return null;
+    }
+
+    let remainingText = this.trailingCleanBuffer;
+    this.trailingCleanBuffer = '';
+
+    if (remainingText) {
+      // At the very end of the stream, we must clean up any partial tags.
+      const lastTagStart = remainingText.lastIndexOf('<');
+      if (lastTagStart !== -1) {
+        const potentialFragment = remainingText.substring(lastTagStart);
+        if (
+          this.openingTag.startsWith(potentialFragment) ||
+          this.closingTag.startsWith(potentialFragment)
+        ) {
+          // It is a partial tag, so we trim it off before flushing.
+          remainingText = remainingText.substring(0, lastTagStart);
+        }
+      }
+
+      if (remainingText) {
+        const type = this.isToolTurn ? ChunkType.ToolReasoning : ChunkType.FinalAnswer;
+        return [{ type, text: remainingText }];
+      }
+    }
+
+    return null;
+  }
+
+  private flushAndClassifyBuffer(type: ChunkType): ClassifiedChunk[] {
+    const combinedText = this.buffer.join('');
+    this.buffer = [];
+    const cleanedText = this.cleanAndManageBuffer(combinedText);
+    return cleanedText ? [{ type, text: cleanedText }] : [];
+  }
+
+  /**
+   * A stream-safe method to clean tags from text using pattern matching.
+   * This is more robust than the previous length-based heuristic.
+   */
+  private cleanAndManageBuffer(newText: string): string {
+    let textToProcess = this.trailingCleanBuffer + newText;
+
+    // Replace any complete tags within the current working text
+    textToProcess = textToProcess.replace(this.openingTag, '').replace(this.closingTag, '');
+
+    // Now, decide what part of textToProcess is safe to emit.
+    let safeToEmit = textToProcess;
+
+    // Find the last potential start of a tag ('<')
+    const lastTagStart = textToProcess.lastIndexOf('<');
+
+    if (lastTagStart !== -1) {
+      const potentialFragment = textToProcess.substring(lastTagStart);
+      // Check if this fragment could be the start of either of our tags
+      if (
+        this.openingTag.startsWith(potentialFragment) ||
+        this.closingTag.startsWith(potentialFragment)
+      ) {
+        // It's a potential partial tag. Hold it back for the next chunk.
+        safeToEmit = textToProcess.substring(0, lastTagStart);
+        this.trailingCleanBuffer = potentialFragment;
+      } else {
+        // It's a '<' but not part of our tags, so clear the trailing buffer
+        this.trailingCleanBuffer = '';
+      }
+    } else {
+      this.trailingCleanBuffer = '';
+    }
+
+    return safeToEmit;
+  }
+}


### PR DESCRIPTION
## Summary

Previously, during text streaming in the ReAct loop of the agent, we were not able to identify when the text chunks were attached to a tool call, leading to a UI glitch where we were appending those "tool call text" to the main response. In addition, this was causing a second UI glitch at the end of the stream, because that text was then not persisted and was "disappearing" from the UI.

This PR addresses this, by adding instructions to the agent to always start text messages attached to tool call with `<tool_reasoning>`, so that we can properly identify them and evict them during streaming (that, and some Hell-ish utility to handle the stream state in real time, reaching Gemini's limits...)

https://github.com/user-attachments/assets/d33d8e9f-2591-4684-ae58-b21776a9b4eb

Fixes: https://github.com/elastic/search-team/issues/10458 (mostly related)
