### PR TITLE
[Agent Builder] Truncate Labels for Agents and Tools

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/list/agents_list.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/list/agents_list.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
 import type {
   EuiBasicTableColumn,
   EuiTableActionsColumnType,
@@ -13,22 +12,23 @@ import type {
   EuiTableFieldDataColumnType,
 } from '@elastic/eui';
 import {
-  EuiBadge,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiInMemoryTable,
   EuiLink,
   EuiText,
-  EuiIcon,
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { oneChatDefaultAgentId, type AgentDefinition } from '@kbn/onechat-common';
+import React, { useMemo } from 'react';
+import { useDeleteAgent } from '../../../context/delete_agent_context';
 import { useOnechatAgents } from '../../../hooks/agents/use_agents';
-import { appPaths } from '../../../utils/app_paths';
 import { useNavigation } from '../../../hooks/use_navigation';
 import { searchParamNames } from '../../../search_param_names';
-import { useDeleteAgent } from '../../../context/delete_agent_context';
+import { appPaths } from '../../../utils/app_paths';
+import { Labels } from '../../common/labels';
 import { AgentAvatar } from '../agent_avatar';
 
 const columnNames = {
@@ -96,15 +96,13 @@ export const AgentsList: React.FC = () => {
     const agentLabels: EuiTableFieldDataColumnType<AgentDefinition> = {
       field: 'labels',
       name: columnNames.labels,
-      render: (labels?: string[]) => (
-        <EuiFlexGroup direction="row" wrap>
-          {labels?.map((label) => (
-            <EuiFlexItem key={label} grow={false}>
-              <EuiBadge>{label}</EuiBadge>
-            </EuiFlexItem>
-          ))}
-        </EuiFlexGroup>
-      ),
+      render: (labels?: string[]) => {
+        if (!labels) {
+          return null;
+        }
+
+        return <Labels labels={labels} />;
+      },
     };
 
     const agentActions: EuiTableActionsColumnType<AgentDefinition> = {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/common/labels.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/common/labels.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiBadge,
+  EuiBadgeGroup,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { forwardRef, useEffect, useRef, useState } from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+const LabelGroup = forwardRef<HTMLDivElement, { labels: string[]; className?: string }>(
+  ({ labels, className }, ref) => {
+    return (
+      <EuiBadgeGroup className={className} gutterSize="s" ref={ref}>
+        {labels.map((label) => (
+          <EuiBadge key={label} color="hollow">
+            {label}
+          </EuiBadge>
+        ))}
+      </EuiBadgeGroup>
+    );
+  }
+);
+
+export const Labels: React.FC<{ labels: string[] }> = ({ labels }) => {
+  const [isViewAllPopoverOpen, setIsViewAllPopoverOpen] = useState(false);
+  const [isTruncated, setIsTruncated] = useState(false);
+  const { euiTheme } = useEuiTheme();
+  const viewAllLabelsContainerStyles = css`
+    max-inline-size: calc(${euiTheme.size.xxxxl} * 5);
+  `;
+  const truncatedContainerHeight = euiTheme.size.l;
+  const truncatedStyles = css`
+    max-block-size: ${truncatedContainerHeight};
+    overflow: hidden;
+  `;
+  const labelsContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (labelsContainerRef.current) {
+      const isContentTruncated =
+        labelsContainerRef.current.scrollHeight > labelsContainerRef.current.clientHeight;
+      setIsTruncated(isContentTruncated);
+    }
+  }, [labels]);
+
+  if (labels.length === 0) {
+    return null;
+  }
+  if (!isTruncated) {
+    return <LabelGroup labels={labels} css={truncatedStyles} ref={labelsContainerRef} />;
+  }
+  return (
+    <EuiFlexGroup alignItems="center" gutterSize="s">
+      <EuiFlexItem grow={false}>
+        <LabelGroup labels={labels} css={truncatedStyles} ref={labelsContainerRef} />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiPopover
+          panelProps={{ css: viewAllLabelsContainerStyles }}
+          isOpen={isViewAllPopoverOpen}
+          closePopover={() => {
+            setIsViewAllPopoverOpen(false);
+          }}
+          button={
+            <EuiButtonEmpty
+              size="s"
+              onClick={() => {
+                setIsViewAllPopoverOpen((open) => !open);
+              }}
+            >
+              <FormattedMessage
+                id="xpack.onechat.labels.viewAll.buttonLabel"
+                defaultMessage="View all ({numLabels})"
+                values={{ numLabels: labels.length }}
+              />
+            </EuiButtonEmpty>
+          }
+        >
+          <LabelGroup labels={labels} />
+        </EuiPopover>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/common/labels.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/common/labels.tsx
@@ -52,8 +52,7 @@ const ViewMorePopover: React.FC<{ labels: string[] }> = ({ labels }) => {
         >
           <FormattedMessage
             id="xpack.onechat.labels.viewMore.buttonLabel"
-            defaultMessage="View more ({numLabels})"
-            values={{ numLabels: labels.length }}
+            defaultMessage="View more"
           />
         </EuiButtonEmpty>
       }

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tags/tool_tags.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tags/tool_tags.tsx
@@ -5,21 +5,13 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiBadgeGroup } from '@elastic/eui';
 import React from 'react';
+import { Labels } from '../../common/labels';
 
 interface OnechatToolTagsProps {
   tags: string[];
 }
 
 export const OnechatToolTags: React.FC<OnechatToolTagsProps> = ({ tags }) => {
-  return (
-    <EuiBadgeGroup>
-      {tags.map((tag) => (
-        <EuiBadge key={tag} color="hollow">
-          {tag}
-        </EuiBadge>
-      ))}
-    </EuiBadgeGroup>
-  );
+  return <Labels labels={tags} />;
 };


### PR DESCRIPTION
## Summary
When we have more than 4 labels, we show the remaining in a popover
<img width="1237" height="437" alt="image" src="https://github.com/user-attachments/assets/6bbb5830-f6fe-43dd-9d50-8b5584996ede" />

Popover:
<img width="442" height="186" alt="image" src="https://github.com/user-attachments/assets/835bf7bb-f6ba-418c-a399-d025b1bfd730" />

When we have 4 labels or less, no popover is shown
<img width="1239" height="186" alt="image" src="https://github.com/user-attachments/assets/58353c53-4318-4a13-b706-525b3e1aca78" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


