### PR TITLE
[CI] Fix scout run generator's issue with downloading Kibana

### DIFF
--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -66,6 +66,8 @@ steps:
     agents:
       machineType: n2-standard-2
     timeout_in_minutes: 10
+    depends_on:
+      - build
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:

--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -64,6 +64,8 @@ steps:
       provider: gcp
       machineType: n2-standard-2
     timeout_in_minutes: 10
+    depends_on:
+        - build
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -54,6 +54,8 @@ steps:
       provider: gcp
       machineType: n2-standard-2
     timeout_in_minutes: 10
+    depends_on:
+      - build
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -187,6 +187,8 @@ steps:
       machineType: n2-standard-2
       diskSizeGb: 85
     timeout_in_minutes: 10
+    depends_on:
+      - build
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:

--- a/.buildkite/pipelines/pointer_compression.yml
+++ b/.buildkite/pipelines/pointer_compression.yml
@@ -59,6 +59,8 @@ steps:
       provider: gcp
       machineType: n2-standard-2
     timeout_in_minutes: 10
+    depends_on:
+      - build
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:

--- a/.buildkite/pipelines/pull_request/scout_tests.yml
+++ b/.buildkite/pipelines/pull_request/scout_tests.yml
@@ -4,6 +4,8 @@ steps:
     agents:
       machineType: n2-standard-2
     timeout_in_minutes: 10
+    depends_on:
+      - build
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:


### PR DESCRIPTION
## Summary
Adds a dependency on build for scout; in some pipelines, the scout step generator didn't wait for the Kibana build to be available

The reason why it was working on `on-merge` or `pull-request` is because those pipelines had a hard wait step after the Kibana build phase.