### PR TITLE
[Obs AI Assistant] Migrate alerts eval scenarios to Phoenix

### DIFF
--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/alerts/alerts.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/alerts/alerts.spec.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RuleResponse } from '@kbn/alerting-plugin/common/routes/rule/response/types/v1';
+import moment from 'moment';
+import { apm, timerange } from '@kbn/apm-synthtrace-client';
+import { createEvaluateAlertsDataset } from './evaluate_alerts_dataset';
+import type { EvaluateAlertsDataset } from './evaluate_alerts_dataset';
+import { evaluate as base } from '../../src/evaluate';
+import {
+  apmTransactionRateAIAssistant,
+  customThresholdAIAssistantLogCount,
+} from '../../src/alert_templates/alerts';
+
+/**
+ * NOTE: This scenario has been migrated from the legacy evaluation framework.
+ * - x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/alerts/index.spec.ts
+ * Any changes should be made in both places until the legacy evaluation framework is removed.
+ */
+
+const evaluate = base.extend<{
+  evaluateAlerts: EvaluateAlertsDataset;
+}>({
+  evaluateAlerts: [
+    ({ chatClient, evaluators, phoenixClient }, use) => {
+      use(
+        createEvaluateAlertsDataset({
+          chatClient,
+          evaluators,
+          phoenixClient,
+        })
+      );
+    },
+    { scope: 'test' },
+  ],
+});
+
+evaluate.describe('Alerts', { tag: '@svlOblt' }, () => {
+  const ruleIds: string[] = [];
+
+  evaluate.beforeAll(async ({ kbnClient, apmSynthtraceEsClient, log }) => {
+    log.info('Creating APM rule');
+    const responseApmRule = await kbnClient.request<RuleResponse>({
+      method: 'POST',
+      path: '/api/alerting/rule',
+      body: apmTransactionRateAIAssistant.ruleParams,
+    });
+    ruleIds.push(responseApmRule.data.id);
+
+    log.info('Creating dataview');
+    try {
+      await kbnClient.request({
+        method: 'POST',
+        path: '/api/content_management/rpc/create',
+        body: customThresholdAIAssistantLogCount.dataViewParams,
+      });
+    } catch (error) {
+      if (error?.status === 409) {
+        log.info('Data view already exists, skipping creation');
+      } else {
+        throw error;
+      }
+    }
+
+    log.info('Creating logs rule');
+    const responseLogsRule = await kbnClient.request<RuleResponse>({
+      method: 'POST',
+      path: '/api/alerting/rule',
+      body: customThresholdAIAssistantLogCount.ruleParams,
+    });
+    ruleIds.push(responseLogsRule.data.id);
+
+    log.debug('Cleaning APM indices');
+    await apmSynthtraceEsClient.clean();
+
+    const myServiceInstance = apm.service('my-service', 'production', 'go').instance('my-instance');
+    log.debug('Indexing synthtrace data');
+    await apmSynthtraceEsClient.index(
+      timerange(moment().subtract(15, 'minutes'), moment())
+        .interval('1m')
+        .rate(10)
+        .generator((timestamp) => [
+          myServiceInstance
+            .transaction('GET /api')
+            .timestamp(timestamp)
+            .duration(50)
+            .failure()
+            .errors(
+              myServiceInstance
+                .error({ message: 'errorMessage', type: 'My Type' })
+                .timestamp(timestamp)
+            ),
+          myServiceInstance
+            .transaction('GET /api')
+            .timestamp(timestamp)
+            .duration(50)
+            .outcome('success'),
+        ])
+    );
+
+    log.debug('Triggering a rule run');
+    await Promise.all(
+      ruleIds.map((ruleId) =>
+        kbnClient.request<void>({
+          method: 'POST',
+          path: `/internal/alerting/rule/${ruleId}/_run_soon`,
+        })
+      )
+    );
+
+    log.debug('Waiting 2.5s to make sure all indices are refreshed');
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+  });
+
+  evaluate('summary of active alerts', async ({ evaluateAlerts }) => {
+    await evaluateAlerts({
+      dataset: {
+        name: 'alerts: active alerts',
+        description: 'Summarizes currently active alerts over the last 4 hours',
+        examples: [
+          {
+            input: {
+              question: 'Are there any active alerts over the last 4 hours?',
+            },
+            output: {
+              criteria: [
+                'Correctly uses the `alerts` function to fetch data for the current time range',
+                'Retrieves 2 alerts',
+                'Responds with a summary of the current active alerts',
+              ],
+            },
+            metadata: {},
+          },
+        ],
+      },
+    });
+  });
+
+  evaluate('filtered alerts', async ({ evaluateAlerts }) => {
+    await evaluateAlerts({
+      dataset: {
+        name: 'alerts: filtered alerts',
+        description:
+          'Checks threshold alerts and then filters by service.name:"my-service" or within the same prompt',
+        examples: [
+          {
+            input: {
+              question: 'Do I have any active threshold alerts for the service my-service?',
+            },
+            output: {
+              criteria: [
+                'Uses the get_alerts_dataset_info function',
+                'Correctly uses the alerts function',
+                'Returns two alerts related to threshold',
+                'After the second question, uses alerts function to filtering on service.name my-service to retrieve active alerts for that service. The filter should be `service.name:"my-service"` or `service.name:my-service`.',
+                'Summarizes the active alerts for the `my-service` service',
+              ],
+            },
+            metadata: {},
+          },
+        ],
+      },
+    });
+  });
+
+  evaluate.afterAll(async ({ kbnClient, apmSynthtraceEsClient, esClient }) => {
+    await apmSynthtraceEsClient.clean();
+    await esClient.deleteByQuery({
+      index: '.alerts-observability-*',
+      query: {
+        match_all: {},
+      },
+      refresh: true,
+    });
+
+    for (const ruleId of ruleIds) {
+      await kbnClient.request({
+        method: 'DELETE',
+        path: `/api/alerting/rule/${ruleId}`,
+      });
+    }
+
+    await kbnClient.request({
+      method: 'POST',
+      path: `/api/content_management/rpc/delete`,
+      body: {
+        contentTypeId: customThresholdAIAssistantLogCount.dataViewParams.contentTypeId,
+        id: customThresholdAIAssistantLogCount.dataViewParams.options.id,
+        options: { force: true },
+        version: 1,
+      },
+    });
+  });
+});

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/alerts/evaluate_alerts_dataset.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/alerts/evaluate_alerts_dataset.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Example } from '@arizeai/phoenix-client/dist/esm/types/datasets';
+import type { DefaultEvaluators, KibanaPhoenixClient } from '@kbn/evals';
+import type { EvaluationDataset } from '@kbn/evals/src/types';
+import type { ObservabilityAIAssistantEvaluationChatClient } from '../../src/chat_client';
+
+interface AlertsExample extends Example {
+  input: {
+    question: string;
+  };
+  output: {
+    criteria?: string[];
+  };
+}
+
+export type EvaluateAlertsDataset = ({
+  dataset: { name, description, examples },
+}: {
+  dataset: {
+    name: string;
+    description: string;
+    examples: AlertsExample[];
+  };
+}) => Promise<void>;
+
+export function createEvaluateAlertsDataset({
+  evaluators,
+  phoenixClient,
+  chatClient,
+}: {
+  evaluators: DefaultEvaluators;
+  phoenixClient: KibanaPhoenixClient;
+  chatClient: ObservabilityAIAssistantEvaluationChatClient;
+}): EvaluateAlertsDataset {
+  return async function evaluateAlertsDataset({
+    dataset: { name, description, examples },
+  }: {
+    dataset: {
+      name: string;
+      description: string;
+      examples: AlertsExample[];
+    };
+  }) {
+    const dataset = {
+      name,
+      description,
+      examples,
+    } satisfies EvaluationDataset;
+
+    await phoenixClient.runExperiment(
+      {
+        dataset,
+        task: async ({ input }) => {
+          const response = await chatClient.complete({
+            messages: input.question,
+          });
+
+          return {
+            errors: response.errors,
+            messages: response.messages,
+          };
+        },
+      },
+      [
+        {
+          name: 'alerts-evaluator',
+          kind: 'LLM',
+          evaluate: async ({ input, output, expected, metadata }) => {
+            const result = await evaluators
+              .criteria(expected.criteria ?? [])
+              .evaluate({ input, expected, output, metadata });
+
+            return result;
+          },
+        },
+      ]
+    );
+  };
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/alert_templates/alerts.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/alert_templates/alerts.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { COMPARATORS } from '@kbn/alerting-comparators';
+
+export enum Aggregators {
+  COUNT = 'count',
+  AVERAGE = 'avg',
+  SUM = 'sum',
+  MIN = 'min',
+  MAX = 'max',
+  CARDINALITY = 'cardinality',
+}
+
+export const customThresholdAIAssistantLogCount = {
+  dataViewParams: {
+    contentTypeId: 'index-pattern',
+    data: {
+      fieldAttrs: '{}',
+      title: 'logs-apm*',
+      timeFieldName: '@timestamp',
+      sourceFilters: '[]',
+      fields: '[]',
+      fieldFormatMap: '{}',
+      typeMeta: '{}',
+      runtimeFieldMap: '{}',
+      name: 'logs_synth',
+    },
+    options: { id: 'logs_synth' },
+    version: 1,
+  },
+
+  ruleParams: {
+    tags: ['observability'],
+    consumer: 'logs',
+    name: 'Threshold surpassed in AI Assistant eval',
+    rule_type_id: 'observability.rules.custom_threshold',
+    params: {
+      criteria: [
+        {
+          comparator: COMPARATORS.GREATER_THAN,
+          threshold: [10],
+          timeSize: 2,
+          timeUnit: 'h',
+          metrics: [{ name: 'A', filter: '', aggType: Aggregators.COUNT }],
+        },
+      ],
+      groupBy: ['service.name'],
+      alertOnNoData: true,
+      alertOnGroupDisappear: true,
+      searchConfiguration: {
+        query: {
+          query: '',
+          language: 'kuery',
+        },
+        index: 'logs_synth',
+      },
+    },
+    actions: [],
+    schedule: {
+      interval: '1m',
+    },
+  },
+};
+
+export const customThresholdAIAssistantMetricAvg = {
+  ruleParams: {
+    consumer: 'logs',
+    name: 'metric_synth',
+    rule_type_id: 'observability.rules.custom_threshold',
+    params: {
+      criteria: [
+        {
+          comparator: COMPARATORS.GREATER_THAN,
+          threshold: [0.5],
+          timeSize: 2,
+          timeUnit: 'h',
+          metrics: [
+            { name: 'A', field: 'system.cpu.total.norm.pct', aggType: Aggregators.AVERAGE },
+          ],
+        },
+      ],
+      groupBy: ['service.name'],
+      searchConfiguration: {
+        query: {
+          query: '',
+        },
+      },
+    },
+    actions: [],
+    schedule: {
+      interval: '1m',
+    },
+  },
+};
+
+export const apmTransactionRateAIAssistant = {
+  ruleParams: {
+    consumer: 'apm',
+    name: 'apm_transaction_rate_AIAssistant',
+    rule_type_id: 'apm.transaction_error_rate',
+    params: {
+      threshold: 10,
+      windowSize: 1,
+      windowUnit: 'h',
+      transactionType: undefined,
+      serviceName: undefined,
+      environment: 'production',
+      searchConfiguration: {
+        query: {
+          query: ``,
+          language: 'kuery',
+        },
+      },
+      groupBy: ['service.name', 'service.environment'],
+      useKqlFilter: true,
+    },
+    actions: [],
+    schedule: {
+      interval: '1m',
+    },
+  },
+};

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/tsconfig.json
@@ -26,5 +26,6 @@
     "@kbn/inference-common",
     "@kbn/product-doc-base-plugin",
     "@kbn/alerts-ui-shared",
+    "@kbn/alerting-comparators",
   ]
 }

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/alerts/index.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/alerts/index.spec.ts
@@ -18,6 +18,12 @@ import {
   customThresholdAIAssistantLogCount,
 } from '../../alert_templates/templates';
 
+/**
+ * NOTE: This scenario has been migrated to the new evaluation framework.
+ * - x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/evals/alerts/alerts.spec.ts
+ * Any changes should be made in both places until the legacy evaluation framework is removed.
+ */
+
 describe('Alerts', () => {
   const ruleIds: any[] = [];
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/232507

## Summary

Migrate alerts evaluation scenarios to Phoenix

<img width="641" height="482" alt="image" src="https://github.com/user-attachments/assets/673eb52c-1974-4ab7-a830-ded1523f1f47" />

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



