### PR TITLE
[Agent Builder] Adjust conversation spacing

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_response.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_response.tsx
@@ -35,7 +35,7 @@ export const RoundResponse: React.FC<RoundResponseProps> = ({
   return (
     <EuiFlexGroup
       direction="column"
-      gutterSize="s"
+      gutterSize="m"
       aria-label={i18n.translate('xpack.onechat.round.assistantResponse', {
         defaultMessage: 'Assistant response',
       })}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_sidebar/conversation_sections.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_sidebar/conversation_sections.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiListGroup, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiListGroup, EuiText, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import type { ConversationWithoutRounds } from '@kbn/onechat-common';
@@ -24,6 +24,10 @@ const emptyStyles = css`
 `;
 
 export const ConversationSections: React.FC<ConversationSectionsProps> = ({ conversations }) => {
+  const { euiTheme } = useEuiTheme();
+  const sectionTitleStyles = css`
+    margin-inline-start: ${euiTheme.size.s};
+  `;
   const timeSections = useMemo(() => {
     if (!conversations || conversations.length === 0) {
       return [];
@@ -44,7 +48,7 @@ export const ConversationSections: React.FC<ConversationSectionsProps> = ({ conv
       {timeSections.map(({ label, conversations: sectionConversations }) => (
         <EuiFlexItem key={label} grow={false}>
           <EuiFlexGroup direction="column" gutterSize="s">
-            <EuiText size="xs" color="subdued">
+            <EuiText css={sectionTitleStyles} size="xs" color="subdued">
               {label}
             </EuiText>
 


### PR DESCRIPTION
## Summary

#### Conversation history section title has increased left margin
<img width="356" height="214" alt="image" src="https://github.com/user-attachments/assets/381b215d-5e7b-47ce-9c58-5a39850e7d1b" />

#### Increased space between thinking panel and agent response
<img width="858" height="530" alt="image" src="https://github.com/user-attachments/assets/ad73744c-6be4-4908-8ca4-c9a729458021" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
