### PR TITLE
[ES|QL] Handle properly recommended queries with one pipe

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/options/recommended_queries/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/options/recommended_queries/index.ts
@@ -10,35 +10,12 @@ import { i18n } from '@kbn/i18n';
 import type { RecommendedQuery, RecommendedField } from '@kbn/esql-types';
 import type { GetColumnsByTypeFn, ISuggestionItem } from '../../types';
 import { METADATA_FIELDS } from '../metadata';
+import { prettifyQueryTemplate, prettifyQuery } from './utils';
 
 export interface EditorExtensions {
   recommendedQueries: RecommendedQuery[];
   recommendedFields: RecommendedField[];
 }
-
-const prettifyQuery = (src: string): string => {
-  // Split by pipes and format each command on its own line with indentation
-  const parts = src.split('|').map((part) => part.trim());
-
-  return parts
-    .map((part, index) => {
-      if (index === 0) {
-        // First part (FROM command) - no leading pipe or indentation
-        return part;
-      } else {
-        // All subsequent commands start with pipe and have 2-space indentation
-        return `  | ${part}`;
-      }
-    })
-    .join('\n');
-};
-
-const prettifyQueryTemplate = (query: string) => {
-  const formattedQuery = prettifyQuery(query);
-  // remove the FROM command if it exists
-  const queryParts = formattedQuery.split('|');
-  return `\n|${queryParts.slice(1).join('|')}`;
-};
 
 // Order starts with the simple ones and goes to more complex ones
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/options/recommended_queries/utils.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/options/recommended_queries/utils.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { prettifyQueryTemplate, prettifyQuery } from './utils';
+
+describe('prettifyQueryTemplate', () => {
+  it('should return empty string when query has no pipes', () => {
+    const query = 'FROM logs';
+    const result = prettifyQueryTemplate(query);
+    expect(result).toBe('');
+  });
+
+  it('should remove FROM command and return formatted template when query has pipes', () => {
+    const query = 'FROM logs | WHERE status = "error"';
+    const result = prettifyQueryTemplate(query);
+    expect(result).toBe('\n| WHERE status = "error"');
+  });
+});
+
+describe('prettifyQuery', () => {
+  it('should format single command without pipe', () => {
+    const query = 'FROM logs';
+    const result = prettifyQuery(query);
+    expect(result).toBe('FROM logs');
+  });
+
+  it('should format multiple commands with proper indentation', () => {
+    const query = 'FROM logs | WHERE status = "error" | STATS count = COUNT(*)';
+    const result = prettifyQuery(query);
+    expect(result).toBe('FROM logs\n  | WHERE status = "error"\n  | STATS count = COUNT(*)');
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/options/recommended_queries/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/options/recommended_queries/utils.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const prettifyQuery = (src: string): string => {
+  // Split by pipes and format each command on its own line with indentation
+  const parts = src.split('|').map((part) => part.trim());
+
+  return parts
+    .map((part, index) => {
+      if (index === 0) {
+        // First part (FROM command) - no leading pipe or indentation
+        return part;
+      } else {
+        // All subsequent commands start with pipe and have 2-space indentation
+        return `  | ${part}`;
+      }
+    })
+    .join('\n');
+};
+
+export const prettifyQueryTemplate = (query: string) => {
+  const formattedQuery = prettifyQuery(query);
+  // remove the FROM command if it exists
+  const queryParts = formattedQuery.split('|');
+  // If there's only one part (no pipes), return empty string
+  if (queryParts.length <= 1) {
+    return '';
+  }
+  return `\n|${queryParts.slice(1).join('|')}`;
+};


### PR DESCRIPTION
## Summary

It prettifies correctly recommended queries with one pipe. We don't have one at the moment but the obs wants to add the `from metrics*` and the prettifier didnt check this case. I added some tests too.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




