### PR TITLE
[CI] Increase `onechat` bundle limit

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -115,7 +115,7 @@ pageLoadAssetSize:
   observabilityLogsExplorer: 4918
   observabilityOnboarding: 12872
   observabilityShared: 82382
-  onechat: 14281
+  onechat: 15709
   osquery: 47588
   painlessLab: 6299
   presentationPanel: 11484


### PR DESCRIPTION
## Summary
It seems slow increments to the bundle size at `onechat` grew over the limits. This can be by having 2 PRs checked separately below limits, but when both in main, they overgrew the previous limits.

This PR sets limits to 15709

This was the straw that broke the camel's back: https://github.com/elastic/kibana/pull/235157 (https://buildkite.com/elastic/kibana-on-merge/builds/77176)