### PR TITLE
Fix index search UI validations

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/index_search/index_search_pattern.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/index_search/index_search_pattern.tsx
@@ -43,7 +43,7 @@ export const IndexSearchPattern: React.FC = () => {
     setPageIndex(0);
   }, [patternValue]);
 
-  const { data, isLoading, error } = useIndexSearchSources({
+  const { data, isLoading } = useIndexSearchSources({
     pattern: patternValue,
   });
 

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/index_search/index_search_pattern.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/index_search/index_search_pattern.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   EuiBadge,
   EuiBasicTable,
@@ -17,6 +17,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { useController, useFormContext } from 'react-hook-form';
 import { css } from '@emotion/react';
+import { EsResourceType } from '@kbn/onechat-common';
 import { labels } from '../../../../../utils/i18n';
 import { useIndexSearchSources } from '../../../../../hooks/tools/use_resolve_search_sources';
 import type { IndexSearchToolFormData } from '../../types/tool_form_types';
@@ -24,28 +25,13 @@ import type { IndexSearchToolFormData } from '../../types/tool_form_types';
 const DEFAULT_PAGE_SIZE = 5;
 
 export const IndexSearchPattern: React.FC = () => {
-  const { control, setValue, setError, clearErrors } = useFormContext<IndexSearchToolFormData>();
+  const { control, setValue, trigger } = useFormContext<IndexSearchToolFormData>();
   const {
     field: { ref, value, onChange, onBlur, name },
     fieldState,
   } = useController({
     name: 'pattern',
     control,
-    rules: {
-      required: {
-        value: true,
-        message: i18n.translate('xpack.onechat.tools.indexPattern.pattern.requiredError', {
-          defaultMessage: 'Pattern is required.',
-        }),
-      },
-      pattern: {
-        value: /^(?!.*,$).+$/,
-        message: i18n.translate('xpack.onechat.tools.indexPattern.pattern.trailingCommaError', {
-          defaultMessage:
-            'Pattern cannot end with a comma. Add another pattern or remove the comma.',
-        }),
-      },
-    },
   });
 
   const patternValue = value ?? '';
@@ -64,28 +50,6 @@ export const IndexSearchPattern: React.FC = () => {
   const items = useMemo(() => (hasQuery ? data?.results ?? [] : []), [data, hasQuery]);
   const total = hasQuery ? data?.total ?? 0 : 0;
 
-  const validatePattern = useCallback(() => {
-    if (fieldState.invalid) return;
-
-    if (error) {
-      setError('pattern', {
-        type: 'error',
-        message: i18n.translate('xpack.onechat.tools.indexPattern.pattern.error', {
-          defaultMessage: 'Error loading index patterns.',
-        }),
-      });
-    } else if (patternValue && total === 0) {
-      setError('pattern', {
-        type: 'noMatches',
-        message: i18n.translate('xpack.onechat.tools.indexPattern.pattern.noMatchesError', {
-          defaultMessage: 'No matches found for this pattern.',
-        }),
-      });
-    } else if (!patternValue || total > 0) {
-      clearErrors('pattern');
-    }
-  }, [patternValue, total, error, setError, clearErrors, fieldState.invalid]);
-
   const pageOfItems = useMemo(() => {
     const start = pageIndex * pageSize;
     const end = start + pageSize;
@@ -102,11 +66,11 @@ export const IndexSearchPattern: React.FC = () => {
       render: (type: string) => {
         return (
           <EuiBadge color="hollow" data-test-subj="onechatIndexPatternBadge">
-            {type === 'index'
+            {type === EsResourceType.index
               ? labels.tools.indexTypeLabel
-              : type === 'alias'
+              : type === EsResourceType.alias
               ? labels.tools.aliasTypeLabel
-              : type === 'data_stream'
+              : type === EsResourceType.dataStream
               ? labels.tools.dataStreamTypeLabel
               : undefined}
           </EuiBadge>
@@ -133,8 +97,10 @@ export const IndexSearchPattern: React.FC = () => {
           }),
           icon: 'plusInCircle',
           type: 'icon',
-          onClick: (item: { name: string }) =>
-            setValue('pattern', item.name, { shouldDirty: true, shouldValidate: true }),
+          onClick: async (item: { name: string }) => {
+            setValue('pattern', item.name, { shouldDirty: true, shouldValidate: true });
+            await trigger('pattern');
+          },
         },
       ],
     },
@@ -146,10 +112,7 @@ export const IndexSearchPattern: React.FC = () => {
         name={name}
         value={patternValue}
         onChange={onChange}
-        onBlur={() => {
-          onBlur();
-          validatePattern();
-        }}
+        onBlur={onBlur}
         inputRef={ref}
         isInvalid={fieldState.invalid}
         aria-label={i18n.translate('xpack.onechat.tools.indexPattern.pattern.inputAriaLabel', {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/validation/index_search_tool_form_validation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/validation/index_search_tool_form_validation.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { ToolType } from '@kbn/onechat-common/tools';
+import { set } from '@kbn/safer-lodash-set';
+import { z } from '@kbn/zod';
+import { get } from 'lodash';
+import { useCallback } from 'react';
+import type { Resolver } from 'react-hook-form';
+import type { IndexSearchToolFormData } from '../types/tool_form_types';
+import { sharedValidationSchemas } from './shared_tool_validation';
+import { useOnechatServices } from '../../../../hooks/use_onechat_service';
+
+const indexSearchI18nMessages = {
+  pattern: {
+    requiredError: i18n.translate('xpack.onechat.tools.indexPattern.pattern.requiredError', {
+      defaultMessage: 'Pattern is required.',
+    }),
+    trailingCommaError: i18n.translate(
+      'xpack.onechat.tools.indexPattern.pattern.trailingCommaError',
+      {
+        defaultMessage: 'Pattern cannot end with a comma. Add another pattern or remove the comma.',
+      }
+    ),
+    noMatchesError: i18n.translate('xpack.onechat.tools.indexPattern.pattern.noMatchesError', {
+      defaultMessage: 'No matches found for this pattern.',
+    }),
+    apiError: i18n.translate('xpack.onechat.tools.indexPattern.pattern.error', {
+      defaultMessage: 'Error loading index patterns.',
+    }),
+  },
+};
+
+export const useIndexSearchToolFormValidationResolver = (): Resolver<IndexSearchToolFormData> => {
+  const { toolsService } = useOnechatServices();
+
+  return useCallback(
+    async (data) => {
+      try {
+        const values = await indexSearchFormValidationSchema(toolsService).parseAsync(data);
+        return {
+          values,
+          errors: {},
+        };
+      } catch (error: unknown) {
+        if (!(error instanceof z.ZodError)) {
+          throw error;
+        }
+        const errors = error.issues.reduce<Record<string, { type: string; message: string }>>(
+          (errorMap, issue) => {
+            const path = issue.path.join('.');
+            if (!get(errorMap, path)) {
+              set(errorMap, path, {
+                type: issue.code,
+                message: issue.message,
+              });
+            }
+            return errorMap;
+          },
+          {}
+        );
+
+        return {
+          values: {},
+          errors,
+        };
+      }
+    },
+    [toolsService]
+  );
+};
+
+const indexSearchFormValidationSchema = (toolsService: any) =>
+  z.object({
+    toolId: sharedValidationSchemas.toolId,
+    description: sharedValidationSchemas.description,
+    labels: sharedValidationSchemas.labels,
+
+    // Index Search specific validation with async target checking
+    pattern: z
+      .string()
+      .min(1, { message: indexSearchI18nMessages.pattern.requiredError })
+      .regex(/^(?!.*,$).+$/, { message: indexSearchI18nMessages.pattern.trailingCommaError })
+      .refine(
+        async (pattern) => {
+          if (!pattern || !pattern.trim()) {
+            return true; // Let required validation handle empty values
+          }
+
+          try {
+            const response = await toolsService.resolveSearchSources({ pattern });
+            return response.total > 0;
+          } catch {
+            // If API call fails, we'll show an API error instead of no matches
+            throw new Error(indexSearchI18nMessages.pattern.apiError);
+          }
+        },
+        { message: indexSearchI18nMessages.pattern.noMatchesError }
+      ),
+
+    type: z.literal(ToolType.index_search),
+  });

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/validation/index_search_tool_form_validation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/validation/index_search_tool_form_validation.ts
@@ -85,7 +85,7 @@ const indexSearchFormValidationSchema = (toolsService: ToolsService) =>
     pattern: z
       .string()
       .min(1, { message: indexSearchI18nMessages.pattern.requiredError })
-      .regex(/^(?!.*,$).+$/, { message: indexSearchI18nMessages.pattern.trailingCommaError })
+      .regex(/^.+[^,]$/, { message: indexSearchI18nMessages.pattern.trailingCommaError })
       .refine(
         async (pattern) => {
           if (!pattern || !pattern.trim()) {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/validation/shared_tool_validation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/validation/shared_tool_validation.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import {
+  toolIdRegexp,
+  toolIdMaxLength,
+  isReservedToolId,
+  isInProtectedNamespace,
+  hasProtectedNamespaceName,
+} from '@kbn/onechat-common/tools';
+import { z } from '@kbn/zod';
+
+export const sharedI18nMessages = {
+  toolId: {
+    requiredError: i18n.translate('xpack.onechat.tools.newTool.validation.toolId.requiredError', {
+      defaultMessage: 'Tool ID is required.',
+    }),
+    tooLongError: i18n.translate('xpack.onechat.tools.newTool.validation.toolId.tooLongError', {
+      defaultMessage: 'Tool ID must be 63 characters or less.',
+    }),
+    formatError: i18n.translate('xpack.onechat.tools.newTool.validation.toolId.formatError', {
+      defaultMessage:
+        'Tool ID must start with a letter and contain only lowercase letters, numbers, and hyphens.',
+    }),
+    reservedError: (name: string) =>
+      i18n.translate('xpack.onechat.tools.newTool.validation.toolId.reservedError', {
+        defaultMessage: 'Tool ID "{name}" is reserved.',
+        values: { name },
+      }),
+    protectedNamespaceError: (name: string) =>
+      i18n.translate('xpack.onechat.tools.newTool.validation.toolId.protectedNamespaceError', {
+        defaultMessage: 'Tool ID "{name}" uses a protected namespace.',
+        values: { name },
+      }),
+  },
+  description: {
+    requiredError: i18n.translate(
+      'xpack.onechat.tools.newTool.validation.description.requiredError',
+      {
+        defaultMessage: 'Description is required.',
+      }
+    ),
+  },
+};
+
+// Shared validation schemas for common fields
+export const sharedValidationSchemas = {
+  toolId: z
+    .string()
+    .min(1, { message: sharedI18nMessages.toolId.requiredError })
+    .max(toolIdMaxLength, { message: sharedI18nMessages.toolId.tooLongError })
+    .regex(toolIdRegexp, { message: sharedI18nMessages.toolId.formatError })
+    .refine(
+      (name) => !isReservedToolId(name),
+      (name) => ({
+        message: sharedI18nMessages.toolId.reservedError(name),
+      })
+    )
+    .refine(
+      (name) => !isInProtectedNamespace(name) && !hasProtectedNamespaceName(name),
+      (name) => ({
+        message: sharedI18nMessages.toolId.protectedNamespaceError(name),
+      })
+    ),
+
+  description: z.string().min(1, { message: sharedI18nMessages.description.requiredError }),
+
+  labels: z.array(z.string()),
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
@@ -102,6 +102,7 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
   const [showTestFlyout, setShowTestFlyout] = useState(false);
 
   const currentToolId = watch('toolId');
+  const currentToolType = watch('type');
 
   // Handle opening test tool flyout on navigation
   useEffect(() => {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
@@ -102,7 +102,6 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
   const [showTestFlyout, setShowTestFlyout] = useState(false);
 
   const currentToolId = watch('toolId');
-  const currentToolType = watch('type');
 
   // Handle opening test tool flyout on navigation
   useEffect(() => {

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tool_form.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tool_form.ts
@@ -14,7 +14,7 @@ import type { ToolFormData } from '../../components/tools/form/types/tool_form_t
 import { useEsqlToolFormValidationResolver } from '../../components/tools/form/validation/esql_tool_form_validation';
 import { useIndexSearchToolFormValidationResolver } from '../../components/tools/form/validation/index_search_tool_form_validation';
 
-export const getDefaultValues = (toolType: ToolType): ToolFormData => {
+const getDefaultValues = (toolType: ToolType): ToolFormData => {
   switch (toolType) {
     case ToolType.esql:
       return {

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tool_form.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tool_form.ts
@@ -7,10 +7,14 @@
 
 import type { ToolDefinitionWithSchema } from '@kbn/onechat-common';
 import { ToolType } from '@kbn/onechat-common';
-import type { Resolver } from 'react-hook-form';
+import type { Resolver, ResolverOptions } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 import { useCallback } from 'react';
-import type { ToolFormData } from '../../components/tools/form/types/tool_form_types';
+import type {
+  EsqlToolFormData,
+  IndexSearchToolFormData,
+  ToolFormData,
+} from '../../components/tools/form/types/tool_form_types';
 import { useEsqlToolFormValidationResolver } from '../../components/tools/form/validation/esql_tool_form_validation';
 import { useIndexSearchToolFormValidationResolver } from '../../components/tools/form/validation/index_search_tool_form_validation';
 
@@ -55,9 +59,17 @@ export const useToolForm = (tool?: ToolDefinitionWithSchema, initialToolType?: T
 
       switch (currentType) {
         case ToolType.esql:
-          return esqlResolver(data as any, context as any, options as any);
+          return esqlResolver(
+            data as EsqlToolFormData,
+            context,
+            options as ResolverOptions<EsqlToolFormData>
+          );
         case ToolType.index_search:
-          return indexSearchResolver(data as any, context as any, options as any);
+          return indexSearchResolver(
+            data as IndexSearchToolFormData,
+            context,
+            options as ResolverOptions<IndexSearchToolFormData>
+          );
         default:
           // For builtin tools or unknown types, just return valid
           return {


### PR DESCRIPTION
## Summary

Adds:
- index search tool resolver
- refactors resolver to limit duplication
- switch resolvers based on tool type (that was the main issue, we would load the new tool page with esql as default .. so even after selecting different tool type the resolver wouldn't be changed.. refreshing the page was helping)
- previously, once page was loaded with index_search type... the id valudation wasn't working at all,,, 

No index search tool validation works


https://github.com/user-attachments/assets/5f91d2ac-186f-4a9f-8e97-19a83b4d0a8e


