### PR TITLE
[Controls Anywhere] Place variable controls above ES|QL panel during creation

### DIFF
--- a/examples/embeddable_examples/public/react_embeddables/data_table/create_data_table_action.ts
+++ b/examples/embeddable_examples/public/react_embeddables/data_table/create_data_table_action.ts
@@ -33,7 +33,7 @@ export const createDataTableAction = {
         panelType: DATA_TABLE_ID,
       },
       {
-        displaySuccessMessage: true, // shows a toast and scrolls to panel
+        displaySuccessMessage: true,
       }
     );
   },

--- a/examples/embeddable_examples/public/react_embeddables/data_table/create_data_table_action.ts
+++ b/examples/embeddable_examples/public/react_embeddables/data_table/create_data_table_action.ts
@@ -32,7 +32,9 @@ export const createDataTableAction = {
       {
         panelType: DATA_TABLE_ID,
       },
-      true
+      {
+        displaySuccessMessage: true, // shows a toast and scrolls to panel
+      }
     );
   },
   getDisplayName: () =>

--- a/examples/embeddable_examples/public/react_embeddables/register_saved_object_example.ts
+++ b/examples/embeddable_examples/public/react_embeddables/register_saved_object_example.ts
@@ -23,7 +23,9 @@ export const registerMyEmbeddableSavedObject = (embeddableSetup: EmbeddableSetup
             rawState: savedObject.attributes,
           },
         },
-        true // shows a toast and scrolls to panel
+        {
+          displaySuccessMessage: true, // shows a toast and scrolls to panel
+        }
       );
     },
     savedObjectType: MY_SAVED_OBJECT_TYPE,

--- a/examples/embeddable_examples/public/react_embeddables/search/create_search_panel_action.ts
+++ b/examples/embeddable_examples/public/react_embeddables/search/create_search_panel_action.ts
@@ -29,7 +29,7 @@ export const createSearchPanelAction = {
         panelType: SEARCH_EMBEDDABLE_TYPE,
       },
       {
-        displaySuccessMessage: true, // shows a toast and scrolls to panel
+        displaySuccessMessage: true,
       }
     );
   },

--- a/examples/embeddable_examples/public/react_embeddables/search/create_search_panel_action.ts
+++ b/examples/embeddable_examples/public/react_embeddables/search/create_search_panel_action.ts
@@ -28,7 +28,9 @@ export const createSearchPanelAction = {
       {
         panelType: SEARCH_EMBEDDABLE_TYPE,
       },
-      true
+      {
+        displaySuccessMessage: true, // shows a toast and scrolls to panel
+      }
     );
   },
 };

--- a/examples/portable_dashboards_example/public/dashboard_with_controls_example.tsx
+++ b/examples/portable_dashboards_example/public/dashboard_with_controls_example.tsx
@@ -27,7 +27,9 @@ export const DashboardWithControlsExample = ({ dataView }: { dataView: DataView 
         {
           panelType: FILTER_DEBUGGER_EMBEDDABLE_ID,
         },
-        true
+        {
+          displaySuccessMessage: true, // shows a toast and scrolls to panel
+        }
       )
       .catch(() => {
         // ignore error - its an example

--- a/examples/portable_dashboards_example/public/dashboard_with_controls_example.tsx
+++ b/examples/portable_dashboards_example/public/dashboard_with_controls_example.tsx
@@ -28,7 +28,7 @@ export const DashboardWithControlsExample = ({ dataView }: { dataView: DataView 
           panelType: FILTER_DEBUGGER_EMBEDDABLE_ID,
         },
         {
-          displaySuccessMessage: true, // shows a toast and scrolls to panel
+          displaySuccessMessage: true,
         }
       )
       .catch(() => {

--- a/src/platform/packages/shared/presentation/presentation_containers/interfaces/can_add_new_panel.ts
+++ b/src/platform/packages/shared/presentation/presentation_containers/interfaces/can_add_new_panel.ts
@@ -15,7 +15,10 @@ import type { PanelPackage } from './presentation_container';
 export interface CanAddNewPanel {
   addNewPanel: <StateType extends object, ApiType extends unknown = unknown>(
     panel: PanelPackage<StateType>,
-    displaySuccessMessage?: boolean
+    options?: {
+      displaySuccessMessage?: boolean;
+      beside?: string; // ID of an existing panel to place the new panel beside
+    }
   ) => Promise<ApiType | undefined>;
 }
 

--- a/src/platform/plugins/private/links/public/plugin.ts
+++ b/src/platform/plugins/private/links/public/plugin.ts
@@ -77,7 +77,9 @@ export class LinksPlugin
                 },
               },
             },
-            true
+            {
+              displaySuccessMessage: true, // shows a toast and scrolls to panel
+            }
           );
         },
         savedObjectType: LINKS_SAVED_OBJECT_TYPE,

--- a/src/platform/plugins/private/links/public/plugin.ts
+++ b/src/platform/plugins/private/links/public/plugin.ts
@@ -78,7 +78,7 @@ export class LinksPlugin
               },
             },
             {
-              displaySuccessMessage: true, // shows a toast and scrolls to panel
+              displaySuccessMessage: true,
             }
           );
         },

--- a/src/platform/plugins/shared/controls/public/actions/create_control_action.tsx
+++ b/src/platform/plugins/shared/controls/public/actions/create_control_action.tsx
@@ -89,7 +89,7 @@ export const createDataControlOfType = <
         },
       },
       {
-        displaySuccessMessage: true, // shows a toast and scrolls to panel
+        displaySuccessMessage: true,
       }
     );
   }

--- a/src/platform/plugins/shared/controls/public/actions/create_control_action.tsx
+++ b/src/platform/plugins/shared/controls/public/actions/create_control_action.tsx
@@ -88,7 +88,9 @@ export const createDataControlOfType = <
           rawState: state,
         },
       },
-      true
+      {
+        displaySuccessMessage: true, // shows a toast and scrolls to panel
+      }
     );
   }
 };

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
@@ -154,7 +154,8 @@ export function initializeLayoutManager(
   const placeNewPanel = async (
     uuid: string,
     panelPackage: PanelPackage,
-    gridData?: DashboardPanel['gridData']
+    gridData?: DashboardPanel['gridData'],
+    beside?: string
   ): Promise<DashboardLayout> => {
     const { panelType: type, serializedState } = panelPackage;
     if (gridData) {
@@ -179,6 +180,7 @@ export function initializeLayoutManager(
         currentPanels: layout$.value.panels,
         height: panelPlacementSettings.height,
         width: panelPlacementSettings.width,
+        beside,
       }
     );
     return {
@@ -247,7 +249,10 @@ export function initializeLayoutManager(
   // --------------------------------------------------------------------------------------
   const addNewPanel = async <ApiType>(
     panelPackage: PanelPackage,
-    displaySuccessMessage?: boolean,
+    options?: {
+      displaySuccessMessage?: boolean;
+      beside?: string;
+    },
     gridData?: DashboardPanel['gridData']
   ) => {
     const { panelType: type, serializedState, maybePanelId } = panelPackage;
@@ -256,9 +261,9 @@ export function initializeLayoutManager(
 
     if (serializedState) currentChildState[uuid] = serializedState;
 
-    layout$.next(await placeNewPanel(uuid, panelPackage, gridData));
+    layout$.next(await placeNewPanel(uuid, panelPackage, gridData, options?.beside));
 
-    if (displaySuccessMessage) {
+    if (options?.displaySuccessMessage) {
       const title = (serializedState?.rawState as SerializedTitles)?.title;
       coreServices.notifications.toasts.addSuccess({
         title: getPanelAddedSuccessString(title),
@@ -291,7 +296,11 @@ export function initializeLayoutManager(
     if (!existingGridData) throw new PanelNotFoundError();
 
     removePanel(idToRemove);
-    const newPanel = await addNewPanel<DefaultEmbeddableApi>(panelPackage, false, existingGridData);
+    const newPanel = await addNewPanel<DefaultEmbeddableApi>(
+      panelPackage,
+      { displaySuccessMessage: false },
+      existingGridData
+    );
     return newPanel.uuid;
   };
 

--- a/src/platform/plugins/shared/dashboard/public/panel_placement/place_new_panel_strategies.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/panel_placement/place_new_panel_strategies.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { DashboardLayout } from '../dashboard_api/layout_manager';
 import { getMockLayout, getMockLayoutWithSections } from '../mocks';
 import { PanelPlacementStrategy } from '../plugin_constants';
 import { runPanelPlacementStrategy } from './place_new_panel_strategies';
@@ -86,6 +87,34 @@ describe('new panel placement strategies', () => {
           };
         }, {})
       );
+    });
+
+    it('place panel above another panel', () => {
+      const panels: DashboardLayout['panels'] = {
+        ...getMockLayout().panels,
+        '3': {
+          gridData: { x: 6, y: 6, w: 6, h: 6, i: '3' }, // below panel 2
+          type: 'testPanelType',
+        },
+      };
+      const { newPanelPlacement, otherPanels } = runPanelPlacementStrategy(
+        PanelPlacementStrategy.placeAtTop,
+        { width: 6, height: 6, currentPanels: panels, beside: '3' }
+      );
+      expect(newPanelPlacement).toEqual({
+        x: 6,
+        y: 6, // place below panel 2 but above panel 3
+        w: 6,
+        h: 6,
+      });
+      // panels 1 and 2 shouldn't move
+      expect(otherPanels['1'].gridData).toEqual(panels['1'].gridData);
+      expect(otherPanels['2'].gridData).toEqual(panels['2'].gridData);
+      // panel 3 should have been pushed down by the height of the new panel
+      expect(otherPanels['3'].gridData).toEqual({
+        ...panels['3'].gridData,
+        y: panels['3'].gridData.y + newPanelPlacement.h,
+      });
     });
   });
 
@@ -174,6 +203,28 @@ describe('new panel placement strategies', () => {
       expect(newPanelPlacement).toEqual({
         x: 0,
         y: 12, // maxY is 12 for section1; maxY of 100 in section 0 is ignored
+        w: 6,
+        h: 6,
+      });
+      expect(otherPanels).toEqual(panels); // other panels don't move with this strategy
+    });
+
+    it('place panel beside another panel', () => {
+      const panels: DashboardLayout['panels'] = {
+        ...getMockLayout().panels,
+        '3': {
+          gridData: { x: 6, y: 6, w: 6, h: 6, i: '3' }, // below panel 2
+          type: 'testPanelType',
+        },
+      };
+      const { newPanelPlacement, otherPanels } = runPanelPlacementStrategy(
+        PanelPlacementStrategy.findTopLeftMostOpenSpace,
+        { width: 6, height: 6, currentPanels: panels, beside: '3' }
+      );
+      // place beside panel 3
+      expect(newPanelPlacement).toEqual({
+        x: 0,
+        y: 6,
         w: 6,
         h: 6,
       });

--- a/src/platform/plugins/shared/dashboard/public/panel_placement/types.ts
+++ b/src/platform/plugins/shared/dashboard/public/panel_placement/types.ts
@@ -29,6 +29,7 @@ export interface PanelPlacementProps {
   height: number;
   currentPanels: DashboardLayout['panels'];
   sectionId?: string; // section where panel is being placed
+  beside?: string; // the ID of the panel to place the new panel relative to
 }
 
 export interface PanelResizeSettings {

--- a/src/platform/plugins/shared/discover/public/plugin.tsx
+++ b/src/platform/plugins/shared/discover/public/plugin.tsx
@@ -416,7 +416,7 @@ export class DiscoverPlugin
             },
           },
           {
-            displaySuccessMessage: true, // shows a toast and scrolls to panel
+            displaySuccessMessage: true,
           }
         );
       },

--- a/src/platform/plugins/shared/discover/public/plugin.tsx
+++ b/src/platform/plugins/shared/discover/public/plugin.tsx
@@ -415,7 +415,9 @@ export class DiscoverPlugin
               ],
             },
           },
-          true
+          {
+            displaySuccessMessage: true, // shows a toast and scrolls to panel
+          }
         );
       },
       savedObjectType: SavedSearchType,

--- a/src/platform/plugins/shared/visualizations/public/plugin.ts
+++ b/src/platform/plugins/shared/visualizations/public/plugin.ts
@@ -482,7 +482,9 @@ export class VisualizationsPlugin
               ],
             },
           },
-          true
+          {
+            displaySuccessMessage: true, // shows a toast and scrolls to panel
+          }
         );
       },
       savedObjectType: VISUALIZE_EMBEDDABLE_TYPE,

--- a/src/platform/plugins/shared/visualizations/public/plugin.ts
+++ b/src/platform/plugins/shared/visualizations/public/plugin.ts
@@ -483,7 +483,7 @@ export class VisualizationsPlugin
             },
           },
           {
-            displaySuccessMessage: true, // shows a toast and scrolls to panel
+            displaySuccessMessage: true,
           }
         );
       },

--- a/x-pack/platform/plugins/shared/embeddable_alerts_table/public/actions/add_alerts_table_action.tsx
+++ b/x-pack/platform/plugins/shared/embeddable_alerts_table/public/actions/add_alerts_table_action.tsx
@@ -59,7 +59,7 @@ export const getAddAlertsTableAction = (
                     serializedState: { rawState: { tableConfig } },
                   },
                   {
-                    displaySuccessMessage: true, // shows a toast and scrolls to panel
+                    displaySuccessMessage: true,
                   }
                 );
               }}

--- a/x-pack/platform/plugins/shared/embeddable_alerts_table/public/actions/add_alerts_table_action.tsx
+++ b/x-pack/platform/plugins/shared/embeddable_alerts_table/public/actions/add_alerts_table_action.tsx
@@ -58,7 +58,9 @@ export const getAddAlertsTableAction = (
                     panelType: EMBEDDABLE_ALERTS_TABLE_ID,
                     serializedState: { rawState: { tableConfig } },
                   },
-                  true
+                  {
+                    displaySuccessMessage: true, // shows a toast and scrolls to panel
+                  }
                 );
               }}
             />

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/use_esql_variables.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/use_esql_variables.ts
@@ -43,14 +43,19 @@ export const useESQLVariables = ({
       }
 
       // add a new control
-      parentApi.addNewPanel({
-        panelType: 'esqlControl',
-        serializedState: {
-          rawState: {
-            ...controlState,
+      parentApi.addNewPanel(
+        {
+          panelType: 'esqlControl',
+          serializedState: {
+            rawState: {
+              ...controlState,
+            },
           },
         },
-      });
+        {
+          beside: panelId,
+        }
+      );
       if (panel && updatedQuery && attributes) {
         panel.updateAttributes({
           ...attributes,

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -411,7 +411,9 @@ export class LensPlugin {
                 ],
               },
             },
-            true
+            {
+              displaySuccessMessage: true, // shows a toast and scrolls to panel
+            }
           );
         },
         savedObjectType: LENS_EMBEDDABLE_TYPE,

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -412,7 +412,7 @@ export class LensPlugin {
               },
             },
             {
-              displaySuccessMessage: true, // shows a toast and scrolls to panel
+              displaySuccessMessage: true,
             }
           );
         },

--- a/x-pack/platform/plugins/shared/maps/public/react_embeddable/setup_map_embeddable.ts
+++ b/x-pack/platform/plugins/shared/maps/public/react_embeddable/setup_map_embeddable.ts
@@ -40,7 +40,9 @@ export function setupMapEmbeddable(embeddableSetup: EmbeddableSetup) {
             ],
           },
         },
-        true
+        {
+          displaySuccessMessage: true, // shows a toast and scrolls to panel
+        }
       );
     },
     savedObjectType: MAP_SAVED_OBJECT_TYPE,

--- a/x-pack/platform/plugins/shared/maps/public/react_embeddable/setup_map_embeddable.ts
+++ b/x-pack/platform/plugins/shared/maps/public/react_embeddable/setup_map_embeddable.ts
@@ -41,7 +41,7 @@ export function setupMapEmbeddable(embeddableSetup: EmbeddableSetup) {
           },
         },
         {
-          displaySuccessMessage: true, // shows a toast and scrolls to panel
+          displaySuccessMessage: true,
         }
       );
     },

--- a/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_alerts_panel_action.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_alerts_panel_action.tsx
@@ -45,7 +45,7 @@ export function createAddAlertsPanelAction(
             serializedState: { rawState: initialState },
           },
           {
-            displaySuccessMessage: true, // shows a toast and scrolls to panel
+            displaySuccessMessage: true,
           }
         );
       } catch (e) {

--- a/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_alerts_panel_action.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_alerts_panel_action.tsx
@@ -44,7 +44,9 @@ export function createAddAlertsPanelAction(
             panelType: SLO_ALERTS_EMBEDDABLE_ID,
             serializedState: { rawState: initialState },
           },
-          true
+          {
+            displaySuccessMessage: true, // shows a toast and scrolls to panel
+          }
         );
       } catch (e) {
         return Promise.reject();

--- a/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_burn_rate_panel_action.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_burn_rate_panel_action.tsx
@@ -47,7 +47,7 @@ export function createBurnRatePanelAction(
             serializedState: { rawState: initialState },
           },
           {
-            displaySuccessMessage: true, // shows a toast and scrolls to panel
+            displaySuccessMessage: true,
           }
         );
       } catch (e) {

--- a/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_burn_rate_panel_action.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_burn_rate_panel_action.tsx
@@ -46,7 +46,9 @@ export function createBurnRatePanelAction(
             panelType: SLO_BURN_RATE_EMBEDDABLE_ID,
             serializedState: { rawState: initialState },
           },
-          true
+          {
+            displaySuccessMessage: true, // shows a toast and scrolls to panel
+          }
         );
       } catch (e) {
         return Promise.reject();

--- a/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_error_budget_action.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_error_budget_action.tsx
@@ -43,7 +43,9 @@ export function createAddErrorBudgetPanelAction(
             panelType: SLO_ERROR_BUDGET_ID,
             serializedState: { rawState: initialState },
           },
-          true
+          {
+            displaySuccessMessage: true, // shows a toast and scrolls to panel
+          }
         );
       } catch (e) {
         return Promise.reject();

--- a/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_error_budget_action.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_error_budget_action.tsx
@@ -44,7 +44,7 @@ export function createAddErrorBudgetPanelAction(
             serializedState: { rawState: initialState },
           },
           {
-            displaySuccessMessage: true, // shows a toast and scrolls to panel
+            displaySuccessMessage: true,
           }
         );
       } catch (e) {

--- a/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_overview_panel_action.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_overview_panel_action.tsx
@@ -47,7 +47,7 @@ export function createOverviewPanelAction(
             },
           },
           {
-            displaySuccessMessage: true, // shows a toast and scrolls to panel
+            displaySuccessMessage: true,
           }
         );
       } catch (e) {

--- a/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_overview_panel_action.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/ui_actions/create_overview_panel_action.tsx
@@ -46,7 +46,9 @@ export function createOverviewPanelAction(
               rawState: initialState,
             },
           },
-          true
+          {
+            displaySuccessMessage: true, // shows a toast and scrolls to panel
+          }
         );
       } catch (e) {
         return Promise.reject();


### PR DESCRIPTION
> [!WARNING]
> **_This work is being merged into a feature branch, not main!_**
> Because of this, we only need a review from @elastic/kibana-presentation for now.
>
> Type failures are expected because the feature branch is currently in an incomplete state, where the controls that have not yet been converted (range slider, etc.) are dependent on things that no longer exist.


Closes https://github.com/elastic/kibana/issues/234677

## Summary

This PR adds a `beside` argument to the `addNewPanel` function and adopts both the `placeAtTop` and `findTopLeftMostOpenSpace` panel placement strategies to respect this new argument. Note that the large file count is due to me changing the shape of the `addNewPanel` arguments - i.e. the old `displaySuccessMessage` argument is now nested under the optional `options` argument, which also includes the new `beside` attribute.

We then use this new `beside` option so that, when creating a control during the creation of an ES|QL panel, the control gets placed above the panel it is relevant to:

https://github.com/user-attachments/assets/9d39b086-0ebd-4d87-b63e-06d818e5fefa

