### PR TITLE
[Metrics][Discover] Fix metrics chart data issue by passing timeRange

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.test.ts
@@ -11,14 +11,12 @@ import { DIMENSIONS_COLUMN } from './constants';
 import { createESQLQuery } from './create_esql_query';
 
 describe('createESQLQuery', () => {
-  const baseTimeRange = { from: '2025-09-04T00:00:00Z', to: '2025-09-04T01:00:00Z' };
-
   it('should generate a basic AVG query for a metric field', () => {
-    const query = createESQLQuery({ metricField: 'cpu.usage', timeRange: baseTimeRange });
+    const query = createESQLQuery({ metricField: 'cpu.usage' });
     expect(query).toBe(
       `
 TS metrics-*
-  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, "2025-09-04T00:00:00Z", "2025-09-04T01:00:00Z")
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
 `.trim()
     );
   });
@@ -27,12 +25,11 @@ TS metrics-*
     const query = createESQLQuery({
       metricField: 'requests.count',
       instrument: 'counter',
-      timeRange: baseTimeRange,
     });
     expect(query).toBe(
       `
 TS metrics-*
-  | STATS SUM(RATE(requests.count)) BY BUCKET(@timestamp, 100, "2025-09-04T00:00:00Z", "2025-09-04T01:00:00Z")
+  | STATS SUM(RATE(requests.count)) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
 `.trim()
     );
   });
@@ -41,13 +38,12 @@ TS metrics-*
     const query = createESQLQuery({
       metricField: 'cpu.usage',
       dimensions: ['host.name'],
-      timeRange: baseTimeRange,
     });
     expect(query).toBe(
       `
 TS metrics-*
   | WHERE host.name IS NOT NULL
-  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, "2025-09-04T00:00:00Z", "2025-09-04T01:00:00Z"), host.name
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend), host.name
   | RENAME host.name AS ${DIMENSIONS_COLUMN}
 `.trim()
     );
@@ -57,13 +53,12 @@ TS metrics-*
     const query = createESQLQuery({
       metricField: 'cpu.usage',
       dimensions: ['host.name', 'container.id'],
-      timeRange: baseTimeRange,
     });
     expect(query).toBe(
       `
 TS metrics-*
   | WHERE host.name IS NOT NULL AND container.id IS NOT NULL
-  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, "2025-09-04T00:00:00Z", "2025-09-04T01:00:00Z"), host.name, container.id
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend), host.name, container.id
   | EVAL ${DIMENSIONS_COLUMN} = CONCAT(host.name, " › ", container.id)
   | DROP host.name, container.id
 `.trim()
@@ -78,7 +73,6 @@ TS metrics-*
         { field: 'host.name', value: 'host-2' },
         { field: 'region', value: 'us-east' },
       ],
-      timeRange: baseTimeRange,
     });
 
     expect(query).toBe(
@@ -86,17 +80,17 @@ TS metrics-*
 TS metrics-*
   | WHERE host.name IN ("host-1", "host-2")
   | WHERE region IN ("us-east")
-  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, "2025-09-04T00:00:00Z", "2025-09-04T01:00:00Z")
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
 `.trim()
     );
   });
 
   it('should apply default index if none is provided', () => {
-    const query = createESQLQuery({ metricField: 'cpu.usage', timeRange: baseTimeRange });
+    const query = createESQLQuery({ metricField: 'cpu.usage' });
     expect(query).toBe(
       `
 TS metrics-*
-  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, "2025-09-04T00:00:00Z", "2025-09-04T01:00:00Z")
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
 `.trim()
     );
   });
@@ -105,12 +99,11 @@ TS metrics-*
     const query = createESQLQuery({
       metricField: 'cpu.usage',
       index: 'custom-metrics-*',
-      timeRange: baseTimeRange,
     });
     expect(query).toBe(
       `
 TS custom-metrics-*
-  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, "2025-09-04T00:00:00Z", "2025-09-04T01:00:00Z")
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
 `.trim()
     );
   });
@@ -120,7 +113,7 @@ TS custom-metrics-*
     expect(query).toBe(
       `
 TS metrics-*
-  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, NOW() - 15 minute, NOW())
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
 `.trim()
     );
   });

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { TimeRange } from '@kbn/data-plugin/common';
 import type { QueryOperator } from '@kbn/esql-composer';
 import { drop, evaluate, stats, timeseries, where, rename } from '@kbn/esql-composer';
 import { DIMENSIONS_COLUMN } from './constants';
@@ -18,7 +17,6 @@ interface CreateESQLQueryParams {
   instrument?: string;
   dimensions?: string[];
   filters?: Array<{ field: string; value: string }>;
-  timeRange?: TimeRange;
 }
 
 const separator = '\u203A'.normalize('NFC');
@@ -26,7 +24,6 @@ const separator = '\u203A'.normalize('NFC');
 export function createESQLQuery({
   index = 'metrics-*',
   instrument,
-  timeRange,
   dimensions = [],
   metricField,
   filters,

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
@@ -60,24 +60,14 @@ export function createESQLQuery({
       : (query) => query,
     instrument === 'counter'
       ? stats(
-          `SUM(RATE(??metricField)) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)${
+          `SUM(RATE(\`${metricField}\`)) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)${
             dimensions.length > 0 ? `, ${dimensions.join(',')}` : ''
-          }`,
-          {
-            metricField,
-            _tstart: timeRange?.from ?? 'NOW() - 15 minute',
-            _tend: timeRange?.to ?? 'NOW()',
-          }
+          }`
         )
       : stats(
-          `AVG(??metricField) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend) ${
+          `AVG(\`${metricField}\`) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend) ${
             dimensions.length > 0 ? `, ${dimensions.join(',')}` : ''
-          }`,
-          {
-            metricField,
-            _tstart: timeRange?.from ?? 'NOW() - 15 minute',
-            _tend: timeRange?.to ?? 'NOW()',
-          }
+          }`
         ),
     ...(dimensions.length > 0
       ? dimensions.length === 1

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts
@@ -40,6 +40,7 @@ export const useChartLayers = ({
         esqlQuery: query,
         search: services.data.search.search,
         signal: abortController?.signal,
+        timeRange,
       }),
 
     [query, services.data.search.search, timeRange]


### PR DESCRIPTION
## 🍒 Summary

This change fixes an issue where the metrics chart would not display data correctly because the `timeRange` was not being passed to the function responsible for fetching column information from the ESQL query.

## 🛠️ Changes

- Modified `use_chart_layers.ts` to pass the `timeRange` object to the `getESQLQueryColumns` function. This ensures that the time range substitution for `?_tstart` and `?_tend` occurs correctly.
- Updated `create_esql_query.ts` to remove the now-redundant time range parameter substitution and adjust field quoting, simplifying the query creation logic.

🤖 This pull request was assisted by Gemini CLI

Gemini's contribution was focused on code explanation and debugging analysis; the code changes were implemented by the user.
