### PR TITLE
[Discover] Fix issue with actions column header size

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/custom_control_columns/actions_column/actions_header.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/custom_control_columns/actions_column/actions_header.tsx
@@ -7,21 +7,28 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useLayoutEffect, useRef, useState } from 'react';
-import { EuiIconTip, EuiScreenReaderOnly } from '@elastic/eui';
+import React, { useCallback, useState } from 'react';
+import {
+  type EuiResizeObserverProps,
+  EuiIconTip,
+  EuiResizeObserver,
+  EuiScreenReaderOnly,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import ColumnHeaderTruncateContainer from '../../column_header_truncate_container';
 
 export const ActionsHeader = ({ maxWidth }: { maxWidth: number }) => {
-  const textRef = useRef<HTMLSpanElement>(null);
   const [showText, setShowText] = useState(false);
 
-  useLayoutEffect(() => {
-    if (!textRef.current) return;
-    const textWidth = textRef.current.getBoundingClientRect().width;
-    setShowText(textWidth < maxWidth);
-  }, [textRef, maxWidth, setShowText]);
+  const measure: EuiResizeObserverProps['onResize'] = useCallback(
+    (dimensions) => {
+      if (!dimensions) return;
+
+      setShowText(dimensions.width < maxWidth);
+    },
+    [maxWidth]
+  );
 
   const actionsText = i18n.translate('unifiedDataTable.controlColumnsActionHeader', {
     defaultMessage: 'Actions',
@@ -40,25 +47,26 @@ export const ActionsHeader = ({ maxWidth }: { maxWidth: number }) => {
         <span data-test-subj="unifiedDataTable_actionsColumnHeaderText">{actionsText}</span>
       ) : (
         <EuiIconTip
-          iconProps={{
-            'data-test-subj': 'unifiedDataTable_actionsColumnHeaderIcon',
-          }}
+          iconProps={{ 'data-test-subj': 'unifiedDataTable_actionsColumnHeaderIcon' }}
           type="info"
           content={actionsText}
         />
       )}
-      {/* Hidden measurement span */}
-      <span
-        ref={textRef}
-        css={css`
-          position: absolute;
-          visibility: hidden;
-          white-space: nowrap;
-          pointer-events: none;
-        `}
-      >
-        {actionsText}
-      </span>
+      <EuiResizeObserver onResize={measure}>
+        {(resizeRef) => (
+          <span
+            ref={resizeRef}
+            css={css`
+              position: absolute;
+              visibility: hidden;
+              white-space: nowrap;
+              pointer-events: none;
+            `}
+          >
+            {actionsText}
+          </span>
+        )}
+      </EuiResizeObserver>
     </ColumnHeaderTruncateContainer>
   );
 };


### PR DESCRIPTION
## Summary

This PR fixes the bug with showing "Actions" header column name even if there was no space and info icon would fit better.
It uses the EuiResizeObserver to get the dimentions of the action column and decide if we should show icon or full text.
Resolves: #234647

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->