### PR TITLE
[ML] Inference endpoints UI: Adds tech preview for e5 preconfig endpoint

### DIFF
--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
@@ -104,6 +104,14 @@ const inferenceEndpoints = [
       model_id: 'elser_model_2',
     },
   },
+  {
+    inference_id: '.multilingual-embed-v1-elastic',
+    task_type: 'text_embedding',
+    service: 'elastic',
+    service_settings: {
+      model_id: 'multilingual-embed-v1',
+    },
+  },
 ] as InferenceAPIConfigResponse[];
 
 jest.mock('../../hooks/use_delete_endpoint', () => ({
@@ -120,12 +128,13 @@ describe('When the tabular page is loaded', () => {
     expect(rows[1]).toHaveTextContent('.elser-2-elastic');
     expect(rows[2]).toHaveTextContent('.elser-2-elasticsearch');
     expect(rows[3]).toHaveTextContent('.multilingual-e5-small-elasticsearch');
-    expect(rows[4]).toHaveTextContent('.sparkles');
-    expect(rows[5]).toHaveTextContent('custom-inference-id');
-    expect(rows[6]).toHaveTextContent('elastic-rerank');
-    expect(rows[7]).toHaveTextContent('local-model');
-    expect(rows[8]).toHaveTextContent('my-elser-model-05');
-    expect(rows[9]).toHaveTextContent('third-party-model');
+    expect(rows[4]).toHaveTextContent('.multilingual-embed-v1-elastic');
+    expect(rows[5]).toHaveTextContent('.sparkles');
+    expect(rows[6]).toHaveTextContent('custom-inference-id');
+    expect(rows[7]).toHaveTextContent('elastic-rerank');
+    expect(rows[8]).toHaveTextContent('local-model');
+    expect(rows[9]).toHaveTextContent('my-elser-model-05');
+    expect(rows[10]).toHaveTextContent('third-party-model');
   });
 
   it('should display all service and model ids in the table', () => {
@@ -142,22 +151,25 @@ describe('When the tabular page is loaded', () => {
     expect(rows[3]).toHaveTextContent('.multilingual-e5-small');
 
     expect(rows[4]).toHaveTextContent('Elastic');
-    expect(rows[4]).toHaveTextContent('rainbow-sprinkles');
+    expect(rows[4]).toHaveTextContent('multilingual-embed-v1');
 
     expect(rows[5]).toHaveTextContent('Elastic');
-    expect(rows[5]).toHaveTextContent('elser_model_2');
+    expect(rows[5]).toHaveTextContent('rainbow-sprinkles');
 
-    expect(rows[6]).toHaveTextContent('Elasticsearch');
-    expect(rows[6]).toHaveTextContent('.rerank-v1');
+    expect(rows[6]).toHaveTextContent('Elastic');
+    expect(rows[6]).toHaveTextContent('elser_model_2');
 
     expect(rows[7]).toHaveTextContent('Elasticsearch');
-    expect(rows[7]).toHaveTextContent('.own_model');
+    expect(rows[7]).toHaveTextContent('.rerank-v1');
 
     expect(rows[8]).toHaveTextContent('Elasticsearch');
-    expect(rows[8]).toHaveTextContent('.elser_model_2');
+    expect(rows[8]).toHaveTextContent('.own_model');
 
-    expect(rows[9]).toHaveTextContent('OpenAI');
-    expect(rows[9]).toHaveTextContent('.own_model');
+    expect(rows[9]).toHaveTextContent('Elasticsearch');
+    expect(rows[9]).toHaveTextContent('.elser_model_2');
+
+    expect(rows[10]).toHaveTextContent('OpenAI');
+    expect(rows[10]).toHaveTextContent('.own_model');
   });
 
   it('should only disable delete action for preconfigured endpoints', () => {
@@ -176,7 +188,7 @@ describe('When the tabular page is loaded', () => {
     render(<TabularPage inferenceEndpoints={inferenceEndpoints} />);
 
     act(() => {
-      screen.getAllByTestId('euiCollapsedItemActionsButton')[4].click();
+      screen.getAllByTestId('euiCollapsedItemActionsButton')[5].click();
     });
 
     const deleteAction = screen.getByTestId(/inferenceUIDeleteAction/);
@@ -194,14 +206,15 @@ describe('When the tabular page is loaded', () => {
     expect(rows[2]).toHaveTextContent(preconfigured);
     expect(rows[3]).toHaveTextContent(preconfigured);
     expect(rows[4]).toHaveTextContent(preconfigured);
-    expect(rows[5]).not.toHaveTextContent(preconfigured);
+    expect(rows[5]).toHaveTextContent(preconfigured);
     expect(rows[6]).not.toHaveTextContent(preconfigured);
     expect(rows[7]).not.toHaveTextContent(preconfigured);
     expect(rows[8]).not.toHaveTextContent(preconfigured);
     expect(rows[9]).not.toHaveTextContent(preconfigured);
+    expect(rows[10]).not.toHaveTextContent(preconfigured);
   });
 
-  it('should show tech preview badge only for reranker-v1 model, rainbow-sprinkles, and preconfigured elser_model_2', () => {
+  it('should show tech preview badge only for reranker-v1 model, rainbow-sprinkles, multilingual-embed-v1, and preconfigured elser_model_2', () => {
     render(<TabularPage inferenceEndpoints={inferenceEndpoints} />);
 
     const techPreview = 'TECH PREVIEW';
@@ -211,10 +224,11 @@ describe('When the tabular page is loaded', () => {
     expect(rows[2]).not.toHaveTextContent(techPreview);
     expect(rows[3]).not.toHaveTextContent(techPreview);
     expect(rows[4]).toHaveTextContent(techPreview);
-    expect(rows[5]).not.toHaveTextContent(techPreview);
-    expect(rows[6]).toHaveTextContent(techPreview);
-    expect(rows[7]).not.toHaveTextContent(techPreview);
+    expect(rows[5]).toHaveTextContent(techPreview);
+    expect(rows[6]).not.toHaveTextContent(techPreview);
+    expect(rows[7]).toHaveTextContent(techPreview);
     expect(rows[8]).not.toHaveTextContent(techPreview);
     expect(rows[9]).not.toHaveTextContent(techPreview);
+    expect(rows[10]).not.toHaveTextContent(techPreview);
   });
 });

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/reranker_helper.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/reranker_helper.ts
@@ -30,6 +30,9 @@ export const isProviderTechPreview = (provider: InferenceInferenceEndpointInfo) 
     modelId === 'rainbow-sprinkles' ||
     (modelId === 'elser_model_2' &&
       inferenceId.startsWith('.') &&
+      service === ServiceProviderKeys.elastic) ||
+    (modelId === 'multilingual-embed-v1' &&
+      inferenceId.startsWith('.') &&
       service === ServiceProviderKeys.elastic)
   ) {
     return true;


### PR DESCRIPTION
## Summary

Related issue: https://github.com/elastic/search-team/issues/10983

Ensures `Tech Preview` badge is shown for the default inference endpoint for e5.

<img width="1680" height="694" alt="image" src="https://github.com/user-attachments/assets/3b98d12b-7653-4c2b-8dd5-2b896b1b6f63" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



