### PR TITLE
WIP

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-common/agents/definition.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/agents/definition.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import type { ToolSelection } from '../tools';
+import { TOOL_SELECTION_SCHEMA } from '../tools';
+import { schema, TypeOf } from '@kbn/config-schema';
 
 /**
  * The type of an agent.
@@ -30,51 +31,22 @@ export interface AgentDescriptor {
   description: string;
 }
 
-/**
- * Definition of a onechat agent.
- */
-export interface AgentDefinition {
-  /**
-   * Id of the agent
-   */
-  id: string;
-  /**
-   * The type of the agent (only for type for now, here for future-proofing)
-   */
-  type: AgentType;
-  /**
-   * Human-readable name for the agent.
-   */
-  name: string;
-  /**
-   * Human-readable description for the agent.
-   */
-  description: string;
-  /**
-   * Optional labels used to organize or filter agents
-   */
-  labels?: string[];
-  /**
-   * Optional color used to represent the agent in the UI
-   */
-  avatar_color?: string;
-  /**
-   * Optional symbol used to represent the agent in the UI
-   */
-  avatar_symbol?: string;
-  /**
-   * Configuration associated with this agent
-   */
-  configuration: AgentConfiguration;
-}
+export const AGENT_CONFIGURATION_SCHEMA = schema.object({
+  instructions: schema.maybe(schema.string()),
+  tools: TOOL_SELECTION_SCHEMA,
+});
 
-export interface AgentConfiguration {
-  /**
-   * Custom instruction for the agent
-   */
-  instructions?: string;
-  /**
-   * List of tools exposed to the agent
-   */
-  tools: ToolSelection[];
-}
+export const AGENT_DEFINITION_SCHEMA = schema.object({
+  id: schema.string(),
+  type: schema.literal('chat'),
+  name: schema.string(),
+  description: schema.string(),
+  labels: schema.maybe(schema.arrayOf(schema.string())),
+  avatar_color: schema.maybe(schema.string()),
+  avatar_symbol: schema.maybe(schema.string()),
+  configuration: AGENT_CONFIGURATION_SCHEMA
+});
+
+export type AgentDefinition = TypeOf<typeof AGENT_DEFINITION_SCHEMA>;
+
+export type AgentConfiguration = TypeOf<typeof AGENT_CONFIGURATION_SCHEMA>;

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/constants.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/constants.ts
@@ -7,6 +7,7 @@
 
 import { ToolType } from './definition';
 import { internalNamespaces } from './namespaces';
+import { schema, TypeOf } from '@kbn/config-schema';
 
 const platformCoreTool = (toolName: string) => {
   return `${internalNamespaces.platformCore}.${toolName}`;
@@ -42,3 +43,27 @@ export const defaultAgentToolIds = [
  * Agent will perform poorly if it has too many tools.
  */
 export const activeToolsCountWarningThreshold = 24;
+
+
+export const TOOL_DEFINITION_SCHEMA = schema.object({
+  id: schema.string(),
+  // @ts-expect-error schema.oneOf expects at least one element, and `map` returns a list
+  type: schema.oneOf(editableToolTypes.map((type) => schema.literal(type))),
+  description: schema.string({ defaultValue: '' }),
+  readonly: schema.boolean(),
+  tags: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  // actual config validation is done in the tool service
+  configuration: schema.recordOf(schema.string(), schema.any()),
+});
+
+export const TOOL_DEFINITION_WITH_SCHEMA_SCHEMA = schema.object({
+  id: schema.string(),
+  // @ts-expect-error schema.oneOf expects at least one element, and `map` returns a list
+  type: schema.oneOf(editableToolTypes.map((type) => schema.literal(type))),
+  description: schema.string({ defaultValue: '' }),
+  readonly: schema.boolean(),
+  tags: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  // actual config validation is done in the tool service
+  configuration: schema.recordOf(schema.string(), schema.any()),
+  schema: schema.object({}, { unknowns: 'allow' })
+});

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/definition.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/definition.ts
@@ -6,6 +6,8 @@
  */
 
 import type { JsonSchema7ObjectType } from 'zod-to-json-schema';
+import { schema, TypeOf } from '@kbn/config-schema';
+
 
 /**
  * Possible types of tools
@@ -24,6 +26,7 @@ export enum ToolType {
    */
   index_search = 'index_search',
 }
+
 
 /**
  * Serializable representation of a tool, without its handler or schema.

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/index.ts
@@ -22,6 +22,7 @@ export {
   filterToolsBySelection,
   allToolsSelectionWildcard,
   allToolsSelection,
+  TOOL_SELECTION_SCHEMA,
 } from './tool_selection';
 export {
   type EsqlToolConfig,

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/tool_result.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/tool_result.ts
@@ -7,6 +7,7 @@
 
 import type { SearchRequest } from '@elastic/elasticsearch/lib/api/types';
 import type { EsqlEsqlColumnInfo, FieldValue } from '@elastic/elasticsearch/lib/api/types';
+import { schema } from '@kbn/config-schema';
 
 export enum ToolResultType {
   resource = 'resource',
@@ -59,6 +60,77 @@ export interface ErrorResult {
     metadata?: Record<string, unknown>;
   };
 }
+
+export const TOOL_RESULT_SCHEMA = schema.oneOf([
+  // ErrorResult
+  schema.object({
+    type: schema.literal(ToolResultType.error),
+    data: schema.object({
+      message: schema.string(),
+      stack: schema.maybe(schema.object({}, {unknowns: 'allow'})),
+      metadata: schema.maybe(schema.object({}, {unknowns: 'allow'}))
+    })
+  }),
+  //OtherResult
+  schema.object({
+    type: schema.literal(ToolResultType.other),
+    data: schema.object({}, {unknowns: 'allow'})
+  }),
+  //QueryResult
+  schema.object({
+    type: schema.literal(ToolResultType.query),
+    data: schema.oneOf([
+      schema.object({
+        dsl: schema.object({}) // idk how to represent this
+      }),
+      schema.object({
+        esql: schema.string()
+      })
+    ])
+  }),
+  // TabularData
+  schema.object({
+    tool_result_id: schema.string(),
+    type: schema.literal(ToolResultType.tabularData),
+    data: schema.object({
+      source: schema.maybe(
+        schema.literal('esql')
+      ),
+      query: schema.string(),
+      columns: schema.arrayOf(
+        schema.object({
+          name: schema.string(),
+          type: schema.string()
+        })
+      ),
+      values: schema.arrayOf(schema.arrayOf(
+        schema.maybe(
+          schema.oneOf(
+            [
+              schema.boolean(),
+              schema.number(),
+              schema.string()
+            ]
+          )
+        )
+      ))
+    })
+  }),
+  // ResourceResult
+  schema.object({
+    type: schema.literal(ToolResultType.resource),
+    data: schema.object({
+      reference: schema.object({
+        id: schema.string(),
+        index: schema.string(),
+        routing: schema.maybe(schema.string())
+      }),
+      title: schema.maybe(schema.string()),
+      partial: schema.maybe(schema.boolean()),
+      content: schema.object({}, { unknowns: 'allow'})
+    })
+  })
+])
 
 export type ToolResult =
   | ResourceResult

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/tool_selection.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/tool_selection.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ToolDefinition } from './definition';
+import { schema, TypeOf } from '@kbn/config-schema';
 
 export type ToolSelectionRelevantFields = Pick<ToolDefinition, 'id'>;
 
@@ -43,7 +44,14 @@ export interface ByIdsToolSelection {
 /**
  * All possible subtypes for tool selection - for now there is only one.
  */
-export type ToolSelection = ByIdsToolSelection;
+
+export const TOOL_SELECTION_SCHEMA = schema.arrayOf(
+  schema.object({
+    tool_ids: schema.arrayOf(schema.string()),
+  })
+);
+
+export type ToolSelection = TypeOf<typeof TOOL_SELECTION_SCHEMA>;
 
 /**
  * Check if a given {@link ToolSelection} is a {@link ByIdsToolSelection}

--- a/x-pack/platform/plugins/shared/onechat/server/routes/agents.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/agents.ts
@@ -18,14 +18,11 @@ import type {
   ListAgentResponse,
 } from '../../common/http_api/agents';
 import { getTechnicalPreviewWarning } from './utils';
+import { AGENT_DEFINITION_SCHEMA } from '@kbn/onechat-common/agents/definition';
+import { TOOL_SELECTION_SCHEMA } from '@kbn/onechat-common/tools';
 
 const TECHNICAL_PREVIEW_WARNING = getTechnicalPreviewWarning('Elastic Agent API');
 
-const TOOL_SELECTION_SCHEMA = schema.arrayOf(
-  schema.object({
-    tool_ids: schema.arrayOf(schema.string()),
-  })
-);
 
 export function registerAgentRoutes({ router, getInternalServices, logger }: RouteDependencies) {
   const wrapHandler = getHandlerWrapper({ logger });
@@ -50,7 +47,13 @@ export function registerAgentRoutes({ router, getInternalServices, logger }: Rou
     .addVersion(
       {
         version: '2023-10-31',
-        validate: false,
+        validate: {
+          response: { 
+            200: {
+              body: () => schema.object({ results: schema.arrayOf(AGENT_DEFINITION_SCHEMA) })
+            }
+          }
+        },
       },
       wrapHandler(async (ctx, request, response) => {
         const { agents: agentsService } = getInternalServices();
@@ -82,6 +85,11 @@ export function registerAgentRoutes({ router, getInternalServices, logger }: Rou
         version: '2023-10-31',
         validate: {
           request: { params: schema.object({ id: schema.string() }) },
+          response: { 
+            200: {
+              body: () => AGENT_DEFINITION_SCHEMA
+            }
+          }
         },
       },
       wrapHandler(async (ctx, request, response) => {
@@ -128,6 +136,11 @@ export function registerAgentRoutes({ router, getInternalServices, logger }: Rou
               }),
             }),
           },
+          response: {
+            200: {
+              body: () => AGENT_DEFINITION_SCHEMA
+            }
+          }
         },
       },
       wrapHandler(async (ctx, request, response) => {
@@ -175,6 +188,11 @@ export function registerAgentRoutes({ router, getInternalServices, logger }: Rou
               ),
             }),
           },
+          response: {
+            200: {
+              body: () => AGENT_DEFINITION_SCHEMA
+            }
+          },
         },
       },
       wrapHandler(async (ctx, request, response) => {
@@ -207,6 +225,11 @@ export function registerAgentRoutes({ router, getInternalServices, logger }: Rou
         version: '2023-10-31',
         validate: {
           request: { params: schema.object({ id: schema.string() }) },
+          response: {
+            200: {
+              body: () => schema.object({ success: schema.boolean() })
+            }
+          }
         },
       },
       wrapHandler(async (ctx, request, response) => {

--- a/x-pack/platform/plugins/shared/onechat/server/routes/tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/tools.ts
@@ -22,6 +22,8 @@ import type {
 import { apiPrivileges } from '../../common/features';
 import { publicApiPath } from '../../common/constants';
 import { getTechnicalPreviewWarning } from './utils';
+import { TOOL_DEFINITION_WITH_SCHEMA_SCHEMA } from '@kbn/onechat-common/tools/constants';
+import { TOOL_RESULT_SCHEMA } from '@kbn/onechat-common/tools/tool_result';
 
 const TECHNICAL_PREVIEW_WARNING = getTechnicalPreviewWarning('Elastic Tool API');
 
@@ -46,7 +48,15 @@ export function registerToolsRoutes({ router, getInternalServices, logger }: Rou
       },
     })
     .addVersion(
-      { version: '2023-10-31', validate: false },
+      { version: '2023-10-31', validate: {
+        response: {
+          200: {
+            body: () => schema.object({ 
+              results: schema.arrayOf(TOOL_DEFINITION_WITH_SCHEMA_SCHEMA)
+            })
+          }
+        }
+      } },
       wrapHandler(async (ctx, request, response) => {
         const { tools: toolService } = getInternalServices();
         const registry = await toolService.getRegistry({ request });
@@ -85,6 +95,11 @@ export function registerToolsRoutes({ router, getInternalServices, logger }: Rou
               id: schema.string(),
             }),
           },
+          response: {
+            200: {
+              body: () => schema.arrayOf(TOOL_DEFINITION_WITH_SCHEMA_SCHEMA)
+            }
+          }
         },
       },
       wrapHandler(async (ctx, request, response) => {
@@ -129,6 +144,11 @@ export function registerToolsRoutes({ router, getInternalServices, logger }: Rou
               // actual config validation is done in the tool service
               configuration: schema.recordOf(schema.string(), schema.any()),
             }),
+          },
+          response: {
+            200: {
+              body: () => schema.arrayOf(TOOL_DEFINITION_WITH_SCHEMA_SCHEMA)
+            }
           },
         },
       },
@@ -175,6 +195,11 @@ export function registerToolsRoutes({ router, getInternalServices, logger }: Rou
               configuration: schema.maybe(schema.recordOf(schema.string(), schema.any())),
             }),
           },
+          response: {
+            200: {
+              body: () => schema.arrayOf(TOOL_DEFINITION_WITH_SCHEMA_SCHEMA)
+            }
+          },
         },
       },
       wrapHandler(async (ctx, request, response) => {
@@ -215,6 +240,13 @@ export function registerToolsRoutes({ router, getInternalServices, logger }: Rou
               id: schema.string(),
             }),
           },
+          response: {
+            200: {
+              body: () => schema.object({
+                success: schema.boolean()
+              })
+            }
+          },
         },
       },
       wrapHandler(async (ctx, request, response) => {
@@ -252,6 +284,16 @@ export function registerToolsRoutes({ router, getInternalServices, logger }: Rou
               tool_id: schema.string({}),
               tool_params: schema.recordOf(schema.string(), schema.any()),
             }),
+          },
+          response: {
+            200: {
+              body: () => schema.object({
+                results: schema.arrayOf(TOOL_RESULT_SCHEMA)
+              })
+            },
+            400: {
+              body: () => schema.object({message: schema.string()})
+            }
           },
         },
       },


### PR DESCRIPTION
This PR demonstrates some changes to start showing response format in the documentation generated from the agent_builder package.

To test the changes, you can download a file below and run it with `bump-cli`:

```
npm install -g bump-cli
npx bump preview <path_to_json_file>
```

Examples:

- With no changes, head of `main` branch: [agent_builder_no_changes.json](https://github.com/user-attachments/files/22384287/agent_builder_no_changes.json)
- With changes to show responses from the API endpoints (did it for Agent and Tool API group for demonstration purposes): [agent_builder.json](https://github.com/user-attachments/files/22384238/agent_builder.json)
