### PR TITLE
[ES|QL] Lookup join - don't show save button if row has no values

### DIFF
--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.test.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.test.ts
@@ -45,7 +45,7 @@ describe('IndexUpdateService', () => {
       const query = await firstValueFrom(service.esqlQuery$);
 
       expect(query.toLowerCase()).toBe(
-        'from "my-index" metadata _id, _source | where qstr("*200*") | limit 1000 | sort @timestamp desc'
+        'from "my-index" metadata _id, _source | where qstr("*200* or 200") | limit 1000 | sort @timestamp desc'
       );
     });
 
@@ -55,7 +55,7 @@ describe('IndexUpdateService', () => {
 
       const query = await firstValueFrom(service.esqlDiscoverQuery$);
 
-      expect(query).toBe('FROM "logs-*" | WHERE QSTR("*ERROR*") | LIMIT 1000');
+      expect(query).toBe('FROM "logs-*" | WHERE QSTR("*ERROR* OR ERROR") | LIMIT 1000');
     });
   });
 

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.test.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.test.ts
@@ -60,14 +60,14 @@ describe('IndexUpdateService', () => {
   });
 
   describe('Unsaved changes', () => {
-    it('marks unsaved changes after adding a new row', async () => {
+    it('unsaved changes should be falseafter adding a new empty row', async () => {
       const initial = await firstValueFrom(service.hasUnsavedChanges$);
       expect(initial).toBe(false);
 
       service.addEmptyRow();
 
       const afterAdd = await firstValueFrom(service.hasUnsavedChanges$);
-      expect(afterAdd).toBe(true);
+      expect(afterAdd).toBe(false);
     });
 
     it('marks unsaved changes after updating a doc', async () => {

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.test.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.test.ts
@@ -60,7 +60,7 @@ describe('IndexUpdateService', () => {
   });
 
   describe('Unsaved changes', () => {
-    it('unsaved changes should be falseafter adding a new empty row', async () => {
+    it('unsaved changes should be false after adding a new empty row', async () => {
       const initial = await firstValueFrom(service.hasUnsavedChanges$);
       expect(initial).toBe(false);
 

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -254,7 +254,7 @@ export class IndexUpdateService {
       : esql`FROM ${indexName}`;
 
     if (qstr) {
-      query.pipe`WHERE qstr(${`*${qstr}*`})`;
+      query.pipe`WHERE qstr(${`*${qstr}* OR ${qstr}`})`;
     }
 
     query.pipe`LIMIT ${DOCS_PER_FETCH}`;

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -457,9 +457,13 @@ export class IndexUpdateService {
       this.bufferState$
         .pipe(
           map((actions) =>
-            actions.some((action) =>
-              (['add-doc', 'delete-doc'] as Array<keyof ActionMap>).includes(action.type)
-            )
+            actions.some((action) => {
+              if (action.type === 'add-doc') {
+                // Only consider rows with at least one value
+                return Object.keys(action.payload.value).length > 0;
+              }
+              return action.type === 'delete-doc';
+            })
           )
         )
         .subscribe(this._hasUnsavedChanges$)
@@ -554,7 +558,7 @@ export class IndexUpdateService {
                 this.destroy();
               }
             } else {
-              const errorDetail = response.items
+              const errorDetail = response?.items
                 .map((item) => Object.values(item)[0])
                 .filter((res) => res.error)
                 .map((res) => `- ${res.error?.type}: ${res.error?.reason}`)


### PR DESCRIPTION
## Summary
Don't display the save button anymore if the only change is an empty row, as we don't perform any api call to save it.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



