### PR TITLE
[Discover] Remove usage of deprecated savedObjects.client

### DIFF
--- a/examples/discover_customization_examples/public/plugin.tsx
+++ b/examples/discover_customization_examples/public/plugin.tsx
@@ -9,7 +9,7 @@
 
 import type { IconType } from '@elastic/eui';
 import { EuiButton, EuiContextMenu, EuiFlexItem, EuiPopover } from '@elastic/eui';
-import type { CoreSetup, CoreStart, Plugin, SimpleSavedObject } from '@kbn/core/public';
+import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import type { DeveloperExamplesSetup } from '@kbn/developer-examples-plugin/public';
 import type {
   CustomizationCallback,
@@ -159,72 +159,6 @@ export class DiscoverCustomizationExamplesPlugin implements Plugin {
                       title: 'Saved logs views',
                       items: savedSearches.map((savedSearch) => ({
                         name: savedSearch.attributes.title,
-                        onClick: () => stateContainer.actions.onOpenSavedSearch(savedSearch.id),
-                        icon: savedSearch.id === currentSavedSearch.id ? 'check' : 'empty',
-                        'data-test-subj': `logsViewSelectorOption-${savedSearch.attributes.title.replace(
-                          /[^a-zA-Z0-9]/g,
-                          ''
-                        )}`,
-                      })),
-                    },
-                  ]}
-                />
-              </EuiPopover>
-            </EuiFlexItem>
-          );
-        },
-      });
-
-      customizations.set({
-        id: 'search_bar',
-        CustomDataViewPicker: () => {
-          const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-          const togglePopover = () => setIsPopoverOpen((open) => !open);
-          const closePopover = () => setIsPopoverOpen(false);
-          const [savedSearches, setSavedSearches] = useState<
-            Array<SimpleSavedObject<{ title: string }>>
-          >([]);
-
-          useEffect(() => {
-            core.savedObjects.client
-              .find<{ title: string }>({ type: 'search' })
-              .then((response) => {
-                setSavedSearches(response.savedObjects);
-              });
-          }, []);
-
-          const currentSavedSearch = useObservable(
-            stateContainer.savedSearchState.getCurrent$(),
-            stateContainer.savedSearchState.getState()
-          );
-
-          return (
-            <EuiFlexItem grow={false}>
-              <EuiPopover
-                button={
-                  <EuiButton
-                    iconType="arrowDown"
-                    iconSide="right"
-                    fullWidth
-                    onClick={togglePopover}
-                    data-test-subj="logsViewSelectorButton"
-                  >
-                    {currentSavedSearch.title ?? 'None selected'}
-                  </EuiButton>
-                }
-                isOpen={isPopoverOpen}
-                panelPaddingSize="none"
-                closePopover={closePopover}
-              >
-                <EuiContextMenu
-                  size="s"
-                  initialPanelId={0}
-                  panels={[
-                    {
-                      id: 0,
-                      title: 'Saved logs views',
-                      items: savedSearches.map((savedSearch) => ({
-                        name: savedSearch.get('title'),
                         onClick: () => stateContainer.actions.onOpenSavedSearch(savedSearch.id),
                         icon: savedSearch.id === currentSavedSearch.id ? 'check' : 'empty',
                         'data-test-subj': `logsViewSelectorOption-${savedSearch.attributes.title.replace(


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/224357

## Summary

Removed the last remaining usage of `savedObjects.client`.

## Testing

Run kibana with `yarn start --run-examples` and navigate to Discover Customization at http://localhost:5601/app/discoverCustomizationExamples

Check that the data picker is different from usual.

<img width="342" height="204" alt="Screenshot 2025-09-10 at 14 47 07" src="https://github.com/user-attachments/assets/83d2b29f-800d-4ee6-819d-da25dfb0ad39" />



