### PR TITLE
[AI / CI] Add action to automatically request Copilot review based on team labels

### DIFF
--- a/.github/workflows/copilot-request-review.yml
+++ b/.github/workflows/copilot-request-review.yml
@@ -1,0 +1,48 @@
+name: Request review from Copilot for specific team PRs
+
+on:
+  pull_request_target:
+    types:
+      - ready_for_review
+    branches:
+      - 'main'
+
+jobs:
+  request_review:
+    name: Request review from Copilot
+    runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
+    steps:
+      - name: Check for team labels
+        id: check_labels
+        run: |
+          # Team labels that should get Copilot reviews automatically
+          TEAMS=(
+            "Team:Operations"
+          )
+
+          PR_LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+
+          # Check if any team label matches
+          SHOULD_REQUEST_REVIEW=false
+          for team in "${TEAMS[@]}"; do
+            if echo "$PR_LABELS" | grep -q "\"$team\""; then
+              echo "Found matching team label: $team"
+              SHOULD_REQUEST_REVIEW=true
+              break
+            fi
+          done
+
+          echo "should_request_review=$SHOULD_REQUEST_REVIEW" >> $GITHUB_OUTPUT
+
+      - name: Request Copilot review
+        if: steps.check_labels.outputs.should_request_review == 'true'
+        env:
+          GITHUB_TOKEN: ${{secrets.KIBANAMACHINE_TOKEN}}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Requesting Copilot review for PR #$PR_NUMBER"
+
+          # Workaround from https://github.com/cli/cli/issues/10598
+          gh api --method POST "/repos/elastic/kibana/pulls/${PR_NUMBER}/requested_reviewers" \
+            -f "reviewers[]=copilot-pull-request-reviewer[bot]"

--- a/.github/workflows/copilot-request-review.yml
+++ b/.github/workflows/copilot-request-review.yml
@@ -22,9 +22,8 @@ jobs:
           )
 
           PR_LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-
-          # Check if any team label matches
           SHOULD_REQUEST_REVIEW=false
+
           for team in "${TEAMS[@]}"; do
             if echo "$PR_LABELS" | grep -q "\"$team\""; then
               echo "Found matching team label: $team"


### PR DESCRIPTION
## Summary

Closes #234705

This action will automatically request Copilot review when specific team labels are present and the PR is marked "Ready for Review". An alternative would be to use codeowners + teams instead of labels. This would be a bit more far reaching since it would include any PR with a teams changes rather than only PRs the team creates.

### Testing
The Copilot review for this PR was request with the GH CLI to validate the call works.