### PR TITLE
[agent builder] fix tool id sanitization

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/tools.test.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/tools.test.ts
@@ -9,7 +9,7 @@ import { z } from '@kbn/zod';
 import { loggerMock } from '@kbn/logging-mocks';
 import { ToolType } from '@kbn/onechat-common';
 import type { ExecutableTool } from '@kbn/onechat-server';
-import { createToolIdMappings, toolToLangchain } from './tools';
+import { createToolIdMappings, toolToLangchain, sanitizeToolId } from './tools';
 import { ToolResultType } from '@kbn/onechat-common/tools/tool_result';
 
 const createTool = (
@@ -99,5 +99,17 @@ describe('createToolIdMappings', () => {
       '^some_tool': 'some_tool',
       some_tool: 'some_tool_1',
     });
+  });
+});
+
+describe('sanitizeToolId', () => {
+  it('replace `.` with `_` in tool names', () => {
+    expect(sanitizeToolId('test.foo')).toEqual('test_foo');
+    expect(sanitizeToolId('platform.core.search')).toEqual('platform_core_search');
+  });
+
+  it('removes forbidden characters', () => {
+    expect(sanitizeToolId('test+()')).toEqual('test');
+    expect(sanitizeToolId('a&b^c')).toEqual('abc');
   });
 });

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/tools.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/tools.ts
@@ -65,7 +65,7 @@ export const toolsToLangchain = async ({
 };
 
 export const sanitizeToolId = (toolId: string): string => {
-  return toolId.replace('.', '_').replace(/[^a-zA-Z0-9_-]/g, '');
+  return toolId.replaceAll('.', '_').replace(/[^a-zA-Z0-9_-]/g, '');
 };
 
 /**


### PR DESCRIPTION
## Summary

Fix minor bug with tool id sanitIzation - only first `.` character was being replaced to `_`
