### PR TITLE
[ci] Lint yamls upon commit

### DIFF
--- a/packages/kbn-ts-projects/ts_project.ts
+++ b/packages/kbn-ts-projects/ts_project.ts
@@ -43,6 +43,10 @@ function expand(name: string, patterns: string[], knownPaths: string[]) {
     matcher: makeMatcher([pattern]),
   }));
 
+  if (!knownPaths) {
+    throw new Error('TS Project map missing, make sure you run `yarn kbn bootstrap`');
+  }
+
   const selected = matchers.map(({ matcher, pattern }) => ({
     pattern,
     matches: knownPaths.filter(matcher),

--- a/packages/kbn-ts-projects/ts_project.ts
+++ b/packages/kbn-ts-projects/ts_project.ts
@@ -43,10 +43,6 @@ function expand(name: string, patterns: string[], knownPaths: string[]) {
     matcher: makeMatcher([pattern]),
   }));
 
-  if (!knownPaths) {
-    throw new Error('TS Project map missing, make sure you run `yarn kbn bootstrap`');
-  }
-
   const selected = matchers.map(({ matcher, pattern }) => ({
     pattern,
     matches: knownPaths.filter(matcher),
@@ -75,6 +71,10 @@ export class TsProject {
     }
 
     const tsConfigRepoRels: string[] = JSON.parse(Fs.readFileSync(mapPath, 'utf8'));
+
+    if (!tsConfigRepoRels || !tsConfigRepoRels.length) {
+      throw new Error('TS Project map missing, make sure you run `yarn kbn bootstrap`');
+    }
 
     const ignores = expand('ignore', options.ignore, tsConfigRepoRels);
     const disableTypeCheck = expand('disableTypeCheck', options.disableTypeCheck, tsConfigRepoRels);

--- a/src/dev/run_precommit_hook.js
+++ b/src/dev/run_precommit_hook.js
@@ -109,22 +109,22 @@ class YamlLintCheck extends PrecommitCheck {
     const yamlFiles = files.filter((file) => this.isYamlFile(file.getRelativePath()));
 
     if (yamlFiles.length === 0) {
-      log.info('No YAML files to check');
+      log.verbose('No YAML files to check');
       return;
     }
 
-    log.info(`Checking ${yamlFiles.length} YAML files for syntax errors`);
+    log.verbose(`Checking ${yamlFiles.length} YAML files for syntax errors`);
 
     const errors = [];
     for (const file of yamlFiles) {
       try {
-        const content = await readFile(file, 'utf8');
+        const content = await readFile(file.getAbsolutePath(), 'utf8');
         yamlLoad(content, {
-          filename: file,
+          filename: file.getRelativePath(),
           strict: true,
         });
       } catch (error) {
-        errors.push(`Error in ${file}:\n${error.message}`);
+        errors.push(`Error in ${file.getRelativePath()}:\n${error.message}`);
       }
     }
 
@@ -161,7 +161,7 @@ run(
       return;
     }
 
-    log.info('Running pre-commit checks...');
+    log.verbose('Running pre-commit checks...');
     const results = await Promise.all(
       PRECOMMIT_CHECKS.map(async (check) => {
         const startTime = Date.now();
@@ -170,7 +170,7 @@ run(
           stage: flags.stage,
         });
         const duration = Date.now() - startTime;
-        log.info(`${check.name} completed in ${duration}ms`);
+        log.verbose(`${check.name} completed in ${duration}ms`);
         return result;
       })
     );

--- a/src/dev/run_precommit_hook.js
+++ b/src/dev/run_precommit_hook.js
@@ -121,7 +121,6 @@ class YamlLintCheck extends PrecommitCheck {
         const content = await readFile(file.getAbsolutePath(), 'utf8');
         yamlLoad(content, {
           filename: file.getRelativePath(),
-          strict: true,
         });
       } catch (error) {
         errors.push(`Error in ${file.getRelativePath()}:\n${error.message}`);

--- a/src/platform/packages/shared/kbn-dev-utils/src/precommit_hook/script_source.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/precommit_hook/script_source.ts
@@ -99,7 +99,7 @@ execute_precommit_hook() {
 
 execute_precommit_hook || {
   echo "Pre-commit hook failed (add --no-verify to bypass)";
-  echo '  For eslint failures you can try running \`node scripts/precommit_hook --fix\`';
+  echo '  For fixable failures you can try running \`node scripts/precommit_hook --fix\`';
   exit 1;
 }
 


### PR DESCRIPTION
## Summary
We've seen earlier where we've edited yaml files, and managed to push them with some syntax issues. This adds a safeguard locally to try to avoid those issues.

- Refactors `run_precommit_hook.js` to allow for more checks
- Adds a yaml linting step to the pre-commit hook
- (unrelated) Clarifies missing bootstrap error (*)


(*)
If you've wanted to get the TS project list after a branch switch, it gave this error:
```
ts_project.ts:48
    matches: knownPaths.filter(matcher),
                        ^
TypeError: knownPaths.filter is not a function
    at map (ts_project.ts:48:25)
```
Meaning, you should re-bootstrap. It's now more explicit with an error:
```
ts_project.ts:76
      throw new Error('TS Project map missing, make sure you run `yarn kbn bootstrap`');
            ^
Error: TS Project map missing, make sure you run `yarn kbn bootstrap`
    at Function.loadAll (ts_project.ts:76:13)
```

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->