### PR TITLE
[ES|QL] add error codes back until displayed in editor

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
@@ -7,25 +7,26 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useMemo } from 'react';
-import { i18n } from '@kbn/i18n';
 import {
+  EuiButtonEmpty,
+  EuiDescriptionList,
+  EuiDescriptionListDescription,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
   EuiPopover,
-  EuiDescriptionList,
-  EuiDescriptionListDescription,
-  EuiButtonEmpty,
-  euiTextBreakWord,
   EuiSwitch,
   EuiText,
+  euiTextBreakWord,
   useEuiTheme,
 } from '@elastic/eui';
-import { css } from '@emotion/react';
 import { css as classNameCss } from '@emotion/css';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { filterDataErrors, type MonacoMessage } from '../helpers';
+import React, { useCallback, useMemo } from 'react';
+import type { MonacoMessage } from '@kbn/monaco/src/languages/esql/language';
+import { filterDataErrors } from '../helpers';
 import type { DataErrorsControl } from '../types';
 
 interface TypeConsts {

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
@@ -7,32 +7,32 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { memo, useState, useCallback, useMemo } from 'react';
-import { i18n } from '@kbn/i18n';
 import {
-  EuiText,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiCode,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiCode,
-  EuiButtonIcon,
-  EuiButtonEmpty,
+  EuiText,
   EuiToolTip,
 } from '@elastic/eui';
 import type { Interpolation, Theme } from '@emotion/react';
 import { css } from '@emotion/react';
+import { getLimitFromESQLQuery } from '@kbn/esql-utils';
+import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import {
-  LanguageDocumentationInline,
   LanguageDocumentationFlyout,
+  LanguageDocumentationInline,
 } from '@kbn/language-documentation';
-import { getLimitFromESQLQuery } from '@kbn/esql-utils';
-import { type MonacoMessage } from '../helpers';
-import { ErrorsWarningsFooterPopover } from './errors_warnings_popover';
-import { QueryHistoryAction, HistoryAndStarredQueriesTabs } from './history_starred_queries';
-import { SubmitFeedbackComponent } from './feedback_component';
-import { QueryWrapComponent } from './query_wrap_component';
-import { KeyboardShortcuts } from './keyboard_shortcuts';
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import type { MonacoMessage } from '@kbn/monaco/src/languages/esql/language';
 import type { DataErrorsControl, ESQLEditorDeps } from '../types';
+import { ErrorsWarningsFooterPopover } from './errors_warnings_popover';
+import { SubmitFeedbackComponent } from './feedback_component';
+import { HistoryAndStarredQueriesTabs, QueryHistoryAction } from './history_starred_queries';
+import { KeyboardShortcuts } from './keyboard_shortcuts';
+import { QueryWrapComponent } from './query_wrap_component';
 
 const isMac = navigator.platform.toLowerCase().indexOf('mac') >= 0;
 const COMMAND_KEY = isMac ? '⌘' : '^';

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.test.tsx
@@ -7,19 +7,19 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
-import userEvent from '@testing-library/user-event';
-import { BehaviorSubject } from 'rxjs';
+import type { SerializedStyles } from '@emotion/react';
 import type { IUiSettingsClient } from '@kbn/core/public';
-import { renderWithI18n } from '@kbn/test-jest-helpers';
-import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import { ESQLEditor } from './esql_editor';
-import type { ESQLEditorProps } from './types';
 import { coreMock } from '@kbn/core/public/mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
 import { waitFor } from '@testing-library/dom';
 import { act } from '@testing-library/react';
-import type { SerializedStyles } from '@emotion/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { BehaviorSubject } from 'rxjs';
+import { ESQLEditor } from './esql_editor';
+import type { ESQLEditorProps } from './types';
 
 const mockValidate = jest.fn().mockResolvedValue({ errors: [], warnings: [] });
 jest.mock('@kbn/monaco', () => ({
@@ -212,37 +212,68 @@ describe('ESQLEditor', () => {
     expect(queryByTestId('ESQLEditor-run-query-button')).not.toBeInTheDocument();
   });
 
-  it('should render the data errors switch if the dataErrorsControl prop is set', async () => {
-    const newProps = {
-      ...props,
-      dataErrorsControl: { enabled: true, onChange: jest.fn() },
-    };
-    mockValidate.mockResolvedValue({
-      errors: [{ message: 'Data error example', severity: 'error' }],
-      warnings: [],
-    });
-    const { queryByTestId } = renderWithI18n(renderESQLEditorComponent(newProps));
-    await waitFor(() => {
-      expect(queryByTestId('ESQLEditor-footerPopoverButton-error')).toBeInTheDocument();
-    });
-    act(() => {
-      queryByTestId('ESQLEditor-footerPopoverButton-error')?.click();
-    });
-    expect(queryByTestId('ESQLEditor-footerPopover-dataErrorsSwitch')).toBeInTheDocument();
-  });
+  describe('data errors switch', () => {
+    test('shown with errors enabled', async () => {
+      const newProps = {
+        ...props,
+        dataErrorsControl: { enabled: true, onChange: jest.fn() },
+      };
+      mockValidate.mockResolvedValue({
+        errors: [
+          { message: 'Data error example', severity: 'error', code: 'unknownColumn' },
+          { message: 'Data error example', severity: 'error', code: 'unknownIndex' },
+        ],
+        warnings: [],
+      });
+      const { queryByTestId, queryAllByText } = renderWithI18n(renderESQLEditorComponent(newProps));
+      await waitFor(() => {
+        expect(queryByTestId('ESQLEditor-footerPopoverButton-error')).toBeInTheDocument();
+      });
+      act(() => {
+        queryByTestId('ESQLEditor-footerPopoverButton-error')?.click();
+      });
+      expect(queryByTestId('ESQLEditor-footerPopover-dataErrorsSwitch')).toBeInTheDocument();
 
-  it('should not render the data errors switch if the dataErrorsControl prop is not set', async () => {
-    mockValidate.mockResolvedValue({
-      errors: [{ message: 'Data error example', severity: 'error' }],
-      warnings: [],
+      expect(queryAllByText('Data error example')).toHaveLength(2);
     });
-    const { queryByTestId } = renderWithI18n(renderESQLEditorComponent(props));
-    await waitFor(() => {
-      expect(queryByTestId('ESQLEditor-footerPopoverButton-error')).toBeInTheDocument();
+
+    test('shown with errors disabled', async () => {
+      const newProps = {
+        ...props,
+        dataErrorsControl: { enabled: false, onChange: jest.fn() },
+      };
+      mockValidate.mockResolvedValue({
+        errors: [
+          { message: 'Data error example', severity: 'error', code: 'unknownColumn' },
+          { message: 'Data error example', severity: 'error', code: 'unknownIndex' },
+        ],
+        warnings: [],
+      });
+      const { queryByTestId, queryAllByText } = renderWithI18n(renderESQLEditorComponent(newProps));
+      await waitFor(() => {
+        expect(queryByTestId('ESQLEditor-footerPopoverButton-error')).toBeInTheDocument();
+      });
+      act(() => {
+        queryByTestId('ESQLEditor-footerPopoverButton-error')?.click();
+      });
+      expect(queryByTestId('ESQLEditor-footerPopover-dataErrorsSwitch')).toBeInTheDocument();
+
+      expect(queryAllByText('Data error example')).toHaveLength(0);
     });
-    act(() => {
-      queryByTestId('ESQLEditor-footerPopoverButton-error')?.click();
+
+    test('not shown when prop not set', async () => {
+      mockValidate.mockResolvedValue({
+        errors: [{ message: 'Data error example', severity: 'error' }],
+        warnings: [],
+      });
+      const { queryByTestId } = renderWithI18n(renderESQLEditorComponent(props));
+      await waitFor(() => {
+        expect(queryByTestId('ESQLEditor-footerPopoverButton-error')).toBeInTheDocument();
+      });
+      act(() => {
+        queryByTestId('ESQLEditor-footerPopoverButton-error')?.click();
+      });
+      expect(queryByTestId('ESQLEditor-footerPopover-dataErrorsSwitch')).not.toBeInTheDocument();
     });
-    expect(queryByTestId('ESQLEditor-footerPopover-dataErrorsSwitch')).not.toBeInTheDocument();
   });
 });

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -687,7 +687,13 @@ const ESQLEditorInternal = function ESQLEditor({
       }
       if (active) {
         setEditorMessages({ errors: parserErrors, warnings: parserWarnings });
-        monaco.editor.setModelMarkers(editorModel.current, 'Unified search', markers);
+        monaco.editor.setModelMarkers(
+          editorModel.current,
+          'Unified search',
+          // don't show the code in the editor
+          // but we need it above
+          markers.map((m) => ({ ...m, code: undefined }))
+        );
         return;
       }
     },

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -8,74 +8,74 @@
  */
 
 import {
+  EuiButton,
+  EuiDatePicker,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiOutsideClickDetector,
-  useEuiTheme,
-  EuiDatePicker,
-  EuiToolTip,
-  EuiButton,
-  type EuiButtonColor,
-  useGeneratedHtmlId,
   EuiFormLabel,
+  EuiOutsideClickDetector,
+  EuiToolTip,
+  useEuiTheme,
+  useGeneratedHtmlId,
+  type EuiButtonColor,
 } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
-import moment from 'moment';
-import { isEqual, memoize } from 'lodash';
+import { Global, css } from '@emotion/react';
 import type { CodeEditorProps } from '@kbn/code-editor';
 import { CodeEditor } from '@kbn/code-editor';
-import type { SerializedEnrichPolicy } from '@kbn/index-management-shared-types';
-import useObservable from 'react-use/lib/useObservable';
-import { KBN_FIELD_TYPES } from '@kbn/field-types';
 import type { CoreStart } from '@kbn/core/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { AggregateQuery, TimeRange } from '@kbn/es-query';
-import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
-import type { ILicense } from '@kbn/licensing-types';
-import { ESQLLang, ESQL_LANG_ID, monaco, type ESQLCallbacks } from '@kbn/monaco';
-import type { ComponentProps } from 'react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { fixESQLQueryWithVariables, getRemoteClustersFromESQLQuery } from '@kbn/esql-utils';
-import { createPortal } from 'react-dom';
-import { css, Global } from '@emotion/react';
+import type { FieldType } from '@kbn/esql-ast';
+import type { ESQLFieldWithMetadata } from '@kbn/esql-ast/src/commands_registry/types';
 import {
   ESQLVariableType,
   type ESQLControlVariable,
   type IndicesAutocompleteResult,
 } from '@kbn/esql-types';
-import type { ESQLFieldWithMetadata } from '@kbn/esql-ast/src/commands_registry/types';
-import type { FieldType } from '@kbn/esql-ast';
+import { fixESQLQueryWithVariables, getRemoteClustersFromESQLQuery } from '@kbn/esql-utils';
+import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
+import { KBN_FIELD_TYPES } from '@kbn/field-types';
+import { i18n } from '@kbn/i18n';
+import type { SerializedEnrichPolicy } from '@kbn/index-management-shared-types';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { ILicense } from '@kbn/licensing-types';
+import { ESQLLang, ESQL_LANG_ID, monaco, type ESQLCallbacks } from '@kbn/monaco';
+import type { MonacoMessage } from '@kbn/monaco/src/languages/esql/language';
+import { isEqual, memoize } from 'lodash';
+import moment from 'moment';
+import type { ComponentProps } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import useObservable from 'react-use/lib/useObservable';
+import { useCanCreateLookupIndex, useLookupIndexCommand } from './custom_commands';
 import { EditorFooter } from './editor_footer';
-import { fetchFieldsFromESQL } from './fetch_fields_from_esql';
-import {
-  clearCacheWhenOld,
-  getESQLSources,
-  parseErrors,
-  parseWarning,
-  useDebounceWithOptions,
-  onKeyDownResizeHandler,
-  onMouseDownResizeHandler,
-  getEditorOverwrites,
-  type MonacoMessage,
-  filterDataErrors,
-} from './helpers';
-import { addQueriesToCache } from './history_local_storage';
-import { ResizableButton } from './resizable_button';
 import {
   EDITOR_INITIAL_HEIGHT,
   EDITOR_INITIAL_HEIGHT_INLINE_EDITING,
-  RESIZABLE_CONTAINER_INITIAL_HEIGHT,
   EDITOR_MAX_HEIGHT,
+  RESIZABLE_CONTAINER_INITIAL_HEIGHT,
   esqlEditorStyles,
 } from './esql_editor.styles';
-import type {
-  ESQLEditorProps as ESQLEditorPropsInternal,
-  ESQLEditorDeps,
-  ControlsContext,
-} from './types';
+import { fetchFieldsFromESQL } from './fetch_fields_from_esql';
+import {
+  clearCacheWhenOld,
+  filterDataErrors,
+  getESQLSources,
+  getEditorOverwrites,
+  onKeyDownResizeHandler,
+  onMouseDownResizeHandler,
+  parseErrors,
+  parseWarning,
+  useDebounceWithOptions,
+} from './helpers';
+import { addQueriesToCache } from './history_local_storage';
+import { ResizableButton } from './resizable_button';
 import { useRestorableState, withRestorableState } from './restorable_state';
-import { useCanCreateLookupIndex, useLookupIndexCommand } from './custom_commands';
+import type {
+  ControlsContext,
+  ESQLEditorDeps,
+  ESQLEditorProps as ESQLEditorPropsInternal,
+} from './types';
 
 // for editor width smaller than this value we want to start hiding some text
 const BREAKPOINT_WIDTH = 540;

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -8,14 +8,14 @@
  */
 
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
-import type { MonacoMessage } from './helpers';
 import {
-  parseErrors,
-  parseWarning,
+  filterDataErrors,
   getIndicesList,
   getRemoteIndicesList,
-  filterDataErrors,
+  parseErrors,
+  parseWarning,
 } from './helpers';
+import type { MonacoMessage } from '@kbn/monaco/src/languages/esql/language';
 
 describe('helpers', function () {
   describe('parseErrors', function () {

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -32,6 +32,7 @@ describe('helpers', function () {
           severity: 8,
           startColumn: 8,
           startLineNumber: 1,
+          code: 'errorFromES',
         },
       ]);
     });
@@ -56,6 +57,7 @@ describe('helpers', function () {
           severity: 8,
           startColumn: 7,
           startLineNumber: 3,
+          code: 'errorFromES',
         },
       ]);
     });
@@ -71,6 +73,7 @@ describe('helpers', function () {
           severity: 8,
           startColumn: 1,
           startLineNumber: 1,
+          code: 'unknownError',
         },
       ]);
     });
@@ -89,6 +92,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 52,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
       ]);
     });
@@ -105,6 +109,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 52,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
         {
           endColumn: 169,
@@ -114,6 +119,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 84,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
       ]);
     });
@@ -130,6 +136,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 52,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
         {
           endColumn: 169,
@@ -139,6 +146,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 84,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
       ]);
     });
@@ -155,6 +163,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 1,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
         {
           endColumn: 10,
@@ -164,6 +173,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 1,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
         {
           endColumn: 10,
@@ -173,6 +183,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 1,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
       ]);
     });
@@ -188,6 +199,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 1,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
         {
           endColumn: 10,
@@ -197,6 +209,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 1,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
         {
           endColumn: 138,
@@ -206,6 +219,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 52,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
       ]);
     });
@@ -220,6 +234,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 1,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
         {
           endColumn: 40,
@@ -228,6 +243,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 9,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
         {
           endColumn: 18,
@@ -236,6 +252,7 @@ describe('helpers', function () {
           severity: 4,
           startColumn: 9,
           startLineNumber: 1,
+          code: 'warningFromES',
         },
       ]);
     });
@@ -365,12 +382,9 @@ describe('helpers', function () {
         { code: 'unknownIndex' },
         { code: 'unknownColumn' },
         { code: 'other' },
-        { code: { value: 'unknownIndex' } },
-        { code: { value: 'unknownColumn' } },
-        { code: { value: 'other' } },
       ] as MonacoMessage[];
 
-      expect(filterDataErrors(errors)).toEqual([{ code: 'other' }, { code: { value: 'other' } }]);
+      expect(filterDataErrors(errors)).toEqual([{ code: 'other' }]);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/esql_error_listener.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/esql_error_listener.ts
@@ -53,6 +53,7 @@ export class ESQLErrorListener extends ErrorListener<any> {
       endColumn,
       message: textMessage,
       severity: 'error',
+      code: 'syntaxError',
     });
   }
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/parser.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/parser.ts
@@ -358,6 +358,7 @@ export class Parser {
             endColumn: 0,
             message: `Invalid query [${this.src}]`,
             severity: 'error',
+            code: 'parseError',
           },
         ],
         tokens: [],

--- a/src/platform/packages/shared/kbn-esql-ast/src/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/types.ts
@@ -553,7 +553,7 @@ export interface EditorError {
   startColumn: number;
   endColumn: number;
   message: string;
-  code?: string;
+  code: string;
   severity: 'error' | 'warning' | number;
 }
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/types.ts
@@ -13,6 +13,6 @@ export interface EditorError {
   startColumn: number;
   endColumn: number;
   message: string;
-  code?: string;
+  code: string;
   severity: 'error' | 'warning' | number;
 }

--- a/src/platform/packages/shared/kbn-monaco/src/common/error_listener.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/common/error_listener.ts
@@ -35,6 +35,7 @@ export class ANTLRErrorListener extends ErrorListener<any> {
       endColumn,
       message,
       severity: 8,
+      code: 'syntaxError',
     });
   }
 

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.ts
@@ -7,18 +7,18 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { validateQuery, type ESQLCallbacks, suggest } from '@kbn/esql-validation-autocomplete';
-import { esqlFunctionNames } from '@kbn/esql-ast/src/definitions/generated/function_names';
 import { monarch } from '@elastic/monaco-esql';
 import * as monarchDefinitions from '@elastic/monaco-esql/lib/definitions';
+import { esqlFunctionNames } from '@kbn/esql-ast/src/definitions/generated/function_names';
+import { suggest, validateQuery, type ESQLCallbacks } from '@kbn/esql-validation-autocomplete';
 import { monaco } from '../../monaco_imports';
+import type { CustomLangModuleType } from '../../types';
 import { ESQL_LANG_ID } from './lib/constants';
-import { buildEsqlTheme } from './lib/theme';
-import { wrapAsMonacoSuggestions } from './lib/converters/suggestions';
 import { wrapAsMonacoMessages } from './lib/converters/positions';
+import { wrapAsMonacoSuggestions } from './lib/converters/suggestions';
 import { getHoverItem } from './lib/hover/hover';
 import { monacoPositionToOffset } from './lib/shared/utils';
-import type { CustomLangModuleType } from '../../types';
+import { buildEsqlTheme } from './lib/theme';
 
 const removeKeywordSuffix = (name: string) => {
   return name.endsWith('.keyword') ? name.slice(0, -8) : name;
@@ -26,7 +26,9 @@ const removeKeywordSuffix = (name: string) => {
 
 export const ESQL_AUTOCOMPLETE_TRIGGER_CHARS = ['(', ' ', '[', '?'];
 
-export const ESQLLang: CustomLangModuleType<ESQLCallbacks> = {
+export type MonacoMessage = monaco.editor.IMarkerData & { code: string };
+
+export const ESQLLang: CustomLangModuleType<ESQLCallbacks, MonacoMessage> = {
   ID: ESQL_LANG_ID,
   async onLanguage() {
     const language = monarch.create({

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/converters/positions.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/converters/positions.ts
@@ -51,6 +51,7 @@ export function wrapAsMonacoMessages(
       ? offsetToRowColumn(queryString, e.location.max || 0)
       : fallbackPosition;
     return {
+      code: e.code,
       message: e.text,
       startColumn: startPosition.column,
       startLineNumber: startPosition.lineNumber,

--- a/src/platform/packages/shared/kbn-monaco/src/types.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/types.ts
@@ -28,21 +28,21 @@ export interface CompleteLangModuleType extends LangModuleType {
   validation$: () => Observable<LangValidation>;
 }
 
-export interface LanguageProvidersModule<Deps = unknown> {
+interface LanguageProvidersModule<Deps = unknown, MarkerDataType = monaco.editor.IMarkerData> {
   validate: (
     model: monaco.editor.ITextModel,
     code: string,
     callbacks?: Deps
-  ) => Promise<{ errors: monaco.editor.IMarkerData[]; warnings: monaco.editor.IMarkerData[] }>;
+  ) => Promise<{ errors: MarkerDataType[]; warnings: MarkerDataType[] }>;
   getSuggestionProvider: (callbacks?: Deps) => monaco.languages.CompletionItemProvider;
   getSignatureProvider?: (callbacks?: Deps) => monaco.languages.SignatureHelpProvider;
   getHoverProvider?: (callbacks?: Deps) => monaco.languages.HoverProvider;
   getCodeActionProvider?: (callbacks?: Deps) => monaco.languages.CodeActionProvider;
 }
 
-export interface CustomLangModuleType<Deps = unknown>
+export interface CustomLangModuleType<Deps = unknown, MarkerDataType = monaco.editor.IMarkerData>
   extends Omit<LangModuleType, 'getSuggestionProvider' | 'onLanguage'>,
-    LanguageProvidersModule<Deps> {
+    LanguageProvidersModule<Deps, MarkerDataType> {
   onLanguage: NonNullable<LangModuleType['onLanguage']>;
 }
 
@@ -53,7 +53,7 @@ export interface MonacoEditorError {
   endLineNumber: number;
   endColumn: number;
   message: string;
-  code?: string | undefined;
+  code: string;
 }
 
 export interface LangValidation {


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/234069

also: makes `message.code` a required prop in the `ES|QL` editor so that we don't remove it again
