### PR TITLE
[Metrics][Discover] Fix Lens config builder usage

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_extra_actions.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_extra_actions.ts
@@ -21,12 +21,12 @@ export const useLensExtraActions = (config: UseLensExtraActions): Action[] => {
   const extraActions = useMemo(() => {
     const actions: Action[] = [];
 
-    if (config.copyToDashboard) {
+    if (config.copyToDashboard?.onClick) {
       actions.push(getCopyToDashboardAction(config.copyToDashboard.onClick));
     }
 
     return actions;
-  }, [config.copyToDashboard]);
+  }, [config.copyToDashboard?.onClick]);
 
   return extraActions;
 };

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.test.ts
@@ -88,23 +88,30 @@ describe('useLensProps', () => {
     );
 
     await waitFor(() => {
-      expect(LensConfigBuilder.prototype.build).toHaveBeenCalledWith({
-        chartType: 'xy',
-        title: 'Test Chart',
-        layers: mockChartLayers,
-        axisTitleVisibility: {
-          showYRightAxisTitle: false,
-          showXAxisTitle: false,
-          showYAxisTitle: false,
+      expect(LensConfigBuilder.prototype.build).toHaveBeenCalledWith(
+        {
+          chartType: 'xy',
+          title: 'Test Chart',
+          layers: mockChartLayers,
+          axisTitleVisibility: {
+            showYRightAxisTitle: false,
+            showXAxisTitle: false,
+            showYAxisTitle: false,
+          },
+          dataset: {
+            esql: 'FROM metrics-*',
+          },
+          fittingFunction: 'Linear',
+          legend: {
+            show: false,
+          },
         },
-        dataset: {
-          esql: 'FROM metrics-*',
-        },
-        fittingFunction: 'Linear',
-        legend: {
-          show: false,
-        },
-      });
+        {
+          query: {
+            esql: 'FROM metrics-*',
+          },
+        }
+      );
     });
   });
 

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
@@ -35,7 +35,6 @@ export type LensProps = Pick<
   | 'searchSessionId'
   | 'executionContext'
   | 'onLoad'
-  | 'abortController'
 >;
 export const useLensProps = ({
   title,
@@ -101,7 +100,13 @@ export const useLensProps = ({
 
     const builder = new LensConfigBuilder(services.dataViews);
 
-    attributes$.current.next((await builder.build(lensParams)) as LensAttributes);
+    attributes$.current.next(
+      (await builder.build(lensParams, {
+        query: {
+          esql: query,
+        },
+      })) as LensAttributes
+    );
   }, [lensParams, services.dataViews]);
 
   const buildLensProps = useCallback(() => {
@@ -153,7 +158,6 @@ const getLensProps = ({
   searchSessionId?: string;
   attributes: LensAttributes;
   timeRange: TimeRange;
-  abortController?: AbortController;
 }): LensProps => ({
   id: 'metricsExperienceLensComponent',
   viewMode: 'view',

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/lens_wrapper.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/lens_wrapper.tsx
@@ -18,12 +18,7 @@ export type LensWrapperProps = {
   lensProps: LensProps;
 } & Pick<ChartSectionProps, 'services' | 'onBrushEnd' | 'onFilter' | 'abortController'>;
 
-const DEFAULT_DISABLED_ACTIONS = [
-  'ACTION_CUSTOMIZE_PANEL',
-  'ACTION_EXPORT_CSV',
-  // temporarily disabiling it until we figure out this action
-  'ACTION_OPEN_IN_DISCOVER',
-];
+const DEFAULT_DISABLED_ACTIONS = ['ACTION_CUSTOMIZE_PANEL', 'ACTION_EXPORT_CSV'];
 
 export function LensWrapper({
   lensProps,


### PR DESCRIPTION
fixes [234623](https://github.com/elastic/kibana/issues/234623)

## Summary

This PR fixes the usage of the Lens config builder to allow it to construct the correct object for the embeddable render an ESQL visualization

**Explore in Discover** 
>[!NOTE]
> Ignore the grid

![explore_in_discover](https://github.com/user-attachments/assets/2f2b60b4-155e-4cce-af01-013536c80cec)


**Edit visualization**
![edit_visulization](https://github.com/user-attachments/assets/8e93902e-f815-4633-bf79-23f48a68848b)

**Create alert rule**
![create_alert_rule](https://github.com/user-attachments/assets/bf1e982b-5a2b-4b9d-977a-f15788c841ea)

## How to test
- Clone https://github.com/simianhacker/simian-forge/tree/main
- Run ` ./forge --dataset hosts --count 25 --interval 30s`
- Set the following config to `kibana.dev.yml`
```yml
discover.experimental.enabledProfiles:
  - observability-metrics-data-source-profile
metricsExperience.enabled: true
 ```
- Navigate to Discover and Switch to ESQL mode
- Validate the items from the description
