### PR TITLE
[Homepage][Bug] Fix api key counter in badge after getting created API key

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/api_key_form.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/api_key_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   EuiBadge,
   EuiButton,
@@ -19,8 +19,10 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { FormInfoField } from '@kbn/search-shared-ui';
 import { i18n } from '@kbn/i18n';
 import { ApiKeyFlyoutWrapper, useSearchApiKey, Status } from '@kbn/search-api-keys-components';
+import { useQueryClient } from '@tanstack/react-query';
 import { useGetApiKeys } from '../hooks/api/use_api_key';
 import { useKibana } from '../hooks/use_kibana';
+import { QueryKeys } from '../constants';
 
 interface ApiKeyFormProps {
   hasTitle?: boolean;
@@ -127,6 +129,11 @@ export const ApiKeyForm: React.FC<ApiKeyFormProps> = () => {
   const { share } = useKibana().services;
   const locator = share?.url?.locators.get('MANAGEMENT_APP_LOCATOR');
   const manageKeysLink = locator?.useUrl({ sectionId: 'security', appId: 'api_keys' });
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.invalidateQueries([QueryKeys.ApiKey]);
+  }, [apiKey, queryClient]);
 
   return (
     <EuiFlexGroup direction="column" gutterSize="s">


### PR DESCRIPTION
## Summary
When an API key is created on the homepage, either automatically on first load or using the api key flyout, the API key count badge doesn't update.
Now when api key changed, we trigger update status method

<img width="736" height="594" alt="image" src="https://github.com/user-attachments/assets/23d1c630-41f5-484d-b9e9-717012371125" />


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


