### PR TITLE
[Agent Builder] Standardize spacing between numbered list items in rendered mark content

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/chat_message_text.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/chat_message_text.tsx
@@ -18,6 +18,7 @@ import {
   EuiText,
   getDefaultEuiMarkdownParsingPlugins,
   getDefaultEuiMarkdownProcessingPlugins,
+  useEuiTheme,
 } from '@elastic/eui';
 import { type PluggableList } from 'unified';
 import type { ConversationRoundStep } from '@kbn/onechat-common';
@@ -41,8 +42,19 @@ interface Props {
  * Also handles "loading" state by appending the blinking cursor.
  */
 export function ChatMessageText({ content, steps: stepsFromCurrentRound }: Props) {
+  const { euiTheme } = useEuiTheme();
+
   const containerClassName = css`
     overflow-wrap: anywhere;
+
+    /* Standardize spacing between numbered list items */
+    ol > li:not(:first-child) {
+      margin-top: ${euiTheme.size.s};
+    }
+
+    ol > li > p {
+      margin-bottom: ${euiTheme.size.s};
+    }
   `;
 
   const { startDependencies } = useOnechatServices();


### PR DESCRIPTION
## Summary

Before
<img width="909" height="829" alt="image" src="https://github.com/user-attachments/assets/7a1ac6f2-858d-4d99-acf8-244b05e90808" />

After
<img width="914" height="783" alt="image" src="https://github.com/user-attachments/assets/dc11e99c-35a6-49fd-8ed4-bd49ec0a82f5" />



