### PR TITLE
[agent builder] relevance search: use full content instead of highlights

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/inner_tools.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/inner_tools.ts
@@ -27,9 +27,10 @@ const convertMatchResult = (result: MatchResult): ResourceResult => {
         index: result.index,
       },
       partial: true,
-      content: {
-        highlights: result.highlights,
-      },
+      content: result.content,
+      // content: {
+      //   highlights: result.highlights,
+      // },
     },
   };
 };


### PR DESCRIPTION
## Summary

Return the full content of text fields of the documents instead of just the highlights from the `relevance_search` search strategy.

We observe a non-negligible improvements in Groundedness for both text retrieval and hybrid type of queries, with a deta too high to just being some noise.


### Eval details

Ran against GPT-4 (yes, still can't target Claude without hitting rate limit errors) using Gemini 2.5-pro as evaluator

| Dataset | Metric | Full Content (Run 1) | Highlights (Run 2) |
| :--- | :--- | :---: | :---: |
| **Text Retrieval** | Factuality | 42.6% | 42.3% |
| | **Groundedness** | **42.7%** | 31.5% |
| | Relevance | 54.1% | 54.4% |
| | Sequence Accuracy | 92.1% | 95.2% |
| **Analytical** | Factuality | 45.2% | 41.5% |
| | Groundedness | 70.7% | 68.6% |
| | Relevance | 83.0% | 84.8% |
| | Sequence Accuracy | 100.0% | 100.0% |
| **Hybrid** | Factuality | 18.7% | 17.1% |
| | **Groundedness** | **61.9%** | 55.2% |
| | Relevance | 69.0% | 72.2% |
| | Sequence Accuracy | 92.2% | 100.0% |
| **Unanswerable** | Factuality | 36.5% | 36.0% |
| | Groundedness | 33.3% | 28.1% |
| | Relevance | 59.1% | 59.2% |
| | Sequence Accuracy | 93.2% | 95.7% |
| **Ambiguous** | Factuality | 48.1% | 44.9% |
| | Groundedness | 25.0% | 33.3% |
| | Relevance | 64.6% | 63.2% |
| | Sequence Accuracy | 100.0% | 100.0% |
| **Overall** | **Factuality** | **39.3%** | **37.9%** |
| | **Groundedness** | **48.4%** | **42.0%** |
| | **Relevance** | **63.7%** | **64.6%** |
| | **Sequence Accuracy** | **94.4%** | **97.2%** |