### PR TITLE
[Agent builder] Debounce scroll handler and fix visualisations loading height

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/visualize_esql.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/visualize_esql.tsx
@@ -19,6 +19,8 @@ import useAsync from 'react-use/lib/useAsync';
 import type { TabularDataResult } from '@kbn/onechat-common/tools/tool_result';
 import { esFieldTypeToKibanaFieldType } from '@kbn/field-types';
 
+const VISUALIZATION_HEIGHT = 240;
+
 interface VisualizeESQLProps {
   lens: LensPublicStart;
   dataViews: DataViewsServicePublic;
@@ -104,16 +106,20 @@ export function VisualizeESQL({
     preferredChartType,
   ]);
 
-  if (!lensHelpersAsync.value || !dataViewAsync.value || !lensInput) {
-    return <EuiLoadingSpinner />;
-  }
+  const isLoading = !lensHelpersAsync.value || !dataViewAsync.value || !lensInput;
 
   return (
-    <lens.EmbeddableComponent
-      {...lensInput}
-      style={{
-        height: 240,
-      }}
-    />
+    <div style={{ height: VISUALIZATION_HEIGHT }}>
+      {isLoading ? (
+        <EuiLoadingSpinner />
+      ) : (
+        <lens.EmbeddableComponent
+          {...lensInput}
+          style={{
+            height: VISUALIZATION_HEIGHT,
+          }}
+        />
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/search-team/issues/11018 

**Problem 1: Scroll Button Race Condition**
- The scroll event listener was firing too frequently, causing the scroll button to appear incorrectly
- [x] Solution: Added 20ms debounce delay to prevent race conditions in scroll event handling

**Problem 2: Visualization Loading Height Jump**
- Visualizations caused content to not stick to bottom on first load because loading spinners had no height, causing dynamic growing
- [x] Solution: Wrapped loading spinners in a 240px container to maintain consistent height during loading, preventing layout shifts



