### PR TITLE
[Metrics][Discover] Dimensions and Values dropdowns should respect a maximum number of items selected

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/dimensions_selector.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/dimensions_selector.tsx
@@ -14,6 +14,8 @@ import { i18n } from '@kbn/i18n';
 import { ToolbarSelector, type SelectableEntry } from '@kbn/shared-ux-toolbar-selector';
 import { ClearAllSection } from './clear_all_section';
 
+const MAX_DIMENSIONS_SELECTIONS = 10;
+
 interface DimensionsFilterProps {
   fields: Array<{
     name: string;
@@ -79,19 +81,28 @@ export const DimensionsSelector = ({
   }, [fields, selectedDimensions, allDimensions]);
 
   const options: SelectableEntry[] = useMemo(() => {
-    return allDimensions.map<SelectableEntry>((dimension) => ({
-      value: dimension.name,
-      label: dimension.name,
-      checked: selectedDimensions.includes(dimension.name) ? 'on' : undefined,
-      disabled: !intersectingDimensions.has(dimension.name),
-      toolTipContent: dimension.description,
-      key: dimension.name,
-    }));
+    const isAtMaxLimit = selectedDimensions.length >= MAX_DIMENSIONS_SELECTIONS;
+    return allDimensions.map<SelectableEntry>((dimension) => {
+      const isSelected = selectedDimensions.includes(dimension.name);
+      const isIntersecting = intersectingDimensions.has(dimension.name);
+      const isDisabledByLimit = !isSelected && isAtMaxLimit;
+
+      return {
+        value: dimension.name,
+        label: dimension.name,
+        checked: isSelected ? 'on' : undefined,
+        disabled: !isIntersecting || isDisabledByLimit,
+        key: dimension.name,
+      };
+    });
   }, [allDimensions, selectedDimensions, intersectingDimensions]);
 
   const handleChange = useCallback(
     (chosenOption?: SelectableEntry[]) => {
-      onChange(chosenOption?.map((p) => p.value) ?? []);
+      const newSelection = chosenOption?.map((p) => p.value) ?? [];
+      // Enforce the maximum limit
+      const limitedSelection = newSelection.slice(0, MAX_DIMENSIONS_SELECTIONS);
+      onChange(limitedSelection);
     },
     [onChange]
   );
@@ -121,18 +132,24 @@ export const DimensionsSelector = ({
   }, [selectedDimensions]);
 
   const popoverContentBelowSearch = useMemo(() => {
+    const isAtMaxLimit = selectedDimensions.length >= MAX_DIMENSIONS_SELECTIONS;
+    const statusMessage = isAtMaxLimit
+      ? i18n.translate('metricsExperience.dimensionsSelector.maxLimitStatusMessage', {
+          defaultMessage:
+            'Maximum of {maxDimensions} dimensions selected ({count}/{maxDimensions})',
+          values: { count: selectedDimensions.length, maxDimensions: MAX_DIMENSIONS_SELECTIONS },
+        })
+      : i18n.translate('metricsExperience.dimensionsSelector.selectedStatusMessage', {
+          defaultMessage:
+            '{count, plural, one {# dimension selected} other {# dimensions selected}}',
+          values: { count: selectedDimensions.length },
+        });
+
     return (
       <ClearAllSection
         selectedOptionsLength={selectedDimensions.length}
         onClearAllAction={onClear}
-        selectedOptionsMessage={i18n.translate(
-          'metricsExperience.dimensionsSelector.selectedStatusMessage',
-          {
-            defaultMessage:
-              '{count, plural, one {# dimension selected} other {# dimensions selected}}',
-            values: { count: selectedDimensions.length },
-          }
-        )}
+        selectedOptionsMessage={statusMessage}
       />
     );
   }, [onClear, selectedDimensions.length]);

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/values_selector.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/values_selector.tsx
@@ -24,6 +24,8 @@ import { FIELD_VALUE_SEPARATOR } from '../../common/utils';
 import { useDimensionsQuery } from '../../hooks';
 import { ClearAllSection } from './clear_all_section';
 
+const MAX_VALUES_SELECTIONS = 10;
+
 interface ValuesFilterProps {
   selectedDimensions: string[];
   selectedValues: string[];
@@ -56,6 +58,7 @@ export const ValuesSelector = ({
   const options: SelectableEntry[] = useMemo(() => {
     const groupedValues = new Map<string, string[]>();
     const selectedSet = new Set(selectedValues);
+    const isAtMaxLimit = selectedValues.length >= MAX_VALUES_SELECTIONS;
 
     values.forEach(({ value, field }) => {
       const arr = groupedValues.get(field) ?? [];
@@ -67,10 +70,14 @@ export const ValuesSelector = ({
       { label: field, isGroupLabel: true, value: field },
       ...fieldValues.map<SelectableEntry>((value) => {
         const key = `${field}${FIELD_VALUE_SEPARATOR}${value}`;
+        const isSelected = selectedSet.has(key);
+        const isDisabledByLimit = !isSelected && isAtMaxLimit;
+
         return {
           value,
           label: value,
-          checked: selectedSet.has(key) ? 'on' : undefined,
+          checked: isSelected ? 'on' : undefined,
+          disabled: isDisabledByLimit,
           key,
         };
       }),
@@ -83,7 +90,9 @@ export const ValuesSelector = ({
         ?.filter((option) => !option.isGroupLabel && option.key)
         .map((option) => option.key!);
 
-      onChange(newSelectedValues ?? []);
+      // Enforce the maximum limit
+      const limitedSelection = (newSelectedValues ?? []).slice(0, MAX_VALUES_SELECTIONS);
+      onChange(limitedSelection);
     },
     [onChange]
   );
@@ -123,17 +132,22 @@ export const ValuesSelector = ({
   }, [isLoading, selectedValues.length]);
 
   const popoverContentBelowSearch = useMemo(() => {
+    const isAtMaxLimit = selectedValues.length >= MAX_VALUES_SELECTIONS;
+    const statusMessage = isAtMaxLimit
+      ? i18n.translate('metricsExperience.valuesSelector.maxLimitStatusMessage', {
+          defaultMessage: 'Maximum of {maxValues} values selected ({count}/{maxValues})',
+          values: { count: selectedValues.length, maxValues: MAX_VALUES_SELECTIONS },
+        })
+      : i18n.translate('metricsExperience.valuesSelector.selectedStatusMessage', {
+          defaultMessage: '{count, plural, one {# value selected} other {# values selected}}',
+          values: { count: selectedValues.length },
+        });
+
     return (
       <ClearAllSection
         selectedOptionsLength={selectedValues.length}
         onClearAllAction={onClear}
-        selectedOptionsMessage={i18n.translate(
-          'metricsExperience.valuesSelector.selectedStatusMessage',
-          {
-            defaultMessage: '{count, plural, one {# value selected} other {# values selected}}',
-            values: { count: selectedValues.length },
-          }
-        )}
+        selectedOptionsMessage={statusMessage}
       />
     );
   }, [selectedValues.length, onClear]);


### PR DESCRIPTION
Closes #234885
## Summary

This PR limits the dimensions and value selection to 10 options at a time.

Dimensions: 

<img width="3550" height="894" alt="image" src="https://github.com/user-attachments/assets/eb456baf-2f45-4df3-b78c-445f4f05c497" />


Fields:

<img width="2446" height="1204" alt="image" src="https://github.com/user-attachments/assets/8732dff5-415d-4896-a9b5-1220128c9335" />


## How to test
- Clone https://github.com/simianhacker/simian-forge/tree/main
- Run ` ./forge --dataset hosts --count 25 --interval 30s`
- Set the following config to `kibana.dev.yml`

> [!WARNING]  
>  There has been a change after the last merge with the main branch, where the FF was introduced

```yml
discover.experimental.enabledProfiles:
  - observability-metrics-data-source-profile
feature_flags.overrides:
  metricsExperienceEnabled: true
 ```
- Navigate to Discover and Switch to ESQL mode
- Run `FROM metrics-*` search
- Validate if:
  - Selecting fields and dimensions is still working as before
  - The selection limit (of 10) is enforced in both selectors, and a message is shown to notify the user about the limit (like in the screenshots above)