### PR TITLE
[onechat] add ES|QL `LIMIT` instructions to ES|QL gen tools

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/generate_esql.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/generate_esql.ts
@@ -72,6 +72,47 @@ ${context ?? 'No additional context provided.'}
 
 ${formatResourceWithSampledValues({ resource: resolvedResource, indentLevel: 0 })}
 
+<directives>
+## Safety LIMIT
+
+### 1. The Golden Rule: Always Limit Final Output
+
+Your primary directive is **Query Safety**. Every ES|QL query you generate that returns multiple rows **must** conclude with a LIMIT clause.
+The only exception is for aggregation queries that are guaranteed to return a single row (e.g., STATS without a GROUP BY).
+
+### 2. Retrieving Raw Events (Default Behavior)
+
+This applies when the query's primary purpose is to return a list of individual documents or events.
+
+* **Default Limit:** If the user's request does not specify a number of results (e.g., "show me errors"), you **must** append a default safety limit of LIMIT 100.
+* **User-Specified Limit:** If the user *does* specify a number (e.g., "get me 20 logs"), use their number in the LIMIT clause.
+* **Notification:** When applying the default limit, always inform the user. (e.g., "I've added a LIMIT 100 to the query for performance.")
+
+### 3. Working with Aggregated Data (GROUP BY)
+
+This applies when using GROUP BY to categorize and count results. The LIMIT here controls the number of *groups* returned.
+
+* **Default Aggregation Limit:** If the user asks for grouped results without specifying a quantity (e.g., "what are the top source IPs?", "count events by hostname"), you **must** default to returning the top 100 groups by appending LIMIT 100.
+* **User-Specified Aggregation Limit:** If the user asks for a specific number of groups (e.g., "top 5 users," "bottom 20 hosts"), use their number in the LIMIT clause.
+* **Single-Row Aggregations:** If a query uses an aggregation like STATS but has **no GROUP BY clause**, it will only return a single row. In this case, a LIMIT clause is unnecessary and **should not** be added.
+
+### 4. Handle "All Data" Requests Safely
+
+This rule applies to all query types. If the user asks for "all data," "every group," or implies an unbounded result set, you **must not** generate a query without a LIMIT. Instead, use a safety limit of 1000, and inform the user about it and the reasons
+
+## Examples in Action
+
+### Scenario 1: Raw Events (User is vague)
+* **User Prompt:** "Find authentication failures."
+* **Agent's Response:** > I've added a \`LIMIT 100\` to the query to ensure performance. You can ask for more if you need.
+
+\`\`\`esql
+FROM my-auth-logs-*
+| WHERE auth.result == "failure"
+| LIMIT 100
+\`\`\`
+</directives>
+
 Based on all the information above, generate the ES|QL query.
 `,
   });

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/generate_esql.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/generate_esql.ts
@@ -73,44 +73,15 @@ ${context ?? 'No additional context provided.'}
 ${formatResourceWithSampledValues({ resource: resolvedResource, indentLevel: 0 })}
 
 <directives>
-## Safety LIMIT
+## ES|QL Safety Rules
 
-### 1. The Golden Rule: Always Limit Final Output
+1. **LIMIT is Mandatory:** All multi-row queries **must** end with a \`LIMIT\`. The only exception is for single-row aggregations (e.g., \`STATS\` without a \`GROUP BY\`).
 
-Your primary directive is **Query Safety**. Every ES|QL query you generate that returns multiple rows **must** conclude with a LIMIT clause.
-The only exception is for aggregation queries that are guaranteed to return a single row (e.g., STATS without a GROUP BY).
+2. **Applying Limits:**
+    * **User-Specified:** If the user provides a number ("top 10", "get 50"), use it for the \`LIMIT\`.
+    * **Default:** If no number is given, default to \`LIMIT 100\` for both raw events and \`GROUP BY\` results. Notify the user when you apply this default (e.g., "I've added a \`LIMIT 100\` for safety.").
 
-### 2. Retrieving Raw Events (Default Behavior)
-
-This applies when the query's primary purpose is to return a list of individual documents or events.
-
-* **Default Limit:** If the user's request does not specify a number of results (e.g., "show me errors"), you **must** append a default safety limit of LIMIT 100.
-* **User-Specified Limit:** If the user *does* specify a number (e.g., "get me 20 logs"), use their number in the LIMIT clause.
-* **Notification:** When applying the default limit, always inform the user. (e.g., "I've added a LIMIT 100 to the query for performance.")
-
-### 3. Working with Aggregated Data (GROUP BY)
-
-This applies when using GROUP BY to categorize and count results. The LIMIT here controls the number of *groups* returned.
-
-* **Default Aggregation Limit:** If the user asks for grouped results without specifying a quantity (e.g., "what are the top source IPs?", "count events by hostname"), you **must** default to returning the top 100 groups by appending LIMIT 100.
-* **User-Specified Aggregation Limit:** If the user asks for a specific number of groups (e.g., "top 5 users," "bottom 20 hosts"), use their number in the LIMIT clause.
-* **Single-Row Aggregations:** If a query uses an aggregation like STATS but has **no GROUP BY clause**, it will only return a single row. In this case, a LIMIT clause is unnecessary and **should not** be added.
-
-### 4. Handle "All Data" Requests Safely
-
-This rule applies to all query types. If the user asks for "all data," "every group," or implies an unbounded result set, you **must not** generate a query without a LIMIT. Instead, use a safety limit of 1000, and inform the user about it and the reasons
-
-## Examples in Action
-
-### Scenario 1: Raw Events (User is vague)
-* **User Prompt:** "Find authentication failures."
-* **Agent's Response:** > I've added a \`LIMIT 100\` to the query to ensure performance. You can ask for more if you need.
-
-\`\`\`esql
-FROM my-auth-logs-*
-| WHERE auth.result == "failure"
-| LIMIT 100
-\`\`\`
+3. **Handling "All Data" Requests:** If a user asks for "all" results, apply a safety \`LIMIT 1000\` and state that this limit was added to protect the system.
 </directives>
 
 Based on all the information above, generate the ES|QL query.

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/generate_esql.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/generate_esql.ts
@@ -81,7 +81,7 @@ ${formatResourceWithSampledValues({ resource: resolvedResource, indentLevel: 0 }
     * **User-Specified:** If the user provides a number ("top 10", "get 50"), use it for the \`LIMIT\`.
     * **Default:** If no number is given, default to \`LIMIT 100\` for both raw events and \`GROUP BY\` results. Notify the user when you apply this default (e.g., "I've added a \`LIMIT 100\` for safety.").
 
-3. **Handling "All Data" Requests:** If a user asks for "all" results, apply a safety \`LIMIT 1000\` and state that this limit was added to protect the system.
+3. **Handling "All Data" Requests:** If a user asks for "all" results, apply a safety \`LIMIT 250\` and state that this limit was added to protect the system.
 </directives>
 
 Based on all the information above, generate the ES|QL query.


### PR DESCRIPTION
## Summary

Add instructions to add a safety `LIMIT` command to the prompt we use when calling the ES|QL gen task

