### PR TITLE
🌊 Streams: Remove fields from default mapping

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/component_templates/generate_layer.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/component_templates/generate_layer.test.ts
@@ -117,13 +117,6 @@ describe('generateLayer', () => {
                     "subobjects": false,
                     "type": "object",
                   },
-                  "dropped_attributes_count": Object {
-                    "type": "long",
-                  },
-                  "schema_url": Object {
-                    "ignore_above": 1024,
-                    "type": "keyword",
-                  },
                 },
                 "type": "object",
               },

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/component_templates/logs_layer.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/component_templates/logs_layer.ts
@@ -58,25 +58,7 @@ export const baseFields: FieldDefinition = {
   'stream.name': {
     type: 'system',
   },
-  'scope.dropped_attributes_count': {
-    type: 'long',
-  },
-  dropped_attributes_count: {
-    type: 'long',
-  },
-  'resource.dropped_attributes_count': {
-    type: 'long',
-  },
-  'resource.schema_url': {
-    type: 'keyword',
-  },
   'scope.name': {
-    type: 'keyword',
-  },
-  'scope.schema_url': {
-    type: 'keyword',
-  },
-  'scope.version': {
     type: 'keyword',
   },
   trace_id: {
@@ -122,13 +104,6 @@ export const baseMappings: Exclude<MappingTypeMapping['properties'], undefined> 
   resource: {
     type: 'object',
     properties: {
-      dropped_attributes_count: {
-        type: 'long',
-      },
-      schema_url: {
-        ignore_above: 1024,
-        type: 'keyword',
-      },
       attributes: {
         type: 'object',
         subobjects: false,

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/helpers/create_streams.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/helpers/create_streams.ts
@@ -28,25 +28,7 @@ const streams: StreamPutItem[] = [
             '@timestamp': {
               type: 'date',
             },
-            'scope.dropped_attributes_count': {
-              type: 'long',
-            },
-            dropped_attributes_count: {
-              type: 'long',
-            },
-            'resource.dropped_attributes_count': {
-              type: 'long',
-            },
-            'resource.schema_url': {
-              type: 'keyword',
-            },
             'scope.name': {
-              type: 'keyword',
-            },
-            'scope.schema_url': {
-              type: 'keyword',
-            },
-            'scope.version': {
               type: 'keyword',
             },
             trace_id: {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/root_stream.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/root_stream.ts
@@ -27,25 +27,7 @@ const rootStreamDefinition: Streams.WiredStream.Definition = {
         '@timestamp': {
           type: 'date',
         },
-        'scope.dropped_attributes_count': {
-          type: 'long',
-        },
-        dropped_attributes_count: {
-          type: 'long',
-        },
-        'resource.dropped_attributes_count': {
-          type: 'long',
-        },
-        'resource.schema_url': {
-          type: 'keyword',
-        },
         'scope.name': {
-          type: 'keyword',
-        },
-        'scope.schema_url': {
-          type: 'keyword',
-        },
-        'scope.version': {
           type: 'keyword',
         },
         trace_id: {


### PR DESCRIPTION
As discussed in https://github.com/elastic/streams-program/discussions/493 , remove a couple of fields from the wired logs stream root mapping.

It should still be possible to map these fields in child streams.