### PR TITLE
[ES|QL] Returns all available recommended queries per solution in empty state

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
@@ -315,7 +315,8 @@ export function createCustomCallbackMocks(
     getJoinIndices: jest.fn(async () => ({ indices: joinIndices })),
     getTimeseriesIndices: jest.fn(async () => ({ indices: timeseriesIndices })),
     getEditorExtensions: jest.fn(async (queryString: string) => {
-      if (queryString.includes('logs*')) {
+      // from * is called in the empty state
+      if (queryString.includes('logs*') || queryString === 'from *') {
         return {
           recommendedQueries: editorExtensions.recommendedQueries,
           recommendedFields: editorExtensions.recommendedFields,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -116,7 +116,7 @@ export async function suggest(
           innerText,
           resourceRetriever
         );
-        const editorExtensions = (await resourceRetriever?.getEditorExtensions?.(fromCommand)) ?? {
+        const editorExtensions = (await resourceRetriever?.getEditorExtensions?.('from *')) ?? {
           recommendedQueries: [],
         };
         const recommendedQueriesSuggestionsFromExtensions = mapRecommendedQueriesFromExtensions(

--- a/src/platform/plugins/shared/esql/server/extensions_registry/index.test.ts
+++ b/src/platform/plugins/shared/esql/server/extensions_registry/index.test.ts
@@ -225,6 +225,16 @@ describe('ESQLExtensionsRegistry', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('should return all existing recommended queries if from * is used', () => {
+      const result = registry.getRecommendedQueries('FROM *', availableDatasources, 'oblt');
+
+      expect(result).toEqual([
+        { name: 'Logs Query', query: 'FROM logs-2023 | STATS count()' },
+        { name: 'Metrics Query', query: 'FROM metrics | STATS max(bytes)' },
+        { name: 'Wildcard Logs Query', query: 'FROM logs-* | LIMIT 5' },
+      ]);
+    });
   });
 
   // --- unsetRecommendedQueries tests ---


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/235463

The extensions registry returns all recommended queries per solution if you ask them with `FROM *`. I added a test which proves it.

When we are requesting the extensions on an empty state, I am now asking them with from * for the empty state.

<img width="517" height="319" alt="image" src="https://github.com/user-attachments/assets/7fcc9748-10f9-402a-8ccf-d9575a2b8769" />


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



