### PR TITLE
[CI] Fix missing `kbn-monaco` dep setup

### DIFF
--- a/src/platform/packages/private/kbn-ui-shared-deps-src/moon.yml
+++ b/src/platform/packages/private/kbn-ui-shared-deps-src/moon.yml
@@ -36,7 +36,6 @@ tasks:
     inputs:
       - '@group(src)'
       - 'webpack.config.js'
-      - '@group(src)'
       - '/src/platform/packages/shared/kbn-repo-info/**/*.{js,ts,tsx}'
       - '/src/platform/packages/shared/kbn-ui-theme/**/*.{js,ts,tsx}'
       - '/src/platform/packages/shared/kbn-i18n/**/*.{js,ts,tsx}'

--- a/src/platform/packages/shared/kbn-monaco/moon.yml
+++ b/src/platform/packages/shared/kbn-monaco/moon.yml
@@ -26,10 +26,15 @@ tasks:
   build-webpack:
     command: yarn
     args:
-      - 'build'
+      - build
     inputs:
       - '@group(src)'
-      - 'webpack.config.js'
+      - webpack.config.js
+      - /src/platform/packages/shared/kbn-esql-ast/**/*.{js,ts,tsx}
+      - /src/platform/packages/shared/kbn-esql-types/**/*.{js,ts,tsx}
+      - /src/platform/packages/shared/kbn-esql-validation-autocomplete/**/*.{js,ts,tsx}
+      - /src/platform/packages/shared/kbn-i18n/**/*.{js,ts,tsx}
+      - /src/platform/packages/shared/kbn-repo-info/**/*.{js,ts,tsx}
     outputs:
       - /target/build/src/platform/packages/shared/kbn-monaco
   watch-webpack:
@@ -39,6 +44,6 @@ tasks:
     command: yarn
     args:
       - build
-      - --watch
+      - '--watch'
     outputs:
       - /target/build/src/platform/packages/shared/kbn-monaco


### PR DESCRIPTION
## Summary
Similar to https://github.com/elastic/kibana/pull/234593 this PR adds dependency setup manually to `@kbn/monaco` to avoid bad cache getting stuck.

(also removes a duplication)

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->