### PR TITLE
[Agent Builder] Adjust plus icon usages

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/list/agents.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/list/agents.tsx
@@ -24,7 +24,7 @@ export const OnechatAgents = () => {
   const { createOnechatUrl } = useNavigation();
   const headerButtons = [
     <EuiButton
-      iconType={'plusInCircleFilled'}
+      iconType="plus"
       color="primary"
       fill
       iconSide="left"

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/esql/esql_params.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/esql/esql_params.tsx
@@ -88,7 +88,7 @@ const EsqlParamActions: React.FC<EsqlParamActionsProps> = ({ onAppend, onReplace
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiButtonEmpty
-          iconType="plus"
+          iconType="plusInCircle"
           color="primary"
           size="s"
           onClick={() => {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tools.tsx
@@ -31,7 +31,7 @@ export const OnechatTools = () => {
           <EuiButton
             key="new-esql-tool-button"
             fill
-            iconType="plusInCircleFilled"
+            iconType="plus"
             onClick={() => createTool(ToolType.esql)}
           >
             <EuiText size="s">{labels.tools.newToolButton}</EuiText>


### PR DESCRIPTION
- Remove usage of plusInCircleFilled
- Use plusInCircle for tertiary actions

## Summary

<img width="1256" height="126" alt="image" src="https://github.com/user-attachments/assets/192a0a66-c26f-4fe4-b19f-25f54289f110" />
<img width="1262" height="172" alt="image" src="https://github.com/user-attachments/assets/8959302b-dbff-48f2-b60b-43f278378664" />
<img width="843" height="117" alt="image" src="https://github.com/user-attachments/assets/2b9f3255-cabd-438a-b452-396ee30c8052" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


