### PR TITLE
[Streams] Change data quality flyout from overlay to push

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/index.tsx
@@ -90,7 +90,8 @@ export default function QualityIssueFlyout() {
 
   return (
     <EuiFlyout
-      maxWidth={450}
+      type="push"
+      size="s"
       onClose={closeDegradedFieldFlyout}
       aria-labelledby={pushedFlyoutTitleId}
       data-test-subj={'datasetQualityDetailsDegradedFieldFlyout'}

--- a/x-pack/solutions/observability/test/functional/apps/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/solutions/observability/test/functional/apps/dataset_quality/degraded_field_flyout.ts
@@ -528,6 +528,26 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
             PageObjects.datasetQuality.testSubjectSelectors.datasetQualityDetailsDegradedFieldFlyout
           );
         });
+
+        it('should close the flyout when current quality switch is toggled on and the flyout is already open with an old field ', async () => {
+          await PageObjects.datasetQuality.navigateToDetails({
+            dataStream: degradedDatasetWithLimitDataStreamName,
+            expandedDegradedField: 'cloud',
+          });
+
+          await testSubjects.existOrFail(
+            PageObjects.datasetQuality.testSubjectSelectors.datasetQualityDetailsDegradedFieldFlyout
+          );
+
+          await testSubjects.click(
+            PageObjects.datasetQuality.testSubjectSelectors
+              .datasetQualityDetailsOverviewDegradedFieldToggleSwitch
+          );
+
+          await testSubjects.missingOrFail(
+            PageObjects.datasetQuality.testSubjectSelectors.datasetQualityDetailsDegradedFieldFlyout
+          );
+        });
       });
 
       describe('character limit exceeded', () => {

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/degraded_field_flyout.ts
@@ -526,6 +526,26 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             PageObjects.datasetQuality.testSubjectSelectors.datasetQualityDetailsDegradedFieldFlyout
           );
         });
+
+        it('should close the flyout when current quality switch is toggled on and the flyout is already open with an old field ', async () => {
+          await PageObjects.datasetQuality.navigateToDetails({
+            dataStream: degradedDatasetWithLimitDataStreamName,
+            expandedDegradedField: 'cloud',
+          });
+
+          await testSubjects.existOrFail(
+            PageObjects.datasetQuality.testSubjectSelectors.datasetQualityDetailsDegradedFieldFlyout
+          );
+
+          await testSubjects.click(
+            PageObjects.datasetQuality.testSubjectSelectors
+              .datasetQualityDetailsOverviewDegradedFieldToggleSwitch
+          );
+
+          await testSubjects.missingOrFail(
+            PageObjects.datasetQuality.testSubjectSelectors.datasetQualityDetailsDegradedFieldFlyout
+          );
+        });
       });
 
       describe('character limit exceeded', () => {


### PR DESCRIPTION
## Summary

Closes #233507

This PR changes the `QualityIssueFlyout` back to push flyout type (it was changed to `overlay` in #231169).

Changes:

- Changed `QualityIssueFlyout` to `type="push"`
- Brought back the deleted functional tests.

<img width="1918" height="955" alt="Screenshot 2025-09-15 at 11 05 28" src="https://github.com/user-attachments/assets/f1f14dc2-0260-4fcc-b5ab-83d2206b869a" />

### How to test

1. Run `POST kbn:/api/streams/_enable` in the Console to enable Streams UI
2. Refresh the page
3. Run script to generate data `node scripts/synthtrace.js failed_logs --live --kibana=http://elastic:changeme@localhost:5601/ --target=http://elastic:changeme@localhost:9200/ --liveBucketSize=1000`
4. Navigate to Stack Management > Data Set Quality
5. Select data set with Poor quality
6. Open flyout by pressing Expand button next to the issue
<img width="1919" height="956" alt="Screenshot 2025-09-15 at 11 08 58" src="https://github.com/user-attachments/assets/05ee56bb-f3f7-43b6-8171-6bd9f6154e7b" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.