### PR TITLE
fix(core, config-schema): properly handle `context` in `recordOf` and `mapOf` schemas

### DIFF
--- a/src/platform/packages/shared/kbn-config-schema/src/internals/index.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/internals/index.ts
@@ -320,6 +320,7 @@ export const internals: JoiRoot = Joi.extend(
               validatedEntryKey = Joi.attempt(entryKey, args.key, {
                 presence: 'required',
                 stripUnknown: prefs.stripUnknown,
+                context: prefs.context,
               });
             } catch (e) {
               return error('map.key', { entryKey, reason: e });
@@ -330,6 +331,7 @@ export const internals: JoiRoot = Joi.extend(
               validatedEntryValue = Joi.attempt(entryValue, args.value, {
                 presence: 'required',
                 stripUnknown: prefs.stripUnknown,
+                context: prefs.context,
               });
             } catch (e) {
               return error('map.value', { entryKey, reason: e });
@@ -395,6 +397,7 @@ export const internals: JoiRoot = Joi.extend(
               validatedEntryKey = Joi.attempt(entryKey, args.key, {
                 presence: 'required',
                 stripUnknown: prefs.stripUnknown,
+                context: prefs.context,
               });
             } catch (e) {
               return error('record.key', { entryKey, reason: e });
@@ -405,6 +408,7 @@ export const internals: JoiRoot = Joi.extend(
               validatedEntryValue = Joi.attempt(entryValue, args.value, {
                 presence: 'required',
                 stripUnknown: prefs.stripUnknown,
+                context: prefs.context,
               });
             } catch (e) {
               return error('record.value', { entryKey, reason: e });

--- a/src/platform/packages/shared/kbn-config-schema/src/types/map_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/map_type.test.ts
@@ -362,3 +362,28 @@ describe('nested unknowns', () => {
     expect(type.validate(value, void 0, void 0, {})).toStrictEqual(expected);
   });
 });
+
+test('handles references', () => {
+  const type = schema.mapOf(
+    schema.string(),
+    schema.conditional(
+      schema.contextRef('scenario'),
+      'context',
+      schema.object({
+        value: schema.string({ defaultValue: schema.contextRef('context_value') }),
+        sibling: schema.string({ defaultValue: 'sibling#1' }),
+      }),
+      schema.object({
+        value: schema.string({ defaultValue: schema.siblingRef('sibling') }),
+        sibling: schema.string({ defaultValue: 'sibling#1' }),
+      })
+    )
+  );
+
+  expect(
+    type.validate(new Map([['key', {}]]), { scenario: 'context', context_value: 'context#1' })
+  ).toEqual(new Map([['key', { value: 'context#1', sibling: 'sibling#1' }]]));
+  expect(
+    type.validate(new Map([['key', {}]]), { scenario: 'sibling', context_value: 'context#1' })
+  ).toEqual(new Map([['key', { value: 'sibling#1', sibling: 'sibling#1' }]]));
+});


### PR DESCRIPTION
## Summary

Properly handle `context` in `recordOf` and `mapOf` schemas.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->