### PR TITLE
[Agent Builder] Show full tool traces in a flyout

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/conversation_rounds.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/conversation_rounds.tsx
@@ -38,7 +38,8 @@ export const ConversationRounds: React.FC<ConversationRoundsProps> = ({
           defaultMessage: 'Conversation messages',
         })}
       >
-        {conversationRounds.map(({ input, response, steps }, index) => {
+        {conversationRounds.map((round, index) => {
+          const { input, response, steps } = round;
           const isCurrentRound = index === conversationRounds.length - 1;
           const isLoading = isResponseLoading && isCurrentRound;
           const isError = Boolean(error) && isCurrentRound;
@@ -56,7 +57,12 @@ export const ConversationRounds: React.FC<ConversationRoundsProps> = ({
                 isError ? (
                   <RoundError error={error} onRetry={retry} />
                 ) : (
-                  <RoundResponse response={response} steps={steps} isLoading={isLoading} />
+                  <RoundResponse
+                    rawRound={round}
+                    response={response}
+                    steps={steps}
+                    isLoading={isLoading}
+                  />
                 )
               }
             />

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_flyout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_flyout.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlyout, EuiFlyoutHeader, EuiTitle, EuiFlyoutBody, EuiCodeBlock } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { ConversationRound } from '@kbn/onechat-common';
+import { css } from '@emotion/react';
+
+const rawResponseFlyoutTitle = i18n.translate(
+  'xpack.onechat.conversation.rawResponseFlyout.title',
+  {
+    defaultMessage: 'Raw Response',
+  }
+);
+
+interface RawResponseFlyoutProps {
+  isOpen: boolean;
+  onClose: () => void;
+  rawRound: ConversationRound;
+}
+
+export const RoundFlyout: React.FC<RawResponseFlyoutProps> = ({ isOpen, onClose, rawRound }) => {
+  if (!isOpen) return null;
+
+  return (
+    <EuiFlyout onClose={onClose} aria-labelledby="rawResponseFlyoutTitle" size="m">
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id="rawResponseFlyoutTitle">{rawResponseFlyoutTitle}</h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiCodeBlock
+          language="json"
+          fontSize="s"
+          paddingSize="m"
+          isCopyable={true}
+          css={css`
+            overflow: auto;
+          `}
+        >
+          {JSON.stringify(rawRound, null, 2)}
+        </EuiCodeBlock>
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_response.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_response.tsx
@@ -7,19 +7,25 @@
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type { AssistantResponse, ConversationRoundStep } from '@kbn/onechat-common';
+import type {
+  AssistantResponse,
+  ConversationRound,
+  ConversationRoundStep,
+} from '@kbn/onechat-common';
 import React from 'react';
 import { useTimer } from '../../../hooks/use_timer';
 import { ChatMessageText } from './chat_message_text';
 import { RoundThinking } from './round_thinking/round_thinking';
 
 export interface RoundResponseProps {
+  rawRound: ConversationRound;
   response: AssistantResponse;
   steps: ConversationRoundStep[];
   isLoading: boolean;
 }
 
 export const RoundResponse: React.FC<RoundResponseProps> = ({
+  rawRound,
   response: { message },
   steps,
   isLoading,
@@ -36,7 +42,7 @@ export const RoundResponse: React.FC<RoundResponseProps> = ({
     >
       {showThinking && (
         <EuiFlexItem grow={false}>
-          <RoundThinking steps={steps} isLoading={isLoading} timer={timer} />
+          <RoundThinking steps={steps} isLoading={isLoading} timer={timer} rawRound={rawRound} />
         </EuiFlexItem>
       )}
 

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/round_thinking.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/round_thinking.tsx
@@ -7,6 +7,7 @@
 
 import {
   EuiAccordion,
+  EuiButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
@@ -15,13 +16,15 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import type { ConversationRoundStep } from '@kbn/onechat-common';
-import React from 'react';
+import type { ConversationRound, ConversationRoundStep } from '@kbn/onechat-common';
+import React, { useState } from 'react';
 import type { Timer } from '../../../../hooks/use_timer';
 import { RoundTimer } from './round_timer';
 import { RoundSteps } from './steps/round_steps';
+import { RoundFlyout } from '../round_flyout';
 
 interface RoundThinkingProps {
+  rawRound: ConversationRound;
   steps: ConversationRoundStep[];
   isLoading: boolean;
   timer: Timer;
@@ -37,10 +40,19 @@ const thinkingLabel = i18n.translate('xpack.onechat.conversation.thinking.label'
 const thinkingCompletedLabel = i18n.translate('xpack.onechat.conversation.thinking.completed', {
   defaultMessage: 'Thinking completed',
 });
+const rawResponseButtonLabel = i18n.translate('xpack.onechat.conversation.rawResponseButton', {
+  defaultMessage: 'View raw response',
+});
 
-export const RoundThinking: React.FC<RoundThinkingProps> = ({ steps, isLoading, timer }) => {
+export const RoundThinking: React.FC<RoundThinkingProps> = ({
+  steps,
+  isLoading,
+  timer,
+  rawRound,
+}) => {
   const { euiTheme } = useEuiTheme();
   const thinkingAccordionId = useGeneratedHtmlId({ prefix: 'roundThinkingAccordion' });
+  const [showFlyout, setShowFlyout] = useState(false);
 
   if (steps.length === 0) {
     return timer.showTimer ? (
@@ -57,6 +69,10 @@ export const RoundThinking: React.FC<RoundThinkingProps> = ({ steps, isLoading, 
       padding: ${euiTheme.size.s} 0;
     }
   `;
+
+  const toggleFlyout = () => {
+    setShowFlyout(!showFlyout);
+  };
 
   return (
     <EuiAccordion
@@ -75,7 +91,13 @@ export const RoundThinking: React.FC<RoundThinkingProps> = ({ steps, isLoading, 
     >
       <EuiPanel paddingSize="l" hasShadow={false} hasBorder={false} color="subdued">
         <RoundSteps steps={steps} />
+        {!isLoading && (
+          <EuiButton iconType={'code'} color="primary" iconSide="left" onClick={toggleFlyout}>
+            {rawResponseButtonLabel}
+          </EuiButton>
+        )}
       </EuiPanel>
+      <RoundFlyout isOpen={showFlyout} onClose={toggleFlyout} rawRound={rawRound} />
     </EuiAccordion>
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation.ts
@@ -63,7 +63,7 @@ export const useConversationRounds = () => {
     if (Boolean(error) && pendingMessage) {
       return [
         ...rounds,
-        { input: { message: pendingMessage }, response: { message: '' }, steps: [] },
+        { id: '', input: { message: pendingMessage }, response: { message: '' }, steps: [] },
       ];
     }
     return rounds;


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/search-team/issues/10977

- Adds a button at the bottom of each round (after it has finished loading), which when pressed, opens a flyout view will the full round information
- TBD: how much of the raw round information do we want to show in the flyout? What should be included/what shouldn't be? Right now, I've left it as everything, the full raw round.

https://github.com/user-attachments/assets/f4a0fb7e-e474-4b36-8ae8-e95899a15a50

