### PR TITLE
[ResponseOps] Fix serverless rule page flaky tests

### DIFF
--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/rules/custom_threshold_consumer.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/rules/custom_threshold_consumer.ts
@@ -95,7 +95,8 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     describe('both logs and infrastructure privileges', () => {
       const uuid = ` ${uuidv4()}`;
       const ruleName = `Custom threshold rule${uuid}`;
-      it('logs in with privileged role', async () => {
+
+      before(async () => {
         await svlCommonPage.loginWithPrivilegedRole();
       });
 
@@ -115,10 +116,14 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     describe('only logs privileges', () => {
       const uuid = ` ${uuidv4()}`;
       const ruleName = `Custom threshold rule${uuid}`;
-      it('logs in with logs only role', async () => {
-        await samlAuth.setCustomRole(ROLES.logs_only);
 
+      before(async () => {
+        await samlAuth.setCustomRole(ROLES.logs_only);
         await svlCommonPage.loginWithCustomRole();
+      });
+
+      after(async () => {
+        await samlAuth.deleteCustomRole();
       });
 
       createCustomThresholdRule({ ruleName });
@@ -138,10 +143,13 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       const uuid = ` ${uuidv4()}`;
       const ruleName = `Custom threshold rule${uuid}`;
 
-      it('logs in with infra only role', async () => {
+      before(async () => {
         await samlAuth.setCustomRole(ROLES.infra_only);
-
         await svlCommonPage.loginWithCustomRole();
+      });
+
+      after(async () => {
+        await samlAuth.deleteCustomRole();
       });
 
       createCustomThresholdRule({ ruleName });

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/rules/es_query_consumer.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/rules/es_query_consumer.ts
@@ -93,7 +93,8 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     describe('both logs and infrastructure privileges', () => {
       const uuid = ` ${uuidv4()}`;
       const ruleName = `ES Query rule${uuid}`;
-      it('logs in with privileged role', async () => {
+
+      before(async () => {
         await svlCommonPage.loginWithPrivilegedRole();
       });
 
@@ -113,10 +114,14 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     describe('only logs privileges', () => {
       const uuid = ` ${uuidv4()}`;
       const ruleName = `ES Query rule${uuid}`;
-      it('logs in with logs only role', async () => {
-        await samlAuth.setCustomRole(ROLES.logs_only);
 
+      before(async () => {
+        await samlAuth.setCustomRole(ROLES.logs_only);
         await svlCommonPage.loginWithCustomRole();
+      });
+
+      after(async () => {
+        await samlAuth.deleteCustomRole();
       });
 
       createESQueryRule({ ruleName });
@@ -136,10 +141,13 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       const uuid = ` ${uuidv4()}`;
       const ruleName = `ES Query rule${uuid}`;
 
-      it('logs in with infra only role', async () => {
+      before(async () => {
         await samlAuth.setCustomRole(ROLES.infra_only);
-
         await svlCommonPage.loginWithCustomRole();
+      });
+
+      after(async () => {
+        await samlAuth.deleteCustomRole();
       });
 
       createESQueryRule({ ruleName });


### PR DESCRIPTION
## Summary

I moved the page login to the `before` block of the test suites and added an after to clear the custom roles as recommended in the docs.

## Flaky test runner

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9319

