### PR TITLE
[Agent Builder] Resolve form discrepancies between Agents and Tools, other bugfixes

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-common/agents/agent_ids.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/agents/agent_ids.ts
@@ -5,11 +5,6 @@
  * 2.0.
  */
 
-export {
-  AgentType,
-  oneChatDefaultAgentId,
-  type AgentDescriptor,
-  type AgentDefinition,
-  type AgentConfiguration,
-} from './definition';
-export { agentIdRegexp } from './agent_ids';
+// - Must start and end with letter or digit
+// - Can contain letters, digits, hyphens, underscores
+export const agentIdRegexp = /^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$/;

--- a/x-pack/platform/packages/shared/onechat/onechat-common/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/index.ts
@@ -78,6 +78,7 @@ export {
   type AgentDescriptor,
   type AgentDefinition,
   type AgentConfiguration,
+  agentIdRegexp,
 } from './agents';
 export {
   type RoundInput,

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/active_tools_status.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/active_tools_status.tsx
@@ -5,21 +5,17 @@
  * 2.0.
  */
 
+import React from 'react';
 import {
+  EuiPanel,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiText,
   EuiIcon,
   EuiLink,
-  EuiPanel,
   EuiProgress,
-  EuiText,
-  useEuiTheme,
 } from '@elastic/eui';
-import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
-import { useFormContext } from 'react-hook-form';
-import type { AgentFormData } from './agent_form';
 
 interface ActiveToolsStatusProps {
   activeToolsCount: number;
@@ -30,24 +26,14 @@ export const ActiveToolsStatus: React.FC<ActiveToolsStatusProps> = ({
   activeToolsCount,
   warningThreshold,
 }) => {
-  const { euiTheme } = useEuiTheme();
-  const {
-    formState: { errors },
-  } = useFormContext<AgentFormData>();
   const isOverThreshold = activeToolsCount > warningThreshold;
   const isZeroTools = activeToolsCount === 0;
-  const shouldShowWarning = isOverThreshold;
-  const shouldShowError = isZeroTools;
+  const shouldShowWarning = isOverThreshold || isZeroTools;
 
-  const statusColor = shouldShowWarning ? 'warning' : shouldShowError ? 'danger' : 'success';
-  const iconType = shouldShowWarning || shouldShowError ? 'alert' : 'checkInCircleFilled';
+  const statusColor = shouldShowWarning ? 'warning' : 'success';
+  const iconType = shouldShowWarning ? 'alert' : 'checkInCircleFilled';
 
-  const statusMessage = shouldShowError
-    ? i18n.translate('xpack.onechat.activeToolsStatus.errorStatusMessage', {
-        defaultMessage: 'Error status: {count} active tools',
-        values: { count: activeToolsCount },
-      })
-    : shouldShowWarning
+  const statusMessage = shouldShowWarning
     ? i18n.translate('xpack.onechat.activeToolsStatus.warningStatusMessage', {
         defaultMessage: 'Warning status: {count} active tools',
         values: { count: activeToolsCount },
@@ -58,125 +44,101 @@ export const ActiveToolsStatus: React.FC<ActiveToolsStatusProps> = ({
       });
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="xs">
-      <EuiPanel
-        hasBorder={true}
-        hasShadow={false}
-        paddingSize="m"
-        aria-label={i18n.translate('xpack.onechat.activeToolsStatus.panelLabel', {
-          defaultMessage: 'Active tools status panel',
-        })}
-        css={
-          errors.configuration?.tools
-            ? css`
-                border-color: ${euiTheme.colors.danger};
-                &::after {
-                  border-color: ${euiTheme.colors.danger};
-                }
-              `
-            : undefined
-        }
-        role="region"
-      >
-        <EuiFlexGroup alignItems="center" gutterSize="l">
-          <EuiFlexItem grow={1}>
-            <EuiFlexGroup direction="column">
-              <EuiFlexItem>
-                <EuiFlexGroup direction="row" gutterSize="s" alignItems="center" responsive={false}>
-                  <EuiFlexItem grow={false}>
-                    <EuiIcon
-                      type={iconType}
-                      color={statusColor}
-                      size="m"
-                      aria-label={
-                        shouldShowError
-                          ? i18n.translate('xpack.onechat.activeToolsStatus.errorStatusIcon', {
-                              defaultMessage: 'Error status icon',
-                            })
-                          : shouldShowWarning
-                          ? i18n.translate('xpack.onechat.activeToolsStatus.warningStatusIcon', {
-                              defaultMessage: 'Warning status icon',
-                            })
-                          : i18n.translate('xpack.onechat.activeToolsStatus.successStatusIcon', {
-                              defaultMessage: 'Success status icon',
-                            })
-                      }
-                    />
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiText size="m" color={statusColor}>
-                      <strong aria-label={statusMessage}>
-                        {i18n.translate('xpack.onechat.activeToolsStatus.title', {
-                          defaultMessage: 'You have {count} active tools',
-                          values: { count: activeToolsCount },
-                        })}
-                      </strong>
-                    </EuiText>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiText size="s" color="subdued">
-                  {i18n.translate('xpack.onechat.activeToolsStatus.description', {
-                    defaultMessage:
-                      'Tools are the skills your agent can use to get things done. For best results, try to keep the list under {threshold} — it helps your agent stay focused and respond more clearly.',
-                    values: { threshold: warningThreshold },
+    <EuiPanel
+      hasBorder={true}
+      hasShadow={false}
+      paddingSize="m"
+      aria-label={i18n.translate('xpack.onechat.activeToolsStatus.panelLabel', {
+        defaultMessage: 'Active tools status panel',
+      })}
+      role="region"
+    >
+      <EuiFlexGroup alignItems="center" gutterSize="l">
+        <EuiFlexItem grow={1}>
+          <EuiFlexGroup direction="column">
+            <EuiFlexItem>
+              <EuiFlexGroup direction="row" gutterSize="s" alignItems="center" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiIcon
+                    type={iconType}
+                    color={statusColor}
+                    size="m"
+                    aria-label={
+                      shouldShowWarning
+                        ? i18n.translate('xpack.onechat.activeToolsStatus.warningStatusIcon', {
+                            defaultMessage: 'Warning status icon',
+                          })
+                        : i18n.translate('xpack.onechat.activeToolsStatus.successStatusIcon', {
+                            defaultMessage: 'Success status icon',
+                          })
+                    }
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="m" color={statusColor}>
+                    <strong aria-label={statusMessage}>
+                      {i18n.translate('xpack.onechat.activeToolsStatus.title', {
+                        defaultMessage: 'You have {count} active tools',
+                        values: { count: activeToolsCount },
+                      })}
+                    </strong>
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText size="s" color="subdued">
+                {i18n.translate('xpack.onechat.activeToolsStatus.description', {
+                  defaultMessage:
+                    'Tools are the skills your agent can use to get things done. For best results, try to keep the list under {threshold} — it helps your agent stay focused and respond more clearly.',
+                  values: { threshold: warningThreshold },
+                })}
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiLink
+                href="#"
+                aria-label={i18n.translate('xpack.onechat.activeToolsStatus.learnMoreAriaLabel', {
+                  defaultMessage: 'Learn more about active tools management',
+                })}
+              >
+                <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
+                  {i18n.translate('xpack.onechat.activeToolsStatus.learnMore', {
+                    defaultMessage: 'Learn more',
                   })}
-                </EuiText>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiLink
-                  href="#"
-                  aria-label={i18n.translate('xpack.onechat.activeToolsStatus.learnMoreAriaLabel', {
-                    defaultMessage: 'Learn more about active tools management',
-                  })}
-                >
-                  <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
-                    {i18n.translate('xpack.onechat.activeToolsStatus.learnMore', {
-                      defaultMessage: 'Learn more',
+                  <EuiIcon
+                    type="popout"
+                    aria-label={i18n.translate('xpack.onechat.activeToolsStatus.externalLinkIcon', {
+                      defaultMessage: 'External link',
                     })}
-                    <EuiIcon
-                      type="popout"
-                      aria-label={i18n.translate(
-                        'xpack.onechat.activeToolsStatus.externalLinkIcon',
-                        {
-                          defaultMessage: 'External link',
-                        }
-                      )}
-                    />
-                  </EuiFlexGroup>
-                </EuiLink>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
+                  />
+                </EuiFlexGroup>
+              </EuiLink>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
 
-          <EuiFlexItem grow={1}>
-            <EuiFlexGroup direction="column" gutterSize="s">
-              <EuiFlexItem>
-                <EuiProgress
-                  value={activeToolsCount}
-                  max={warningThreshold}
-                  color={statusColor}
-                  size="m"
-                  label={i18n.translate('xpack.onechat.activeToolsStatus.progressLabel', {
-                    defaultMessage: 'Active tools',
-                  })}
-                  valueText={`${activeToolsCount}/${warningThreshold}`}
-                  aria-label={i18n.translate('xpack.onechat.activeToolsStatus.progressAriaLabel', {
-                    defaultMessage: 'Progress: {current} out of {max} active tools',
-                    values: { current: activeToolsCount, max: warningThreshold },
-                  })}
-                />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPanel>
-      {errors.configuration?.tools && (
-        <EuiText size="xs" color="danger">
-          {errors.configuration.tools.message}
-        </EuiText>
-      )}
-    </EuiFlexGroup>
+        <EuiFlexItem grow={1}>
+          <EuiFlexGroup direction="column" gutterSize="s">
+            <EuiFlexItem>
+              <EuiProgress
+                value={activeToolsCount}
+                max={warningThreshold}
+                color={statusColor}
+                size="m"
+                label={i18n.translate('xpack.onechat.activeToolsStatus.progressLabel', {
+                  defaultMessage: 'Active tools',
+                })}
+                valueText={`${activeToolsCount}/${warningThreshold}`}
+                aria-label={i18n.translate('xpack.onechat.activeToolsStatus.progressAriaLabel', {
+                  defaultMessage: 'Progress: {current} out of {max} active tools',
+                  values: { current: activeToolsCount, max: warningThreshold },
+                })}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/active_tools_status.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/active_tools_status.tsx
@@ -5,17 +5,21 @@
  * 2.0.
  */
 
-import React from 'react';
 import {
-  EuiPanel,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiText,
   EuiIcon,
   EuiLink,
+  EuiPanel,
   EuiProgress,
+  EuiText,
+  useEuiTheme,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import type { AgentFormData } from './agent_form';
 
 interface ActiveToolsStatusProps {
   activeToolsCount: number;
@@ -26,14 +30,24 @@ export const ActiveToolsStatus: React.FC<ActiveToolsStatusProps> = ({
   activeToolsCount,
   warningThreshold,
 }) => {
+  const { euiTheme } = useEuiTheme();
+  const {
+    formState: { errors },
+  } = useFormContext<AgentFormData>();
   const isOverThreshold = activeToolsCount > warningThreshold;
   const isZeroTools = activeToolsCount === 0;
-  const shouldShowWarning = isOverThreshold || isZeroTools;
+  const shouldShowWarning = isOverThreshold;
+  const shouldShowError = isZeroTools;
 
-  const statusColor = shouldShowWarning ? 'warning' : 'success';
-  const iconType = shouldShowWarning ? 'alert' : 'checkInCircleFilled';
+  const statusColor = shouldShowWarning ? 'warning' : shouldShowError ? 'danger' : 'success';
+  const iconType = shouldShowWarning || shouldShowError ? 'alert' : 'checkInCircleFilled';
 
-  const statusMessage = shouldShowWarning
+  const statusMessage = shouldShowError
+    ? i18n.translate('xpack.onechat.activeToolsStatus.errorStatusMessage', {
+        defaultMessage: 'Error status: {count} active tools',
+        values: { count: activeToolsCount },
+      })
+    : shouldShowWarning
     ? i18n.translate('xpack.onechat.activeToolsStatus.warningStatusMessage', {
         defaultMessage: 'Warning status: {count} active tools',
         values: { count: activeToolsCount },
@@ -44,101 +58,125 @@ export const ActiveToolsStatus: React.FC<ActiveToolsStatusProps> = ({
       });
 
   return (
-    <EuiPanel
-      hasBorder={true}
-      hasShadow={false}
-      paddingSize="m"
-      aria-label={i18n.translate('xpack.onechat.activeToolsStatus.panelLabel', {
-        defaultMessage: 'Active tools status panel',
-      })}
-      role="region"
-    >
-      <EuiFlexGroup alignItems="center" gutterSize="l">
-        <EuiFlexItem grow={1}>
-          <EuiFlexGroup direction="column">
-            <EuiFlexItem>
-              <EuiFlexGroup direction="row" gutterSize="s" alignItems="center" responsive={false}>
-                <EuiFlexItem grow={false}>
-                  <EuiIcon
-                    type={iconType}
-                    color={statusColor}
-                    size="m"
-                    aria-label={
-                      shouldShowWarning
-                        ? i18n.translate('xpack.onechat.activeToolsStatus.warningStatusIcon', {
-                            defaultMessage: 'Warning status icon',
-                          })
-                        : i18n.translate('xpack.onechat.activeToolsStatus.successStatusIcon', {
-                            defaultMessage: 'Success status icon',
-                          })
-                    }
-                  />
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiText size="m" color={statusColor}>
-                    <strong aria-label={statusMessage}>
-                      {i18n.translate('xpack.onechat.activeToolsStatus.title', {
-                        defaultMessage: 'You have {count} active tools',
-                        values: { count: activeToolsCount },
-                      })}
-                    </strong>
-                  </EuiText>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiText size="s" color="subdued">
-                {i18n.translate('xpack.onechat.activeToolsStatus.description', {
-                  defaultMessage:
-                    'Tools are the skills your agent can use to get things done. For best results, try to keep the list under {threshold} — it helps your agent stay focused and respond more clearly.',
-                  values: { threshold: warningThreshold },
-                })}
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiLink
-                href="#"
-                aria-label={i18n.translate('xpack.onechat.activeToolsStatus.learnMoreAriaLabel', {
-                  defaultMessage: 'Learn more about active tools management',
-                })}
-              >
-                <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
-                  {i18n.translate('xpack.onechat.activeToolsStatus.learnMore', {
-                    defaultMessage: 'Learn more',
-                  })}
-                  <EuiIcon
-                    type="popout"
-                    aria-label={i18n.translate('xpack.onechat.activeToolsStatus.externalLinkIcon', {
-                      defaultMessage: 'External link',
-                    })}
-                  />
+    <EuiFlexGroup direction="column" gutterSize="xs">
+      <EuiPanel
+        hasBorder={true}
+        hasShadow={false}
+        paddingSize="m"
+        aria-label={i18n.translate('xpack.onechat.activeToolsStatus.panelLabel', {
+          defaultMessage: 'Active tools status panel',
+        })}
+        css={
+          errors.configuration?.tools
+            ? css`
+                border-color: ${euiTheme.colors.danger};
+                &::after {
+                  border-color: ${euiTheme.colors.danger};
+                }
+              `
+            : undefined
+        }
+        role="region"
+      >
+        <EuiFlexGroup alignItems="center" gutterSize="l">
+          <EuiFlexItem grow={1}>
+            <EuiFlexGroup direction="column">
+              <EuiFlexItem>
+                <EuiFlexGroup direction="row" gutterSize="s" alignItems="center" responsive={false}>
+                  <EuiFlexItem grow={false}>
+                    <EuiIcon
+                      type={iconType}
+                      color={statusColor}
+                      size="m"
+                      aria-label={
+                        shouldShowError
+                          ? i18n.translate('xpack.onechat.activeToolsStatus.errorStatusIcon', {
+                              defaultMessage: 'Error status icon',
+                            })
+                          : shouldShowWarning
+                          ? i18n.translate('xpack.onechat.activeToolsStatus.warningStatusIcon', {
+                              defaultMessage: 'Warning status icon',
+                            })
+                          : i18n.translate('xpack.onechat.activeToolsStatus.successStatusIcon', {
+                              defaultMessage: 'Success status icon',
+                            })
+                      }
+                    />
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiText size="m" color={statusColor}>
+                      <strong aria-label={statusMessage}>
+                        {i18n.translate('xpack.onechat.activeToolsStatus.title', {
+                          defaultMessage: 'You have {count} active tools',
+                          values: { count: activeToolsCount },
+                        })}
+                      </strong>
+                    </EuiText>
+                  </EuiFlexItem>
                 </EuiFlexGroup>
-              </EuiLink>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText size="s" color="subdued">
+                  {i18n.translate('xpack.onechat.activeToolsStatus.description', {
+                    defaultMessage:
+                      'Tools are the skills your agent can use to get things done. For best results, try to keep the list under {threshold} — it helps your agent stay focused and respond more clearly.',
+                    values: { threshold: warningThreshold },
+                  })}
+                </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiLink
+                  href="#"
+                  aria-label={i18n.translate('xpack.onechat.activeToolsStatus.learnMoreAriaLabel', {
+                    defaultMessage: 'Learn more about active tools management',
+                  })}
+                >
+                  <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
+                    {i18n.translate('xpack.onechat.activeToolsStatus.learnMore', {
+                      defaultMessage: 'Learn more',
+                    })}
+                    <EuiIcon
+                      type="popout"
+                      aria-label={i18n.translate(
+                        'xpack.onechat.activeToolsStatus.externalLinkIcon',
+                        {
+                          defaultMessage: 'External link',
+                        }
+                      )}
+                    />
+                  </EuiFlexGroup>
+                </EuiLink>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
 
-        <EuiFlexItem grow={1}>
-          <EuiFlexGroup direction="column" gutterSize="s">
-            <EuiFlexItem>
-              <EuiProgress
-                value={activeToolsCount}
-                max={warningThreshold}
-                color={statusColor}
-                size="m"
-                label={i18n.translate('xpack.onechat.activeToolsStatus.progressLabel', {
-                  defaultMessage: 'Active tools',
-                })}
-                valueText={`${activeToolsCount}/${warningThreshold}`}
-                aria-label={i18n.translate('xpack.onechat.activeToolsStatus.progressAriaLabel', {
-                  defaultMessage: 'Progress: {current} out of {max} active tools',
-                  values: { current: activeToolsCount, max: warningThreshold },
-                })}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiPanel>
+          <EuiFlexItem grow={1}>
+            <EuiFlexGroup direction="column" gutterSize="s">
+              <EuiFlexItem>
+                <EuiProgress
+                  value={activeToolsCount}
+                  max={warningThreshold}
+                  color={statusColor}
+                  size="m"
+                  label={i18n.translate('xpack.onechat.activeToolsStatus.progressLabel', {
+                    defaultMessage: 'Active tools',
+                  })}
+                  valueText={`${activeToolsCount}/${warningThreshold}`}
+                  aria-label={i18n.translate('xpack.onechat.activeToolsStatus.progressAriaLabel', {
+                    defaultMessage: 'Progress: {current} out of {max} active tools',
+                    values: { current: activeToolsCount, max: warningThreshold },
+                  })}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+      {errors.configuration?.tools && (
+        <EuiText size="xs" color="danger">
+          {errors.configuration.tools.message}
+        </EuiText>
+      )}
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form.tsx
@@ -139,14 +139,17 @@ export const AgentForm: React.FC<AgentFormProps> = ({ editingAgentId, onDelete }
     async (
       data: AgentFormData,
       {
-        shouldRedirect = true,
+        navigateToListView = true,
         buttonId = BUTTON_IDS.SAVE,
-      }: { shouldRedirect?: boolean; buttonId?: string } = {}
+      }: { navigateToListView?: boolean; buttonId?: string } = {}
     ) => {
       setSubmittingButtonId(buttonId);
-      await submit(data);
-      setSubmittingButtonId(undefined);
-      if (shouldRedirect) {
+      try {
+        await submit(data);
+      } finally {
+        setSubmittingButtonId(undefined);
+      }
+      if (navigateToListView) {
         navigateToOnechatUrl(appPaths.agents.list);
       }
     },
@@ -157,7 +160,7 @@ export const AgentForm: React.FC<AgentFormProps> = ({ editingAgentId, onDelete }
     async (data: AgentFormData) => {
       await handleSave(data, {
         buttonId: BUTTON_IDS.SAVE_AND_CHAT,
-        shouldRedirect: false,
+        navigateToListView: false,
       });
       navigateToOnechatUrl(appPaths.chat.newWithAgent({ agentId: data.id }));
     },

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form.tsx
@@ -145,6 +145,7 @@ export const AgentForm: React.FC<AgentFormProps> = ({ editingAgentId, onDelete }
     ) => {
       setSubmittingButtonId(buttonId);
       await submit(data);
+      setSubmittingButtonId(undefined);
       if (shouldRedirect) {
         navigateToOnechatUrl(appPaths.agents.list);
       }
@@ -175,12 +176,6 @@ export const AgentForm: React.FC<AgentFormProps> = ({ editingAgentId, onDelete }
   const activeToolsCount = useMemo(() => {
     return filterToolsBySelection(tools, agentTools).length;
   }, [tools, agentTools]);
-
-  useEffect(() => {
-    if (!isSubmitting) {
-      setSubmittingButtonId(undefined);
-    }
-  }, [isSubmitting]);
 
   const tabs = useMemo<EuiTabbedContentTab[]>(
     () => [

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form_validation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form_validation.ts
@@ -60,10 +60,6 @@ export const agentFormSchema = z.object({
     .optional(),
   configuration: z.object({
     instructions: z.string().optional(),
-    tools: z.array(z.any()).min(1, {
-      message: i18n.translate('xpack.onechat.agents.form.toolsRequired', {
-        defaultMessage: 'Tools are required.',
-      }),
-    }),
+    tools: z.array(z.any()),
   }),
 });

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form_validation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form_validation.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { agentIdRegexp } from '@kbn/onechat-common';
+import { z } from '@kbn/zod';
+import { isValidAgentAvatarColor } from '../../../utils/color';
+
+export const agentFormSchema = z.object({
+  id: z
+    .string()
+    .min(1, {
+      message: i18n.translate('xpack.onechat.agents.form.idRequired', {
+        defaultMessage: 'Agent ID is required.',
+      }),
+    })
+    .regex(agentIdRegexp, {
+      message: i18n.translate('xpack.onechat.agents.form.idInvalid', {
+        defaultMessage:
+          'Agent ID must start and end with a letter or number, and can only contain lowercase letters, numbers, hyphens, and underscores.',
+      }),
+    }),
+  name: z.string().min(1, {
+    message: i18n.translate('xpack.onechat.agents.form.nameRequired', {
+      defaultMessage: 'Agent name is required.',
+    }),
+  }),
+  description: z.string().min(1, {
+    message: i18n.translate('xpack.onechat.agents.form.descriptionRequired', {
+      defaultMessage: 'Agent description is required.',
+    }),
+  }),
+  labels: z.array(z.string()).optional(),
+  avatar_color: z
+    .string()
+    .optional()
+    .refine(
+      (value) => {
+        if (!value) return true;
+        return isValidAgentAvatarColor(value);
+      },
+      {
+        message: i18n.translate('xpack.onechat.agents.form.avatarColorInvalidError', {
+          defaultMessage:
+            'Please enter a valid hex color code. This can either be a three or six character hex value.',
+        }),
+      }
+    ),
+  avatar_symbol: z
+    .string()
+    .max(2, {
+      message: i18n.translate('xpack.onechat.agents.form.avatarSymbolMaxLengthError', {
+        defaultMessage: 'Avatar symbol must be 2 characters or less.',
+      }),
+    })
+    .optional(),
+  configuration: z.object({
+    instructions: z.string().optional(),
+    tools: z.array(z.any()).min(1, {
+      message: i18n.translate('xpack.onechat.agents.form.toolsRequired', {
+        defaultMessage: 'Tools are required.',
+      }),
+    }),
+  }),
+});

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/tabs/settings_tab.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/tabs/settings_tab.tsx
@@ -30,7 +30,6 @@ import { Controller } from 'react-hook-form';
 import { labels } from '../../../../utils/i18n';
 import { useAgentLabels } from '../../../../hooks/agents/use_agent_labels';
 import type { AgentFormData } from '../agent_form';
-import { isValidAgentAvatarColor } from '../../../../utils/color';
 
 interface AgentSettingsTabProps {
   control: Control<AgentFormData>;
@@ -142,11 +141,6 @@ export const AgentSettingsTab: React.FC<AgentSettingsTabProps> = ({
             <Controller
               name="id"
               control={control}
-              rules={{
-                required: i18n.translate('xpack.onechat.agents.form.idRequired', {
-                  defaultMessage: 'Agent ID is required',
-                }),
-              }}
               render={({ field: { ref, ...rest } }) => (
                 <EuiFieldText
                   {...rest}
@@ -354,11 +348,6 @@ export const AgentSettingsTab: React.FC<AgentSettingsTabProps> = ({
             <Controller
               name="name"
               control={control}
-              rules={{
-                required: i18n.translate('xpack.onechat.agents.form.nameRequired', {
-                  defaultMessage: 'Agent name is required',
-                }),
-              }}
               render={({ field: { ref, ...rest } }) => (
                 <EuiFieldText
                   {...rest}
@@ -383,11 +372,6 @@ export const AgentSettingsTab: React.FC<AgentSettingsTabProps> = ({
             <Controller
               name="description"
               control={control}
-              rules={{
-                required: i18n.translate('xpack.onechat.agents.form.descriptionRequired', {
-                  defaultMessage: 'Agent description is required',
-                }),
-              }}
               render={({ field: { ref, ...rest } }) => (
                 <EuiTextArea
                   {...rest}
@@ -422,17 +406,6 @@ export const AgentSettingsTab: React.FC<AgentSettingsTabProps> = ({
                 <Controller
                   name="avatar_color"
                   control={control}
-                  rules={{
-                    validate: (value) => {
-                      if (value && !isValidAgentAvatarColor(value)) {
-                        return i18n.translate('xpack.onechat.agents.form.avatarColorInvalidError', {
-                          defaultMessage:
-                            'Please enter a valid hex color code. This can either be a three or six character hex value.',
-                        });
-                      }
-                      return true;
-                    },
-                  }}
                   render={({ field: { onChange, value } }) => (
                     <EuiColorPicker
                       onChange={onChange}
@@ -463,20 +436,13 @@ export const AgentSettingsTab: React.FC<AgentSettingsTabProps> = ({
                 <Controller
                   name="avatar_symbol"
                   control={control}
-                  rules={{
-                    maxLength: {
-                      value: 2,
-                      message: i18n.translate(
-                        'xpack.onechat.agents.form.avatarSymbolMaxLengthError',
-                        {
-                          defaultMessage: 'Avatar symbol must be 2 characters or less',
-                        }
-                      ),
-                    },
-                  }}
                   render={({ field: { ref, ...rest } }) => (
                     <EuiFieldText
                       {...rest}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        rest.onChange(value.slice(0, 2));
+                      }}
                       inputRef={ref}
                       disabled={isFormDisabled}
                       isInvalid={!!formState.errors.avatar_symbol}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/tool_edit_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/tool_edit_context_menu.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiButtonIcon,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiPopover,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useState } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { useNavigation } from '../../../../hooks/use_navigation';
+import { useToolsActions } from '../../../../context/tools_provider';
+import { labels } from '../../../../utils/i18n';
+import type { ToolFormData } from '../types/tool_form_types';
+import { appPaths } from '../../../../utils/app_paths';
+
+export const ToolEditContextMenu = () => {
+  const { euiTheme } = useEuiTheme();
+  const { navigateToOnechatUrl } = useNavigation();
+  const { cloneTool, deleteTool } = useToolsActions();
+  const { control } = useFormContext<ToolFormData>();
+  const toolId = useWatch({ name: 'toolId', control });
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <EuiPopover
+      panelPaddingSize="xs"
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      zIndex={Number(euiTheme.levels.header) - 1}
+      button={
+        <EuiButtonIcon
+          size="m"
+          iconType="boxesVertical"
+          onClick={() => setIsOpen((openState) => !openState)}
+          aria-label={labels.tools.editToolContextMenuButtonLabel}
+        />
+      }
+    >
+      <EuiContextMenuPanel
+        size="s"
+        items={[
+          <EuiContextMenuItem
+            key="clone"
+            icon="copy"
+            size="s"
+            onClick={() => {
+              cloneTool(toolId);
+            }}
+          >
+            {labels.tools.cloneToolButtonLabel}
+          </EuiContextMenuItem>,
+          <EuiContextMenuItem
+            key="delete"
+            icon="trash"
+            size="s"
+            css={css`
+              color: ${euiTheme.colors.textDanger};
+            `}
+            onClick={() => {
+              setIsOpen(false);
+              deleteTool(toolId, { onConfirm: () => navigateToOnechatUrl(appPaths.tools.list) });
+            }}
+          >
+            {labels.tools.deleteToolButtonLabel}
+          </EuiContextMenuItem>,
+        ]}
+      />
+    </EuiPopover>
+  );
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/tool_form_section.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/tool_form_section.tsx
@@ -7,6 +7,7 @@
 
 import type { IconType } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiLink, EuiText, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { isEqual } from 'lodash';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 import React, { memo } from 'react';
@@ -58,7 +59,14 @@ export const ToolFormSection: FC<PropsWithChildren<ToolFormSectionProps>> = memo
             )}
           </EuiFlexGroup>
         </EuiFlexItem>
-        <EuiFlexItem grow={2}>{children}</EuiFlexItem>
+        <EuiFlexItem
+          grow={2}
+          css={css`
+            overflow-x: auto; /* Fixes a bug where the ES|QL editor misbehaves on horizontal resize */
+          `}
+        >
+          {children}
+        </EuiFlexItem>
       </EuiFlexGroup>
     );
   },

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/table/tools_table_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/table/tools_table_context_menu.tsx
@@ -16,7 +16,7 @@ import { css } from '@emotion/react';
 import type { ToolDefinitionWithSchema } from '@kbn/onechat-common';
 import React, { useState } from 'react';
 import { labels } from '../../../utils/i18n';
-import { useToolsActions } from '../../../context/tools_table_provider';
+import { useToolsActions } from '../../../context/tools_provider';
 
 export interface ToolContextMenuProps {
   tool: ToolDefinitionWithSchema;

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/table/tools_table_header.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/table/tools_table_header.tsx
@@ -16,7 +16,7 @@ import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { ToolDefinitionWithSchema } from '@kbn/onechat-common';
 import React, { useCallback } from 'react';
-import { useToolsActions } from '../../../context/tools_table_provider';
+import { useToolsActions } from '../../../context/tools_provider';
 import { labels } from '../../../utils/i18n';
 
 export interface ToolsTableHeaderProps {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/table/tools_table_id.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/table/tools_table_id.tsx
@@ -10,7 +10,7 @@ import { css } from '@emotion/react';
 import type { ToolDefinitionWithSchema } from '@kbn/onechat-common';
 import React from 'react';
 import { truncateAtNewline } from '../../../utils/truncate_at_newline';
-import { useToolsActions } from '../../../context/tools_table_provider';
+import { useToolsActions } from '../../../context/tools_provider';
 
 export interface ToolIdWithDescriptionProps {
   tool: ToolDefinitionWithSchema;

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/table/tools_table_quick_actions.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/table/tools_table_quick_actions.tsx
@@ -9,7 +9,7 @@ import { EuiButtonIcon, EuiFlexGroup } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { ToolDefinitionWithSchema } from '@kbn/onechat-common';
 import React from 'react';
-import { useToolsActions } from '../../../context/tools_table_provider';
+import { useToolsActions } from '../../../context/tools_provider';
 import { labels } from '../../../utils/i18n';
 
 export interface ToolQuickActionsProps {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { EuiButtonProps } from '@elastic/eui';
 import {
   EuiBadge,
   EuiButton,
@@ -16,6 +17,7 @@ import {
   EuiToolTip,
   useEuiTheme,
   useGeneratedHtmlId,
+  useIsWithinBreakpoints,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -33,8 +35,10 @@ import type {
 } from '../../../../common/http_api/tools';
 import { useToolForm } from '../../hooks/tools/use_tool_form';
 import { useNavigation } from '../../hooks/use_navigation';
+import { useQueryState } from '../../hooks/use_query_state';
 import { appPaths } from '../../utils/app_paths';
 import { labels } from '../../utils/i18n';
+import { transformBuiltInToolToFormData } from '../../utils/transform_built_in_form_data';
 import {
   transformEsqlFormDataForCreate,
   transformEsqlFormDataForUpdate,
@@ -45,12 +49,16 @@ import {
   transformIndexSearchFormDataForUpdate,
   transformIndexSearchToolToFormData,
 } from '../../utils/transform_index_search_form_data';
+import { OPEN_TEST_FLYOUT_QUERY_PARAM, TOOL_TYPE_QUERY_PARAM } from './create_tool';
 import { ToolTestFlyout } from './execute/test_tools';
+import { ToolEditContextMenu } from './form/components/tool_edit_context_menu';
 import { ToolForm, ToolFormMode } from './form/tool_form';
 import type { ToolFormData } from './form/types/tool_form_types';
-import { transformBuiltInToolToFormData } from '../../utils/transform_built_in_form_data';
-import { OPEN_TEST_FLYOUT_QUERY_PARAM, TOOL_TYPE_QUERY_PARAM } from './create_tool';
-import { useQueryState } from '../../hooks/use_query_state';
+
+const BUTTON_IDS = {
+  SAVE: 'save',
+  SAVE_AND_TEST: 'saveAndTest',
+} as const;
 
 interface ToolBaseProps {
   tool?: ToolDefinitionWithSchema;
@@ -79,6 +87,7 @@ export type ToolProps = ToolCreateProps | ToolEditProps | ToolViewProps;
 
 export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting, saveTool }) => {
   const { euiTheme } = useEuiTheme();
+  const isMobile = useIsWithinBreakpoints(['xs', 's']);
   const { navigateToOnechatUrl } = useNavigation();
   const [openTestFlyoutParam, setOpenTestFlyoutParam] = useQueryState<boolean>(
     OPEN_TEST_FLYOUT_QUERY_PARAM,
@@ -98,8 +107,9 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
 
   const form = useToolForm(tool, initialToolType);
   const { reset, formState, watch, handleSubmit } = form;
-  const { errors } = formState;
+  const { errors, isDirty } = formState;
   const [showTestFlyout, setShowTestFlyout] = useState(false);
+  const [submittingButtonId, setSubmittingButtonId] = useState<string | undefined>();
 
   const currentToolId = watch('toolId');
 
@@ -116,8 +126,15 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
   }, [navigateToOnechatUrl]);
 
   const handleSave = useCallback(
-    async (data: ToolFormData, shouldRedirect = true) => {
+    async (
+      data: ToolFormData,
+      {
+        shouldRedirect = true,
+        buttonId = BUTTON_IDS.SAVE,
+      }: { shouldRedirect?: boolean; buttonId?: string } = {}
+    ) => {
       if (mode === ToolFormMode.View) return;
+      setSubmittingButtonId(buttonId);
       if (mode === ToolFormMode.Edit) {
         switch (data.type) {
           case ToolType.esql:
@@ -154,7 +171,7 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
 
   const handleSaveAndTest = useCallback(
     async (data: ToolFormData) => {
-      await handleSave(data, false);
+      await handleSave(data, { shouldRedirect: false, buttonId: BUTTON_IDS.SAVE_AND_TEST });
       handleTestTool();
     },
     [handleSave, handleTestTool]
@@ -177,55 +194,77 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
   });
 
   const isViewMode = mode === ToolFormMode.View;
+  const hasErrors = Object.keys(errors).length > 0;
 
-  const saveButton = (
-    <EuiButton
-      size="s"
-      type="submit"
-      fill
-      iconType="save"
-      form={toolFormId}
-      disabled={Object.keys(errors).length > 0 || isSubmitting}
-      isLoading={isSubmitting}
-      css={css`
-        width: 124px;
-      `}
-    >
-      {labels.tools.saveButtonLabel}
-    </EuiButton>
+  useEffect(() => {
+    if (!isSubmitting) {
+      setSubmittingButtonId(undefined);
+    }
+  }, [isSubmitting]);
+
+  const renderSaveButton = useCallback(
+    ({ size = 's' }: Pick<EuiButtonProps, 'size'> = {}) => {
+      const saveButton = (
+        <EuiButton
+          size={size}
+          type="submit"
+          fill
+          iconType="save"
+          form={toolFormId}
+          disabled={hasErrors || isSubmitting || (mode === ToolFormMode.Edit && !isDirty)}
+          isLoading={submittingButtonId === BUTTON_IDS.SAVE}
+          minWidth={mode === ToolFormMode.Create ? '124px' : '112px'}
+        >
+          {labels.tools.saveButtonLabel}
+        </EuiButton>
+      );
+      return hasErrors ? (
+        <EuiToolTip display="block" content={labels.tools.saveButtonTooltip}>
+          {saveButton}
+        </EuiToolTip>
+      ) : (
+        saveButton
+      );
+    },
+    [toolFormId, hasErrors, isSubmitting, mode, isDirty, submittingButtonId]
   );
 
-  const saveAndTestButton = (
-    <EuiButton
-      size="s"
-      iconType="play"
-      onClick={handleSubmit(handleSaveAndTest)}
-      disabled={Object.keys(errors).length > 0 || isSubmitting}
-      isLoading={isSubmitting}
-      css={css`
-        width: 124px;
-      `}
-    >
-      {i18n.translate('xpack.onechat.tools.esqlToolFlyout.saveAndTestButtonLabel', {
-        defaultMessage: 'Save & test',
-      })}
-    </EuiButton>
-  );
-
-  const testButton = (
-    <EuiButton
-      size="s"
-      onClick={handleTestTool}
-      disabled={Object.keys(errors).length > 0}
-      iconType="play"
-      css={css`
-        width: 124px;
-      `}
-    >
-      {i18n.translate('xpack.onechat.tools.esqlToolFlyout.testButtonLabel', {
-        defaultMessage: 'Test',
-      })}
-    </EuiButton>
+  const renderTestButton = useCallback(
+    ({ size = 's' }: Pick<EuiButtonProps, 'size'> = {}) => {
+      const isCreateMode = mode === ToolFormMode.Create;
+      const commonProps: EuiButtonProps = {
+        size,
+        iconType: 'play',
+        isDisabled: hasErrors || isSubmitting,
+      };
+      return isCreateMode ? (
+        <EuiButton
+          {...commonProps}
+          onClick={handleSubmit(handleSaveAndTest)}
+          isLoading={submittingButtonId === BUTTON_IDS.SAVE_AND_TEST}
+          minWidth="124px"
+        >
+          {i18n.translate('xpack.onechat.tools.esqlToolFlyout.saveAndTestButtonLabel', {
+            defaultMessage: 'Save & test',
+          })}
+        </EuiButton>
+      ) : (
+        <EuiButton {...commonProps} onClick={handleTestTool} minWidth="112px">
+          {i18n.translate('xpack.onechat.tools.esqlToolFlyout.testButtonLabel', {
+            defaultMessage: 'Test',
+          })}
+        </EuiButton>
+      );
+    },
+    [
+      mode,
+      handleSubmit,
+      handleSaveAndTest,
+      handleTestTool,
+      hasErrors,
+      isSubmitting,
+      submittingButtonId,
+    ]
   );
 
   return (
@@ -248,6 +287,12 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
               )}
             </EuiFlexGroup>
           }
+          rightSideItems={[
+            ...(mode !== ToolFormMode.View ? [renderSaveButton({ size: 'm' })] : []),
+            renderTestButton({ size: 'm' }),
+            ...(mode === ToolFormMode.Edit ? [<ToolEditContextMenu />] : []),
+          ]}
+          rightSideGroupProps={{ gutterSize: 's' }}
           css={css`
             background-color: ${euiTheme.colors.backgroundBasePlain};
             border-block-end: none;
@@ -280,7 +325,11 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
               )}
             </>
           )}
-          <EuiSpacer size="xl" />
+          <EuiSpacer
+            css={css`
+              height: ${!isMobile || isViewMode ? euiTheme.size.xxxxl : '144px'};
+            `}
+          />
         </KibanaPageTemplate.Section>
         <KibanaPageTemplate.BottomBar
           css={css`
@@ -292,26 +341,16 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
           usePortal
         >
           <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
-            {!isViewMode && (
+            {mode !== ToolFormMode.View && (
               <EuiFlexItem grow={false}>
-                <EuiButtonEmpty size="s" iconType="cross" onClick={handleCancel}>
+                <EuiButtonEmpty size="s" iconType="cross" color="text" onClick={handleCancel}>
                   {labels.tools.cancelButtonLabel}
                 </EuiButtonEmpty>
               </EuiFlexItem>
             )}
-            <EuiFlexItem grow={false}>
-              {mode === ToolFormMode.Create ? saveAndTestButton : testButton}
-            </EuiFlexItem>
-            {!isViewMode && (
-              <EuiFlexItem grow={false}>
-                {Object.keys(errors).length > 0 ? (
-                  <EuiToolTip display="block" content={labels.tools.saveButtonTooltip}>
-                    {saveButton}
-                  </EuiToolTip>
-                ) : (
-                  saveButton
-                )}
-              </EuiFlexItem>
+            <EuiFlexItem grow={false}>{renderTestButton()}</EuiFlexItem>
+            {mode !== ToolFormMode.View && (
+              <EuiFlexItem grow={false}>{renderSaveButton()}</EuiFlexItem>
             )}
           </EuiFlexGroup>
         </KibanaPageTemplate.BottomBar>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
@@ -158,6 +158,7 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
             break;
         }
       }
+      setSubmittingButtonId(undefined);
       if (shouldRedirect) {
         navigateToOnechatUrl(appPaths.tools.list);
       }
@@ -195,12 +196,6 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
 
   const isViewMode = mode === ToolFormMode.View;
   const hasErrors = Object.keys(errors).length > 0;
-
-  useEffect(() => {
-    if (!isSubmitting) {
-      setSubmittingButtonId(undefined);
-    }
-  }, [isSubmitting]);
 
   const renderSaveButton = useCallback(
     ({ size = 's' }: Pick<EuiButtonProps, 'size'> = {}) => {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
@@ -129,37 +129,40 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
     async (
       data: ToolFormData,
       {
-        shouldRedirect = true,
+        navigateToListView = true,
         buttonId = BUTTON_IDS.SAVE,
-      }: { shouldRedirect?: boolean; buttonId?: string } = {}
+      }: { navigateToListView?: boolean; buttonId?: string } = {}
     ) => {
       if (mode === ToolFormMode.View) return;
       setSubmittingButtonId(buttonId);
-      if (mode === ToolFormMode.Edit) {
-        switch (data.type) {
-          case ToolType.esql:
-            await saveTool(transformEsqlFormDataForUpdate(data));
-            break;
-          case ToolType.index_search:
-            await saveTool(transformIndexSearchFormDataForUpdate(data));
-            break;
-          default:
-            break;
+      try {
+        if (mode === ToolFormMode.Edit) {
+          switch (data.type) {
+            case ToolType.esql:
+              await saveTool(transformEsqlFormDataForUpdate(data));
+              break;
+            case ToolType.index_search:
+              await saveTool(transformIndexSearchFormDataForUpdate(data));
+              break;
+            default:
+              break;
+          }
+        } else {
+          switch (data.type) {
+            case ToolType.esql:
+              await saveTool(transformEsqlFormDataForCreate(data));
+              break;
+            case ToolType.index_search:
+              await saveTool(transformIndexSearchFormDataForCreate(data));
+              break;
+            default:
+              break;
+          }
         }
-      } else {
-        switch (data.type) {
-          case ToolType.esql:
-            await saveTool(transformEsqlFormDataForCreate(data));
-            break;
-          case ToolType.index_search:
-            await saveTool(transformIndexSearchFormDataForCreate(data));
-            break;
-          default:
-            break;
-        }
+      } finally {
+        setSubmittingButtonId(undefined);
       }
-      setSubmittingButtonId(undefined);
-      if (shouldRedirect) {
+      if (navigateToListView) {
         navigateToOnechatUrl(appPaths.tools.list);
       }
     },
@@ -172,7 +175,7 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
 
   const handleSaveAndTest = useCallback(
     async (data: ToolFormData) => {
-      await handleSave(data, { shouldRedirect: false, buttonId: BUTTON_IDS.SAVE_AND_TEST });
+      await handleSave(data, { navigateToListView: false, buttonId: BUTTON_IDS.SAVE_AND_TEST });
       handleTestTool();
     },
     [handleSave, handleTestTool]

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tools.tsx
@@ -10,7 +10,7 @@ import { css } from '@emotion/react';
 import { ToolType } from '@kbn/onechat-common';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import React from 'react';
-import { useToolsActions } from '../../context/tools_table_provider';
+import { useToolsActions } from '../../context/tools_provider';
 import { labels } from '../../utils/i18n';
 import { OnechatToolsTable } from './table/tools_table';
 import { McpConnectionButton } from './mcp_server/mcp_connection_button';

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/tools_provider.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/tools_provider.tsx
@@ -22,7 +22,10 @@ export interface ToolsActionsContextType {
   createTool: (toolType: ToolType) => void;
   editTool: (toolId: string) => void;
   viewTool: (toolId: string) => void;
-  deleteTool: (toolId: string) => void;
+  deleteTool: (
+    toolId: string,
+    callbacks?: { onConfirm?: () => void; onCancel?: () => void }
+  ) => void;
   bulkDeleteTools: (toolIds: string[]) => void;
   cloneTool: (toolId: string) => void;
   testTool: (toolId: string) => void;
@@ -32,11 +35,9 @@ export interface ToolsActionsContextType {
   getViewToolUrl: (toolId: string) => string;
 }
 
-export const ToolsTableActionsContext = createContext<ToolsActionsContextType | undefined>(
-  undefined
-);
+export const ToolsActionsContext = createContext<ToolsActionsContextType | undefined>(undefined);
 
-export const ToolsTableProvider = ({ children }: { children: React.ReactNode }) => {
+export const ToolsProvider = ({ children }: { children: React.ReactNode }) => {
   const { navigateToOnechatUrl, createOnechatUrl } = useNavigation();
 
   const createTool = useCallback(
@@ -135,7 +136,7 @@ export const ToolsTableProvider = ({ children }: { children: React.ReactNode }) 
   });
 
   return (
-    <ToolsTableActionsContext.Provider
+    <ToolsActionsContext.Provider
       value={{
         deleteTool,
         bulkDeleteTools,
@@ -181,12 +182,12 @@ export const ToolsTableProvider = ({ children }: { children: React.ReactNode }) 
           <EuiText>{labels.tools.bulkDeleteEsqlToolsConfirmationText}</EuiText>
         </EuiConfirmModal>
       )}
-    </ToolsTableActionsContext.Provider>
+    </ToolsActionsContext.Provider>
   );
 };
 
 export const useToolsActions = () => {
-  const context = useContext(ToolsTableActionsContext);
+  const context = useContext(ToolsActionsContext);
   if (!context) {
     throw new Error('useToolsActions must be used within a ToolsProvider');
   }

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/agents/use_agent_edit.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/agents/use_agent_edit.ts
@@ -106,12 +106,12 @@ export function useAgentEdit({
   }, [agentId, agent, isClone]);
 
   const submit = useCallback(
-    (data: AgentEditState) => {
+    async (data: AgentEditState) => {
       if (editingAgentId) {
         const { id, ...updatedAgent } = data;
-        updateMutation.mutate(updatedAgent);
+        await updateMutation.mutateAsync(updatedAgent);
       } else {
-        createMutation.mutate(data);
+        await createMutation.mutateAsync(data);
       }
     },
     [editingAgentId, createMutation, updateMutation]

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_delete_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_delete_tools.ts
@@ -8,7 +8,7 @@
 import { formatOnechatErrorMessage } from '@kbn/onechat-browser';
 import type { UseMutationOptions } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { BulkDeleteToolResponse, DeleteToolResponse } from '../../../../common/http_api/tools';
 import { queryKeys } from '../../query_keys';
 import { labels } from '../../utils/i18n';
@@ -98,12 +98,22 @@ export const useDeleteTool = ({
 } = {}) => {
   const { addSuccessToast, addErrorToast } = useToasts();
   const [deleteToolId, setDeleteToolId] = useState<string | null>(null);
+  const onConfirmCallbackRef = useRef<() => void>();
+  const onCancelCallbackRef = useRef<() => void>();
 
   const isModalOpen = deleteToolId !== null;
 
-  const deleteTool = useCallback((toolId: string) => {
-    setDeleteToolId(toolId);
-  }, []);
+  const deleteTool = useCallback(
+    (
+      toolId: string,
+      { onConfirm, onCancel }: { onConfirm?: () => void; onCancel?: () => void } = {}
+    ) => {
+      setDeleteToolId(toolId);
+      onConfirmCallbackRef.current = onConfirm;
+      onCancelCallbackRef.current = onCancel;
+    },
+    []
+  );
 
   const handleSuccess: DeleteToolSuccessCallback = (data, { toolId }) => {
     if (!data.success) {
@@ -140,10 +150,14 @@ export const useDeleteTool = ({
     }
 
     await deleteToolMutation({ toolId: deleteToolId }, { onSuccess, onError });
+    onConfirmCallbackRef.current?.();
+    onConfirmCallbackRef.current = undefined;
   }, [deleteToolId, deleteToolMutation, onSuccess, onError]);
 
   const cancelDelete = useCallback(() => {
     setDeleteToolId(null);
+    onCancelCallbackRef.current?.();
+    onCancelCallbackRef.current = undefined;
   }, []);
 
   return {

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tool_form.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tool_form.ts
@@ -7,16 +7,17 @@
 
 import type { ToolDefinitionWithSchema } from '@kbn/onechat-common';
 import { ToolType } from '@kbn/onechat-common';
+import { useCallback } from 'react';
 import type { Resolver, ResolverOptions } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
-import { useCallback } from 'react';
 import type {
   EsqlToolFormData,
   IndexSearchToolFormData,
   ToolFormData,
 } from '../../components/tools/form/types/tool_form_types';
-import { useEsqlToolFormValidationResolver } from '../../components/tools/form/validation/esql_tool_form_validation';
+import { esqlFormValidationSchema } from '../../components/tools/form/validation/esql_tool_form_validation';
 import { useIndexSearchToolFormValidationResolver } from '../../components/tools/form/validation/index_search_tool_form_validation';
+import { zodResolver } from '../../utils/zod_resolver';
 
 const getDefaultValues = (toolType: ToolType): ToolFormData => {
   switch (toolType) {
@@ -48,7 +49,7 @@ const getDefaultValues = (toolType: ToolType): ToolFormData => {
 };
 
 export const useToolForm = (tool?: ToolDefinitionWithSchema, initialToolType?: ToolType) => {
-  const esqlResolver = useEsqlToolFormValidationResolver();
+  const esqlResolver = zodResolver(esqlFormValidationSchema);
   const indexSearchResolver = useIndexSearchToolFormValidationResolver();
 
   const toolType = tool?.type ?? initialToolType ?? ToolType.esql;

--- a/x-pack/platform/plugins/shared/onechat/public/application/pages/tool_details.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/pages/tool_details.tsx
@@ -15,6 +15,7 @@ import { useBreadcrumb } from '../hooks/use_breadcrumbs';
 import { useNavigation } from '../hooks/use_navigation';
 import { appPaths } from '../utils/app_paths';
 import { labels } from '../utils/i18n';
+import { ToolsProvider } from '../context/tools_provider';
 
 export const OnechatToolDetailsPage = () => {
   const { toolId } = useParams<{ toolId: string }>();
@@ -47,5 +48,5 @@ export const OnechatToolDetailsPage = () => {
     return;
   }
 
-  return tool.readonly ? <ViewTool /> : <EditTool />;
+  return <ToolsProvider>{tool.readonly ? <ViewTool /> : <EditTool />}</ToolsProvider>;
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/pages/tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/pages/tools.tsx
@@ -10,13 +10,13 @@ import { OnechatTools } from '../components/tools/tools';
 import { useBreadcrumb } from '../hooks/use_breadcrumbs';
 import { appPaths } from '../utils/app_paths';
 import { labels } from '../utils/i18n';
-import { ToolsTableProvider } from '../context/tools_table_provider';
+import { ToolsProvider } from '../context/tools_provider';
 
 export const OnechatToolsPage = () => {
   useBreadcrumb([{ text: labels.tools.title, path: appPaths.tools.list }]);
   return (
-    <ToolsTableProvider>
+    <ToolsProvider>
       <OnechatTools />
-    </ToolsTableProvider>
+    </ToolsProvider>
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/utils/i18n.ts
@@ -34,6 +34,12 @@ export const labels = {
       defaultMessage: 'Edit index search tool',
     }),
 
+    editToolContextMenuButtonLabel: i18n.translate(
+      'xpack.onechat.tools.editToolContextMenuButtonLabel',
+      {
+        defaultMessage: 'Edit tool context menu',
+      }
+    ),
     saveButtonLabel: i18n.translate('xpack.onechat.tools.saveButtonLabel', {
       defaultMessage: 'Save',
     }),

--- a/x-pack/platform/plugins/shared/onechat/public/application/utils/zod_resolver.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/utils/zod_resolver.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { set } from '@kbn/safer-lodash-set';
+import { z } from '@kbn/zod';
+import { get } from 'lodash';
+import type { FieldValues, ResolverOptions } from 'react-hook-form';
+
+export const zodResolver =
+  <T extends FieldValues>(schema: z.ZodSchema<T>) =>
+  async (data: T, context: any, options: ResolverOptions<T>) => {
+    try {
+      const values = await schema.parseAsync(data);
+      return {
+        values,
+        errors: {},
+      };
+    } catch (error: unknown) {
+      if (!(error instanceof z.ZodError)) {
+        throw error;
+      }
+      const errors = error.issues.reduce<Record<string, { type: string; message: string }>>(
+        (errorMap, issue) => {
+          const path = issue.path.join('.');
+          if (!get(errorMap, path)) {
+            set(errorMap, path, {
+              type: issue.code,
+              message: issue.message,
+            });
+          }
+          return errorMap;
+        },
+        {}
+      );
+
+      return {
+        values: {},
+        errors,
+      };
+    }
+  };

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/client/utils.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/client/utils.ts
@@ -5,18 +5,18 @@
  * 2.0.
  */
 
-import { allToolsSelectionWildcard, createBadRequestError } from '@kbn/onechat-common';
+import {
+  agentIdRegexp,
+  allToolsSelectionWildcard,
+  createBadRequestError,
+} from '@kbn/onechat-common';
 import type { ToolSelection } from '@kbn/onechat-common';
 import type { KibanaRequest } from '@kbn/core/server';
 import type { ToolRegistry } from '../../tools';
 import type { InternalToolDefinition } from '../../tools/tool_provider';
 
-// - Must start and end with letter or digit
-// - Can contain letters, digits, hyphens, underscores
-const idRegexp = /^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$/;
-
 export const ensureValidId = (id: string) => {
-  if (!idRegexp.test(id)) {
+  if (!agentIdRegexp.test(id)) {
     throw createBadRequestError(`Invalid agent id: ${id}`);
   }
 };


### PR DESCRIPTION
## Summary

This change focuses on aligning the general look and feel between the Agent forms and Tool forms in Agent Builder, including the following:

__Agent forms:__
- Implement the bottom actions bar on the Agent page
  - Add "Save and chat" from the Agent creation page
- Allow the user to clone agents from the page actions context menu
- Move to Zod schema validation for easier rules management
- Add frontend validation for Agent ID
- Restrict the avatar symbol field to 2 characters, addresses issue I've noticed when entering emojis with ZWJ characters
~~- Validate that agents have at least 1 tool~~ Reverted in 868dc718b2c839331fad2d6947d1482293046d9c: aligned that agents can be useful without tools
- Validation occurs `onBlur` instead of `onChange` (same as Tools) 
- Add a badge showing how many tools the user has selected
- Other minor fixes (mobile, z-index bugs, spinners showing up on multiple buttons)

__Tools forms:__
- Implement page actions (top-right) for Tools (Create/Edit/View)
  - Implement the page actions context menu, so users can clone and delete their tools from the edit page
- Other minor fixes (horizontal resize breaking for configuration section, mobile, z-index bugs, spinners showing up on multiple buttons) 


### Demo
__Tool Create + Agent Create/Edit__
(Ignore the ES|QL validation error, just a problem with my local setup)

https://github.com/user-attachments/assets/fe0416af-54eb-4207-a9c2-0cc1a00be2c7

__Tool Edit__
<img width="1512" height="823" alt="Screenshot 2025-09-11 at 1 52 34 PM" src="https://github.com/user-attachments/assets/e576b773-4e7a-477b-9546-090f7e8a8f23" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




