### PR TITLE
[Discover] adds field icon for field type to field popover

### DIFF
--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover_header.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover_header.test.tsx
@@ -8,8 +8,9 @@
  */
 
 import React from 'react';
-import { EuiButtonIcon } from '@elastic/eui';
-import { mountWithIntl } from '@kbn/test-jest-helpers';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
 import { stubLogstashDataView as dataView } from '@kbn/data-views-plugin/common/data_view.stub';
 import { FieldPopoverHeader } from './field_popover_header';
 
@@ -17,23 +18,23 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
   it('should render correctly without actions', async () => {
     const mockClose = jest.fn();
     const fieldName = 'extension';
-    const wrapper = mountWithIntl(
+    renderWithI18n(
       <FieldPopoverHeader
         field={dataView.fields.find((field) => field.name === fieldName)!}
         closePopover={mockClose}
       />
     );
 
-    expect(wrapper.text()).toBe(fieldName);
-    expect(wrapper.find(EuiButtonIcon)).toHaveLength(0);
+    expect(await screen.findByText(fieldName)).toBeVisible();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
   it('should render correctly with all actions', async () => {
     const mockClose = jest.fn();
-    const fieldName = 'extension';
+    const fieldName = 'extension.keyword';
     const field = dataView.fields.find((f) => f.name === fieldName)!;
     jest.spyOn(field, 'isRuntimeField', 'get').mockImplementation(() => true);
-    const wrapper = mountWithIntl(
+    renderWithI18n(
       <FieldPopoverHeader
         field={field}
         closePopover={mockClose}
@@ -45,23 +46,13 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
       />
     );
 
-    expect(wrapper.text()).toBe(fieldName);
-    expect(
-      wrapper.find(`[data-test-subj="fieldPopoverHeader_addBreakdownField-${fieldName}"]`).exists()
-    ).toBeTruthy();
-    expect(
-      wrapper.find(`[data-test-subj="fieldPopoverHeader_addField-${fieldName}"]`).exists()
-    ).toBeTruthy();
-    expect(
-      wrapper.find(`[data-test-subj="fieldPopoverHeader_addExistsFilter-${fieldName}"]`).exists()
-    ).toBeTruthy();
-    expect(
-      wrapper.find(`[data-test-subj="fieldPopoverHeader_editField-${fieldName}"]`).exists()
-    ).toBeTruthy();
-    expect(
-      wrapper.find(`[data-test-subj="fieldPopoverHeader_deleteField-${fieldName}"]`).exists()
-    ).toBeTruthy();
-    expect(wrapper.find(EuiButtonIcon)).toHaveLength(5);
+    expect(await screen.findByText(fieldName)).toBeVisible();
+    expect(screen.queryByTestId(`fieldPopoverHeader_addBreakdownField-${fieldName}`)).toBeVisible();
+    expect(screen.queryByTestId(`fieldPopoverHeader_addField-${fieldName}`)).toBeVisible();
+    expect(screen.queryByTestId(`fieldPopoverHeader_addExistsFilter-${fieldName}`)).toBeVisible();
+    expect(screen.queryByTestId(`fieldPopoverHeader_editField-${fieldName}`)).toBeVisible();
+    expect(screen.queryByTestId(`fieldPopoverHeader_deleteField-${fieldName}`)).toBeVisible();
+    expect(screen.getAllByRole('button')).toHaveLength(5);
   });
 
   it('should correctly handle add-breakdown-field action', async () => {
@@ -69,7 +60,7 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
     const mockAddBreakdownField = jest.fn();
     const fieldName = 'extension';
     const field = dataView.fields.find((f) => f.name === fieldName)!;
-    const wrapper = mountWithIntl(
+    renderWithI18n(
       <FieldPopoverHeader
         field={field}
         closePopover={mockClose}
@@ -77,10 +68,7 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
       />
     );
 
-    wrapper
-      .find(`[data-test-subj="fieldPopoverHeader_addBreakdownField-${fieldName}"]`)
-      .first()
-      .simulate('click');
+    await userEvent.click(screen.getByTestId(`fieldPopoverHeader_addBreakdownField-${fieldName}`));
 
     expect(mockClose).toHaveBeenCalled();
     expect(mockAddBreakdownField).toHaveBeenCalledWith(field);
@@ -91,7 +79,7 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
     const mockAddField = jest.fn();
     const fieldName = 'extension';
     const field = dataView.fields.find((f) => f.name === fieldName)!;
-    const wrapper = mountWithIntl(
+    renderWithI18n(
       <FieldPopoverHeader
         field={field}
         closePopover={mockClose}
@@ -99,10 +87,7 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
       />
     );
 
-    wrapper
-      .find(`[data-test-subj="fieldPopoverHeader_addField-${fieldName}"]`)
-      .first()
-      .simulate('click');
+    await userEvent.click(screen.getByTestId(`fieldPopoverHeader_addField-${fieldName}`));
 
     expect(mockClose).toHaveBeenCalled();
     expect(mockAddField).toHaveBeenCalledWith(field);
@@ -115,24 +100,21 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
     const field = dataView.fields.find((f) => f.name === fieldName)!;
 
     // available
-    let wrapper = mountWithIntl(
+    const { rerender } = renderWithI18n(
       <FieldPopoverHeader field={field} closePopover={mockClose} onAddFilter={mockAddFilter} />
     );
-    wrapper
-      .find(`[data-test-subj="fieldPopoverHeader_addExistsFilter-${fieldName}"]`)
-      .first()
-      .simulate('click');
+    await userEvent.click(screen.getByTestId(`fieldPopoverHeader_addExistsFilter-${fieldName}`));
     expect(mockClose).toHaveBeenCalled();
     expect(mockAddFilter).toHaveBeenCalledWith('_exists_', fieldName, '+');
 
     // hidden
     jest.spyOn(field, 'filterable', 'get').mockImplementation(() => false);
-    wrapper = mountWithIntl(
+    rerender(
       <FieldPopoverHeader field={field} closePopover={mockClose} onAddFilter={mockAddFilter} />
     );
     expect(
-      wrapper.find(`[data-test-subj="fieldPopoverHeader_addExistsFilter-${fieldName}"]`).exists()
-    ).toBeFalsy();
+      screen.queryByTestId(`fieldPopoverHeader_addExistsFilter-${fieldName}`)
+    ).not.toBeInTheDocument();
   });
 
   it('should correctly handle edit-field action', async () => {
@@ -143,25 +125,22 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
 
     // available
     jest.spyOn(field, 'isRuntimeField', 'get').mockImplementation(() => true);
-    let wrapper = mountWithIntl(
+    const { rerender } = renderWithI18n(
       <FieldPopoverHeader field={field} closePopover={mockClose} onEditField={mockEditField} />
     );
-    wrapper
-      .find(`[data-test-subj="fieldPopoverHeader_editField-${fieldName}"]`)
-      .first()
-      .simulate('click');
+    await userEvent.click(screen.getByTestId(`fieldPopoverHeader_editField-${fieldName}`));
     expect(mockClose).toHaveBeenCalled();
     expect(mockEditField).toHaveBeenCalledWith(fieldName);
 
     // hidden
     jest.spyOn(field, 'isRuntimeField', 'get').mockImplementation(() => false);
     jest.spyOn(field, 'type', 'get').mockImplementation(() => 'unknown');
-    wrapper = mountWithIntl(
+    rerender(
       <FieldPopoverHeader field={field} closePopover={mockClose} onEditField={mockEditField} />
     );
     expect(
-      wrapper.find(`[data-test-subj="fieldPopoverHeader_editField-${fieldName}"]`).exists()
-    ).toBeFalsy();
+      screen.queryByTestId(`fieldPopoverHeader_editField-${fieldName}`)
+    ).not.toBeInTheDocument();
   });
 
   it('should correctly handle delete-field action', async () => {
@@ -172,23 +151,49 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
 
     // available
     jest.spyOn(field, 'isRuntimeField', 'get').mockImplementation(() => true);
-    let wrapper = mountWithIntl(
+    const { rerender } = renderWithI18n(
       <FieldPopoverHeader field={field} closePopover={mockClose} onDeleteField={mockDeleteField} />
     );
-    wrapper
-      .find(`[data-test-subj="fieldPopoverHeader_deleteField-${fieldName}"]`)
-      .first()
-      .simulate('click');
+    await userEvent.click(screen.getByTestId(`fieldPopoverHeader_deleteField-${fieldName}`));
     expect(mockClose).toHaveBeenCalled();
     expect(mockDeleteField).toHaveBeenCalledWith(fieldName);
 
     // hidden
     jest.spyOn(field, 'isRuntimeField', 'get').mockImplementation(() => false);
-    wrapper = mountWithIntl(
+    rerender(
       <FieldPopoverHeader field={field} closePopover={mockClose} onDeleteField={mockDeleteField} />
     );
     expect(
-      wrapper.find(`[data-test-subj="fieldPopoverHeader_deleteField-${fieldName}"]`).exists()
-    ).toBeFalsy();
+      screen.queryByTestId(`fieldPopoverHeader_deleteField-${fieldName}`)
+    ).not.toBeInTheDocument();
+  });
+
+  it('should render correctly the field type icon on the header', () => {
+    const fieldName = 'extension';
+    const field = dataView.fields.find((f) => f.name === fieldName)!;
+    renderWithI18n(<FieldPopoverHeader field={field} closePopover={jest.fn()} />);
+
+    expect(screen.getByTestId(`fieldPopoverHeader_icon-${fieldName}`)).toBeVisible();
+  });
+
+  it('should handle getCustomFieldType', () => {
+    const mockGetCustomFieldType = jest.fn().mockImplementation((field) => {
+      if (field.name === 'extension') {
+        return 'custom';
+      }
+      return 'string';
+    });
+    const fieldName = 'extension';
+    const field = dataView.fields.find((f) => f.name === fieldName)!;
+    renderWithI18n(
+      <FieldPopoverHeader
+        field={field}
+        closePopover={jest.fn()}
+        getCustomFieldType={mockGetCustomFieldType}
+      />
+    );
+
+    expect(mockGetCustomFieldType).toHaveBeenCalledWith(field);
+    expect(screen.getByTitle('custom')).toBeVisible();
   });
 });

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover_header.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover_header.test.tsx
@@ -46,12 +46,12 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
       />
     );
 
-    expect(await screen.findByText(fieldName)).toBeVisible();
-    expect(screen.queryByTestId(`fieldPopoverHeader_addBreakdownField-${fieldName}`)).toBeVisible();
-    expect(screen.queryByTestId(`fieldPopoverHeader_addField-${fieldName}`)).toBeVisible();
-    expect(screen.queryByTestId(`fieldPopoverHeader_addExistsFilter-${fieldName}`)).toBeVisible();
-    expect(screen.queryByTestId(`fieldPopoverHeader_editField-${fieldName}`)).toBeVisible();
-    expect(screen.queryByTestId(`fieldPopoverHeader_deleteField-${fieldName}`)).toBeVisible();
+    expect(screen.getByText(fieldName)).toBeVisible();
+    expect(screen.getByTestId(`fieldPopoverHeader_addBreakdownField-${fieldName}`)).toBeVisible();
+    expect(screen.getByTestId(`fieldPopoverHeader_addField-${fieldName}`)).toBeVisible();
+    expect(screen.getByTestId(`fieldPopoverHeader_addExistsFilter-${fieldName}`)).toBeVisible();
+    expect(screen.getByTestId(`fieldPopoverHeader_editField-${fieldName}`)).toBeVisible();
+    expect(screen.getByTestId(`fieldPopoverHeader_deleteField-${fieldName}`)).toBeVisible();
     expect(screen.getAllByRole('button')).toHaveLength(5);
   });
 
@@ -100,16 +100,22 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
     const field = dataView.fields.find((f) => f.name === fieldName)!;
 
     // available
-    const { rerender } = renderWithI18n(
+    renderWithI18n(
       <FieldPopoverHeader field={field} closePopover={mockClose} onAddFilter={mockAddFilter} />
     );
     await userEvent.click(screen.getByTestId(`fieldPopoverHeader_addExistsFilter-${fieldName}`));
     expect(mockClose).toHaveBeenCalled();
     expect(mockAddFilter).toHaveBeenCalledWith('_exists_', fieldName, '+');
+  });
 
-    // hidden
+  it('should correctly handle hidden add-exists-filter action', async () => {
+    const mockClose = jest.fn();
+    const mockAddFilter = jest.fn();
+    const fieldName = 'extension';
+    const field = dataView.fields.find((f) => f.name === fieldName)!;
+
     jest.spyOn(field, 'filterable', 'get').mockImplementation(() => false);
-    rerender(
+    renderWithI18n(
       <FieldPopoverHeader field={field} closePopover={mockClose} onAddFilter={mockAddFilter} />
     );
     expect(
@@ -125,17 +131,23 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
 
     // available
     jest.spyOn(field, 'isRuntimeField', 'get').mockImplementation(() => true);
-    const { rerender } = renderWithI18n(
+    renderWithI18n(
       <FieldPopoverHeader field={field} closePopover={mockClose} onEditField={mockEditField} />
     );
     await userEvent.click(screen.getByTestId(`fieldPopoverHeader_editField-${fieldName}`));
     expect(mockClose).toHaveBeenCalled();
     expect(mockEditField).toHaveBeenCalledWith(fieldName);
+  });
 
-    // hidden
+  it('should correctly handle hidden edit-field action', async () => {
+    const mockClose = jest.fn();
+    const mockEditField = jest.fn();
+    const fieldName = 'extension';
+    const field = dataView.fields.find((f) => f.name === fieldName)!;
+
     jest.spyOn(field, 'isRuntimeField', 'get').mockImplementation(() => false);
     jest.spyOn(field, 'type', 'get').mockImplementation(() => 'unknown');
-    rerender(
+    renderWithI18n(
       <FieldPopoverHeader field={field} closePopover={mockClose} onEditField={mockEditField} />
     );
     expect(
@@ -151,16 +163,22 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
 
     // available
     jest.spyOn(field, 'isRuntimeField', 'get').mockImplementation(() => true);
-    const { rerender } = renderWithI18n(
+    renderWithI18n(
       <FieldPopoverHeader field={field} closePopover={mockClose} onDeleteField={mockDeleteField} />
     );
     await userEvent.click(screen.getByTestId(`fieldPopoverHeader_deleteField-${fieldName}`));
     expect(mockClose).toHaveBeenCalled();
     expect(mockDeleteField).toHaveBeenCalledWith(fieldName);
+  });
 
-    // hidden
+  it('should correctly handle hidden delete-field action', async () => {
+    const mockClose = jest.fn();
+    const mockDeleteField = jest.fn();
+    const fieldName = 'extension';
+    const field = dataView.fields.find((f) => f.name === fieldName)!;
+
     jest.spyOn(field, 'isRuntimeField', 'get').mockImplementation(() => false);
-    rerender(
+    renderWithI18n(
       <FieldPopoverHeader field={field} closePopover={mockClose} onDeleteField={mockDeleteField} />
     );
     expect(
@@ -177,12 +195,7 @@ describe('UnifiedFieldList <FieldPopoverHeader />', () => {
   });
 
   it('should handle getCustomFieldType', () => {
-    const mockGetCustomFieldType = jest.fn().mockImplementation((field) => {
-      if (field.name === 'extension') {
-        return 'custom';
-      }
-      return 'string';
-    });
+    const mockGetCustomFieldType = jest.fn().mockReturnValue('custom');
     const fieldName = 'extension';
     const field = dataView.fields.find((f) => f.name === fieldName)!;
     renderWithI18n(

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover_header.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover_header.tsx
@@ -18,10 +18,10 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { FieldDescription } from '@kbn/field-utils';
+import { FieldDescription, FieldIcon, getFieldIconProps } from '@kbn/field-utils';
 import type { DataViewField } from '@kbn/data-views-plugin/common';
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
-import type { AddFieldFilterHandler } from '../../types';
+import type { AddFieldFilterHandler, GetCustomFieldType } from '../../types';
 
 export interface FieldPopoverHeaderProps {
   field: DataViewField;
@@ -30,6 +30,7 @@ export interface FieldPopoverHeaderProps {
   buttonAddFilterProps?: Partial<EuiButtonIconProps>;
   buttonEditFieldProps?: Partial<EuiButtonIconProps>;
   buttonDeleteFieldProps?: Partial<EuiButtonIconProps>;
+  getCustomFieldType?: GetCustomFieldType<DataViewField>;
   onAddBreakdownField?: (field: DataViewField | undefined) => void;
   onAddFieldToWorkspace?: (field: DataViewField) => unknown;
   onAddFilter?: AddFieldFilterHandler;
@@ -47,6 +48,7 @@ export const FieldPopoverHeader: React.FC<FieldPopoverHeaderProps> = ({
   buttonAddFilterProps,
   buttonEditFieldProps,
   buttonDeleteFieldProps,
+  getCustomFieldType,
   onAddBreakdownField,
   onAddFieldToWorkspace,
   onAddFilter,
@@ -90,9 +92,16 @@ export const FieldPopoverHeader: React.FC<FieldPopoverHeaderProps> = ({
     }
   );
 
+  const iconProps = getCustomFieldType
+    ? { type: getCustomFieldType(field) }
+    : getFieldIconProps(field);
+
   return (
     <>
       <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <FieldIcon {...iconProps} />
+        </EuiFlexItem>
         <EuiFlexItem grow={true}>
           <EuiTitle size="xxs" data-test-subj="fieldPopoverHeader_fieldDisplayName">
             <h5 className="eui-textBreakWord">{field.displayName}</h5>

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover_header.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover_header.tsx
@@ -100,7 +100,7 @@ export const FieldPopoverHeader: React.FC<FieldPopoverHeaderProps> = ({
     <>
       <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
         <EuiFlexItem grow={false}>
-          <FieldIcon {...iconProps} />
+          <FieldIcon {...iconProps} data-test-subj={`fieldPopoverHeader_icon-${field.name}`} />
         </EuiFlexItem>
         <EuiFlexItem grow={true}>
           <EuiTitle size="xxs" data-test-subj="fieldPopoverHeader_fieldDisplayName">

--- a/x-pack/platform/plugins/shared/lens/public/datasources/common/field_item.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/common/field_item.tsx
@@ -131,6 +131,13 @@ export function InnerFieldItem(props: FieldItemProps) {
     setOpen(false);
   }, [setOpen]);
 
+  const adaptedGetCustomFieldType = useMemo(() => {
+    if (isTextBasedColumnField(field) && getCustomFieldType) {
+      return () => getCustomFieldType(field);
+    }
+    return undefined;
+  }, [field, getCustomFieldType]);
+
   const addFilterAndClose: AddFieldFilterHandler | undefined = useMemo(
     () =>
       filterManager && indexPattern
@@ -304,6 +311,7 @@ export function InnerFieldItem(props: FieldItemProps) {
               field={dataViewField}
               closePopover={closePopover}
               buttonAddFieldToWorkspaceProps={buttonAddFieldToWorkspaceProps}
+              getCustomFieldType={adaptedGetCustomFieldType}
               onAddFieldToWorkspace={onAddFieldToWorkspace}
               onAddFilter={addFilterAndClose}
               onEditField={editFieldAndClose}


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/233678

When clicking on a field from the field list in discover, the field type icon is changed to the drag icon correctly but we lose the information of the type in that state. In this pr we add the field type icon in the popover header to keep this information always available and visible.

<img width="720" height="354" alt="image" src="https://github.com/user-attachments/assets/91f1761a-40f4-44cd-b027-8857ad999b79" />

With the icon on the popover

<img width="675" height="405" alt="image" src="https://github.com/user-attachments/assets/15a0c002-db8d-46a1-8c5a-44e995e74a29" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



