### PR TITLE
[SharedUX][A11y] Announce log rate analysis info popover

### DIFF
--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_info_popover.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_info_popover.tsx
@@ -7,7 +7,14 @@
 
 import React, { useState, type FC } from 'react';
 
-import { useEuiTheme, EuiBadge, EuiPopover, EuiPopoverTitle, EuiText } from '@elastic/eui';
+import {
+  useEuiTheme,
+  EuiBadge,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiText,
+  htmlIdGenerator,
+} from '@elastic/eui';
 
 import { LOG_RATE_ANALYSIS_TYPE } from '@kbn/aiops-log-rate-analysis';
 import { useAppSelector } from '@kbn/aiops-log-rate-analysis/state';
@@ -48,6 +55,7 @@ export const LogRateAnalysisInfoPopover: FC = () => {
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
+  const popoverTitleId = htmlIdGenerator()('logRateAnalysisInfoPopoverTitle');
   const infoTitlePrefix = i18n.translate('xpack.aiops.analysis.analysisTypeInfoTitlePrefix', {
     defaultMessage: 'Analysis type: ',
   });
@@ -107,9 +115,10 @@ export const LogRateAnalysisInfoPopover: FC = () => {
       isOpen={isPopoverOpen}
       ownFocus
       panelPaddingSize="m"
+      aria-labelledby={popoverTitleId}
     >
       {infoTitle && (
-        <EuiPopoverTitle>
+        <EuiPopoverTitle id={popoverTitleId}>
           {infoTitlePrefix}
           {infoTitle}
         </EuiPopoverTitle>


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/216005

## Summary

Added `aria-labelledby` attribute to the popover associated to the relevant popover title. 

## Testing
**- Safari:**
Before announcement:

<img width="980" height="698" alt="Screenshot 2025-09-11 at 10 57 42" src="https://github.com/user-attachments/assets/35f162e0-7af0-44c8-a963-35dfe4327915" />

After announcement:

<img width="959" height="727" alt="Screenshot 2025-09-11 at 10 20 05" src="https://github.com/user-attachments/assets/097596cd-f683-492d-9035-cb6f12fe8467" />

**- Chrome:**
Before a11y tree:

<img width="2351" height="663" alt="Screenshot 2025-09-11 at 10 54 02" src="https://github.com/user-attachments/assets/4e6c0af6-e24b-417f-a809-6df6f959e4dd" />

After a11y tree:

<img width="2396" height="633" alt="Screenshot 2025-09-11 at 10 52 51" src="https://github.com/user-attachments/assets/955219d5-4ea7-41bc-972d-2614c1c57c30" />


See [discussion](https://elastic.slack.com/archives/C04UK0RDL2J/p1744641509849679?thread_ts=1744637550.194309&cid=C04UK0RDL2J) on why `role="dialog"` and `aria-labelledby`cannot be tested on Chrome+VO.






<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->