### PR TITLE
[SharedUX] Update canvas-confetti renovate backport strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4694,7 +4694,7 @@
       "labels": [
         "Team:SharedUX",
         "release_note:skip",
-        "backport:skip"
+        "backport:current-major"
       ],
       "enabled": true
     }


### PR DESCRIPTION
## Summary

- Following security team advice and updating our backport strategy for recently added `canvas-confetti` dependency to `current-major`. 
- Once me move to `9.3` we should update this once again to `previous-minor`.

Related PR: https://github.com/elastic/kibana/pull/234187 


