### PR TITLE
[Dataset quality] Redirecting to discover from wired and classic streams

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/failed_docs/error_stacktrace_link.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/failed_docs/error_stacktrace_link.tsx
@@ -30,7 +30,7 @@ export const ErrorStacktraceLink = ({
   });
 
   const { linkProps } = useRedirectLink({
-    dataStreamStat: datasetDetails,
+    dataStreamStat: datasetDetails.rawName,
     query,
     sendTelemetry,
     timeRangeConfig: timeRange,

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/index.tsx
@@ -72,7 +72,7 @@ export default function QualityIssueFlyout() {
   });
 
   const redirectLinkProps = useRedirectLink({
-    dataStreamStat: datasetDetails,
+    dataStreamStat: datasetDetails.rawName,
     timeRangeConfig: timeRange,
     query: {
       language: 'kuery',

--- a/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_quality_issues_docs_chart.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_quality_issues_docs_chart.ts
@@ -177,7 +177,7 @@ export const useQualityIssuesDocsChart = () => {
   });
 
   const redirectLinkProps = useRedirectLink({
-    dataStreamStat: datasetDetails,
+    dataStreamStat: datasetDetails.rawName,
     query: { language: 'kuery', query },
     timeRangeConfig: timeRange,
     breakdownField: breakdownDataViewField?.name,

--- a/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_redirect_link.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_redirect_link.ts
@@ -163,14 +163,15 @@ const getDataView = <T extends BasicDataStream | string>({
   dataStreamStat: T;
   selector?: DataStreamSelector;
 }): { dataViewId: string; dataViewTitle: string } => {
+  const dataViewSelector = selector ? `${selector}` : '';
   if (dataStreamStat && typeof dataStreamStat === 'string') {
-    return { dataViewId: dataStreamStat, dataViewTitle: dataStreamStat };
+    const dataViewId = `${dataStreamStat}${dataViewSelector}`;
+    return { dataViewId, dataViewTitle: dataViewId };
   }
 
   const { name, namespace, type, integration } = dataStreamStat as BasicDataStream;
 
   const dataViewNamespace = `${namespace || '*'}`;
-  const dataViewSelector = selector ? `${selector}` : '';
   const dataViewId = `${type}-${name}-${dataViewNamespace}${dataViewSelector}`;
   const dataViewTitle = integration
     ? `[${integration.title}] ${name}-${dataViewNamespace}${dataViewSelector}`


### PR DESCRIPTION
in https://github.com/elastic/kibana/pull/230442 we integrated dataset quality to streams. In there we identified a small bug when navigating to discover: In the original version of dataset quality we were relying in the `${type}-${dataset}-${namespace}` shape but streams has a different one, so instead of splitting the rawName of the dataset we are now redirecting using it as it is.

Since the integration is targeting `9.2` no backport is required.