### PR TITLE
[Agent Builder] Clicking "Found X records" should open Discover in a new tab

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/tabular_data_result_step.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/tabular_data_result_step.tsx
@@ -49,6 +49,7 @@ export const TabularDataResultStep: React.FC<TabularDataResultStepProps> = ({
       {discoverUrl && (
         <EuiLink
           href={discoverUrl}
+          target="_blank"
           data-test-subj="onechat-esql-data-result-see-in-discover"
           aria-label={i18n.translate(
             'xpack.onechat.conversation.thinking.tabularDataResultStep.seeInDiscoverAriaLabel',
@@ -57,19 +58,16 @@ export const TabularDataResultStep: React.FC<TabularDataResultStepProps> = ({
             }
           )}
         >
-          <EuiFlexGroup direction="row" gutterSize="xs" alignItems="center">
-            {i18n.translate(
-              'xpack.onechat.conversation.thinking.tabularDataResultStep.foundRecordsMessage',
-              {
-                defaultMessage:
-                  '{totalDocuments, plural, one {{totalDocuments, number} record} other {{totalDocuments, number} records}}',
-                values: {
-                  totalDocuments: data.values.length,
-                },
-              }
-            )}
-            <EuiIcon type="popout" />
-          </EuiFlexGroup>
+          {i18n.translate(
+            'xpack.onechat.conversation.thinking.tabularDataResultStep.foundRecordsMessage',
+            {
+              defaultMessage:
+                '{totalDocuments, plural, one {{totalDocuments, number} record} other {{totalDocuments, number} records}}',
+              values: {
+                totalDocuments: data.values.length,
+              },
+            }
+          )}
         </EuiLink>
       )}
     </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/tabular_data_result_step.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/tabular_data_result_step.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React, { useMemo } from 'react';
-import { EuiFlexGroup, EuiIcon, EuiLink, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiLink, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { TabularDataResult } from '@kbn/onechat-common/tools/tool_result';
 import { useOnechatServices } from '../../../../../hooks/use_onechat_service';


### PR DESCRIPTION
## Summary

fixes https://github.com/elastic/search-team/issues/10997

The issue:
- Expand the "Thinking" panel and click on one of the "Found X records" tab
- Click the Expand icon to see the full JSON in discover
- See that it opens in the same page

We should make this open in a separate tab. My using the same page to link to discover, the conversation will be halted if the agent is still thinking, and it will have no recollection of this previous message by the time you return.

