### PR TITLE
[Agent Builder]: Nits around ES|QL search in index search tool type

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/i18n.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/i18n.ts
@@ -36,7 +36,7 @@ export const progressMessages = {
   },
   performingNlSearch: ({ query }: { query: string }) => {
     return i18n.translate('xpack.onechat.tools.search.progress.performingTextSearch', {
-      defaultMessage: 'Generating an ES|QL for "{query}"',
+      defaultMessage: 'Generating an ES|QL query for "{query}"',
       values: {
         query,
       },

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/tabular_data_result_step.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/tabular_data_result_step.tsx
@@ -40,34 +40,34 @@ export const TabularDataResultStep: React.FC<TabularDataResultStepProps> = ({
   return (
     <EuiFlexGroup direction="row" gutterSize="xs" alignItems="center">
       <EuiText size="s">
-        {i18n.translate(
-          'xpack.onechat.conversation.thinking.tabularDataResultStep.foundRecordsMessagePrefix',
-          {
-            defaultMessage: 'Found',
-          }
-        )}
+        <FormattedMessage
+          id="xpack.onechat.conversation.thinking.tabularDataResultStep.foundRecordsMessage"
+          defaultMessage="Found {results}"
+          values={{
+            results: (
+              <EuiLink
+                href={discoverUrl}
+                data-test-subj="onechat-esql-data-result-see-in-discover"
+                aria-label={i18n.translate(
+                  'xpack.onechat.conversation.thinking.tabularDataResultStep.seeInDiscoverAriaLabel',
+                  {
+                    defaultMessage: 'See results in Discover',
+                  }
+                )}
+                target="_blank"
+              >
+                <FormattedMessage
+                  id="xpack.onechat.conversation.thinking.tabularDataResultStep.foundRecordsMessage"
+                  defaultMessage="{totalResults, plural, one {{totalResults, number} result} other {{totalResults, number} results}}"
+                  values={{
+                    totalResults: data.values.length,
+                  }}
+                />
+              </EuiLink>
+            ),
+          }}
+        />
       </EuiText>
-      {discoverUrl && (
-        <EuiLink
-          href={discoverUrl}
-          data-test-subj="onechat-esql-data-result-see-in-discover"
-          aria-label={i18n.translate(
-            'xpack.onechat.conversation.thinking.tabularDataResultStep.seeInDiscoverAriaLabel',
-            {
-              defaultMessage: 'See documents in Discover',
-            }
-          )}
-          target="_blank"
-        >
-          <FormattedMessage
-            id="xpack.onechat.conversation.thinking.tabularDataResultStep.foundRecordsMessage"
-            defaultMessage="{totalDocuments, plural, one {{totalDocuments, number} document} other {{totalDocuments, number} documents}}"
-            values={{
-              totalDocuments: data.values.length,
-            }}
-          />
-        </EuiLink>
-      )}
     </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/tabular_data_result_step.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/tabular_data_result_step.tsx
@@ -51,7 +51,7 @@ export const TabularDataResultStep: React.FC<TabularDataResultStepProps> = ({
                 aria-label={i18n.translate(
                   'xpack.onechat.conversation.thinking.tabularDataResultStep.seeInDiscoverAriaLabel',
                   {
-                    defaultMessage: 'See results in Discover',
+                    defaultMessage: 'Explore results in Discover',
                   }
                 )}
                 target="_blank"


### PR DESCRIPTION
## Summary

- `documents` -> `results`
- `ES|QL` -> `ES|QL query`

Fix i18n usage 

<img width="948" height="775" alt="Screenshot 2025-09-17 at 10 00 06" src="https://github.com/user-attachments/assets/828f3422-6188-462a-b58b-480d317d912e" />
