### PR TITLE
[Discover] Support unsaved changes across tabs

### DIFF
--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/edit_tab_label.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/edit_tab_label.tsx
@@ -9,7 +9,7 @@
 
 import type { ChangeEvent } from 'react';
 import React, { useCallback, useEffect, useState } from 'react';
-import { EuiFieldText, keys, useEuiTheme } from '@elastic/eui';
+import { EuiFieldText, keys, mathWithUnits, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { TabItem } from '../../types';
 import { MAX_TAB_LABEL_LENGTH } from '../../constants';
@@ -86,7 +86,7 @@ export const EditTabLabel: React.FC<EditTabLabelProps> = ({ item, onLabelEdited,
       inputRef={setInputNode}
       data-test-subj={`unifiedTabs_editTabLabelInput_${item.id}`}
       css={css`
-        block-size: 28px;
+        block-size: ${mathWithUnits([euiTheme.size.xl, euiTheme.size.xs], (xl, xs) => xl - xs)};
         margin-top: ${euiTheme.size.xxs};
       `}
       compressed

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.tsx
@@ -24,6 +24,7 @@ import {
   useGeneratedHtmlId,
   EuiProgress,
   EuiTextTruncate,
+  EuiIcon,
 } from '@elastic/eui';
 import { TabMenu } from '../tab_menu';
 import { EditTabLabel, type EditTabLabelProps } from './edit_tab_label';
@@ -36,6 +37,7 @@ import { TabPreview } from '../tab_preview';
 export interface TabProps {
   item: TabItem;
   isSelected: boolean;
+  isUnsaved?: boolean;
   isDragging?: boolean;
   dragHandleProps?: DraggableProvidedDragHandleProps | null;
   tabContentId: string;
@@ -50,10 +52,19 @@ export interface TabProps {
   onSelectedTabKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => Promise<void>;
 }
 
+const closeButtonLabel = i18n.translate('unifiedTabs.closeTabButton', {
+  defaultMessage: 'Close tab',
+});
+
+const unsavedChangesIndicatorTitle = i18n.translate('unifiedTabs.unsavedChangesTabIndicatorTitle', {
+  defaultMessage: 'Unsaved changes',
+});
+
 export const Tab: React.FC<TabProps> = (props) => {
   const {
     item,
     isSelected,
+    isUnsaved,
     isDragging,
     dragHandleProps,
     tabContentId,
@@ -73,10 +84,6 @@ export const Tab: React.FC<TabProps> = (props) => {
   const [showPreview, setShowPreview] = useState<boolean>(false);
   const [isActionPopoverOpen, setActionPopover] = useState<boolean>(false);
   const previewData = useMemo(() => getPreviewData(item), [getPreviewData, item]);
-
-  const closeButtonLabel = i18n.translate('unifiedTabs.closeTabButton', {
-    defaultMessage: 'Close tab',
-  });
 
   const hidePreview = useCallback(() => setShowPreview(false), [setShowPreview]);
 
@@ -198,21 +205,30 @@ export const Tab: React.FC<TabProps> = (props) => {
               {previewData.status === TabStatus.RUNNING && (
                 <EuiProgress size="xs" color="accent" position="absolute" />
               )}
-              <EuiText
-                id={tabLabelId}
-                color="inherit"
-                size="s"
-                css={getTabLabelCss(euiTheme)}
-                className="unifiedTabs__tabLabelText"
+              <EuiFlexGroup
+                gutterSize="xs"
+                alignItems="center"
+                justifyContent="spaceBetween"
+                wrap={false}
+                responsive={false}
               >
-                <EuiTextTruncate
-                  text={item.label}
-                  // Truncation width must be equal to max tab width minus padding
-                  width={tabsSizeConfig.regularTabMaxWidth - euiTheme.base}
-                  truncation="middle"
-                  title=""
-                />
-              </EuiText>
+                <EuiText
+                  id={tabLabelId}
+                  color="inherit"
+                  size="s"
+                  css={getTabLabelCss(euiTheme)}
+                  className="unifiedTabs__tabLabelText"
+                >
+                  <EuiTextTruncate
+                    text={item.label}
+                    // Truncation width must be equal to max tab width minus padding
+                    width={tabsSizeConfig.regularTabMaxWidth - euiTheme.base}
+                    truncation="middle"
+                    title=""
+                  />
+                </EuiText>
+                {isUnsaved && <EuiIcon type="dot" title={unsavedChangesIndicatorTitle} />}
+              </EuiFlexGroup>
             </div>
           )}
         </div>

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.tsx
@@ -216,7 +216,7 @@ export const Tab: React.FC<TabProps> = (props) => {
                   id={tabLabelId}
                   color="inherit"
                   size="s"
-                  css={getTabLabelCss(euiTheme)}
+                  css={getTabLabelCss()}
                   className="unifiedTabs__tabLabelText"
                 >
                   <EuiTextTruncate
@@ -298,14 +298,12 @@ function getTabContainerCss(
 
   return css`
     position: relative;
-    display: inline-block;
     border-right: ${euiTheme.border.thin};
     border-color: ${isDragging ? 'transparent' : euiTheme.colors.lightShade};
-    height: ${euiTheme.size.xl};
     min-width: ${tabsSizeConfig.regularTabMinWidth}px;
     max-width: ${tabsSizeConfig.regularTabMaxWidth}px;
 
-    color: ${isSelected ? euiTheme.colors.text : euiTheme.colors.subduedText};
+    color: ${isSelected || isDragging ? euiTheme.colors.text : euiTheme.colors.subduedText};
 
     .unifiedTabs__tabActions {
       position: absolute;
@@ -313,7 +311,6 @@ function getTabContainerCss(
       right: ${euiTheme.size.xs};
       opacity: 0;
       transition: opacity ${euiTheme.animation.fast};
-      pointer-events: auto;
     }
 
     &:hover,
@@ -335,20 +332,15 @@ function getTabContainerCss(
       }
     }
 
-    ${!isSelected
-      ? `
-          &:hover {
-            color: ${euiTheme.colors.text};
-        }`
-      : ''}
+    &:hover {
+      color: ${euiTheme.colors.text};
+    }
   `;
 }
 
 function getTabContentCss(euiTheme: EuiThemeComputed) {
   return css`
-    position: relative;
     display: inline-flex;
-    flex-direction: row;
     align-items: center;
     width: 100%;
     height: ${euiTheme.size.xl};
@@ -358,22 +350,12 @@ function getTabContentCss(euiTheme: EuiThemeComputed) {
 
 function getTabLabelContainerCss(euiTheme: EuiThemeComputed) {
   return css`
-    width: 100%;
-    height: ${euiTheme.size.l};
-    padding-top: ${euiTheme.size.xxs};
     padding-inline: ${euiTheme.size.xs};
-    text-align: left;
-    color: inherit;
-    border: none;
-    border-radius: 0;
-    background: transparent;
   `;
 }
 
-function getTabLabelCss(euiTheme: EuiThemeComputed) {
+function getTabLabelCss() {
   return css`
-    white-space: nowrap;
-    transform: translateZ(0);
     overflow: hidden;
   `;
 }

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.tsx
@@ -25,7 +25,6 @@ import {
   EuiProgress,
   EuiTextTruncate,
   EuiIcon,
-  CanvasTextUtils,
 } from '@elastic/eui';
 import { TabMenu } from '../tab_menu';
 import { EditTabLabel, type EditTabLabelProps } from './edit_tab_label';
@@ -34,6 +33,7 @@ import type { TabItem, TabsSizeConfig, GetTabMenuItems, TabsServices } from '../
 import { TabStatus, type TabPreviewData } from '../../types';
 import { TabWithBackground } from '../tabs_visual_glue_to_header/tab_with_background';
 import { TabPreview } from '../tab_preview';
+import { useTabLabelWidth } from './use_tab_label_width';
 
 export interface TabProps {
   item: TabItem;
@@ -169,49 +169,16 @@ export const Tab: React.FC<TabProps> = (props) => {
     [isSelected, isDragging, onSelectEvent, setActionPopover, onSelectedTabKeyDown]
   );
 
+  const { tabLabelRef, tabLabelWidth, tabLabelTextWidth } = useTabLabelWidth({
+    item,
+    tabsSizeConfig,
+  });
+
   useEffect(() => {
     if (isInlineEditActive && !isSelected) {
       setIsInlineEditActive(false);
     }
   }, [isInlineEditActive, isSelected, setIsInlineEditActive]);
-
-  const container = useRef<HTMLDivElement | null>(null);
-  const [textUtils, setTextUtils] = useState<CanvasTextUtils>();
-  const { labelWidth, labelTextWidth } = useMemo(() => {
-    if (!textUtils) {
-      return { labelWidth: 0, labelTextWidth: 0 };
-    }
-
-    textUtils.setTextToCheck(item.label);
-
-    const textWidth = Math.ceil(textUtils.textWidth);
-    const indicatorWidth = euiTheme.base * 1.25;
-    const textWithIndicatorWidth = textWidth + indicatorWidth;
-    const tabPaddingWidth = euiTheme.base;
-    const resolvedLabelWidth = Math.max(
-      Math.min(textWithIndicatorWidth, tabsSizeConfig.regularTabMaxWidth - tabPaddingWidth),
-      tabsSizeConfig.regularTabMinWidth - tabPaddingWidth
-    );
-
-    return {
-      labelWidth: resolvedLabelWidth,
-      labelTextWidth: resolvedLabelWidth - indicatorWidth,
-    };
-  }, [
-    euiTheme.base,
-    item.label,
-    tabsSizeConfig.regularTabMaxWidth,
-    tabsSizeConfig.regularTabMinWidth,
-    textUtils,
-  ]);
-
-  useEffect(() => {
-    if (!container.current) {
-      return;
-    }
-
-    setTextUtils(new CanvasTextUtils({ container: container.current }));
-  }, []);
 
   const mainTabContent = (
     <div css={getTabContainerCss(euiTheme, tabsSizeConfig, isSelected, isDragging)}>
@@ -245,13 +212,13 @@ export const Tab: React.FC<TabProps> = (props) => {
                 <EuiProgress size="xs" color="accent" position="absolute" />
               )}
               <EuiFlexGroup
-                ref={container}
+                ref={tabLabelRef}
                 gutterSize="xs"
                 alignItems="center"
                 justifyContent="spaceBetween"
                 wrap={false}
                 responsive={false}
-                style={{ width: labelWidth }}
+                style={{ width: tabLabelWidth }}
               >
                 <EuiText
                   id={tabLabelId}
@@ -262,7 +229,7 @@ export const Tab: React.FC<TabProps> = (props) => {
                 >
                   <EuiTextTruncate
                     text={item.label}
-                    width={labelTextWidth}
+                    width={tabLabelTextWidth}
                     truncation="middle"
                     title=""
                   />

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/use_tab_label_width.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/use_tab_label_width.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { CanvasTextUtils, useEuiTheme } from '@elastic/eui';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { TabItem, TabsSizeConfig } from '../../types';
+
+export const useTabLabelWidth = ({
+  item,
+  tabsSizeConfig,
+}: {
+  item: TabItem;
+  tabsSizeConfig: TabsSizeConfig;
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const tabLabelRef = useRef<HTMLDivElement | null>(null);
+  const [textUtils, setTextUtils] = useState<CanvasTextUtils>();
+
+  const { tabLabelWidth, tabLabelTextWidth } = useMemo(() => {
+    if (!textUtils) {
+      return { tabLabelWidth: 0, tabLabelTextWidth: 0 };
+    }
+
+    textUtils.setTextToCheck(item.label);
+
+    const textWidth = Math.ceil(textUtils.textWidth);
+    const indicatorWidth = euiTheme.base * 1.25;
+    const textWithIndicatorWidth = textWidth + indicatorWidth;
+    const tabPaddingWidth = euiTheme.base;
+    const resolvedLabelWidth = Math.max(
+      Math.min(textWithIndicatorWidth, tabsSizeConfig.regularTabMaxWidth - tabPaddingWidth),
+      tabsSizeConfig.regularTabMinWidth - tabPaddingWidth
+    );
+
+    return {
+      tabLabelWidth: resolvedLabelWidth,
+      tabLabelTextWidth: resolvedLabelWidth - indicatorWidth,
+    };
+  }, [
+    euiTheme.base,
+    item.label,
+    tabsSizeConfig.regularTabMaxWidth,
+    tabsSizeConfig.regularTabMinWidth,
+    textUtils,
+  ]);
+
+  useEffect(() => {
+    if (!tabLabelRef.current) {
+      return;
+    }
+
+    setTextUtils(new CanvasTextUtils({ container: tabLabelRef.current }));
+  }, []);
+
+  return { tabLabelRef, tabLabelWidth, tabLabelTextWidth };
+};

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/use_tab_label_width.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/use_tab_label_width.tsx
@@ -33,9 +33,11 @@ export const useTabLabelWidth = ({
     const indicatorWidth = euiTheme.base * 1.25;
     const textWithIndicatorWidth = textWidth + indicatorWidth;
     const tabPaddingWidth = euiTheme.base;
+    const maxWidthWithoutPadding = tabsSizeConfig.regularTabMaxWidth - tabPaddingWidth;
+    const minWidthWithoutPadding = tabsSizeConfig.regularTabMinWidth - tabPaddingWidth;
     const resolvedLabelWidth = Math.max(
-      Math.min(textWithIndicatorWidth, tabsSizeConfig.regularTabMaxWidth - tabPaddingWidth),
-      tabsSizeConfig.regularTabMinWidth - tabPaddingWidth
+      Math.min(textWithIndicatorWidth, maxWidthWithoutPadding),
+      minWidthWithoutPadding
     );
 
     return {

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/use_tab_label_width.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/use_tab_label_width.tsx
@@ -33,11 +33,12 @@ export const useTabLabelWidth = ({
     const indicatorWidth = euiTheme.base * 1.25;
     const textWithIndicatorWidth = textWidth + indicatorWidth;
     const tabPaddingWidth = euiTheme.base;
-    const maxWidthWithoutPadding = tabsSizeConfig.regularTabMaxWidth - tabPaddingWidth;
-    const minWidthWithoutPadding = tabsSizeConfig.regularTabMinWidth - tabPaddingWidth;
+    const tabBorderWidth = parseInt(String(euiTheme.border.width.thin), 10);
+    const maxLabelWidth = tabsSizeConfig.regularTabMaxWidth - tabPaddingWidth - tabBorderWidth;
+    const minLabelWidth = tabsSizeConfig.regularTabMinWidth - tabPaddingWidth - tabBorderWidth;
     const resolvedLabelWidth = Math.max(
-      Math.min(textWithIndicatorWidth, maxWidthWithoutPadding),
-      minWidthWithoutPadding
+      Math.min(textWithIndicatorWidth, maxLabelWidth),
+      minLabelWidth
     );
 
     return {
@@ -46,6 +47,7 @@ export const useTabLabelWidth = ({
     };
   }, [
     euiTheme.base,
+    euiTheme.border.width.thin,
     item.label,
     tabsSizeConfig.regularTabMaxWidth,
     tabsSizeConfig.regularTabMinWidth,

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabbed_content/tabbed_content.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabbed_content/tabbed_content.tsx
@@ -28,7 +28,7 @@ import type { TabItem, TabsServices, TabPreviewData } from '../../types';
 import { getNextTabNumber } from '../../utils/get_next_tab_number';
 import { MAX_ITEMS_COUNT } from '../../constants';
 
-export interface TabbedContentProps extends Pick<TabsBarProps, 'maxItemsCount'> {
+export interface TabbedContentProps extends Pick<TabsBarProps, 'unsavedItemIds' | 'maxItemsCount'> {
   items: TabItem[];
   selectedItemId?: string;
   recentlyClosedItems: TabItem[];
@@ -50,6 +50,7 @@ export const TabbedContent: React.FC<TabbedContentProps> = ({
   items: managedItems,
   selectedItemId: managedSelectedItemId,
   recentlyClosedItems,
+  unsavedItemIds,
   maxItemsCount = MAX_ITEMS_COUNT,
   services,
   hideTabsBar = false,
@@ -180,6 +181,7 @@ export const TabbedContent: React.FC<TabbedContentProps> = ({
             items={items}
             selectedItem={selectedItem}
             recentlyClosedItems={recentlyClosedItems}
+            unsavedItemIds={unsavedItemIds}
             maxItemsCount={maxItemsCount}
             tabContentId={tabContentId}
             getTabMenuItems={getTabMenuItems}

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_bar/tabs_bar.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_bar/tabs_bar.tsx
@@ -57,6 +57,7 @@ export type TabsBarProps = Pick<
   items: TabItem[];
   selectedItem: TabItem | null;
   recentlyClosedItems: TabItem[];
+  unsavedItemIds?: Set<string>;
   maxItemsCount?: number;
   services: TabsServices;
   onAdd: () => Promise<void>;
@@ -74,6 +75,7 @@ export const TabsBar = forwardRef<TabsBarApi, TabsBarProps>(
       items,
       selectedItem,
       recentlyClosedItems,
+      unsavedItemIds,
       maxItemsCount,
       tabContentId,
       getTabMenuItems,
@@ -241,6 +243,7 @@ export const TabsBar = forwardRef<TabsBarApi, TabsBarProps>(
                               key={item.id}
                               item={item}
                               isSelected={selectedItem?.id === item.id}
+                              isUnsaved={unsavedItemIds?.has(item.id)}
                               isDragging={isDragging}
                               dragHandleProps={dragHandleProps}
                               tabContentId={tabContentId}

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_bar/tabs_bar.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_bar/tabs_bar.tsx
@@ -57,7 +57,7 @@ export type TabsBarProps = Pick<
   items: TabItem[];
   selectedItem: TabItem | null;
   recentlyClosedItems: TabItem[];
-  unsavedItemIds?: Set<string>;
+  unsavedItemIds?: string[];
   maxItemsCount?: number;
   services: TabsServices;
   onAdd: () => Promise<void>;
@@ -243,7 +243,7 @@ export const TabsBar = forwardRef<TabsBarApi, TabsBarProps>(
                               key={item.id}
                               item={item}
                               isSelected={selectedItem?.id === item.id}
-                              isUnsaved={unsavedItemIds?.has(item.id)}
+                              isUnsaved={unsavedItemIds?.includes(item.id)}
                               isDragging={isDragging}
                               dragHandleProps={dragHandleProps}
                               tabContentId={tabContentId}

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_visual_glue_to_header/tab_with_background.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_visual_glue_to_header/tab_with_background.tsx
@@ -39,7 +39,9 @@ export const TabWithBackground = React.forwardRef<HTMLDivElement, TabWithBackgro
         // tab main background and another background color on hover
         css={css`
           display: inline-block;
-          background: ${isSelected ? selectedTabBackgroundColor : euiTheme.colors.lightestShade};
+          background: ${isSelected || isDragging
+            ? selectedTabBackgroundColor
+            : euiTheme.colors.lightestShade};
           transition: background ${euiTheme.animation.fast};
           ${isDragging
             ? `

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_histogram_layout.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_histogram_layout.test.tsx
@@ -130,7 +130,6 @@ const mountComponent = async ({
     searchSessionId: noSearchSessionId ? undefined : mockSearchSessionId,
   });
   stateContainer.dataState.data$ = savedSearchData$;
-  stateContainer.actions.undoSavedSearchChanges = jest.fn();
 
   const props: DiscoverMainContentProps = {
     dataView,

--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { type IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
 import useMount from 'react-use/lib/useMount';
@@ -25,7 +25,6 @@ import {
   useCurrentTabRuntimeState,
   useCurrentTabSelector,
   useCurrentTabAction,
-  TabInitialFetchState,
 } from '../../state_management/redux';
 import type {
   CustomizationCallback,
@@ -74,7 +73,6 @@ export const SingleTabView = ({
 
   const initializationState = useInternalStateSelector((state) => state.initializationState);
   const currentTabId = useCurrentTabSelector((tab) => tab.id);
-  const currentTabInitialFetchState = useCurrentTabSelector((tab) => tab.initialFetchState);
   const currentStateContainer = useCurrentTabRuntimeState(
     runtimeStateManager,
     (tab) => tab.stateContainer$
@@ -141,25 +139,6 @@ export const SingleTabView = ({
       });
     }
   });
-
-  const setInitialFetchState = useCurrentTabAction(internalStateActions.setInitialFetchState);
-  const shouldTriggerInitialFetch =
-    currentStateContainer &&
-    initializeTabState.value?.showNoDataPage === false &&
-    currentTabInitialFetchState !== TabInitialFetchState.triggered;
-
-  useEffect(() => {
-    if (shouldTriggerInitialFetch) {
-      currentStateContainer.actions.fetchData(true);
-      dispatch(setInitialFetchState({ initialFetchState: TabInitialFetchState.triggered }));
-    }
-  }, [
-    currentStateContainer?.actions,
-    currentTabInitialFetchState,
-    dispatch,
-    setInitialFetchState,
-    shouldTriggerInitialFetch,
-  ]);
 
   if (initializeTabState.loading) {
     return <BrandedLoadingIndicator />;

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
@@ -18,6 +18,7 @@ import {
   selectIsTabsBarHidden,
   useInternalStateDispatch,
   useInternalStateSelector,
+  selectHasUnsavedChanges,
 } from '../../state_management/redux';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { usePreviewData } from './use_preview_data';
@@ -32,6 +33,12 @@ export const TabsView = (props: SingleTabViewProps) => {
   const currentTabId = useInternalStateSelector((state) => state.tabs.unsafeCurrentId);
   const { getPreviewData } = usePreviewData(props.runtimeStateManager);
   const hideTabsBar = useInternalStateSelector(selectIsTabsBarHidden);
+  const { unsavedTabIds } = useInternalStateSelector((state) =>
+    selectHasUnsavedChanges(state, {
+      runtimeStateManager: props.runtimeStateManager,
+      services,
+    })
+  );
 
   const onChanged: UnifiedTabsProps['onChanged'] = useCallback(
     (updateState) => dispatch(internalStateActions.updateTabs(updateState)),
@@ -54,6 +61,7 @@ export const TabsView = (props: SingleTabViewProps) => {
       items={items}
       selectedItemId={currentTabId}
       recentlyClosedItems={recentlyClosedItems}
+      unsavedItemIds={unsavedTabIds}
       maxItemsCount={MAX_TABS_COUNT}
       hideTabsBar={hideTabsBar}
       createItem={createItem}

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
@@ -55,7 +55,7 @@ export const TabsView = (props: SingleTabViewProps) => {
       items={items}
       selectedItemId={currentTabId}
       recentlyClosedItems={recentlyClosedItems}
-      unsavedItemIds={new Set(unsavedTabIds)}
+      unsavedItemIds={unsavedTabIds}
       maxItemsCount={MAX_TABS_COUNT}
       hideTabsBar={hideTabsBar}
       createItem={createItem}

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
@@ -18,7 +18,6 @@ import {
   selectIsTabsBarHidden,
   useInternalStateDispatch,
   useInternalStateSelector,
-  selectHasUnsavedChanges,
 } from '../../state_management/redux';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { usePreviewData } from './use_preview_data';
@@ -33,12 +32,7 @@ export const TabsView = (props: SingleTabViewProps) => {
   const currentTabId = useInternalStateSelector((state) => state.tabs.unsafeCurrentId);
   const { getPreviewData } = usePreviewData(props.runtimeStateManager);
   const hideTabsBar = useInternalStateSelector(selectIsTabsBarHidden);
-  const { unsavedTabIds } = useInternalStateSelector((state) =>
-    selectHasUnsavedChanges(state, {
-      runtimeStateManager: props.runtimeStateManager,
-      services,
-    })
-  );
+  const unsavedTabIds = useInternalStateSelector((state) => state.tabs.unsavedIds);
 
   const onChanged: UnifiedTabsProps['onChanged'] = useCallback(
     (updateState) => dispatch(internalStateActions.updateTabs(updateState)),
@@ -61,7 +55,7 @@ export const TabsView = (props: SingleTabViewProps) => {
       items={items}
       selectedItemId={currentTabId}
       recentlyClosedItems={recentlyClosedItems}
-      unsavedItemIds={unsavedTabIds}
+      unsavedItemIds={new Set(unsavedTabIds)}
       maxItemsCount={MAX_TABS_COUNT}
       hideTabsBar={hideTabsBar}
       createItem={createItem}

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
@@ -18,6 +18,7 @@ import type { TopNavCustomization } from '../../../../customizations';
 import type { DiscoverServices } from '../../../../build_services';
 import { SolutionsViewBadge } from './solutions_view_badge';
 import { onSaveDiscoverSession } from './save_discover_session';
+import { internalStateActions } from '../../state_management/redux';
 
 /**
  * Helper function to build the top nav badges
@@ -59,7 +60,18 @@ export const getTopNavBadges = ({
       getTopNavUnsavedChangesBadge({
         onRevert: async () => {
           dismissFlyouts([DiscoverFlyouts.lensEdit]);
-          await stateContainer.actions.undoSavedSearchChanges();
+
+          const { persistedDiscoverSession } = stateContainer.internalState.getState();
+
+          if (persistedDiscoverSession) {
+            await stateContainer.internalState
+              .dispatch(
+                internalStateActions.resetDiscoverSession({
+                  discoverSession: persistedDiscoverSession,
+                })
+              )
+              .unwrap();
+          }
         },
         onSave:
           services.capabilities.discover_v2.save && !isManaged

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
@@ -65,12 +65,7 @@ export const getTopNavBadges = ({
 
           if (persistedDiscoverSession) {
             await stateContainer.internalState
-              .dispatch(
-                internalStateActions.resetDiscoverSession({
-                  discoverSession: persistedDiscoverSession,
-                  resetInitialFetchState: true,
-                })
-              )
+              .dispatch(internalStateActions.resetDiscoverSession())
               .unwrap();
           }
         },

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
@@ -68,6 +68,7 @@ export const getTopNavBadges = ({
               .dispatch(
                 internalStateActions.resetDiscoverSession({
                   discoverSession: persistedDiscoverSession,
+                  resetInitialFetchState: true,
                 })
               )
               .unwrap();

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
@@ -39,7 +39,7 @@ export const useDiscoverTopNav = ({
   // const hasUnsavedChanges = Boolean(
   //   hasSavedSearchChanges && stateContainer.savedSearchState.getId()
   // );
-  const hasUnsavedChanges = useInternalStateSelector((state) =>
+  const { hasUnsavedChanges } = useInternalStateSelector((state) =>
     selectHasUnsavedChanges(state, {
       runtimeStateManager: stateContainer.runtimeStateManager,
       services,

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
@@ -20,7 +20,12 @@ import {
 import type { DiscoverStateContainer } from '../../state_management/discover_state';
 import { getTopNavBadges } from './get_top_nav_badges';
 import { useTopNavLinks } from './use_top_nav_links';
-import { useAdHocDataViews, useCurrentDataView } from '../../state_management/redux';
+import {
+  selectHasUnsavedChanges,
+  useAdHocDataViews,
+  useCurrentDataView,
+  useInternalStateSelector,
+} from '../../state_management/redux';
 import { useHasShareIntegration } from '../../hooks/use_has_share_integration';
 
 export const useDiscoverTopNav = ({
@@ -30,9 +35,15 @@ export const useDiscoverTopNav = ({
 }) => {
   const services = useDiscoverServices();
   const topNavCustomization = useDiscoverCustomization('top_nav');
-  const hasSavedSearchChanges = useObservable(stateContainer.savedSearchState.getHasChanged$());
-  const hasUnsavedChanges = Boolean(
-    hasSavedSearchChanges && stateContainer.savedSearchState.getId()
+  // const hasSavedSearchChanges = useObservable(stateContainer.savedSearchState.getHasChanged$());
+  // const hasUnsavedChanges = Boolean(
+  //   hasSavedSearchChanges && stateContainer.savedSearchState.getId()
+  // );
+  const hasUnsavedChanges = useInternalStateSelector((state) =>
+    selectHasUnsavedChanges(state, {
+      runtimeStateManager: stateContainer.runtimeStateManager,
+      services,
+    })
   );
 
   const topNavBadges = useMemo(

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
@@ -8,7 +8,6 @@
  */
 
 import { useMemo } from 'react';
-import useObservable from 'react-use/lib/useObservable';
 import { useDiscoverCustomization } from '../../../../customizations';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { useInspector } from '../../hooks/use_inspector';

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
@@ -12,17 +12,13 @@ import { useDiscoverCustomization } from '../../../../customizations';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { useInspector } from '../../hooks/use_inspector';
 import { useIsEsqlMode } from '../../hooks/use_is_esql_mode';
-import {
-  useSavedSearch,
-  useSavedSearchHasChanged,
-} from '../../state_management/discover_state_provider';
 import type { DiscoverStateContainer } from '../../state_management/discover_state';
 import { getTopNavBadges } from './get_top_nav_badges';
 import { useTopNavLinks } from './use_top_nav_links';
 import {
-  selectHasUnsavedChanges,
   useAdHocDataViews,
   useCurrentDataView,
+  useCurrentTabSelector,
   useInternalStateSelector,
 } from '../../state_management/redux';
 import { useHasShareIntegration } from '../../hooks/use_has_share_integration';
@@ -34,16 +30,7 @@ export const useDiscoverTopNav = ({
 }) => {
   const services = useDiscoverServices();
   const topNavCustomization = useDiscoverCustomization('top_nav');
-  // const hasSavedSearchChanges = useObservable(stateContainer.savedSearchState.getHasChanged$());
-  // const hasUnsavedChanges = Boolean(
-  //   hasSavedSearchChanges && stateContainer.savedSearchState.getId()
-  // );
-  const { hasUnsavedChanges } = useInternalStateSelector((state) =>
-    selectHasUnsavedChanges(state, {
-      runtimeStateManager: stateContainer.runtimeStateManager,
-      services,
-    })
-  );
+  const hasUnsavedChanges = useInternalStateSelector((state) => state.hasUnsavedChanges);
 
   const topNavBadges = useMemo(
     () =>
@@ -55,9 +42,14 @@ export const useDiscoverTopNav = ({
       }),
     [stateContainer, services, hasUnsavedChanges, topNavCustomization]
   );
-  const savedSearchId = useSavedSearch().id;
-  const savedSearchHasChanged = useSavedSearchHasChanged();
-  const shouldShowESQLToDataViewTransitionModal = !savedSearchId || savedSearchHasChanged;
+
+  const persistedDiscoverSession = useInternalStateSelector(
+    (state) => state.persistedDiscoverSession
+  );
+  const unsavedTabIds = useInternalStateSelector((state) => state.tabs.unsavedIds);
+  const currentTabId = useCurrentTabSelector((tab) => tab.id);
+  const shouldShowESQLToDataViewTransitionModal =
+    !persistedDiscoverSession || unsavedTabIds.includes(currentTabId);
   const dataView = useCurrentDataView();
   const adHocDataViews = useAdHocDataViews();
   const isEsqlMode = useIsEsqlMode();

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.test.tsx
@@ -26,13 +26,6 @@ import { DiscoverTestProvider } from '../../__mocks__/test_provider';
 import type { AppMountParameters } from '@kbn/core/public';
 import { createRuntimeStateManager } from './state_management/redux';
 import { BehaviorSubject } from 'rxjs';
-import {
-  getRuntimeStateManagerMock,
-  getTabRuntimeStateMock,
-} from './state_management/redux/__mocks__/runtime_state.mocks';
-import { type DiscoverStateContainer } from './state_management/discover_state';
-import type { AppLeaveActionFactory } from '@kbn/core-application-browser';
-import { getDiscoverStateMock } from '../../__mocks__/discover_state.mock';
 
 let mockCustomizationService: Promise<DiscoverCustomizationService> | undefined;
 
@@ -203,84 +196,5 @@ describe('DiscoverMainRoute', () => {
     setupComponent({ hasESData: true, hasUserDataView: true });
 
     expect(screen.getByLabelText('Loading')).toBeInTheDocument();
-  });
-
-  describe.each([
-    { hasChanged: false, id: undefined, description: "hasn't changed and is not saved" },
-    { hasChanged: true, id: undefined, description: 'has changed and is not saved' },
-    { hasChanged: false, id: '1234', description: "hasn't changed and is saved" },
-  ])('when $description', ({ hasChanged, id }) => {
-    it('should call the default action', () => {
-      // Given
-      const discoverStateContainer = getDiscoverStateMock();
-      discoverStateContainer.savedSearchState.getHasChanged$ = () =>
-        new BehaviorSubject(hasChanged);
-      discoverStateContainer.savedSearchState.getId = () => id;
-
-      const tabMock = getTabRuntimeStateMock({
-        stateContainer$: new BehaviorSubject<DiscoverStateContainer | undefined>(
-          discoverStateContainer
-        ),
-      });
-
-      mockCreateRuntimeStateManager.mockReturnValue(
-        getRuntimeStateManagerMock({
-          tabs: { byId: { 'tab-mock': tabMock } },
-        })
-      );
-
-      const defaultFn = jest.fn();
-      const onAppLeave = jest
-        .fn()
-        .mockImplementation((callback: (actions: AppLeaveActionFactory) => void) => {
-          callback({
-            default: defaultFn,
-            confirm: jest.fn(),
-          });
-        });
-
-      // When
-      setupComponent({ onAppLeave });
-
-      // Then
-      expect(defaultFn).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('when there are unsaved changes', () => {
-    it('should call the confirm action', () => {
-      // Given
-      const discoverStateContainer = getDiscoverStateMock();
-      discoverStateContainer.savedSearchState.getHasChanged$ = () => new BehaviorSubject(true);
-      discoverStateContainer.savedSearchState.getId = () => '1234';
-
-      const tabMock = getTabRuntimeStateMock({
-        stateContainer$: new BehaviorSubject<DiscoverStateContainer | undefined>(
-          discoverStateContainer
-        ),
-      });
-
-      mockCreateRuntimeStateManager.mockReturnValue(
-        getRuntimeStateManagerMock({
-          tabs: { byId: { 'tab-mock': tabMock } },
-        })
-      );
-
-      const confirmFn = jest.fn();
-      const onAppLeave = jest
-        .fn()
-        .mockImplementation((callback: (actions: AppLeaveActionFactory) => void) => {
-          callback({
-            default: jest.fn(),
-            confirm: confirmFn,
-          });
-        });
-
-      // When
-      setupComponent({ onAppLeave });
-
-      // Then
-      expect(confirmFn).toHaveBeenCalledTimes(1);
-    });
   });
 });

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_saved_search_container.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_saved_search_container.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getSavedSearchContainer, isEqualSavedSearch } from './discover_saved_search_container';
+import { getSavedSearchContainer } from './discover_saved_search_container';
 import type { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { discoverServiceMock } from '../../../__mocks__/services';
 import {
@@ -15,11 +15,7 @@ import {
   createSavedSearchMock,
   savedSearchMock,
 } from '../../../__mocks__/saved_search';
-import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
-import { dataViewComplexMock } from '../../../__mocks__/data_view_complex';
 import { createKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
-import { VIEW_MODE } from '../../../../common/constants';
-import { createSearchSourceMock } from '@kbn/data-plugin/common/search/search_source/mocks';
 import {
   createInternalStateStore,
   createRuntimeStateManager,
@@ -27,7 +23,6 @@ import {
   selectTab,
 } from './redux';
 import { mockCustomizationContext } from '../../../customizations/__mocks__/customization_context';
-import { mockControlState } from '../../../__mocks__/esql_controls';
 import { omit } from 'lodash';
 import { createTabsStorageManager } from './tabs_storage_manager';
 
@@ -91,118 +86,13 @@ describe('DiscoverSavedSearchContainer', () => {
       const initialSavedSearch = container.getInitial$().getValue();
       const currentSavedSearch = container.getCurrent$().getValue();
 
-      expect(isEqualSavedSearch(initialSavedSearch, currentSavedSearch)).toBeTruthy();
-    });
-
-    it('should reset hasChanged$ to false', () => {
-      const container = getSavedSearchContainer({
-        services,
-        internalState,
-        getCurrentTab,
+      expect({
+        ...omit(initialSavedSearch, 'searchSource'),
+        searchSource: initialSavedSearch.searchSource.serialize(),
+      }).toEqual({
+        ...omit(currentSavedSearch, 'searchSource'),
+        searchSource: currentSavedSearch.searchSource.serialize(),
       });
-      const newSavedSearch: SavedSearch = { ...savedSearch, title: 'New title' };
-
-      container.set(newSavedSearch);
-      expect(container.getHasChanged$().getValue()).toBe(false);
-    });
-  });
-
-  describe('update', () => {
-    it('updates a saved search by app state providing hideChart', async () => {
-      const savedSearchContainer = getSavedSearchContainer({
-        services: discoverServiceMock,
-        internalState,
-        getCurrentTab,
-      });
-      savedSearchContainer.set(savedSearch);
-      const updated = savedSearchContainer.update({ nextState: { hideChart: true } });
-      expect(savedSearchContainer.getHasChanged$().getValue()).toBe(true);
-      savedSearchContainer.set(updated);
-      expect(savedSearchContainer.getHasChanged$().getValue()).toBe(false);
-      savedSearchContainer.update({ nextState: { hideChart: false } });
-      expect(savedSearchContainer.getHasChanged$().getValue()).toBe(true);
-      savedSearchContainer.update({ nextState: { hideChart: true } });
-      expect(savedSearchContainer.getHasChanged$().getValue()).toBe(false);
-    });
-    it('updates a saved search by data view', async () => {
-      const savedSearchContainer = getSavedSearchContainer({
-        services: discoverServiceMock,
-        internalState,
-        getCurrentTab,
-      });
-      const updated = savedSearchContainer.update({ nextDataView: dataViewMock });
-      expect(savedSearchContainer.getHasChanged$().getValue()).toBe(true);
-      savedSearchContainer.set(updated);
-      expect(savedSearchContainer.getHasChanged$().getValue()).toBe(false);
-      savedSearchContainer.update({ nextDataView: dataViewComplexMock });
-      expect(savedSearchContainer.getHasChanged$().getValue()).toBe(true);
-      savedSearchContainer.update({ nextDataView: dataViewMock });
-      expect(savedSearchContainer.getHasChanged$().getValue()).toBe(false);
-    });
-  });
-
-  describe('isEqualSavedSearch', () => {
-    it('should return true for equal saved searches', () => {
-      const savedSearch1 = savedSearchMock;
-      const savedSearch2 = { ...savedSearchMock };
-      expect(isEqualSavedSearch(savedSearch1, savedSearch2)).toBe(true);
-    });
-
-    it('should return false for different saved searches', () => {
-      const savedSearch1 = savedSearchMock;
-      const savedSearch2 = { ...savedSearchMock, title: 'New title' };
-      expect(isEqualSavedSearch(savedSearch1, savedSearch2)).toBe(false);
-    });
-
-    it('should return true for saved searches with equal default values of viewMode and false otherwise', () => {
-      const savedSearch1 = { ...savedSearchMock, viewMode: undefined };
-      const savedSearch2 = { ...savedSearchMock, viewMode: VIEW_MODE.DOCUMENT_LEVEL };
-      const savedSearch3 = { ...savedSearchMock, viewMode: VIEW_MODE.AGGREGATED_LEVEL };
-      expect(isEqualSavedSearch(savedSearch1, savedSearch2)).toBe(true);
-      expect(isEqualSavedSearch(savedSearch2, savedSearch1)).toBe(true);
-      expect(isEqualSavedSearch(savedSearch1, savedSearch3)).toBe(false);
-      expect(isEqualSavedSearch(savedSearch2, savedSearch3)).toBe(false);
-    });
-
-    it('should return true for saved searches with equal default values of breakdownField and false otherwise', () => {
-      const savedSearch1 = { ...savedSearchMock, breakdownField: undefined };
-      const savedSearch2 = { ...savedSearchMock, breakdownField: '' };
-      const savedSearch3 = { ...savedSearchMock, breakdownField: 'test' };
-      expect(isEqualSavedSearch(savedSearch1, savedSearch2)).toBe(true);
-      expect(isEqualSavedSearch(savedSearch2, savedSearch1)).toBe(true);
-      expect(isEqualSavedSearch(savedSearch1, savedSearch3)).toBe(false);
-      expect(isEqualSavedSearch(savedSearch2, savedSearch3)).toBe(false);
-    });
-
-    it('should check searchSource fields', () => {
-      const savedSearch1 = {
-        ...savedSearchMock,
-        searchSource: createSearchSourceMock({
-          index: savedSearchMock.searchSource.getField('index'),
-        }),
-      };
-      const savedSearch2 = {
-        ...savedSearchMock,
-        searchSource: createSearchSourceMock({
-          index: savedSearchMock.searchSource.getField('index'),
-        }),
-      };
-      expect(isEqualSavedSearch(savedSearch1, savedSearch1)).toBe(true);
-      expect(isEqualSavedSearch(savedSearch1, savedSearch2)).toBe(true);
-      savedSearch2.searchSource.setField('query', { language: 'lucene', query: 'test' });
-      expect(isEqualSavedSearch(savedSearch1, savedSearch2)).toBe(false);
-    });
-
-    it('should return false for different control states', () => {
-      const savedSearch1 = {
-        ...savedSearchMock,
-        controlGroupState: {
-          ...mockControlState,
-          panel1: { ...mockControlState.panel1, selectedOptions: ['baz'] },
-        },
-      };
-      const savedSearch2 = { ...savedSearchMock, controlGroupState: mockControlState };
-      expect(isEqualSavedSearch(savedSearch1, savedSearch2)).toBe(false);
     });
   });
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_saved_search_container.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_saved_search_container.ts
@@ -9,28 +9,16 @@
 
 import type { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { BehaviorSubject } from 'rxjs';
-import { cloneDeep } from 'lodash';
 import type { ControlPanelsState } from '@kbn/controls-plugin/public';
 import type { ESQLControlState } from '@kbn/esql-types';
-import type { FilterCompareOptions } from '@kbn/es-query';
-import { COMPARE_ALL_OPTIONS, isOfAggregateQueryType } from '@kbn/es-query';
-import type { SearchSourceFields } from '@kbn/data-plugin/common';
+import { isOfAggregateQueryType } from '@kbn/es-query';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { UnifiedHistogramVisContext } from '@kbn/unified-histogram';
-import { canImportVisContext } from '@kbn/unified-histogram';
-import { isEqual, isFunction } from 'lodash';
-import { VIEW_MODE } from '../../../../common/constants';
 import { updateSavedSearch } from './utils/update_saved_search';
 import { addLog } from '../../../utils/add_log';
 import type { DiscoverAppState } from './discover_app_state_container';
-import { isEqualFilters } from './discover_app_state_container';
 import type { DiscoverServices } from '../../../build_services';
 import type { InternalStateStore, TabState } from './redux';
-
-const FILTERS_COMPARE_OPTIONS: FilterCompareOptions = {
-  ...COMPARE_ALL_OPTIONS,
-  state: false, // We don't compare filter types (global vs appState).
-};
 
 export interface UpdateParams {
   /**
@@ -48,8 +36,7 @@ export interface UpdateParams {
 }
 
 /**
- * Container for the saved search state, allowing to load, update and persist the saved search
- * Can also be used to track changes to the saved search
+ * Container for the saved search state, allowing to update the saved search
  * It centralizes functionality that was spread across the Discover main codebase
  * There are 2 hooks to access the state of the saved search in React components:
  * - useSavedSearch for the current state, that's updated on every relevant state change
@@ -79,11 +66,6 @@ export interface DiscoverSavedSearchContainer {
    */
   getTitle: () => string | undefined;
   /**
-   * Get an BehaviorSubject containing the state if there have been changes to the initial state of the saved search
-   * Can be used to track if the saved search has been modified and displayed in the UI
-   */
-  getHasChanged$: () => BehaviorSubject<boolean>;
-  /**
    * Get the current state of the saved search
    */
   getState: () => SavedSearch;
@@ -94,8 +76,7 @@ export interface DiscoverSavedSearchContainer {
    */
   set: (savedSearch: SavedSearch) => SavedSearch;
   /**
-   * Similar to set, but does not reset the initial state,
-   * ensuring unsaved changes are tracked
+   * Similar to set, but does not reset the initial state
    * @param nextSavedSearch
    */
   assignNextSavedSearch: (nextSavedSearch: SavedSearch) => void;
@@ -132,10 +113,8 @@ export function getSavedSearchContainer({
   const initialSavedSearch = services.savedSearch.getNew();
   const savedSearchInitial$ = new BehaviorSubject(initialSavedSearch);
   const savedSearchCurrent$ = new BehaviorSubject(copySavedSearch(initialSavedSearch));
-  const hasChanged$ = new BehaviorSubject(false);
   const set = (savedSearch: SavedSearch) => {
     addLog('[savedSearch] set', savedSearch);
-    hasChanged$.next(false);
     savedSearchCurrent$.next(savedSearch);
     savedSearchInitial$.next(copySavedSearch(savedSearch));
     return savedSearch;
@@ -143,7 +122,6 @@ export function getSavedSearchContainer({
   const getState = () => savedSearchCurrent$.getValue();
   const getInitial$ = () => savedSearchInitial$;
   const getCurrent$ = () => savedSearchCurrent$;
-  const getHasChanged$ = () => hasChanged$;
   const getTitle = () => savedSearchCurrent$.getValue().title;
   const getId = () => savedSearchCurrent$.getValue().id;
 
@@ -174,8 +152,6 @@ export function getSavedSearchContainer({
   };
 
   const assignNextSavedSearch = ({ nextSavedSearch }: { nextSavedSearch: SavedSearch }) => {
-    const hasChanged = !isEqualSavedSearch(savedSearchInitial$.getValue(), nextSavedSearch);
-    hasChanged$.next(hasChanged);
     savedSearchCurrent$.next(nextSavedSearch);
   };
 
@@ -255,7 +231,6 @@ export function getSavedSearchContainer({
   return {
     initUrlTracking,
     getCurrent$,
-    getHasChanged$,
     getId,
     getInitial$,
     getState,
@@ -278,119 +253,4 @@ export function copySavedSearch(savedSearch: SavedSearch): SavedSearch {
     ...savedSearch,
     ...{ searchSource: savedSearch.searchSource.createCopy() },
   };
-}
-
-export function isEqualSavedSearch(savedSearchPrev: SavedSearch, savedSearchNext: SavedSearch) {
-  const { searchSource: prevSearchSource, ...prevSavedSearch } = savedSearchPrev;
-  const { searchSource: nextSearchSource, ...nextSavedSearchWithoutSearchSource } = savedSearchNext;
-
-  const keys = new Set([
-    ...Object.keys(prevSavedSearch),
-    ...Object.keys(nextSavedSearchWithoutSearchSource),
-  ] as Array<keyof Omit<SavedSearch, 'searchSource'>>);
-
-  // at least one change in saved search attributes
-  const hasChangesInSavedSearch = [...keys].some((key) => {
-    if (
-      ['usesAdHocDataView', 'hideChart'].includes(key) &&
-      typeof prevSavedSearch[key] === 'undefined' &&
-      nextSavedSearchWithoutSearchSource[key] === false
-    ) {
-      return false; // ignore when value was changed from `undefined` to `false` as it happens per app logic, not by a user action
-    }
-
-    const prevValue = getSavedSearchFieldForComparison(prevSavedSearch, key);
-    const nextValue = getSavedSearchFieldForComparison(nextSavedSearchWithoutSearchSource, key);
-
-    const isSame = isEqual(prevValue, nextValue);
-
-    if (!isSame) {
-      addLog('[savedSearch] difference between initial and changed version', {
-        key,
-        before: prevSavedSearch[key],
-        after: nextSavedSearchWithoutSearchSource[key],
-      });
-    }
-
-    return !isSame;
-  });
-
-  if (hasChangesInSavedSearch) {
-    return false;
-  }
-
-  // at least one change in search source fields
-  const hasChangesInSearchSource = (
-    ['filter', 'query', 'index'] as Array<keyof SearchSourceFields>
-  ).some((key) => {
-    const prevValue = getSearchSourceFieldValueForComparison(prevSearchSource, key);
-    const nextValue = getSearchSourceFieldValueForComparison(nextSearchSource, key);
-
-    const isSame =
-      key === 'filter'
-        ? isEqualFilters(prevValue, nextValue, FILTERS_COMPARE_OPTIONS) // if a filter gets pinned and the order of filters does not change, we don't show the unsaved changes badge
-        : isEqual(prevValue, nextValue);
-
-    if (!isSame) {
-      addLog('[savedSearch] difference between initial and changed version', {
-        key,
-        before: prevValue,
-        after: nextValue,
-      });
-    }
-
-    return !isSame;
-  });
-
-  if (hasChangesInSearchSource) {
-    return false;
-  }
-
-  addLog('[savedSearch] no difference between initial and changed version');
-
-  return true;
-}
-
-function getSavedSearchFieldForComparison(
-  savedSearch: Omit<SavedSearch, 'searchSource'>,
-  fieldName: keyof Omit<SavedSearch, 'searchSource'>
-) {
-  if (fieldName === 'visContext') {
-    const visContext = cloneDeep(savedSearch.visContext);
-    if (canImportVisContext(visContext) && visContext?.attributes?.title) {
-      // ignore differences in title as it sometimes does not match the actual vis type/shape
-      visContext.attributes.title = 'same';
-    }
-    return visContext;
-  }
-
-  if (fieldName === 'breakdownField') {
-    return savedSearch.breakdownField || ''; // ignore the difference between an empty string and undefined
-  }
-
-  if (fieldName === 'viewMode') {
-    // By default, viewMode: undefined is equivalent to documents view
-    // So they should be treated as same
-    return savedSearch.viewMode ?? VIEW_MODE.DOCUMENT_LEVEL;
-  }
-
-  return savedSearch[fieldName];
-}
-
-function getSearchSourceFieldValueForComparison(
-  searchSource: SavedSearch['searchSource'],
-  searchSourceFieldName: keyof SearchSourceFields
-) {
-  if (searchSourceFieldName === 'index') {
-    const query = searchSource.getField('query');
-    // ad-hoc data view id can change, so we rather compare the ES|QL query itself here
-    return query && 'esql' in query ? query.esql : searchSource.getField('index')?.id;
-  }
-
-  if (searchSourceFieldName === 'filter') {
-    const filterField = searchSource.getField('filter');
-    return isFunction(filterField) ? filterField() : filterField;
-  }
-
-  return searchSource.getField(searchSourceFieldName);
 }

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
@@ -1307,7 +1307,7 @@ describe('Discover state', () => {
       state.actions.stopSyncing();
     });
 
-    test('undoSavedSearchChanges - when changing data views', async () => {
+    test('resetDiscoverSession - when changing data views', async () => {
       const { state, customizationService, runtimeStateManager, getCurrentUrl } = await getState(
         '/',
         {
@@ -1353,7 +1353,12 @@ describe('Discover state', () => {
       ).toBe(dataViewComplexMock.id);
 
       // Undo all changes to the saved search, this should trigger a fetch, again
-      await state.actions.undoSavedSearchChanges();
+      const { persistedDiscoverSession } = state.internalState.getState();
+      if (persistedDiscoverSession) {
+        await state.internalState.dispatch(
+          internalStateActions.resetDiscoverSession({ discoverSession: persistedDiscoverSession })
+        );
+      }
       await new Promise(process.nextTick);
       expect(getCurrentUrl()).toBe(initialUrlState);
       await waitFor(() => {
@@ -1369,7 +1374,7 @@ describe('Discover state', () => {
       state.actions.stopSyncing();
     });
 
-    test('undoSavedSearchChanges with timeRestore', async () => {
+    test('resetDiscoverSession with timeRestore', async () => {
       const savedSearch = {
         ...savedSearchMockWithTimeField,
         timeRestore: true,
@@ -1394,7 +1399,12 @@ describe('Discover state', () => {
       expect(setTime).toHaveBeenCalledTimes(1);
       expect(setTime).toHaveBeenLastCalledWith({ from: 'now-15d', to: 'now-10d' });
       expect(setRefreshInterval).toHaveBeenLastCalledWith({ pause: false, value: 1000 });
-      await state.actions.undoSavedSearchChanges();
+      const { persistedDiscoverSession } = state.internalState.getState();
+      if (persistedDiscoverSession) {
+        await state.internalState.dispatch(
+          internalStateActions.resetDiscoverSession({ discoverSession: persistedDiscoverSession })
+        );
+      }
       expect(setTime).toHaveBeenCalledTimes(2);
       expect(setTime).toHaveBeenLastCalledWith({ from: 'now-15d', to: 'now-10d' });
       expect(setRefreshInterval).toHaveBeenCalledWith({ pause: false, value: 1000 });

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
@@ -1249,7 +1249,7 @@ describe('Discover state', () => {
       expect(state.savedSearchState.getState().hideChart).toBe(false);
       state.savedSearchState.update({ nextState: { hideChart: true } });
       expect(state.savedSearchState.getState().hideChart).toBe(true);
-      state.actions.onOpenSavedSearch(savedSearchMock.id!);
+      await state.actions.onOpenSavedSearch(savedSearchMock.id!);
       expect(state.savedSearchState.getState().hideChart).toBe(false);
       state.actions.stopSyncing();
     });
@@ -1353,12 +1353,7 @@ describe('Discover state', () => {
       ).toBe(dataViewComplexMock.id);
 
       // Undo all changes to the saved search, this should trigger a fetch, again
-      const { persistedDiscoverSession } = state.internalState.getState();
-      if (persistedDiscoverSession) {
-        await state.internalState.dispatch(
-          internalStateActions.resetDiscoverSession({ discoverSession: persistedDiscoverSession })
-        );
-      }
+      await state.internalState.dispatch(internalStateActions.resetDiscoverSession());
       await new Promise(process.nextTick);
       expect(getCurrentUrl()).toBe(initialUrlState);
       await waitFor(() => {
@@ -1399,12 +1394,7 @@ describe('Discover state', () => {
       expect(setTime).toHaveBeenCalledTimes(1);
       expect(setTime).toHaveBeenLastCalledWith({ from: 'now-15d', to: 'now-10d' });
       expect(setRefreshInterval).toHaveBeenLastCalledWith({ pause: false, value: 1000 });
-      const { persistedDiscoverSession } = state.internalState.getState();
-      if (persistedDiscoverSession) {
-        await state.internalState.dispatch(
-          internalStateActions.resetDiscoverSession({ discoverSession: persistedDiscoverSession })
-        );
-      }
+      await state.internalState.dispatch(internalStateActions.resetDiscoverSession());
       expect(setTime).toHaveBeenCalledTimes(2);
       expect(setTime).toHaveBeenLastCalledWith({ from: 'now-15d', to: 'now-10d' });
       expect(setRefreshInterval).toHaveBeenCalledWith({ pause: false, value: 1000 });

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
@@ -12,6 +12,7 @@ import { createSearchSessionRestorationDataProvider } from './discover_state';
 import {
   fromSavedSearchToSavedObjectTab,
   internalStateActions,
+  selectHasUnsavedChanges,
   selectTabRuntimeState,
 } from './redux';
 import type { History } from 'history';
@@ -462,7 +463,11 @@ describe('Discover state', () => {
       expect(getCurrentUrl()).toMatchInlineSnapshot(
         `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),dataSource:(dataViewId:the-data-view-id,type:dataView),interval:auto,sort:!())"`
       );
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
+      const { hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      });
+      expect(hasUnsavedChanges).toBe(false);
       const { searchSource, ...savedSearch } = state.savedSearchState.getState();
       expect(savedSearch).toMatchInlineSnapshot(`
               Object {
@@ -503,7 +508,11 @@ describe('Discover state', () => {
       expect(getCurrentUrl()).toMatchInlineSnapshot(
         `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),dataSource:(dataViewId:the-data-view-id,type:dataView),interval:auto,sort:!())"`
       );
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
+      const { hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      });
+      expect(hasUnsavedChanges).toBe(false);
       state.actions.stopSyncing();
     });
 
@@ -527,7 +536,11 @@ describe('Discover state', () => {
       expect(getCurrentUrl()).toMatchInlineSnapshot(
         `"/#?_a=(columns:!(bytes),dataSource:(dataViewId:the-data-view-id,type:dataView),interval:month,sort:!())&_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))"`
       );
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
+      const { hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      });
+      expect(hasUnsavedChanges).toBe(false);
       state.actions.stopSyncing();
     });
 
@@ -551,7 +564,11 @@ describe('Discover state', () => {
       expect(getCurrentUrl()).toMatchInlineSnapshot(
         `"/#?_a=(columns:!(bytes),dataSource:(dataViewId:the-data-view-id,type:dataView),interval:month,sort:!())&_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))"`
       );
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
+      const { hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      });
+      expect(hasUnsavedChanges).toBe(false);
       state.actions.stopSyncing();
     });
 
@@ -588,7 +605,11 @@ describe('Discover state', () => {
       expect(getCurrentUrl()).toMatchInlineSnapshot(
         `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),dataSource:(dataViewId:the-data-view-id,type:dataView),grid:(),hideChart:!f,interval:auto,sort:!())"`
       );
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
+      const { hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      });
+      expect(hasUnsavedChanges).toBe(false);
       state.actions.stopSyncing();
     });
 
@@ -611,7 +632,11 @@ describe('Discover state', () => {
       expect(getCurrentUrl()).toMatchInlineSnapshot(
         `"/#?_a=(columns:!(message),dataSource:(dataViewId:the-data-view-id,type:dataView),grid:(),hideChart:!f,interval:month,sort:!())&_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))"`
       );
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(true);
+      const { hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      });
+      expect(hasUnsavedChanges).toBe(true);
       state.actions.stopSyncing();
     });
 
@@ -637,7 +662,11 @@ describe('Discover state', () => {
         })
       );
       await new Promise(process.nextTick);
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(true);
+      const { hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      });
+      expect(hasUnsavedChanges).toBe(true);
       state.actions.stopSyncing();
     });
 
@@ -667,7 +696,11 @@ describe('Discover state', () => {
         })
       );
       await new Promise(process.nextTick);
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(true);
+      const { hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      });
+      expect(hasUnsavedChanges).toBe(true);
       state.actions.stopSyncing();
     });
 
@@ -697,7 +730,11 @@ describe('Discover state', () => {
         })
       );
       await new Promise(process.nextTick);
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
+      const { hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      });
+      expect(hasUnsavedChanges).toBe(false);
       state.actions.stopSyncing();
     });
 
@@ -819,7 +856,11 @@ describe('Discover state', () => {
       expect(state.savedSearchState.getState().searchSource.getField('index')?.id).toBe(
         'the-data-view-id'
       );
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
+      let { hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      });
+      expect(hasUnsavedChanges).toBe(false);
       savedSearch = { ...copySavedSearch(savedSearchMockWithTimeField), id: savedSearch.id };
       savedSearchWithDefaults = updateSavedSearch({
         savedSearch,
@@ -869,7 +910,11 @@ describe('Discover state', () => {
       expect(state.savedSearchState.getState().searchSource.getField('index')?.id).toBe(
         'index-pattern-with-timefield-id'
       );
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
+      ({ hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      }));
+      expect(hasUnsavedChanges).toBe(false);
       savedSearch = copySavedSearch(savedSearchMock);
       savedSearchWithDefaults = updateSavedSearch({
         savedSearch,
@@ -922,7 +967,11 @@ describe('Discover state', () => {
       expect(state.savedSearchState.getState().searchSource.getField('index')?.id).toBe(
         'index-pattern-with-timefield-id'
       );
-      expect(state.savedSearchState.getHasChanged$().getValue()).toBe(true);
+      ({ hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      }));
+      expect(hasUnsavedChanges).toBe(true);
     });
 
     test('loadSavedSearch generating a new saved search, updated by ad-hoc data view', async () => {
@@ -956,7 +1005,11 @@ describe('Discover state', () => {
       expect(
         state.savedSearchState.getCurrent$().getValue().searchSource?.getField('index')?.id
       ).toEqual(dataViewSpecMock.id);
-      expect(state.savedSearchState.getHasChanged$().getValue()).toEqual(false);
+      const { hasUnsavedChanges } = selectHasUnsavedChanges(state.internalState.getState(), {
+        runtimeStateManager: state.runtimeStateManager,
+        services: mockServices,
+      });
+      expect(hasUnsavedChanges).toBe(false);
       expect(state.runtimeStateManager.adHocDataViews$.getValue().length).toBe(1);
     });
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
@@ -331,10 +331,14 @@ export function getDiscoverStateContainer({
 
   const onOpenSavedSearch = async (newSavedSearchId: string) => {
     addLog('[discoverState] onOpenSavedSearch', newSavedSearchId);
-    const currentSavedSearch = savedSearchContainer.getState();
-    if (currentSavedSearch.id && currentSavedSearch.id === newSavedSearchId) {
+    const { persistedDiscoverSession } = internalState.getState();
+    if (persistedDiscoverSession?.id === newSavedSearchId) {
       addLog('[discoverState] undo changes since saved search did not change');
-      await undoSavedSearchChanges();
+      await internalState
+        .dispatch(
+          internalStateActions.resetDiscoverSession({ discoverSession: persistedDiscoverSession })
+        )
+        .unwrap();
     } else {
       addLog('[discoverState] onOpenSavedSearch open view URL');
       services.locator.navigate({

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
@@ -334,14 +334,7 @@ export function getDiscoverStateContainer({
     const { persistedDiscoverSession } = internalState.getState();
     if (persistedDiscoverSession?.id === newSavedSearchId) {
       addLog('[discoverState] undo changes since saved search did not change');
-      await internalState
-        .dispatch(
-          internalStateActions.resetDiscoverSession({
-            discoverSession: persistedDiscoverSession,
-            resetInitialFetchState: true,
-          })
-        )
-        .unwrap();
+      await internalState.dispatch(internalStateActions.resetDiscoverSession()).unwrap();
     } else {
       addLog('[discoverState] onOpenSavedSearch open view URL');
       services.locator.navigate({

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
@@ -336,7 +336,10 @@ export function getDiscoverStateContainer({
       addLog('[discoverState] undo changes since saved search did not change');
       await internalState
         .dispatch(
-          internalStateActions.resetDiscoverSession({ discoverSession: persistedDiscoverSession })
+          internalStateActions.resetDiscoverSession({
+            discoverSession: persistedDiscoverSession,
+            resetInitialFetchState: true,
+          })
         )
         .unwrap();
     } else {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
@@ -175,7 +175,7 @@ export interface DiscoverStateContainer {
      * Triggered when a saved search is opened in the savedObject finder
      * @param savedSearchId
      */
-    onOpenSavedSearch: (savedSearchId: string) => void;
+    onOpenSavedSearch: (savedSearchId: string) => Promise<void>;
     /**
      * Triggered when the unified search bar query is updated
      * @param payload

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state_provider.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state_provider.tsx
@@ -31,19 +31,11 @@ function createStateHelpers() {
       container!.savedSearchState.getInitial$().getValue()
     );
   };
-  const useSavedSearchHasChanged = () => {
-    const container = useContainer();
-    return useObservable<boolean>(
-      container!.savedSearchState.getHasChanged$(),
-      container!.savedSearchState.getHasChanged$().getValue()
-    );
-  };
 
   return {
     Provider: context.Provider,
     useSavedSearch,
     useSavedSearchInitial,
-    useSavedSearchHasChanged,
   };
 }
 
@@ -51,7 +43,6 @@ export const {
   Provider: DiscoverStateProvider,
   useSavedSearchInitial,
   useSavedSearch,
-  useSavedSearchHasChanged,
 } = createStateHelpers();
 
 export const DiscoverMainProvider = ({

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/hooks/use_unsaved_changes.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/hooks/use_unsaved_changes.test.tsx
@@ -1,0 +1,205 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useUnsavedChanges } from './use_unsaved_changes';
+import type { DiscoverStateContainer } from '../discover_state';
+import { getDiscoverStateMock } from '../../../../__mocks__/discover_state.mock';
+import type { DiscoverServices } from '../../../../build_services';
+import { createDiscoverServicesMock } from '../../../../__mocks__/services';
+import type { AppMountParameters } from '@kbn/core/public';
+import { DiscoverTestProvider } from '../../../../__mocks__/test_provider';
+import React from 'react';
+import {
+  fromSavedSearchToSavedObjectTab,
+  internalStateActions,
+  selectHasUnsavedChanges,
+} from '../redux';
+import { getTabStateMock } from '../redux/__mocks__/internal_state.mocks';
+import { getConnectedCustomizationService } from '../../../../customizations';
+import type { DiscoverSession } from '@kbn/saved-search-plugin/common';
+import type { AppLeaveActionFactory } from '@kbn/core-application-browser';
+
+const mockSelectHasUnsavedChanges = jest.mocked(selectHasUnsavedChanges);
+
+jest.mock('../redux/selectors', () => {
+  const originalModule = jest.requireActual('../redux/selectors');
+  return {
+    ...originalModule,
+    selectHasUnsavedChanges: jest.fn(originalModule.selectHasUnsavedChanges),
+  };
+});
+
+describe('useUnsavedChanges', () => {
+  const setup = async ({
+    stateContainer = getDiscoverStateMock(),
+    services = createDiscoverServicesMock(),
+    onAppLeave,
+  }: {
+    stateContainer?: DiscoverStateContainer;
+    services?: DiscoverServices;
+    onAppLeave?: AppMountParameters['onAppLeave'];
+  } = {}) => {
+    const result = renderHook(useUnsavedChanges, {
+      initialProps: {
+        internalState: stateContainer.internalState,
+        runtimeStateManager: stateContainer.runtimeStateManager,
+        onAppLeave,
+      },
+      wrapper: ({ children }) => (
+        <DiscoverTestProvider services={services} stateContainer={stateContainer}>
+          {children}
+        </DiscoverTestProvider>
+      ),
+    });
+    return { result, stateContainer, services };
+  };
+
+  const changeTabs = async (stateContainer: DiscoverStateContainer) => {
+    const newTab = getTabStateMock({ id: 'newTab' });
+    await stateContainer.internalState.dispatch(
+      internalStateActions.updateTabs({
+        items: [newTab],
+        selectedItem: newTab,
+      })
+    );
+    stateContainer.internalState.dispatch(
+      internalStateActions.setInitializationState({ hasESData: true, hasUserDataView: true })
+    );
+    await stateContainer.internalState.dispatch(
+      internalStateActions.initializeSingleTab({
+        tabId: newTab.id,
+        initializeSingleTabParams: {
+          stateContainer,
+          customizationService: await getConnectedCustomizationService({
+            customizationCallbacks: [],
+            stateContainer,
+          }),
+          dataViewSpec: undefined,
+          defaultUrlState: undefined,
+        },
+      })
+    );
+    return { newTab };
+  };
+
+  beforeEach(() => {
+    mockSelectHasUnsavedChanges.mockClear();
+  });
+
+  it('should detect changes on mount', async () => {
+    const { stateContainer, services } = await setup();
+    expect(mockSelectHasUnsavedChanges).toHaveBeenCalledTimes(1);
+    expect(mockSelectHasUnsavedChanges).toHaveBeenCalledWith(
+      stateContainer.internalState.getState(),
+      { runtimeStateManager: stateContainer.runtimeStateManager, services }
+    );
+    expect(stateContainer.internalState.getState().hasUnsavedChanges).toBe(false);
+    expect(stateContainer.internalState.getState().tabs.unsavedIds).toEqual([]);
+  });
+
+  it('should detect changes when saved search changes', async () => {
+    const { stateContainer } = await setup();
+    expect(stateContainer.internalState.getState().hasUnsavedChanges).toBe(false);
+    expect(stateContainer.internalState.getState().tabs.unsavedIds).toEqual([]);
+    const savedSearch = stateContainer.savedSearchState.getState();
+    stateContainer.savedSearchState.assignNextSavedSearch({
+      ...savedSearch,
+      columns: ['newColumn'],
+    });
+    expect(stateContainer.internalState.getState().hasUnsavedChanges).toBe(true);
+    expect(stateContainer.internalState.getState().tabs.unsavedIds).toEqual([
+      stateContainer.getCurrentTab().id,
+    ]);
+  });
+
+  it('should detect changes when tabs change', async () => {
+    const { stateContainer } = await setup();
+    expect(stateContainer.internalState.getState().hasUnsavedChanges).toBe(false);
+    expect(stateContainer.internalState.getState().tabs.unsavedIds).toEqual([]);
+    const { newTab } = await changeTabs(stateContainer);
+    expect(stateContainer.internalState.getState().hasUnsavedChanges).toBe(true);
+    expect(stateContainer.internalState.getState().tabs.unsavedIds).toEqual([newTab.id]);
+  });
+
+  it('should detect changes when persisted discover session changes', async () => {
+    const { stateContainer, services } = await setup();
+    expect(stateContainer.internalState.getState().hasUnsavedChanges).toBe(false);
+    expect(stateContainer.internalState.getState().tabs.unsavedIds).toEqual([]);
+    const { newTab } = await changeTabs(stateContainer);
+    expect(stateContainer.internalState.getState().hasUnsavedChanges).toBe(true);
+    expect(stateContainer.internalState.getState().tabs.unsavedIds).toEqual([newTab.id]);
+    const newDiscoverSession: DiscoverSession = {
+      ...stateContainer.internalState.getState().persistedDiscoverSession!,
+      tabs: [
+        fromSavedSearchToSavedObjectTab({
+          tab: newTab,
+          savedSearch: stateContainer.savedSearchState.getState(),
+          services,
+        }),
+      ],
+    };
+    stateContainer.internalState.dispatch(
+      internalStateActions.saveDiscoverSession.fulfilled(
+        {
+          discoverSession: newDiscoverSession,
+        },
+        'requestId',
+        {
+          newTitle: newDiscoverSession.title,
+          newCopyOnSave: false,
+          newTimeRestore: false,
+          newDescription: newDiscoverSession.description,
+          newTags: [],
+          isTitleDuplicateConfirmed: false,
+          onTitleDuplicate: () => {},
+        }
+      )
+    );
+    expect(stateContainer.internalState.getState().hasUnsavedChanges).toBe(false);
+    expect(stateContainer.internalState.getState().tabs.unsavedIds).toEqual([]);
+  });
+
+  it('should call the onAppLeave default action when there are no unsaved changes', async () => {
+    let onAppLeaveCallback: (actions: AppLeaveActionFactory) => void = () => {};
+    const onAppLeave = jest.fn().mockImplementation((callback: typeof onAppLeaveCallback) => {
+      onAppLeaveCallback = callback;
+    });
+    await setup({ onAppLeave });
+    const defaultFn = jest.fn();
+    const confirmFn = jest.fn();
+    onAppLeaveCallback({
+      default: defaultFn,
+      confirm: confirmFn,
+    });
+    expect(defaultFn).toHaveBeenCalledTimes(1);
+    expect(confirmFn).not.toHaveBeenCalled();
+  });
+
+  it('should call the onAppLeave confirm action when there are unsaved changes', async () => {
+    let onAppLeaveCallback: (actions: AppLeaveActionFactory) => void = () => {};
+    const onAppLeave = jest.fn().mockImplementation((callback: typeof onAppLeaveCallback) => {
+      onAppLeaveCallback = callback;
+    });
+    const { stateContainer } = await setup({ onAppLeave });
+    const savedSearch = stateContainer.savedSearchState.getState();
+    stateContainer.savedSearchState.assignNextSavedSearch({
+      ...savedSearch,
+      columns: ['newColumn'],
+    });
+    const defaultFn = jest.fn();
+    const confirmFn = jest.fn();
+    onAppLeaveCallback({
+      default: defaultFn,
+      confirm: confirmFn,
+    });
+    expect(defaultFn).not.toHaveBeenCalled();
+    expect(confirmFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/hooks/use_unsaved_changes.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/hooks/use_unsaved_changes.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  type BehaviorSubject,
+  combineLatest,
+  distinctUntilChanged,
+  from,
+  map,
+  switchMap,
+  debounceTime,
+} from 'rxjs';
+import type { SavedSearch } from '@kbn/saved-search-plugin/public';
+import { useEffect, useState } from 'react';
+import type { AppMountParameters } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+import { isEqual } from 'lodash';
+import {
+  internalStateActions,
+  selectHasUnsavedChanges,
+  selectTabRuntimeState,
+  type InternalStateStore,
+  type RuntimeStateManager,
+} from '../redux';
+import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+
+export const useUnsavedChanges = ({
+  internalState,
+  runtimeStateManager,
+  onAppLeave,
+}: {
+  internalState: InternalStateStore;
+  runtimeStateManager: RuntimeStateManager;
+  onAppLeave?: AppMountParameters['onAppLeave'];
+}) => {
+  const services = useDiscoverServices();
+  const [savedSearches$] = useState(() =>
+    from(internalState).pipe(
+      map((state) => state.tabs.allIds),
+      distinctUntilChanged((prev, curr) => isEqual(prev, curr)),
+      switchMap((allTabIds) => {
+        const stateContainerObservables = allTabIds.map(
+          (tabId) => selectTabRuntimeState(runtimeStateManager, tabId).stateContainer$
+        );
+
+        return combineLatest(stateContainerObservables);
+      }),
+      switchMap((allTabStateContainers) => {
+        const savedSearchObservables: Array<BehaviorSubject<SavedSearch>> = [];
+
+        for (const tabStateContainer of allTabStateContainers) {
+          const savedSearch$ = tabStateContainer?.savedSearchState.getCurrent$();
+
+          if (savedSearch$) {
+            savedSearchObservables.push(savedSearch$);
+          }
+        }
+
+        return combineLatest(savedSearchObservables);
+      }),
+      debounceTime(50)
+    )
+  );
+
+  useEffect(() => {
+    const subscription = savedSearches$.subscribe(() => {
+      internalState.dispatch(
+        internalStateActions.setUnsavedChanges(
+          selectHasUnsavedChanges(internalState.getState(), { runtimeStateManager, services })
+        )
+      );
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [internalState, runtimeStateManager, savedSearches$, services]);
+
+  useEffect(() => {
+    onAppLeave?.((actions) => {
+      const { hasUnsavedChanges } = internalState.getState();
+
+      if (!hasUnsavedChanges) return actions.default();
+
+      return actions.confirm(
+        i18n.translate('discover.confirmModal.confirmTextDescription', {
+          defaultMessage:
+            "You'll lose unsaved changes if you open another Discover session before returning to this one.",
+        }),
+        i18n.translate('discover.confirmModal.title', {
+          defaultMessage: 'Unsaved changes',
+        }),
+        () => {},
+        i18n.translate('discover.confirmModal.confirmText', {
+          defaultMessage: 'Leave without saving',
+        }),
+        'danger'
+      );
+    });
+  }, [internalState, onAppLeave]);
+};

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/hooks/use_unsaved_changes.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/hooks/use_unsaved_changes.ts
@@ -41,9 +41,11 @@ export const useUnsavedChanges = ({
   const services = useDiscoverServices();
   const [onChange$] = useState(() =>
     from(internalState).pipe(
-      map(selectAllTabs),
-      distinctUntilChanged(),
-      switchMap((allTabs) => {
+      map((state) => [selectAllTabs(state), state.persistedDiscoverSession] as const),
+      distinctUntilChanged(([prevTabs, prevSession], [currTabs, currSession]) => {
+        return prevTabs === currTabs && prevSession === currSession;
+      }),
+      switchMap(([allTabs]) => {
         const stateContainerObservables = allTabs.map(
           (tab) => selectTabRuntimeState(runtimeStateManager, tab.id).stateContainer$
         );

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/index.ts
@@ -11,3 +11,4 @@ export * from './data_views';
 export * from './initialize_single_tab';
 export * from './tabs';
 export * from './save_discover_session';
+export * from './reset_discover_session';

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/initialize_single_tab.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/initialize_single_tab.ts
@@ -288,9 +288,9 @@ export const initializeSingleTab: InternalStateThunkActionCreator<
     stateContainer$.next(stateContainer);
     customizationService$.next(customizationService);
 
-    // Begin syncing the state
+    // Begin syncing the state and trigger the initial fetch
     stateContainer.actions.initializeAndSync();
-
+    stateContainer.actions.fetchData(true);
     discoverTabLoadTracker.reportEvent();
 
     return { showNoDataPage: false };

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/initialize_single_tab.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/initialize_single_tab.ts
@@ -288,9 +288,9 @@ export const initializeSingleTab: InternalStateThunkActionCreator<
     stateContainer$.next(stateContainer);
     customizationService$.next(customizationService);
 
-    // Begin syncing the state and trigger the initial fetch
+    // Begin syncing the state
     stateContainer.actions.initializeAndSync();
-    stateContainer.actions.fetchData(true);
+
     discoverTabLoadTracker.reportEvent();
 
     return { showNoDataPage: false };

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/reset_discover_session.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/reset_discover_session.ts
@@ -62,10 +62,13 @@ export const resetDiscoverSession = createInternalStateAsyncThunk(
       })
     );
 
+    const selectedTabId =
+      allTabs.find((tab) => tab.id === state.tabs.unsafeCurrentId)?.id ?? allTabs[0]?.id;
+
     dispatch(
       setTabs({
         allTabs,
-        selectedTabId: state.tabs.unsafeCurrentId,
+        selectedTabId,
         recentlyClosedTabs: selectRecentlyClosedTabs(state),
       })
     );

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/reset_discover_session.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/reset_discover_session.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DiscoverSession } from '@kbn/saved-search-plugin/common';
+import { internalStateSlice } from '../internal_state';
+import { selectTabRuntimeState } from '../runtime_state';
+import { selectRecentlyClosedTabs, selectTab } from '../selectors';
+import {
+  fromSavedObjectTabToSavedSearch,
+  fromSavedObjectTabToTabState,
+} from '../tab_mapping_utils';
+import { createInternalStateAsyncThunk } from '../utils';
+import { setDataView } from './data_views';
+import { setTabs } from './tabs';
+
+export const resetDiscoverSession = createInternalStateAsyncThunk(
+  'internalState/resetDiscoverSession',
+  async (
+    { discoverSession }: { discoverSession: DiscoverSession },
+    { dispatch, getState, extra: { services, runtimeStateManager } }
+  ) => {
+    const state = getState();
+
+    await Promise.all(
+      discoverSession.tabs.map(async (tab) => {
+        dispatch(internalStateSlice.actions.resetOnSavedSearchChange({ tabId: tab.id }));
+
+        const tabRuntimeState = selectTabRuntimeState(runtimeStateManager, tab.id);
+        const tabStateContainer = tabRuntimeState.stateContainer$.getValue();
+
+        if (!tabStateContainer) {
+          return;
+        }
+
+        const savedSearch = await fromSavedObjectTabToSavedSearch({
+          tab,
+          discoverSession,
+          services,
+        });
+        const dataView = savedSearch.searchSource.getField('index');
+
+        if (dataView) {
+          dispatch(setDataView({ tabId: tab.id, dataView }));
+        }
+
+        tabStateContainer.savedSearchState.set(savedSearch);
+        tabStateContainer.actions.undoSavedSearchChanges();
+        tabStateContainer.appState.resetInitialState();
+      })
+    );
+
+    const allTabs = discoverSession.tabs.map((tab) =>
+      fromSavedObjectTabToTabState({
+        tab,
+        existingTab: selectTab(state, tab.id),
+      })
+    );
+
+    dispatch(
+      setTabs({
+        allTabs,
+        selectedTabId: state.tabs.unsafeCurrentId,
+        recentlyClosedTabs: selectRecentlyClosedTabs(state),
+      })
+    );
+  }
+);

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/reset_discover_session.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/reset_discover_session.ts
@@ -10,7 +10,7 @@
 import type { DiscoverSession } from '@kbn/saved-search-plugin/common';
 import { internalStateSlice } from '../internal_state';
 import { selectTabRuntimeState } from '../runtime_state';
-import { selectHasUnsavedChanges, selectTab } from '../selectors';
+import { selectTab } from '../selectors';
 import {
   fromSavedObjectTabToSavedSearch,
   fromSavedObjectTabToTabState,
@@ -34,9 +34,7 @@ export const resetDiscoverSession = createInternalStateAsyncThunk(
 
     // If an updated session is provided, we know it has just been saved and all tab state is up to date.
     // Otherwise we're resetting the current session, and need to detect changes to mark tabs for refetch.
-    const { unsavedTabIds } = updatedDiscoverSession
-      ? { unsavedTabIds: new Set<string>() }
-      : selectHasUnsavedChanges(state, { runtimeStateManager, services });
+    const unsavedTabIds = updatedDiscoverSession ? [] : state.tabs.unsavedIds;
 
     const allTabs = await Promise.all(
       discoverSession.tabs.map(async (tab) => {
@@ -69,7 +67,7 @@ export const resetDiscoverSession = createInternalStateAsyncThunk(
 
         // If the tab had changes, we force-fetch when selecting it so the data matches the UI state.
         // We don't need to do this for the current tab since it's already being synced.
-        if (tab.id !== state.tabs.unsafeCurrentId && unsavedTabIds.has(tab.id)) {
+        if (tab.id !== state.tabs.unsafeCurrentId && unsavedTabIds.includes(tab.id)) {
           tabState.forceFetchOnSelect = true;
         }
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/reset_discover_session.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/reset_discover_session.ts
@@ -10,14 +10,14 @@
 import type { DiscoverSession } from '@kbn/saved-search-plugin/common';
 import { internalStateSlice } from '../internal_state';
 import { selectTabRuntimeState } from '../runtime_state';
-import { selectHasUnsavedChanges, selectRecentlyClosedTabs, selectTab } from '../selectors';
+import { selectHasUnsavedChanges, selectTab } from '../selectors';
 import {
   fromSavedObjectTabToSavedSearch,
   fromSavedObjectTabToTabState,
 } from '../tab_mapping_utils';
 import { createInternalStateAsyncThunk } from '../utils';
 import { setDataView } from './data_views';
-import { setTabs } from './tabs';
+import { updateTabs } from './tabs';
 
 export const resetDiscoverSession = createInternalStateAsyncThunk(
   'internalState/resetDiscoverSession',
@@ -77,15 +77,8 @@ export const resetDiscoverSession = createInternalStateAsyncThunk(
       })
     );
 
-    const selectedTabId =
-      allTabs.find((tab) => tab.id === state.tabs.unsafeCurrentId)?.id ?? allTabs[0]?.id;
+    const selectedTab = allTabs.find((tab) => tab.id === state.tabs.unsafeCurrentId) ?? allTabs[0];
 
-    dispatch(
-      setTabs({
-        allTabs,
-        selectedTabId,
-        recentlyClosedTabs: selectRecentlyClosedTabs(state),
-      })
-    );
+    await dispatch(updateTabs({ items: allTabs, selectedItem: selectedTab }));
   }
 );

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/reset_discover_session.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/reset_discover_session.ts
@@ -43,7 +43,7 @@ export const resetDiscoverSession = createInternalStateAsyncThunk(
         dispatch(internalStateSlice.actions.resetOnSavedSearchChange({ tabId: tab.id }));
 
         const tabRuntimeState = selectTabRuntimeState(runtimeStateManager, tab.id);
-        const tabStateContainer = tabRuntimeState.stateContainer$.getValue();
+        const tabStateContainer = tabRuntimeState?.stateContainer$.getValue();
 
         if (tabStateContainer) {
           const savedSearch = await fromSavedObjectTabToSavedSearch({

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/save_discover_session.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/save_discover_session.ts
@@ -18,18 +18,15 @@ import type { DataViewSpec } from '@kbn/data-views-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { cloneDeep, isObject } from 'lodash';
 import { ESQL_TYPE } from '@kbn/data-view-utils';
-import { selectAllTabs, selectRecentlyClosedTabs, selectTab } from '../selectors';
+import { selectAllTabs } from '../selectors';
 import { createInternalStateAsyncThunk } from '../utils';
 import { selectTabRuntimeState } from '../runtime_state';
-import { internalStateSlice } from '../internal_state';
 import {
-  fromSavedObjectTabToSavedSearch,
-  fromSavedObjectTabToTabState,
   fromSavedSearchToSavedObjectTab,
   fromTabStateToSavedObjectTab,
 } from '../tab_mapping_utils';
-import { appendAdHocDataViews, replaceAdHocDataViewWithId, setDataView } from './data_views';
-import { setTabs } from './tabs';
+import { appendAdHocDataViews, replaceAdHocDataViewWithId } from './data_views';
+import { resetDiscoverSession } from './reset_discover_session';
 
 type AdHocDataViewAction = 'copy' | 'replace';
 
@@ -208,48 +205,7 @@ export const saveDiscoverSession = createInternalStateAsyncThunk(
     const discoverSession = await services.savedSearch.saveDiscoverSession(saveParams, saveOptions);
 
     if (discoverSession) {
-      await Promise.all(
-        updatedTabs.map(async (tab) => {
-          dispatch(internalStateSlice.actions.resetOnSavedSearchChange({ tabId: tab.id }));
-
-          const tabRuntimeState = selectTabRuntimeState(runtimeStateManager, tab.id);
-          const tabStateContainer = tabRuntimeState.stateContainer$.getValue();
-
-          if (!tabStateContainer) {
-            return;
-          }
-
-          const savedSearch = await fromSavedObjectTabToSavedSearch({
-            tab,
-            discoverSession,
-            services,
-          });
-          const dataView = savedSearch.searchSource.getField('index');
-
-          if (dataView) {
-            dispatch(setDataView({ tabId: tab.id, dataView }));
-          }
-
-          tabStateContainer.savedSearchState.set(savedSearch);
-          tabStateContainer.actions.undoSavedSearchChanges();
-          tabStateContainer.appState.resetInitialState();
-        })
-      );
-
-      const allTabs = discoverSession.tabs.map((tab) =>
-        fromSavedObjectTabToTabState({
-          tab,
-          existingTab: selectTab(state, tab.id),
-        })
-      );
-
-      dispatch(
-        setTabs({
-          allTabs,
-          selectedTabId: state.tabs.unsafeCurrentId,
-          recentlyClosedTabs: selectRecentlyClosedTabs(state),
-        })
-      );
+      await dispatch(resetDiscoverSession({ discoverSession })).unwrap();
     }
 
     return { discoverSession };

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/save_discover_session.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/save_discover_session.ts
@@ -205,7 +205,7 @@ export const saveDiscoverSession = createInternalStateAsyncThunk(
     const discoverSession = await services.savedSearch.saveDiscoverSession(saveParams, saveOptions);
 
     if (discoverSession) {
-      await dispatch(resetDiscoverSession({ discoverSession })).unwrap();
+      await dispatch(resetDiscoverSession({ updatedDiscoverSession: discoverSession })).unwrap();
     }
 
     return { discoverSession };

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -15,7 +15,7 @@ import { i18n } from '@kbn/i18n';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import { getInitialESQLQuery } from '@kbn/esql-utils';
 import { createDataSource } from '../../../../../../common/data_sources/utils';
-import { TabInitialFetchState, type TabState } from '../types';
+import { type TabState } from '../types';
 import { selectAllTabs, selectRecentlyClosedTabs, selectTab } from '../selectors';
 import {
   internalStateSlice,
@@ -204,11 +204,12 @@ export const updateTabs: InternalStateThunkActionCreator<[TabbedContentState], P
           query ?? services.data.query.queryString.getDefaultQuery()
         );
 
-        if (nextTab.initialFetchState === TabInitialFetchState.forceTrigger) {
-          nextTabStateContainer.dataState.reset();
-        }
-
         nextTabStateContainer.actions.initializeAndSync();
+
+        if (nextTab.forceFetchOnSelect) {
+          nextTabStateContainer.dataState.reset();
+          nextTabStateContainer.actions.fetchData();
+        }
       } else {
         await urlStateStorage.set(GLOBAL_STATE_URL_KEY, null);
         await urlStateStorage.set(APP_STATE_URL_KEY, null);

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -15,7 +15,7 @@ import { i18n } from '@kbn/i18n';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import { getInitialESQLQuery } from '@kbn/esql-utils';
 import { createDataSource } from '../../../../../../common/data_sources/utils';
-import type { TabState } from '../types';
+import { TabInitialFetchState, type TabState } from '../types';
 import { selectAllTabs, selectRecentlyClosedTabs, selectTab } from '../selectors';
 import {
   internalStateSlice,
@@ -203,6 +203,10 @@ export const updateTabs: InternalStateThunkActionCreator<[TabbedContentState], P
         services.data.query.queryString.setQuery(
           query ?? services.data.query.queryString.getDefaultQuery()
         );
+
+        if (nextTab.initialFetchState === TabInitialFetchState.forceTrigger) {
+          nextTabStateContainer.dataState.reset();
+        }
 
         nextTabStateContainer.actions.initializeAndSync();
       } else {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -159,12 +159,10 @@ export const updateTabs: InternalStateThunkActionCreator<
             return tab;
           }
 
-          const isCurrentModeESQL = isOfAggregateQueryType(currentQuery);
-
           tab.initialAppState = {
-            query: isCurrentModeESQL
-              ? { esql: getInitialESQLQuery(currentDataView, true) }
-              : undefined,
+            ...(isOfAggregateQueryType(currentQuery)
+              ? { query: { esql: getInitialESQLQuery(currentDataView, true) } }
+              : {}),
             dataSource: createDataSource({
               dataView: currentDataView,
               query: currentQuery,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -7,13 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { TabbedContentState } from '@kbn/unified-tabs/src/components/tabbed_content/tabbed_content';
-import { cloneDeep, differenceBy, omit, pick } from 'lodash';
+import { cloneDeep, differenceBy, omit } from 'lodash';
 import type { QueryState } from '@kbn/data-plugin/common';
 import { getSavedSearchFullPathUrl } from '@kbn/saved-search-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import { getInitialESQLQuery } from '@kbn/esql-utils';
+import type { TabItem } from '@kbn/unified-tabs';
 import { createDataSource } from '../../../../../../common/data_sources/utils';
 import { type TabState } from '../types';
 import { selectAllTabs, selectRecentlyClosedTabs, selectTab } from '../selectors';
@@ -92,7 +92,10 @@ export const setTabs: InternalStateThunkActionCreator<
     );
   };
 
-export const updateTabs: InternalStateThunkActionCreator<[TabbedContentState], Promise<void>> =
+export const updateTabs: InternalStateThunkActionCreator<
+  [{ items: TabState[] | TabItem[]; selectedItem: TabState | TabItem | null }],
+  Promise<void>
+> =
   ({ items, selectedItem }) =>
   async (dispatch, getState, { services, runtimeStateManager, urlStateStorage }) => {
     const currentState = getState();
@@ -113,7 +116,7 @@ export const updateTabs: InternalStateThunkActionCreator<[TabbedContentState], P
           },
         },
         ...existingTab,
-        ...pick(item, 'id', 'label', 'duplicatedFromId'),
+        ...item,
       };
 
       if (!existingTab) {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
@@ -8,11 +8,11 @@
  */
 
 import type { TabItem } from '@kbn/unified-tabs';
-import { TabInitialFetchState, type TabState } from './types';
+import { type TabState } from './types';
 
 export const DEFAULT_TAB_STATE: Omit<TabState, keyof TabItem> = {
   globalState: {},
-  initialFetchState: TabInitialFetchState.firstTrigger,
+  forceFetchOnSelect: false,
   isDataViewLoading: false,
   dataRequestParams: {
     timeRangeAbsolute: undefined,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
@@ -8,10 +8,11 @@
  */
 
 import type { TabItem } from '@kbn/unified-tabs';
-import type { TabState } from './types';
+import { TabInitialFetchState, type TabState } from './types';
 
 export const DEFAULT_TAB_STATE: Omit<TabState, keyof TabItem> = {
   globalState: {},
+  initialFetchState: TabInitialFetchState.firstTrigger,
   isDataViewLoading: false,
   dataRequestParams: {
     timeRangeAbsolute: undefined,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
@@ -25,6 +25,7 @@ import {
   clearAllTabs,
   initializeTabs,
   saveDiscoverSession,
+  resetDiscoverSession,
 } from './actions';
 
 export type {
@@ -61,6 +62,7 @@ export const internalStateActions = {
   clearAllTabs,
   initializeTabs,
   saveDiscoverSession,
+  resetDiscoverSession,
 };
 
 export {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
@@ -28,11 +28,12 @@ import {
   resetDiscoverSession,
 } from './actions';
 
-export type {
-  DiscoverInternalState,
-  TabState,
-  TabStateGlobalState,
-  InternalStateDataRequestParams,
+export {
+  type DiscoverInternalState,
+  type TabState,
+  type TabStateGlobalState,
+  type InternalStateDataRequestParams,
+  TabInitialFetchState,
 } from './types';
 
 export { DEFAULT_TAB_STATE } from './constants';

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
@@ -79,6 +79,7 @@ export {
   selectRecentlyClosedTabs,
   selectTab,
   selectIsTabsBarHidden,
+  selectHasUnsavedChanges,
 } from './selectors';
 
 export {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
@@ -33,7 +33,6 @@ export {
   type TabState,
   type TabStateGlobalState,
   type InternalStateDataRequestParams,
-  TabInitialFetchState,
 } from './types';
 
 export { DEFAULT_TAB_STATE } from './constants';

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -40,7 +40,7 @@ import {
   type RecentlyClosedTabState,
 } from './types';
 import { loadDataViewList, initializeTabs, saveDiscoverSession } from './actions';
-import { selectTab } from './selectors';
+import { type HasUnsavedChangesResult, selectTab } from './selectors';
 import type { TabsStorageManager } from '../tabs_storage_manager';
 
 const MIDDLEWARE_THROTTLE_MS = 300;
@@ -51,6 +51,7 @@ const initialState: DiscoverInternalState = {
   userId: undefined,
   spaceId: undefined,
   persistedDiscoverSession: undefined,
+  hasUnsavedChanges: false,
   defaultProfileAdHocDataViewIds: [],
   savedDataViews: [],
   expandedDoc: undefined,
@@ -60,8 +61,9 @@ const initialState: DiscoverInternalState = {
     areInitializing: false,
     byId: {},
     allIds: [],
-    unsafeCurrentId: '',
+    unsavedIds: [],
     recentlyClosedTabIds: [],
+    unsafeCurrentId: '',
   },
 };
 
@@ -113,6 +115,11 @@ export const internalStateSlice = createSlice({
       state.tabs.allIds = action.payload.allTabs.map((tab) => tab.id);
       state.tabs.unsafeCurrentId = action.payload.selectedTabId;
       state.tabs.recentlyClosedTabIds = action.payload.recentlyClosedTabs.map((tab) => tab.id);
+    },
+
+    setUnsavedChanges: (state, action: PayloadAction<HasUnsavedChangesResult>) => {
+      state.hasUnsavedChanges = action.payload.hasUnsavedChanges;
+      state.tabs.unsavedIds = Array.from(action.payload.unsavedTabIds);
     },
 
     setForceFetchOnSelect: (state, action: TabAction<Pick<TabState, 'forceFetchOnSelect'>>) =>

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -105,7 +105,8 @@ export const internalStateSlice = createSlice({
       >(
         (acc, tab) => ({
           ...acc,
-          [tab.id]: tab,
+          [tab.id]:
+            tab.id === action.payload.selectedTabId ? { ...tab, forceFetchOnSelect: false } : tab,
         }),
         {}
       );
@@ -114,9 +115,9 @@ export const internalStateSlice = createSlice({
       state.tabs.recentlyClosedTabIds = action.payload.recentlyClosedTabs.map((tab) => tab.id);
     },
 
-    setInitialFetchState: (state, action: TabAction<Pick<TabState, 'initialFetchState'>>) =>
+    setForceFetchOnSelect: (state, action: TabAction<Pick<TabState, 'forceFetchOnSelect'>>) =>
       withTab(state, action, (tab) => {
-        tab.initialFetchState = action.payload.initialFetchState;
+        tab.forceFetchOnSelect = action.payload.forceFetchOnSelect;
       }),
 
     setIsDataViewLoading: (state, action: TabAction<Pick<TabState, 'isDataViewLoading'>>) =>

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -119,7 +119,7 @@ export const internalStateSlice = createSlice({
 
     setUnsavedChanges: (state, action: PayloadAction<HasUnsavedChangesResult>) => {
       state.hasUnsavedChanges = action.payload.hasUnsavedChanges;
-      state.tabs.unsavedIds = Array.from(action.payload.unsavedTabIds);
+      state.tabs.unsavedIds = action.payload.unsavedTabIds;
     },
 
     setForceFetchOnSelect: (state, action: TabAction<Pick<TabState, 'forceFetchOnSelect'>>) =>

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -36,7 +36,6 @@ import {
 import {
   TabsBarVisibility,
   type DiscoverInternalState,
-  type InternalStateDataRequestParams,
   type TabState,
   type RecentlyClosedTabState,
 } from './types';
@@ -115,7 +114,12 @@ export const internalStateSlice = createSlice({
       state.tabs.recentlyClosedTabIds = action.payload.recentlyClosedTabs.map((tab) => tab.id);
     },
 
-    setIsDataViewLoading: (state, action: TabAction<{ isDataViewLoading: boolean }>) =>
+    setInitialFetchState: (state, action: TabAction<Pick<TabState, 'initialFetchState'>>) =>
+      withTab(state, action, (tab) => {
+        tab.initialFetchState = action.payload.initialFetchState;
+      }),
+
+    setIsDataViewLoading: (state, action: TabAction<Pick<TabState, 'isDataViewLoading'>>) =>
       withTab(state, action, (tab) => {
         tab.isDataViewLoading = action.payload.isDataViewLoading;
       }),
@@ -144,29 +148,19 @@ export const internalStateSlice = createSlice({
       state.initialDocViewerTabId = undefined;
     },
 
-    setDataRequestParams: (
-      state,
-      action: TabAction<{ dataRequestParams: InternalStateDataRequestParams }>
-    ) =>
+    setDataRequestParams: (state, action: TabAction<Pick<TabState, 'dataRequestParams'>>) =>
       withTab(state, action, (tab) => {
         tab.dataRequestParams = action.payload.dataRequestParams;
       }),
 
-    setGlobalState: (
-      state,
-      action: TabAction<{
-        globalState: TabState['globalState'];
-      }>
-    ) =>
+    setGlobalState: (state, action: TabAction<Pick<TabState, 'globalState'>>) =>
       withTab(state, action, (tab) => {
         tab.globalState = action.payload.globalState;
       }),
 
     setOverriddenVisContextAfterInvalidation: (
       state,
-      action: TabAction<{
-        overriddenVisContextAfterInvalidation: TabState['overriddenVisContextAfterInvalidation'];
-      }>
+      action: TabAction<Pick<TabState, 'overriddenVisContextAfterInvalidation'>>
     ) =>
       withTab(state, action, (tab) => {
         tab.overriddenVisContextAfterInvalidation =
@@ -209,10 +203,7 @@ export const internalStateSlice = createSlice({
           },
         },
       }),
-      reducer: (
-        state,
-        action: TabAction<{ resetDefaultProfileState: TabState['resetDefaultProfileState'] }>
-      ) =>
+      reducer: (state, action: TabAction<Pick<TabState, 'resetDefaultProfileState'>>) =>
         withTab(state, action, (tab) => {
           tab.resetDefaultProfileState = action.payload.resetDefaultProfileState;
         }),

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { selectAllTabs, selectRecentlyClosedTabs, selectTab, selectIsTabsBarHidden } from './tabs';

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/index.ts
@@ -8,3 +8,4 @@
  */
 
 export { selectAllTabs, selectRecentlyClosedTabs, selectTab, selectIsTabsBarHidden } from './tabs';
+export { selectHasUnsavedChanges } from './unsaved_changes';

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/index.ts
@@ -8,4 +8,4 @@
  */
 
 export { selectAllTabs, selectRecentlyClosedTabs, selectTab, selectIsTabsBarHidden } from './tabs';
-export { selectHasUnsavedChanges } from './unsaved_changes';
+export { type HasUnsavedChangesResult, selectHasUnsavedChanges } from './unsaved_changes';

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/tabs.ts
@@ -8,8 +8,8 @@
  */
 
 import { createSelector } from '@reduxjs/toolkit';
-import type { DiscoverInternalState, RecentlyClosedTabState } from './types';
-import { TabsBarVisibility } from './types';
+import type { DiscoverInternalState, RecentlyClosedTabState } from '../types';
+import { TabsBarVisibility } from '../types';
 
 export const selectTab = (state: DiscoverInternalState, tabId: string) => state.tabs.byId[tabId];
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
@@ -1,0 +1,257 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { VIEW_MODE, type SavedSearch } from '@kbn/saved-search-plugin/public';
+import { cloneDeep, isEqual, isFunction } from 'lodash';
+import type { SearchSourceFields } from '@kbn/data-plugin/public';
+import type { FilterCompareOptions } from '@kbn/es-query';
+import { COMPARE_ALL_OPTIONS } from '@kbn/es-query';
+import { canImportVisContext } from '@kbn/unified-histogram';
+import type { DiscoverSessionTab } from '@kbn/saved-search-plugin/common';
+import { DataGridDensity } from '@kbn/unified-data-table';
+import { isEqualFilters } from '../../discover_app_state_container';
+import { addLog } from '../../../../../utils/add_log';
+import { selectTab } from './tabs';
+import { selectTabRuntimeState, type RuntimeStateManager } from '../runtime_state';
+import type { DiscoverInternalState } from '../types';
+import {
+  fromSavedSearchToSavedObjectTab,
+  fromTabStateToSavedObjectTab,
+} from '../tab_mapping_utils';
+import type { DiscoverServices } from '../../../../../build_services';
+
+export const selectHasUnsavedChanges = (
+  state: DiscoverInternalState,
+  {
+    runtimeStateManager,
+    services,
+  }: { runtimeStateManager: RuntimeStateManager; services: DiscoverServices }
+) => {
+  const persistedDiscoverSession = state.persistedDiscoverSession;
+
+  if (!persistedDiscoverSession) {
+    return false;
+  }
+
+  const persistedTabIds = persistedDiscoverSession.tabs.map((tab) => tab.id);
+  const currentTabsIds = state.tabs.allIds;
+
+  if (!isEqual(persistedTabIds, currentTabsIds)) {
+    return true;
+  }
+
+  for (const tabId of currentTabsIds) {
+    const persistedTab = persistedDiscoverSession.tabs.find((tab) => tab.id === tabId);
+
+    // this should never happen as we already compare tab ids above
+    if (!persistedTab) {
+      return true;
+    }
+
+    const tabState = selectTab(state, tabId);
+    const tabRuntimeState = selectTabRuntimeState(runtimeStateManager, tabId);
+    const tabStateContainer = tabRuntimeState?.stateContainer$.getValue();
+    const normalizedTab = tabStateContainer
+      ? fromSavedSearchToSavedObjectTab({
+          tab: tabState,
+          savedSearch: tabStateContainer.savedSearchState.getState(),
+          services,
+        })
+      : fromTabStateToSavedObjectTab({
+          tab: tabState,
+          timeRestore: Boolean(persistedTab.timeRestore),
+          services,
+        });
+
+    for (const stringKey of Object.keys(tabComparators)) {
+      const key = stringKey as keyof DiscoverSessionTab;
+      const compare = tabComparators[key] as CompareValues<DiscoverSessionTab[typeof key]>;
+
+      if (!compare(persistedTab[key], normalizedTab[key])) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+type CompareValues<T> = (a: T, b: T) => boolean;
+
+type TabComparators = {
+  [K in keyof DiscoverSessionTab]-?: CompareValues<DiscoverSessionTab[K]>;
+};
+
+const compareCoerced =
+  <T>(defaultValue: T): CompareValues<T> =>
+  (a: T | undefined, b: T | undefined) => {
+    // Coerce null to undefined
+    a ??= undefined;
+    b ??= undefined;
+
+    // Equal if both are undefined
+    if (a === undefined && b === undefined) {
+      return true;
+    }
+
+    // Coerce undefined to default value
+    a ??= defaultValue;
+    b ??= defaultValue;
+
+    return isEqual(a, b);
+  };
+
+const compareTabField = <K extends keyof DiscoverSessionTab>(
+  _key: K,
+  defaultValue: DiscoverSessionTab[K]
+) => compareCoerced(defaultValue);
+
+const tabComparators: TabComparators = {
+  id: compareTabField('id', ''),
+  label: compareTabField('label', ''),
+  sort: compareTabField('sort', []),
+  columns: compareTabField('columns', []),
+  grid: compareTabField('grid', {}),
+  hideChart: compareTabField('hideChart', false),
+  isTextBasedQuery: compareTabField('isTextBasedQuery', false),
+  usesAdHocDataView: compareTabField('usesAdHocDataView', false),
+  serializedSearchSource: compareTabField('serializedSearchSource', {}),
+  viewMode: compareTabField('viewMode', VIEW_MODE.DOCUMENT_LEVEL),
+  hideAggregatedPreview: compareTabField('hideAggregatedPreview', false),
+  rowHeight: compareTabField('rowHeight', 0),
+  headerRowHeight: compareTabField('headerRowHeight', 0),
+  timeRestore: compareTabField('timeRestore', false),
+  timeRange: compareTabField('timeRange', { from: '', to: '' }),
+  refreshInterval: compareTabField('refreshInterval', { pause: true, value: 0 }),
+  rowsPerPage: compareTabField('rowsPerPage', 0),
+  sampleSize: compareTabField('sampleSize', 0),
+  breakdownField: compareTabField('breakdownField', ''),
+  density: compareTabField('density', DataGridDensity.COMPACT),
+  visContext: compareTabField('visContext', {}),
+};
+
+const FILTERS_COMPARE_OPTIONS: FilterCompareOptions = {
+  ...COMPARE_ALL_OPTIONS,
+  state: false, // We don't compare filter types (global vs appState).
+};
+
+export function isEqualSavedSearch(savedSearchPrev: SavedSearch, savedSearchNext: SavedSearch) {
+  const { searchSource: prevSearchSource, ...prevSavedSearch } = savedSearchPrev;
+  const { searchSource: nextSearchSource, ...nextSavedSearchWithoutSearchSource } = savedSearchNext;
+
+  const keys = new Set([
+    ...Object.keys(prevSavedSearch),
+    ...Object.keys(nextSavedSearchWithoutSearchSource),
+  ] as Array<keyof Omit<SavedSearch, 'searchSource'>>);
+
+  // at least one change in saved search attributes
+  const hasChangesInSavedSearch = [...keys].some((key) => {
+    if (
+      ['usesAdHocDataView', 'hideChart'].includes(key) &&
+      typeof prevSavedSearch[key] === 'undefined' &&
+      nextSavedSearchWithoutSearchSource[key] === false
+    ) {
+      return false; // ignore when value was changed from `undefined` to `false` as it happens per app logic, not by a user action
+    }
+
+    const prevValue = getSavedSearchFieldForComparison(prevSavedSearch, key);
+    const nextValue = getSavedSearchFieldForComparison(nextSavedSearchWithoutSearchSource, key);
+
+    const isSame = isEqual(prevValue, nextValue);
+
+    if (!isSame) {
+      addLog('[savedSearch] difference between initial and changed version', {
+        key,
+        before: prevSavedSearch[key],
+        after: nextSavedSearchWithoutSearchSource[key],
+      });
+    }
+
+    return !isSame;
+  });
+
+  if (hasChangesInSavedSearch) {
+    return false;
+  }
+
+  // at least one change in search source fields
+  const hasChangesInSearchSource = (
+    ['filter', 'query', 'index'] as Array<keyof SearchSourceFields>
+  ).some((key) => {
+    const prevValue = getSearchSourceFieldValueForComparison(prevSearchSource, key);
+    const nextValue = getSearchSourceFieldValueForComparison(nextSearchSource, key);
+
+    const isSame =
+      key === 'filter'
+        ? isEqualFilters(prevValue, nextValue, FILTERS_COMPARE_OPTIONS) // if a filter gets pinned and the order of filters does not change, we don't show the unsaved changes badge
+        : isEqual(prevValue, nextValue);
+
+    if (!isSame) {
+      addLog('[savedSearch] difference between initial and changed version', {
+        key,
+        before: prevValue,
+        after: nextValue,
+      });
+    }
+
+    return !isSame;
+  });
+
+  if (hasChangesInSearchSource) {
+    return false;
+  }
+
+  addLog('[savedSearch] no difference between initial and changed version');
+
+  return true;
+}
+
+function getSavedSearchFieldForComparison(
+  savedSearch: Omit<SavedSearch, 'searchSource'>,
+  fieldName: keyof Omit<SavedSearch, 'searchSource'>
+) {
+  if (fieldName === 'visContext') {
+    const visContext = cloneDeep(savedSearch.visContext);
+    if (canImportVisContext(visContext) && visContext?.attributes?.title) {
+      // ignore differences in title as it sometimes does not match the actual vis type/shape
+      visContext.attributes.title = 'same';
+    }
+    return visContext;
+  }
+
+  if (fieldName === 'breakdownField') {
+    return savedSearch.breakdownField || ''; // ignore the difference between an empty string and undefined
+  }
+
+  if (fieldName === 'viewMode') {
+    // By default, viewMode: undefined is equivalent to documents view
+    // So they should be treated as same
+    return savedSearch.viewMode ?? VIEW_MODE.DOCUMENT_LEVEL;
+  }
+
+  return savedSearch[fieldName];
+}
+
+function getSearchSourceFieldValueForComparison(
+  searchSource: SavedSearch['searchSource'],
+  searchSourceFieldName: keyof SearchSourceFields
+) {
+  if (searchSourceFieldName === 'index') {
+    const query = searchSource.getField('query');
+    // ad-hoc data view id can change, so we rather compare the ES|QL query itself here
+    return query && 'esql' in query ? query.esql : searchSource.getField('index')?.id;
+  }
+
+  if (searchSourceFieldName === 'filter') {
+    const filterField = searchSource.getField('filter');
+    return isFunction(filterField) ? filterField() : filterField;
+  }
+
+  return searchSource.getField(searchSourceFieldName);
+}

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
@@ -73,9 +73,9 @@ export const selectHasUnsavedChanges = (
           services,
         });
 
-    for (const stringKey of Object.keys(tabComparators)) {
+    for (const stringKey of Object.keys(TAB_COMPARATORS)) {
       const key = stringKey as keyof DiscoverSessionTab;
-      const compare = tabComparators[key] as FieldComparator<DiscoverSessionTab[typeof key]>;
+      const compare = TAB_COMPARATORS[key] as FieldComparator<DiscoverSessionTab[typeof key]>;
       const prevField = persistedTab[key];
       const nextField = normalizedTab[key];
 
@@ -102,6 +102,8 @@ type FieldComparator<T> = (a: T, b: T) => boolean;
 type TabComparators = {
   [K in keyof DiscoverSessionTab]-?: FieldComparator<DiscoverSessionTab[K]>;
 };
+
+const NOOP_COMPARATOR: FieldComparator<unknown> = () => true;
 
 const defaultValueComparator =
   <T>(defaultValue: T): FieldComparator<T> =>
@@ -166,15 +168,17 @@ const visContextComparator: TabComparators['visContext'] = (visContextA, visCont
   return isEqual(getAdjustedVisContext(visContextA), getAdjustedVisContext(visContextB));
 };
 
-const tabComparators: TabComparators = {
+const TAB_COMPARATORS: TabComparators = {
   id: fieldComparator('id', ''),
   label: fieldComparator('label', ''),
   sort: fieldComparator('sort', []),
   columns: fieldComparator('columns', []),
   grid: fieldComparator('grid', {}),
   hideChart: fieldComparator('hideChart', false),
-  isTextBasedQuery: fieldComparator('isTextBasedQuery', false),
-  usesAdHocDataView: fieldComparator('usesAdHocDataView', false),
+  // isTextBasedQuery is derived from the query itself and can be ignored
+  isTextBasedQuery: NOOP_COMPARATOR,
+  // usesAdHocDataView is derived from the data view itself and can be ignored
+  usesAdHocDataView: NOOP_COMPARATOR,
   serializedSearchSource: searchSourceComparator,
   // By default, viewMode: undefined is equivalent to documents view
   // So they should be treated as same

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
@@ -8,7 +8,7 @@
  */
 
 import { VIEW_MODE } from '@kbn/saved-search-plugin/public';
-import { difference, isEqual, isObject, omit } from 'lodash';
+import { isEqual, isObject, omit } from 'lodash';
 import type { SerializedSearchSourceFields } from '@kbn/data-plugin/public';
 import type { FilterCompareOptions } from '@kbn/es-query';
 import { COMPARE_ALL_OPTIONS, isOfAggregateQueryType } from '@kbn/es-query';
@@ -51,11 +51,10 @@ export const selectHasUnsavedChanges = (
   const persistedTabIds = persistedDiscoverSession.tabs.map((tab) => tab.id);
   const currentTabsIds = state.tabs.allIds;
 
+  let tabIdsChanged = false;
+
   if (!isEqual(persistedTabIds, currentTabsIds)) {
-    return {
-      hasUnsavedChanges: true,
-      unsavedTabIds: new Set(difference(currentTabsIds, persistedTabIds)),
-    };
+    tabIdsChanged = true;
   }
 
   const unsavedTabIds = new Set<string>();
@@ -63,7 +62,6 @@ export const selectHasUnsavedChanges = (
   for (const tabId of currentTabsIds) {
     const persistedTab = persistedDiscoverSession.tabs.find((tab) => tab.id === tabId);
 
-    // this should never happen as we already compare tab ids above
     if (!persistedTab) {
       unsavedTabIds.add(tabId);
       continue;
@@ -106,7 +104,7 @@ export const selectHasUnsavedChanges = (
 
   addLog('[DiscoverSession] no difference between initial and changed version');
 
-  return { hasUnsavedChanges: unsavedTabIds.size > 0, unsavedTabIds };
+  return { hasUnsavedChanges: tabIdsChanged || unsavedTabIds.size > 0, unsavedTabIds };
 };
 
 type FieldComparator<T> = (a: T, b: T) => boolean;

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
@@ -102,9 +102,13 @@ export const selectHasUnsavedChanges = (
     }
   }
 
-  addLog('[DiscoverSession] no difference between initial and changed version');
+  const hasUnsavedChanges = tabIdsChanged || unsavedTabIds.length > 0;
 
-  return { hasUnsavedChanges: tabIdsChanged || unsavedTabIds.length > 0, unsavedTabIds };
+  if (!hasUnsavedChanges) {
+    addLog('[DiscoverSession] no difference between initial and changed version');
+  }
+
+  return { hasUnsavedChanges, unsavedTabIds };
 };
 
 type FieldComparator<T> = (a: T, b: T) => boolean;
@@ -139,7 +143,7 @@ const fieldComparator = <K extends keyof DiscoverSessionTab>(
   defaultValue: DiscoverSessionTab[K]
 ) => defaultValueComparator(defaultValue);
 
-const FILTERS_COMPARE_OPTIONS: FilterCompareOptions = {
+const FILTER_COMPARE_OPTIONS: FilterCompareOptions = {
   ...COMPARE_ALL_OPTIONS,
   state: false, // We don't compare filter types (global vs appState).
 };
@@ -162,7 +166,7 @@ const searchSourceComparator: TabComparators['serializedSearchSource'] = (
   return (
     // if a filter gets pinned and the order of filters does not change,
     // we don't show the unsaved changes badge
-    isEqualFilters(filtersA, filtersB, FILTERS_COMPARE_OPTIONS) &&
+    isEqualFilters(filtersA, filtersB, FILTER_COMPARE_OPTIONS) &&
     isEqual(searchSourceA.query, searchSourceB.query) &&
     getAdjustedDataViewId(searchSourceA) === getAdjustedDataViewId(searchSourceB)
   );

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
@@ -29,7 +29,7 @@ import type { DiscoverServices } from '../../../../../build_services';
 
 export interface HasUnsavedChangesResult {
   hasUnsavedChanges: boolean;
-  unsavedTabIds: Set<string>;
+  unsavedTabIds: string[];
 }
 
 export const selectHasUnsavedChanges = (
@@ -45,7 +45,7 @@ export const selectHasUnsavedChanges = (
   const persistedDiscoverSession = state.persistedDiscoverSession;
 
   if (!persistedDiscoverSession) {
-    return { hasUnsavedChanges: false, unsavedTabIds: new Set() };
+    return { hasUnsavedChanges: false, unsavedTabIds: [] };
   }
 
   const persistedTabIds = persistedDiscoverSession.tabs.map((tab) => tab.id);
@@ -57,13 +57,13 @@ export const selectHasUnsavedChanges = (
     tabIdsChanged = true;
   }
 
-  const unsavedTabIds = new Set<string>();
+  const unsavedTabIds: string[] = [];
 
   for (const tabId of currentTabsIds) {
     const persistedTab = persistedDiscoverSession.tabs.find((tab) => tab.id === tabId);
 
     if (!persistedTab) {
-      unsavedTabIds.add(tabId);
+      unsavedTabIds.push(tabId);
       continue;
     }
 
@@ -96,7 +96,7 @@ export const selectHasUnsavedChanges = (
           after: nextField,
         });
 
-        unsavedTabIds.add(tabId);
+        unsavedTabIds.push(tabId);
         break;
       }
     }
@@ -104,7 +104,7 @@ export const selectHasUnsavedChanges = (
 
   addLog('[DiscoverSession] no difference between initial and changed version');
 
-  return { hasUnsavedChanges: tabIdsChanged || unsavedTabIds.size > 0, unsavedTabIds };
+  return { hasUnsavedChanges: tabIdsChanged || unsavedTabIds.length > 0, unsavedTabIds };
 };
 
 type FieldComparator<T> = (a: T, b: T) => boolean;

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/unsaved_changes.ts
@@ -204,4 +204,5 @@ const TAB_COMPARATORS: TabComparators = {
   breakdownField: fieldComparator('breakdownField', ''),
   density: fieldComparator('density', DataGridDensity.COMPACT),
   visContext: visContextComparator,
+  controlGroupJson: fieldComparator('controlGroupJson', ''),
 };

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.test.ts
@@ -64,6 +64,7 @@ describe('tab mapping utils', () => {
           },
           "duplicatedFromId": "0",
           "esqlVariables": undefined,
+          "forceFetchOnSelect": false,
           "globalState": Object {
             "refreshInterval": Object {
               "pause": true,
@@ -133,6 +134,7 @@ describe('tab mapping utils', () => {
           },
           "duplicatedFromId": "0",
           "esqlVariables": undefined,
+          "forceFetchOnSelect": false,
           "globalState": Object {
             "refreshInterval": Object {
               "pause": false,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -35,12 +35,6 @@ export interface TabStateGlobalState {
   filters?: Filter[];
 }
 
-export enum TabInitialFetchState {
-  firstTrigger = 'firstTrigger',
-  forceTrigger = 'forceTrigger',
-  triggered = 'triggered',
-}
-
 export interface TabState extends TabItem {
   // Initial state for the tab (provided before the tab is initialized).
   initialInternalState?: {
@@ -57,7 +51,7 @@ export interface TabState extends TabItem {
    * ESQL query variables
    */
   esqlVariables: ESQLControlVariable[] | undefined;
-  initialFetchState: TabInitialFetchState;
+  forceFetchOnSelect: boolean;
   isDataViewLoading: boolean;
   dataRequestParams: InternalStateDataRequestParams;
   overriddenVisContextAfterInvalidation: UnifiedHistogramVisContext | {} | undefined; // it will be used during saved search saving

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -35,6 +35,12 @@ export interface TabStateGlobalState {
   filters?: Filter[];
 }
 
+export enum TabInitialFetchState {
+  firstTrigger = 'firstTrigger',
+  forceTrigger = 'forceTrigger',
+  triggered = 'triggered',
+}
+
 export interface TabState extends TabItem {
   // Initial state for the tab (provided before the tab is initialized).
   initialInternalState?: {
@@ -51,6 +57,7 @@ export interface TabState extends TabItem {
    * ESQL query variables
    */
   esqlVariables: ESQLControlVariable[] | undefined;
+  initialFetchState: TabInitialFetchState;
   isDataViewLoading: boolean;
   dataRequestParams: InternalStateDataRequestParams;
   overriddenVisContextAfterInvalidation: UnifiedHistogramVisContext | {} | undefined; // it will be used during saved search saving

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -85,6 +85,7 @@ export interface DiscoverInternalState {
   userId: string | undefined;
   spaceId: string | undefined;
   persistedDiscoverSession: DiscoverSession | undefined;
+  hasUnsavedChanges: boolean;
   savedDataViews: DataViewListItem[];
   defaultProfileAdHocDataViewIds: string[];
   expandedDoc: DataTableRecord | undefined;
@@ -95,6 +96,7 @@ export interface DiscoverInternalState {
     areInitializing: boolean;
     byId: Record<string, TabState | RecentlyClosedTabState>;
     allIds: string[];
+    unsavedIds: string[];
     recentlyClosedTabIds: string[];
     /**
      * WARNING: You probably don't want to use this property.

--- a/src/platform/test/functional/page_objects/unified_tabs.ts
+++ b/src/platform/test/functional/page_objects/unified_tabs.ts
@@ -27,10 +27,11 @@ export class UnifiedTabsPageObject extends FtrService {
     for (const tabElement of tabElements) {
       const tabRoleElement = await tabElement.findByCssSelector('[role="tab"]');
       if ((await tabRoleElement.getAttribute('aria-selected')) === 'true') {
+        const labelTextElement = await tabElement.findByTestSubject('fullText');
         return {
           element: tabElement,
           index: tabElements.indexOf(tabElement),
-          label: await tabElement.getVisibleText(),
+          label: await labelTextElement.getVisibleText(),
         };
       }
     }
@@ -49,7 +50,8 @@ export class UnifiedTabsPageObject extends FtrService {
     const tabElements = await this.getTabElements();
     return await Promise.all(
       tabElements.map(async (tabElement) => {
-        return await tabElement.getVisibleText();
+        const labelTextElement = await tabElement.findByTestSubject('fullText');
+        return await labelTextElement.getVisibleText();
       })
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/esql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/esql/index.tsx
@@ -235,12 +235,9 @@ export const DiscoverTabContent: FC<DiscoverTabContentProps> = ({ timelineId }) 
         next: setDiscoverInternalState,
       });
 
-      const savedSearchStateSub = stateContainer.savedSearchState.getHasChanged$().subscribe({
-        next: (hasChanged) => {
-          if (hasChanged) {
-            const latestSavedSearchState = stateContainer.savedSearchState.getState();
-            setDiscoverSavedSearchState(latestSavedSearchState);
-          }
+      const savedSearchStateSub = stateContainer.savedSearchState.getCurrent$().subscribe({
+        next: (latestSavedSearchState) => {
+          setDiscoverSavedSearchState(latestSavedSearchState);
         },
       });
 


### PR DESCRIPTION
## Summary

This PR adds support for detecting and reverting unsaved changes across Discover tabs, including at the individual tab level where an unsaved tab indicator will be shown for new and modified tabs:
<img src="https://github.com/user-attachments/assets/9f5de9ae-9543-4e82-871d-be73f10c8684" />

~~**Note: I'm still working on adding more tests for the changes, but am opening up the PR for review and testing while I finish them since the overall functionality should be working now.**~~ Additional tests will be added in a followup issue #236158 since this PR is blocking additional important 9.2 work.

Resolves #233860.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.