### PR TITLE
[Elastic Assistant] Fix authentication issue in shared conversations Cypress test

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/shared_conversations.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/shared_conversations.cy.ts
@@ -90,7 +90,7 @@ describe('Assistant Conversation Sharing', { tags: ['@ess', '@serverless'] }, ()
   };
   before(() => {
     loginSecondaryUser(isServerless, secondaryUser);
-    logout();
+    cy.clearCookies();
   });
   beforeEach(() => {
     deleteConnectors();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/shared_conversations.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/shared_conversations.cy.ts
@@ -42,7 +42,7 @@ import {
 import { deleteConversations, waitForConversation } from '../../tasks/api_calls/assistant';
 import { azureConnectorAPIPayload, createAzureConnector } from '../../tasks/api_calls/connectors';
 import { deleteConnectors } from '../../tasks/api_calls/common';
-import { login, loginWithUser, logout } from '../../tasks/login';
+import { login, loginWithUser } from '../../tasks/login';
 import { visit, visitGetStartedPage } from '../../tasks/navigation';
 const userRole: MessageRole = 'user';
 const assistantRole: MessageRole = 'assistant';


### PR DESCRIPTION
## Summary

Fixes a 401 authentication error occurring in the AI Assistant shared conversations Cypress test when running in serverless environments.

### Problem
The test was failing during the `before` hook with a 401 Unauthorized error when attempting to logout using the `logout()` function. This was specifically happening in serverless environments where the authentication flow differs from ESS.

### Solution
Replace `logout()` with `cy.clearCookies()` in the before hook. This approach:
- Is already used successfully throughout the rest of the test file
- Is the established pattern for user switching in Cypress tests
- Works correctly in both ESS and serverless environments

### Changes
- `x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/shared_conversations.cy.ts`: Replace `logout()` call with `cy.clearCookies()` in line 93

### Testing
- [x] Verified the change follows the existing pattern in the same test file
- [x] Confirmed `cy.clearCookies()` is used in lines 175, 209, 233, 258 for user switching

### Related Issues
Resolves authentication failures in serverless environments for the AI Assistant shared conversations test suite.