### PR TITLE
agent builder: rename resolve targets endpoint

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/routes/internal/tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/internal/tools.ts
@@ -72,7 +72,7 @@ export function registerInternalToolsRoutes({
   // resolve search sources (internal)
   router.get(
     {
-      path: '/internal/chat/tools/_resolve_search_sources',
+      path: `${internalApiPath}/tools/_resolve_search_sources`,
       validate: {
         query: schema.object({
           pattern: schema.string(),


### PR DESCRIPTION
## Summary

Agent builder rename api root police

fixes: https://github.com/elastic/search-team/issues/10961 (more related, but still)