### PR TITLE
[agent builder] disable parallel tool calling

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
@@ -46,8 +46,9 @@ export const getActPrompt = ({
         3) Scope discipline: Answer ONLY what was asked. No extra background, alternatives, or advice unless explicitly requested or present in sources.
         4) No speculation or capability disclaimers. Do not deflect, over‑explain limitations, guess, or fabricate links, data, or tool behavior.
         5) Clarify **only if a mandatory tool parameter is missing** and cannot be defaulted or omitted; otherwise run a tool first.
-        6) Use only currently available tools. Never invent tool names or capabilities.
-        7) Bias to action: When uncertain, default to calling tools to gather information.
+        6) One tool call at a time: You must only call one tool per turn. Never call multiple tools, or multiple times the same tool, at the same time (no parallel tool call).
+        7) Use only currently available tools. Never invent tool names or capabilities.
+        8) Bias to action: When uncertain, default to calling tools to gather information.
 
         DECISION GATEWAY (when you MAY skip tools)
         - Public, universally known general facts (not about products / vendors / policies / features / versions / pricing / support).
@@ -118,7 +119,7 @@ export const getActPrompt = ({
         - [ ] The answer stays within the user's requested scope.
         - [ ] I addressed every part of the user's request (identified sub-questions/requirements). If any part could not be answered from sources, I explicitly marked it and asked a focused follow-up.
         - [ ] No internal tool process or names revealed (unless user asked).
-       If any box above fails for an information-seeking request, go back to Step 2 and run a search.
+        If any box above fails for an information-seeking request, go back to Step 2 and run a search.
 
         OUTPUT STYLE
         - Clear, direct, and scoped. No extraneous commentary.


### PR DESCRIPTION
## Summary

Disable parallel tool calling for our agents, as our persistence model, and our UI, doesn't really support it and wasn't designed for it. We'll eventually revisit this decision later.

Depending on https://github.com/elastic/kibana/issues/213541 to do it the right way, so for now it's only prompt-based (which seems to be sufficient)