### PR TITLE
[Controls Anywhere] Add titlesManager to ESQL control

### DIFF
--- a/src/platform/packages/shared/kbn-esql-types/src/variables_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/variables_types.ts
@@ -46,8 +46,6 @@ export interface PublishesESQLVariable {
 export type ControlWidthOptions = 'small' | 'medium' | 'large';
 
 export interface ESQLControlState {
-  grow?: boolean;
-  width?: ControlWidthOptions;
   title: string;
   selectedOptions: string[];
   variableName: string;

--- a/src/platform/plugins/shared/controls/public/control_group/control_group_renderer/control_group_renderer.tsx
+++ b/src/platform/plugins/shared/controls/public/control_group/control_group_renderer/control_group_renderer.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { BehaviorSubject, Subject, map } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 import { cloneDeep } from 'lodash';
 

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
@@ -73,6 +73,7 @@ export const getESQLControlFactory = (): EmbeddableFactory<ESQLControlState, ESQ
         },
         onReset: (lastSaved) => {
           selections.reinitializeState(lastSaved?.rawState);
+          titlesManager.reinitializeState(lastSaved?.rawState);
         },
       });
 


### PR DESCRIPTION
## Summary

> [!WARNING]
> **_This work is being merged into a feature branch, not main!_**
> Because of this, we only need a review from @elastic/kibana-presentation for now.
>
> Type failures are expected because the feature branch is currently in an incomplete state, where the controls that have not yet been converted are dependent on things that no longer exist.


Adds a `titlesManager` to ES|QL controls. This allows the panel title to update on edit. Previously it required a page reload to correctly update.

To test:

- Change the optional `Label` of an ES|QL control and ensure it updates on save
- Remove the optional `Label` and ensure the panel title switches to the variable name on save