### PR TITLE
[ML] Inference endpoints UI: Adds tech preview for rerank preconfig endpoint

### DIFF
--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
@@ -112,6 +112,14 @@ const inferenceEndpoints = [
       model_id: 'multilingual-embed-v1',
     },
   },
+  {
+    inference_id: '.rerank-v1-elastic',
+    task_type: 'rerank',
+    service: 'elastic',
+    service_settings: {
+      model_id: 'rerank-v1',
+    },
+  },
 ] as InferenceAPIConfigResponse[];
 
 jest.mock('../../hooks/use_delete_endpoint', () => ({
@@ -129,12 +137,13 @@ describe('When the tabular page is loaded', () => {
     expect(rows[2]).toHaveTextContent('.elser-2-elasticsearch');
     expect(rows[3]).toHaveTextContent('.multilingual-e5-small-elasticsearch');
     expect(rows[4]).toHaveTextContent('.multilingual-embed-v1-elastic');
-    expect(rows[5]).toHaveTextContent('.sparkles');
-    expect(rows[6]).toHaveTextContent('custom-inference-id');
-    expect(rows[7]).toHaveTextContent('elastic-rerank');
-    expect(rows[8]).toHaveTextContent('local-model');
-    expect(rows[9]).toHaveTextContent('my-elser-model-05');
-    expect(rows[10]).toHaveTextContent('third-party-model');
+    expect(rows[5]).toHaveTextContent('.rerank-v1-elastic');
+    expect(rows[6]).toHaveTextContent('.sparkles');
+    expect(rows[7]).toHaveTextContent('custom-inference-id');
+    expect(rows[8]).toHaveTextContent('elastic-rerank');
+    expect(rows[9]).toHaveTextContent('local-model');
+    expect(rows[10]).toHaveTextContent('my-elser-model-05');
+    expect(rows[11]).toHaveTextContent('third-party-model');
   });
 
   it('should display all service and model ids in the table', () => {
@@ -154,22 +163,25 @@ describe('When the tabular page is loaded', () => {
     expect(rows[4]).toHaveTextContent('multilingual-embed-v1');
 
     expect(rows[5]).toHaveTextContent('Elastic');
-    expect(rows[5]).toHaveTextContent('rainbow-sprinkles');
+    expect(rows[5]).toHaveTextContent('rerank-v1');
 
     expect(rows[6]).toHaveTextContent('Elastic');
-    expect(rows[6]).toHaveTextContent('elser_model_2');
+    expect(rows[6]).toHaveTextContent('rainbow-sprinkles');
 
-    expect(rows[7]).toHaveTextContent('Elasticsearch');
-    expect(rows[7]).toHaveTextContent('.rerank-v1');
+    expect(rows[7]).toHaveTextContent('Elastic');
+    expect(rows[7]).toHaveTextContent('elser_model_2');
 
     expect(rows[8]).toHaveTextContent('Elasticsearch');
-    expect(rows[8]).toHaveTextContent('.own_model');
+    expect(rows[8]).toHaveTextContent('.rerank-v1');
 
     expect(rows[9]).toHaveTextContent('Elasticsearch');
-    expect(rows[9]).toHaveTextContent('.elser_model_2');
+    expect(rows[9]).toHaveTextContent('.own_model');
 
-    expect(rows[10]).toHaveTextContent('OpenAI');
-    expect(rows[10]).toHaveTextContent('.own_model');
+    expect(rows[10]).toHaveTextContent('Elasticsearch');
+    expect(rows[10]).toHaveTextContent('.elser_model_2');
+
+    expect(rows[11]).toHaveTextContent('OpenAI');
+    expect(rows[11]).toHaveTextContent('.own_model');
   });
 
   it('should only disable delete action for preconfigured endpoints', () => {
@@ -188,7 +200,7 @@ describe('When the tabular page is loaded', () => {
     render(<TabularPage inferenceEndpoints={inferenceEndpoints} />);
 
     act(() => {
-      screen.getAllByTestId('euiCollapsedItemActionsButton')[5].click();
+      screen.getAllByTestId('euiCollapsedItemActionsButton')[6].click();
     });
 
     const deleteAction = screen.getByTestId(/inferenceUIDeleteAction/);
@@ -207,14 +219,15 @@ describe('When the tabular page is loaded', () => {
     expect(rows[3]).toHaveTextContent(preconfigured);
     expect(rows[4]).toHaveTextContent(preconfigured);
     expect(rows[5]).toHaveTextContent(preconfigured);
-    expect(rows[6]).not.toHaveTextContent(preconfigured);
+    expect(rows[6]).toHaveTextContent(preconfigured);
     expect(rows[7]).not.toHaveTextContent(preconfigured);
     expect(rows[8]).not.toHaveTextContent(preconfigured);
     expect(rows[9]).not.toHaveTextContent(preconfigured);
     expect(rows[10]).not.toHaveTextContent(preconfigured);
+    expect(rows[11]).not.toHaveTextContent(preconfigured);
   });
 
-  it('should show tech preview badge only for reranker-v1 model, rainbow-sprinkles, multilingual-embed-v1, and preconfigured elser_model_2', () => {
+  it('should show tech preview badge only for reranker-v1 model, rainbow-sprinkles, multilingual-embed-v1, rerank-v1, and preconfigured elser_model_2', () => {
     render(<TabularPage inferenceEndpoints={inferenceEndpoints} />);
 
     const techPreview = 'TECH PREVIEW';
@@ -225,10 +238,11 @@ describe('When the tabular page is loaded', () => {
     expect(rows[3]).not.toHaveTextContent(techPreview);
     expect(rows[4]).toHaveTextContent(techPreview);
     expect(rows[5]).toHaveTextContent(techPreview);
-    expect(rows[6]).not.toHaveTextContent(techPreview);
-    expect(rows[7]).toHaveTextContent(techPreview);
-    expect(rows[8]).not.toHaveTextContent(techPreview);
+    expect(rows[6]).toHaveTextContent(techPreview);
+    expect(rows[7]).not.toHaveTextContent(techPreview);
+    expect(rows[8]).toHaveTextContent(techPreview);
     expect(rows[9]).not.toHaveTextContent(techPreview);
     expect(rows[10]).not.toHaveTextContent(techPreview);
+    expect(rows[11]).not.toHaveTextContent(techPreview);
   });
 });

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/reranker_helper.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/reranker_helper.ts
@@ -31,7 +31,7 @@ export const isProviderTechPreview = (provider: InferenceInferenceEndpointInfo) 
     (modelId === 'elser_model_2' &&
       inferenceId.startsWith('.') &&
       service === ServiceProviderKeys.elastic) ||
-    (modelId === 'multilingual-embed-v1' &&
+    ((modelId === 'multilingual-embed-v1' || modelId === 'rerank-v1') &&
       inferenceId.startsWith('.') &&
       service === ServiceProviderKeys.elastic)
   ) {


### PR DESCRIPTION
## Summary

Related issue: https://github.com/elastic/search-team/issues/10982

Ensures Tech Preview badge is shown for the default inference endpoint.

<img width="1741" height="703" alt="image" src="https://github.com/user-attachments/assets/76bacfd2-b3f6-4113-8f25-d2766807b63c" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


