### PR TITLE
Fix missing label node details

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.test.tsx
@@ -106,6 +106,42 @@ describe('LabelNode', () => {
     });
   });
 
+  test('renders ips when present', () => {
+    const props = {
+      ...baseProps,
+      data: {
+        ...baseProps.data,
+        ips: ['127.0.0.1'],
+      },
+    };
+    render(
+      <ReactFlow>
+        <LabelNode {...props} />
+      </ReactFlow>
+    );
+
+    expect(screen.queryByTestId(GRAPH_IPS_TEXT_ID)).toBeInTheDocument();
+    expect(screen.queryByTestId(GRAPH_FLAGS_BADGE_ID)).not.toBeInTheDocument();
+  });
+
+  test('renders country flags when present', () => {
+    const props = {
+      ...baseProps,
+      data: {
+        ...baseProps.data,
+        countryCodes: ['us'],
+      },
+    };
+    render(
+      <ReactFlow>
+        <LabelNode {...props} />
+      </ReactFlow>
+    );
+
+    expect(screen.queryByTestId(GRAPH_IPS_TEXT_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(GRAPH_FLAGS_BADGE_ID)).toBeInTheDocument();
+  });
+
   test('renders ips and country flags when present', () => {
     const props = {
       ...baseProps,
@@ -121,8 +157,8 @@ describe('LabelNode', () => {
       </ReactFlow>
     );
 
-    expect(screen.getByTestId(GRAPH_IPS_TEXT_ID)).toBeInTheDocument();
-    expect(screen.getByTestId(GRAPH_FLAGS_BADGE_ID)).toBeInTheDocument();
+    expect(screen.queryByTestId(GRAPH_IPS_TEXT_ID)).toBeInTheDocument();
+    expect(screen.queryByTestId(GRAPH_FLAGS_BADGE_ID)).toBeInTheDocument();
   });
 
   describe('Shape colors', () => {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
@@ -166,9 +166,7 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
           />
         </LabelNodeContainer>
       </EuiToolTip>
-      {ips && ips?.length > 0 && countryCodes && countryCodes.length > 0 && (
-        <LabelNodeDetails ips={ips} countryCodes={countryCodes} />
-      )}
+      <LabelNodeDetails ips={ips} countryCodes={countryCodes} />
     </>
   );
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_details.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_details.test.tsx
@@ -14,12 +14,12 @@ import { GRAPH_IPS_TEXT_ID, GRAPH_IPS_PLUS_COUNT_ID, GRAPH_FLAGS_BADGE_ID } from
 describe('LabelNodeDetails', () => {
   test('renders empty div when no props are provided', () => {
     const { container } = render(<LabelNodeDetails />);
-    expect(container.firstChild).toBeEmptyDOMElement();
+    expect(container.firstChild).toBeNull();
   });
 
   test('renders empty div when empty arrays are provided', () => {
     const { container } = render(<LabelNodeDetails ips={[]} countryCodes={[]} />);
-    expect(container.firstChild).toBeEmptyDOMElement();
+    expect(container.firstChild).toBeNull();
   });
 
   test('renders Ips component when ips are provided', () => {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_details.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_details.tsx
@@ -19,7 +19,9 @@ export interface LabelNodeDetailsProps {
 
 export const LabelNodeDetails = ({ ips, countryCodes }: LabelNodeDetailsProps) => {
   const { euiTheme } = useEuiTheme();
-  return (
+  const shouldRenderIps = ips && ips.length > 0;
+  const shouldRenderCountryFlags = countryCodes && countryCodes.length > 0;
+  return shouldRenderIps || shouldRenderCountryFlags ? (
     <div
       css={css`
         display: flex;
@@ -29,8 +31,8 @@ export const LabelNodeDetails = ({ ips, countryCodes }: LabelNodeDetailsProps) =
         margin-top: ${euiTheme.size.xs};
       `}
     >
-      {ips && ips.length > 0 && <Ips ips={ips} />}
-      {countryCodes && countryCodes.length > 0 && <CountryFlags countryCodes={countryCodes} />}
+      {shouldRenderIps && <Ips ips={ips} />}
+      {shouldRenderCountryFlags && <CountryFlags countryCodes={countryCodes} />}
     </div>
-  );
+  ) : null;
 };


### PR DESCRIPTION
## Summary

Fix `<LabelNode>` missing the contextual details (ips, geolocation) if any of the fields is missing. 

Solution replaces AND operator with OR. It also adds 2 unit tests for when any of these fields is missing.

### Screenshots

| Before | After |
|--------|--------|
| <img width="378" height="675" alt="Screenshot 2025-09-16 at 12 20 37" src="https://github.com/user-attachments/assets/6321ca21-c638-4dce-8a78-c20a6d7a4618" /> | <img width="338" height="664" alt="Screenshot 2025-09-16 at 12 20 16" src="https://github.com/user-attachments/assets/37d5ba80-39eb-41fa-9c3d-eb6dafb094a7" /> |

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No risks.