### PR TITLE
[9.1] [Security Solution] Fix matches being included for fields that do not support it (#233127)

### DIFF
--- a/x-pack/solutions/security/packages/kbn-securitysolution-list-utils/src/autocomplete_operators/index.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-list-utils/src/autocomplete_operators/index.ts
@@ -141,6 +141,10 @@ export const ALL_OPERATORS: OperatorOption[] = [
   doesNotMatchOperator,
 ];
 
+export const ALL_OPERATORS_SANS_MATCHES: OperatorOption[] = ALL_OPERATORS.filter(
+  (operator) => operator !== matchesOperator && operator !== doesNotMatchOperator
+);
+
 export const EXCEPTION_OPERATORS_SANS_LISTS: OperatorOption[] = [
   isOperator,
   isNotOperator,

--- a/x-pack/solutions/security/packages/kbn-securitysolution-list-utils/src/helpers/index.test.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-list-utils/src/helpers/index.test.ts
@@ -16,7 +16,6 @@ import {
   ALL_OPERATORS,
   ALL_OPERATORS_SANS_MATCHES,
   DETECTION_ENGINE_EXCEPTION_OPERATORS,
-  EXCEPTION_OPERATORS_SANS_LISTS,
   doesNotExistOperator,
   doesNotMatchOperator,
   existsOperator,
@@ -469,33 +468,6 @@ describe('Helpers', () => {
         true
       );
       expect(result).toEqual([isOperator, isNotOperator, existsOperator, doesNotExistOperator]);
-    });
-
-    it('returns EXCEPTION_OPERATORS_SANS_LISTS if value lists disabled, it should include value list operators and field supports matches', () => {
-      const result = getOperatorOptions(
-        getItem({ field: fieldSupportMatches }),
-        'endpoint_trusted_devices',
-        false,
-        false
-      );
-      expect(result).toEqual(EXCEPTION_OPERATORS_SANS_LISTS);
-    });
-
-    it('returns basic operators if value lists disabled and field does not support matches', () => {
-      const result = getOperatorOptions(
-        getItem({ field: fieldNotSupportMatches }),
-        'endpoint_trusted_devices',
-        false,
-        false
-      );
-      expect(result).toEqual([
-        isOperator,
-        isNotOperator,
-        isOneOfOperator,
-        isNotOneOfOperator,
-        existsOperator,
-        doesNotExistOperator,
-      ]);
     });
 
     it('returns DETECTION_ENGINE_EXCEPTION_OPERATORS if detection list, it should include value list operators, and supports matches', () => {

--- a/x-pack/solutions/security/packages/kbn-securitysolution-list-utils/src/helpers/index.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-list-utils/src/helpers/index.ts
@@ -53,6 +53,7 @@ import {
   isNotInListOperator,
   matchesOperator,
   doesNotMatchOperator,
+  ALL_OPERATORS_SANS_MATCHES,
 } from '../autocomplete_operators';
 
 import {
@@ -725,8 +726,9 @@ export const getOperatorOptions = (
           doesNotExistOperator,
         ];
   } else {
+    const supportMatches = fieldSupportsMatches(item.field);
     return listType === 'detection'
-      ? fieldSupportsMatches(item.field)
+      ? supportMatches
         ? DETECTION_ENGINE_EXCEPTION_OPERATORS
         : [
             isOperator,
@@ -738,7 +740,9 @@ export const getOperatorOptions = (
             isInListOperator,
             isNotInListOperator,
           ]
-      : ALL_OPERATORS;
+      : supportMatches
+      ? ALL_OPERATORS
+      : ALL_OPERATORS_SANS_MATCHES;
   }
 };
 

--- a/x-pack/solutions/security/plugins/lists/public/exceptions/components/builder/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/lists/public/exceptions/components/builder/helpers.test.ts
@@ -15,10 +15,7 @@ import {
   ListOperatorTypeEnum as OperatorTypeEnum,
 } from '@kbn/securitysolution-io-ts-list-types';
 import {
-  ALL_OPERATORS,
   BuilderEntry,
-  DETECTION_ENGINE_EXCEPTION_OPERATORS,
-  EXCEPTION_OPERATORS_SANS_LISTS,
   EmptyEntry,
   ExceptionsBuilderExceptionItem,
   ExceptionsBuilderReturnExceptionItem,

--- a/x-pack/solutions/security/plugins/lists/public/exceptions/components/builder/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/lists/public/exceptions/components/builder/helpers.test.ts
@@ -25,7 +25,6 @@ import {
   FormattedBuilderEntry,
   OperatorOption,
   doesNotExistOperator,
-  doesNotMatchOperator,
   existsOperator,
   filterExceptionItems,
   getCorrespondingKeywordField,
@@ -41,7 +40,6 @@ import {
   getFormattedBuilderEntries,
   getFormattedBuilderEntry,
   getNewExceptionItem,
-  getOperatorOptions,
   getOperatorType,
   getUpdatedEntriesOnDelete,
   isEntryNested,
@@ -51,7 +49,6 @@ import {
   isNotOperator,
   isOneOfOperator,
   isOperator,
-  matchesOperator,
 } from '@kbn/securitysolution-list-utils';
 import { DataViewBase, DataViewFieldBase } from '@kbn/es-query';
 import { fields, getField } from '@kbn/data-plugin/common/mocks';
@@ -492,148 +489,6 @@ describe('Exception builder helpers', () => {
         operator: OperatorEnum.INCLUDED,
         type: 'list',
       };
-      expect(output).toEqual(expected);
-    });
-  });
-
-  describe('#getOperatorOptions', () => {
-    test('it returns "isOperator" when field type is nested but field itself has not yet been selected', () => {
-      const payloadItem: FormattedBuilderEntry = getMockNestedParentBuilderEntry();
-      const output = getOperatorOptions(payloadItem, 'endpoint', false);
-      const expected: OperatorOption[] = [isOperator];
-      expect(output).toEqual(expected);
-    });
-
-    test('it returns "isOperator" if no field selected', () => {
-      const payloadItem: FormattedBuilderEntry = { ...getMockBuilderEntry(), field: undefined };
-      const output = getOperatorOptions(payloadItem, 'endpoint', false);
-      const expected: OperatorOption[] = [isOperator];
-      expect(output).toEqual(expected);
-    });
-
-    describe('"endpoint" list type', () => {
-      test('it returns operators "is", "isOneOf", "matches" and "doesNotMatch" if item is nested and field supports "matches"', () => {
-        const payloadItem: FormattedBuilderEntry = getMockNestedBuilderEntry();
-        const output = getOperatorOptions(payloadItem, 'endpoint', false);
-        const expected: OperatorOption[] = [
-          isOperator,
-          isOneOfOperator,
-          matchesOperator,
-          doesNotMatchOperator,
-        ];
-        expect(output).toEqual(expected);
-      });
-
-      test('it returns operators "is" and "isOneOf" if item is nested and field does not support "matches"', () => {
-        const payloadItem: FormattedBuilderEntry = {
-          ...getMockNestedBuilderEntry(),
-          field: getField('ip'),
-        };
-        const output = getOperatorOptions(payloadItem, 'endpoint', false);
-        const expected: OperatorOption[] = [isOperator, isOneOfOperator];
-        expect(output).toEqual(expected);
-      });
-
-      test('it returns operators "is", "isOneOf", "matches" and "doesNotMatch" if field supports "matches"', () => {
-        const payloadItem: FormattedBuilderEntry = {
-          ...getMockBuilderEntry(),
-          field: getField('@tags'),
-        };
-        const output = getOperatorOptions(payloadItem, 'endpoint', false);
-        const expected: OperatorOption[] = [
-          isOperator,
-          isOneOfOperator,
-          matchesOperator,
-          doesNotMatchOperator,
-        ];
-        expect(output).toEqual(expected);
-      });
-
-      test('it returns "isOperator" and "isOneOfOperator" if field does not support "matches"', () => {
-        const payloadItem: FormattedBuilderEntry = getMockBuilderEntry();
-        const output = getOperatorOptions(payloadItem, 'endpoint', false);
-        const expected: OperatorOption[] = [isOperator, isOneOfOperator];
-        expect(output).toEqual(expected);
-      });
-
-      test('it returns "isOperator" and field type is boolean', () => {
-        const payloadItem: FormattedBuilderEntry = getMockBuilderEntry();
-        const output = getOperatorOptions(payloadItem, 'endpoint', true);
-        const expected: OperatorOption[] = [isOperator];
-        expect(output).toEqual(expected);
-      });
-    });
-
-    test('it returns "isOperator", "isOneOfOperator", and "existsOperator" if item is nested and "listType" is "detection"', () => {
-      const payloadItem: FormattedBuilderEntry = getMockNestedBuilderEntry();
-      const output = getOperatorOptions(payloadItem, 'detection', false);
-      const expected: OperatorOption[] = [isOperator, isOneOfOperator, existsOperator];
-      expect(output).toEqual(expected);
-    });
-
-    test('it returns "isOperator" and "existsOperator" if item is nested, "listType" is "detection", and field type is boolean', () => {
-      const payloadItem: FormattedBuilderEntry = getMockNestedBuilderEntry();
-      const output = getOperatorOptions(payloadItem, 'detection', true);
-      const expected: OperatorOption[] = [isOperator, existsOperator];
-      expect(output).toEqual(expected);
-    });
-
-    test('it returns "isOperator", "isNotOperator", "doesNotExistOperator" and "existsOperator" if field type is boolean', () => {
-      const payloadItem: FormattedBuilderEntry = getMockBuilderEntry();
-      const output = getOperatorOptions(payloadItem, 'detection', true);
-      const expected: OperatorOption[] = [
-        isOperator,
-        isNotOperator,
-        existsOperator,
-        doesNotExistOperator,
-      ];
-      expect(output).toEqual(expected);
-    });
-
-    test('it returns list operators if specified to', () => {
-      const payloadItem: FormattedBuilderEntry = getMockBuilderEntry();
-      const output = getOperatorOptions(payloadItem, 'detection', false, true);
-      expect(output.some((operator) => operator.value === 'is_not_in_list')).toBeTruthy();
-      expect(output.some((operator) => operator.value === 'is_in_list')).toBeTruthy();
-    });
-
-    test('it does not return list operators if specified not to', () => {
-      const payloadItem: FormattedBuilderEntry = {
-        ...getMockBuilderEntry(),
-        field: getField('@tags'),
-      };
-      const output = getOperatorOptions(payloadItem, 'detection', false, false);
-      expect(output).toEqual(EXCEPTION_OPERATORS_SANS_LISTS);
-    });
-
-    test('it returns all possible operators if list type is not "detection"', () => {
-      const payloadItem: FormattedBuilderEntry = getMockBuilderEntry();
-      const output = getOperatorOptions(payloadItem, 'endpoint_events', false, true);
-      expect(output).toEqual(ALL_OPERATORS);
-    });
-
-    test('it returns all operators supported by detection engine if list type is "detection"', () => {
-      const payloadItem: FormattedBuilderEntry = {
-        ...getMockBuilderEntry(),
-        field: getField('@tags'),
-      };
-      const output = getOperatorOptions(payloadItem, 'detection', false, true);
-      expect(output).toEqual(DETECTION_ENGINE_EXCEPTION_OPERATORS);
-    });
-
-    test('it excludes wildcard operators if list type is "detection" and field is not a string', () => {
-      const payloadItem: FormattedBuilderEntry = getMockBuilderEntry();
-      const output = getOperatorOptions(payloadItem, 'detection', false, true);
-      const expected: OperatorOption[] = [
-        isOperator,
-        isNotOperator,
-        isOneOfOperator,
-        isNotOneOfOperator,
-        existsOperator,
-        doesNotExistOperator,
-        isInListOperator,
-        isNotInListOperator,
-      ];
       expect(output).toEqual(expected);
     });
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution] Fix matches being included for fields that do not support it (#233127)](https://github.com/elastic/kibana/pull/233127)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Edgar Santos","email":"edgar.santos@elastic.co"},"sourceCommit":{"committedDate":"2025-09-16T07:35:13Z","message":"[Security Solution] Fix matches being included for fields that do not support it (#233127)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/226117\nThe `matches` operator was always being returned as a fallback scenario\nregardless if the field supported that operator or not. This PR fixes\nthis by checking if the field supports matches, if it doesn't then it\nexcludes those operators.\n\n## How to test\nCreate an index with some data and a rule based on it. \nThen attempt to create an exception. You will see that the default field\nthat you get in the form no longer shows match opetators (because it is\nnot supported). Matches will show if the field supports it. In this\ncase, you can select the metadata field `_id` which supports matches and\nyou will see that match operators are shown in the list.\n\n\n\n\nhttps://github.com/user-attachments/assets/65b79786-7cb3-46a0-9d01-a3fd8b5e82e1\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9679946298364f87481ee8ccf258a01a73765e4a","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Detection Engine","backport:version","v9.2.0","v8.19.5","v9.1.5"],"title":"[Security Solution] Fix matches being included for fields that do not support it","number":233127,"url":"https://github.com/elastic/kibana/pull/233127","mergeCommit":{"message":"[Security Solution] Fix matches being included for fields that do not support it (#233127)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/226117\nThe `matches` operator was always being returned as a fallback scenario\nregardless if the field supported that operator or not. This PR fixes\nthis by checking if the field supports matches, if it doesn't then it\nexcludes those operators.\n\n## How to test\nCreate an index with some data and a rule based on it. \nThen attempt to create an exception. You will see that the default field\nthat you get in the form no longer shows match opetators (because it is\nnot supported). Matches will show if the field supports it. In this\ncase, you can select the metadata field `_id` which supports matches and\nyou will see that match operators are shown in the list.\n\n\n\n\nhttps://github.com/user-attachments/assets/65b79786-7cb3-46a0-9d01-a3fd8b5e82e1\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9679946298364f87481ee8ccf258a01a73765e4a"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/233127","number":233127,"mergeCommit":{"message":"[Security Solution] Fix matches being included for fields that do not support it (#233127)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/226117\nThe `matches` operator was always being returned as a fallback scenario\nregardless if the field supported that operator or not. This PR fixes\nthis by checking if the field supports matches, if it doesn't then it\nexcludes those operators.\n\n## How to test\nCreate an index with some data and a rule based on it. \nThen attempt to create an exception. You will see that the default field\nthat you get in the form no longer shows match opetators (because it is\nnot supported). Matches will show if the field supports it. In this\ncase, you can select the metadata field `_id` which supports matches and\nyou will see that match operators are shown in the list.\n\n\n\n\nhttps://github.com/user-attachments/assets/65b79786-7cb3-46a0-9d01-a3fd8b5e82e1\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9679946298364f87481ee8ccf258a01a73765e4a"}},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->