### PR TITLE
[ES|QL] Align editor footer buttons

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/feedback_component.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/feedback_component.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiFlexItem, EuiIconTip, useEuiTheme, EuiLink, EuiButtonEmpty } from '@elastic/eui';
+import { EuiFlexItem, useEuiTheme, EuiButtonEmpty, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { FEEDBACK_LINK } from '@kbn/esql-utils';
 
@@ -19,25 +19,19 @@ export function SubmitFeedbackComponent({ isSpaceReduced }: { isSpaceReduced?: b
     <>
       {isSpaceReduced && (
         <EuiFlexItem grow={false}>
-          <EuiLink
-            href={FEEDBACK_LINK}
-            external={false}
-            target="_blank"
-            data-test-subj="ESQLEditor-feedback-link"
+          <EuiToolTip
+            position="top"
+            content={i18n.translate('esqlEditor.query.feedback', {
+              defaultMessage: 'Feedback',
+            })}
           >
-            <EuiIconTip
-              type="editorComment"
-              color="primary"
-              size="m"
-              css={css`
-                margin-right: ${euiTheme.size.s};
-              `}
-              content={i18n.translate('esqlEditor.query.feedback', {
-                defaultMessage: 'Feedback',
-              })}
-              position="top"
+            <EuiButtonIcon
+              href={FEEDBACK_LINK}
+              iconType="editorComment"
+              target="_blank"
+              data-test-subj="ESQLEditor-feedback-link"
             />
-          </EuiLink>
+          </EuiToolTip>
         </EuiFlexItem>
       )}
       {!isSpaceReduced && (

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
@@ -25,8 +25,6 @@ import {
   EuiNotificationBadge,
   EuiFieldSearch,
   EuiText,
-  EuiIconTip,
-  EuiLink,
   EuiIcon,
 } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -61,27 +59,24 @@ export function QueryHistoryAction({
     <>
       {isSpaceReduced && (
         <EuiFlexItem grow={false} data-test-subj="ESQLEditor-toggle-query-history-icon">
-          <EuiLink
-            onClick={toggleHistory}
-            external={false}
-            data-test-subj="ESQLEditor-hide-queries-link"
+          <EuiToolTip
+            position="top"
+            content={
+              isHistoryOpen
+                ? i18n.translate('esqlEditor.query.hideQueriesLabel', {
+                    defaultMessage: 'Hide recent queries',
+                  })
+                : i18n.translate('esqlEditor.query.showQueriesLabel', {
+                    defaultMessage: 'Show recent queries',
+                  })
+            }
           >
-            <EuiIconTip
-              type="clockCounter"
-              color="primary"
-              size="m"
-              content={
-                isHistoryOpen
-                  ? i18n.translate('esqlEditor.query.hideQueriesLabel', {
-                      defaultMessage: 'Hide recent queries',
-                    })
-                  : i18n.translate('esqlEditor.query.showQueriesLabel', {
-                      defaultMessage: 'Show recent queries',
-                    })
-              }
-              position="top"
+            <EuiButtonIcon
+              onClick={toggleHistory}
+              iconType="clockCounter"
+              data-test-subj="ESQLEditor-hide-queries-link"
             />
-          </EuiLink>
+          </EuiToolTip>
         </EuiFlexItem>
       )}
       {!isSpaceReduced && (


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/234281
## Summary
Some of the footer buttons were wrapped in `EuiLink` and others in `EuiButtonIcon` causing them to have different hover behaviour and alignment.

Normalised all of them to use `EuiButtonIcon` as it comes with a nice hover style.

### Before
<img width="439" height="251" alt="image" src="https://github.com/user-attachments/assets/52a49302-9903-4ac2-a261-a288b0e3137c" />

### After 
<img width="439" height="251" alt="image" src="https://github.com/user-attachments/assets/0b43f575-86ae-485c-a824-a9c73bbc39f1" />
