### PR TITLE
[Security assistant] Show error toast when user tries to access inaccessible conversation

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/conversations/conversations.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/conversations/conversations.ts
@@ -49,12 +49,22 @@ export const getConversationById = async ({
 
     return response as Conversation;
   } catch (error) {
-    toasts?.addError(error.body && error.body.message ? new Error(error.body.message) : error, {
-      title: i18n.translate('xpack.elasticAssistant.conversations.getConversationError', {
-        defaultMessage: 'Error fetching conversation by id {id}',
-        values: { id },
-      }),
-    });
+    // Check if this is a 403 Forbidden error
+    if (error.response?.status === 403) {
+      toasts?.addError(error.body && error.body.message ? new Error(error.body.message) : error, {
+        title: i18n.translate('xpack.elasticAssistant.conversations.accessDeniedError', {
+          defaultMessage: 'Access denied to conversation',
+        }),
+      });
+    } else {
+      // For other errors (like 404), show the generic error message
+      toasts?.addError(error.body && error.body.message ? new Error(error.body.message) : error, {
+        title: i18n.translate('xpack.elasticAssistant.conversations.getConversationError', {
+          defaultMessage: 'Error fetching conversation by id {id}',
+          values: { id },
+        }),
+      });
+    }
     throw error;
   }
 };

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/use_current_conversation/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/use_current_conversation/index.test.tsx
@@ -316,7 +316,7 @@ describe('useCurrentConversation', () => {
       }),
     });
 
-    expect(mockUseConversation.getConversation).toHaveBeenCalledWith(mockData.welcome_id.id, true);
+    expect(mockUseConversation.getConversation).toHaveBeenCalledWith(mockData.welcome_id.id, false);
 
     await act(async () => {
       await result.current.handleOnConversationSelected({

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/use_current_conversation/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/use_current_conversation/index.tsx
@@ -292,7 +292,7 @@ export const useCurrentConversation = ({
     handleOnConversationSelected({
       cId: lastConversation.id,
       cTitle: lastConversation.title,
-      silent: true,
+      silent: false,
     });
   }, [lastConversation, handleOnConversationSelected, currentConversation, mayUpdateConversations]);
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/data_clients.mock.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/data_clients.mock.ts
@@ -43,6 +43,7 @@ const createConversationsDataClientMock = () => {
     createConversation: jest.fn(),
     deleteConversation: jest.fn(),
     deleteAllConversations: jest.fn(),
+    conversationExists: jest.fn(),
     getConversation: jest.fn(),
     updateConversation: jest.fn(),
     getReader: jest.fn(),

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/conversation_exists.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/conversation_exists.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { conversationExists } from './conversation_exists';
+
+describe('conversationExists', () => {
+  let loggerMock: ReturnType<typeof loggingSystemMock.createLogger>;
+  let esClient: ReturnType<
+    typeof elasticsearchClientMock.createScopedClusterClient
+  >['asCurrentUser'];
+
+  beforeEach(() => {
+    loggerMock = loggingSystemMock.createLogger();
+    esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
+  });
+
+  test('returns true when conversation exists', async () => {
+    esClient.search.mockResponse({
+      hits: {
+        total: { value: 1 },
+        hits: [],
+      },
+    } as any);
+
+    const result = await conversationExists({
+      esClient,
+      logger: loggerMock,
+      conversationIndex: '.kibana-elastic-ai-assistant-conversations',
+      id: 'test-id',
+    });
+
+    expect(result).toBe(true);
+    expect(esClient.search).toHaveBeenCalledWith({
+      query: {
+        bool: {
+          must: [
+            {
+              term: {
+                _id: 'test-id',
+              },
+            },
+          ],
+        },
+      },
+      _source: false,
+      ignore_unavailable: true,
+      index: '.kibana-elastic-ai-assistant-conversations',
+      size: 0,
+    });
+  });
+
+  test('returns false when conversation does not exist', async () => {
+    esClient.search.mockResponse({
+      hits: {
+        total: { value: 0 },
+        hits: [],
+      },
+    } as any);
+
+    const result = await conversationExists({
+      esClient,
+      logger: loggerMock,
+      conversationIndex: '.kibana-elastic-ai-assistant-conversations',
+      id: 'non-existent-id',
+    });
+
+    expect(result).toBe(false);
+  });
+
+  test('returns false and logs error when search throws error', async () => {
+    const error = new Error('Search failed');
+    esClient.search.mockRejectedValue(error);
+
+    const result = await conversationExists({
+      esClient,
+      logger: loggerMock,
+      conversationIndex: '.kibana-elastic-ai-assistant-conversations',
+      id: 'test-id',
+    });
+
+    expect(result).toBe(false);
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      'Error checking if conversation exists: Error: Search failed with id: test-id'
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/conversation_exists.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/conversation_exists.test.ts
@@ -26,7 +26,7 @@ describe('conversationExists', () => {
         total: { value: 1 },
         hits: [],
       },
-    } as any);
+    });
 
     const result = await conversationExists({
       esClient,
@@ -61,7 +61,7 @@ describe('conversationExists', () => {
         total: { value: 0 },
         hits: [],
       },
-    } as any);
+    });
 
     const result = await conversationExists({
       esClient,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/conversation_exists.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/conversation_exists.test.ts
@@ -8,6 +8,8 @@
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { conversationExists } from './conversation_exists';
+import { getBasicEmptySearchResponse } from '../../__mocks__/response';
+import { getConversationSearchEsMock } from '../../__mocks__/conversations_schema.mock';
 
 describe('conversationExists', () => {
   let loggerMock: ReturnType<typeof loggingSystemMock.createLogger>;
@@ -21,12 +23,7 @@ describe('conversationExists', () => {
   });
 
   test('returns true when conversation exists', async () => {
-    esClient.search.mockResponse({
-      hits: {
-        total: { value: 1 },
-        hits: [],
-      },
-    });
+    esClient.search.mockResponse(getConversationSearchEsMock());
 
     const result = await conversationExists({
       esClient,
@@ -56,12 +53,7 @@ describe('conversationExists', () => {
   });
 
   test('returns false when conversation does not exist', async () => {
-    esClient.search.mockResponse({
-      hits: {
-        total: { value: 0 },
-        hits: [],
-      },
-    });
+    esClient.search.mockResponse(getBasicEmptySearchResponse());
 
     const result = await conversationExists({
       esClient,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/conversation_exists.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/conversation_exists.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { EsConversationSchema } from './types';
+
+/**
+ * Checks if a conversation exists by ID without user access filtering
+ */
+export const conversationExists = async ({
+  esClient,
+  logger,
+  conversationIndex,
+  id,
+}: {
+  esClient: ElasticsearchClient;
+  logger: Logger;
+  conversationIndex: string;
+  id: string;
+}): Promise<boolean> => {
+  try {
+    const response = await esClient.search<EsConversationSchema>({
+      query: {
+        bool: {
+          must: [
+            {
+              term: {
+                _id: id,
+              },
+            },
+          ],
+        },
+      },
+      _source: false,
+      ignore_unavailable: true,
+      index: conversationIndex,
+      size: 0,
+    });
+    return (response.hits.total as { value: number }).value > 0;
+  } catch (err) {
+    logger.error(`Error checking if conversation exists: ${err} with id: ${id}`);
+    return false;
+  }
+};

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/index.ts
@@ -16,6 +16,7 @@ import type { DeleteByQueryResponse } from '@elastic/elasticsearch/lib/api/types
 import { createConversation } from './create_conversation';
 import { updateConversation } from './update_conversation';
 import { getConversation } from './get_conversation';
+import { conversationExists } from './conversation_exists';
 import { deleteConversation } from './delete_conversation';
 import { appendConversationMessages } from './append_conversation_messages';
 import type { AIAssistantDataClientParams } from '..';
@@ -34,6 +35,22 @@ export class AIAssistantConversationsDataClient extends AIAssistantDataClient {
   constructor(public readonly options: AIAssistantDataClientParams) {
     super(options);
   }
+
+  /**
+   * Checks if a conversation exists by ID without user access filtering.
+   * @param options
+   * @param options.id The conversation id to check.
+   * @returns Promise<boolean> indicating whether the conversation exists
+   */
+  public conversationExists = async ({ id }: { id: string }): Promise<boolean> => {
+    const esClient = await this.options.elasticsearchClientPromise;
+    return conversationExists({
+      esClient,
+      logger: this.options.logger,
+      conversationIndex: this.indexTemplateAndPattern.alias,
+      id,
+    });
+  };
 
   /**
    * Gets a conversation by its id.

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/shared_conversations.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/shared_conversations.cy.ts
@@ -38,6 +38,8 @@ import {
   toggleConversationSideMenu,
   typeAndSendMessage,
   selectGlobal,
+  assertAccessErrorToast,
+  assertGenericConversationErrorToast,
 } from '../../tasks/assistant';
 import { deleteConversations, waitForConversation } from '../../tasks/api_calls/assistant';
 import { azureConnectorAPIPayload, createAzureConnector } from '../../tasks/api_calls/connectors';
@@ -295,6 +297,24 @@ describe('Assistant Conversation Sharing', { tags: ['@ess', '@serverless'] }, ()
       visit(`${origin}/app/security/get_started?assistant=${mockConvo1.id}`);
     });
     assertConversationTitle(mockConvo1.title);
+  });
+
+  it('Visiting a URL with the assistant param shows access error when user does not have access to the conversation', () => {
+    cy.clearCookies();
+
+    // Login as elastic user who should have access to shared conversations
+    loginSecondaryUser(isServerless, secondaryUser);
+
+    cy.location('origin').then((origin) => {
+      visit(`${origin}/app/security/get_started?assistant=${mockConvo1.id}`);
+    });
+    assertAccessErrorToast();
+
+    cy.location('origin').then((origin) => {
+      visit(`${origin}/app/security/get_started?assistant=does-not-exist`);
+    });
+
+    assertGenericConversationErrorToast();
   });
 });
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/assistant.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/assistant.ts
@@ -69,7 +69,7 @@ import {
   CONVO_CONTEXT_MENU_DUPLICATE,
   SHARED_SELECT_OPTION,
 } from '../screens/ai_assistant';
-import { SUCCESS_TOASTER_HEADER } from '../screens/alerts_detection_rules';
+import { SUCCESS_TOASTER_HEADER, TOASTER } from '../screens/alerts_detection_rules';
 
 export const openAssistant = (context?: 'rule' | 'alert') => {
   if (!context) {
@@ -446,3 +446,11 @@ export const duplicateConversation = (conversationName: string) => {
 export const assertMessageUser = (user: string, messageIndex: number) => {
   cy.get(`.euiCommentEvent__headerUsername`).eq(messageIndex).should('have.text', user);
 };
+
+export function assertAccessErrorToast(): void {
+  cy.get(TOASTER).should('contain', 'Access denied to conversation');
+}
+
+export function assertGenericConversationErrorToast(): void {
+  cy.get(TOASTER).should('contain', 'Error fetching conversation by id');
+}


### PR DESCRIPTION
## Fix: Show error toast when user tries to access inaccessible conversation

### Problem
When a user tries to access a conversation they don't have permission to view, the AI Assistant silently opens a new conversation without informing the user why the original conversation wasn't accessible. This creates a confusing user experience where users don't understand why their conversation link didn't work.

### Solution
- **Backend**: Updated the read conversation route to return `403 Forbidden` instead of `404 Not Found` when a conversation exists but the user lacks access
- **Frontend**: Added specific error handling to show an "Access denied to conversation" toast for 403 errors
- **Behavior**: 
  - `403 Forbidden`: Shows access denied error toast
     <img width="1194" height="766" alt="Screenshot 2025-09-11 at 2 00 27 PM" src="https://github.com/user-attachments/assets/b87b3159-7974-4141-a047-ba496fd5ef87" />
  - `404 Not Found`: Shows generic error toast
    <img width="1188" height="766" alt="Screenshot 2025-09-11 at 2 00 41 PM" src="https://github.com/user-attachments/assets/c8c6c037-f516-4edf-b385-2b474a108786" />

### Changes
- **Server**: Modified `read_route.ts` to distinguish between non-existent conversations (404) and inaccessible conversations (403)
- **Client**: Updated `getConversationById` to show specific error toast for 403 errors

### Testing
- Added unit tests for new `conversationExists` function
- Added cypress tests to confirm 403 error toast appears when accessing restricted conversations

Fixes [#234398](https://github.com/elastic/kibana/issues/234398)