### PR TITLE
Adds support for more dimension types in the metrics experience

### DIFF
--- a/src/platform/plugins/shared/metrics_experience/common/fields/constants.ts
+++ b/src/platform/plugins/shared/metrics_experience/common/fields/constants.ts
@@ -21,3 +21,16 @@ export const NUMERIC_TYPES = [
   ES_FIELD_TYPES.UNSIGNED_LONG,
   ES_FIELD_TYPES.HISTOGRAM,
 ];
+
+// For the dimensions, the field MUST have `time_series_dimension` attribute set
+// in the mappings and it can only be the following types:
+export const DIMENSION_TYPES = [
+  ES_FIELD_TYPES.KEYWORD,
+  ES_FIELD_TYPES.IP,
+  ES_FIELD_TYPES.BOOLEAN,
+  ES_FIELD_TYPES.LONG,
+  ES_FIELD_TYPES.INTEGER,
+  ES_FIELD_TYPES.SHORT,
+  ES_FIELD_TYPES.BYTE,
+  ES_FIELD_TYPES.UNSIGNED_LONG,
+];

--- a/src/platform/plugins/shared/metrics_experience/server/lib/dimensions/extract_dimensions.test.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/lib/dimensions/extract_dimensions.test.ts
@@ -51,6 +51,14 @@ describe('extractDimensions', () => {
         time_series_dimension: false,
       },
     },
+    'host.ip': {
+      ip: {
+        aggregatable: true,
+        searchable: true,
+        type: 'ip',
+        time_series_dimension: true,
+      },
+    },
     _metric_names_hash: {
       keyword: {
         aggregatable: true,
@@ -84,6 +92,11 @@ describe('extractDimensions', () => {
         name: 'service.name',
         type: 'keyword',
         description: 'The service name',
+      },
+      {
+        name: 'host.ip',
+        type: 'ip',
+        description: undefined,
       },
     ]);
   });

--- a/src/platform/plugins/shared/metrics_experience/server/lib/fields/retrieve_fieldcaps.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/lib/fields/retrieve_fieldcaps.ts
@@ -9,9 +9,8 @@
 
 import type { FieldCapsFieldCapability, Fields } from '@elastic/elasticsearch/lib/api/types';
 import { type ElasticsearchClient } from '@kbn/core/server';
-import { ES_FIELD_TYPES } from '@kbn/field-types';
 import { dateRangeQuery } from '@kbn/es-query';
-import { NUMERIC_TYPES } from '../../../common/fields/constants';
+import { DIMENSION_TYPES, NUMERIC_TYPES } from '../../../common/fields/constants';
 
 export async function retrieveFieldCaps({
   esClient,
@@ -44,6 +43,8 @@ export async function retrieveFieldCaps({
     return dataStreamFieldCapsMap;
   }
 
+  const uniqueFieldTypes = new Set([...NUMERIC_TYPES, ...DIMENSION_TYPES]);
+
   // Call field caps in parallel for each data stream
   const fieldCapsPromises = dataStreams.map(async (dataStream) => {
     const fieldCaps = await esClient.fieldCaps({
@@ -51,7 +52,7 @@ export async function retrieveFieldCaps({
       fields,
       include_unmapped: false,
       index_filter: dateRangeQuery(from, to)[0],
-      types: [...NUMERIC_TYPES, ES_FIELD_TYPES.KEYWORD],
+      types: [...uniqueFieldTypes],
     });
 
     dataStreamFieldCapsMap.set(dataStream.name, fieldCaps.fields);


### PR DESCRIPTION
## 🍒 Summary

Adds support for more dimension types in the metrics experience.

## 🛠️ Changes

- Exports a new `DIMENSION_TYPES` constant to define additional valid field types for dimensions.
- Updates the `retrieveFieldCaps` function to include these new dimension types in its query.
- Adds a test case to ensure that IP fields are correctly extracted as dimensions.

Fixes #233140

<img width="1095" height="575" alt="image" src="https://github.com/user-attachments/assets/c8061878-7b75-4a90-bc50-4a2c7bbf74d3" />


