### PR TITLE
[ResponseOps][Connectors] Jira Service Management Connector phase 2

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/jira-service-management/model.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/jira-service-management/model.test.tsx
@@ -27,16 +27,13 @@ beforeAll(() => {
   }
 });
 
-// Temporarily skipped until we enable the frontend part of the JSM connector
-// https://github.com/elastic/kibana/issues/231571
-
-describe.skip('connectorTypeRegistry.get() works', () => {
+describe('connectorTypeRegistry.get() works', () => {
   it('sets the id field in the connector type static data to the correct value', () => {
     expect(connectorTypeModel.id).toEqual(JIRA_SERVICE_MANAGEMENT_CONNECTOR_TYPE_ID);
   });
 });
 
-describe.skip('jira service management action params validation', () => {
+describe('jira service management action params validation', () => {
   it('results in no errors when the action params are valid for creating an alert', async () => {
     const actionParams = {
       subAction: JiraServiceManagementSubActions.CreateAlert,

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/jira-service-management/model.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/jira-service-management/model.tsx
@@ -44,8 +44,6 @@ export const getConnectorType = (): ConnectorTypeModel<
 > => {
   return {
     id: '.jira-service-management',
-    // Hidden while in intermediate release
-    hideInUi: true,
     iconClass: lazy(() => import('./jsm_logo')),
     selectMessage: SELECT_MESSAGE,
     actionTypeTitle: TITLE,

--- a/x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/index.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/index.ts
@@ -11,6 +11,7 @@ export default ({ loadTestFile }: FtrProviderContext) => {
   describe('Connectors', function () {
     loadTestFile(require.resolve('./general'));
     loadTestFile(require.resolve('./opsgenie'));
+    loadTestFile(require.resolve('./jsm'));
     loadTestFile(require.resolve('./tines'));
     loadTestFile(require.resolve('./slack'));
     loadTestFile(require.resolve('./webhook'));

--- a/x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/jsm.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/jsm.ts
@@ -1,0 +1,384 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../../../ftr_provider_context';
+import type { ObjectRemover } from '../../../lib/object_remover';
+import { generateUniqueKey } from '../../../lib/get_test_data';
+import { createSlackConnectorAndObjectRemover, getConnectorByName } from './utils';
+
+export default ({ getPageObjects, getService }: FtrProviderContext) => {
+  const testSubjects = getService('testSubjects');
+  const pageObjects = getPageObjects(['common', 'triggersActionsUI', 'header']);
+  const find = getService('find');
+  const retry = getService('retry');
+  const supertest = getService('supertest');
+  const actions = getService('actions');
+  const rules = getService('rules');
+  const browser = getService('browser');
+  const toasts = getService('toasts');
+  let objectRemover: ObjectRemover;
+
+  describe('Jira Service Management', () => {
+    before(async () => {
+      objectRemover = await createSlackConnectorAndObjectRemover({ getService });
+    });
+
+    after(async () => {
+      await objectRemover.removeAll();
+    });
+
+    describe('connector page', () => {
+      beforeEach(async () => {
+        await pageObjects.common.navigateToApp('triggersActionsConnectors');
+      });
+
+      it('should create the connector', async () => {
+        const connectorName = generateUniqueKey();
+
+        await actions.jsm.createNewConnector({
+          name: connectorName,
+          apiKey: 'apiKey',
+        });
+
+        const toastTitle = await toasts.getTitleAndDismiss();
+        expect(toastTitle).to.eql(`Created '${connectorName}'`);
+
+        await pageObjects.triggersActionsUI.searchConnectors(connectorName);
+
+        const searchResults = await pageObjects.triggersActionsUI.getConnectorsList();
+        expect(searchResults).to.eql([
+          {
+            name: connectorName,
+            actionType: 'Jira Service Management',
+          },
+        ]);
+        const connector = await getConnectorByName(connectorName, supertest);
+        objectRemover.add(connector.id, 'connector', 'actions');
+      });
+
+      it('should edit the connector', async () => {
+        const connectorName = generateUniqueKey();
+        const updatedConnectorName = `${connectorName}updated`;
+        const createdAction = await createJsmConnector(connectorName);
+        objectRemover.add(createdAction.id, 'connector', 'actions');
+        await browser.refresh();
+
+        await pageObjects.triggersActionsUI.searchConnectors(connectorName);
+
+        const searchResultsBeforeEdit = await pageObjects.triggersActionsUI.getConnectorsList();
+        expect(searchResultsBeforeEdit.length).to.eql(1);
+
+        await find.clickByCssSelector('[data-test-subj="connectorsTableCell-name"] button');
+        await actions.jsm.updateConnectorFields({
+          name: updatedConnectorName,
+          apiKey: 'apiKey',
+        });
+
+        const toastTitle = await toasts.getTitleAndDismiss();
+        expect(toastTitle).to.eql(`Updated '${updatedConnectorName}'`);
+
+        await testSubjects.click('euiFlyoutCloseButton');
+        await pageObjects.triggersActionsUI.searchConnectors(updatedConnectorName);
+
+        const searchResultsAfterEdit = await pageObjects.triggersActionsUI.getConnectorsList();
+        expect(searchResultsAfterEdit).to.eql([
+          {
+            name: updatedConnectorName,
+            actionType: 'Jira Service Management',
+          },
+        ]);
+      });
+
+      it('should reset connector when canceling an edit', async () => {
+        const connectorName = generateUniqueKey();
+        const createdAction = await createJsmConnector(connectorName);
+        objectRemover.add(createdAction.id, 'connector', 'actions');
+        await browser.refresh();
+
+        await pageObjects.triggersActionsUI.searchConnectors(connectorName);
+
+        const searchResultsBeforeEdit = await pageObjects.triggersActionsUI.getConnectorsList();
+        expect(searchResultsBeforeEdit.length).to.eql(1);
+
+        await find.clickByCssSelector('[data-test-subj="connectorsTableCell-name"] button');
+
+        await testSubjects.setValue('nameInput', 'some test name to cancel');
+        await testSubjects.click('edit-connector-flyout-close-btn');
+        await testSubjects.click('confirmModalConfirmButton');
+
+        await find.waitForDeletedByCssSelector(
+          '[data-test-subj="edit-connector-flyout-close-btn"]'
+        );
+
+        await pageObjects.triggersActionsUI.searchConnectors(connectorName);
+
+        await find.clickByCssSelector('[data-test-subj="connectorsTableCell-name"] button');
+        expect(await testSubjects.getAttribute('nameInput', 'value')).to.eql(connectorName);
+        await testSubjects.click('euiFlyoutCloseButton');
+      });
+
+      it('should disable the run button when the message field is not filled', async () => {
+        const connectorName = generateUniqueKey();
+        const createdAction = await createJsmConnector(connectorName);
+        objectRemover.add(createdAction.id, 'connector', 'actions');
+        await browser.refresh();
+
+        await pageObjects.triggersActionsUI.searchConnectors(connectorName);
+
+        const searchResultsBeforeEdit = await pageObjects.triggersActionsUI.getConnectorsList();
+        expect(searchResultsBeforeEdit.length).to.eql(1);
+
+        await find.clickByCssSelector('[data-test-subj="connectorsTableCell-name"] button');
+
+        await find.clickByCssSelector('[data-test-subj="testConnectorTab"]');
+
+        expect(await testSubjects.isEnabled('executeActionButton')).to.be(false);
+      });
+
+      describe('test page', () => {
+        let connectorId = '';
+
+        before(async () => {
+          const connectorName = generateUniqueKey();
+          const createdAction = await createJsmConnector(connectorName);
+          connectorId = createdAction.id;
+          objectRemover.add(createdAction.id, 'connector', 'actions');
+        });
+
+        beforeEach(async () => {
+          await testSubjects.click(`edit${connectorId}`);
+          await testSubjects.click('testConnectorTab');
+        });
+
+        afterEach(async () => {
+          await actions.common.cancelConnectorForm();
+        });
+
+        it('should show the sub action selector when in test mode', async () => {
+          await testSubjects.existOrFail('jsm-subActionSelect');
+        });
+
+        it('should preserve the alias when switching between create and close alert actions', async () => {
+          await testSubjects.setValue('aliasInput', 'new alias');
+          await testSubjects.selectValue('jsm-subActionSelect', 'closeAlert');
+
+          expect(await testSubjects.getAttribute('jsm-subActionSelect', 'value')).to.be(
+            'closeAlert'
+          );
+          expect(await testSubjects.getAttribute('aliasInput', 'value')).to.be('new alias');
+        });
+
+        it('should not preserve the message when switching to close alert and back to create alert', async () => {
+          await testSubjects.setValue('messageInput', 'a message');
+          await testSubjects.selectValue('jsm-subActionSelect', 'closeAlert');
+
+          await testSubjects.missingOrFail('messageInput');
+          await retry.waitFor('message input to be displayed', async () => {
+            await testSubjects.selectValue('jsm-subActionSelect', 'createAlert');
+            return await testSubjects.exists('messageInput');
+          });
+
+          expect(await testSubjects.getAttribute('messageInput', 'value')).to.be('');
+        });
+
+        describe('createAlert', () => {
+          it('should show the additional options for creating an alert when clicking more options', async () => {
+            await testSubjects.click('jsm-display-more-options');
+
+            await testSubjects.existOrFail('entityInput');
+            await testSubjects.existOrFail('sourceInput');
+            await testSubjects.existOrFail('userInput');
+            await testSubjects.existOrFail('noteTextArea');
+          });
+
+          it('should show and then hide the additional form options for creating an alert when clicking the button twice', async () => {
+            await testSubjects.click('jsm-display-more-options');
+
+            await testSubjects.existOrFail('entityInput');
+
+            await testSubjects.click('jsm-display-more-options');
+            await testSubjects.missingOrFail('entityInput');
+          });
+
+          it('should populate the json editor with the message, description, and alias', async () => {
+            await testSubjects.setValue('messageInput', 'a message');
+            await testSubjects.setValue('descriptionTextArea', 'a description');
+            await testSubjects.setValue('aliasInput', 'an alias');
+            await testSubjects.setValue('jsm-prioritySelect', 'P5');
+            await testSubjects.setValue('jsm-tags', 'a tag');
+
+            await testSubjects.click('jsm-show-json-editor-toggle');
+
+            const parsedValue = await actions.jsm.getObjFromJsonEditor();
+            expect(parsedValue).to.eql({
+              message: 'a message',
+              description: 'a description',
+              alias: 'an alias',
+              priority: 'P5',
+              tags: ['a tag'],
+            });
+          });
+
+          it('should populate the form with the values from the json editor', async () => {
+            await testSubjects.click('jsm-show-json-editor-toggle');
+
+            await actions.jsm.setJsonEditor({
+              message: 'a message',
+              description: 'a description',
+              alias: 'an alias',
+              priority: 'P3',
+              tags: ['tag1'],
+            });
+            await testSubjects.click('jsm-show-json-editor-toggle');
+
+            expect(await testSubjects.getAttribute('messageInput', 'value')).to.be('a message');
+            expect(await testSubjects.getAttribute('descriptionTextArea', 'value')).to.be(
+              'a description'
+            );
+            expect(await testSubjects.getAttribute('aliasInput', 'value')).to.be('an alias');
+            expect(await testSubjects.getAttribute('jsm-prioritySelect', 'value')).to.eql('P3');
+            expect(await (await testSubjects.find('jsm-tags')).getVisibleText()).to.eql('tag1');
+          });
+
+          it('should disable the run button when the json editor validation fails', async () => {
+            await testSubjects.click('jsm-show-json-editor-toggle');
+
+            await actions.jsm.setJsonEditor({
+              message: '',
+            });
+
+            expect(await testSubjects.isEnabled('executeActionButton')).to.be(false);
+          });
+        });
+
+        describe('closeAlert', () => {
+          it('should show the additional options for closing an alert when clicking more options', async () => {
+            await testSubjects.selectValue('jsm-subActionSelect', 'closeAlert');
+
+            await testSubjects.click('jsm-display-more-options');
+
+            await testSubjects.existOrFail('sourceInput');
+            await testSubjects.existOrFail('userInput');
+          });
+
+          it('should show and then hide the additional form options for closing an alert when clicking the button twice', async () => {
+            await testSubjects.selectValue('jsm-subActionSelect', 'closeAlert');
+
+            await testSubjects.click('jsm-display-more-options');
+
+            await testSubjects.existOrFail('sourceInput');
+
+            await testSubjects.click('jsm-display-more-options');
+            await testSubjects.missingOrFail('sourceInput');
+          });
+        });
+      });
+    });
+
+    describe('alerts page', () => {
+      const defaultAlias = '{{rule.id}}:{{alert.id}}';
+      const connectorName = generateUniqueKey();
+
+      before(async () => {
+        const createdAction = await createJsmConnector(connectorName);
+        objectRemover.add(createdAction.id, 'connector', 'actions');
+
+        await pageObjects.common.navigateToApp('triggersActions');
+      });
+
+      beforeEach(async () => {
+        await setupRule();
+        await selectJsmConnectorInRuleAction(connectorName);
+      });
+
+      afterEach(async () => {
+        await rules.common.cancelRuleCreation();
+      });
+
+      it('should default to the create alert action', async () => {
+        await find.clickByButtonText('Message');
+        await testSubjects.existOrFail('messageInput');
+
+        expect(await testSubjects.getAttribute('aliasInput', 'value')).to.eql(defaultAlias);
+      });
+
+      it('should default to the close alert action when setting the run when to recovered', async () => {
+        await find.clickByButtonText('Settings');
+        await testSubjects.click('ruleActionsSettingsSelectActionGroup');
+        await testSubjects.click('addNewActionConnectorActionGroup-recovered');
+
+        await find.clickByButtonText('Message');
+        expect(await testSubjects.getAttribute('aliasInput', 'value')).to.eql(defaultAlias);
+        await testSubjects.existOrFail('noteTextArea');
+        await testSubjects.missingOrFail('messageInput');
+      });
+
+      it('should not preserve the alias when switching run when to recover', async () => {
+        await find.clickByButtonText('Message');
+        await testSubjects.setValue('aliasInput', 'an alias');
+
+        await find.clickByButtonText('Settings');
+        await testSubjects.click('ruleActionsSettingsSelectActionGroup');
+        await testSubjects.click('addNewActionConnectorActionGroup-recovered');
+
+        await find.clickByButtonText('Message');
+        await testSubjects.missingOrFail('messageInput');
+        expect(await testSubjects.getAttribute('aliasInput', 'value')).to.be(defaultAlias);
+      });
+
+      it('should not preserve the alias when switching run when to threshold met', async () => {
+        await find.clickByButtonText('Settings');
+        await testSubjects.click('ruleActionsSettingsSelectActionGroup');
+        await testSubjects.click('addNewActionConnectorActionGroup-recovered');
+
+        await find.clickByButtonText('Message');
+        await testSubjects.missingOrFail('messageInput');
+        await testSubjects.setValue('aliasInput', 'an alias');
+
+        await find.clickByButtonText('Settings');
+        await testSubjects.click('ruleActionsSettingsSelectActionGroup');
+        await testSubjects.click('addNewActionConnectorActionGroup-threshold met');
+
+        await find.clickByButtonText('Message');
+        await testSubjects.exists('messageInput');
+        expect(await testSubjects.getAttribute('aliasInput', 'value')).to.be(defaultAlias);
+      });
+
+      it('should show the message is required error when clicking the save button', async () => {
+        expect(
+          await (await testSubjects.find('rulePageFooterSaveButton')).getAttribute('disabled')
+        ).to.be('true');
+      });
+    });
+
+    const setupRule = async () => {
+      const alertName = generateUniqueKey();
+      await retry.try(async () => {
+        await rules.common.defineIndexThresholdAlert(alertName);
+      });
+    };
+
+    const selectJsmConnectorInRuleAction = async (name: string) => {
+      await testSubjects.click('ruleActionsAddActionButton');
+      await testSubjects.existOrFail('ruleActionsConnectorsModal');
+      await find.clickByButtonText(name);
+
+      await find.clickByButtonText('Settings');
+      await rules.common.setNotifyThrottleInput();
+    };
+
+    const createJsmConnector = async (name: string) => {
+      return actions.api.createConnector({
+        name,
+        config: {},
+        secrets: { apiKey: '1234' },
+        connectorTypeId: '.jira-service-management',
+      });
+    };
+  });
+};

--- a/x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/jsm.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/jsm.ts
@@ -375,7 +375,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     const createJsmConnector = async (name: string) => {
       return actions.api.createConnector({
         name,
-        config: {},
+        config: { apiUrl: 'https://test.com' },
         secrets: { apiKey: '1234' },
         connectorTypeId: '.jira-service-management',
       });


### PR DESCRIPTION
## 📄 Summary

> [!IMPORTANT]
> This PR completes the intermediate release process for the new JSM connector.

- Enables the JSM connector UI
- Unskips/adds back UI-related tests

## 🧪 Verification steps

The JSM connector UI was verified in the [phase 1 PR](https://github.com/elastic/kibana/pull/231155).

<details>
<summary>

## 🔗 References

Closes #231571

## Release Notes

Adds a new Connector for Jira Service Management

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
- [ ] ~~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.