### PR TITLE
[Security Solution] remove code that prevented having multiple identical adhoc dataviews

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/slices.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/slices.test.ts
@@ -7,10 +7,10 @@
 
 import type { DataView } from '@kbn/data-views-plugin/common';
 import {
-  sharedDataViewManagerSlice,
   createDataViewSelectionSlice,
-  initialSharedState,
   initialScopeState,
+  initialSharedState,
+  sharedDataViewManagerSlice,
 } from './slices';
 import { selectDataViewAsync } from './actions';
 import { DataViewManagerScopeName } from '../constants';
@@ -77,24 +77,6 @@ describe('slices', () => {
 
         expect(state.adhocDataViews).toHaveLength(1);
         expect(state.adhocDataViews[0]).toEqual({ title: 'new ad hoc view' });
-      });
-
-      it('should not add a duplicate ad hoc data view', () => {
-        const initialState = {
-          ...initialSharedState,
-          adhocDataViews: [{ title: 'test ad hoc view' }],
-        };
-
-        const duplicateDataView = {
-          title: 'test ad hoc view',
-          isPersisted: () => false,
-          toSpec: () => ({ title: 'test ad hoc view' }),
-        } as unknown as DataView;
-
-        const state = reducer(initialState, actions.addDataView(duplicateDataView));
-
-        expect(state.adhocDataViews).toHaveLength(1);
-        expect(state.adhocDataViews[0]).toEqual({ title: 'test ad hoc view' });
       });
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/slices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/slices.ts
@@ -7,7 +7,7 @@
 
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import type { DataViewSpec, DataView } from '@kbn/data-views-plugin/common';
+import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
 import type { DataViewManagerScopeName } from '../constants';
 import { SLICE_PREFIX } from '../constants';
 import type {
@@ -59,10 +59,6 @@ export const sharedDataViewManagerSlice = createSlice({
 
         state.dataViews.push(dataViewSpec);
       } else {
-        if (state.adhocDataViews.find((dv) => dv.title === dataViewSpec.title)) {
-          return;
-        }
-
         state.adhocDataViews.push(dataViewSpec);
       }
     },


### PR DESCRIPTION
## Summary

This PR removes a small piece of logic that prevented users to created multiple ad-hoc dataViews with the same list of indices. Dataviews with the same list of indices can still have a different set of runtime fields, hence removing this limitation.

The code modified has actually not being deployed to production yet as it's hidden behind the `newDataViewPickerEnabled` feature flag.

### How to test

- turn on `newDataViewPickerEnabled` feature flag
- duplicate an existing dataView and create without saving
- duplicate the same dataView a second time, also without saving

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/235189