### PR TITLE
[Synthtrace] Add apiKey option for authentication

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace/README.md
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/README.md
@@ -140,6 +140,14 @@ Or you can pass only `--kibana` and the CLI will infer the Elasticsearch URL fro
 node scripts/synthtrace simple_trace.ts --target=https://<username>:<password>@your-cloud-cluster.kb.us-west2.gcp.elastic-cloud.com/
 ```
 
+#### Using CLI with an API key
+
+You can use a Kibana API key for authentication by passing the `--apiKey` option. When the `--apiKey` is provided, it will be used for authentication with both Elasticsearch and Kibana, taking precedence over other types of authentication.
+
+```sh
+node scripts/synthtrace simple_trace.ts --target=https://my-deployment.es.us-central1.gcp.elastic.cloud --apiKey="your-api-key"
+```
+
 ### Understanding Scenario Files
 
 Scenario files accept 3 arguments, 2 of them optional and 1 mandatory
@@ -158,6 +166,7 @@ The following options are supported:
 |---------------------|----------|:--------|--------------------------------------------------------------------------------------------|
 | `--target`          | [string] |         | Elasticsearch target                                                                       |
 | `--kibana`          | [string] |         | Kibana target, used to bootstrap datastreams/mappings/templates/settings                   |
+| `--apiKey`          | [string] |         | API key for Kibana                                                                         |
 | `--versionOverride` | [string] |         | String to be used for `observer.version`. Defauls to the version of the installed package. |
 
 Note:

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/run_synthtrace.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/run_synthtrace.ts
@@ -38,6 +38,10 @@ function options(y: Argv) {
       describe: 'Kibana target, used to bootstrap datastreams/mappings/templates/settings',
       string: true,
     })
+    .option('apiKey', {
+      describe: 'Kibana API key',
+      string: true,
+    })
     .option('from', {
       description: 'The start of the time window',
     })

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/bootstrap.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/bootstrap.ts
@@ -27,11 +27,13 @@ export async function bootstrap({
 
   const kibanaClient = getKibanaClient({
     target: kibanaUrl,
+    apiKey: runOptions.apiKey,
     logger,
   });
 
   const client = new Client({
     node: esUrl,
+    ...(runOptions.apiKey && { auth: { apiKey: runOptions.apiKey } }),
     tls: getEsClientTlsSettings(esUrl),
     Connection: HttpConnection,
     requestTimeout: 30_000,

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/get_api_key_header.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/get_api_key_header.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const getApiKeyHeader = (apiKey?: string) => {
+  return apiKey ? { Authorization: `ApiKey ${apiKey}` } : undefined;
+};

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/get_kibana_client.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/get_kibana_client.ts
@@ -9,16 +9,19 @@
 
 import { KibanaClient } from '../../lib/shared/base_kibana_client';
 import type { Logger } from '../../lib/utils/create_logger';
+import { getApiKeyHeader } from './get_api_key_header';
 
 export function getKibanaClient({
   target,
   username,
   password,
+  apiKey,
   logger,
 }: {
   target: string;
   username?: string;
   password?: string;
+  apiKey?: string;
   logger: Logger;
 }) {
   const url = new URL(target);
@@ -29,6 +32,7 @@ export function getKibanaClient({
 
   const kibanaClient = new KibanaClient({
     target: url.toString(),
+    headers: getApiKeyHeader(apiKey),
   });
 
   return kibanaClient;

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/get_service_urls.test.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/get_service_urls.test.ts
@@ -38,9 +38,11 @@ describe('getServiceUrls', () => {
       const expectedValidAuth = 'elastic:changeme';
 
       mockFetchWithAllowedSegments([expectedValidAuth]);
-      await expectServiceUrls(undefined, undefined, {
+      await expectServiceUrls(undefined, undefined, undefined, {
         esUrl: 'http://elastic:changeme@localhost:9200',
         kibanaUrl: 'http://elastic:changeme@localhost:5601',
+        esHeaders: undefined,
+        kibanaHeaders: undefined,
       });
     });
 
@@ -48,9 +50,11 @@ describe('getServiceUrls', () => {
       const expectedValidAuth = 'elastic:changeme';
 
       mockFetchWithAllowedSegments([expectedValidAuth]);
-      await expectServiceUrls('http://localhost:9200', 'http://localhost:5601', {
+      await expectServiceUrls('http://localhost:9200', 'http://localhost:5601', undefined, {
         esUrl: 'http://elastic:changeme@localhost:9200',
         kibanaUrl: 'http://elastic:changeme@localhost:5601',
+        esHeaders: undefined,
+        kibanaHeaders: undefined,
       });
     });
 
@@ -59,9 +63,11 @@ describe('getServiceUrls', () => {
       const expectedValidAuth = 'elastic:changeme';
 
       mockFetchWithAllowedSegments([expectedValidAuth]);
-      await expectServiceUrls(undefined, kibana, {
+      await expectServiceUrls(undefined, kibana, undefined, {
         esUrl: 'http://elastic:changeme@localhost:9200',
         kibanaUrl: 'http://elastic:changeme@localhost:5601',
+        esHeaders: undefined,
+        kibanaHeaders: undefined,
       });
     });
 
@@ -70,9 +76,11 @@ describe('getServiceUrls', () => {
       const expectedValidAuth = 'elastic:changeme';
 
       mockFetchWithAllowedSegments([expectedValidAuth]);
-      await expectServiceUrls(target, undefined, {
+      await expectServiceUrls(target, undefined, undefined, {
         esUrl: 'http://elastic:changeme@localhost:9200',
         kibanaUrl: 'http://elastic:changeme@localhost:5601',
+        esHeaders: undefined,
+        kibanaHeaders: undefined,
       });
     });
 
@@ -83,9 +91,12 @@ describe('getServiceUrls', () => {
       await expectServiceUrls(
         target,
         undefined,
+        undefined,
         {
           esUrl: 'http://elastic:changeme@localhost:9200',
           kibanaUrl: 'http://elastic:changeme@localhost:5601',
+          esHeaders: undefined,
+          kibanaHeaders: undefined,
         },
         `Failed to authenticate user for ${target}`
       );
@@ -99,9 +110,12 @@ describe('getServiceUrls', () => {
       await expectServiceUrls(
         target,
         kibana,
+        undefined,
         {
           esUrl: 'http://elastic:changeme@localhost:9200',
           kibanaUrl: 'http://elastic:changeme@localhost:5601',
+          esHeaders: undefined,
+          kibanaHeaders: undefined,
         },
         `Could not connect to Kibana.`
       );
@@ -115,9 +129,12 @@ describe('getServiceUrls', () => {
       await expectServiceUrls(
         undefined,
         kibana,
+        undefined,
         {
           esUrl: 'http://elastic:changeme@localhost:9200',
           kibanaUrl: 'http://elastic:changeme@localhost:5601',
+          esHeaders: undefined,
+          kibanaHeaders: undefined,
         },
         `Could not discover Elasticsearch URL based on Kibana URL ${kibana.replace(authStr, '.*')}.` // On CI auth is stripped
       );
@@ -132,9 +149,11 @@ describe('getServiceUrls', () => {
         `https://${expectedValidAuth}@localhost:9200`,
         `http://${expectedValidAuth}@localhost:5601`,
       ]); // Only allow https for ES and http for Kibana
-      await expectServiceUrls(undefined, undefined, {
+      await expectServiceUrls(undefined, undefined, undefined, {
         esUrl: 'https://elastic_serverless:changeme@localhost:9200',
         kibanaUrl: 'http://elastic_serverless:changeme@localhost:5601',
+        esHeaders: undefined,
+        kibanaHeaders: undefined,
       });
     });
 
@@ -142,9 +161,24 @@ describe('getServiceUrls', () => {
       const expectedValidAuth = 'elastic_serverless:changeme';
 
       mockFetchWithAllowedSegments([`https://${expectedValidAuth}`]); // Only allow https urls
-      await expectServiceUrls('https://localhost:9200', 'https://localhost:5601', {
+      await expectServiceUrls('https://localhost:9200', 'https://localhost:5601', undefined, {
         esUrl: 'https://elastic_serverless:changeme@localhost:9200',
         kibanaUrl: 'https://elastic_serverless:changeme@localhost:5601',
+        esHeaders: undefined,
+        kibanaHeaders: undefined,
+      });
+    });
+
+    it('should use apiKey when it is provided', async () => {
+      const apiKey = 'myTestApiKey';
+      const headers = { Authorization: `ApiKey ${apiKey}` };
+
+      mockFetchWithAllowedSegments(['localhost']);
+      await expectServiceUrls('https://localhost:9200', 'https://localhost:5601', apiKey, {
+        esUrl: 'https://localhost:9200',
+        kibanaUrl: 'https://localhost:5601',
+        esHeaders: headers,
+        kibanaHeaders: headers,
       });
     });
 
@@ -155,9 +189,12 @@ describe('getServiceUrls', () => {
       await expectServiceUrls(
         target,
         undefined,
+        undefined,
         {
           esUrl: 'https://elastic_serverless:changeme@localhost:9200',
           kibanaUrl: 'http://elastic_serverless:changeme@localhost:5601',
+          esHeaders: undefined,
+          kibanaHeaders: undefined,
         },
         `Could not connect to Kibana.`
       );
@@ -168,9 +205,11 @@ describe('getServiceUrls', () => {
       const kibana = 'https://elastic_serverless:changeme@host-2:5601';
 
       mockFetchWithAllowedSegments([target, kibana]); // Allow both URLs
-      await expectServiceUrls(target, kibana, {
+      await expectServiceUrls(target, kibana, undefined, {
         esUrl: 'https://elastic_serverless:changeme@host-1:9200',
         kibanaUrl: 'https://elastic_serverless:changeme@host-2:5601',
+        esHeaders: undefined,
+        kibanaHeaders: undefined,
       });
     });
 
@@ -180,9 +219,11 @@ describe('getServiceUrls', () => {
 
       const warnSpy = jest.spyOn(logger, 'warning');
       mockFetchWithAllowedSegments([target, kibana]);
-      await expectServiceUrls(target, kibana, {
+      await expectServiceUrls(target, kibana, undefined, {
         esUrl: 'https://elastic_serverless:changeme@127.0.0.1:9200',
         kibanaUrl: 'https://elastic_serverless:changeme@localhost:5601',
+        esHeaders: undefined,
+        kibanaHeaders: undefined,
       });
 
       expect(warnSpy).toHaveBeenCalledWith(
@@ -197,9 +238,11 @@ describe('getServiceUrls', () => {
       const expectedKibanaUrl = target.replace('.es', '.kb');
 
       mockFetchWithAllowedSegments([target, expectedKibanaUrl]);
-      await expectServiceUrls(target, undefined, {
+      await expectServiceUrls(target, undefined, undefined, {
         esUrl: target,
         kibanaUrl: expectedKibanaUrl,
+        esHeaders: undefined,
+        kibanaHeaders: undefined,
       });
     });
 
@@ -208,9 +251,11 @@ describe('getServiceUrls', () => {
       const expectedEsUrl = kibana.replace('.kb', '.es');
 
       mockFetchWithAllowedSegments([kibana, expectedEsUrl]);
-      await expectServiceUrls(undefined, kibana, {
+      await expectServiceUrls(undefined, kibana, undefined, {
         esUrl: expectedEsUrl,
         kibanaUrl: kibana,
+        esHeaders: undefined,
+        kibanaHeaders: undefined,
       });
     });
   });
@@ -229,16 +274,17 @@ function mockFetchWithAllowedSegments(allowedUrlSegments: string[]) {
 function expectServiceUrls(
   target?: string,
   kibana?: string,
+  apiKey?: string,
   expected?: Awaited<ReturnType<typeof getServiceUrls>>,
   throws?: string
 ) {
   if (throws) {
-    return expect(getServiceUrls({ ...runOptions, logger, target, kibana })).rejects.toThrow(
-      new RegExp(throws)
-    );
+    return expect(
+      getServiceUrls({ ...runOptions, logger, target, kibana, apiKey })
+    ).rejects.toThrow(new RegExp(throws));
   }
 
-  return expect(getServiceUrls({ ...runOptions, logger, target, kibana })).resolves.toEqual(
+  return expect(getServiceUrls({ ...runOptions, logger, target, kibana, apiKey })).resolves.toEqual(
     expected
   );
 }

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/parse_run_cli_flags.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/parse_run_cli_flags.ts
@@ -75,6 +75,7 @@ export function parseRunCliFlags(flags: RunCliFlags) {
       'target',
       'workers',
       'kibana',
+      'apiKey',
       'concurrency',
       'versionOverride',
       'clean',


### PR DESCRIPTION
Closes https://github.com/elastic/observability-dev/issues/4800 (internal)

## Summary

This PR introduces a new apiKey option to the synthtrace tool, allowing for authentication using an API key. Here is how you can use this option:

```
 node scripts/synthtrace simple_trace.ts --target=https://my-deployment.es.us-central1.gcp.elastic.cloud --apiKey="your-api-key"
```

### 🧪 How to test

In a Serverless project, create an API Key in Kibana (in the view shown below) and use it in the above command.

<img width="3006" height="422" alt="image" src="https://github.com/user-attachments/assets/95bec4d5-4470-4e6f-9a06-af9d49fdb601" />
