### PR TITLE
Add postProcess option to generateOpenApiDocument

### DIFF
--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.ts
@@ -42,6 +42,11 @@ export interface GenerateOpenApiDocumentOptions {
   tags?: string[];
   env?: Env;
   filters?: GenerateOpenApiDocumentOptionsFilters;
+  /**
+   * Optional handler to post-process the generated OpenAPI document before returning.
+   * Receives the OAS document and should return the modified document.
+   */
+  postProcess?: (oas: OpenAPIV3.Document) => OpenAPIV3.Document | Promise<OpenAPIV3.Document>;
 }
 
 export const generateOpenApiDocument = async (
@@ -77,7 +82,7 @@ export const generateOpenApiDocument = async (
     Object.assign(paths, result.paths);
   }
   const tags = buildGlobalTags(paths, opts.tags);
-  return {
+  let oas: OpenAPIV3.Document = {
     openapi: openApiVersion,
     info: {
       title: opts.title,
@@ -108,4 +113,10 @@ export const generateOpenApiDocument = async (
     tags,
     externalDocs: opts.docsUrl ? { url: opts.docsUrl } : undefined,
   };
+
+  if (opts.postProcess) {
+    oas = await opts.postProcess(oas);
+  }
+
+  return oas;
 };


### PR DESCRIPTION
Closes #233797

## Summary

This PR introduces a mechanism to allow custom sorting and post-processing of OAS properties generated from the router. The primary motivation is to give consumers control over the order and transformations applied to fields in the generated OpenAPI Specification (OAS), improving the readability and usability of the API documentation.

### Key Changes

- Adds a post-processing hook.
- Allows extension points for custom property ordering and transformations on the final OAS output.
- Includes examples in tests on ordering logic.

### Motivation

Currently, OAS properties are emitted in the order returned by `joi-to-json`, with no built-in way for custom sorting. This PR addresses the need for user-defined property order and additional OAS output adjustments.
---

Please let me know if further changes are required!

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.