### PR TITLE
[CI] Clear EPR cached docker image in an EPR cache verification scenario

### DIFF
--- a/.buildkite/scripts/common/setup_executors.sh
+++ b/.buildkite/scripts/common/setup_executors.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Executor-related setup
+
+echo '--- Executor Setup'
+
+# if FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE is set,
+# we should clear previously cached EPR images,
+# (as the package registry image is quite big to keep 2 versions of)
+DEFAULT_FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE='docker.elastic.co/kibana-ci/package-registry-distribution:lite'
+if [ -n "${FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE:-}" && "${FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE}" != "${DEFAULT_FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE}" ]; then
+  echo 'Clearing previously cached EPR images'
+  EPR_IMAGES=$(docker images -q "${DEFAULT_FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE}")
+  if [ -n "${EPR_IMAGES}" ]; then
+    docker rmi -f "${EPR_IMAGES}"
+    echo "Cleared ${EPR_IMAGES} EPR images"
+  fi
+fi

--- a/.buildkite/scripts/common/setup_executors.sh
+++ b/.buildkite/scripts/common/setup_executors.sh
@@ -9,7 +9,9 @@ echo '--- Executor Setup'
 # we should clear previously cached EPR images,
 # (as the package registry image is quite big to keep 2 versions of)
 DEFAULT_FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE='docker.elastic.co/kibana-ci/package-registry-distribution:lite'
-if [ -n "${FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE:-}" && "${FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE}" != "${DEFAULT_FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE}" ]; then
+if [[ -n "${FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE:-}" \
+      && "${FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE}" != "${DEFAULT_FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE}" \
+]]; then
   echo 'Clearing previously cached EPR images'
   EPR_IMAGES=$(docker images -q "${DEFAULT_FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE}")
   if [ -n "${EPR_IMAGES}" ]; then

--- a/.buildkite/scripts/common/setup_executors.sh
+++ b/.buildkite/scripts/common/setup_executors.sh
@@ -9,12 +9,15 @@ echo '--- Executor Setup'
 # we should clear previously cached EPR images,
 # (as the package registry image is quite big to keep 2 versions of)
 DEFAULT_FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE='docker.elastic.co/kibana-ci/package-registry-distribution:lite'
-if [[ -n "${FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE:-}" \
+
+# Test docker is available
+if [[ `command -v docker` \
+      && -n "${FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE:-}" \
       && "${FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE}" != "${DEFAULT_FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE}" \
 ]]; then
   echo 'Clearing previously cached EPR images'
   EPR_IMAGES=$(docker images -q "${DEFAULT_FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE}")
-  if [ -n "${EPR_IMAGES}" ]; then
+  if [[ -n "${EPR_IMAGES}" ]]; then
     docker rmi -f "${EPR_IMAGES}"
     echo "Cleared ${EPR_IMAGES} EPR images"
   fi

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 source .buildkite/scripts/common/env.sh
 source .buildkite/scripts/common/setup_job_env.sh
+source .buildkite/scripts/common/setup_executors.sh
 
 if [[ "${SKIP_NODE_SETUP:-}" =~ ^(1|true)$ ]]; then
   echo "Skipping node setup (SKIP_NODE_SETUP=$SKIP_NODE_SETUP)"


### PR DESCRIPTION
## Summary
We've been getting errors about running out of disk space in EPR image validation pipelines. 

In those pipelines, we are pulling a new version of EPR, that together with the VM-cached image will deplete our disk in several cases. This PR adds an executor-setup step at buildkite's pre-command hook that would clear the cache, and make room for the validated image.

Correct behavior (without FTR retries) can be observed here: https://buildkite.com/elastic/kibana-package-registry-verify-and-promote/builds/276#_

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->