### PR TITLE
[Search] Nav v2 updates

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
@@ -225,9 +225,10 @@ export const getNavigationTreeDefinition = ({
                   children: [
                     { link: 'searchSynonyms:synonyms' },
                     { link: 'searchQueryRules' },
-                    { link: 'searchInferenceEndpoints:inferenceEndpoints', sideNavVersion: 'v1' },
+                    { link: 'searchInferenceEndpoints:inferenceEndpoints' },
                   ],
                   id: 'relevance',
+                  sideNavVersion: 'v1',
                   title: i18n.translate('xpack.enterpriseSearch.searchNav.relevance', {
                     defaultMessage: 'Relevance',
                   }),
@@ -359,6 +360,16 @@ export const getNavigationTreeDefinition = ({
                         'xpack.enterpriseSearch.searchNav.ingest.pipelines.title',
                         {
                           defaultMessage: 'Ingest',
+                        }
+                      ),
+                    },
+                    {
+                      children: [{ link: 'searchSynonyms:synonyms' }, { link: 'searchQueryRules' }],
+                      id: 'search_relevance',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.searchNav.ingest.relevance.title',
+                        {
+                          defaultMessage: 'Relevance',
                         }
                       ),
                     },

--- a/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
@@ -334,10 +334,12 @@ export const getNavigationTreeDefinition = ({
                               pathNameSerialized.startsWith(
                                 prepend('/app/elasticsearch/index_management/indices')
                               ) ||
-                              pathNameSerialized.startsWith(prepend('/app/elasticsearch/indices'))
+                              pathNameSerialized.startsWith(
+                                prepend('/app/management/data/index_management')
+                              )
                             );
                           },
-                          link: 'elasticsearchIndexManagement',
+                          link: 'management:index_management',
                         },
                         { link: 'management:index_lifecycle_management' },
                         { link: 'management:snapshot_restore' },
@@ -477,6 +479,16 @@ export const getNavigationTreeDefinition = ({
                         },
                         {
                           children: [
+                            { link: 'management:genAiSettings' },
+                            { link: 'management:agentBuilder' },
+                            { link: 'management:aiAssistantManagementSelection' },
+                          ],
+                          title: i18n.translate('xpack.enterpriseSearch.searchNav.management.ai', {
+                            defaultMessage: 'AI',
+                          }),
+                        },
+                        {
+                          children: [
                             { link: 'management:users' },
                             { link: 'management:roles' },
                             { link: 'management:api_keys' },
@@ -508,9 +520,6 @@ export const getNavigationTreeDefinition = ({
                             { link: 'management:filesManagement' },
                             { link: 'management:objects' },
                             { link: 'management:tags' },
-                            { link: 'management:genAiSettings' },
-                            { link: 'management:aiAssistantManagementSelection' },
-                            { link: 'management:agentBuilder' },
                             { link: 'management:search_sessions' },
                             { link: 'management:spaces' },
                             { link: 'management:settings' },

--- a/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
@@ -383,10 +383,6 @@ export const getNavigationTreeDefinition = ({
                   }),
                 },
                 {
-                  id: 'monitoring',
-                  link: 'monitoring',
-                },
-                {
                   breadcrumbStatus: 'hidden',
                   children: [
                     {
@@ -402,6 +398,17 @@ export const getNavigationTreeDefinition = ({
                     {
                       iconV2: 'managementApp',
                       children: [
+                        {
+                          children: [
+                            {
+                              id: 'monitoring',
+                              link: 'monitoring',
+                            },
+                          ],
+                          id: 'monitoring',
+                          sideNavVersion: 'v2',
+                          title: '',
+                        },
                         {
                           children: [
                             { link: 'management:ingest_pipelines' },
@@ -436,8 +443,8 @@ export const getNavigationTreeDefinition = ({
                         },
                         {
                           children: [
+                            { link: 'management:triggersActionsAlerts' },
                             { link: 'management:triggersActions' },
-                            { link: 'management:cases' },
                             { link: 'management:triggersActionsConnectors' },
                             { link: 'management:reporting' },
                             { link: 'management:jobsListLink' },
@@ -458,6 +465,8 @@ export const getNavigationTreeDefinition = ({
                               link: 'searchInferenceEndpoints:inferenceEndpoints',
                               sideNavVersion: 'v2',
                             },
+                            { link: 'management:anomaly_detection' },
+                            { link: 'management:analytics' },
                           ],
                           title: i18n.translate(
                             'xpack.enterpriseSearch.searchNav.management.machineLearning',
@@ -484,7 +493,6 @@ export const getNavigationTreeDefinition = ({
                           children: [
                             { link: 'management:cross_cluster_replication' },
                             { link: 'management:remote_clusters' },
-                            { link: 'management:migrate_data' },
                           ],
                           title: i18n.translate(
                             'xpack.enterpriseSearch.searchNav.management.dataV2',
@@ -499,27 +507,10 @@ export const getNavigationTreeDefinition = ({
                             { link: 'management:dataViews' },
                             { link: 'management:filesManagement' },
                             { link: 'management:objects' },
-                            {
-                              getIsActive: ({ pathNameSerialized, prepend }) => {
-                                const someSubItemSelected = searchApps?.some((app) =>
-                                  app.items?.some((item) => item.isSelected)
-                                );
-
-                                if (someSubItemSelected) return false;
-
-                                return (
-                                  pathNameSerialized ===
-                                  prepend(
-                                    `/app/elasticsearch/applications${SEARCH_APPLICATIONS_PATH}`
-                                  )
-                                );
-                              },
-                              iconV2: 'searchProfilerApp' /* TODO: review icon */,
-                              link: 'enterpriseSearchApplications:searchApplications',
-                              renderAs: 'item',
-                              sideNavVersion: 'v2',
-                            },
                             { link: 'management:tags' },
+                            { link: 'management:genAiSettings' },
+                            { link: 'management:aiAssistantManagementSelection' },
+                            { link: 'management:agentBuilder' },
                             { link: 'management:search_sessions' },
                             { link: 'management:spaces' },
                             { link: 'management:settings' },
@@ -530,16 +521,6 @@ export const getNavigationTreeDefinition = ({
                               defaultMessage: 'Kibana',
                             }
                           ),
-                        },
-                        {
-                          children: [
-                            { link: 'management:genAiSettings' },
-                            { link: 'management:agentBuilder' },
-                            { link: 'management:aiAssistantManagementSelection' },
-                          ],
-                          title: i18n.translate('xpack.enterpriseSearch.searchNav.management.ai', {
-                            defaultMessage: 'AI',
-                          }),
                         },
                         {
                           children: [

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -294,6 +294,7 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                   { link: 'management:transform' },
                   { link: 'management:rollup_jobs' },
                   { link: 'management:data_quality', breadcrumbStatus: 'hidden' },
+                  { link: 'management:data_usage' },
                 ],
                 title: i18n.translate('xpack.serverlessSearch.nav.ingest.indices.title', {
                   defaultMessage: 'Indices, data streams and roll ups',
@@ -306,12 +307,6 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                 ],
                 title: i18n.translate('xpack.serverlessSearch.nav.ingest.pipelines.title', {
                   defaultMessage: 'Ingest',
-                }),
-              },
-              {
-                children: [{ link: 'management:dataViews' }, { link: 'management:data_usage' }],
-                title: i18n.translate('xpack.serverlessSearch.nav.ingest.dataViews.title', {
-                  defaultMessage: 'Data views and usage',
                 }),
               },
               {
@@ -410,6 +405,7 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                     title: CONTENT_TITLE,
                     breadcrumbStatus: 'hidden',
                     children: [
+                      { link: 'management:dataViews' },
                       { link: 'management:spaces', breadcrumbStatus: 'hidden' },
                       { link: 'management:objects', breadcrumbStatus: 'hidden' },
                       { link: 'management:filesManagement', breadcrumbStatus: 'hidden' },
@@ -447,8 +443,18 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
             sideNavVersion: 'v2',
             children: [
               {
-                id: 'cloud_links',
-                title: '',
+                id: 'settings_access',
+                title: ACCESS_TITLE,
+                children: [
+                  { link: 'management:api_keys', breadcrumbStatus: 'hidden' },
+                  { link: 'management:roles', breadcrumbStatus: 'hidden' },
+                ],
+              },
+              {
+                id: 'organization',
+                title: i18n.translate('xpack.serverlessSearch.nav.adminAndSettings.org.title', {
+                  defaultMessage: 'Organization',
+                }),
                 children: [
                   {
                     id: 'cloudLinkBilling',
@@ -459,14 +465,6 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                     cloudLink: 'deployment',
                     title: PERFORMANCE_TITLE,
                   },
-                ],
-              },
-              {
-                id: 'settings_access',
-                title: ACCESS_TITLE,
-                children: [
-                  { link: 'management:api_keys', breadcrumbStatus: 'hidden' },
-                  { link: 'management:roles', breadcrumbStatus: 'hidden' },
                   {
                     cloudLink: 'userAndRoles',
                     title: MANAGE_ORG_MEMBERS_TITLE,

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -162,6 +162,7 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
             title: i18n.translate('xpack.serverlessSearch.nav.relevance', {
               defaultMessage: 'Relevance',
             }),
+            sideNavVersion: 'v1',
             spaceBefore: 'm',
             children: [
               {
@@ -187,7 +188,6 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                   }
                 ),
                 link: 'searchInferenceEndpoints',
-                sideNavVersion: 'v1', // Moved to stack management -> ML in v2
               },
             ],
           },
@@ -306,6 +306,19 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                 ],
                 title: i18n.translate('xpack.serverlessSearch.nav.ingest.pipelines.title', {
                   defaultMessage: 'Ingest',
+                }),
+              },
+              {
+                children: [{ link: 'management:dataViews' }, { link: 'management:data_usage' }],
+                title: i18n.translate('xpack.serverlessSearch.nav.ingest.dataViews.title', {
+                  defaultMessage: 'Data views and usage',
+                }),
+              },
+              {
+                children: [{ link: 'searchSynonyms:synonyms' }, { link: 'searchQueryRules' }],
+                id: 'search_relevance',
+                title: i18n.translate('xpack.serverlessSearch.nav.ingest.relevance.title', {
+                  defaultMessage: 'Relevance',
                 }),
               },
             ],

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -87,18 +87,6 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
             sideNavVersion: 'v1',
           },
           {
-            children: [
-              { link: 'agent_builder:conversations' },
-              { link: 'agent_builder:tools' },
-              { link: 'agent_builder:agents' },
-            ],
-            iconV2: 'comment',
-            id: 'agent_builder',
-            renderAs: 'panelOpener',
-            sideNavVersion: 'v2',
-            title: AGENTS_TITLE,
-          },
-          {
             link: 'discover',
           },
           {
@@ -122,6 +110,18 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
               },
             ],
             sideNavVersion: 'v1',
+          },
+          {
+            children: [
+              { link: 'agent_builder:conversations' },
+              { link: 'agent_builder:tools' },
+              { link: 'agent_builder:agents' },
+            ],
+            iconV2: 'comment',
+            id: 'agent_builder',
+            renderAs: 'panelOpener',
+            sideNavVersion: 'v2',
+            title: AGENTS_TITLE,
           },
           {
             id: 'build',
@@ -506,6 +506,7 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                 breadcrumbStatus: 'hidden',
                 children: [
                   { link: 'management:settings', breadcrumbStatus: 'hidden' },
+                  { link: 'management:agentBuilder', breadcrumbStatus: 'hidden' },
                   {
                     link: 'management:observabilityAiAssistantManagement',
                     breadcrumbStatus: 'hidden',

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -44,6 +44,9 @@ const OTHER_TITLE = i18n.translate('xpack.serverlessSearch.nav.mngt.other', {
 const AGENTS_TITLE = i18n.translate('xpack.serverlessSearch.nav.agents', {
   defaultMessage: 'Agents',
 });
+const AI_TITLE = i18n.translate('xpack.serverlessSearch.nav.adminAndSettings.ai.title', {
+  defaultMessage: 'AI',
+});
 
 export const navigationTree = ({ isAppRegistered }: ApplicationStart): NavigationTreeDefinition => {
   function isAvailable<T>(appId: string, content: T): T[] {
@@ -279,22 +282,24 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
               {
                 children: [
                   {
-                    breadcrumbStatus: 'hidden',
                     getIsActive: ({ pathNameSerialized, prepend }) => {
                       return (
                         pathNameSerialized.startsWith(
                           prepend('/app/elasticsearch/index_management/indices')
-                        ) || pathNameSerialized.startsWith(prepend('/app/elasticsearch/indices'))
+                        ) ||
+                        pathNameSerialized.startsWith(
+                          prepend('/app/management/data/index_management')
+                        )
                       );
                     },
-                    link: 'elasticsearchIndexManagement',
+                    link: 'management:index_management',
                   },
                   { link: 'management:index_lifecycle_management' },
                   { link: 'management:snapshot_restore' },
                   { link: 'management:transform' },
                   { link: 'management:rollup_jobs' },
                   { link: 'management:data_quality', breadcrumbStatus: 'hidden' },
-                  { link: 'management:data_usage' },
+                  { link: 'management:data_usage', breadcrumbStatus: 'hidden' },
                 ],
                 title: i18n.translate('xpack.serverlessSearch.nav.ingest.indices.title', {
                   defaultMessage: 'Indices, data streams and roll ups',
@@ -391,7 +396,7 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                     children: [{ link: 'management:trained_models', breadcrumbStatus: 'hidden' }],
                   },
                   {
-                    title: 'AI',
+                    title: AI_TITLE,
                     children: [
                       { link: 'management:genAiSettings', breadcrumbStatus: 'hidden' },
                       { link: 'management:agentBuilder', breadcrumbStatus: 'hidden' },
@@ -467,7 +472,12 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                   },
                   {
                     cloudLink: 'userAndRoles',
-                    title: MANAGE_ORG_MEMBERS_TITLE,
+                    title: i18n.translate(
+                      'xpack.serverlessSearch.nav.adminAndSettings.org.members.title',
+                      {
+                        defaultMessage: 'Members',
+                      }
+                    ),
                   },
                 ],
               },
@@ -491,14 +501,21 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                     link: 'searchInferenceEndpoints',
                     breadcrumbStatus: 'hidden',
                   },
+                  { link: 'management:anomaly_detection' },
+                  { link: 'management:analytics' },
                 ],
               },
               {
-                id: 'settings_data',
-                title: i18n.translate('xpack.serverlessSearch.nav.settings.data', {
-                  defaultMessage: 'Data',
-                }),
-                children: [{ link: 'management:data_usage', breadcrumbStatus: 'hidden' }],
+                id: 'settings_ai',
+                title: AI_TITLE,
+                children: [
+                  { link: 'management:genAiSettings', breadcrumbStatus: 'hidden' },
+                  { link: 'management:agentBuilder', breadcrumbStatus: 'hidden' },
+                  {
+                    link: 'management:observabilityAiAssistantManagement',
+                    breadcrumbStatus: 'hidden',
+                  },
+                ],
               },
               {
                 id: 'settings_content',
@@ -513,16 +530,14 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                 ],
               },
               {
-                title: OTHER_TITLE,
-                breadcrumbStatus: 'hidden',
-                children: [
-                  { link: 'management:settings', breadcrumbStatus: 'hidden' },
-                  { link: 'management:agentBuilder', breadcrumbStatus: 'hidden' },
+                title: i18n.translate(
+                  'xpack.serverlessSearch.nav.adminAndSettings.settings.title',
                   {
-                    link: 'management:observabilityAiAssistantManagement',
-                    breadcrumbStatus: 'hidden',
-                  },
-                ],
+                    defaultMessage: 'Settings',
+                  }
+                ),
+                breadcrumbStatus: 'hidden',
+                children: [{ link: 'management:settings', breadcrumbStatus: 'hidden' }],
               },
             ],
           },

--- a/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
@@ -59,7 +59,6 @@ export default function searchSolutionNavigation({
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dashboards' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Developer Tools' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Stack Monitoring' });
 
       if (isV2) {
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Agents' });
@@ -222,7 +221,6 @@ export default function searchSolutionNavigation({
             'machine_learning',
             'dev_tools',
             'ingest_and_data',
-            'monitoring',
             'stack_management',
             // more:
             'maps',
@@ -254,7 +252,6 @@ export default function searchSolutionNavigation({
           'searchInferenceEndpoints:inferenceEndpoints',
           'search_project_nav_footer',
           'dev_tools',
-          'monitoring',
           'project_settings_project_nav',
           'management:trained_models',
           'stack_management',

--- a/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
@@ -58,8 +58,6 @@ export default function searchSolutionNavigation({
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Discover' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dashboards' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Synonyms' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Query rules' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Developer Tools' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Stack Monitoring' });
 
@@ -73,6 +71,8 @@ export default function searchSolutionNavigation({
       } else {
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Index Management' });
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Search applications' });
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Synonyms' });
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Query rules' });
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Inference endpoints' });
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Management' });
       }
@@ -124,16 +124,6 @@ export default function searchSolutionNavigation({
               link: { deepLinkId: 'searchPlayground' },
               breadcrumbs: ['Build', 'Playground'],
               pageTestSubject: 'playgroundsListPage',
-            },
-            {
-              link: { deepLinkId: 'searchSynonyms:synonyms' },
-              breadcrumbs: ['Relevance', 'Synonyms'],
-              pageTestSubject: 'searchSynonymsOverviewPage',
-            },
-            {
-              link: { deepLinkId: 'searchQueryRules' },
-              breadcrumbs: ['Relevance', 'Query rules'],
-              pageTestSubject: 'queryRulesBasePage',
             },
             {
               link: { deepLinkId: 'graph' },
@@ -229,8 +219,6 @@ export default function searchSolutionNavigation({
             'discover',
             'dashboards',
             'searchPlayground',
-            'searchSynonyms:synonyms',
-            'searchQueryRules',
             'machine_learning',
             'dev_tools',
             'ingest_and_data',

--- a/x-pack/solutions/search/test/functional_solution_sidenav/tests/search_sidenav.ts
+++ b/x-pack/solutions/search/test/functional_solution_sidenav/tests/search_sidenav.ts
@@ -57,13 +57,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
           // navigate to a different section
           await solutionNavigation.sidenav.clickLink({
-            deepLinkId: 'searchSynonyms:synonyms',
+            deepLinkId: 'searchPlayground',
           });
           await solutionNavigation.sidenav.expectLinkActive({
-            deepLinkId: 'searchSynonyms:synonyms',
+            deepLinkId: 'searchPlayground',
           });
-          await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Relevance' });
-          await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Synonyms' });
+          await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Build' });
+          await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Playground' });
         } else {
           // check the Data > Indices section
           await solutionNavigation.sidenav.clickLink({

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/navigation.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/navigation.ts
@@ -99,16 +99,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
               pageTestSubject: 'playgroundsListPage',
             },
             {
-              link: { deepLinkId: 'searchSynonyms' },
-              breadcrumbs: ['Relevance', 'Synonyms'],
-              pageTestSubject: 'searchSynonymsOverviewPage',
-            },
-            {
-              link: { deepLinkId: 'searchQueryRules' },
-              breadcrumbs: ['Relevance', 'Query rules'],
-              pageTestSubject: 'queryRulesBasePage',
-            },
-            {
               link: { deepLinkId: 'dev_tools:console' },
               breadcrumbs: ['Developer Tools'],
               pageTestSubject: 'console',
@@ -273,13 +263,13 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Discover' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dashboards' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Synonyms' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Query rules' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Developer Tools' });
 
       if (isV1) {
         // All these items have been moved to sub menus in the footer
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Index Management' });
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Synonyms' });
+        await solutionNavigation.sidenav.expectLinkExists({ text: 'Query rules' });
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Inference endpoints' });
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Trained Models' });
         await solutionNavigation.sidenav.expectLinkExists({ text: 'Performance' });
@@ -336,8 +326,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
             'discover',
             'dashboards',
             'searchPlayground',
-            'searchSynonyms',
-            'searchQueryRules',
             'machine_learning',
             'maps',
             'visualize',


### PR DESCRIPTION
## Summary

v2 Nav tweaks:
- Moved `Agents` below `Dashboard`
- Added agent builder management page to v2 settings `Other` section
  - This was added to AI section in V1, but not added to v2 which this change fixes. 
- Moved Synonyms & Query Rules to the ingest & data sub-menu under a `Relevance` title
- Updates to Management footer section to align with latest IA

### Screenshots
Relevance links moved out of top-nav
<img width="397" height="951" alt="image" src="https://github.com/user-attachments/assets/5b641d0a-9e5c-40f4-91fa-8000cc9179f2" />

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

