### PR TITLE
fix: add default monaco contrib import for cmd+/ comment toggling

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/monaco_imports.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/monaco_imports.ts
@@ -30,6 +30,7 @@ import 'monaco-editor/esm/vs/editor/contrib/codeAction/browser/codeActionContrib
 // import 'monaco-editor/esm/vs/editor/contrib/codeAction/browser/codeActionKeybindingResolver.js';
 import 'monaco-editor/esm/vs/editor/contrib/codeAction/browser/codeActionMenu.js';
 import 'monaco-editor/esm/vs/editor/contrib/codeAction/browser/codeActionModel.js';
+import 'monaco-editor/esm/vs/editor/contrib/comment/browser/comment.js'; // Needed for CMD+/ comment toggling
 
 import 'monaco-editor/esm/vs/editor/contrib/find/browser/findController'; // Needed for Search bar functionality
 import 'monaco-editor/esm/vs/editor/standalone/browser/inspectTokens/inspectTokens.js'; // Needed for inspect tokens functionality


### PR DESCRIPTION
## Before

Using familiar command CMD + / while focus in monaco editor opens search bar
<img width="1624" height="1056" alt="Screenshot 2025-09-17 at 13 52 54" src="https://github.com/user-attachments/assets/6d875a61-5d3e-4d3f-aa76-c659afbe55d4" />

Some teams re-implemented default comment toggling logic, e.g.:
- esql_editor - https://github.com/elastic/kibana/commit/5193d4569838a07b0673456f72a00b6b541cb96b
```
[ES|QL] Allows to comment out the current line with the keyboard (https://github.com/elastic/kibana/pull/184637)
## Summary

Closes https://github.com/elastic/kibana/issues/184521

It allows the users to comment out the current line by typing `CMD + /`,
bringing it closer to what a developer would expect.
```

## After

Familiar command CMD + / works out of the box unless overwritten

https://github.com/user-attachments/assets/c2164575-f3aa-4bd8-8bab-70b2c2e34f7f


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



