### PR TITLE
Remove inline function call

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details_contextual_insights.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details_contextual_insights.tsx
@@ -86,7 +86,7 @@ export function AlertDetailContextualInsights({ alert }: { alert: AlertData | nu
     }
   }, [alert, http, observabilityAIAssistant]);
 
-  if (!ObservabilityAIAssistantContextualInsight || !getAlertContextMessages()) {
+  if (!ObservabilityAIAssistantContextualInsight) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

We [made this change](https://github.com/elastic/kibana/pull/195208) to prevent a layout bug with the contextual insight component that writes an empty div even when there are no messages to write. But this solution results in over-calling this expensive function. This PR rolls that back to avoid OOM errors.

We can find a different way to fix the layout bug.

## To reproduce

* Make sure you have an AI connector enabled for your local setup
* Create a custom threshold rule that will fire
* Go to the alert details page for this alert
* Notice the network panel shows 3 calls to the `alert_details_contextual_insights` endpoint, without any interaction with the "Contextual insights" accordion panel

### Before 

<img width="1072" height="897" alt="Screenshot 2025-09-16 at 1 19 13 PM" src="https://github.com/user-attachments/assets/4bb5a89e-83b6-42da-a5cd-9163c2a97b50" />

### After

In this branch, you will see no calls to that same endpoint unless the panel is opened.

<img width="1080" height="901" alt="Screenshot 2025-09-16 at 1 19 38 PM" src="https://github.com/user-attachments/assets/258a9673-de7f-4813-ba20-76422d6e9136" />



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->