### PR TITLE
[WIP][One Discover] Add Sidebar toggle state to ContextAwareness

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
@@ -324,9 +324,20 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
     return () => onAddColumnWithTracking(draggingFieldName);
   }, [onAddColumnWithTracking, draggingFieldName, currentColumns]);
 
+  const getSidebarToggleStateAccessor = useProfileAccessor('getSidebarToggleState');
+  const sidebarToggleState = useMemo(() => {
+    return getSidebarToggleStateAccessor(() => {
+      return { isCollapsed: false, toggle: () => {} };
+    })();
+  }, [getSidebarToggleStateAccessor]);
+
   const [sidebarToggleState$] = useState<BehaviorSubject<SidebarToggleState>>(
     () => new BehaviorSubject<SidebarToggleState>({ isCollapsed: false, toggle: () => {} })
   );
+
+  useMemo(() => {
+    sidebarToggleState$.next(sidebarToggleState);
+  }, [sidebarToggleState, sidebarToggleState$]);
 
   const panelsToggle: ReactElement<PanelsToggleProps> = useMemo(() => {
     return (

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
@@ -324,20 +324,9 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
     return () => onAddColumnWithTracking(draggingFieldName);
   }, [onAddColumnWithTracking, draggingFieldName, currentColumns]);
 
-  const getSidebarToggleStateAccessor = useProfileAccessor('getSidebarToggleState');
-  const sidebarToggleState = useMemo(() => {
-    return getSidebarToggleStateAccessor(() => {
-      return { isCollapsed: false, toggle: () => {} };
-    })();
-  }, [getSidebarToggleStateAccessor]);
-
   const [sidebarToggleState$] = useState<BehaviorSubject<SidebarToggleState>>(
     () => new BehaviorSubject<SidebarToggleState>({ isCollapsed: false, toggle: () => {} })
   );
-
-  useMemo(() => {
-    sidebarToggleState$.next(sidebarToggleState);
-  }, [sidebarToggleState, sidebarToggleState$]);
 
   const panelsToggle: ReactElement<PanelsToggleProps> = useMemo(() => {
     return (

--- a/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -356,7 +356,7 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
 
   const isSidebarCollapsed = useObservable(
     unifiedFieldListSidebarContainerApi?.sidebarVisibility.isCollapsed$ ?? of(false),
-    false
+    sidebarToggleState$.getValue().isCollapsed
   );
 
   useEffect(() => {

--- a/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -356,8 +356,20 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
 
   const isSidebarCollapsed = useObservable(
     unifiedFieldListSidebarContainerApi?.sidebarVisibility.isCollapsed$ ?? of(false),
-    sidebarToggleState$.getValue().isCollapsed
+    false
   );
+
+  const getSidebarToggleStateAccessor = useProfileAccessor('getSidebarToggleState');
+  useMemo(() => {
+    const initialSidebarState = getSidebarToggleStateAccessor(() => {
+      return undefined;
+    })();
+    if (initialSidebarState) {
+      const currentState = sidebarToggleState$.getValue();
+      currentState.toggle?.(initialSidebarState.isCollapsed);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getSidebarToggleStateAccessor]);
 
   useEffect(() => {
     sidebarToggleState$.next({

--- a/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -359,17 +359,17 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
     false
   );
 
-  const getSidebarToggleStateAccessor = useProfileAccessor('getSidebarToggleState');
+  const getSidebarToggleStateOverrideAccessor = useProfileAccessor('getSidebarToggleStateOverride');
   useMemo(() => {
-    const initialSidebarState = getSidebarToggleStateAccessor(() => {
+    const sidebarStateOverride = getSidebarToggleStateOverrideAccessor(() => {
       return undefined;
     })();
-    if (initialSidebarState) {
+    if (sidebarStateOverride) {
       const currentState = sidebarToggleState$.getValue();
-      currentState.toggle?.(initialSidebarState.isCollapsed);
+      currentState.toggle?.(sidebarStateOverride.isCollapsed);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getSidebarToggleStateAccessor]);
+  }, [getSidebarToggleStateOverrideAccessor]);
 
   useEffect(() => {
     sidebarToggleState$.next({

--- a/src/platform/plugins/shared/discover/public/application/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/types.ts
@@ -31,3 +31,10 @@ export interface SidebarToggleState {
   isCollapsed: boolean;
   toggle: undefined | ((isCollapsed: boolean) => void);
 }
+
+// The type used to override the sidebar toggle state when a context aware profile is applied (e.g. Metrics)
+export type SidebarToggleStateOverride =
+  | {
+      isCollapsed: boolean;
+    }
+  | undefined;

--- a/src/platform/plugins/shared/discover/public/components/panels_toggle/panels_toggle.tsx
+++ b/src/platform/plugins/shared/discover/public/components/panels_toggle/panels_toggle.tsx
@@ -45,10 +45,8 @@ export const PanelsToggle: React.FC<PanelsToggleProps> = ({
 
   const sidebarToggleState = useObservable(sidebarToggleState$);
   const isSidebarCollapsed = sidebarToggleState?.isCollapsed ?? false;
-
   const isInsideHistogram = renderedFor === 'histogram';
   const isInsideDiscoverContent = !isInsideHistogram;
-
   const buttons = [
     ...((isInsideHistogram && isSidebarCollapsed) ||
     (isInsideDiscoverContent && isSidebarCollapsed && (isChartHidden || !isChartAvailable))

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/metrics_data_source_profile/accessor/sidebar_section.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/metrics_data_source_profile/accessor/sidebar_section.tsx
@@ -8,20 +8,18 @@
  */
 import type { MetricsExperienceClient } from '@kbn/metrics-experience-plugin/public';
 import { once } from 'lodash';
-import { BehaviorSubject } from 'rxjs';
 import type { SidebarToggleState } from '../../../../../application/types';
 import type { DataSourceProfileProvider } from '../../../../profiles';
 
 export const createSidebarToggleState = (
   metricsExperienceClient?: MetricsExperienceClient
 ): DataSourceProfileProvider['profile']['getSidebarToggleState'] =>
-  once((prev: () => BehaviorSubject<SidebarToggleState>) =>
+  once((prev: () => SidebarToggleState) =>
     once(() => {
-      return prev
-        ? prev()
-        : new BehaviorSubject<SidebarToggleState>({
-            isCollapsed: true,
-            toggle: undefined,
-          });
+      return {
+        ...(prev ? prev() : {}),
+        isCollapsed: true,
+        toggle: undefined,
+      };
     })
   );

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/metrics_data_source_profile/accessor/sidebar_section.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/metrics_data_source_profile/accessor/sidebar_section.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { MetricsExperienceClient } from '@kbn/metrics-experience-plugin/public';
+import { once } from 'lodash';
+import { BehaviorSubject } from 'rxjs';
+import type { SidebarToggleState } from '../../../../../application/types';
+import type { DataSourceProfileProvider } from '../../../../profiles';
+
+export const createSidebarToggleState = (
+  metricsExperienceClient?: MetricsExperienceClient
+): DataSourceProfileProvider['profile']['getSidebarToggleState'] =>
+  once((prev: () => BehaviorSubject<SidebarToggleState>) =>
+    once(() => {
+      return prev
+        ? prev()
+        : new BehaviorSubject<SidebarToggleState>({
+            isCollapsed: true,
+            toggle: undefined,
+          });
+    })
+  );

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/metrics_data_source_profile/accessor/sidebar_section.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/metrics_data_source_profile/accessor/sidebar_section.tsx
@@ -8,18 +8,17 @@
  */
 import type { MetricsExperienceClient } from '@kbn/metrics-experience-plugin/public';
 import { once } from 'lodash';
-import type { SidebarToggleState } from '../../../../../application/types';
-import type { DataSourceProfileProvider } from '../../../../profiles';
+import type { SidebarToggleStateOverride } from '../../../../application/types';
+import type { DataSourceProfileProvider } from '../../../profiles';
 
 export const createSidebarToggleState = (
   metricsExperienceClient?: MetricsExperienceClient
-): DataSourceProfileProvider['profile']['getSidebarToggleState'] =>
-  once((prev: () => SidebarToggleState) =>
+): DataSourceProfileProvider['profile']['getSidebarToggleStateOverride'] =>
+  once((prev: () => SidebarToggleStateOverride) =>
     once(() => {
       return {
         ...(prev ? prev() : {}),
         isCollapsed: true,
-        toggle: undefined,
       };
     })
   );

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -26,7 +26,6 @@ import type { FunctionComponent, PropsWithChildren } from 'react';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import type { ChartSectionConfiguration } from '@kbn/unified-histogram/types';
 import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
-import type { BehaviorSubject } from 'rxjs';
 import type { DiscoverDataSource } from '../../common/data_sources';
 import type { DiscoverAppState } from '../application/main/state_management/discover_app_state_container';
 import type { DiscoverStateContainer } from '../application/main/state_management/discover_state';
@@ -369,7 +368,7 @@ export interface Profile {
   /**
    * Sidebar
    */
-  getSidebarToggleState: () => BehaviorSubject<SidebarToggleState>;
+  getSidebarToggleState: () => SidebarToggleState;
 
   /**
    * Chart

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -29,7 +29,7 @@ import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
 import type { DiscoverDataSource } from '../../common/data_sources';
 import type { DiscoverAppState } from '../application/main/state_management/discover_app_state_container';
 import type { DiscoverStateContainer } from '../application/main/state_management/discover_state';
-import type { SidebarToggleState } from '../application/types';
+import type { SidebarToggleStateOverride } from '../application/types';
 
 /**
  * Supports extending the Discover app menu
@@ -370,7 +370,7 @@ export interface Profile {
    * e.g.: with metric queries, the intention is to close the sidebar.
    * @returns The sidebar toggle state, or `undefined` if default behavior is desired.
    */
-  getSidebarToggleState: () => SidebarToggleState | undefined;
+  getSidebarToggleStateOverride: () => SidebarToggleStateOverride;
 
   /**
    * Chart

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -26,9 +26,11 @@ import type { FunctionComponent, PropsWithChildren } from 'react';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import type { ChartSectionConfiguration } from '@kbn/unified-histogram/types';
 import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import type { BehaviorSubject } from 'rxjs';
 import type { DiscoverDataSource } from '../../common/data_sources';
 import type { DiscoverAppState } from '../application/main/state_management/discover_app_state_container';
 import type { DiscoverStateContainer } from '../application/main/state_management/discover_state';
+import type { SidebarToggleState } from '../application/types';
 
 /**
  * Supports extending the Discover app menu
@@ -363,6 +365,11 @@ export interface Profile {
   getDefaultAdHocDataViews: () => Array<
     Omit<DataViewSpec, 'id'> & { id: NonNullable<DataViewSpec['id']> }
   >;
+
+  /**
+   * Sidebar
+   */
+  getSidebarToggleState: () => BehaviorSubject<SidebarToggleState>;
 
   /**
    * Chart

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -368,7 +368,7 @@ export interface Profile {
   /**
    * Sidebar
    */
-  getSidebarToggleState: () => SidebarToggleState;
+  getSidebarToggleState: () => SidebarToggleState | undefined;
 
   /**
    * Chart

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -366,7 +366,9 @@ export interface Profile {
   >;
 
   /**
-   * Sidebar
+   * Gets the intended initial SidebarToggleState after the profile is resolved.
+   * e.g.: with metric queries, the intention is to close the sidebar.
+   * @returns The sidebar toggle state, or `undefined` if default behavior is desired.
    */
   getSidebarToggleState: () => SidebarToggleState | undefined;
 


### PR DESCRIPTION
## Summary
fixes #233009 
This PR is an attempt to add the sidebar toggle state in OneDiscover to the ContextAwareness. The goal is to automatically hid the sidebar when `metric-*` is used in the query.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



