### PR TITLE
[9.1] [Security Solution] Add event-based telemetry for prebuilt rule upgrade API (#234571)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/create_upgradeable_rules_payload.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/create_upgradeable_rules_payload.ts
@@ -24,6 +24,7 @@ import { calculateThreeWayRuleFieldsDiff } from '../../logic/diff/calculation/ca
 import { convertPrebuiltRuleAssetToRuleResponse } from '../../../rule_management/logic/detection_rules_client/converters/convert_prebuilt_rule_asset_to_rule_response';
 import type { RuleTriad } from '../../model/rule_groups/get_rule_groups';
 import { getValueForField } from './get_value_for_field';
+import type { RuleUpgradeContext } from './update_rule_telemetry';
 
 interface CreateModifiedPrebuiltRuleAssetsProps {
   upgradeableRules: RuleTriad[];
@@ -34,6 +35,7 @@ interface CreateModifiedPrebuiltRuleAssetsProps {
 interface ProcessedRules {
   modifiedPrebuiltRuleAssets: PrebuiltRuleAsset[];
   processingErrors: Array<PromisePoolError<{ rule_id: string }>>;
+  ruleUpgradeContexts: RuleUpgradeContext[];
 }
 
 export const createModifiedPrebuiltRuleAssets = ({
@@ -48,7 +50,7 @@ export const createModifiedPrebuiltRuleAssets = ({
       on_conflict: onConflict,
     } = requestBody;
 
-    const { modifiedPrebuiltRuleAssets, processingErrors } =
+    const { modifiedPrebuiltRuleAssets, processingErrors, ruleUpgradeContexts } =
       upgradeableRules.reduce<ProcessedRules>(
         (processedRules, upgradeableRule) => {
           const targetRuleType = upgradeableRule.target.type;
@@ -107,25 +109,33 @@ export const createModifiedPrebuiltRuleAssets = ({
 
             processedRules.modifiedPrebuiltRuleAssets.push(modifiedPrebuiltRuleAsset);
 
+            processedRules.ruleUpgradeContexts.push({
+              ruleId,
+              ruleName: upgradeableRule.target.name,
+              hasBaseVersion: !!upgradeableRule.base,
+              fieldsDiff: calculatedRuleDiff,
+            });
+
             return processedRules;
           } catch (err) {
             processedRules.processingErrors.push({
               error: err,
               item: { rule_id: ruleId },
             });
-
             return processedRules;
           }
         },
         {
           modifiedPrebuiltRuleAssets: [],
           processingErrors: [],
+          ruleUpgradeContexts: [],
         }
       );
 
     return {
       modifiedPrebuiltRuleAssets,
       processingErrors,
+      ruleUpgradeContexts,
     };
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_handler.ts
@@ -8,6 +8,7 @@
 import type { Logger, KibanaRequest, KibanaResponseFactory } from '@kbn/core/server';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import type {
+  FullThreeWayRuleDiff,
   PerformRuleUpgradeRequestBody,
   PerformRuleUpgradeResponseBody,
   RuleUpgradeSpecifier,
@@ -38,10 +39,11 @@ import type {
 } from '../../../../../../common/api/detection_engine';
 import type { PromisePoolError } from '../../../../../utils/promise_pool';
 import { zipRuleVersions } from '../../logic/rule_versions/zip_rule_versions';
-import type { RuleVersions } from '../../logic/diff/calculate_rule_diff';
 import { calculateRuleDiff } from '../../logic/diff/calculate_rule_diff';
 import type { RuleTriad } from '../../model/rule_groups/get_rule_groups';
 import { getPossibleUpgrades } from '../../logic/utils';
+import type { RuleUpgradeContext } from './update_rule_telemetry';
+import { sendRuleUpdateTelemetryEvents } from './update_rule_telemetry';
 
 export const performRuleUpgradeHandler = async (
   context: SecuritySolutionRequestHandlerContext,
@@ -59,6 +61,7 @@ export const performRuleUpgradeHandler = async (
     const ruleAssetsClient = createPrebuiltRuleAssetsClient(soClient);
     const ruleObjectsClient = createPrebuiltRuleObjectsClient(rulesClient);
     const mlAuthz = ctx.securitySolution.getMlAuthz();
+    const analytics = ctx.securitySolution.getAnalytics();
 
     const { isRulesCustomizationEnabled } = detectionRulesClient.getRuleCustomizationStatus();
     const defaultPickVersion = isRulesCustomizationEnabled
@@ -79,6 +82,7 @@ export const performRuleUpgradeHandler = async (
     const updatedRules: RuleResponse[] = [];
     const ruleErrors: Array<PromisePoolError<{ rule_id: string }>> = [];
     const allErrors: PerformRuleUpgradeResponseBody['errors'] = [];
+    const ruleUpgradeContextsMap = new Map<string, RuleUpgradeContext>();
 
     const ruleUpgradeQueue: Array<{
       rule_id: RuleSignatureId;
@@ -165,13 +169,21 @@ export const performRuleUpgradeHandler = async (
               ? request.body.rules.find((x) => x.rule_id === targetRule.rule_id)
               : undefined;
 
-          const conflict = getRuleUpgradeConflictState(ruleVersions, ruleUpgradeSpecifier);
+          const { ruleDiff } = calculateRuleDiff(ruleVersions);
+          const conflict = getRuleUpgradeConflictState(ruleDiff, ruleUpgradeSpecifier);
 
           if (conflict !== ThreeWayDiffConflict.NONE) {
             skippedRules.push({
               rule_id: targetRule.rule_id,
               reason: SkipRuleUpgradeReasonEnum.CONFLICT,
               conflict,
+            });
+
+            ruleUpgradeContextsMap.set(targetRule.rule_id, {
+              ruleId: targetRule.rule_id,
+              ruleName: currentVersion.name,
+              hasBaseVersion: !!baseVersion,
+              fieldsDiff: ruleDiff.fields,
             });
             return;
           }
@@ -185,12 +197,17 @@ export const performRuleUpgradeHandler = async (
         });
       });
 
-      const { modifiedPrebuiltRuleAssets, processingErrors } = createModifiedPrebuiltRuleAssets({
-        upgradeableRules,
-        requestBody: request.body,
-        defaultPickVersion,
-      });
+      const { modifiedPrebuiltRuleAssets, processingErrors, ruleUpgradeContexts } =
+        createModifiedPrebuiltRuleAssets({
+          upgradeableRules,
+          requestBody: request.body,
+          defaultPickVersion,
+        });
       ruleErrors.push(...processingErrors);
+
+      ruleUpgradeContexts.forEach((ruleUpgradeContext) => {
+        ruleUpgradeContextsMap.set(ruleUpgradeContext.ruleId, ruleUpgradeContext);
+      });
 
       if (isDryRun) {
         updatedRules.push(
@@ -220,6 +237,14 @@ export const performRuleUpgradeHandler = async (
           rules: [],
         });
       }
+
+      sendRuleUpdateTelemetryEvents(
+        analytics,
+        ruleUpgradeContextsMap,
+        updatedRules,
+        ruleErrors,
+        skippedRules
+      );
     }
 
     const body: PerformRuleUpgradeResponseBody = {
@@ -247,11 +272,9 @@ export const performRuleUpgradeHandler = async (
 };
 
 function getRuleUpgradeConflictState(
-  ruleVersions: RuleVersions,
+  ruleDiff: FullThreeWayRuleDiff,
   ruleUpgradeSpecifier?: RuleUpgradeSpecifier
 ): ThreeWayDiffConflict {
-  const { ruleDiff } = calculateRuleDiff(ruleVersions);
-
   if (ruleDiff.num_fields_with_conflicts === 0) {
     return ThreeWayDiffConflict.NONE;
   }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/update_rule_telemetry.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/update_rule_telemetry.test.ts
@@ -1,0 +1,312 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnalyticsServiceStart } from '@kbn/core/server';
+import {
+  ThreeWayDiffConflict,
+  ThreeWayDiffOutcome,
+} from '../../../../../../common/api/detection_engine/prebuilt_rules';
+import { DETECTION_RULE_UPGRADE_EVENT } from '../../../../telemetry/event_based/events';
+import type { RuleUpgradeContext } from './update_rule_telemetry';
+import { sendRuleUpdateTelemetryEvents } from './update_rule_telemetry';
+
+const mockAnalytics = (): AnalyticsServiceStart =>
+  ({ reportEvent: jest.fn() } as unknown as AnalyticsServiceStart);
+
+const createMockRuleUpdateContext = (
+  overrides: Partial<RuleUpgradeContext> = {}
+): RuleUpgradeContext => ({
+  ruleId: 'r1',
+  ruleName: 'Rule r1',
+  hasBaseVersion: true,
+  fieldsDiff: {
+    name: {
+      conflict: ThreeWayDiffConflict.SOLVABLE,
+      diff_outcome: ThreeWayDiffOutcome.StockValueCanUpdate,
+    },
+  },
+  ...overrides,
+});
+
+describe('sendRuleUpdateTelemetryEvents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('emits SUCCESS with calculated updated fields for processed rule', () => {
+    const analytics = mockAnalytics();
+
+    sendRuleUpdateTelemetryEvents(
+      analytics,
+      new Map([
+        [
+          'r1',
+          createMockRuleUpdateContext({
+            ruleId: 'r1',
+            ruleName: 'Rule r1',
+          }),
+        ],
+      ]),
+      [{ rule_id: 'r1' }],
+      [],
+      []
+    );
+
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(1);
+    const [eventType, payload] = (analytics.reportEvent as jest.Mock).mock.calls[0];
+
+    expect(eventType).toBe(DETECTION_RULE_UPGRADE_EVENT.eventType);
+
+    expect(payload.ruleId).toBe('r1');
+    expect(payload.ruleName).toBe('Rule r1');
+    expect(payload.hasBaseVersion).toBe(true);
+    expect(payload.finalResult).toBe('SUCCESS');
+
+    expect(payload.updatedFieldsSummary).toEqual({
+      count: 1,
+      nonSolvableConflictsCount: 0,
+      solvableConflictsCount: 1,
+      noConflictsCount: 0,
+    });
+    expect(payload.updatedFieldsTotal).toEqual(['name']);
+    expect(payload.updatedFieldsWithSolvableConflicts).toEqual(['name']);
+    expect(payload.updatedFieldsWithNonSolvableConflicts).toEqual([]);
+    expect(payload.updatedFieldsWithNoConflicts).toEqual([]);
+  });
+
+  test('ignores fields that are not updatable outcomes', () => {
+    const analytics = mockAnalytics();
+
+    const notUpdatableCtx = createMockRuleUpdateContext({
+      fieldsDiff: {
+        description: {
+          conflict: ThreeWayDiffConflict.NONE,
+          diff_outcome: ThreeWayDiffOutcome.StockValueNoUpdate,
+        },
+        version: {
+          conflict: ThreeWayDiffConflict.NONE,
+          diff_outcome: ThreeWayDiffOutcome.StockValueCanUpdate,
+        },
+      },
+    });
+
+    sendRuleUpdateTelemetryEvents(
+      analytics,
+      new Map([['r1', notUpdatableCtx]]),
+      [{ rule_id: 'r1' }],
+      [],
+      []
+    );
+
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(1);
+    const [, payload] = (analytics.reportEvent as jest.Mock).mock.calls[0];
+
+    expect(payload.updatedFieldsSummary).toEqual({
+      count: 0,
+      nonSolvableConflictsCount: 0,
+      solvableConflictsCount: 0,
+      noConflictsCount: 0,
+    });
+    expect(payload.updatedFieldsTotal).toEqual([]);
+    expect(payload.updatedFieldsWithSolvableConflicts).toEqual([]);
+    expect(payload.updatedFieldsWithNonSolvableConflicts).toEqual([]);
+    expect(payload.updatedFieldsWithNoConflicts).toEqual([]);
+  });
+
+  test('emits ERROR for rules present in errors set', () => {
+    const analytics = mockAnalytics();
+
+    sendRuleUpdateTelemetryEvents(
+      analytics,
+      new Map([
+        [
+          'r1',
+          createMockRuleUpdateContext({
+            ruleId: 'r1',
+            ruleName: 'Rule r1',
+          }),
+        ],
+      ]),
+      [],
+      [{ item: { rule_id: 'r1' } }],
+      []
+    );
+
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(1);
+    const [, payload] = (analytics.reportEvent as jest.Mock).mock.calls[0];
+    expect(payload.finalResult).toBe('ERROR');
+    expect(payload.ruleId).toBe('r1');
+    expect(payload.ruleName).toBe('Rule r1');
+    expect(payload.hasBaseVersion).toBe(true);
+    expect(payload.updatedFieldsSummary).toEqual({
+      count: 1,
+      nonSolvableConflictsCount: 0,
+      solvableConflictsCount: 1,
+      noConflictsCount: 0,
+    });
+    expect(payload.updatedFieldsTotal).toEqual(['name']);
+    expect(payload.updatedFieldsWithSolvableConflicts).toEqual(['name']);
+    expect(payload.updatedFieldsWithNonSolvableConflicts).toEqual([]);
+    expect(payload.updatedFieldsWithNoConflicts).toEqual([]);
+  });
+
+  test('emits SKIP for rules present in skipped set', () => {
+    const analytics = mockAnalytics();
+
+    sendRuleUpdateTelemetryEvents(
+      analytics,
+      new Map([
+        [
+          'r1',
+          createMockRuleUpdateContext({
+            ruleId: 'r1',
+            ruleName: 'Rule r1',
+          }),
+        ],
+      ]),
+      [],
+      [],
+      [{ rule_id: 'r1' }]
+    );
+
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(1);
+    const [, payload] = (analytics.reportEvent as jest.Mock).mock.calls[0];
+    expect(payload.finalResult).toBe('SKIP');
+    expect(payload.ruleId).toBe('r1');
+    expect(payload.ruleName).toBe('Rule r1');
+    expect(payload.hasBaseVersion).toBe(true);
+    expect(payload.updatedFieldsSummary).toEqual({
+      count: 1,
+      nonSolvableConflictsCount: 0,
+      solvableConflictsCount: 1,
+      noConflictsCount: 0,
+    });
+    expect(payload.updatedFieldsTotal).toEqual(['name']);
+    expect(payload.updatedFieldsWithSolvableConflicts).toEqual(['name']);
+    expect(payload.updatedFieldsWithNonSolvableConflicts).toEqual([]);
+    expect(payload.updatedFieldsWithNoConflicts).toEqual([]);
+  });
+
+  test('does not emit when there is no matching context for outcome lists', () => {
+    const analytics = mockAnalytics();
+
+    sendRuleUpdateTelemetryEvents(
+      analytics,
+      new Map([
+        [
+          'r1',
+          createMockRuleUpdateContext({
+            ruleId: 'r1',
+            ruleName: 'Rule r1',
+          }),
+        ],
+      ]),
+      [{ rule_id: 'x' }],
+      [{ item: { rule_id: 'y' } }],
+      [{ rule_id: 'z' }]
+    );
+
+    expect(analytics.reportEvent).not.toHaveBeenCalled();
+  });
+
+  test('emits multiple events when multiple outcomes exist', () => {
+    const analytics = mockAnalytics();
+
+    const c1 = createMockRuleUpdateContext({ ruleId: 'r1', ruleName: 'Rule r1' });
+    const c2 = createMockRuleUpdateContext({
+      ruleId: 'r2',
+      ruleName: 'Rule r2',
+      fieldsDiff: {
+        severity: {
+          conflict: ThreeWayDiffConflict.NON_SOLVABLE,
+          diff_outcome: ThreeWayDiffOutcome.CustomizedValueCanUpdate,
+        },
+      },
+      hasBaseVersion: false,
+    });
+    const c3 = createMockRuleUpdateContext({
+      ruleId: 'r3',
+      ruleName: 'Rule r3',
+      fieldsDiff: {
+        note: {
+          conflict: ThreeWayDiffConflict.NONE,
+          diff_outcome: ThreeWayDiffOutcome.StockValueCanUpdate,
+        },
+      },
+    });
+
+    const c4 = createMockRuleUpdateContext({
+      ruleId: 'r4',
+      ruleName: 'Rule r4',
+      fieldsDiff: {
+        description: {
+          conflict: ThreeWayDiffConflict.SOLVABLE,
+          diff_outcome: ThreeWayDiffOutcome.StockValueCanUpdate,
+        },
+      },
+    });
+
+    sendRuleUpdateTelemetryEvents(
+      analytics,
+      new Map([
+        ['r1', c1],
+        ['r2', c2],
+        ['r3', c3],
+        ['r4', c4],
+      ]),
+      [{ rule_id: 'r1' }, { rule_id: 'r3' }],
+      [{ item: { rule_id: 'r2' } }],
+      [{ rule_id: 'r4' }]
+    );
+
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(4);
+
+    const payloads = (analytics.reportEvent as jest.Mock).mock.calls.map(([, p]) => p);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const payloadsMap = new Map(payloads.map((payload: any) => [payload.ruleId, payload]));
+
+    expect(payloadsMap.get('r1')!.finalResult).toBe('SUCCESS');
+    expect(payloadsMap.get('r1')!.updatedFieldsWithSolvableConflicts).toEqual(['name']);
+    expect(payloadsMap.get('r1')!.hasBaseVersion).toBe(true);
+    expect(payloadsMap.get('r1')!.updatedFieldsSummary).toEqual({
+      count: 1,
+      nonSolvableConflictsCount: 0,
+      solvableConflictsCount: 1,
+      noConflictsCount: 0,
+    });
+
+    expect(payloadsMap.get('r2')!.finalResult).toBe('ERROR');
+    expect(payloadsMap.get('r2')!.hasBaseVersion).toBe(false);
+    expect(payloadsMap.get('r2')!.updatedFieldsWithNonSolvableConflicts).toEqual(['severity']);
+    expect(payloadsMap.get('r2')!.updatedFieldsSummary).toEqual({
+      count: 1,
+      nonSolvableConflictsCount: 1,
+      solvableConflictsCount: 0,
+      noConflictsCount: 0,
+    });
+
+    expect(payloadsMap.get('r3')!.finalResult).toBe('SUCCESS');
+    expect(payloadsMap.get('r3')!.hasBaseVersion).toBe(true);
+    expect(payloadsMap.get('r3')!.updatedFieldsWithNoConflicts).toEqual(['note']);
+    expect(payloadsMap.get('r3')!.updatedFieldsSummary).toEqual({
+      count: 1,
+      nonSolvableConflictsCount: 0,
+      solvableConflictsCount: 0,
+      noConflictsCount: 1,
+    });
+
+    expect(payloadsMap.get('r4')!.finalResult).toBe('SKIP');
+    expect(payloadsMap.get('r4')!.hasBaseVersion).toBe(true);
+    expect(payloadsMap.get('r4')!.updatedFieldsWithSolvableConflicts).toEqual(['description']);
+    expect(payloadsMap.get('r4')!.updatedFieldsSummary).toEqual({
+      count: 1,
+      nonSolvableConflictsCount: 0,
+      solvableConflictsCount: 1,
+      noConflictsCount: 0,
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/update_rule_telemetry.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/update_rule_telemetry.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { AnalyticsServiceStart } from '@kbn/core/server';
+import {
+  ThreeWayDiffOutcome,
+  ThreeWayDiffConflict,
+} from '../../../../../../common/api/detection_engine/prebuilt_rules';
+import { DETECTION_RULE_UPGRADE_EVENT } from '../../../../telemetry/event_based/events';
+
+interface BasicDiffInfo {
+  conflict: ThreeWayDiffConflict;
+  diff_outcome?: ThreeWayDiffOutcome;
+}
+
+type BasicRuleFieldsDiff = Record<string, BasicDiffInfo>;
+
+type UpdateRuleFinalResult = 'SUCCESS' | 'SKIP' | 'ERROR';
+
+export interface RuleUpgradeContext {
+  ruleId: string;
+  ruleName: string;
+  hasBaseVersion: boolean;
+  fieldsDiff: BasicRuleFieldsDiff;
+}
+
+export interface RuleUpgradeTelemetry {
+  ruleId: string;
+  ruleName: string;
+  hasBaseVersion: boolean;
+  updatedFieldsSummary: {
+    count: number;
+    nonSolvableConflictsCount: number;
+    solvableConflictsCount: number;
+    noConflictsCount: number;
+  };
+  updatedFieldsTotal: string[];
+  updatedFieldsWithNonSolvableConflicts: string[];
+  updatedFieldsWithSolvableConflicts: string[];
+  updatedFieldsWithNoConflicts: string[];
+  finalResult: UpdateRuleFinalResult;
+}
+
+interface BasicRuleResponse {
+  rule_id: string;
+}
+
+interface BasicInstallationError {
+  item: {
+    rule_id: string;
+  };
+}
+
+interface BasicSkippedRule {
+  rule_id: string;
+}
+
+export function sendRuleUpdateTelemetryEvents(
+  analytics: AnalyticsServiceStart,
+  RuleUpdateContextsMap: Map<string, RuleUpgradeContext>,
+  updatedRules: BasicRuleResponse[],
+  installationErrors: BasicInstallationError[],
+  skippedRules: BasicSkippedRule[]
+) {
+  try {
+    for (const ruleResponse of updatedRules) {
+      const ruleUpdateContext = RuleUpdateContextsMap.get(ruleResponse.rule_id);
+      if (ruleUpdateContext) {
+        const event: RuleUpgradeTelemetry = createRuleUpdateTelemetryEvent({
+          fieldsDiff: ruleUpdateContext.fieldsDiff,
+          ruleId: ruleUpdateContext.ruleId,
+          ruleName: ruleUpdateContext.ruleName,
+          hasBaseVersion: ruleUpdateContext.hasBaseVersion,
+          finalResult: 'SUCCESS',
+        });
+        analytics.reportEvent(DETECTION_RULE_UPGRADE_EVENT.eventType, event);
+      }
+    }
+
+    for (const erroredRule of installationErrors) {
+      const ruleUpdateContext = RuleUpdateContextsMap.get(erroredRule.item.rule_id);
+      if (ruleUpdateContext) {
+        const event: RuleUpgradeTelemetry = createRuleUpdateTelemetryEvent({
+          fieldsDiff: ruleUpdateContext.fieldsDiff,
+          ruleId: ruleUpdateContext.ruleId,
+          ruleName: ruleUpdateContext.ruleName,
+          hasBaseVersion: ruleUpdateContext.hasBaseVersion,
+          finalResult: 'ERROR',
+        });
+        analytics.reportEvent(DETECTION_RULE_UPGRADE_EVENT.eventType, event);
+      }
+    }
+
+    for (const skippedRule of skippedRules) {
+      const ruleUpdateContext = RuleUpdateContextsMap.get(skippedRule.rule_id);
+      if (ruleUpdateContext) {
+        const event: RuleUpgradeTelemetry = createRuleUpdateTelemetryEvent({
+          fieldsDiff: ruleUpdateContext.fieldsDiff,
+          ruleId: ruleUpdateContext.ruleId,
+          ruleName: ruleUpdateContext.ruleName,
+          hasBaseVersion: ruleUpdateContext.hasBaseVersion,
+          finalResult: 'SKIP',
+        });
+        analytics.reportEvent(DETECTION_RULE_UPGRADE_EVENT.eventType, event);
+      }
+    }
+  } catch (e) {
+    // we don't want telemetry errors to impact the main flow
+    // eslint-disable-next-line no-console
+    console.error('Failed to send detection rule update telemetry', e);
+  }
+}
+
+interface CreateRuleUpdateTelemetryEventParams {
+  fieldsDiff: BasicRuleFieldsDiff;
+  ruleId: string;
+  ruleName: string;
+  hasBaseVersion: boolean;
+  finalResult: UpdateRuleFinalResult;
+}
+
+function createRuleUpdateTelemetryEvent({
+  fieldsDiff,
+  ruleId,
+  ruleName,
+  hasBaseVersion,
+  finalResult,
+}: CreateRuleUpdateTelemetryEventParams): RuleUpgradeTelemetry {
+  const updatedFieldsTotal: string[] = [];
+  const updatedFieldsWithNonSolvableConflicts: string[] = [];
+  const updatedFieldsWithSolvableConflicts: string[] = [];
+  const updatedFieldsWithNoConflicts: string[] = [];
+
+  Object.entries(fieldsDiff).forEach(([fieldName, diff]) => {
+    if (fieldName === 'version') {
+      return;
+    }
+
+    const isUpdatableOutcome =
+      diff.diff_outcome === ThreeWayDiffOutcome.CustomizedValueSameUpdate ||
+      diff.diff_outcome === ThreeWayDiffOutcome.StockValueCanUpdate ||
+      diff.diff_outcome === ThreeWayDiffOutcome.CustomizedValueCanUpdate ||
+      diff.diff_outcome === ThreeWayDiffOutcome.MissingBaseCanUpdate;
+
+    if (!isUpdatableOutcome) {
+      return;
+    }
+
+    updatedFieldsTotal.push(fieldName);
+
+    switch (diff.conflict) {
+      case ThreeWayDiffConflict.NON_SOLVABLE:
+        updatedFieldsWithNonSolvableConflicts.push(fieldName);
+        break;
+      case ThreeWayDiffConflict.SOLVABLE:
+        updatedFieldsWithSolvableConflicts.push(fieldName);
+        break;
+      case ThreeWayDiffConflict.NONE:
+      default:
+        updatedFieldsWithNoConflicts.push(fieldName);
+        break;
+    }
+  });
+
+  return {
+    ruleId,
+    ruleName,
+    hasBaseVersion,
+    updatedFieldsSummary: {
+      count: updatedFieldsTotal.length,
+      nonSolvableConflictsCount: updatedFieldsWithNonSolvableConflicts.length,
+      solvableConflictsCount: updatedFieldsWithSolvableConflicts.length,
+      noConflictsCount: updatedFieldsWithNoConflicts.length,
+    },
+    updatedFieldsTotal,
+    updatedFieldsWithNonSolvableConflicts,
+    updatedFieldsWithSolvableConflicts,
+    updatedFieldsWithNoConflicts,
+    finalResult,
+  };
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
@@ -8,7 +8,7 @@
 import type { AwaitedProperties } from '@kbn/utility-types';
 import type { MockedKeys } from '@kbn/utility-types-jest';
 import type { KibanaRequest } from '@kbn/core/server';
-import { coreMock } from '@kbn/core/server/mocks';
+import { analyticsServiceMock, coreMock } from '@kbn/core/server/mocks';
 import { loggerMock } from '@kbn/logging-mocks';
 
 import type { ActionsApiRequestHandlerContext } from '@kbn/actions-plugin/server';
@@ -150,6 +150,7 @@ const createSecuritySolutionRequestContextMock = (
 
   return {
     core,
+    getAnalytics: jest.fn(() => analyticsServiceMock.createAnalyticsServiceSetup()),
     getServerBasePath: jest.fn(() => ''),
     getEndpointAuthz: jest.fn(async () =>
       getEndpointAuthzInitialStateMock(overrides.endpointAuthz)

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -25,6 +25,81 @@ import type {
   HealthDiagnosticQueryResult,
   HealthDiagnosticQueryStats,
 } from '../diagnostic/health_diagnostic_service.types';
+import type { RuleUpgradeTelemetry } from '../../detection_engine/prebuilt_rules/api/perform_rule_upgrade/update_rule_telemetry';
+
+// Telemetry event that is sent for each rule that is upgraded during a prebuilt rule upgrade
+export const DETECTION_RULE_UPGRADE_EVENT: EventTypeOpts<RuleUpgradeTelemetry> = {
+  eventType: 'detection_rule_upgrade',
+  schema: {
+    ruleId: { type: 'keyword', _meta: { description: 'Rule ID' } },
+    ruleName: { type: 'keyword', _meta: { description: 'Rule name' } },
+    hasBaseVersion: {
+      type: 'boolean',
+      _meta: { description: 'True if base version exists for this rule' },
+    },
+    finalResult: {
+      type: 'keyword',
+      _meta: { description: 'Overall outcome: SUCCESS | SKIP | ERROR' },
+    },
+    updatedFieldsSummary: {
+      properties: {
+        count: { type: 'long', _meta: { description: 'Number of updated fields' } },
+        nonSolvableConflictsCount: {
+          type: 'long',
+          _meta: { description: 'Number of non-solvable conflicts' },
+        },
+        solvableConflictsCount: {
+          type: 'long',
+          _meta: { description: 'Number of solvable conflicts' },
+        },
+        noConflictsCount: {
+          type: 'long',
+          _meta: { description: 'Number of fields without conflicts' },
+        },
+      },
+    },
+    updatedFieldsTotal: {
+      type: 'array',
+      items: {
+        type: 'keyword',
+        _meta: {
+          description: 'Rule field name',
+        },
+      },
+      _meta: { description: 'Fields that were updated' },
+    },
+    updatedFieldsWithNonSolvableConflicts: {
+      type: 'array',
+      items: {
+        type: 'keyword',
+        _meta: {
+          description: 'Rule field name',
+        },
+      },
+      _meta: { description: 'Fields with non-solvable conflicts' },
+    },
+    updatedFieldsWithSolvableConflicts: {
+      type: 'array',
+      items: {
+        type: 'keyword',
+        _meta: {
+          description: 'Rule field name',
+        },
+      },
+      _meta: { description: 'Fields with solvable conflicts' },
+    },
+    updatedFieldsWithNoConflicts: {
+      type: 'array',
+      items: {
+        type: 'keyword',
+        _meta: {
+          description: 'Rule field name',
+        },
+      },
+      _meta: { description: 'Fields updated without conflicts' },
+    },
+  },
+};
 
 export const RISK_SCORE_EXECUTION_SUCCESS_EVENT: EventTypeOpts<{
   scoresWritten: number;
@@ -1617,6 +1692,7 @@ export const GAP_DETECTED_EVENT: EventTypeOpts<{
 };
 
 export const events = [
+  DETECTION_RULE_UPGRADE_EVENT,
   RISK_SCORE_EXECUTION_SUCCESS_EVENT,
   RISK_SCORE_EXECUTION_ERROR_EVENT,
   RISK_SCORE_EXECUTION_CANCELLATION_EVENT,

--- a/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
@@ -144,6 +144,8 @@ export class RequestContextFactory implements IRequestContextFactory {
     return {
       core: coreContext,
 
+      getAnalytics: () => core.analytics,
+
       getServerBasePath: () => core.http.basePath.serverBasePath,
 
       getEndpointAuthz: async (): Promise<Immutable<EndpointAuthz>> => {

--- a/x-pack/solutions/security/plugins/security_solution/server/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+  AnalyticsServiceSetup,
   CoreRequestHandlerContext,
   CustomRequestHandlerContext,
   IRouter,
@@ -51,6 +52,7 @@ export { AppClient };
 
 export interface SecuritySolutionApiRequestHandlerContext {
   core: CoreRequestHandlerContext;
+  getAnalytics: () => AnalyticsServiceSetup;
   getServerBasePath: () => string;
   getEndpointAuthz: () => Promise<Immutable<EndpointAuthz>>;
   getEndpointService: () => EndpointAppContextService;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution] Add event-based telemetry for prebuilt rule upgrade API (#234571)](https://github.com/elastic/kibana/pull/234571)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jacek Kolezynski","email":"jacek.kolezynski@elastic.co"},"sourceCommit":{"committedDate":"2025-09-17T07:45:06Z","message":"[Security Solution] Add event-based telemetry for prebuilt rule upgrade API (#234571)\n\n**Partially resolves: #140369**\n\n## Summary\n\nThis is another PR from of a series of PRs I am planning to create to\ncover the requirements in the #140369 ticket.\n\nThe requirement covered in this ticket is req. #6: \"Events for\nperforming update (EBT backend)\" and req. #7 \"Missing base versions\".\n\nI am adding sending telemetry events in handling of rule update request.\nEach rule updated will send its own event with information about:\n- ruleId\n- ruleName\n- if missing base version\n- final result of the update\n- updated fields (with breakdown per conflict type). \n\nI tried to make the changes as little invasive as possible, and decided\nto create a separate file, `update_rule_telemetry.ts`, where the logic\nof building the events and sending them is encapsulated.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"a2b7329e26fe9031d387138cf0f019aa4c53cd93","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:version","v9.2.0","v8.18.8","v8.19.5","v9.0.8","v9.1.5"],"title":"[Security Solution] Add event-based telemetry for prebuilt rule upgrade API","number":234571,"url":"https://github.com/elastic/kibana/pull/234571","mergeCommit":{"message":"[Security Solution] Add event-based telemetry for prebuilt rule upgrade API (#234571)\n\n**Partially resolves: #140369**\n\n## Summary\n\nThis is another PR from of a series of PRs I am planning to create to\ncover the requirements in the #140369 ticket.\n\nThe requirement covered in this ticket is req. #6: \"Events for\nperforming update (EBT backend)\" and req. #7 \"Missing base versions\".\n\nI am adding sending telemetry events in handling of rule update request.\nEach rule updated will send its own event with information about:\n- ruleId\n- ruleName\n- if missing base version\n- final result of the update\n- updated fields (with breakdown per conflict type). \n\nI tried to make the changes as little invasive as possible, and decided\nto create a separate file, `update_rule_telemetry.ts`, where the logic\nof building the events and sending them is encapsulated.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"a2b7329e26fe9031d387138cf0f019aa4c53cd93"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.19","9.0","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/234571","number":234571,"mergeCommit":{"message":"[Security Solution] Add event-based telemetry for prebuilt rule upgrade API (#234571)\n\n**Partially resolves: #140369**\n\n## Summary\n\nThis is another PR from of a series of PRs I am planning to create to\ncover the requirements in the #140369 ticket.\n\nThe requirement covered in this ticket is req. #6: \"Events for\nperforming update (EBT backend)\" and req. #7 \"Missing base versions\".\n\nI am adding sending telemetry events in handling of rule update request.\nEach rule updated will send its own event with information about:\n- ruleId\n- ruleName\n- if missing base version\n- final result of the update\n- updated fields (with breakdown per conflict type). \n\nI tried to make the changes as little invasive as possible, and decided\nto create a separate file, `update_rule_telemetry.ts`, where the logic\nof building the events and sending them is encapsulated.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"a2b7329e26fe9031d387138cf0f019aa4c53cd93"}},{"branch":"8.18","label":"v8.18.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->