### PR TITLE
Hide side-nav during report generation

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v1/sidenav.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v1/sidenav.tsx
@@ -13,6 +13,7 @@ import { EuiCollapsibleNavBeta } from '@elastic/eui';
 import useObservable from 'react-use/lib/useObservable';
 import type { Observable } from 'rxjs';
 import { css } from '@emotion/css';
+import classnames from 'classnames';
 import type { NavigationProps } from './navigation';
 import { Navigation } from './navigation';
 
@@ -41,6 +42,15 @@ const CollapsibleNavigationFlyout = ({
   children: React.ReactNode;
 }) => {
   const isCollapsed = useObservable(isCollapsed$, false);
+  const className = classnames(
+    'hide-for-sharing',
+    css`
+      .euiFlyoutBody__overflowContent {
+        height: 100%;
+      }
+    `
+  );
+
   return (
     <EuiCollapsibleNavBeta
       data-test-subj="projectLayoutSideNav"
@@ -50,11 +60,7 @@ const CollapsibleNavigationFlyout = ({
         overflow: 'visible',
         clipPath: `polygon(0 0, calc(var(--euiCollapsibleNavOffset) + ${PANEL_WIDTH}px) 0, calc(var(--euiCollapsibleNavOffset) + ${PANEL_WIDTH}px) 100%, 0 100%)`,
       }}
-      className={css`
-        .euiFlyoutBody__overflowContent {
-          height: 100%;
-        }
-      `}
+      className={className}
     >
       {children}
     </EuiCollapsibleNavBeta>

--- a/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v2/fixed_layout_sidenav.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v2/fixed_layout_sidenav.tsx
@@ -71,6 +71,7 @@ const CollapsibleNavigationFlyout: FunctionComponent<{
         pushMinBreakpoint="xs"
         hideCloseButton={true}
         onClose={() => {}}
+        className="hide-for-sharing"
       >
         <div css={{ height: '100%', display: 'flex' }}>{children(childrenProps)}</div>
       </EuiFlyout>


### PR DESCRIPTION
Fixes: #227187

When we request a report we send the target element's width and use it to create a browser window. 
Therefore the element's width becomes the window width. When the side-nav is visible on the page, it pushes the dashboard to the  right and makes it smaller. As we take only the target element's screenshot and use the width we passed as param as image width in the pdf, it becomes skewed.

This PR removes the side-nav from the page during the report generation. So the dashboard uses the full window width which is the original number we passed initially.

## To verify:

Add `Sample web logs` data.
Change the solution view in the Space to something other than Classic.
Go to `Dashboards > Sample Logs Data` and generate a PDF report.
The screenshot should not be skewed.

Add the below config to your kibana.yml
```
feature_flags.overrides:
  core.chrome.projectSideNav: 'v2'
```
Go to `Dashboards > Sample Logs Data` and generate a PDF report.
The fix should be working with the new side-nav as well.






<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->