### PR TITLE
[ES|QL] fix column name detection

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/expand_evals.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/expand_evals.ts
@@ -26,11 +26,15 @@ export function expandEvals(commands: ESQLCommand[]): ESQLCommand[] {
     if (command.name.toLowerCase() === 'eval') {
       for (const arg of command.args) {
         expanded.push(
-          Builder.command({
-            name: 'eval',
-            args: [arg],
-            location: command.location,
-          })
+          Builder.command(
+            {
+              name: 'eval',
+              args: [arg],
+            },
+            {
+              location: command.location,
+            }
+          )
         );
       }
     } else {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/resources_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/resources_helpers.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { parse, EDITOR_MARKER } from '@kbn/esql-ast';
+import { parse, EDITOR_MARKER, BasicPrettyPrinter } from '@kbn/esql-ast';
 import { getQueryForFields } from './resources_helpers';
 
 describe('getQueryForFields', () => {
@@ -26,7 +26,7 @@ describe('getQueryForFields', () => {
 
     const result = getQueryForFields(query, root);
 
-    expect(result).toEqual(expected);
+    expect(BasicPrettyPrinter.print(result)).toEqual(expected);
   };
 
   it('should return everything up till the last command', () => {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/resources_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/resources_helpers.ts
@@ -249,7 +249,7 @@ export function getQueryForFields(
 
 function buildQueryUntilPreviousCommand(root: ESQLAstQueryExpression) {
   if (root.commands.length === 1) {
-    return { ...root.commands[0] };
+    return { ...root, commands: [root.commands[0]] };
   } else {
     return { ...root, commands: root.commands.slice(0, -1) };
   }

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/column_caching.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/column_caching.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { setup } from './helpers';
+
+describe('column caching and casing', () => {
+  it('expression columns are cached case-sensitively', async () => {
+    const { expectErrors } = await setup();
+    await expectErrors('FROM index | EVAL TrIm("") | EVAL `TrIm("")`', []);
+    await expectErrors('FROM index | EVAL TrIm("") | EVAL `TRIM("")`', [
+      'Unknown column "TRIM("")"',
+    ]);
+  });
+
+  it('case changes bust the cache', async () => {
+    const { expectErrors } = await setup();
+    // first populate the cache with capitalized TRIM query
+    await expectErrors('FROM index | EVAL ABS(1) | EVAL `ABS(1)`', []);
+
+    // change the case of the TRIM to trim, which should bust the cache and create an error
+    await expectErrors('FROM index | EVAL abs(1) | EVAL `ABS(1)`', ['Unknown column "ABS(1)"']);
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.ts
@@ -60,7 +60,11 @@ export function getSubqueriesToValidate(rootCommands: ESQLCommand[]) {
     subsequences.push(expandedCommands.slice(0, i + 1));
   }
 
-  return subsequences.map((subsequence) => Builder.expression.query(subsequence));
+  return subsequences.map((subsequence) =>
+    Builder.expression.query(subsequence, {
+      location: { min: 0, max: subsequence[subsequence.length - 1].location.max },
+    })
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

1. Fixes the column name detection (bug introduced in https://github.com/elastic/kibana/pull/233221)

**Before**
<img width="711" height="203" alt="Screenshot 2025-09-11 at 9 00 34 AM" src="https://github.com/user-attachments/assets/285a97a5-4341-4f25-a969-46cd00cc669b" />

**After**
<img width="703" height="176" alt="Screenshot 2025-09-11 at 9 42 13 AM" src="https://github.com/user-attachments/assets/69f923f6-7d15-4cf9-aeaa-027544240c2e" />


2. Makes case changes bust the columns cache. To do this I had to make the cache keys sections of the original query, since there's no way to preserve casing through a parse-serialize process. The side effect is that there will be more cache misses.

This fixes this case (pre-existing bug)

https://github.com/user-attachments/assets/cb74f1ce-a650-4617-84df-f5b943d9c165



### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
