### PR TITLE
Extend HTTP Guidance after TF tests

### DIFF
--- a/dev_docs/contributing/kibana_http_api_design_guidelines.mdx
+++ b/dev_docs/contributing/kibana_http_api_design_guidelines.mdx
@@ -396,6 +396,11 @@ Choose sensible defaults. When uncertain, ask API callers to make informed decis
 
 Changing the value of a default may, in some cases, have a devastating result similar to a breaking change.
 
+**Should be returned in the response (most of the time)**
+
+Public API configurable defaults should be returned in the response. Internal defaults do not need to be returned.
+Refer to <DocLink id="kibHttpApiTfGuidelines" section="return-as-much-as-you-can-and-handle-defaults-carefully" text="Terraform's guidelines on defaults" /> to learn more.
+
 ### Validation
 
 **Runtime validation should be as narrow as feasible**

--- a/dev_docs/contributing/kibana_http_api_tf_guidelines.mdx
+++ b/dev_docs/contributing/kibana_http_api_tf_guidelines.mdx
@@ -260,15 +260,15 @@ Many Kibana APIs have extensive configuration options. Requiring users to specif
 
 [Our tests](https://github.com/elastic/kibana-team/issues/2001) show the following facts:
 
-* Excess fields that Terraform doesn't understand are not a problem: it dismisses them when comparing the resource.
-* When a resource attribute is defined as `Optional: true, Computed: true`, it allows external changes if the customer doesn't specify a value: Kibana can change the defaults, not return it, or a user can manually change that attribute without Terraform noticing.
-* Defining a resource attribute as `Optional: true, Default: <default value>` provides a more consistent behavior to the user (it identifies external changes), but can tighten the Terraform provider's version support matrix: if Kibana changes the default value, Terraform will still set its internal default instead. Bear in mind that our Terraform provider doesn't follow the Stack release cycle, so we can't guarantee that the default value will be the same as the one in the Stack.
+* The API can return fields that Terraform doesn't understand (e.g.: a new version of Kibana returns extra fields in the response, or it returns fields that Terraform users shouldn't be concerned about like `last_updated` or `created_by`): Terraform dismisses them when comparing the resource.
+* Resource attributes defined as `Optional: true, Computed: true`: Terraform won't detect changes. This means we can change the defaults, choose not to return it, and users can manually change that attribute without Terraform noticing the change.
+* Defining a resource attribute as `Optional: true, Default: <default value>` provides a more consistent behavior to the user (it identifies external changes), but can tighten the Terraform provider's version support matrix: if Kibana changes the default value, Terraform won't know about the change until the Terraform resource configuration gets updated. Keep in mind that our Terraform provider doesn't follow the Stack release cycle, so we can't guarantee that the default value will be the same as the one in the Stack.
 
 This is why the overall recommendation is to return as much information as possible and define the optional attributes in the [Terraform provider](https://github.com/elastic/terraform-provider-elasticstack/tree/main/internal/kibana) as `Optional: true, Default: <default value>`.
 
 **So can't I return slimmed-down information?**
 
-If you have a use case where you'd like your API to remove defaults from the response, you can do so, but we recommend that you add a query parameter to disable this behavior so that Terraform can always retrieve them.
+If you have a use case where you'd like your API to remove defaults from the response, you can do so, but we recommend that you add a query parameter to control stripping defaults so that Terraform can always retrieve them by requesting the full response.
 
 ### Be predictable
 

--- a/dev_docs/contributing/kibana_http_api_tf_guidelines.mdx
+++ b/dev_docs/contributing/kibana_http_api_tf_guidelines.mdx
@@ -252,11 +252,23 @@ The cost of not catching errors early is interrupted workflow, repetitive plan/a
 
 ### Return as much as you can, and handle defaults carefully
 
-Terraform needs complete information to track resource state effectively. If your API doesn't return enough details, Terraform can't properly detect changes or manage drift.
+Terraform needs complete information to track resource state effectively. If your API doesn't return enough details, Terraform can't properly detect changes or manage drift. For this reason, **the overall recommendation is to _return as much information as possible and define the optional attributes in the [Terraform provider](https://github.com/elastic/terraform-provider-elasticstack/tree/main/internal/kibana) as `Optional: true, Default: <default value>`._**
 
 **The challenge with defaults**
 
 Many Kibana APIs have extensive configuration options. Requiring users to specify every single value would create verbose, unwieldy configurations. We need to keep in mind that changing a default may cause Terraform to get out-of-sync and so view changes to defaults as a breaking change until we can update our provider.
+
+[Our tests](https://github.com/elastic/kibana-team/issues/2001) show the following facts:
+
+* Excess fields that Terraform doesn't understand are not a problem: it dismisses them when comparing the resource.
+* When a resource attribute is defined as `Optional: true, Computed: true`, it allows external changes if the customer doesn't specify a value: Kibana can change the defaults, not return it, or a user can manually change that attribute without Terraform noticing.
+* Defining a resource attribute as `Optional: true, Default: <default value>` provides a more consistent behavior to the user (it identifies external changes), but can tighten the Terraform provider's version support matrix: if Kibana changes the default value, Terraform will still set its internal default instead. Bear in mind that our Terraform provider doesn't follow the Stack release cycle, so we can't guarantee that the default value will be the same as the one in the Stack.
+
+This is why the overall recommendation is to return as much information as possible and define the optional attributes in the [Terraform provider](https://github.com/elastic/terraform-provider-elasticstack/tree/main/internal/kibana) as `Optional: true, Default: <default value>`.
+
+**So can't I return slimmed-down information?**
+
+If you have a use case where you'd like your API to remove defaults from the response, you can do so, but we recommend that you add a query parameter to disable this behavior so that Terraform can always retrieve them.
 
 ### Be predictable
 

--- a/dev_docs/contributing/kibana_http_api_tf_guidelines.mdx
+++ b/dev_docs/contributing/kibana_http_api_tf_guidelines.mdx
@@ -270,8 +270,6 @@ This is why the overall recommendation is to return as much information as possi
 
 If you have a use case where you'd like your API to remove defaults from the response, you can do so, but we recommend that you add a query parameter to control stripping defaults so that Terraform can always retrieve them by requesting the full response.
 
-To achieve smaller responses, we recommend following Elasticsearch's approach, by using `filter_path` ([docs](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/common-options#common-options-response-filtering)).
-
 ### Be predictable
 
 Terraform relies on the same input resulting in the same output. Avoid using fields like "last modified time"—Terraform can’t compare those meaningfully. This can be tricky with sensitive fields or when your API relies on randomness.

--- a/dev_docs/contributing/kibana_http_api_tf_guidelines.mdx
+++ b/dev_docs/contributing/kibana_http_api_tf_guidelines.mdx
@@ -260,15 +260,17 @@ Many Kibana APIs have extensive configuration options. Requiring users to specif
 
 [Our tests](https://github.com/elastic/kibana-team/issues/2001) show the following facts:
 
+* Defining a resource attribute as `Optional: true, Default: <default value>` (_recommended_) provides a more consistent behavior to the user (it identifies external changes, and ensures a consistent default value fixed by their Terraform Provider's version), but can restrict the Terraform provider's version support matrix: if Kibana changes the default value, Terraform won't know about the change until the Terraform resource configuration gets updated. Keep in mind that our Terraform provider doesn't follow the Stack release cycle, so we can't guarantee that the default value will be the same as the one in the Stack. Also, the opposite can occur: a more recent version of the Terraform provider may have a default value that is not supported by an older version of Kibana. However, there is an easy workaround: the user can define a valid value if this occurs.
+* Resource attributes defined as `Optional: true, Computed: true`: Terraform won't detect changes unless explicitly defined by the Terraform user. This means we can change the defaults, choose not to return it, and UI users can manually change that attribute without Terraform noticing the change if no explicit value is provided by the user in their terraform definition.
 * The API can return fields that Terraform doesn't understand (e.g.: a new version of Kibana returns extra fields in the response, or it returns fields that Terraform users shouldn't be concerned about like `last_updated` or `created_by`): Terraform dismisses them when comparing the resource.
-* Resource attributes defined as `Optional: true, Computed: true`: Terraform won't detect changes. This means we can change the defaults, choose not to return it, and users can manually change that attribute without Terraform noticing the change.
-* Defining a resource attribute as `Optional: true, Default: <default value>` provides a more consistent behavior to the user (it identifies external changes), but can tighten the Terraform provider's version support matrix: if Kibana changes the default value, Terraform won't know about the change until the Terraform resource configuration gets updated. Keep in mind that our Terraform provider doesn't follow the Stack release cycle, so we can't guarantee that the default value will be the same as the one in the Stack.
 
 This is why the overall recommendation is to return as much information as possible and define the optional attributes in the [Terraform provider](https://github.com/elastic/terraform-provider-elasticstack/tree/main/internal/kibana) as `Optional: true, Default: <default value>`.
 
 **So can't I return slimmed-down information?**
 
 If you have a use case where you'd like your API to remove defaults from the response, you can do so, but we recommend that you add a query parameter to control stripping defaults so that Terraform can always retrieve them by requesting the full response.
+
+To achieve smaller responses, we recommend following Elasticsearch's approach, by using `filter_path` ([docs](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/common-options#common-options-response-filtering)).
 
 ### Be predictable
 


### PR DESCRIPTION
## Summary

After we ran extensive testing in TF to understand the behaviour of defaults, this PR extends the recommendation of how to handle optional properties with defaults.


### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



