### PR TITLE
[Security assistant] Fix System Prompt updates from Conversations tab

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
@@ -25,6 +25,8 @@ import {
 } from './const';
 import type { DataViewsContract } from '@kbn/data-views-plugin/public';
 
+const mockSetSelectedSettingsTab = jest.fn();
+
 const mockContext = {
   basePromptContexts: MOCK_QUICK_PROMPTS,
   http: {
@@ -34,7 +36,11 @@ const mockContext = {
   assistantAvailability: {
     isAssistantEnabled: true,
     isAssistantManagementEnabled: true,
+    hasConnectorsAllPrivilege: true,
   },
+  selectedSettingsTab: null,
+  setSelectedSettingsTab: mockSetSelectedSettingsTab,
+  navigateToApp: jest.fn(),
 };
 
 const mockDataViews = {
@@ -100,6 +106,34 @@ describe('AssistantSettingsManagement', () => {
     });
 
     expect(queryByTestId(`bottom-bar`)).not.toBeInTheDocument();
+  });
+
+  describe('useEffect behavior', () => {
+    it('calls onTabChange and clears contextSettingsTab when contextSettingsTab is set', () => {
+      const contextWithTab = {
+        ...mockContext,
+        selectedSettingsTab: SYSTEM_PROMPTS_TAB,
+      };
+      (useAssistantContext as jest.Mock).mockImplementation(() => contextWithTab);
+
+      render(<AssistantSettingsManagement {...testProps} />, { wrapper });
+
+      expect(onTabChange).toHaveBeenCalledWith(SYSTEM_PROMPTS_TAB);
+      expect(mockSetSelectedSettingsTab).toHaveBeenCalledWith(null);
+    });
+
+    it('does not call onTabChange when contextSettingsTab is null', () => {
+      const contextWithoutTab = {
+        ...mockContext,
+        selectedSettingsTab: null,
+      };
+      (useAssistantContext as jest.Mock).mockImplementation(() => contextWithoutTab);
+
+      render(<AssistantSettingsManagement {...testProps} />, { wrapper });
+
+      expect(onTabChange).not.toHaveBeenCalled();
+      expect(mockSetSelectedSettingsTab).not.toHaveBeenCalled();
+    });
   });
 
   describe.each([

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
@@ -62,6 +62,7 @@ export const AssistantSettingsManagement: React.FC<Props> = React.memo(
       if (contextSettingsTab) {
         // contextSettingsTab can be selected from Conversations > System Prompts > Add System Prompt
         onTabChange?.(contextSettingsTab);
+        setSelectedSettingsTab(null);
       }
     }, [onTabChange, contextSettingsTab, setSelectedSettingsTab]);
 


### PR DESCRIPTION
## Fix: Enable repeated System Prompt navigation from Conversations tab

### Problem
Users could navigate from Conversations > System Prompts > Add System Prompt successfully the first time, but subsequent attempts would fail. The issue was that the `selectedSettingsTab` context state wasn't being properly cleared after navigation, preventing users from accessing the System Prompts tab again when editing conversations.

### Steps to Reproduce (Previous Behavior)
1. Go to the Conversations settings tab
2. Edit any conversation entry
3. Click "Add System Prompt" - **✅ Works first time**
4. Navigate back to the Conversations tab
5. Edit the same or different conversation entry

#### Previous behavior 
6. Click "Add System Prompt" again - **❌ Fails - user cannot navigate to System Prompts tab**

#### Expected Behavior (After Fix)
6. Click "Add System Prompt" again - **✅ Works - user can navigate to System Prompts tab repeatedly**

### Solution
Added missing `setSelectedSettingsTab(null)` call in the `useEffect` hook within `AssistantSettingsManagement` component to properly clear the context settings tab state after navigation, enabling repeated navigation attempts.

- [x] Unit tests added to cover the useEffect behavior
- [x] Verified System Prompt navigation works correctly on repeated attempts from Conversations tab
- [x] Confirmed navigation between tabs functions as expected on multiple attempts

Fixes [#197962](https://github.com/elastic/kibana/issues/197962)

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->