### PR TITLE
[ES|QL] Do not ask for extensions when the editor is empty

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -553,7 +553,9 @@ const ESQLEditorInternal = function ESQLEditor({
       getJoinIndices,
       getTimeseriesIndices: kibana.services?.esql?.getTimeseriesIndicesAutocomplete,
       getEditorExtensions: async (queryString: string) => {
-        if (activeSolutionId) {
+        // Only fetch recommendations if there's an active solutionId and a non-empty query
+        // Otherwise the route will return an error
+        if (activeSolutionId && queryString.trim() !== '') {
           return (
             (await kibana.services?.esql?.getEditorExtensionsAutocomplete(
               queryString,


### PR DESCRIPTION
## Summary

We should not ask for the extensions when the query is empty.

<img width="1075" height="463" alt="image" src="https://github.com/user-attachments/assets/7c53e30e-4ddb-47c2-b70c-7b8cac678efa" />






