### PR TITLE
[ES|QL] Parser support for `FIRST` and `LAST` static function names

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/function.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/function.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { parse } from '..';
+import { Parser, parse } from '..';
 import { EsqlQuery } from '../../query';
 import { Walker } from '../../walker';
 
@@ -161,6 +161,54 @@ describe('function AST nodes', () => {
                 literalType: 'param',
                 paramType: 'positional',
                 value: 30035,
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('parses out function name "LAST" static name', () => {
+      const query = 'ROW LAST(1, 2, 3)';
+      const { root, errors } = Parser.parse(query);
+
+      expect(errors.length).toBe(0);
+
+      expect(root.commands).toMatchObject([
+        {
+          type: 'command',
+          name: 'row',
+          args: [
+            {
+              type: 'function',
+              name: 'last',
+              operator: {
+                type: 'identifier',
+                name: 'last',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('parses out function name "FIRST" static name', () => {
+      const query = 'ROW First(1, 2, 3)';
+      const { root, errors } = Parser.parse(query);
+
+      expect(errors.length).toBe(0);
+
+      expect(root.commands).toMatchObject([
+        {
+          type: 'command',
+          name: 'row',
+          args: [
+            {
+              type: 'function',
+              name: 'first',
+              operator: {
+                type: 'identifier',
+                name: 'first',
               },
             },
           ],

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/cst_to_ast_converter.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/cst_to_ast_converter.ts
@@ -2364,13 +2364,27 @@ export class CstToAstConverter {
       incomplete: Boolean(ctx.exception),
     };
 
-    const identifierOrParameter = functionName.identifierOrParameter();
+    const identifierOrParameterCtx = functionName.identifierOrParameter();
 
-    if (identifierOrParameter instanceof cst.IdentifierOrParameterContext) {
-      const operator = this.fromIdentifierOrParam(identifierOrParameter);
+    if (identifierOrParameterCtx instanceof cst.IdentifierOrParameterContext) {
+      const operator = this.fromIdentifierOrParam(identifierOrParameterCtx);
 
       if (operator) {
         node.operator = operator;
+      }
+    } else {
+      const lastCtx = functionName.LAST();
+
+      if (lastCtx) {
+        node.operator = this.fromNodeToIdentifier(lastCtx);
+        node.operator.name = node.operator.name.toLowerCase();
+      } else {
+        const firstCtx = functionName.FIRST();
+
+        if (firstCtx) {
+          node.operator = this.fromNodeToIdentifier(firstCtx);
+          node.operator.name = node.operator.name.toLowerCase();
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Partially addresses https://github.com/elastic/kibana/issues/233705

The latest grammar has introduced two functions (`FIRST` and `LAST`), which are built into the grammar. This PR adds support for including them in our AST from ANTLR CST.


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or 