### PR TITLE
[8.19] [Ingest Pipelines] Fix handling special symbols from navigation (#233651)

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/__jest__/client_integration/ingest_pipelines_clone.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/__jest__/client_integration/ingest_pipelines_clone.test.tsx
@@ -9,10 +9,13 @@ import { act } from 'react-dom/test-utils';
 
 import { setupEnvironment, pageHelpers } from './helpers';
 import { API_BASE_PATH } from '../../common/constants';
-import { PIPELINE_TO_CLONE, PipelinesCloneTestBed } from './helpers/pipelines_clone.helpers';
+import type { PipelinesCloneTestBed } from './helpers/pipelines_clone.helpers';
+import { PIPELINE_TO_CLONE } from './helpers/pipelines_clone.helpers';
+import { getClonePath } from '../../public/application/services/navigation';
 
 const { setup } = pageHelpers.pipelinesClone;
 
+const originalLocation = window.location;
 describe('<PipelinesClone />', () => {
   let testBed: PipelinesCloneTestBed;
 
@@ -21,11 +24,26 @@ describe('<PipelinesClone />', () => {
   beforeEach(async () => {
     httpRequestsMockHelpers.setLoadPipelineResponse(PIPELINE_TO_CLONE.name, PIPELINE_TO_CLONE);
 
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        pathname: getClonePath({ clonedPipelineName: PIPELINE_TO_CLONE.name }),
+      },
+    });
+
     await act(async () => {
       testBed = await setup(httpSetup);
     });
 
     testBed.component.update();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
   });
 
   test('should render the correct page header', () => {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/__jest__/client_integration/ingest_pipelines_edit.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/__jest__/client_integration/ingest_pipelines_edit.test.tsx
@@ -10,9 +10,12 @@ import { act } from 'react-dom/test-utils';
 
 import { setupEnvironment, pageHelpers } from './helpers';
 import { API_BASE_PATH } from '../../common/constants';
-import { PIPELINE_TO_EDIT, PipelinesEditTestBed } from './helpers/pipelines_edit.helpers';
+import type { PipelinesEditTestBed } from './helpers/pipelines_edit.helpers';
+import { PIPELINE_TO_EDIT } from './helpers/pipelines_edit.helpers';
+import { getClonePath } from '../../public/application/services/navigation';
 
 const { setup } = pageHelpers.pipelinesEdit;
+const originalLocation = window.location;
 
 describe('<PipelinesEdit />', () => {
   let testBed: PipelinesEditTestBed;
@@ -22,11 +25,26 @@ describe('<PipelinesEdit />', () => {
   beforeEach(async () => {
     httpRequestsMockHelpers.setLoadPipelineResponse(PIPELINE_TO_EDIT.name, PIPELINE_TO_EDIT);
 
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        pathname: getClonePath({ clonedPipelineName: PIPELINE_TO_EDIT.name }),
+      },
+    });
+
     await act(async () => {
       testBed = await setup(httpSetup);
     });
 
     testBed.component.update();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
   });
 
   test('should render the correct page header', () => {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/lib/normalize_pipeline_name_from_params.test.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/lib/normalize_pipeline_name_from_params.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { normalizePipelineNameFromParams } from './normalize_pipeline_name_from_params';
+
+describe('normalizePipelineNameFromParams', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        pathname: '/app/ingest_pipelines/edit/my-pipeline',
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+
+    jest.clearAllMocks();
+  });
+
+  describe('when pathname ends with unencoded route param', () => {
+    it('should return route param unchanged', () => {
+      const name = 'my-pipeline';
+      window.location.pathname = `app/ingest_pipelines/edit/${name}`;
+
+      const result = normalizePipelineNameFromParams(name);
+
+      expect(result).toBe(name);
+    });
+  });
+
+  describe('when pathname ends with URL-encoded route param', () => {
+    it('should decode URL-encoded route param', () => {
+      const name = encodeURIComponent('my-pipeline');
+      window.location.pathname = `/app/ingest_pipelines/edit/${name}`;
+
+      const result = normalizePipelineNameFromParams(name);
+
+      expect(result).toBe('my-pipeline');
+    });
+  });
+
+  describe('when pathname ends with route param containing special characters', () => {
+    it('should handle special characters in route param', () => {
+      const name = encodeURIComponent('my-pipeline+test');
+      window.location.pathname = `/app/ingest_pipelines/edit/${name}`;
+
+      const result = normalizePipelineNameFromParams(name);
+
+      expect(result).toBe('my-pipeline+test');
+    });
+  });
+
+  describe('when pathname does not end with the route param', () => {
+    it('should extract and decode the last segment of the pathname', () => {
+      // simulating history v4 bug with space instead of +
+      // for context, see https://github.com/elastic/kibana/issues/234500
+      const name = encodeURI('my>pipeline+test');
+      window.location.pathname = `/app/ingest_pipelines/edit/${encodeURIComponent(
+        'my>pipeline+test'
+      )}`;
+
+      const result = normalizePipelineNameFromParams(name);
+
+      expect(result).toBe('my>pipeline+test');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/lib/normalize_pipeline_name_from_params.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/lib/normalize_pipeline_name_from_params.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { attemptToURIDecode } from '../../shared_imports';
+
+export const normalizePipelineNameFromParams = (nameFromRouterParams: string) => {
+  if (window.location.pathname.endsWith(nameFromRouterParams)) {
+    return attemptToURIDecode(nameFromRouterParams);
+  }
+
+  // this is a temporary workaround because history v4
+  // decodes pathname special characters incorrectly
+  // see https://github.com/elastic/kibana/issues/234500
+  return attemptToURIDecode(window.location.pathname.split('/').pop());
+};

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_clone/pipelines_clone.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_clone/pipelines_clone.test.tsx
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { ComponentProps } from 'react';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Route, Router, Routes } from '@kbn/shared-ux-router';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { DeepPartial } from '@kbn/utility-types';
+
+import type { PipelinesCreate } from '../pipelines_create';
+import { PipelinesClone } from './pipelines_clone';
+import type { useKibana } from '../../../shared_imports';
+import { createMemoryHistory } from 'history';
+
+const mockUseKibana = jest.fn();
+
+jest.mock('../../../shared_imports', () => ({
+  ...jest.requireActual('../../../shared_imports'),
+  useKibana: () => mockUseKibana(),
+}));
+
+jest.mock('../pipelines_create', () => ({
+  ...jest.requireActual('../pipelines_create'),
+  PipelinesCreate: (props: ComponentProps<typeof PipelinesCreate>) => (
+    <div data-test-subj="pipelinesCreate">
+      <h1>PIPELINES_CREATE</h1>
+      <div data-test-subj="sourcePipelineName">
+        {props.sourcePipeline ? props.sourcePipeline.name : 'no-source'}
+      </div>
+    </div>
+  ),
+}));
+
+type MockServices = ReturnType<typeof useKibana>['services'];
+type DeepPartialMockServices = DeepPartial<MockServices>;
+
+const createMockServices = (overrides: DeepPartialMockServices = {}): DeepPartialMockServices => ({
+  api: {
+    useLoadPipeline: jest.fn(),
+  },
+  notifications: {
+    toasts: {
+      addError: jest.fn(),
+    },
+  },
+  ...overrides,
+});
+
+const createServicesWithLoad = (
+  loadReturn: Partial<ReturnType<MockServices['api']['useLoadPipeline']>>,
+  overrides: DeepPartialMockServices = {}
+) => {
+  return createMockServices({
+    ...overrides,
+    api: {
+      useLoadPipeline: jest.fn().mockReturnValue({
+        resendRequest: jest.fn(),
+        error: null,
+        data: undefined,
+        isLoading: false,
+        isInitialRequest: false,
+        ...loadReturn,
+      }),
+    },
+  });
+};
+
+const originalLocation = window.location;
+
+const renderWithRoute = (initialRouteEntry: string, services: DeepPartialMockServices) => {
+  // window location is being used in normalizePipelineNameFromParams
+  // but it's not set when rendering via MemoryRouter
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      ...originalLocation,
+      pathname: initialRouteEntry,
+    },
+  });
+
+  mockUseKibana.mockReturnValue({ services });
+  return render(
+    <I18nProvider>
+      <Router history={createMemoryHistory({ initialEntries: [initialRouteEntry] })}>
+        <Routes>
+          <Route exact path={'/create/:sourceName'} component={PipelinesClone} />
+        </Routes>
+      </Router>
+    </I18nProvider>
+  );
+};
+
+describe('PipelinesClone section', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  describe('WHEN mounting the PipelinesClone route', () => {
+    describe('AND the initial request is in flight', () => {
+      it('SHOULD show SectionLoading', () => {
+        const services = createServicesWithLoad({
+          isLoading: true,
+          isInitialRequest: true,
+        });
+
+        renderWithRoute('/create/source-name', services);
+
+        expect(screen.getByTestId('sectionLoading')).toBeInTheDocument();
+      });
+    });
+
+    describe('AND the load pipeline fails after request', () => {
+      it('SHOULD show toast error and still render create form', () => {
+        const mockAddError = jest.fn();
+        const services = createServicesWithLoad(
+          {
+            error: {
+              statusCode: 404,
+              message: 'Not Found',
+              error: 'Not Found',
+            },
+          },
+          { notifications: { toasts: { addError: mockAddError } } }
+        );
+
+        renderWithRoute('/create/source-404', services);
+
+        expect(screen.getByTestId('pipelinesCreate')).toBeInTheDocument();
+        expect(mockAddError).toHaveBeenCalled();
+      });
+    });
+
+    describe('AND the load returns no data and no error after request', () => {
+      it('SHOULD render create form without calling toasts', () => {
+        const mockAddError = jest.fn();
+        const services = createServicesWithLoad(
+          {},
+          { notifications: { toasts: { addError: mockAddError } } }
+        );
+
+        renderWithRoute('/create/source-missing', services);
+
+        expect(screen.getByTestId('pipelinesCreate')).toBeInTheDocument();
+        expect(mockAddError).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('AND the load returns a pipeline', () => {
+      it('SHOULD pass loaded pipeline to PipelinesCreate with "-copy" suffix', () => {
+        const pipeline = {
+          id: 'p1',
+          name: 'orig-pipeline',
+          description: '',
+          processors: [],
+          on_failure: [],
+        };
+        const services = createServicesWithLoad({
+          data: pipeline,
+        });
+
+        renderWithRoute('/create/orig-pipeline', services);
+
+        expect(screen.getByTestId('pipelinesCreate')).toBeInTheDocument();
+        expect(screen.getByTestId('sourcePipelineName').textContent).toBe('orig-pipeline-copy');
+      });
+    });
+
+    describe('AND pipeline name contains special characters', () => {
+      it('SHOULD properly decode the name', () => {
+        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {}); // to suppress history v4 warning
+        // we omit . and * characters which are handled on input validation level
+        // see https://github.com/elastic/kibana/pull/174830
+        const pipelineName = 'my-p!@#$%^&()_+|}{":?><./;\'[]\\=-`~ipeline';
+        // single encoding assumes that it's a reloaded page or opened in a new tab
+        // from a previously transitioned double encoded URL
+        // See https://github.com/elastic/kibana/issues/234500
+        const initialRoute = '/create/' + encodeURIComponent(pipelineName);
+        const pipeline = {
+          id: 'p1',
+          name: pipelineName,
+          description: '',
+          processors: [],
+          on_failure: [],
+        };
+        const services = createServicesWithLoad({ data: pipeline });
+
+        renderWithRoute(initialRoute, services);
+
+        const useLoadPipelineMock = services.api?.useLoadPipeline as jest.Mock;
+
+        const firstCallArg = useLoadPipelineMock.mock.calls[0][0];
+
+        expect(firstCallArg).not.toBe(decodeURI(encodeURIComponent(pipelineName)));
+        expect(firstCallArg).toBe(pipelineName);
+
+        consoleWarn.mockRestore();
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_clone/pipelines_clone.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_clone/pipelines_clone.tsx
@@ -10,8 +10,9 @@ import { RouteComponentProps } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { SectionLoading, useKibana, attemptToURIDecode } from '../../../shared_imports';
+import { SectionLoading, useKibana } from '../../../shared_imports';
 
+import { normalizePipelineNameFromParams } from '../../lib/normalize_pipeline_name_from_params';
 import { PipelinesCreate } from '../pipelines_create';
 import { getErrorText } from '../utils';
 
@@ -27,7 +28,7 @@ export const PipelinesClone: FunctionComponent<RouteComponentProps<ParamProps>> 
   const { sourceName } = props.match.params;
   const { services } = useKibana();
 
-  const decodedSourceName = attemptToURIDecode(sourceName)!;
+  const decodedSourceName = normalizePipelineNameFromParams(sourceName) ?? '';
   const {
     error,
     data: pipeline,

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_create/pipelines_create.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_create/pipelines_create.test.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Route, Router, Routes } from '@kbn/shared-ux-router';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { DeepPartial } from '@kbn/utility-types';
+
+import { PipelinesCreate } from './pipelines_create';
+import type { useKibana } from '../../../shared_imports';
+
+const mockUseKibana = jest.fn();
+
+type MockServices = ReturnType<typeof useKibana>['services'];
+type DeepPartialMockServices = DeepPartial<MockServices>;
+
+const createMockServices = (overrides: DeepPartialMockServices = {}): DeepPartialMockServices => ({
+  api: {
+    createPipeline: jest.fn(),
+  },
+  breadcrumbs: {
+    setBreadcrumbs: jest.fn(),
+  },
+  documentation: {
+    getCreatePipelineUrl: jest.fn().mockReturnValue('http://docs'),
+  },
+  consolePlugin: undefined,
+  ...overrides,
+});
+
+jest.mock('../../../shared_imports', () => ({
+  ...jest.requireActual('../../../shared_imports'),
+  useKibana: () => mockUseKibana(),
+}));
+
+// Mock the PipelineForm to easily assert props passed from PipelinesCreate
+jest.mock('../../components', () => ({
+  PipelineForm: (props: { defaultValue?: { name: string }; canEditName: boolean }) => (
+    <div data-test-subj="pipelineForm">
+      <div data-test-subj="formDefaultValue">
+        {props.defaultValue ? props.defaultValue.name : 'no-default'}
+      </div>
+      <div data-test-subj="canEditName">{String(props.canEditName)}</div>
+    </div>
+  ),
+}));
+
+const renderWithPath = (path: string, services: DeepPartialMockServices) => {
+  mockUseKibana.mockReturnValue({ services });
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return render(
+    <I18nProvider>
+      <Router history={history}>
+        <Routes>
+          <Route exact path={'/create'} component={PipelinesCreate} />
+        </Routes>
+      </Router>
+    </I18nProvider>
+  );
+};
+
+describe('PipelinesCreate section', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('WHEN mounting the PipelinesCreate route', () => {
+    describe('AND no name param is provided', () => {
+      it('SHOULD render the form and allow editing the name', () => {
+        const services = createMockServices();
+
+        renderWithPath('/create', services);
+
+        expect(screen.getByTestId('pipelineForm')).toBeInTheDocument();
+        expect(screen.getByTestId('formDefaultValue').textContent).toBe('no-default');
+        expect(screen.getByTestId('canEditName').textContent).toBe('true');
+      });
+    });
+
+    describe('AND the URL contains a name query param', () => {
+      it('SHOULD prepopulate the form defaultValue.name and disallow editing the name', () => {
+        const services = createMockServices();
+
+        renderWithPath('/create?name=my-pipeline', services);
+
+        expect(screen.getByTestId('pipelineForm')).toBeInTheDocument();
+        expect(screen.getByTestId('formDefaultValue').textContent).toBe('my-pipeline');
+        expect(screen.getByTestId('canEditName').textContent).toBe('false');
+      });
+    });
+
+    describe('AND pipeline name contains special characters', () => {
+      it('SHOULD correctly decode the name and pass it to the form', () => {
+        const services = createMockServices();
+        // we omit . and * characters which are handled on input validation level
+        // see https://github.com/elastic/kibana/pull/174830
+        const pipelineName = 'my-p!@#$%^&()_+|}{":?><./;\'[]\\=-`~ipeline';
+        const encodedPipelineName = encodeURIComponent(pipelineName);
+
+        // route param with special symbols will be encoded; so we provide encoded form in path
+        renderWithPath(`/create?name=${encodedPipelineName}`, services);
+
+        expect(screen.getByTestId('pipelineForm')).toBeInTheDocument();
+        expect(screen.getByTestId('formDefaultValue').textContent).toBe(pipelineName);
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_create/pipelines_create.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_create/pipelines_create.tsx
@@ -31,6 +31,12 @@ function useFormDefaultValue(sourcePipeline?: Pipeline) {
   const history = useHistory<LocationState>();
 
   const locationSearchParams = useMemo(() => {
+    // Note:
+    // No need to decode the search params as URLSearchParams
+    // does that automatically upon reading them
+    //
+    // For the context on why this note exists
+    // see: https://github.com/elastic/kibana/issues/234500
     return new URLSearchParams(history.location.search);
   }, [history.location.search]);
 

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_edit/pipelines_edit.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_edit/pipelines_edit.test.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Route, Router, Routes } from '@kbn/shared-ux-router';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { DeepPartial } from '@kbn/utility-types';
+
+import { PipelinesEdit } from './pipelines_edit';
+import type { useKibana } from '../../../shared_imports';
+import { createMemoryHistory } from 'history';
+
+const mockUseKibana = jest.fn();
+
+type MockServices = ReturnType<typeof useKibana>['services'];
+type DeepPartialMockServices = DeepPartial<MockServices>;
+
+const createMockServices = (overrides: DeepPartialMockServices = {}): DeepPartialMockServices => ({
+  api: {
+    useLoadPipeline: jest.fn(),
+    updatePipeline: jest.fn(),
+  },
+  breadcrumbs: {
+    setBreadcrumbs: jest.fn(),
+  },
+  documentation: {
+    getCreatePipelineUrl: jest.fn().mockReturnValue('http://docs'),
+  },
+  consolePlugin: undefined,
+  ...overrides,
+});
+
+const createServicesWithLoadPipeline = (
+  loadReturn: Partial<ReturnType<MockServices['api']['useLoadPipeline']>>,
+  overrides: DeepPartialMockServices = {}
+) => {
+  return createMockServices({
+    ...overrides,
+    api: {
+      useLoadPipeline: jest.fn().mockReturnValue({
+        error: null,
+        data: undefined,
+        isLoading: false,
+        resendRequest: jest.fn(),
+        ...loadReturn,
+      }),
+      updatePipeline: jest.fn(),
+    },
+  });
+};
+
+jest.mock('../../../shared_imports', () => ({
+  ...jest.requireActual('../../../shared_imports'),
+  useKibana: () => mockUseKibana(),
+  SectionLoading: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="sectionLoading">{children}</div>
+  ),
+}));
+
+jest.mock('../../components', () => ({
+  PipelineForm: (props: { defaultValue?: { name: string }; isEditing: boolean }) => (
+    <div data-test-subj="pipelineForm">
+      <div data-test-subj="formDefaultValue">
+        {props.defaultValue ? props.defaultValue.name : 'no-default'}
+      </div>
+      <div data-test-subj="isEditing">{String(props.isEditing)}</div>
+    </div>
+  ),
+}));
+
+const renderWithRoute = (initialRouteEntry: string, services: DeepPartialMockServices) => {
+  // window location is being used in normalizePipelineNameFromParams
+  // but it's not set when rendering via MemoryRouter
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      ...originalLocation,
+      pathname: initialRouteEntry,
+    },
+  });
+
+  mockUseKibana.mockReturnValue({ services });
+  const history = createMemoryHistory({ initialEntries: [initialRouteEntry] });
+  return render(
+    <I18nProvider>
+      <Router history={history}>
+        <Routes>
+          <Route exact path={'/edit/:name'} component={PipelinesEdit} />
+        </Routes>
+      </Router>
+    </I18nProvider>
+  );
+};
+
+const originalLocation = window.location;
+
+describe('PipelinesEdit section', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  describe('WHEN mounting the PipelinesEdit route', () => {
+    describe('AND the initial request is in flight', () => {
+      it('SHOULD show SectionLoading', () => {
+        const services = createServicesWithLoadPipeline({
+          isLoading: true,
+        });
+
+        renderWithRoute('/edit/source-name', services);
+
+        expect(screen.getByTestId('sectionLoading')).toBeInTheDocument();
+      });
+    });
+
+    describe('AND the load returns an error', () => {
+      it('SHOULD render the error prompt containing decoded pipeline name', () => {
+        const decoded = 'decoded-pipeline+';
+        const services = createServicesWithLoadPipeline({
+          error: {
+            message: 'not found',
+            statusCode: 404,
+            error: 'Not Found',
+          },
+        });
+
+        // route param will be encoded; provide encoded form in path
+        const encoded = encodeURIComponent(decoded);
+        renderWithRoute(`/edit/${encoded}`, services);
+
+        // The component renders an EmptyPrompt with text "Unable to load ''{name}''"
+        expect(screen.getByText(new RegExp(`Unable to load.*${decoded}`))).toBeInTheDocument();
+      });
+    });
+
+    describe('AND the load returns a pipeline', () => {
+      it('SHOULD pass loaded pipeline to PipelineForm and set isEditing=true', () => {
+        const pipeline = {
+          id: 'p1',
+          name: 'orig-pipeline',
+          description: '',
+          processors: [],
+          on_failure: [],
+        };
+        const services = createServicesWithLoadPipeline({
+          data: pipeline,
+        });
+
+        renderWithRoute('/edit/orig-pipeline', services);
+
+        expect(screen.getByTestId('pipelineForm')).toBeInTheDocument();
+        expect(screen.getByTestId('formDefaultValue').textContent).toBe('orig-pipeline');
+        expect(screen.getByTestId('isEditing').textContent).toBe('true');
+      });
+    });
+
+    describe('AND pipeline name contains special characters', () => {
+      it('SHOULD properly decode the name', () => {
+        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {}); // to suppress history v4 warning
+        // we omit . and * characters which are handled on input validation level
+        // see https://github.com/elastic/kibana/pull/174830
+        const pipelineName = 'my-p!@#$%^&()_+|}{":?><./;\'[]\\=-`~ipeline';
+        // single encoding assumes that it's a reloaded page or opened in a new tab
+        // from a previously transitioned double encoded URL
+        // See https://github.com/elastic/kibana/issues/234500
+        const initialRoute = '/edit/' + encodeURIComponent(pipelineName);
+        const pipeline = {
+          id: 'p1',
+          name: pipelineName,
+          description: '',
+          processors: [],
+          on_failure: [],
+        };
+        const services = createServicesWithLoadPipeline({ data: pipeline });
+
+        renderWithRoute(initialRoute, services);
+
+        const useLoadPipelineMock = services.api?.useLoadPipeline as jest.Mock;
+
+        const firstCallArg = useLoadPipelineMock.mock.calls[0][0];
+
+        expect(firstCallArg).not.toBe(decodeURI(encodeURIComponent(pipelineName)));
+        expect(firstCallArg).toBe(pipelineName);
+        consoleWarn.mockRestore();
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_edit/pipelines_edit.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_edit/pipelines_edit.tsx
@@ -17,13 +17,14 @@ import {
   EuiPageTemplate,
 } from '@elastic/eui';
 
-import { Pipeline } from '../../../../common/types';
-import { useKibana, SectionLoading, attemptToURIDecode } from '../../../shared_imports';
+import type { Pipeline } from '../../../../common/types';
+import { useKibana, SectionLoading } from '../../../shared_imports';
 
 import { getListPath } from '../../services/navigation';
 import { PipelineForm } from '../../components';
 import { useRedirectToPathOrRedirectPath } from '../../hooks';
 import { getErrorText } from '../utils';
+import { normalizePipelineNameFromParams } from '../../lib/normalize_pipeline_name_from_params';
 
 interface MatchParams {
   name: string;
@@ -79,7 +80,7 @@ export const PipelinesEdit: React.FunctionComponent<RouteComponentProps<MatchPar
   const [saveError, setSaveError] = useState<any>(null);
   const redirectToPathOrRedirectPath = useRedirectToPathOrRedirectPath(history);
 
-  const decodedPipelineName = attemptToURIDecode(name)!;
+  const decodedPipelineName = normalizePipelineNameFromParams(name) ?? '';
 
   const {
     error,

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/main.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/main.test.tsx
@@ -1,0 +1,368 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComponentProps } from 'react';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Route, Router, Routes } from '@kbn/shared-ux-router';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { DeepPartial } from '@kbn/utility-types';
+
+import { PipelinesList } from './main';
+import type { PipelineTable } from './table';
+import type { SectionLoading, useKibana } from '../../../shared_imports';
+
+const mockUseKibana = jest.fn();
+const mockUseCheckManageProcessorsPrivileges = jest.fn();
+
+type MockServices = ReturnType<typeof useKibana>['services'];
+type DeepPartialMockServices = DeepPartial<MockServices>;
+
+const createMockServices = (overrides: DeepPartialMockServices = {}): DeepPartialMockServices => ({
+  api: {
+    useLoadPipelines: jest.fn(),
+    useLoadPipeline: jest.fn(),
+  },
+  metric: {
+    trackUiMetric: jest.fn(),
+  },
+  breadcrumbs: {
+    setBreadcrumbs: jest.fn(),
+  },
+  config: {
+    enableManageProcessors: false,
+  },
+  documentation: {
+    getIngestNodeUrl: jest.fn().mockReturnValue('http://docs'),
+  },
+  consolePlugin: undefined,
+  ...overrides,
+});
+
+const createServicesWithLoadPipelines = (
+  loadReturn: Partial<ReturnType<MockServices['api']['useLoadPipelines']>>,
+  overrides: DeepPartialMockServices = {}
+) => {
+  return createMockServices({
+    ...overrides,
+    api: {
+      useLoadPipelines: jest.fn().mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: null,
+        resendRequest: jest.fn(),
+        ...loadReturn,
+      }),
+      useLoadPipeline: jest.fn(),
+    },
+  });
+};
+
+jest.mock('../../../shared_imports', () => ({
+  ...jest.requireActual('../../../shared_imports'),
+  useKibana: () => mockUseKibana(),
+  SectionLoading: ({ children }: ComponentProps<typeof SectionLoading>) => (
+    <div data-test-subj="sectionLoading">{children}</div>
+  ),
+}));
+
+jest.mock('../manage_processors', () => ({
+  ...jest.requireActual('../manage_processors'),
+  useCheckManageProcessorsPrivileges: () => mockUseCheckManageProcessorsPrivileges(),
+}));
+
+jest.mock('./empty_list', () => ({
+  ...jest.requireActual('./empty_list'),
+  EmptyList: () => <div data-test-subj="emptyList">EMPTY_LIST</div>,
+}));
+
+const editName = 'p!@# name';
+const cloneName = 'clone$%^name';
+const unknownCreateName = 'create&*()name';
+
+jest.mock('./table', () => ({
+  ...jest.requireActual('./table'),
+  PipelineTable: (props: ComponentProps<typeof PipelineTable>) => (
+    <div data-test-subj="pipelineTable">
+      PIPELINE_TABLE
+      <button
+        data-test-subj="openFlyout"
+        onClick={() => {
+          props.openFlyout('from-table');
+        }}
+      >
+        openFlyout
+      </button>
+      <button
+        data-test-subj="editPipeline"
+        onClick={() => {
+          props.onEditPipelineClick(editName);
+        }}
+      >
+        edit
+      </button>
+      <button
+        data-test-subj="clonePipeline"
+        onClick={() => {
+          props.onClonePipelineClick(cloneName);
+        }}
+      >
+        clone
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('./delete_modal', () => ({
+  ...jest.requireActual('./delete_modal'),
+  PipelineDeleteModal: ({ pipelinesToDelete }: { pipelinesToDelete?: unknown[] }) => (
+    <div data-test-subj="pipelineDeleteModal">DELETE {pipelinesToDelete?.length ?? 0}</div>
+  ),
+}));
+
+jest.mock('./pipeline_flyout', () => ({
+  ...jest.requireActual('./pipeline_flyout'),
+  PipelineFlyout: (props: { ingestPipeline: string; onCreateClick: (name: string) => void }) => (
+    <div data-test-subj="pipelineFlyout">
+      <h1>FLYOUT {props.ingestPipeline}</h1>
+      <button
+        data-test-subj="createUnknownPipeline"
+        onClick={() => {
+          props.onCreateClick(props.ingestPipeline);
+        }}
+      >
+        Create pipeline
+      </button>
+    </div>
+  ),
+}));
+
+const renderPipelinesList = (path: string, services: DeepPartialMockServices) => {
+  mockUseKibana.mockReturnValue({ services });
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return render(
+    <I18nProvider>
+      <Router history={history}>
+        <Routes>
+          <Route exact path={'/'} component={PipelinesList} />
+        </Routes>
+      </Router>
+    </I18nProvider>
+  );
+};
+
+describe('PipelinesList section', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('WHEN mounting the PipelinesList route', () => {
+    describe('AND the API reports loading', () => {
+      it('SHOULD show the SectionLoading with the loading message', () => {
+        const services = createServicesWithLoadPipelines({
+          isLoading: true,
+        });
+
+        renderPipelinesList('/', services);
+
+        expect(screen.getByTestId('sectionLoading')).toBeInTheDocument();
+        expect(services.metric!.trackUiMetric).toHaveBeenCalled();
+        expect(services.breadcrumbs!.setBreadcrumbs).toHaveBeenCalledWith('home');
+      });
+    });
+
+    describe('AND the API reports an error', () => {
+      it('SHOULD render the error prompt and call resendRequest when clicking Try again', () => {
+        const resendRequest = jest.fn();
+        const services = createServicesWithLoadPipelines({
+          error: {
+            message: 'boom',
+            statusCode: 500,
+            error: 'Internal Server Error',
+          },
+          resendRequest,
+        });
+
+        renderPipelinesList('/', services);
+
+        expect(screen.getByText('boom')).toBeInTheDocument();
+
+        const tryAgainButton = screen.getByText('Try again');
+        fireEvent.click(tryAgainButton);
+        expect(resendRequest).toHaveBeenCalled();
+      });
+    });
+
+    describe('AND the API returns an empty list', () => {
+      it('SHOULD render the EmptyList component', () => {
+        const services = createServicesWithLoadPipelines({
+          data: [],
+        });
+
+        renderPipelinesList('/', services);
+
+        expect(screen.getByTestId('emptyList')).toBeInTheDocument();
+      });
+    });
+
+    describe('AND pipelines exist', () => {
+      const mockPipelines = [
+        { name: 'p1', description: '', processors: [], on_failure: [] },
+        { name: 'p2', description: '', processors: [], on_failure: [] },
+      ];
+
+      let services: DeepPartialMockServices;
+
+      beforeEach(() => {
+        services = createServicesWithLoadPipelines({
+          data: mockPipelines,
+        });
+      });
+
+      it('SHOULD render the PipelineTable and allow opening the flyout via table callback', () => {
+        const history = createMemoryHistory({ initialEntries: ['/'] });
+        const historyPushSpy = jest.spyOn(history, 'push');
+        mockUseKibana.mockReturnValue({ services });
+
+        render(
+          <I18nProvider>
+            <Router history={history}>
+              <Routes>
+                <Route exact path={'/'} component={PipelinesList} />
+              </Routes>
+            </Router>
+          </I18nProvider>
+        );
+
+        expect(screen.getByTestId('pipelineTable')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('openFlyout'));
+        expect(historyPushSpy).toHaveBeenCalled();
+      });
+
+      describe('AND WHEN the user clicks edit on a pipeline in the list', () => {
+        it('SHOULD double encode pipeline name and push encoded path', () => {
+          const history = createMemoryHistory({ initialEntries: ['/'] });
+          const historyPushSpy = jest.spyOn(history, 'push');
+          mockUseKibana.mockReturnValue({ services });
+
+          render(
+            <I18nProvider>
+              <Router history={history}>
+                <Routes>
+                  <Route exact path={'/'} component={PipelinesList} />
+                </Routes>
+              </Router>
+            </I18nProvider>
+          );
+
+          fireEvent.click(screen.getByTestId('editPipeline'));
+
+          expect(historyPushSpy).toHaveBeenCalledWith(
+            `/edit/${encodeURIComponent(encodeURIComponent(editName))}`
+          );
+        });
+      });
+
+      describe('AND WHEN the user clicks clone on a pipeline in the list', () => {
+        it('SHOULD double encode cloned pipeline name and push encoded path', () => {
+          const history = createMemoryHistory({ initialEntries: ['/'] });
+          const historyPushSpy = jest.spyOn(history, 'push');
+          jest.spyOn(console, 'warn').mockImplementation(() => {});
+          mockUseKibana.mockReturnValue({ services });
+
+          render(
+            <I18nProvider>
+              <Router history={history}>
+                <Routes>
+                  <Route exact path={'/'} component={PipelinesList} />
+                </Routes>
+              </Router>
+            </I18nProvider>
+          );
+
+          fireEvent.click(screen.getByTestId('clonePipeline'));
+
+          expect(historyPushSpy).toHaveBeenCalledWith(
+            `/create/${encodeURIComponent(encodeURIComponent(cloneName))}`
+          );
+        });
+      });
+
+      describe('AND WHEN the URL contains a pipeline query param', () => {
+        it('SHOULD open the PipelineFlyout on mount', () => {
+          const history = createMemoryHistory({ initialEntries: ['/?pipeline=my-pipeline'] });
+          mockUseKibana.mockReturnValue({ services });
+
+          render(
+            <I18nProvider>
+              <Router history={history}>
+                <Routes>
+                  <Route exact path={'/'} component={PipelinesList} />
+                </Routes>
+              </Router>
+            </I18nProvider>
+          );
+
+          expect(screen.getByTestId('pipelineFlyout')).toBeInTheDocument();
+          expect(screen.getByText('FLYOUT my-pipeline')).toBeInTheDocument();
+        });
+
+        describe('AND WHEN the URL contains an unknown pipeline query name', () => {
+          describe('AND WHEN the user clicks "Create pipeline" button', () => {
+            it('SHOULD navigate to create page with prefilled single encoded name', () => {
+              const history = createMemoryHistory({
+                initialEntries: [`/?pipeline=${encodeURIComponent(unknownCreateName)}`],
+              });
+              const historyPushSpy = jest.spyOn(history, 'push');
+              mockUseKibana.mockReturnValue({ services });
+
+              render(
+                <I18nProvider>
+                  <Router history={history}>
+                    <Routes>
+                      <Route exact path={'/'} component={PipelinesList} />
+                    </Routes>
+                  </Router>
+                </I18nProvider>
+              );
+
+              expect(screen.getByTestId('pipelineFlyout')).toBeInTheDocument();
+              expect(screen.getByText(`FLYOUT ${unknownCreateName}`)).toBeInTheDocument();
+
+              fireEvent.click(screen.getByTestId('createUnknownPipeline'));
+
+              expect(historyPushSpy).toHaveBeenCalledWith(
+                `/create?name=${encodeURIComponent(unknownCreateName)}`
+              );
+            });
+          });
+        });
+      });
+
+      describe('AND WHEN manage processors is enabled and user has privileges', () => {
+        it('SHOULD show the Manage processors button', () => {
+          const servicesWithManageProcessors = createServicesWithLoadPipelines(
+            {
+              data: [{ name: 'p1', description: '', processors: [], on_failure: [] }],
+            },
+            {
+              config: { enableManageProcessors: true },
+            }
+          );
+
+          mockUseCheckManageProcessorsPrivileges.mockReturnValue(true);
+
+          renderPipelinesList('/', servicesWithManageProcessors);
+
+          expect(screen.getByText(/Manage processors/i)).toBeInTheDocument();
+        });
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/main.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/main.test.tsx
@@ -16,6 +16,8 @@ import type { DeepPartial } from '@kbn/utility-types';
 import { PipelinesList } from './main';
 import type { PipelineTable } from './table';
 import type { SectionLoading, useKibana } from '../../../shared_imports';
+import { PipelineFlyout } from './pipeline_flyout';
+import { PipelineDeleteModal } from './delete_modal';
 
 const mockUseKibana = jest.fn();
 const mockUseCheckManageProcessorsPrivileges = jest.fn();
@@ -83,21 +85,12 @@ jest.mock('./empty_list', () => ({
 
 const editName = 'p!@# name';
 const cloneName = 'clone$%^name';
-const unknownCreateName = 'create&*()name';
 
 jest.mock('./table', () => ({
   ...jest.requireActual('./table'),
   PipelineTable: (props: ComponentProps<typeof PipelineTable>) => (
     <div data-test-subj="pipelineTable">
       PIPELINE_TABLE
-      <button
-        data-test-subj="openFlyout"
-        onClick={() => {
-          props.openFlyout('from-table');
-        }}
-      >
-        openFlyout
-      </button>
       <button
         data-test-subj="editPipeline"
         onClick={() => {
@@ -120,24 +113,16 @@ jest.mock('./table', () => ({
 
 jest.mock('./delete_modal', () => ({
   ...jest.requireActual('./delete_modal'),
-  PipelineDeleteModal: ({ pipelinesToDelete }: { pipelinesToDelete?: unknown[] }) => (
+  PipelineDeleteModal: ({ pipelinesToDelete }: ComponentProps<typeof PipelineDeleteModal>) => (
     <div data-test-subj="pipelineDeleteModal">DELETE {pipelinesToDelete?.length ?? 0}</div>
   ),
 }));
 
 jest.mock('./pipeline_flyout', () => ({
   ...jest.requireActual('./pipeline_flyout'),
-  PipelineFlyout: (props: { ingestPipeline: string; onCreateClick: (name: string) => void }) => (
+  PipelineFlyout: (props: ComponentProps<typeof PipelineFlyout>) => (
     <div data-test-subj="pipelineFlyout">
-      <h1>FLYOUT {props.ingestPipeline}</h1>
-      <button
-        data-test-subj="createUnknownPipeline"
-        onClick={() => {
-          props.onCreateClick(props.ingestPipeline);
-        }}
-      >
-        Create pipeline
-      </button>
+      <h1>FLYOUT {props.pipeline}</h1>
     </div>
   ),
 }));
@@ -224,27 +209,6 @@ describe('PipelinesList section', () => {
         });
       });
 
-      it('SHOULD render the PipelineTable and allow opening the flyout via table callback', () => {
-        const history = createMemoryHistory({ initialEntries: ['/'] });
-        const historyPushSpy = jest.spyOn(history, 'push');
-        mockUseKibana.mockReturnValue({ services });
-
-        render(
-          <I18nProvider>
-            <Router history={history}>
-              <Routes>
-                <Route exact path={'/'} component={PipelinesList} />
-              </Routes>
-            </Router>
-          </I18nProvider>
-        );
-
-        expect(screen.getByTestId('pipelineTable')).toBeInTheDocument();
-
-        fireEvent.click(screen.getByTestId('openFlyout'));
-        expect(historyPushSpy).toHaveBeenCalled();
-      });
-
       describe('AND WHEN the user clicks edit on a pipeline in the list', () => {
         it('SHOULD double encode pipeline name and push encoded path', () => {
           const history = createMemoryHistory({ initialEntries: ['/'] });
@@ -311,37 +275,6 @@ describe('PipelinesList section', () => {
 
           expect(screen.getByTestId('pipelineFlyout')).toBeInTheDocument();
           expect(screen.getByText('FLYOUT my-pipeline')).toBeInTheDocument();
-        });
-
-        describe('AND WHEN the URL contains an unknown pipeline query name', () => {
-          describe('AND WHEN the user clicks "Create pipeline" button', () => {
-            it('SHOULD navigate to create page with prefilled single encoded name', () => {
-              const history = createMemoryHistory({
-                initialEntries: [`/?pipeline=${encodeURIComponent(unknownCreateName)}`],
-              });
-              const historyPushSpy = jest.spyOn(history, 'push');
-              mockUseKibana.mockReturnValue({ services });
-
-              render(
-                <I18nProvider>
-                  <Router history={history}>
-                    <Routes>
-                      <Route exact path={'/'} component={PipelinesList} />
-                    </Routes>
-                  </Router>
-                </I18nProvider>
-              );
-
-              expect(screen.getByTestId('pipelineFlyout')).toBeInTheDocument();
-              expect(screen.getByText(`FLYOUT ${unknownCreateName}`)).toBeInTheDocument();
-
-              fireEvent.click(screen.getByTestId('createUnknownPipeline'));
-
-              expect(historyPushSpy).toHaveBeenCalledWith(
-                `/create?name=${encodeURIComponent(unknownCreateName)}`
-              );
-            });
-          });
         });
       });
 

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/main.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/main.tsx
@@ -74,11 +74,17 @@ export const PipelinesList: React.FunctionComponent<RouteComponentProps> = ({
   }, [pipelineNameFromLocation, data]);
 
   const goToEditPipeline = (pipelineName: string) => {
+    // this double encoding (+1 in getEditPath) is a
+    // temporary workaround for history v4 bug with url-encoded
+    // route params see https://github.com/elastic/kibana/issues/234500
     const encodedParam = encodeURIComponent(pipelineName);
     history.push(getEditPath({ pipelineName: encodedParam }));
   };
 
   const goToClonePipeline = (clonedPipelineName: string) => {
+    // this double encoding (+1 in getClonePath) is a
+    // temporary workaround for history v4 bug with url-encoded
+    // route params see https://github.com/elastic/kibana/issues/234500
     const encodedParam = encodeURIComponent(clonedPipelineName);
     history.push(getClonePath({ clonedPipelineName: encodedParam }));
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Ingest Pipelines] Fix handling special symbols from navigation (#233651)](https://github.com/elastic/kibana/pull/233651)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2025-09-11T12:58:25Z","message":"[Ingest Pipelines] Fix handling special symbols from navigation (#233651)\n\nfixes #230536\n\nThis pull request fixes encoding behavior and adds comprehensive test\ncoverage for the ingest pipelines create, clone, and edit sections,\nfocusing on robust handling of pipeline names with special characters\nand addressing known issues with URL encoding/decoding in [history\nv4](https://github.com/remix-run/history/issues/786) fixed in next\nversion of react-router(6+).\n\n## Impacted flows\n\n### Before fix\n\n1. Creating a non-existent pipeline from not-found Flyout, containing\nspecial symbols. (main issue)\n<img width=\"1540\" height=\"1304\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ddc44615-c74d-4021-89bd-6cfc48e6d0ee\"\n/>\n\n2. Editing pipeline containing special symbols in the name -> Reloading\nedit form (newly discovered issue)\n<img width=\"1531\" height=\"1349\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3c1de15f-9f8e-496e-bf08-17dab5753071\"\n/>\n\n3. Cloning pipeline containing special symbols in the name -> Reloading\nclone form (newly discovered issue)\n<img width=\"1548\" height=\"1367\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cff608ce-e921-46c7-b1ad-989dc9f6f0c8\"\n/>\n\n### After fix\n\n\nhttps://github.com/user-attachments/assets/60f4ab29-0c57-4533-b05f-765b1b546410\n\n\nhttps://github.com/user-attachments/assets/3bd37ef1-a60c-4350-b597-027dc6ac6da6\n\n\nhttps://github.com/user-attachments/assets/9d1e847e-3694-4e23-9089-837ba603540c\n\n## How to test\n\n### Unknown pipeline creation case\n\n1. Open a flyout for a non-existing test@custom pipeline (e.g. by\nnavigating to\n`/app/management/ingest/ingest_pipelines?pipeline=test@custom`) and\nclick on \"Create\" button.\n2. See pipeline name correctly showing `test@custom` (instead of\n`test%40custom`)\n\n### Edit page reload with special symbols case\n\n1. Go to `/app/management/ingest/ingest_pipelines/create`\n2. Crete pipeline with name `asd!@#$ asd%^&`\n3. In the opened flyout on the bottom click `Edit pipeline` button\n4. When edit page is loaded, reload the page\n5. See no more error happening\n\n### Clone page reload with special symbols case\n\n1. Go to `/app/management/ingest/ingest_pipelines/create`\n2. Crete pipeline with name `asd!@#$ asd%^&`\n3. In the opened flyout on the bottom click `...` button\n4. Click duplicate page\n5. When the form is loaded, reload the page\n6. See no more error happening\n\n## Release Note\n\n- fix special symbols handling when creating new pipeline from flyout\n- fix edit page crash upon reload, for pipeline that has special symbols\nin the name\n- fix clone page error upon reload, for pipeline that has special\nsymbols in the name\n\n---------\n\nCo-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>","sha":"24ae4db5e990e62e3e716d0807772c996b47ec50","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Kibana Management","Feature:Ingest Node Pipelines","backport:version","v9.2.0","v8.18.8","v8.19.5","v9.0.8","v9.1.5"],"title":"[Ingest Pipelines] Fix handling special symbols from navigation","number":233651,"url":"https://github.com/elastic/kibana/pull/233651","mergeCommit":{"message":"[Ingest Pipelines] Fix handling special symbols from navigation (#233651)\n\nfixes #230536\n\nThis pull request fixes encoding behavior and adds comprehensive test\ncoverage for the ingest pipelines create, clone, and edit sections,\nfocusing on robust handling of pipeline names with special characters\nand addressing known issues with URL encoding/decoding in [history\nv4](https://github.com/remix-run/history/issues/786) fixed in next\nversion of react-router(6+).\n\n## Impacted flows\n\n### Before fix\n\n1. Creating a non-existent pipeline from not-found Flyout, containing\nspecial symbols. (main issue)\n<img width=\"1540\" height=\"1304\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ddc44615-c74d-4021-89bd-6cfc48e6d0ee\"\n/>\n\n2. Editing pipeline containing special symbols in the name -> Reloading\nedit form (newly discovered issue)\n<img width=\"1531\" height=\"1349\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3c1de15f-9f8e-496e-bf08-17dab5753071\"\n/>\n\n3. Cloning pipeline containing special symbols in the name -> Reloading\nclone form (newly discovered issue)\n<img width=\"1548\" height=\"1367\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cff608ce-e921-46c7-b1ad-989dc9f6f0c8\"\n/>\n\n### After fix\n\n\nhttps://github.com/user-attachments/assets/60f4ab29-0c57-4533-b05f-765b1b546410\n\n\nhttps://github.com/user-attachments/assets/3bd37ef1-a60c-4350-b597-027dc6ac6da6\n\n\nhttps://github.com/user-attachments/assets/9d1e847e-3694-4e23-9089-837ba603540c\n\n## How to test\n\n### Unknown pipeline creation case\n\n1. Open a flyout for a non-existing test@custom pipeline (e.g. by\nnavigating to\n`/app/management/ingest/ingest_pipelines?pipeline=test@custom`) and\nclick on \"Create\" button.\n2. See pipeline name correctly showing `test@custom` (instead of\n`test%40custom`)\n\n### Edit page reload with special symbols case\n\n1. Go to `/app/management/ingest/ingest_pipelines/create`\n2. Crete pipeline with name `asd!@#$ asd%^&`\n3. In the opened flyout on the bottom click `Edit pipeline` button\n4. When edit page is loaded, reload the page\n5. See no more error happening\n\n### Clone page reload with special symbols case\n\n1. Go to `/app/management/ingest/ingest_pipelines/create`\n2. Crete pipeline with name `asd!@#$ asd%^&`\n3. In the opened flyout on the bottom click `...` button\n4. Click duplicate page\n5. When the form is loaded, reload the page\n6. See no more error happening\n\n## Release Note\n\n- fix special symbols handling when creating new pipeline from flyout\n- fix edit page crash upon reload, for pipeline that has special symbols\nin the name\n- fix clone page error upon reload, for pipeline that has special\nsymbols in the name\n\n---------\n\nCo-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>","sha":"24ae4db5e990e62e3e716d0807772c996b47ec50"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.19","9.0","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/233651","number":233651,"mergeCommit":{"message":"[Ingest Pipelines] Fix handling special symbols from navigation (#233651)\n\nfixes #230536\n\nThis pull request fixes encoding behavior and adds comprehensive test\ncoverage for the ingest pipelines create, clone, and edit sections,\nfocusing on robust handling of pipeline names with special characters\nand addressing known issues with URL encoding/decoding in [history\nv4](https://github.com/remix-run/history/issues/786) fixed in next\nversion of react-router(6+).\n\n## Impacted flows\n\n### Before fix\n\n1. Creating a non-existent pipeline from not-found Flyout, containing\nspecial symbols. (main issue)\n<img width=\"1540\" height=\"1304\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ddc44615-c74d-4021-89bd-6cfc48e6d0ee\"\n/>\n\n2. Editing pipeline containing special symbols in the name -> Reloading\nedit form (newly discovered issue)\n<img width=\"1531\" height=\"1349\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3c1de15f-9f8e-496e-bf08-17dab5753071\"\n/>\n\n3. Cloning pipeline containing special symbols in the name -> Reloading\nclone form (newly discovered issue)\n<img width=\"1548\" height=\"1367\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cff608ce-e921-46c7-b1ad-989dc9f6f0c8\"\n/>\n\n### After fix\n\n\nhttps://github.com/user-attachments/assets/60f4ab29-0c57-4533-b05f-765b1b546410\n\n\nhttps://github.com/user-attachments/assets/3bd37ef1-a60c-4350-b597-027dc6ac6da6\n\n\nhttps://github.com/user-attachments/assets/9d1e847e-3694-4e23-9089-837ba603540c\n\n## How to test\n\n### Unknown pipeline creation case\n\n1. Open a flyout for a non-existing test@custom pipeline (e.g. by\nnavigating to\n`/app/management/ingest/ingest_pipelines?pipeline=test@custom`) and\nclick on \"Create\" button.\n2. See pipeline name correctly showing `test@custom` (instead of\n`test%40custom`)\n\n### Edit page reload with special symbols case\n\n1. Go to `/app/management/ingest/ingest_pipelines/create`\n2. Crete pipeline with name `asd!@#$ asd%^&`\n3. In the opened flyout on the bottom click `Edit pipeline` button\n4. When edit page is loaded, reload the page\n5. See no more error happening\n\n### Clone page reload with special symbols case\n\n1. Go to `/app/management/ingest/ingest_pipelines/create`\n2. Crete pipeline with name `asd!@#$ asd%^&`\n3. In the opened flyout on the bottom click `...` button\n4. Click duplicate page\n5. When the form is loaded, reload the page\n6. See no more error happening\n\n## Release Note\n\n- fix special symbols handling when creating new pipeline from flyout\n- fix edit page crash upon reload, for pipeline that has special symbols\nin the name\n- fix clone page error upon reload, for pipeline that has special\nsymbols in the name\n\n---------\n\nCo-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>","sha":"24ae4db5e990e62e3e716d0807772c996b47ec50"}},{"branch":"8.18","label":"v8.18.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->