### PR TITLE
[Agent Builder] Filters - Don't reorder selected filter options

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/tools_search_controls.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/tools_search_controls.tsx
@@ -59,6 +59,7 @@ export const ToolsSearchControls: React.FC<ToolsSearchControlsProps> = ({
             view: <FilterOptionWithMatchesBadge name={tag} matches={matchesByTag[tag] ?? 0} />,
           })),
           searchThreshold: 1,
+          autoSortOptions: false,
         },
       ],
       onChange: ({ queryText, error: searchError }: EuiSearchBarOnChangeArgs) => {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/list/agents_list.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/list/agents_list.tsx
@@ -207,6 +207,7 @@ export const AgentsList: React.FC = () => {
             options: labelOptions,
             field: 'labels',
             operator: 'exact',
+            autoSortOptions: false,
           },
         ],
       }}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/table/tools_table_search.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/table/tools_table_search.tsx
@@ -48,6 +48,7 @@ const getToolsTableSearchConfig = ({
         name: tag,
         view: <FilterOptionWithMatchesBadge name={tag} matches={matchesByTag[tag] ?? 0} />,
       })),
+      autoSortOptions: false,
       searchThreshold: 1,
     },
   ],


### PR DESCRIPTION
## Summary

Noted by @jeffvestal 

#### Current behavior
https://github.com/user-attachments/assets/bc14cab8-cd98-4782-9336-c50b0dc2c4b2

#### Desired
The options should not reorder when selected

https://github.com/user-attachments/assets/da14248d-9b5f-479b-81b6-fb16e7618c86



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


