### PR TITLE
[Agent Builder] Add reasoning step and tool call progress events to conversation query data

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/chat/conversation.ts
@@ -91,7 +91,12 @@ export const isToolCallStep = (step: ConversationRoundStep): step is ToolCallSte
   return step.type === ConversationRoundStepType.toolCall;
 };
 
-// reasoning step
+export const createReasoningStep = (reasoningStepWithResult: ReasoningStepData): ReasoningStep => {
+  return {
+    type: ConversationRoundStepType.reasoning,
+    ...reasoningStepWithResult,
+  };
+};
 
 export interface ReasoningStepData {
   /** plain text reasoning content */

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/send_message_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/send_message_context.tsx
@@ -9,12 +9,13 @@ import {
   isConversationCreatedEvent,
   isMessageChunkEvent,
   isMessageCompleteEvent,
+  isReasoningEvent,
   isRoundCompleteEvent,
   isToolCallEvent,
   isToolProgressEvent,
   isToolResultEvent,
 } from '@kbn/onechat-common';
-import { createToolCallStep } from '@kbn/onechat-common/chat/conversation';
+import { createReasoningStep, createToolCallStep } from '@kbn/onechat-common/chat/conversation';
 import { useMutation } from '@tanstack/react-query';
 import React, { createContext, useContext, useRef, useState } from 'react';
 import { unstable_batchedUpdates } from 'react-dom';
@@ -67,6 +68,16 @@ const useSendMessageMutation = ({ connectorId }: UseSendMessageMutationProps = {
             });
           } else if (isToolProgressEvent(event)) {
             setToolProgress(event.data.message);
+            conversationActions.setToolCallProgress({
+              progress: { message: event.data.message },
+              toolCallId: event.data.tool_call_id,
+            });
+          } else if (isReasoningEvent(event)) {
+            conversationActions.addReasoningStep({
+              step: createReasoningStep({
+                reasoning: event.data.reasoning,
+              }),
+            });
           } else if (isToolCallEvent(event)) {
             conversationActions.addToolCall({
               step: createToolCallStep({

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation_actions.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation_actions.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import type { ConversationRound, ToolCallStep } from '@kbn/onechat-common';
+import type {
+  ConversationRound,
+  ReasoningStep,
+  ToolCallProgress,
+  ToolCallStep,
+} from '@kbn/onechat-common';
 import { isToolCallStep } from '@kbn/onechat-common';
 
 import type { Conversation } from '@kbn/onechat-common';
@@ -98,9 +103,31 @@ export const useConversationActions = () => {
         })
       );
     },
+    addReasoningStep: ({ step }: { step: ReasoningStep }) => {
+      setCurrentRound((round) => {
+        round.steps.push(step);
+      });
+    },
     addToolCall: ({ step }: { step: ToolCallStep }) => {
       setCurrentRound((round) => {
         round.steps.push(step);
+      });
+    },
+    setToolCallProgress: ({
+      progress,
+      toolCallId,
+    }: {
+      progress: ToolCallProgress;
+      toolCallId: string;
+    }) => {
+      setCurrentRound((round) => {
+        const step = round.steps.filter(isToolCallStep).find((s) => s.tool_call_id === toolCallId);
+        if (step) {
+          if (!step.progression) {
+            step.progression = [];
+          }
+          step.progression.push(progress);
+        }
       });
     },
     setToolCallResult: ({ results, toolCallId }: { results: ToolResult[]; toolCallId: string }) => {


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/10995

## Summary

Neither reasoning steps nor tool call progress steps are shown in the thinking panel as events are streamed in. Once the events are done streaming, the thinking panel updates to include these missing events. We want the events to be included in the thinking panel as they're streamed in, in the correct order.

Before:
<img width="822" height="388" alt="image" src="https://github.com/user-attachments/assets/e97c42af-06d5-4e80-8b8d-990c5fe591b2" />

After:
<img width="872" height="491" alt="image" src="https://github.com/user-attachments/assets/da30682c-daee-416f-a48c-93ce5c3b58ca" />

- [x] reasoning events are shown in the thinking panel as they're streamed in
- [x] tool call progress events are shown in the thinking panel as they're streamed in
