### PR TITLE
[onechat] add system instructions in user-defined tool descriptions

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/tools.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/tools.ts
@@ -101,6 +101,10 @@ export const toolToLangchain = ({
   logger: Logger;
   sendEvent?: AgentEventEmitterFn;
 }): StructuredTool => {
+  const description = tool.llmDescription
+    ? tool.llmDescription({ description: tool.description, config: tool.configuration })
+    : tool.description;
+
   return toTool(
     async (input, config): Promise<[string, RunToolReturn]> => {
       let onEvent: ToolEventHandlerFn | undefined;
@@ -137,12 +141,11 @@ export const toolToLangchain = ({
     {
       name: toolId ?? tool.id,
       schema: tool.schema,
-      description: tool.description,
+      description,
       verboseParsingErrors: true,
       responseFormat: 'content_and_artifact',
       metadata: {
         toolId: tool.id,
-        toolType: tool.type,
       },
     }
   );

--- a/x-pack/platform/packages/shared/onechat/onechat-server/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-server/index.ts
@@ -17,6 +17,8 @@ export type {
   ExecutableTool,
   ExecutableToolHandlerParams,
   ExecutableToolHandlerFn,
+  LLmDescriptionHandlerParams,
+  LlmDescriptionHandler,
 } from './src/tools';
 export type { ModelProvider, ScopedModel } from './src/model_provider';
 export type {

--- a/x-pack/platform/packages/shared/onechat/onechat-server/src/tools.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-server/src/tools.ts
@@ -51,7 +51,21 @@ export interface ExecutableTool<
    * Run handler that can be used to execute the tool.
    */
   execute: ExecutableToolHandlerFn<z.infer<TSchema>>;
+  /**
+   * Optional handled to add additional instructions to the LLM.
+   * When provided, will replace the description when converting to llm tool.
+   */
+  llmDescription?: LlmDescriptionHandler<TConfig>;
 }
+
+export interface LLmDescriptionHandlerParams<TConfig extends object = {}> {
+  config: TConfig;
+  description: string;
+}
+
+export type LlmDescriptionHandler<TConfig extends object = {}> = (
+  params: LLmDescriptionHandlerParams<TConfig>
+) => string;
 
 /**
  * Param type for {@link ExecutableToolHandlerFn}

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/persisted/tool_types/index_search/to_tool_definition.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/persisted/tool_types/index_search/to_tool_definition.ts
@@ -42,5 +42,28 @@ export function toToolDefinition(
       });
       return { results };
     },
+    llmDescription: (opts) => {
+      return getFullDescription({ description: opts.description, pattern: opts.config.pattern });
+    },
   };
 }
+
+const getFullDescription = ({ pattern, description }: { pattern: string; description: string }) => {
+  return `${description}
+
+  ## Tool usage
+
+  This tool is a a powerful search tool for searching and analyzing data within your Elasticsearch cluster.
+
+  It is configured to search against the following index pattern: \`${pattern}\`.
+
+  It supports both full-text relevance searches and structured analytical queries, based on a natural language query.
+
+  Examples of queries:
+  - "find documents about serverless architecture"
+  - "search for documents mentioning '[some term]' or '[another term]'"
+  - "list all documents where the category is 'electronics'"
+  - "show me the last 5 documents from that index"
+  - "show me the sales over the last year break down by month"
+`;
+};

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_provider.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_provider.ts
@@ -8,7 +8,7 @@
 import type { z, ZodObject } from '@kbn/zod';
 import type { MaybePromise } from '@kbn/utility-types';
 import type { ToolDefinition, ToolType } from '@kbn/onechat-common';
-import type { ToolHandlerFn } from '@kbn/onechat-server';
+import type { ToolHandlerFn, LlmDescriptionHandler } from '@kbn/onechat-server';
 import type { KibanaRequest } from '@kbn/core-http-server';
 
 export interface InternalToolDefinition<
@@ -23,6 +23,11 @@ export interface InternalToolDefinition<
    * Run handler that can be used to execute the tool.
    */
   handler: ToolHandlerFn<z.infer<TSchema>>;
+  /**
+   * Optional handled to add additional instructions to the LLM
+   * when specified, this will fully replace the description when converting to LLM tools.
+   */
+  llmDescription?: LlmDescriptionHandler<TConfig>;
 }
 
 export interface ToolCreateParams<TConfig extends object = {}> {


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/search-team/issues/10903

- Add a mechanism to let tool types add specific instructions in tool descriptions, which will be added to the user-defined description.
- Leverage it to add usage guidelines and examples to the `index_search` tool type

We don't have any proper evaluation dataset, but from some quick testing, it improves the agent's usage of index_search tool quite significantly.

