### PR TITLE
[Synthetics] Fix synthetics policies being created in multiple spaces !!

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
@@ -188,8 +188,6 @@ export class SyncPrivateLocationMonitorsTask {
     encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
   }) {
     const { privateLocationAPI } = this.syntheticsMonitorClient;
-    const privateConfigs: Array<{ config: HeartbeatConfig; globalParams: Record<string, string> }> =
-      [];
 
     const { configsBySpaces, paramsBySpace, spaceIds, maintenanceWindows } =
       await this.getAllMonitorConfigs({
@@ -198,6 +196,11 @@ export class SyncPrivateLocationMonitorsTask {
       });
 
     for (const spaceId of spaceIds) {
+      const privateConfigs: Array<{
+        config: HeartbeatConfig;
+        globalParams: Record<string, string>;
+      }> = [];
+
       const monitors = configsBySpaces[spaceId];
       this.debugLog(`Processing spaceId: ${spaceId}, monitors count: ${monitors?.length ?? 0}`);
       if (!monitors) {

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_global_params_spaces.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_global_params_spaces.ts
@@ -12,6 +12,7 @@ import type {
 import { ConfigKey } from '@kbn/synthetics-plugin/common/runtime_types';
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
 import expect from '@kbn/expect';
+import { omit } from 'lodash';
 import { SyntheticsMonitorTestService } from './services/synthetics_monitor_test_service';
 import type { FtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helper/get_fixture_json';
@@ -27,9 +28,11 @@ export default function ({ getService }: FtrProviderContext) {
 
     const kServer = getService('kibanaServer');
     let locWithSpace: PrivateLocation;
+    let loc2WithSpace: PrivateLocation;
     let _browserMonitorJson: HTTPFields;
     let browserMonitorJson: HTTPFields;
     let newBrowserMonitorId: string;
+    let newBrowserMonitorId2: string;
     let spaceId = '';
 
     const testPrivateLocations = new PrivateLocationTestService(getService);
@@ -54,11 +57,15 @@ export default function ({ getService }: FtrProviderContext) {
         spaceId,
         label: 'Test private location 1',
       });
+      loc2WithSpace = await testPrivateLocations.createPrivateLocation({
+        label: 'Test private location 2',
+      });
     });
 
     it('create monitors in private locations', async () => {
       const newMonitor = browserMonitorJson;
       newMonitor.locations = [locWithSpace];
+      newMonitor.spaces = [spaceId, 'default'];
 
       const res = await monitorTestService.createMonitor({
         monitor: newMonitor,
@@ -70,10 +77,32 @@ export default function ({ getService }: FtrProviderContext) {
           ...newMonitor,
           [ConfigKey.MONITOR_QUERY_ID]: res.body.id,
           [ConfigKey.CONFIG_ID]: res.body.id,
-          spaces: [spaceId],
+          spaces: [spaceId, 'default'],
         })
       );
       newBrowserMonitorId = res.rawBody.id;
+    });
+
+    it('create monitor in private locations 2', async () => {
+      const newMonitor = browserMonitorJson;
+      newMonitor.locations = [loc2WithSpace];
+      newMonitor.spaces = ['default'];
+      newMonitor.name = 'Test HTTP Monitor 03 01';
+
+      const res = await monitorTestService.createMonitor({
+        monitor: newMonitor,
+      });
+
+      expect(res.body).eql(
+        omitMonitorKeys({
+          ...newMonitor,
+          [ConfigKey.MONITOR_QUERY_ID]: res.body.id,
+          [ConfigKey.CONFIG_ID]: res.body.id,
+          spaces: ['default'],
+          locations: [omit(loc2WithSpace, 'spaces')],
+        })
+      );
+      newBrowserMonitorId2 = res.rawBody.id;
     });
 
     it('added an integration for previously added monitor', async () => {
@@ -208,6 +237,17 @@ export default function ({ getService }: FtrProviderContext) {
           location: { id: locWithSpace.id },
         })
       );
+    });
+
+    it('number of package policies matches number of monitors', async () => {
+      const packagePolicies = await supertestAPI.get(
+        '/api/fleet/package_policies?page=1&perPage=2000&kuery=ingest-package-policies.package.name%3A%20synthetics'
+      );
+
+      const monitors = await supertestAPI.get(
+        '/api/synthetics/monitors?page=1&perPage=2000&showFromAllSpaces=true'
+      );
+      expect(packagePolicies.body.total).eql(monitors.body.total);
     });
   });
 }

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_global_params_spaces.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_global_params_spaces.ts
@@ -32,7 +32,6 @@ export default function ({ getService }: FtrProviderContext) {
     let _browserMonitorJson: HTTPFields;
     let browserMonitorJson: HTTPFields;
     let newBrowserMonitorId: string;
-    let newBrowserMonitorId2: string;
     let spaceId = '';
 
     const testPrivateLocations = new PrivateLocationTestService(getService);
@@ -102,7 +101,6 @@ export default function ({ getService }: FtrProviderContext) {
           locations: [omit(loc2WithSpace, 'spaces')],
         })
       );
-      newBrowserMonitorId2 = res.rawBody.id;
     });
 
     it('added an integration for previously added monitor', async () => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/235020

Fix synthetics policies being created in multiple spaces where any monitor exists !!

### Before

1. Create a test space
2. Create 2 private locations one in default space and one in test space
3. Create a monitor in each space test and default against respective private location 
4. Go to fleet agent policies view and there you will be able to see that it create total 3 synthetics package policies against 2 monitors
5. Add a global param, which will trigger the task causing the issue

### After

Repeat above steps and verify that only 2 package policies are created


### API tests
i have added an e2e API tests to verify that package policies matches the number of monitors. 

### Release notes
If user have monitors in multiple spaces using private locations, this will create duplicate extra package policies in the fleet for a monitor, this PR fixes that. This PR makes sure only relevant package policies are created for a monitor.


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->