### PR TITLE
[8.19] 🌊 Streams: Fix classic streams ingest pipeline manipulation (#230053)

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_unwired_stream_pipeline_actions.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_unwired_stream_pipeline_actions.test.ts
@@ -703,6 +703,10 @@ describe('translateUnwiredStreamPipelineActions', () => {
         .mockImplementationOnce(async () => {
           return {
             'my-template-pipeline': {
+              created_date_millis: 123456789,
+              created_date: '2023-10-01T00:00:00.000Z',
+              modified_date_millis: 123456789,
+              modified_date: '2023-10-01T00:00:00.000Z',
               processors: [
                 {
                   set: {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_unwired_stream_pipeline_actions.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_unwired_stream_pipeline_actions.ts
@@ -8,7 +8,7 @@
 import type { IngestPipeline } from '@elastic/elasticsearch/lib/api/types';
 import type { IScopedClusterClient } from '@kbn/core/server';
 import { isNotFoundError } from '@kbn/es-errors';
-import { castArray, groupBy, uniq } from 'lodash';
+import { castArray, groupBy, omit, uniq } from 'lodash';
 import { ASSET_VERSION } from '../../../../../common/constants';
 import type {
   ActionsByType,
@@ -330,15 +330,29 @@ async function findPipelineToModify(
 }
 
 async function getPipeline(id: string, scopedClusterClient: IScopedClusterClient) {
-  return scopedClusterClient.asCurrentUser.ingest
-    .getPipeline({ id })
-    .then((response) => response[id])
-    .catch((error) => {
-      if (isNotFoundError(error)) {
-        return undefined;
-      }
-      throw error;
-    });
+  return (
+    scopedClusterClient.asCurrentUser.ingest
+      .getPipeline({ id })
+      // some keys on the pipeline can't be modified, so we need to clean them up
+      // to avoid errors when updating the pipeline
+      .then((response) => {
+        if (!response[id]) {
+          return undefined;
+        }
+        return omit(response[id], [
+          'created_date_millis',
+          'created_date',
+          'modified_date_millis',
+          'modified_date',
+        ]);
+      })
+      .catch((error) => {
+        if (isNotFoundError(error)) {
+          return undefined;
+        }
+        throw error;
+      })
+  );
 }
 
 async function getIndexTemplate(name: string, scopedClusterClient: IScopedClusterClient) {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/232445

# Backport

This will backport the following commits from `main` to `8.19`:
 - [🌊 Streams: Fix classic streams ingest pipeline manipulation (#230053)](https://github.com/elastic/kibana/pull/230053)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Joe Reuter","email":"johannes.reuter@elastic.co"},"sourceCommit":{"committedDate":"2025-07-31T12:58:52Z","message":"🌊 Streams: Fix classic streams ingest pipeline manipulation (#230053)\n\nFixes https://github.com/elastic/kibana/issues/229733\n\nWith https://github.com/elastic/elasticsearch/pull/130847 , we track the\ncreation and modification date of ingest pipelines.\nAs part of adjusting processing through the streams API, the ingest\npipeline object is loaded, modified and written back. This fails since\nit tries to set the modified/creation timestamps which isn't allowed.\n\nThis PR is stripping out the offending keys","sha":"4561993a2d8d50773ee1a2f1bf4ef7dca7908944","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-ux-logs","Feature:Streams","v9.2.0"],"title":"🌊 Streams: Fix classic streams ingest pipeline manipulation","number":230053,"url":"https://github.com/elastic/kibana/pull/230053","mergeCommit":{"message":"🌊 Streams: Fix classic streams ingest pipeline manipulation (#230053)\n\nFixes https://github.com/elastic/kibana/issues/229733\n\nWith https://github.com/elastic/elasticsearch/pull/130847 , we track the\ncreation and modification date of ingest pipelines.\nAs part of adjusting processing through the streams API, the ingest\npipeline object is loaded, modified and written back. This fails since\nit tries to set the modified/creation timestamps which isn't allowed.\n\nThis PR is stripping out the offending keys","sha":"4561993a2d8d50773ee1a2f1bf4ef7dca7908944"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230053","number":230053,"mergeCommit":{"message":"🌊 Streams: Fix classic streams ingest pipeline manipulation (#230053)\n\nFixes https://github.com/elastic/kibana/issues/229733\n\nWith https://github.com/elastic/elasticsearch/pull/130847 , we track the\ncreation and modification date of ingest pipelines.\nAs part of adjusting processing through the streams API, the ingest\npipeline object is loaded, modified and written back. This fails since\nit tries to set the modified/creation timestamps which isn't allowed.\n\nThis PR is stripping out the offending keys","sha":"4561993a2d8d50773ee1a2f1bf4ef7dca7908944"}}]}] BACKPORT-->