### PR TITLE
[Controls Anywhere] Fix ES|QL options list types

### DIFF
--- a/src/platform/packages/shared/controls/controls-schemas/index.ts
+++ b/src/platform/packages/shared/controls/controls-schemas/index.ts
@@ -14,6 +14,8 @@ export type {
   ControlsGroupState,
   DataControlState,
   OptionsListControlState,
+  OptionsListDSLControlState,
+  OptionsListESQLControlState,
   OptionsListDisplaySettings,
   OptionsListSearchTechnique,
   OptionsListSelection,

--- a/src/platform/packages/shared/controls/controls-schemas/src/options_list_schema.ts
+++ b/src/platform/packages/shared/controls/controls-schemas/src/options_list_schema.ts
@@ -34,7 +34,7 @@ export const optionsListSortSchema = schema.object(
 
 export const optionsListSelectionSchema = schema.oneOf([schema.string(), schema.number()]);
 
-export const optionsListControlSchema = dataControlSchema.extends({
+const optionsListControlBaseParameters = {
   displaySettings: schema.maybe(optionsListDisplaySettingsSchema),
   searchTechnique: schema.maybe(optionsListSearchTechniqueSchema),
   sort: schema.maybe(optionsListSortSchema),
@@ -43,4 +43,22 @@ export const optionsListControlSchema = dataControlSchema.extends({
   runPastTimeout: schema.maybe(schema.boolean({ defaultValue: false })),
   singleSelect: schema.maybe(schema.boolean({ defaultValue: false })),
   exclude: schema.maybe(schema.boolean({ defaultValue: false })),
+};
+
+export const optionsListDSLControlSchema = dataControlSchema.extends(
+  optionsListControlBaseParameters
+);
+export const optionsListESQLControlSchema = schema.object({
+  ...optionsListControlBaseParameters,
+  selectedOptions: schema.arrayOf(schema.string()),
+  variableName: schema.string(),
+  variableType: schema.oneOf([
+    schema.literal('fields'),
+    schema.literal('values'),
+    schema.literal('functions'),
+    schema.literal('time_literal'),
+  ]),
+  esqlQuery: schema.string(),
+  controlType: schema.oneOf([schema.literal('STATIC_VALUES'), schema.literal('VALUES_FROM_QUERY')]),
+  availableOptions: schema.maybe(schema.arrayOf(schema.string())),
 });

--- a/src/platform/packages/shared/controls/controls-schemas/src/types.ts
+++ b/src/platform/packages/shared/controls/controls-schemas/src/types.ts
@@ -11,7 +11,8 @@ import type { TypeOf } from '@kbn/config-schema';
 import type { controlSchema, dataControlSchema } from './control_schema';
 import type { controlsGroupSchema } from './controls_group_schema';
 import type {
-  optionsListControlSchema,
+  optionsListDSLControlSchema,
+  optionsListESQLControlSchema,
   optionsListDisplaySettingsSchema,
   optionsListSearchTechniqueSchema,
   optionsListSelectionSchema,
@@ -24,7 +25,11 @@ export type ControlState = TypeOf<typeof controlSchema>;
 export type DataControlState = TypeOf<typeof dataControlSchema>;
 
 export type OptionsListDisplaySettings = TypeOf<typeof optionsListDisplaySettingsSchema>;
-export type OptionsListControlState = TypeOf<typeof optionsListControlSchema>;
+
+export type OptionsListDSLControlState = TypeOf<typeof optionsListDSLControlSchema>;
+export type OptionsListESQLControlState = TypeOf<typeof optionsListESQLControlSchema>;
+export type OptionsListControlState = OptionsListDSLControlState | OptionsListESQLControlState;
+
 export type OptionsListSearchTechnique = TypeOf<typeof optionsListSearchTechniqueSchema>;
 export type OptionsListSelection = TypeOf<typeof optionsListSelectionSchema>;
 export type OptionsListSortingType = TypeOf<typeof optionsListSortSchema>;

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/mocks/data.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/mocks/data.ts
@@ -7,10 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type {
-  ControlGroupRuntimeState,
-  OptionsListDSLControlState,
-} from '@kbn/controls-plugin/public';
+import type { ControlGroupRuntimeState } from '@kbn/controls-plugin/public';
+import type { OptionsListDSLControlState } from '@kbn/controls-schemas';
 import type { Filter } from '@kbn/es-query';
 import { ALERT_DURATION, ALERT_RULE_NAME, ALERT_START, ALERT_STATUS } from '@kbn/rule-data-utils';
 

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/utils.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/utils.ts
@@ -7,13 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type {
-  ControlGroupRuntimeState,
-  OptionsListDSLControlState,
-  ControlPanelState,
-} from '@kbn/controls-plugin/public';
+import type { ControlGroupRuntimeState, ControlPanelState } from '@kbn/controls-plugin/public';
 
 import { isEmpty, isEqual, pick } from 'lodash';
+import type { OptionsListDSLControlState } from '@kbn/controls-schemas';
 import type { FilterControlConfig } from './types';
 
 export const getPanelsInOrderFromControlsState = (controlState: ControlGroupRuntimeState) => {

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/tsconfig.json
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/tsconfig.json
@@ -35,5 +35,6 @@
     "@kbn/presentation-publishing",
     "@kbn/response-ops-rules-apis",
     "@kbn/controls-constants",
+    "@kbn/controls-schemas",
   ]
 }

--- a/src/platform/plugins/shared/controls/common/options_list/index.ts
+++ b/src/platform/plugins/shared/controls/common/options_list/index.ts
@@ -10,8 +10,6 @@
 export { isValidSearch } from './is_valid_search';
 export { getSelectionAsFieldType } from './options_list_selections';
 export type {
-  OptionsListESQLControlState,
-  OptionsListDSLControlState,
   OptionsListFailureResponse,
   OptionsListRequest,
   OptionsListSuccessResponse,

--- a/src/platform/plugins/shared/controls/common/options_list/types.ts
+++ b/src/platform/plugins/shared/controls/common/options_list/types.ts
@@ -8,12 +8,13 @@
  */
 
 import type {
-  OptionsListControlState as OptionsListDSLControlState,
+  OptionsListControlState,
+  OptionsListDSLControlState,
+  OptionsListESQLControlState,
   OptionsListSelection,
 } from '@kbn/controls-schemas';
 import type { DataView, FieldSpec, RuntimeFieldSpec } from '@kbn/data-views-plugin/common';
 import type { AggregateQuery, BoolQuery, Filter, Query, TimeRange } from '@kbn/es-query';
-import type { ESQLControlState } from '@kbn/esql-types';
 
 /**
  * ----------------------------------------------------------------
@@ -21,10 +22,8 @@ import type { ESQLControlState } from '@kbn/esql-types';
  * ----------------------------------------------------------------
  */
 
-export type OptionsListESQLControlState = ESQLControlState & OptionsListDSLControlState; // TODO: @Zac This should be defined via a schema
-
 export const isOptionsListESQLControlState = (
-  state: OptionsListDSLControlState | undefined
+  state: OptionsListControlState | undefined
 ): state is OptionsListESQLControlState =>
   typeof state !== 'undefined' &&
   Object.hasOwn(state, 'esqlQuery') &&

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/editor_state_manager.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/editor_state_manager.ts
@@ -8,12 +8,12 @@
  */
 
 import { DEFAULT_SEARCH_TECHNIQUE } from '@kbn/controls-constants';
-import type { OptionsListControlState, OptionsListSearchTechnique } from '@kbn/controls-schemas';
+import type { OptionsListDSLControlState, OptionsListSearchTechnique } from '@kbn/controls-schemas';
 import type { StateComparators } from '@kbn/presentation-publishing/state_manager';
 import { initializeStateManager } from '@kbn/presentation-publishing/state_manager';
 
 export type EditorState = Pick<
-  OptionsListControlState,
+  OptionsListDSLControlState,
   'searchTechnique' | 'singleSelect' | 'runPastTimeout'
 >;
 

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
@@ -68,12 +68,12 @@ export const getOptionsListControlFactory = (): EmbeddableFactory<
   return {
     type: OPTIONS_LIST_CONTROL,
     buildEmbeddable: async ({ initialState, finalizeApi, uuid, parentApi }) => {
-      if (isOptionsListESQLControlState(initialState)) {
-        // TODO: @Zac can you fix this type error?
+      const state = initialState.rawState;
+
+      if (isOptionsListESQLControlState(state)) {
         throw new Error('ES|QL control state handling not yet implemented');
       }
 
-      const state = initialState.rawState;
       const editorStateManager = initializeEditorStateManager(state);
       const temporaryStateManager = initializeTemporayStateManager();
       const selectionsManager = initializeSelectionsManager(state);

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/utils/filter_utils.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/utils/filter_utils.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { OptionsListControlState } from '@kbn/controls-schemas';
+import type { OptionsListDSLControlState } from '@kbn/controls-schemas';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import {
   type Filter,
@@ -20,7 +20,7 @@ export const buildFilter = (
   dataView: DataView,
   controlId: string,
   filterState: Pick<
-    OptionsListControlState,
+    OptionsListDSLControlState,
     'fieldName' | 'existsSelected' | 'exclude' | 'selectedOptions'
   >
 ) => {

--- a/src/platform/plugins/shared/controls/public/index.ts
+++ b/src/platform/plugins/shared/controls/public/index.ts
@@ -39,7 +39,6 @@ export type {
   ControlPanelsState,
   DefaultDataControlState,
 } from '../common';
-export type { OptionsListDSLControlState } from '../common/options_list';
 
 export { serializeRuntimeState } from './control_group/utils/serialize_runtime_state';
 


### PR DESCRIPTION
## Summary

> [!WARNING]
> **_This work is being merged into a feature branch, not main!_**
> Because of this, we only need a review from @elastic/kibana-presentation for now.
>
> Type failures are expected because the feature branch is currently in an incomplete state, where the controls that have not yet been converted are dependent on things that no longer exist.

Fixes merge conflicts on the Controls Anywhere branch introduced by https://github.com/elastic/kibana/pull/233126. DSL/ES|QL type definitions for the options list are now defined as schemas.
