### PR TITLE
[Defend Workflows] Add advanced options for ransomware diagnostics opt-out

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -437,6 +437,28 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     ),
   },
   {
+    key: 'mac.advanced.ransomware.diagnostic',
+    first_supported_version: '9.2.0',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.ransomware.diagnostic',
+      {
+        defaultMessage:
+          'Set this to false to disable diagnostic ransomware protection. Default: true.',
+      }
+    ),
+  },
+  {
+    key: 'mac.advanced.events.populate_file_data',
+    first_supported_version: '9.2.0',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.events.populate_file_data',
+      {
+        defaultMessage:
+          'Set this to false to disable collection of header bytes on file events. Default: true.',
+      }
+    ),
+  },
+  {
     key: 'mac.advanced.kernel.connect',
     first_supported_version: '7.9',
     documentation: i18n.translate(


### PR DESCRIPTION
## Summary

2 new advanced option is added to allow users to opt out from collecting ransomware diagnostics on Mac:
- `mac.advanced.ransomware.diagnostic`
- `mac.advanced.events.populate_file_data`

Screenshots:
<img width="815" height="115" alt="image" src="https://github.com/user-attachments/assets/f9eb5fc8-d36d-46a8-8906-d67c356fc888" />
<img width="793" height="123" alt="image" src="https://github.com/user-attachments/assets/af3b674c-d4f7-40d3-8971-f06ac34482e5" />

Excerpt from Agent policy when these options are set
<img width="633" height="39" alt="image" src="https://github.com/user-attachments/assets/22444682-6637-40f1-8c03-61ea2ed99ddf" />
<img width="620" height="154" alt="image" src="https://github.com/user-attachments/assets/6f7f3ce9-4211-4832-988d-ea3bfa2025c6" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
