### PR TITLE
[dev docs] Troubleshooting: simplify & convert to vanilla markdown

### DIFF
--- a/dev_docs/getting_started/troubleshooting.md
+++ b/dev_docs/getting_started/troubleshooting.md
@@ -1,0 +1,51 @@
+---
+id: kibTroubleshooting
+slug: /kibana-dev-docs/getting-started/troubleshooting
+title: Troubleshooting
+description: A collection of tips for working around strange issues.
+date: 2025-08-21
+tags: ['kibana', 'onboarding', 'dev', 'troubleshooting']
+---
+
+### Typescript issues
+
+When switching branches, sometimes the TypeScript cache can get mixed up and show some invalid errors. If you run into TypeScript issues (invalid errors, or if it's taking too long to build types), here a few things to try.
+
+1. Build TypeScript references with the clean command.
+
+```
+node scripts/type_check.js --clean-cache
+```
+
+2. Restore your repository to a totally fresh state by running `git clean`
+
+```
+# dry-run the clean to see what will be deleted
+git clean -fdxn -e /config -e /.vscode
+
+# review the files which will be deleted, consider adding some more excludes (-e)
+# re-run without the dry-run (-n) flag to actually delete the files
+```
+
+### search.check_ccs_compatibility error
+
+If you run into an error that says something like:
+
+```
+[class org.elasticsearch.action.search.SearchRequest] is not compatible version 8.1.0 and the 'search.check_ccs_compatibility' setting is enabled.
+```
+
+it means you are using a new Elasticsearch feature that will not work in a CCS environment because the feature does not exist in older versions. If you are working on an experimental feature and are okay with this limitation, you will have to move the failing test into a special test suite that does not use this setting to get ci to pass. Take this path cautiously. If you do not remember to move the test back into the default test suite when the feature is GA'ed, it will not have proper CCS test coverage.
+
+We added this test coverage in version `8.1` because we accidentally broke core Kibana features (for example, when Discover started using the new fields parameter) for our CCS users. CCS is not a corner case and (excluding certain experimental features) Kibana should always work for our CCS users. This setting is our way of ensuring test coverage.
+
+Please reach out to the [Kibana Operations team](https://github.com/orgs/elastic/teams/kibana-operations) if you have further questions.
+
+### Minified React errors
+
+If you experience minified React errors and want to expand them to their full error messages you will currently need to rebuild the `@kbn/ui-shared-deps-npm` package using "development" mode instead of "production", which can be done by modifying the corresponding line in `packages/kbn-ui-shared-deps-npm/webpack.config.js` and make sure to run `yarn kbn bootstrap` afterwards:
+
+```diff
+-    mode: 'production',
++    mode: 'development',
+```

--- a/dev_docs/migrated_docs/troubleshooting.md
+++ b/dev_docs/migrated_docs/troubleshooting.md
@@ -3,7 +3,7 @@ id: kibTroubleshooting
 slug: /kibana-dev-docs/getting-started/troubleshooting
 title: Troubleshooting
 description: A collection of tips for working around strange issues.
-date: 2021-09-08
+date: 2025-08-21
 tags: ['kibana', 'onboarding', 'dev', 'troubleshooting']
 ---
 


### PR DESCRIPTION
## Summary
- Migrate Troubleshooting documentation from .mdx to .md format to prepare for migration away from docsmobile
- Move content from dev_docs/getting_started/troubleshooting.mdx to dev_docs/migrated_docs/troubleshooting.md
- Rewrite content (with the help of AI) for clarity and brevity