### PR TITLE
🌊 [Group streams] Pass timerange to linked Dashboard renderer

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/linked_dashboards_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/linked_dashboards_view.tsx
@@ -60,7 +60,15 @@ export function LinkedDashboardsView({ definition }: { definition: Streams.all.G
       <EuiSpacer size="xl" />
       {selectedDashboard && (
         <EuiPanel>
-          <DashboardRenderer savedObjectId={selectedDashboard} />
+          <DashboardRenderer
+            savedObjectId={selectedDashboard}
+            getCreationOptions={async () => ({
+              getInitialInput: () => ({
+                viewMode: 'view',
+                timeRange: { from: 'now-15m', to: 'now' },
+              }),
+            })}
+          />
         </EuiPanel>
       )}
     </>


### PR DESCRIPTION
This enables panels to use various time based features that were breaking. If we iterate further on this concept we should obviously add a time picker to the page, this is just a quick bandaid since users can still Open in Dashboards if they need the time picker.