### PR TITLE
[8.19] [Security Solution][Detection Engine] removes FTR "deletes the underlying migration task" test (#233995)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/migrations/finalize_migration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/migrations/finalize_migration.ts
@@ -16,7 +16,6 @@ import { updateMigrationSavedObject } from './update_migration_saved_object';
 /**
  * Finalizes a given migration:
  *   * validates that the migration has completed successfully
- *   * deletes the reindex task document
  *   * applies the deletion policy to the old index
  *   * swaps aliases on the old/new index
  *

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/basic_license_essentials_tier/ess_specific_index_logic/migrations/finalize_alerts_migrations.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/basic_license_essentials_tier/ess_specific_index_logic/migrations/finalize_alerts_migrations.ts
@@ -194,34 +194,6 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(indices.map((s: any) => s.is_outdated)).to.eql([false, false]);
     });
 
-    // it's been skipped since it was originally introduced in
-    // https://github.com/elastic/kibana/pull/85690. Created ticket to track skip.
-    // https://github.com/elastic/kibana/issues/179593
-    it('deletes the underlying migration task', async () => {
-      await waitFor(
-        async () => {
-          const {
-            body: {
-              migrations: [{ completed }],
-            },
-          } = await supertest
-            .post(DETECTION_ENGINE_SIGNALS_FINALIZE_MIGRATION_URL)
-            .set('kbn-xsrf', 'true')
-            .send({ migration_ids: [createdMigration.migration_id] })
-            .expect(200);
-
-          return completed;
-        },
-        `polling finalize_migration until complete`,
-        log
-      );
-
-      // const [{ taskId }] = await getMigration({ id: migration.migration_id });
-      // expect(taskId.length).greaterThan(0);
-      // const { statusCode } = await es.tasks.get({ task_id: taskId }, { ignore: [404] });
-      // expect(statusCode).to.eql(404);
-    });
-
     it('subsequent attempts at finalization are idempotent', async () => {
       await waitFor(
         async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution][Detection Engine] removes FTR "deletes the underlying migration task" test (#233995)](https://github.com/elastic/kibana/pull/233995)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Vitalii Dmyterko","email":"92328789+vitaliidm@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-09-09T12:03:12Z","message":"[Security Solution][Detection Engine] removes FTR \"deletes the underlying migration task\" test (#233995)\n\n## Summary\n\n- addresses https://github.com/elastic/kibana/issues/179593\n- removes FTR \"deletes the underlying migration task\" test\n- test was skipped from the moment it was introduced, 5 yers ago -\nhttps://github.com/elastic/kibana/pull/85690/files#diff-d3ab7ab5d42b0e7dfe7a3162188693eb420f0a819444aa36380148f2a450a6dbR166-R185,\nso was never functional\n- While looked at code of [finalize migration\nutil](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/migrations/finalize_migration.ts),\nI did not see any indications, it actually deletes underlying migration\ntask\n- since this API is deprecated anyway, the most reasonable approach\nseems just to remove that test","sha":"980469abd01528b8c3ad6959fe35f240d95e3584","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detection Engine","backport:version","v9.1.0","v8.19.0","v9.2.0","v9.1.4"],"title":"[Security Solution][Detection Engine] removes FTR \"deletes the underlying migration task\" test","number":233995,"url":"https://github.com/elastic/kibana/pull/233995","mergeCommit":{"message":"[Security Solution][Detection Engine] removes FTR \"deletes the underlying migration task\" test (#233995)\n\n## Summary\n\n- addresses https://github.com/elastic/kibana/issues/179593\n- removes FTR \"deletes the underlying migration task\" test\n- test was skipped from the moment it was introduced, 5 yers ago -\nhttps://github.com/elastic/kibana/pull/85690/files#diff-d3ab7ab5d42b0e7dfe7a3162188693eb420f0a819444aa36380148f2a450a6dbR166-R185,\nso was never functional\n- While looked at code of [finalize migration\nutil](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/migrations/finalize_migration.ts),\nI did not see any indications, it actually deletes underlying migration\ntask\n- since this API is deprecated anyway, the most reasonable approach\nseems just to remove that test","sha":"980469abd01528b8c3ad6959fe35f240d95e3584"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/234430","number":234430,"state":"MERGED","mergeCommit":{"sha":"cba8f00affeae8f004c497e612636ce38eedc2c8","message":"[9.1] [Security Solution][Detection Engine] removes FTR \"deletes the underlying migration task\" test (#233995) (#234430)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution][Detection Engine] removes FTR \"deletes the\nunderlying migration task\" test\n(#233995)](https://github.com/elastic/kibana/pull/233995)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Vitalii Dmyterko <92328789+vitaliidm@users.noreply.github.com>"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/234429","number":234429,"state":"OPEN"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/233995","number":233995,"mergeCommit":{"message":"[Security Solution][Detection Engine] removes FTR \"deletes the underlying migration task\" test (#233995)\n\n## Summary\n\n- addresses https://github.com/elastic/kibana/issues/179593\n- removes FTR \"deletes the underlying migration task\" test\n- test was skipped from the moment it was introduced, 5 yers ago -\nhttps://github.com/elastic/kibana/pull/85690/files#diff-d3ab7ab5d42b0e7dfe7a3162188693eb420f0a819444aa36380148f2a450a6dbR166-R185,\nso was never functional\n- While looked at code of [finalize migration\nutil](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/migrations/finalize_migration.ts),\nI did not see any indications, it actually deletes underlying migration\ntask\n- since this API is deprecated anyway, the most reasonable approach\nseems just to remove that test","sha":"980469abd01528b8c3ad6959fe35f240d95e3584"}}]}] BACKPORT-->