### PR TITLE
[Security solution] Value report CSS fixes

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.tsx
@@ -49,7 +49,19 @@ const AlertFilteringMetricComponent: React.FC<Props> = ({
           fill: ${colors.vis.euiColorVis4};
         }
         .echMetricText {
-          padding: 8px 20px 60px;
+          padding: 8px 16px 60px;
+        }
+        .echMetricText {
+          display: grid !important;
+          grid-template-columns: auto auto 1fr !important;
+          gap: 8px !important;
+          align-items: center !important;
+        }
+        .echMetricText__titlesBlock--left {
+          grid-column: 1 !important;
+        }
+        .echMetricText__icon--right {
+          grid-column: 2 !important;
         }
         .euiPanel,
         .embPanel,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing.tsx
@@ -39,14 +39,20 @@ export const AlertProcessing: React.FC<Props> = ({
   return (
     <div
       css={css`
-        padding: ${size.base};
+        padding: ${size.base} ${size.xl};
       `}
     >
-      <EuiTitle size="s">
-        <h3>{i18n.ALERT_PROCESSING_TITLE}</h3>
+      <EuiTitle size="m">
+        <h2>{i18n.ALERT_PROCESSING_TITLE}</h2>
       </EuiTitle>
       <EuiSpacer size="l" />
-      <EuiFlexGroup gutterSize="s">
+      <EuiFlexGroup
+        gutterSize="xl"
+        data-test-subj="alertProcessingGroup"
+        css={css`
+          gap: 48px;
+        `}
+      >
         <EuiFlexItem
           grow={false}
           css={css`

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/compare_percentage_badge.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/compare_percentage_badge.tsx
@@ -85,7 +85,7 @@ export const ComparePercentageBadge = ({
         z-index: 9999;
         position: relative;
         // positioning hack for Lens Metric
-        top: ${positionForLens ? '-35px' : 'initial'};
+        top: ${positionForLens ? '-40px' : 'initial'};
         left: ${positionForLens ? '20px' : 'initial'};
       `}
     >

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/compare_percentage_badge.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/compare_percentage_badge.tsx
@@ -85,7 +85,7 @@ export const ComparePercentageBadge = ({
         z-index: 9999;
         position: relative;
         // positioning hack for Lens Metric
-        top: ${positionForLens ? '-55px' : 'initial'};
+        top: ${positionForLens ? '-35px' : 'initial'};
         left: ${positionForLens ? '20px' : 'initial'};
       `}
     >

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_metric.tsx
@@ -72,10 +72,12 @@ const CostSavingsMetricComponent: React.FC<Props> = ({
           fill: ${colors.success};
         }
         .echMetricText {
-          padding: 8px 20px 60px;
+          padding: 8px 16px 60px;
         }
         p.echMetricText__value {
           color: ${colors.success};
+          font-size: 48px !important;
+          padding: 10px 0;
         }
         .euiPanel,
         .embPanel__hoverActions > span {

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.tsx
@@ -75,7 +75,7 @@ const CostSavingsTrendComponent: React.FC<Props> = ({
   return (
     <div
       css={css`
-        padding: ${size.base};
+        padding: ${size.base} ${size.xl};
         .euiPanel,
         .embPanel,
         .echMetric,
@@ -86,8 +86,8 @@ const CostSavingsTrendComponent: React.FC<Props> = ({
       `}
       data-test-subj="cost-savings-trend-panel"
     >
-      <EuiTitle size="s">
-        <h3>{i18n.COST_SAVINGS_TREND}</h3>
+      <EuiTitle size="m">
+        <h2>{i18n.COST_SAVINGS_TREND}</h2>
       </EuiTitle>
       <EuiSpacer size="l" />
       <EuiFlexGroup gutterSize="s">
@@ -110,7 +110,7 @@ const CostSavingsTrendComponent: React.FC<Props> = ({
         </EuiFlexItem>
         <EuiFlexItem
           css={css`
-            max-width: ${isSmall ? 'auto' : '300px'};
+            max-width: ${isSmall ? 'auto' : '600px'};
           `}
         >
           <CostSavingsKeyInsight isLoading={isLoading} lensResponse={lensResponse} />

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.tsx
@@ -90,7 +90,12 @@ const CostSavingsTrendComponent: React.FC<Props> = ({
         <h2>{i18n.COST_SAVINGS_TREND}</h2>
       </EuiTitle>
       <EuiSpacer size="l" />
-      <EuiFlexGroup gutterSize="s">
+      <EuiFlexGroup
+        gutterSize="xl"
+        css={css`
+          gap: 48px;
+        `}
+      >
         <EuiFlexItem>
           <VisualizationEmbeddable
             data-test-subj="embeddable-area-chart"

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/executive_summary.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/executive_summary.tsx
@@ -98,7 +98,7 @@ export const ExecutiveSummary: React.FC<Props> = ({
       data-test-subj="executiveSummaryContainer"
       css={css`
         border-radius: ${size.s};
-        padding: ${size.base};
+        padding: ${size.base} ${size.xl};
         min-height: 200px;
       `}
     >

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/index.tsx
@@ -60,6 +60,7 @@ export const AIValueMetrics: React.FC<Props> = ({ setHasAttackDiscoveries, from,
         background: ${colors.backgroundBaseSubdued};
         width: 100%;
         min-height: 100%;
+        border-radius: 8px;
       `}
     >
       <ExecutiveSummary
@@ -73,7 +74,13 @@ export const AIValueMetrics: React.FC<Props> = ({ setHasAttackDiscoveries, from,
         valueMetrics={valueMetrics}
         valueMetricsCompare={valueMetricsCompare}
       />
-      <EuiHorizontalRule />
+      <div
+        css={css`
+          padding: 0 16px;
+        `}
+      >
+        <EuiHorizontalRule />
+      </div>
       {(isLoading || hasAttackDiscoveries) && (
         <>
           <AlertProcessing
@@ -83,7 +90,13 @@ export const AIValueMetrics: React.FC<Props> = ({ setHasAttackDiscoveries, from,
             from={from}
             to={to}
           />
-          <EuiHorizontalRule />
+          <div
+            css={css`
+              padding: 0 16px;
+            `}
+          >
+            <EuiHorizontalRule />
+          </div>
         </>
       )}
       {(isLoading || hasAttackDiscoveries) && (
@@ -95,7 +108,13 @@ export const AIValueMetrics: React.FC<Props> = ({ setHasAttackDiscoveries, from,
             to={to}
             isLoading={isLoading}
           />
-          <EuiHorizontalRule />
+          <div
+            css={css`
+              padding: 0 16px;
+            `}
+          >
+            <EuiHorizontalRule />
+          </div>
         </>
       )}
       <ValueReportSettings

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/threats_detected_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/threats_detected_metric.tsx
@@ -37,7 +37,19 @@ const ThreatsDetectedMetricComponent: React.FC<Props> = ({ from, to }) => {
           fill: ${colors.vis.euiColorVis6};
         }
         .echMetricText {
-          padding: 8px 20px 60px;
+          padding: 8px 16px 60px;
+        }
+        .echMetricText {
+          display: grid !important;
+          grid-template-columns: auto auto 1fr !important;
+          gap: 8px !important;
+          align-items: center !important;
+        }
+        .echMetricText__titlesBlock--left {
+          grid-column: 1 !important;
+        }
+        .echMetricText__icon--right {
+          grid-column: 2 !important;
         }
         .euiPanel,
         .embPanel,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.tsx
@@ -50,7 +50,19 @@ const TimeSavedMetricComponent: React.FC<Props> = ({ from, to, minutesPerAlert }
           fill: ${colors.vis.euiColorVis2};
         }
         .echMetricText {
-          padding: 8px 20px 60px;
+          padding: 8px 16px 60px;
+        }
+        .echMetricText {
+          display: grid !important;
+          grid-template-columns: auto auto 1fr !important;
+          gap: 8px !important;
+          align-items: center !important;
+        }
+        .echMetricText__titlesBlock--left {
+          grid-column: 1 !important;
+        }
+        .echMetricText__icon--right {
+          grid-column: 2 !important;
         }
         .euiPanel,
         .embPanel,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/value_report_settings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/value_report_settings.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback } from 'react';
 
-import { EuiText, EuiLink, EuiIcon, useEuiTheme } from '@elastic/eui';
+import { EuiText, EuiLink, EuiIcon, useEuiTheme, EuiTitle, EuiSpacer } from '@elastic/eui';
 import { useNavigation } from '@kbn/security-solution-navigation';
 import { css } from '@emotion/react';
 import * as i18n from './translations';
@@ -27,14 +27,17 @@ const ValueReportSettingsComponent: React.FC<Props> = ({ minutesPerAlert, analys
     [navigateTo]
   );
   return (
-    <EuiText
-      size="xs"
+    <div
       css={css`
-        padding: ${size.base};
+        padding: ${size.base} ${size.xl};
       `}
+      className="valueReportSettings"
     >
-      <span className="valueReportSettings">
-        <h3>{i18n.COST_CALCULATIONS}</h3>
+      <EuiTitle size="m">
+        <h2>{i18n.COST_CALCULATIONS}</h2>
+      </EuiTitle>
+      <EuiSpacer size="l" />
+      <EuiText size="xs">
         <p>
           {i18n.COST_CALCULATION({ minutesPerAlert, analystHourlyRate })}{' '}
           <EuiLink onClick={goToKibanaSettings}>
@@ -48,9 +51,9 @@ const ValueReportSettingsComponent: React.FC<Props> = ({ minutesPerAlert, analys
             />
           </EuiLink>
         </p>
-      </span>
-      <p>{i18n.LEGAL_DISCLAIMER}</p>
-    </EuiText>
+        <p>{i18n.LEGAL_DISCLAIMER}</p>
+      </EuiText>
+    </div>
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/pages/ai_value.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/pages/ai_value.tsx
@@ -8,6 +8,7 @@ import React, { useState, useRef } from 'react';
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import type { DocLinks } from '@kbn/doc-links';
 import { pick } from 'lodash/fp';
+import { css } from '@emotion/css';
 import { useSyncTimerangeUrlParam } from '../../common/hooks/search_bar/use_sync_timerange_url_param';
 import { ValueReportExporter } from '../components/ai_value/value_report_exporter';
 import { EXPORT_REPORT } from '../components/ai_value/translations';
@@ -76,7 +77,13 @@ const AIValueComponent = () => {
   }
 
   return (
-    <SecuritySolutionPageWrapper data-test-subj="aiValuePage">
+    <SecuritySolutionPageWrapper
+      data-test-subj="aiValuePage"
+      className={css`
+        max-width: 1440px;
+        margin: 0 auto;
+      `}
+    >
       <HeaderPage
         title={i18n.AI_VALUE_DASHBOARD}
         rightSideItems={[


### PR DESCRIPTION
## Summary

Addresses various CSS concerns with the value report documented here: https://docs.google.com/document/d/1ZltO5LrCv1SYvSdfkI_oB_yu2xituIKXMhxQCU5HXFA/edit?tab=t.0

### Before
<img width="2142" height="3978" alt="before" src="https://github.com/user-attachments/assets/7be65fe9-dd60-4654-bcd3-dd3948beacf3" />

### After
<img width="2142" height="3752" alt="after2" src="https://github.com/user-attachments/assets/e713ada4-9e70-44ba-bffa-44d17df4c27c" />