### PR TITLE
[ObsUX][Infra] Add check for APM privileges on asset details page

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/overview/overview.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/overview/overview.tsx
@@ -37,7 +37,7 @@ export const Overview = () => {
   const {
     services: { application },
   } = useKibanaContextForPlugin();
-  const hasApmPermissions = application.capabilities.apm?.show ?? false;
+  const hasApmPermissions = Boolean(application.capabilities.apm?.show);
 
   const metadataSummarySection = isFullPageView ? (
     <MetadataSummaryList

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/overview/overview.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/overview/overview.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { useKibanaContextForPlugin } from '../../../../hooks/use_kibana';
 import {
   MetadataSummaryList,
   MetadataSummaryListCompact,
@@ -33,6 +34,10 @@ export const Overview = () => {
   } = useMetadataStateContext();
   const { metrics } = useDataViewsContext();
   const isFullPageView = renderMode.mode === 'page';
+  const {
+    services: { application },
+  } = useKibanaContextForPlugin();
+  const hasApmPermissions = application.capabilities.apm?.show ?? false;
 
   const metadataSummarySection = isFullPageView ? (
     <MetadataSummaryList
@@ -75,7 +80,7 @@ export const Overview = () => {
           <SectionSeparator />
         </EuiFlexItem>
       ) : null}
-      {entity.type === 'host' ? (
+      {entity.type === 'host' && hasApmPermissions ? (
         <EuiFlexItem grow={false}>
           <ServicesContent hostName={entity.id} dateRange={dateRange} />
           <SectionSeparator />


### PR DESCRIPTION
## Summary

Fixes #190088

This PR solves the error when trying to retrieve services without APM permissions, causing a pop-up to display. 
It won't show the services accordion if the user doesn't have the required privileges.

## Before
<img width="631" height="765" alt="image" src="https://github.com/user-attachments/assets/e6d5ecb5-f5ca-442f-8cb4-4356bc7f9375" />


## After
<img width="642" height="697" alt="image" src="https://github.com/user-attachments/assets/7b0701e2-4ab1-4c65-8b87-d1cf311cf550" />


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->