### PR TITLE
Updating rule type parameter GH action

### DIFF
--- a/.github/workflows/rule-type-param-changes-comment.yml
+++ b/.github/workflows/rule-type-param-changes-comment.yml
@@ -18,7 +18,10 @@ jobs:
           script: |
             const comment = `@${context.payload.pull_request.user.login}, it looks like you're updating the parameters for a rule type!
 
-            Please review the [guidelines](https://docs.elastic.dev/reops/developer-guide/best-practices-rules#upgrades-and-rollbacks) for making additive changes to rule type parameters and determine if your changes require an intermediate release.`;
+            Please review the [guidelines](https://docs.elastic.dev/reops/developer-guide/best-practices-rules#upgrades-and-rollbacks) for making additive changes to rule type parameters and determine if your changes require an intermediate release.
+
+            <!-- Rule type parameter change comment marker -->
+            `;
 
             const { data: existingComments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -26,7 +29,7 @@ jobs:
               issue_number: context.issue.number,
             })
             const botComment = existingComments.find(c => {
-              return c.body.includes('it looks like you're updating the parameters for a rule type')
+              return c.body.includes('<!-- Rule type parameter change comment marker -->')
             })
 
             if (!botComment) {

--- a/.github/workflows/rule-type-param-changes-comment.yml
+++ b/.github/workflows/rule-type-param-changes-comment.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const comment = `@${context.payload.issue.user.login}, it looks like you're updating the parameters for a rule type!
+            const comment = `@${context.payload.pull_request.user.login}, it looks like you're updating the parameters for a rule type!
 
             Please review the [guidelines](https://docs.elastic.dev/reops/developer-guide/best-practices-rules#upgrades-and-rollbacks) for making additive changes to rule type parameters and determine if your changes require an intermediate release.`;
 

--- a/.github/workflows/rule-type-param-changes-comment.yml
+++ b/.github/workflows/rule-type-param-changes-comment.yml
@@ -12,14 +12,28 @@ jobs:
   rule-type-param-changes-comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: wow-actions/auto-comment@2fc064c21cfb2505de3c5c10e1473b8eb7beca1a # v1.1.2
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          pullRequestOpened: |
-            @{{ author }}, it looks like you're updating the parameters for a rule type!
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const comment = `@${context.payload.issue.user.login}, it looks like you're updating the parameters for a rule type!
 
-            Please review the [guidelines](https://docs.elastic.dev/reops/developer-guide/best-practices-rules#upgrades-and-rollbacks) for making additive changes to rule type parameters and determine if your changes require an intermediate release.
-          pullRequestSynchronize: |
-            @{{ author }}, it looks like you're updating the parameters for a rule type!
+            Please review the [guidelines](https://docs.elastic.dev/reops/developer-guide/best-practices-rules#upgrades-and-rollbacks) for making additive changes to rule type parameters and determine if your changes require an intermediate release.`;
 
-            Please review the [guidelines](https://docs.elastic.dev/reops/developer-guide/best-practices-rules#upgrades-and-rollbacks) for making additive changes to rule type parameters and determine if your changes require an intermediate release.
+            const { data: existingComments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = existingComments.find(c => {
+              return c.body.includes('it looks like you're updating the parameters for a rule type')
+            })
+
+            if (!botComment) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              })
+            }

--- a/.github/workflows/rule-type-param-changes-comment.yml
+++ b/.github/workflows/rule-type-param-changes-comment.yml
@@ -33,7 +33,7 @@ jobs:
             })
 
             if (!botComment) {
-              github.rest.issues.createComment({
+              await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/rule-type-param-changes-comment.yml
+++ b/.github/workflows/rule-type-param-changes-comment.yml
@@ -29,7 +29,7 @@ jobs:
               issue_number: context.issue.number,
             })
             const botComment = existingComments.find(c => {
-              return c.body.includes('<!-- Rule type parameter change comment marker -->')
+              return c.body && c.body.includes('<!-- Rule type parameter change comment marker -->')
             })
 
             if (!botComment) {


### PR DESCRIPTION
## Summary

[Initial PR](https://github.com/elastic/kibana/pull/235386) would leave the comment every time the PR was synchronized, which is not ideal, but we want the action to run when the PR is synchronized not just opened because often people forget the update the snapshot when the PR is first opened. This action allows us to check for the existence of the comment and only post if we haven't posted before.