### PR TITLE
[Agent Builder] Fix alert firing on query param change

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form.tsx
@@ -202,6 +202,7 @@ export const AgentForm: React.FC<AgentFormProps> = ({ editingAgentId, onDelete }
     http,
     navigateToUrl,
     openConfirm,
+    shouldPromptOnReplace: false,
   });
 
   const agentTools = watch('configuration.tools');
@@ -345,6 +346,7 @@ export const AgentForm: React.FC<AgentFormProps> = ({ editingAgentId, onDelete }
   if (error) {
     return (
       <EuiCallOut
+        announceOnMount
         title={i18n.translate('xpack.onechat.agents.errorTitle', {
           defaultMessage: 'Error loading agent',
         })}
@@ -532,10 +534,14 @@ export const AgentForm: React.FC<AgentFormProps> = ({ editingAgentId, onDelete }
       >
         <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty size="s" iconType="cross" color="text" onClick={handleCancel}>
-              {i18n.translate('xpack.onechat.agents.cancelButtonLabel', {
-                defaultMessage: 'Cancel',
-              })}
+            <EuiButtonEmpty
+              aria-label={labels.agents.settings.cancelButtonLabel}
+              size="s"
+              iconType="cross"
+              color="text"
+              onClick={handleCancel}
+            >
+              {labels.agents.settings.cancelButtonLabel}
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>{renderChatButton()}</EuiFlexItem>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
@@ -290,6 +290,7 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
     http,
     navigateToUrl,
     openConfirm,
+    shouldPromptOnReplace: false,
   });
 
   return (
@@ -368,7 +369,13 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
           <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
             {mode !== ToolFormMode.View && (
               <EuiFlexItem grow={false}>
-                <EuiButtonEmpty size="s" iconType="cross" color="text" onClick={handleCancel}>
+                <EuiButtonEmpty
+                  aria-label={labels.tools.cancelButtonLabel}
+                  size="s"
+                  iconType="cross"
+                  color="text"
+                  onClick={handleCancel}
+                >
                   {labels.tools.cancelButtonLabel}
                 </EuiButtonEmpty>
               </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/onechat/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/utils/i18n.ts
@@ -232,6 +232,9 @@ export const labels = {
       optionalLabel: i18n.translate('xpack.onechat.agents.form.settings.optionalLabel', {
         defaultMessage: 'Optional',
       }),
+      cancelButtonLabel: i18n.translate('xpack.onechat.agents.form.settings.cancelButtonLabel', {
+        defaultMessage: 'Cancel',
+      }),
     },
   },
   management: {


### PR DESCRIPTION
## Summary

Quick fix to resolve an issue where changing query params — like when changing between index search and ES|QL tool types — would cause the unsaved changes alert to fire.

Also resolved some trivial ESLint warnings related to a11y.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

