### PR TITLE
[ResponseOps][Connectors] Update Jira search endpoint

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/jira/service.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/jira/service.test.ts
@@ -997,7 +997,7 @@ describe('Jira service', () => {
         logger,
         method: 'get',
         configurationUtilities,
-        url: `https://coolsite.net/rest/api/2/search?jql=project%3D%22CK%22%20and%20summary%20~%22Test%20title%22`,
+        url: `https://coolsite.net/rest/api/2/search/jql?jql=project%3D%22CK%22%20and%20summary%20~%22Test%20title%22&fields=summary,key`,
         connectorUsageCollector,
       });
     });
@@ -1024,7 +1024,7 @@ describe('Jira service', () => {
         logger,
         method: 'get',
         configurationUtilities,
-        url: `https://coolsite.net/rest/api/2/search?jql=project%3D%22CK%22%20and%20summary%20~%22%5C%5C%5Bth%5C%5C!s%5C%5C%5Eis%5C%5C(%5C%5C)a%5C%5C-te%5C%5C%2Bst%5C%5C-%5C%5C%7B%5C%5C~is%5C%5C*s%5C%5C%26ue%5C%5C%3For%5C%5C%7Cand%5C%5Cbye%5C%5C%3A%5C%5C%7D%5C%5C%5D%5C%5C%7D%5C%5C%5D%22`,
+        url: `https://coolsite.net/rest/api/2/search/jql?jql=project%3D%22CK%22%20and%20summary%20~%22%5C%5C%5Bth%5C%5C!s%5C%5C%5Eis%5C%5C(%5C%5C)a%5C%5C-te%5C%5C%2Bst%5C%5C-%5C%5C%7B%5C%5C~is%5C%5C*s%5C%5C%26ue%5C%5C%3For%5C%5C%7Cand%5C%5Cbye%5C%5C%3A%5C%5C%7D%5C%5C%5D%5C%5C%7D%5C%5C%5D%22&fields=summary,key`,
         connectorUsageCollector,
       });
     });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/jira/service.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/jira/service.ts
@@ -60,7 +60,7 @@ export const createExternalService = (
   const commentUrl = `${incidentUrl}/{issueId}/comment`;
   const getIssueTypesUrl = `${urlWithoutTrailingSlash}/${BASE_URL}/issue/createmeta/${projectKey}/issuetypes`;
   const getIssueTypeFieldsUrl = `${urlWithoutTrailingSlash}/${BASE_URL}/issue/createmeta/${projectKey}/issuetypes/{issueTypeId}`;
-  const searchUrl = `${urlWithoutTrailingSlash}/${BASE_URL}/search`;
+  const searchUrl = `${urlWithoutTrailingSlash}/${BASE_URL}/search/jql`;
 
   const axiosInstance = axios.create({
     headers: getBasicAuthHeader({ username: email, password: apiToken }),
@@ -441,7 +441,7 @@ export const createExternalService = (
     const jqlEscapedTitle = escapeJqlSpecialCharacters(title);
     const query = `${searchUrl}?jql=${encodeURIComponent(
       `project="${projectKey}" and summary ~"${jqlEscapedTitle}"`
-    )}`;
+    )}&fields=summary,key`;
 
     try {
       const res = await request({


### PR DESCRIPTION
Fixes #235259

## Summary

This PR replaces the deprecated /search API with the [this one](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-search/#api-rest-api-2-search-jql-get).

[Deprecation notes.](https://developer.atlassian.com/changelog/#CHANGE-2046)

## How to test

1. Create a Jira connector
2. Click "Test connector"
3. Change the "issue type" field to `Task`
4. Write something in the field "Parent issue"

<img width="1481" height="637" alt="Screenshot 2025-09-17 at 10 42 44" src="https://github.com/user-attachments/assets/b18f36ab-d2cb-42fa-bf42-cc720ab07fa5" />
