### PR TITLE
Adding GH action to auto comment on rule param changes

### DIFF
--- a/.github/workflows/rule-type-param-changes-comment.yml
+++ b/.github/workflows/rule-type-param-changes-comment.yml
@@ -1,0 +1,20 @@
+name: rule-type-param-changes-comment
+
+on:
+  pull_request_target:
+    types:
+      - opened
+    paths:
+      - 'x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap'
+
+jobs:
+  rule-type-param-changes-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/auto-comment@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pullRequestOpened: |
+            @{{ author }}, it looks like you're updating the parameters for a rule type!
+
+            Please review the [guidelines](https://docs.elastic.dev/reops/developer-guide/best-practices-rules#upgrades-and-rollbacks) for making additive changes to rule type parameters and determine if your changes require an intermediate release.

--- a/.github/workflows/rule-type-param-changes-comment.yml
+++ b/.github/workflows/rule-type-param-changes-comment.yml
@@ -12,7 +12,7 @@ jobs:
   rule-type-param-changes-comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: wow-actions/auto-comment@v1
+      - uses: wow-actions/auto-comment@2fc064c21cfb2505de3c5c10e1473b8eb7beca1a # v1.1.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pullRequestOpened: |

--- a/.github/workflows/rule-type-param-changes-comment.yml
+++ b/.github/workflows/rule-type-param-changes-comment.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - synchronize
     paths:
       - 'x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap'
 

--- a/.github/workflows/rule-type-param-changes-comment.yml
+++ b/.github/workflows/rule-type-param-changes-comment.yml
@@ -19,3 +19,7 @@ jobs:
             @{{ author }}, it looks like you're updating the parameters for a rule type!
 
             Please review the [guidelines](https://docs.elastic.dev/reops/developer-guide/best-practices-rules#upgrades-and-rollbacks) for making additive changes to rule type parameters and determine if your changes require an intermediate release.
+          pullRequestSynchronize: |
+            @{{ author }}, it looks like you're updating the parameters for a rule type!
+
+            Please review the [guidelines](https://docs.elastic.dev/reops/developer-guide/best-practices-rules#upgrades-and-rollbacks) for making additive changes to rule type parameters and determine if your changes require an intermediate release.


### PR DESCRIPTION
## Summary

Adding a Github action to auto-comment on PRs that touch `x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap`.

