### PR TITLE
[ES|QL] Improves the time named params docs

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/literals.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/literals.ts
@@ -24,7 +24,8 @@ export const buildConstantsDefinitions = (
   /**
    * Whether or not to advance the cursor and open the suggestions dialog after inserting the constant.
    */
-  options?: { advanceCursorAndOpenSuggestions?: boolean; addComma?: boolean }
+  options?: { advanceCursorAndOpenSuggestions?: boolean; addComma?: boolean },
+  documentationValue?: string
 ): ISuggestionItem[] =>
   userConstants.map((label) => ({
     label,
@@ -38,6 +39,7 @@ export const buildConstantsDefinitions = (
       i18n.translate('kbn-esql-ast.esql.autocomplete.constantDefinition', {
         defaultMessage: `Constant`,
       }),
+    ...(documentationValue ? { documentation: { value: documentationValue } } : {}),
     sortText: sortText ?? 'A',
     command: options?.advanceCursorAndOpenSuggestions ? TRIGGER_SUGGESTION_COMMAND : undefined,
   }));
@@ -50,10 +52,15 @@ export function getDateLiterals(options?: {
     ...buildConstantsDefinitions(
       TIME_SYSTEM_PARAMS,
       i18n.translate('kbn-esql-ast.esql.autocomplete.namedParamDefinition', {
-        defaultMessage: 'Named parameter',
+        defaultMessage: 'Bind to time filter',
       }),
       '1A',
-      options
+      options,
+      // appears when the user opens the second level popover
+      i18n.translate('kbn-esql-ast.esql.autocomplete.timeNamedParamDoc', {
+        defaultMessage:
+          'Use these parameters to automatically bind to the current time filter range.',
+      })
     ),
     {
       label: i18n.translate('kbn-esql-ast.esql.autocomplete.chooseFromTimePickerLabel', {

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/literals.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/literals.ts
@@ -59,7 +59,7 @@ export function getDateLiterals(options?: {
       // appears when the user opens the second level popover
       i18n.translate('kbn-esql-ast.esql.autocomplete.timeNamedParamDoc', {
         defaultMessage:
-          'Use these parameters to automatically bind to the current time filter range.',
+          'Use the `?_tstart` and `?_tend` parameters to bind a custom timestamp field to Kibana's time filter.',
       })
     ),
     {

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/literals.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/literals.ts
@@ -58,8 +58,7 @@ export function getDateLiterals(options?: {
       options,
       // appears when the user opens the second level popover
       i18n.translate('kbn-esql-ast.esql.autocomplete.timeNamedParamDoc', {
-        defaultMessage:
-          'Use the `?_tstart` and `?_tend` parameters to bind a custom timestamp field to Kibana's time filter.',
+        defaultMessage: `Use the \`?_tstart\` and \`?_tend\` parameters to bind a custom timestamp field to Kibana's time filter.`,
       })
     ),
     {


### PR DESCRIPTION
## Summary

Improves the editor docs when the user is looking at the `_tstart` and `_tend` options

<img width="513" height="320" alt="image" src="https://github.com/user-attachments/assets/e8b3b689-fcb4-43d8-88db-5bc858db3608" />

<img width="906" height="347" alt="image" src="https://github.com/user-attachments/assets/60ac3cb3-7d8a-4ea2-a85a-ee320612ab16" />



