### PR TITLE
[DOCS] Update doc links for global search header

### DIFF
--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -22,7 +22,7 @@ When you have insufficient privileges to edit advanced settings, the edit option
 % TO DO: Use `:class: screenshot`
 ![Example of Advanced Settings Management's read only access indicator in Kibana's header](images/settings-read-only-badge.png)
 
-To add the privilege, go to the **Roles** management page using the navigation menu or the [global search field](docs-content://get-started/the-stack.md#kibana-navigation-search).
+To add the privilege, go to the **Roles** management page using the navigation menu or the [global search field](docs-content://explore-analyze/find-and-organize/find-apps-and-objects.md).
 
 For more information on granting access to {{kib}}, refer to [Granting access to {{kib}}](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles.md).
 
@@ -31,7 +31,7 @@ For more information on granting access to {{kib}}, refer to [Granting access to
 
 Change the settings that apply only to a speific {{kib}} space.
 
-1. Go to the **Advanced settings** page using the navigation menu or the [global search field](docs-content://get-started/the-stack.md#kibana-navigation-search).
+1. Go to the **Advanced settings** page using the navigation menu or the [global search field](docs-content://explore-analyze/find-and-organize/find-apps-and-objects.md).
 2. Click **Space Settings**.
 3. Scroll or search for the setting.
 4. Make your change, then click **Save changes**.
@@ -539,7 +539,7 @@ $$$visualization-visualize-heatmapChartslibrary$$$`visualization:visualize:legac
 
 Change the only settings that apply to all of {{kib}}.
 
-1. Go to the **Advanced settings** page using the navigation menu or the [global search field](docs-content://get-started/the-stack.md#kibana-navigation-search).
+1. Go to the **Advanced settings** page using the navigation menu or the [global search field](docs-content://explore-analyze/find-and-organize/find-apps-and-objects.md).
 2. Click **Global Settings**.
 3. Scroll or search for the setting.
 4. Make your change, then click **Save changes**.

--- a/docs/reference/connectors-kibana/pre-configured-connectors.md
+++ b/docs/reference/connectors-kibana/pre-configured-connectors.md
@@ -64,7 +64,7 @@ Sensitive properties, such as passwords, can also be stored in the [{{kib}} keys
 
 ## View preconfigured connectors [managing-preconfigured-connectors]
 
-go to the **{{connectors-ui}}** page using the navigation menu or the [global search field](docs-content://get-started/the-stack.md#kibana-navigation-search). Preconfigured connectors appear regardless of which space you are in. They are tagged as “preconfigured”, and you cannot delete them.
+go to the **{{connectors-ui}}** page using the navigation menu or the [global search field](docs-content://explore-analyze/find-and-organize/find-apps-and-objects.md). Preconfigured connectors appear regardless of which space you are in. They are tagged as “preconfigured”, and you cannot delete them.
 
 % TO DO: Use `:class: screenshot`
 ![Connectors managing tab with pre-configured](../images/preconfigured-connectors-managing.png)

--- a/docs/reference/connectors-kibana/servicenow-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-action-type.md
@@ -302,7 +302,7 @@ Deprecated connectors will continue to function with the rules they were added t
 
 To update a deprecated connector:
 
-1. Go to the **{{connectors-ui}}** page using the navigation menu or the [global search field](docs-content://get-started/the-stack.md#kibana-navigation-search).
+1. Go to the **{{connectors-ui}}** page using the navigation menu or the [global search field](docs-content://explore-analyze/find-and-organize/find-apps-and-objects.md).
 2. Select the deprecated connector to open the **Edit connector** flyout.
 3. In the warning message, click **Update this connector**.
 4. Complete the guided steps in the **Edit connector** flyout.

--- a/docs/reference/connectors-kibana/servicenow-sir-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-sir-action-type.md
@@ -300,7 +300,7 @@ Deprecated connectors will continue to function with the rules they were added t
 
 To update a deprecated connector:
 
-1. Go to the **{{connectors-ui}}** page using the navigation menu or the [global search field](docs-content://get-started/the-stack.md#kibana-navigation-search).
+1. Go to the **{{connectors-ui}}** page using the navigation menu or the [global search field](docs-content://explore-analyze/find-and-organize/find-apps-and-objects.md).
 2. Select the deprecated connector to open the **Edit connector** flyout.
 3. In the warning message, click **Update this connector**.
 4. Complete the guided steps in the **Edit connector** flyout.


### PR DESCRIPTION
## Summary

This PR updates pages that refer to the global search header to point to https://www.elastic.co/docs/explore-analyze/find-and-organize/find-apps-and-objects instead of the Elastic Stack overview. That topic is not covered in the latter page.


<!--ONMERGE {"backportTargets":["9.0","9.1"]} ONMERGE-->