### PR TITLE
[ES|QL] Fix lookup index editor flaky test

### DIFF
--- a/src/platform/test/functional/services/esql.ts
+++ b/src/platform/test/functional/services/esql.ts
@@ -9,6 +9,7 @@
 
 import expect from '@kbn/expect';
 import type { WebElementWrapper } from '@kbn/ftr-common-functional-ui-services';
+import { Key } from 'selenium-webdriver';
 import { FtrService } from '../ftr_provider_context';
 
 export class ESQLService extends FtrService {
@@ -157,8 +158,16 @@ export class ESQLService extends FtrService {
     await this.monacoEditor.typeCodeEditorValue(query, editorSubjId);
   }
 
-  public async selectEsqlSuggestionByLabel(label: string) {
+  public async triggerSuggestions(editorSubjId = 'ESQLEditor') {
+    const editor = await this.testSubjects.find(editorSubjId);
+    const textarea = await editor.findByCssSelector('textarea');
+    await textarea.type([Key.CONTROL, Key.SPACE]);
+  }
+
+  public async selectEsqlSuggestionByLabel(label: string, editorSubjId = 'ESQLEditor') {
     await this.retry.try(async () => {
+      await this.triggerSuggestions(editorSubjId);
+
       const suggestions = await this.findService.allByCssSelector(
         '.monaco-editor .suggest-widget .monaco-list-row'
       );


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/235125
## Summary
Failure was coming from not finding the suggestions popup after typing in the esql editor.

In an attempt to fix this, this PR adds a ctrl + space keyword stroke in each retry to re-trigger the suggestions box.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



