### PR TITLE
[agent builder] store agent/tool id in properties

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/client/client.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/client/client.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { errors as esErrors } from '@elastic/elasticsearch';
 import type {
   ElasticsearchServiceStart,
   KibanaRequest,
@@ -16,7 +15,6 @@ import {
   type AgentDefinition,
   createAgentNotFoundError,
   createBadRequestError,
-  isAgentNotFoundError,
   oneChatDefaultAgentId,
   type ToolSelection,
   type UserIdAndName,
@@ -30,7 +28,7 @@ import type {
 import type { ToolsServiceStart } from '../../tools';
 import type { AgentProfileStorage } from './storage';
 import { createStorage } from './storage';
-import { createRequestToEs, type Document, fromEs, updateProfile } from './converters';
+import { createRequestToEs, type Document, fromEs, updateRequestToEs } from './converters';
 import { ensureValidId, validateToolSelection } from './utils';
 import { createDefaultAgentDefinition } from './default_definitions';
 
@@ -92,22 +90,16 @@ class AgentClientImpl implements AgentClient {
   }
 
   async get(agentId: string): Promise<AgentDefinition> {
-    let document: Document;
-    try {
-      document = await this.storage.getClient().get({ id: agentId });
-    } catch (e) {
-      if (e instanceof esErrors.ResponseError && e.statusCode === 404) {
-        // if the config for the default agent isn't persisted, we return the default definition
-        if (agentId === oneChatDefaultAgentId) {
-          return createDefaultAgentDefinition();
-        }
-        throw createAgentNotFoundError({ agentId });
+    const document = await this._get(agentId);
+    if (!document) {
+      if (agentId === oneChatDefaultAgentId) {
+        return createDefaultAgentDefinition();
       } else {
-        throw e;
+        throw createAgentNotFoundError({ agentId });
       }
     }
 
-    if (!hasAccess({ profile: document, user: this.user })) {
+    if (!hasAccess({ document, user: this.user })) {
       throw createAgentNotFoundError({ agentId });
     }
 
@@ -120,15 +112,8 @@ class AgentClientImpl implements AgentClient {
       return true;
     }
 
-    try {
-      await this.get(agentId);
-      return true;
-    } catch (e) {
-      if (isAgentNotFoundError(e)) {
-        return false;
-      }
-      throw e;
-    }
+    const document = await this._get(agentId);
+    return document !== undefined;
   }
 
   async list(options: AgentListOptions = {}): Promise<AgentDefinition[]> {
@@ -168,7 +153,6 @@ class AgentClientImpl implements AgentClient {
     });
 
     await this.storage.getClient().index({
-      id: profile.id,
       document: attributes,
     });
 
@@ -181,22 +165,14 @@ class AgentClientImpl implements AgentClient {
       throw createBadRequestError(`Default agent cannot be updated.`);
     }
 
-    const now = new Date();
-
-    let document: Document;
-    try {
-      document = await this.storage.getClient().get({ id: agentId });
-    } catch (e) {
-      if (e instanceof esErrors.ResponseError && e.statusCode === 404) {
-        throw createAgentNotFoundError({
-          agentId,
-        });
-      } else {
-        throw e;
-      }
+    const document = await this._get(agentId);
+    if (!document) {
+      throw createAgentNotFoundError({
+        agentId,
+      });
     }
 
-    if (!hasAccess({ profile: document, user: this.user })) {
+    if (!hasAccess({ document, user: this.user })) {
       throw createAgentNotFoundError({ agentId });
     }
 
@@ -204,14 +180,15 @@ class AgentClientImpl implements AgentClient {
       await this.validateAgentToolSelection(profileUpdate.configuration.tools);
     }
 
-    const updatedConversation = updateProfile({
-      profile: document._source!,
+    const updatedConversation = updateRequestToEs({
+      agentId,
+      currentProps: document._source!,
       update: profileUpdate,
-      updateDate: now,
+      updateDate: new Date(),
     });
 
     await this.storage.getClient().index({
-      id: agentId,
+      id: document._id,
       document: updatedConversation,
     });
 
@@ -225,18 +202,12 @@ class AgentClientImpl implements AgentClient {
       throw createBadRequestError(`Default agent cannot be deleted.`);
     }
 
-    let document: Document;
-    try {
-      document = await this.storage.getClient().get({ id });
-    } catch (e) {
-      if (e instanceof esErrors.ResponseError && e.statusCode === 404) {
-        throw createAgentNotFoundError({ agentId: id });
-      } else {
-        throw e;
-      }
+    const document = await this._get(id);
+    if (!document) {
+      throw createAgentNotFoundError({ agentId: id });
     }
 
-    if (!hasAccess({ profile: document, user: this.user })) {
+    if (!hasAccess({ document, user: this.user })) {
       throw createAgentNotFoundError({ agentId: id });
     }
 
@@ -262,24 +233,42 @@ class AgentClientImpl implements AgentClient {
     if (agentId === oneChatDefaultAgentId) {
       return true;
     }
-    try {
-      await this.storage.getClient().get({ id: agentId });
-      return true;
-    } catch (e) {
-      if (e instanceof esErrors.ResponseError && e.statusCode === 404) {
-        return false;
-      } else {
-        throw e;
-      }
+    const document = await this._get(agentId);
+    return !!document;
+  }
+
+  private async _get(agentId: string): Promise<Document | undefined> {
+    const response = await this.storage.getClient().search({
+      track_total_hits: false,
+      size: 1,
+      terminate_after: 1,
+      query: {
+        bool: {
+          filter: [
+            {
+              bool: {
+                // BWC compatibility with M1 - agentId was stored as the _id
+                should: [{ term: { id: agentId } }, { term: { _id: agentId } }],
+                minimum_should_match: 1,
+              },
+            },
+          ],
+        },
+      },
+    });
+    if (response.hits.hits.length === 0) {
+      return undefined;
+    } else {
+      return response.hits.hits[0] as Document;
     }
   }
 }
 
 const hasAccess = ({
-  profile,
+  document,
   user,
 }: {
-  profile: Pick<Document, '_source'>;
+  document: Pick<Document, '_source'>;
   user: UserIdAndName;
 }) => {
   // no access control for now

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/client/client.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/client/client.ts
@@ -211,7 +211,7 @@ class AgentClientImpl implements AgentClient {
       throw createAgentNotFoundError({ agentId: id });
     }
 
-    const deleteResponse = await this.storage.getClient().delete({ id });
+    const deleteResponse = await this.storage.getClient().delete({ id: document._id });
     return deleteResponse.result === 'deleted';
   }
 

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/client/converters.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/client/converters.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AgentType } from '@kbn/onechat-common';
+import type { AgentCreateRequest, AgentUpdateRequest } from '../../../../common/agents';
+import type { AgentProperties } from './storage';
+import type { Document } from './converters';
+import { createRequestToEs, fromEs, updateRequestToEs } from './converters';
+
+const creationDate = '2024-09-04T06:44:17.944Z';
+const updateDate = '2025-08-04T06:44:19.123Z';
+
+describe('fromEs', () => {
+  const getSampleDoc = (): Document => {
+    return {
+      _id: '_id',
+      _source: {
+        id: 'id',
+        name: 'name',
+        type: AgentType.chat,
+        description: 'description',
+        labels: ['foo', 'bar'],
+        configuration: {
+          instructions: 'instructions',
+          tools: [{ tool_ids: ['id_1', 'id_2'] }],
+        },
+        created_at: creationDate,
+        updated_at: updateDate,
+      },
+    };
+  };
+
+  it('converts an agent document to its definition', () => {
+    const document = getSampleDoc();
+
+    const definition = fromEs(document);
+
+    expect(definition).toEqual({
+      type: AgentType.chat,
+      id: 'id',
+      name: 'name',
+      configuration: {
+        instructions: 'instructions',
+        tools: [
+          {
+            tool_ids: ['id_1', 'id_2'],
+          },
+        ],
+      },
+      description: 'description',
+      labels: ['foo', 'bar'],
+    });
+  });
+
+  it('handles legacy doc format', () => {
+    const document = getSampleDoc();
+    document._id = '_id';
+    // @ts-ignore testing edge case
+    document._source!.id = undefined;
+
+    const definition = fromEs(document);
+
+    expect(definition.id).toEqual('_id');
+  });
+});
+
+describe('createRequestToEs', () => {
+  it('converts a request to the document format', () => {
+    const createRequest: AgentCreateRequest = {
+      id: 'id',
+      name: 'name',
+      description: 'description',
+      configuration: {
+        instructions: 'instructions',
+        tools: [
+          {
+            tool_ids: ['id_1', 'id_2'],
+          },
+        ],
+      },
+      labels: ['foo', 'bar'],
+    };
+
+    const date = new Date();
+
+    const docProperties = createRequestToEs({
+      profile: createRequest,
+      creationDate: date,
+    });
+
+    expect(docProperties).toEqual({
+      type: AgentType.chat,
+      id: 'id',
+      name: 'name',
+      description: 'description',
+      configuration: {
+        instructions: 'instructions',
+        tools: [
+          {
+            tool_ids: ['id_1', 'id_2'],
+          },
+        ],
+      },
+      labels: ['foo', 'bar'],
+      created_at: expect.any(String),
+      updated_at: expect.any(String),
+    });
+  });
+});
+
+describe('updateRequestToEs', () => {
+  it('converts an update request to the document format', () => {
+    const newUpdateDate = new Date();
+
+    const agentProps: AgentProperties = {
+      id: 'id',
+      type: AgentType.chat,
+      name: 'name',
+      description: 'description',
+      configuration: {
+        instructions: 'instructions',
+        tools: [
+          {
+            tool_ids: ['id_1', 'id_2'],
+          },
+        ],
+      },
+      labels: ['foo', 'bar'],
+      created_at: creationDate,
+      updated_at: updateDate,
+    };
+
+    const updateRequest: AgentUpdateRequest = {
+      name: 'new name',
+      configuration: {
+        tools: [{ tool_ids: ['new_id_1', 'new_id_2'] }],
+      },
+    };
+
+    const docProperties = updateRequestToEs({
+      agentId: 'id',
+      currentProps: agentProps,
+      update: updateRequest,
+      updateDate: newUpdateDate,
+    });
+
+    expect(docProperties).toEqual({
+      id: 'id',
+      type: AgentType.chat,
+      name: 'new name',
+      description: 'description',
+      configuration: {
+        instructions: 'instructions',
+        tools: [
+          {
+            tool_ids: ['new_id_1', 'new_id_2'],
+          },
+        ],
+      },
+      labels: ['foo', 'bar'],
+      created_at: creationDate,
+      updated_at: newUpdateDate.toISOString(),
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/client/storage.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/client/storage.ts
@@ -17,6 +17,7 @@ const storageSettings = {
   name: agentsIndexName,
   schema: {
     properties: {
+      id: types.keyword({}),
       name: types.keyword({}),
       type: types.keyword({}),
       description: types.text({}),
@@ -31,6 +32,7 @@ const storageSettings = {
 } satisfies IndexStorageSettings;
 
 export interface AgentProperties {
+  id: string;
   name: string;
   type: AgentType;
   description: string;

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/persisted/client/converter.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/persisted/client/converter.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ToolCreateParams, ToolTypeUpdateParams } from '../../tool_provider';
+import type { ToolDocument } from './types';
+import type { ToolProperties } from './storage';
+import { createAttributes, fromEs, updateDocument } from './converters';
+import { ToolType } from '@kbn/onechat-common';
+
+const creationDate = '2024-09-04T06:44:17.944Z';
+const updateDate = '2025-08-04T06:44:19.123Z';
+
+describe('fromEs', () => {
+  it('converts a tool document to its definition format', () => {
+    const document: ToolDocument = {
+      _id: '_id',
+      _source: {
+        id: 'id',
+        type: ToolType.esql,
+        description: 'description',
+        configuration: {
+          configProp: 'dolly',
+        },
+        tags: [],
+        created_at: creationDate,
+        updated_at: updateDate,
+      },
+    };
+
+    const definition = fromEs(document);
+
+    expect(definition).toEqual({
+      id: 'id',
+      type: ToolType.esql,
+      description: 'description',
+      configuration: {
+        configProp: 'dolly',
+      },
+      tags: [],
+      created_at: '2024-09-04T06:44:17.944Z',
+      updated_at: '2025-08-04T06:44:19.123Z',
+    });
+  });
+});
+
+describe('createAttributes', () => {
+  it('converts the creation request to attributes', () => {
+    const actualCreationDate = new Date();
+    const createRequest: ToolCreateParams = {
+      id: 'id',
+      type: ToolType.esql,
+      description: 'foo',
+      configuration: {
+        hello: 'world',
+      },
+    };
+
+    const properties = createAttributes({
+      createRequest,
+      creationDate: actualCreationDate,
+    });
+
+    expect(properties).toEqual({
+      id: 'id',
+      type: ToolType.esql,
+      description: 'foo',
+      configuration: {
+        hello: 'world',
+      },
+      tags: [],
+      created_at: actualCreationDate.toISOString(),
+      updated_at: actualCreationDate.toISOString(),
+    });
+  });
+});
+
+describe('updateDocument', () => {
+  it('merges the existing and update attributes', () => {
+    const actualUpdateDate = new Date();
+
+    const currentProps: ToolProperties = {
+      id: 'id',
+      type: ToolType.esql,
+      description: 'foo',
+      configuration: {
+        hello: 'world',
+        foo: 'bar',
+      },
+      tags: [],
+      created_at: creationDate,
+      updated_at: updateDate,
+    };
+
+    const update: ToolTypeUpdateParams = {
+      description: 'new desc',
+      configuration: {
+        hello: 'dolly',
+        anotherProp: 'foo',
+      },
+    };
+
+    const merged = updateDocument({
+      current: currentProps,
+      update,
+      updateDate: actualUpdateDate,
+    });
+
+    expect(merged).toEqual({
+      id: 'id',
+      type: ToolType.esql,
+      description: 'new desc',
+      configuration: {
+        anotherProp: 'foo',
+        foo: 'bar',
+        hello: 'dolly',
+      },
+      tags: [],
+      created_at: creationDate,
+      updated_at: actualUpdateDate.toISOString(),
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/persisted/client/converters.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/persisted/client/converters.ts
@@ -16,7 +16,7 @@ export const fromEs = <TConfig extends object = {}>(
     throw new Error('No source found on get conversation response');
   }
   return {
-    id: document._id,
+    id: document._source.id,
     type: document._source.type,
     description: document._source.description,
     tags: document._source.tags,


### PR DESCRIPTION
## Summary

Previously we we using the document's `_id` to store our agents and tool ids. However those ids are user specified, which will cause issues when we will introduce space support (as we can have multiple tools with the same id in different spaces).

This PR addresses it, by using the `id` attribute instead.
- for tools, we were already storing `id` as an attribute (with the same value as the doc `_id`), so changes were easy
- for agents, we were not, so I added some logic to support both the old and new format. it wasn't strictly necessary given we're not live yet, but will avoid all the internal testing cluster to explode because of this change. 

