### PR TITLE
feat(security): get rid of the deprecaed `authRequired` route option in favor of `security.authc.*`

### DIFF
--- a/src/core/packages/apps/server-internal/src/bundle_routes/bundle_route.test.ts
+++ b/src/core/packages/apps/server-internal/src/bundle_routes/bundle_route.test.ts
@@ -44,12 +44,15 @@ describe('registerRouteForBundle', () => {
         path: '/route-path/{path*}',
         options: {
           access: 'public',
-          authRequired: false,
           excludeFromRateLimiter: true,
           httpResource: true,
         },
         validate: expect.any(Object),
         security: {
+          authc: {
+            enabled: false,
+            reason: expect.any(String),
+          },
           authz: {
             enabled: false,
             reason: expect.any(String),

--- a/src/core/packages/apps/server-internal/src/bundle_routes/bundles_route.ts
+++ b/src/core/packages/apps/server-internal/src/bundle_routes/bundles_route.ts
@@ -33,7 +33,6 @@ export function registerRouteForBundle(
       path: `${routePath}{path*}`,
       options: {
         httpResource: true,
-        authRequired: false,
         access: 'public',
         excludeFromRateLimiter: true,
       },
@@ -43,6 +42,10 @@ export function registerRouteForBundle(
         }),
       },
       security: {
+        authc: {
+          enabled: false,
+          reason: 'This route is used for serving assets and does not require authentication.',
+        },
         authz: {
           enabled: false,
           reason: 'This route is used for serving assets and does not require authorization.',

--- a/src/core/packages/apps/server-internal/src/core_app.test.ts
+++ b/src/core/packages/apps/server-internal/src/core_app.test.ts
@@ -133,7 +133,7 @@ describe('CoreApp', () => {
   });
 
   describe('`/status` route', () => {
-    it('is registered with `authRequired: false` is the status page is anonymous', async () => {
+    it('is registered with disabled authentication and authorization if the status page is anonymous', async () => {
       internalCoreSetup.status.isStatusPageAnonymous.mockReturnValue(true);
       await coreApp.setup(internalCoreSetup, emptyPlugins());
 
@@ -142,14 +142,8 @@ describe('CoreApp', () => {
           path: '/status',
           validate: false,
           security: {
-            authz: {
-              enabled: false,
-              reason: expect.any(String),
-            },
-            authc: {
-              enabled: false,
-              reason: expect.any(String),
-            },
+            authz: { enabled: false, reason: expect.any(String) },
+            authc: { enabled: false, reason: expect.any(String) },
           },
         },
         expect.any(Function)

--- a/src/core/packages/apps/server-internal/src/core_app.test.ts
+++ b/src/core/packages/apps/server-internal/src/core_app.test.ts
@@ -156,7 +156,7 @@ describe('CoreApp', () => {
       );
     });
 
-    it('is registered with `authRequired: true` is the status page is not anonymous', async () => {
+    it('is registered with `security.authc.enabled: true` is the status page is not anonymous', async () => {
       internalCoreSetup.status.isStatusPageAnonymous.mockReturnValue(false);
       await coreApp.setup(internalCoreSetup, emptyPlugins());
 

--- a/src/core/packages/capabilities/server-internal/src/capabilities_service.test.ts
+++ b/src/core/packages/capabilities/server-internal/src/capabilities_service.test.ts
@@ -59,6 +59,7 @@ describe('CapabilitiesService', () => {
             },
             authc: {
               enabled: 'optional',
+              reason: expect.any(String),
             },
           },
         }),

--- a/src/core/packages/capabilities/server-internal/src/routes/resolve_capabilities.ts
+++ b/src/core/packages/capabilities/server-internal/src/routes/resolve_capabilities.ts
@@ -20,10 +20,12 @@ export function registerCapabilitiesRoutes(router: IRouter, resolver: Capabiliti
       security: {
         authz: {
           enabled: false,
-          reason: 'This route delegates authorization to the Capabilities Resolver',
+          reason: 'This route delegates authorization to the Capabilities Resolver.',
         },
         authc: {
           enabled: 'optional',
+          reason:
+            'This route is used to compute capabilities for both authenticated and unauthenticated users (e.g. the login page).',
         },
       },
       validate: {

--- a/src/core/packages/http/router-server-internal/src/request.test.ts
+++ b/src/core/packages/http/router-server-internal/src/request.test.ts
@@ -307,7 +307,7 @@ describe('CoreKibanaRequest', () => {
         });
         const kibanaRequest = CoreKibanaRequest.from(request);
 
-        expect(kibanaRequest.route.options.authRequired).toBe('optional');
+        expect(kibanaRequest.route.options.authRequired).toBe(false);
       });
 
       it('handles required auth: { mode: "try" } as "optional"', () => {
@@ -320,7 +320,7 @@ describe('CoreKibanaRequest', () => {
         });
         const kibanaRequest = CoreKibanaRequest.from(request);
 
-        expect(kibanaRequest.route.options.authRequired).toBe('optional');
+        expect(kibanaRequest.route.options.authRequired).toBe(false);
       });
 
       it('throws on auth: strategy name', () => {
@@ -396,6 +396,25 @@ describe('CoreKibanaRequest', () => {
         const kibanaRequest = CoreKibanaRequest.from(request);
 
         expect(kibanaRequest.route.options.authRequired).toBe(true);
+      });
+
+      it('handles required authc: { enabled: optional }', () => {
+        const request = hapiMocks.createRequest({
+          route: {
+            settings: {
+              app: {
+                security: { authc: { enabled: 'optional', reason: 'Authentication is optional' } },
+              },
+            },
+          },
+        });
+        const kibanaRequest = CoreKibanaRequest.from(request);
+
+        expect(kibanaRequest.route.options.authRequired).toBe(false);
+        expect(kibanaRequest.route.options.security?.authc).toEqual({
+          enabled: 'optional',
+          reason: 'Authentication is optional',
+        });
       });
 
       it('handles required authz simple config', () => {

--- a/src/core/packages/http/router-server-internal/src/request.ts
+++ b/src/core/packages/http/router-server-internal/src/request.ts
@@ -325,7 +325,7 @@ export class CoreKibanaRequest<
     );
   }
 
-  private getAuthRequired(request: RawRequest): boolean | 'optional' {
+  private getAuthRequired(request: RawRequest): boolean {
     if (isFakeRawRequest(request)) {
       return true;
     }
@@ -334,7 +334,7 @@ export class CoreKibanaRequest<
     if (typeof authOptions === 'object') {
       // 'try' is used in the legacy platform
       if (authOptions.mode === 'optional' || authOptions.mode === 'try') {
-        return 'optional';
+        return false;
       }
       if (authOptions.mode === 'required') {
         return true;

--- a/src/core/packages/http/router-server-internal/src/request.ts
+++ b/src/core/packages/http/router-server-internal/src/request.ts
@@ -272,7 +272,6 @@ export class CoreKibanaRequest<
 
     const options = {
       ...omitBy({ excludeFromRateLimiter: this.isExcludedFromRateLimiter(request) }, isNil),
-      authRequired: this.getAuthRequired(request),
       // TypeScript note: Casting to `RouterOptions` to fix the following error:
       //
       //     Property 'app' does not exist on type 'RouteSettings'
@@ -311,7 +310,7 @@ export class CoreKibanaRequest<
     };
   }
 
-  private getSecurity(request: RawRequest): RouteSecurity | undefined {
+  private getSecurity(request: RawRequest) {
     const securityConfig = ((request.route?.settings as RouteOptions)?.app as KibanaRouteOptions)
       ?.security;
 
@@ -322,38 +321,6 @@ export class CoreKibanaRequest<
   private getAccess(request: RawRequest): 'internal' | 'public' {
     return (
       ((request.route?.settings as RouteOptions)?.app as KibanaRouteOptions)?.access ?? 'internal'
-    );
-  }
-
-  private getAuthRequired(request: RawRequest): boolean {
-    if (isFakeRawRequest(request)) {
-      return true;
-    }
-
-    const authOptions = request.route.settings.auth;
-    if (typeof authOptions === 'object') {
-      // 'try' is used in the legacy platform
-      if (authOptions.mode === 'optional' || authOptions.mode === 'try') {
-        return false;
-      }
-      if (authOptions.mode === 'required') {
-        return true;
-      }
-    }
-
-    // legacy platform routes
-    if (authOptions === undefined) {
-      return true;
-    }
-
-    // @ts-expect-error According to @types/hapi__hapi, `route.settings` should be of type `RouteSettings`, but it seems that it's actually `RouteOptions` (https://github.com/hapijs/hapi/blob/v18.4.2/lib/route.js#L139)
-    if (authOptions === false) {
-      return false;
-    }
-    throw new Error(
-      `unexpected authentication options: ${JSON.stringify(authOptions)} for route: ${
-        this.url.pathname
-      }${this.url.search}`
     );
   }
 

--- a/src/core/packages/http/router-server-internal/src/route.ts
+++ b/src/core/packages/http/router-server-internal/src/route.ts
@@ -87,7 +87,7 @@ export function buildRoute({
     method,
     path: getRouteFullPath(router.routerPath, route.path),
     options: validOptions(method, route),
-    security: validRouteSecurity(route.security as DeepPartial<RouteSecurity>, route.options),
+    security: validRouteSecurity(route.security as DeepPartial<RouteSecurity>),
     validationSchemas: route.validate,
     isVersioned: false,
   };

--- a/src/core/packages/http/router-server-internal/src/router.ts
+++ b/src/core/packages/http/router-server-internal/src/router.ts
@@ -172,13 +172,13 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
 
   public emitPostValidate = (
     request: KibanaRequest,
-    postValidateConext: PostValidationMetadata = {
+    postValidateContext: PostValidationMetadata = {
       isInternalApiRequest: true,
       isPublicAccess: false,
     }
   ) => {
     const postValidate: RouterEvents = 'onPostValidate';
-    Router.events.emit(postValidate, request, postValidateConext);
+    Router.events.emit(postValidate, request, postValidateContext);
   };
 
   /** @internal */

--- a/src/core/packages/http/router-server-internal/src/security_route_config_validator.test.ts
+++ b/src/core/packages/http/router-server-internal/src/security_route_config_validator.test.ts
@@ -8,7 +8,8 @@
  */
 
 import { validRouteSecurity } from './security_route_config_validator';
-import { ReservedPrivilegesSet } from '@kbn/core-http-server';
+import { ReservedPrivilegesSet, type RouteSecurity } from '@kbn/core-http-server';
+import type { DeepPartial } from '@kbn/utility-types';
 
 describe('RouteSecurity validation', () => {
   it('should pass validation for valid route security with authz enabled and valid required privileges', () => {
@@ -19,6 +20,7 @@ describe('RouteSecurity validation', () => {
         },
         authc: {
           enabled: 'optional',
+          reason: 'Authentication is optional',
         },
       })
     ).not.toThrow();
@@ -176,6 +178,23 @@ describe('RouteSecurity validation', () => {
     );
   });
 
+  it('should fail validation when authc is optional but reason is missing', () => {
+    const routeSecurity = {
+      authz: {
+        requiredPrivileges: ['read'],
+      },
+      authc: {
+        enabled: 'optional',
+      },
+    };
+
+    expect(() =>
+      validRouteSecurity(routeSecurity as DeepPartial<RouteSecurity>)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"[authc.reason]: expected value of type [string] but got [undefined]"`
+    );
+  });
+
   it('should fail validation when authc is provided in multiple configs', () => {
     const routeSecurity = {
       authz: {
@@ -201,6 +220,7 @@ describe('RouteSecurity validation', () => {
         },
         authc: {
           enabled: 'optional',
+          reason: 'Authentication is optional',
         },
       })
     ).not.toThrow();

--- a/src/core/packages/http/router-server-internal/src/security_route_config_validator.ts
+++ b/src/core/packages/http/router-server-internal/src/security_route_config_validator.ts
@@ -10,7 +10,6 @@
 import { schema } from '@kbn/config-schema';
 import type {
   RouteSecurity,
-  RouteConfigOptions,
   AllRequiredCondition,
   AnyRequiredCondition,
 } from '@kbn/core-http-server';
@@ -148,7 +147,9 @@ const authzSchema = schema.object({
 });
 
 const authcSchema = schema.object({
-  enabled: schema.oneOf([schema.literal(true), schema.literal('optional'), schema.literal(false)]),
+  enabled: schema.oneOf([schema.literal(true), schema.literal('optional'), schema.literal(false)], {
+    defaultValue: true,
+  }),
   reason: schema.conditional(
     schema.siblingRef('enabled'),
     schema.oneOf([schema.literal('optional'), schema.literal(false)]),
@@ -159,20 +160,9 @@ const authcSchema = schema.object({
 
 const routeSecuritySchema = schema.object({
   authz: authzSchema,
-  authc: schema.maybe(authcSchema),
+  authc: authcSchema,
 });
 
-export const validRouteSecurity = (
-  routeSecurity?: DeepPartial<RouteSecurity>,
-  options?: DeepPartial<RouteConfigOptions<any>>
-) => {
-  if (!routeSecurity) {
-    return routeSecurity;
-  }
-
-  if (routeSecurity?.authc !== undefined && options?.authRequired !== undefined) {
-    throw new Error('Cannot specify both security.authc and options.authRequired');
-  }
-
+export const validRouteSecurity = (routeSecurity?: DeepPartial<RouteSecurity>) => {
   return routeSecuritySchema.validate(routeSecurity);
 };

--- a/src/core/packages/http/router-server-internal/src/security_route_config_validator.ts
+++ b/src/core/packages/http/router-server-internal/src/security_route_config_validator.ts
@@ -151,7 +151,7 @@ const authcSchema = schema.object({
   enabled: schema.oneOf([schema.literal(true), schema.literal('optional'), schema.literal(false)]),
   reason: schema.conditional(
     schema.siblingRef('enabled'),
-    schema.literal(false),
+    schema.oneOf([schema.literal('optional'), schema.literal(false)]),
     schema.string(),
     schema.never()
   ),

--- a/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.test.ts
+++ b/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.test.ts
@@ -258,7 +258,6 @@ describe('Versioned route', () => {
       summary: 'test',
       description: 'test',
       options: {
-        authRequired: true,
         tags: ['oas:test'],
         timeout: { payload: 60_000, idleSocket: 10_000 },
         xsrfRequired: false,
@@ -281,7 +280,6 @@ describe('Versioned route', () => {
       method: 'post',
       options: {
         access: 'internal',
-        authRequired: true,
         excludeFromOAS: true,
         httpResource: true,
         tags: ['oas:test'],
@@ -667,6 +665,7 @@ describe('Versioned route', () => {
       },
       authc: {
         enabled: 'optional',
+        reason: 'Authentication is optional',
       },
     };
     const securityConfig2: RouteSecurity = {
@@ -813,6 +812,7 @@ describe('Versioned route', () => {
       },
       authc: {
         enabled: 'optional',
+        reason: 'Authentication is optional',
       },
     };
 
@@ -863,6 +863,7 @@ describe('Versioned route', () => {
       },
       authc: {
         enabled: 'optional',
+        reason: 'Authentication is optional',
       },
     };
 
@@ -888,7 +889,7 @@ describe('Versioned route', () => {
     // @ts-expect-error for test purpose
     const security = route.getSecurity({ headers: { [ELASTIC_HTTP_VERSION_HEADER]: '1' } });
 
-    expect(security.authc).toEqual({ enabled: 'optional' });
+    expect(security.authc).toEqual({ enabled: 'optional', reason: 'Authentication is optional' });
 
     expect(security.authz).toEqual({ requiredPrivileges: ['foo', 'bar'] });
   });

--- a/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.ts
+++ b/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.ts
@@ -90,7 +90,7 @@ export class CoreVersionedRoute implements VersionedRoute {
   private isPublic: boolean;
   private env: Env;
   private enableQueryVersion: boolean;
-  private defaultSecurityConfig: RouteSecurity | undefined;
+  private readonly defaultSecurityConfig: RouteSecurity;
   private defaultHandlerResolutionStrategy: HandlerResolutionStrategy;
   private constructor(
     private readonly router: Router,
@@ -111,7 +111,7 @@ export class CoreVersionedRoute implements VersionedRoute {
     this.useDefaultStrategyForPath =
       this.isPublic || useVersionResolutionStrategyForInternalPaths.has(path);
     this.enableQueryVersion = options.enableQueryVersion === true;
-    this.defaultSecurityConfig = validRouteSecurity(options.security, options.options);
+    this.defaultSecurityConfig = validRouteSecurity(options.security);
     this.options = options;
     this.router.registerRoute({
       path: this.path,
@@ -298,8 +298,6 @@ export class CoreVersionedRoute implements VersionedRoute {
 
     // authc can be defined only on the top route level,
     // so we need to merge it with the versioned one which can have different authz per version
-    return security
-      ? { authz: security.authz, authc: this.defaultSecurityConfig?.authc }
-      : undefined;
+    return { authz: security.authz, authc: this.defaultSecurityConfig.authc };
   };
 }

--- a/src/core/packages/http/server-internal/src/http_server.test.ts
+++ b/src/core/packages/http/server-internal/src/http_server.test.ts
@@ -1115,7 +1115,6 @@ test('exposes route details of incoming request to a route handler', async () =>
       path: '/',
       routePath: '/',
       options: {
-        authRequired: true,
         xsrfRequired: false,
         access: 'internal',
         tags: [],
@@ -1341,7 +1340,6 @@ test('exposes route details of incoming request to a route handler (POST + paylo
       path: '/',
       routePath: '/',
       options: {
-        authRequired: true,
         xsrfRequired: true,
         access: 'internal',
         tags: [],
@@ -2139,7 +2137,7 @@ test('exposes authentication details of incoming request to a route handler', as
       path: '/foo',
       validate: false,
       security: {
-        authc: { enabled: 'optional' },
+        authc: { enabled: 'optional', reason: 'test' },
         authz: { enabled: false, reason: 'test' },
       },
     },
@@ -2175,13 +2173,13 @@ test('exposes authentication details of incoming request to a route handler', as
       path: '/foo',
       routePath: '/foo',
       options: {
-        authRequired: 'optional',
+        authRequired: false,
         xsrfRequired: false,
         access: 'internal',
         tags: [],
         timeout: {},
         security: {
-          authc: { enabled: 'optional' },
+          authc: { enabled: 'optional', reason: 'test' },
           authz: { enabled: false, reason: 'test' },
         },
       },

--- a/src/core/packages/http/server-internal/src/http_server.ts
+++ b/src/core/packages/http/server-internal/src/http_server.ts
@@ -23,7 +23,6 @@ import type { CoreVersionedRouter, Router } from '@kbn/core-http-router-server-i
 import { isSafeMethod } from '@kbn/core-http-router-server-internal';
 import type {
   IRouter,
-  RouteConfigOptions,
   KibanaRouteOptions,
   KibanaRequestState,
   RouterRoute,
@@ -381,7 +380,7 @@ export class HttpServer {
   }
 
   private getAuthOption(
-    authRequired: RouteConfigOptions<any>['authRequired'] = true
+    authRequired: boolean | 'optional' = true
   ): undefined | false | { mode: 'required' | 'try' } {
     if (this.authRegistered === false) return undefined;
 

--- a/src/core/packages/http/server-internal/src/lifecycle/auth.ts
+++ b/src/core/packages/http/server-internal/src/lifecycle/auth.ts
@@ -95,7 +95,7 @@ export function adoptToHapiAuthFormat(
 
       if (authResult.isRedirected(result)) {
         // we cannot redirect a user when resources with optional auth requested
-        if (kibanaRequest.route.options.authRequired === 'optional') {
+        if (kibanaRequest.route.options.security?.authc?.enabled === 'optional') {
           return responseToolkit.continue;
         }
 
@@ -108,7 +108,7 @@ export function adoptToHapiAuthFormat(
       }
 
       if (authResult.isNotHandled(result)) {
-        if (kibanaRequest.route.options.authRequired === 'optional') {
+        if (kibanaRequest.route.options.security?.authc?.enabled === 'optional') {
           return responseToolkit.continue;
         }
         return hapiResponseAdapter.handle(lifecycleResponseFactory.unauthorized());

--- a/src/core/packages/http/server/index.ts
+++ b/src/core/packages/http/server/index.ts
@@ -115,7 +115,7 @@ export type {
   AuthzEnabled,
   RouteAuthz,
   RouteAuthc,
-  AuthcDisabled,
+  AuthcDisabledOrOptional,
   AuthcEnabled,
   Privilege,
   PrivilegeSet,

--- a/src/core/packages/http/server/src/lifecycle/auth.ts
+++ b/src/core/packages/http/server/src/lifecycle/auth.ts
@@ -84,13 +84,13 @@ export interface AuthToolkit {
   authenticated: (data?: AuthResultParams) => AuthResult;
   /**
    * User has no credentials.
-   * Allows user to access a resource when authRequired is 'optional'
-   * Rejects a request when authRequired: true
+   * Allows user to access a resource when authentication is 'optional'
+   * Rejects a request when authentication is required.
    * */
   notHandled: () => AuthResult;
   /**
-   * Redirects user to another location to complete authentication when authRequired: true
-   * Allows user to access a resource without redirection when authRequired: 'optional'
+   * Redirects user to another location to complete authentication when authentication is required.
+   * Allows user to access a resource without redirection when authentication is optional.
    * */
   redirected: (headers: { location: string } & ResponseHeaders) => AuthResult;
 }

--- a/src/core/packages/http/server/src/router/index.ts
+++ b/src/core/packages/http/server/src/router/index.ts
@@ -60,7 +60,7 @@ export type {
   AuthzEnabled,
   RouteAuthz,
   RouteAuthc,
-  AuthcDisabled,
+  AuthcDisabledOrOptional,
   AuthcEnabled,
   RouteSecurity,
   AllRequiredCondition,

--- a/src/core/packages/http/server/src/router/request.ts
+++ b/src/core/packages/http/server/src/router/request.ts
@@ -20,7 +20,7 @@ import type { Headers } from './headers';
 export type RouteSecurityGetter = (request?: {
   headers: KibanaRequest['headers'];
   query?: KibanaRequest['query'];
-}) => RouteSecurity | undefined;
+}) => RouteSecurity;
 export type InternalRouteSecurity = RouteSecurity | RouteSecurityGetter;
 
 /**
@@ -55,7 +55,7 @@ export type KibanaRequestRouteOptions<Method extends RouteMethod> = (Method exte
   | 'get'
   | 'options'
   ? Required<Omit<RouteConfigOptions<Method>, 'body'>>
-  : Required<RouteConfigOptions<Method>>) & { security?: RouteSecurity };
+  : Required<RouteConfigOptions<Method>>) & { security: RouteSecurity };
 
 /**
  * Request specific route information exposed to a handler.

--- a/src/core/packages/http/server/src/router/route.ts
+++ b/src/core/packages/http/server/src/router/route.ts
@@ -244,27 +244,28 @@ export interface AuthzDisabled {
 /**
  * Describes the authentication status when authentication is enabled.
  *
- * - `enabled`: A boolean or string indicating the authentication status. Can be `true` (authentication required) or `'optional'` (authentication is optional).
+ * - `enabled`: A boolean indicating that authentication is required, can only be set to `true`.
  */
 export interface AuthcEnabled {
-  enabled: true | 'optional';
+  enabled: true;
 }
 
 /**
- * Describes the state when authentication is disabled.
+ * Describes the state when authentication is performed optionally or not performed at all.
  *
- * - `enabled`: A boolean indicating that authentication is not enabled (`false`).
- * - `reason`: A string explaining why authentication is disabled.
+ * - `enabled`: A boolean or string indicating the authentication status. Can be `false` (authentication isn't performed)
+ *   or `optional` (authentication is performed optionally).
+ * - `reason`: A string explaining why authentication is disabled or optional.
  */
-export interface AuthcDisabled {
-  enabled: false;
+export interface AuthcDisabledOrOptional {
+  enabled: false | 'optional';
   reason: string;
 }
 
 /**
  * Represents the authentication status for a route. It can either be enabled (`AuthcEnabled`) or disabled (`AuthcDisabled`).
  */
-export type RouteAuthc = AuthcEnabled | AuthcDisabled;
+export type RouteAuthc = AuthcEnabled | AuthcDisabledOrOptional;
 
 /**
  * Represents the authorization status for a route. It can either be enabled (`AuthzEnabled`) or disabled (`AuthzDisabled`).
@@ -293,17 +294,11 @@ export enum ReservedPrivilegesSet {
  */
 export interface RouteConfigOptions<Method extends RouteMethod> {
   /**
-   * Defines authentication mode for a route:
-   * - true. A user has to have valid credentials to access a resource
-   * - false. A user can access a resource without any credentials.
-   * - 'optional'. A user can access a resource, and will be authenticated if provided credentials are valid.
-   *               Can be useful when we grant access to a resource but want to identify a user if possible.
-   *
-   * Defaults to `true` if an auth mechanism is registered.
+   * Allows to disable authentication for a specific route. If not specified, defaults to `true`.
    *
    * @deprecated Use `security.authc.enabled` instead
    */
-  authRequired?: boolean | 'optional';
+  authRequired?: false;
 
   /**
    * Defines xsrf protection requirements for a route:

--- a/src/core/packages/http/server/src/router/route.ts
+++ b/src/core/packages/http/server/src/router/route.ts
@@ -277,7 +277,7 @@ export type RouteAuthz = AuthzEnabled | AuthzDisabled;
  */
 export interface RouteSecurity {
   authz: RouteAuthz;
-  authc?: RouteAuthc;
+  authc: RouteAuthc;
 }
 
 /**
@@ -293,13 +293,6 @@ export enum ReservedPrivilegesSet {
  * @public
  */
 export interface RouteConfigOptions<Method extends RouteMethod> {
-  /**
-   * Allows to disable authentication for a specific route. If not specified, defaults to `true`.
-   *
-   * @deprecated Use `security.authc.enabled` instead
-   */
-  authRequired?: false;
-
   /**
    * Defines xsrf protection requirements for a route:
    * - true. Requires an incoming POST/PUT/DELETE request to contain `kbn-xsrf` header.
@@ -555,7 +548,7 @@ export interface RouteConfig<P, Q, B, Method extends RouteMethod> {
   /**
    * Defines the security requirements for a route, including authorization and authentication.
    */
-  security: RouteSecurity;
+  security: Omit<RouteSecurity, 'authc'> & { authc?: RouteAuthc };
 
   /**
    * Additional route options {@link RouteConfigOptions}.

--- a/src/core/packages/http/server/src/router/router.ts
+++ b/src/core/packages/http/server/src/router/router.ts
@@ -126,7 +126,7 @@ export interface RouterRoute {
   method: RouteMethod;
   path: string;
   options: RouteConfigOptions<RouteMethod>;
-  security?: InternalRouteSecurity;
+  security: InternalRouteSecurity;
   /**
    * @note if providing a function to lazily load your validation schemas assume
    *       that the function will only be called once.

--- a/src/core/packages/i18n/server-internal/src/routes/translations.test.ts
+++ b/src/core/packages/i18n/server-internal/src/routes/translations.test.ts
@@ -26,9 +26,18 @@ describe('registerTranslationsRoute', () => {
         path: '/translations/{locale}.json',
         options: {
           access: 'public',
-          authRequired: false,
           excludeFromRateLimiter: true,
           httpResource: true,
+        },
+        security: {
+          authz: {
+            enabled: false,
+            reason: expect.any(String),
+          },
+          authc: {
+            enabled: false,
+            reason: expect.any(String),
+          },
         },
       }),
       expect.any(Function)
@@ -39,9 +48,18 @@ describe('registerTranslationsRoute', () => {
         path: '/translations/XXXX/{locale}.json',
         options: {
           access: 'public',
-          authRequired: false,
           excludeFromRateLimiter: true,
           httpResource: true,
+        },
+        security: {
+          authz: {
+            enabled: false,
+            reason: expect.any(String),
+          },
+          authc: {
+            enabled: false,
+            reason: expect.any(String),
+          },
         },
       }),
       expect.any(Function)

--- a/src/core/packages/i18n/server-internal/src/routes/translations.ts
+++ b/src/core/packages/i18n/server-internal/src/routes/translations.ts
@@ -39,6 +39,10 @@ export const registerTranslationsRoute = ({
         {
           path: routePath,
           security: {
+            authc: {
+              enabled: false,
+              reason: 'This route is only used for serving i18n translations.',
+            },
             authz: {
               enabled: false,
               reason: 'This route is only used for serving i18n translations.',
@@ -52,7 +56,6 @@ export const registerTranslationsRoute = ({
           options: {
             access: 'public',
             httpResource: true,
-            authRequired: false,
             excludeFromRateLimiter: true,
           },
         },

--- a/src/core/packages/rendering/server-internal/src/bootstrap/register_bootstrap_route.test.ts
+++ b/src/core/packages/rendering/server-internal/src/bootstrap/register_bootstrap_route.test.ts
@@ -30,7 +30,16 @@ describe('registerBootstrapRoute', () => {
           access: 'public',
           excludeFromRateLimiter: true,
           tags: ['api'],
-          authRequired: 'optional',
+        },
+        security: {
+          authc: {
+            enabled: 'optional',
+            reason: expect.any(String),
+          },
+          authz: {
+            enabled: false,
+            reason: expect.any(String),
+          },
         },
       }),
       expect.any(Function)

--- a/src/core/packages/rendering/server-internal/src/bootstrap/register_bootstrap_route.ts
+++ b/src/core/packages/rendering/server-internal/src/bootstrap/register_bootstrap_route.ts
@@ -51,13 +51,17 @@ export const registerBootstrapRoute = ({
     {
       path: '/bootstrap-anonymous.js',
       security: {
+        authc: {
+          enabled: 'optional',
+          reason:
+            'This route is used to serve the anonymous bootstrap script and should work for authenticated and unauthenticated requests.',
+        },
         authz: {
           enabled: false,
           reason: 'This route is only used for serving the bootstrap script.',
         },
       },
       options: {
-        authRequired: 'optional',
         tags: ['api'],
         access: 'public',
         excludeFromRateLimiter: true,

--- a/src/core/packages/status/server-internal/src/routes/status.ts
+++ b/src/core/packages/status/server-internal/src/routes/status.ts
@@ -83,13 +83,17 @@ export const registerStatusRoute = ({
     {
       path: '/api/status',
       security: {
+        authc: {
+          enabled: 'optional',
+          reason:
+            'This route should return the full status for authenticated requests and a reduced version for unauthenticated ones.',
+        },
         authz: {
           enabled: false,
           reason: 'Status route should be accessible without authorization.',
         },
       },
       options: {
-        authRequired: 'optional',
         // The `api` tag ensures that unauthenticated calls receive a 401 rather than a 302 redirect to login page.
         // The `security:acceptJWT` tag allows route to be accessed with JWT credentials. It points to
         // ROUTE_TAG_ACCEPT_JWT from '@kbn/security-plugin/server' that cannot be imported here directly.

--- a/src/core/server/integration_tests/http/apm_api_spans.test.ts
+++ b/src/core/server/integration_tests/http/apm_api_spans.test.ts
@@ -129,8 +129,10 @@ describe('APM HTTP API spans', () => {
         {
           path: '/',
           validate: false,
-          options: { authRequired: 'optional' },
-          security: { authz: { enabled: false, reason: '' } },
+          security: {
+            authc: { enabled: 'optional', reason: '' },
+            authz: { enabled: false, reason: '' },
+          },
         },
         (context, req, res) => res.ok({})
       );

--- a/src/core/server/integration_tests/http/core_services.test.ts
+++ b/src/core/server/integration_tests/http/core_services.test.ts
@@ -117,8 +117,10 @@ describe('http service', () => {
           {
             path: '/is-auth',
             validate: false,
-            security: { authz: { enabled: false, reason: '' } },
-            options: { authRequired: 'optional' },
+            security: {
+              authc: { enabled: 'optional', reason: '' },
+              authz: { enabled: false, reason: '' },
+            },
           },
           (context, req, res) => res.ok({ body: { isAuthenticated: auth.isAuthenticated(req) } })
         );
@@ -138,8 +140,10 @@ describe('http service', () => {
           {
             path: '/is-auth',
             validate: false,
-            security: { authz: { enabled: false, reason: '' } },
-            options: { authRequired: 'optional' },
+            security: {
+              authc: { enabled: 'optional', reason: '' },
+              authz: { enabled: false, reason: '' },
+            },
           },
           (context, req, res) => res.ok({ body: { isAuthenticated: auth.isAuthenticated(req) } })
         );

--- a/src/core/server/integration_tests/http/lifecycle.test.ts
+++ b/src/core/server/integration_tests/http/lifecycle.test.ts
@@ -803,7 +803,7 @@ describe('Auth', () => {
     registerAuth(authenticate);
 
     await server.start();
-    await supertest(innerServer.listener).get('/').expect(200, { authRequired: true });
+    await supertest(innerServer.listener).get('/').expect(200);
 
     expect(authenticate).toHaveBeenCalledTimes(1);
   });
@@ -829,29 +829,6 @@ describe('Auth', () => {
     await supertest(innerServer.listener).get('/').expect(200, { authRequired: false });
 
     expect(authenticate).toHaveBeenCalledTimes(0);
-  });
-
-  test('supports enabling auth for a route explicitly', async () => {
-    const { registerAuth, server: innerServer, createRouter } = await server.setup(setupDeps);
-    const router = createRouter('/');
-
-    router.get(
-      {
-        path: '/',
-        validate: false,
-        security: { authz: { enabled: false, reason: '' } },
-        options: { authRequired: true },
-      },
-      (context, req, res) => res.ok({ body: { authRequired: req.route.options.authRequired } })
-    );
-
-    const authenticate = jest.fn().mockImplementation((req, res, t) => t.authenticated({}));
-    await registerAuth(authenticate);
-
-    await server.start();
-    await supertest(innerServer.listener).get('/').expect(200, { authRequired: true });
-
-    expect(authenticate).toHaveBeenCalledTimes(1);
   });
 
   it('supports rejecting a request from an unauthenticated user', async () => {

--- a/src/core/server/integration_tests/http/logging.test.ts
+++ b/src/core/server/integration_tests/http/logging.test.ts
@@ -57,9 +57,11 @@ describe('request logging', () => {
         http.createRouter('/').get(
           {
             path: '/ping',
-            security: { authz: { enabled: false, reason: '' } },
+            security: {
+              authc: { enabled: 'optional', reason: '' },
+              authz: { enabled: false, reason: '' },
+            },
             validate: false,
-            options: { authRequired: 'optional' },
           },
           (context, req, res) => res.ok({ body: 'pong' })
         );
@@ -101,9 +103,11 @@ describe('request logging', () => {
         http.createRouter('/').get(
           {
             path: '/ping',
-            security: { authz: { enabled: false, reason: '' } },
+            security: {
+              authc: { enabled: 'optional', reason: '' },
+              authz: { enabled: false, reason: '' },
+            },
             validate: false,
-            options: { authRequired: 'optional' },
           },
           (context, req, res) => res.ok({ body: 'pong' })
         );
@@ -160,9 +164,11 @@ describe('request logging', () => {
         http.createRouter('/').get(
           {
             path: '/ping',
-            security: { authz: { enabled: false, reason: '' } },
+            security: {
+              authc: { enabled: 'optional', reason: '' },
+              authz: { enabled: false, reason: '' },
+            },
             validate: false,
-            options: { authRequired: 'optional' },
           },
           (context, req, res) => res.ok({ body: 'pong' })
         );
@@ -186,12 +192,14 @@ describe('request logging', () => {
         http.createRouter('/').post(
           {
             path: '/ping',
-            security: { authz: { enabled: false, reason: '' } },
+            security: {
+              authc: { enabled: 'optional', reason: '' },
+              authz: { enabled: false, reason: '' },
+            },
             validate: {
               body: schema.object({ message: schema.string() }),
             },
             options: {
-              authRequired: 'optional',
               body: {
                 accepts: ['application/json'],
               },
@@ -219,9 +227,11 @@ describe('request logging', () => {
         http.createRouter('/').get(
           {
             path: '/a',
-            security: { authz: { enabled: false, reason: '' } },
+            security: {
+              authc: { enabled: 'optional', reason: '' },
+              authz: { enabled: false, reason: '' },
+            },
             validate: false,
-            options: { authRequired: 'optional' },
           },
           (context, req, res) => res.ok({ body: 'pong' })
         );
@@ -243,9 +253,11 @@ describe('request logging', () => {
         http.createRouter('/').get(
           {
             path: '/ping',
-            security: { authz: { enabled: false, reason: '' } },
+            security: {
+              authc: { enabled: 'optional', reason: '' },
+              authz: { enabled: false, reason: '' },
+            },
             validate: false,
-            options: { authRequired: 'optional' },
           },
           (context, req, res) => res.ok({ body: 'pong' })
         );
@@ -265,9 +277,11 @@ describe('request logging', () => {
         http.createRouter('/').get(
           {
             path: '/ping',
-            security: { authz: { enabled: false, reason: '' } },
+            security: {
+              authc: { enabled: 'optional', reason: '' },
+              authz: { enabled: false, reason: '' },
+            },
             validate: false,
-            options: { authRequired: 'optional' },
           },
           (context, req, res) => res.ok({ body: 'pong' })
         );
@@ -287,9 +301,11 @@ describe('request logging', () => {
           http.createRouter('/').get(
             {
               path: '/ping',
-              security: { authz: { enabled: false, reason: '' } },
+              security: {
+                authc: { enabled: 'optional', reason: '' },
+                authz: { enabled: false, reason: '' },
+              },
               validate: false,
-              options: { authRequired: 'optional' },
             },
             (context, req, res) => res.ok({ headers: { bar: 'world' }, body: 'pong' })
           );
@@ -309,12 +325,14 @@ describe('request logging', () => {
           http.createRouter('/').post(
             {
               path: '/ping',
-              security: { authz: { enabled: false, reason: '' } },
+              security: {
+                authc: { enabled: 'optional', reason: '' },
+                authz: { enabled: false, reason: '' },
+              },
               validate: {
                 body: schema.object({ message: schema.string() }),
               },
               options: {
-                authRequired: 'optional',
                 body: {
                   accepts: ['application/json'],
                 },
@@ -379,12 +397,14 @@ describe('request logging', () => {
           http.createRouter('/').post(
             {
               path: '/ping',
-              security: { authz: { enabled: false, reason: '' } },
+              security: {
+                authc: { enabled: 'optional', reason: '' },
+                authz: { enabled: false, reason: '' },
+              },
               validate: {
                 body: schema.object({ message: schema.string() }),
               },
               options: {
-                authRequired: 'optional',
                 body: {
                   accepts: ['application/json'],
                 },
@@ -413,12 +433,14 @@ describe('request logging', () => {
           http.createRouter('/').post(
             {
               path: '/ping',
-              security: { authz: { enabled: false, reason: '' } },
+              security: {
+                authc: { enabled: 'optional', reason: '' },
+                authz: { enabled: false, reason: '' },
+              },
               validate: {
                 body: schema.object({ message: schema.string() }),
               },
               options: {
-                authRequired: 'optional',
                 body: {
                   accepts: ['application/json'],
                 },
@@ -481,12 +503,14 @@ describe('request logging', () => {
           http.createRouter('/').post(
             {
               path: '/ping',
-              security: { authz: { enabled: false, reason: '' } },
+              security: {
+                authc: { enabled: 'optional', reason: '' },
+                authz: { enabled: false, reason: '' },
+              },
               validate: {
                 body: schema.object({ message: schema.string() }),
               },
               options: {
-                authRequired: 'optional',
                 body: {
                   accepts: ['application/json'],
                 },
@@ -516,9 +540,11 @@ describe('request logging', () => {
         http.createRouter('/').get(
           {
             path: '/ping',
-            security: { authz: { enabled: false, reason: '' } },
+            security: {
+              authc: { enabled: 'optional', reason: '' },
+              authz: { enabled: false, reason: '' },
+            },
             validate: false,
-            options: { authRequired: 'optional' },
           },
           (context, req, res) => res.ok({ body: 'pong' })
         );

--- a/src/core/server/integration_tests/http/request_representation.test.ts
+++ b/src/core/server/integration_tests/http/request_representation.test.ts
@@ -53,7 +53,6 @@ describe('request logging', () => {
           path: '/',
           security: { authz: { enabled: false, reason: '' } },
           validate: false,
-          options: { authRequired: true },
         },
         (context, req, res) => {
           return res.ok({ body: { req: String(req) } });
@@ -75,7 +74,6 @@ describe('request logging', () => {
           path: '/',
           security: { authz: { enabled: false, reason: '' } },
           validate: false,
-          options: { authRequired: true },
         },
         (context, req, res) => {
           return res.ok({ body: { req: JSON.stringify(req) } });
@@ -112,7 +110,6 @@ describe('request logging', () => {
           path: '/',
           security: { authz: { enabled: false, reason: '' } },
           validate: false,
-          options: { authRequired: true },
         },
         (context, req, res) => {
           return res.ok({ body: { req: inspect(req) } });
@@ -161,7 +158,6 @@ describe('request logging', () => {
           path: '/',
           security: { authz: { enabled: false, reason: '' } },
           validate: false,
-          options: { authRequired: true },
         },
         (context, req, res) => {
           const rawRequest = ensureRawRequest(req);
@@ -184,7 +180,6 @@ describe('request logging', () => {
           path: '/',
           security: { authz: { enabled: false, reason: '' } },
           validate: false,
-          options: { authRequired: true },
         },
         (context, req, res) => {
           const rawRequest = ensureRawRequest(req);
@@ -208,7 +203,6 @@ describe('request logging', () => {
           path: '/',
           security: { authz: { enabled: false, reason: '' } },
           validate: false,
-          options: { authRequired: true },
         },
         (context, req, res) => {
           const rawRequest = ensureRawRequest(req);
@@ -233,7 +227,6 @@ describe('request logging', () => {
           path: '/',
           security: { authz: { enabled: false, reason: '' } },
           validate: false,
-          options: { authRequired: true },
         },
         (context, req, res) => {
           const rawRawRequest = ensureRawRequest(req).raw.req;
@@ -256,7 +249,6 @@ describe('request logging', () => {
           path: '/',
           security: { authz: { enabled: false, reason: '' } },
           validate: false,
-          options: { authRequired: true },
         },
         (context, req, res) => {
           const rawRawRequest = ensureRawRequest(req).raw.req;
@@ -282,7 +274,6 @@ describe('request logging', () => {
           path: '/',
           security: { authz: { enabled: false, reason: '' } },
           validate: false,
-          options: { authRequired: true },
         },
         (context, req, res) => {
           const rawRawRequest = ensureRawRequest(req).raw.req;

--- a/src/platform/plugins/shared/telemetry/server/routes/telemetry_config.ts
+++ b/src/platform/plugins/shared/telemetry/server/routes/telemetry_config.ts
@@ -99,11 +99,16 @@ export function registerTelemetryConfigRoutes({
     .get({
       access: 'internal',
       path: FetchTelemetryConfigRoute,
-      options: { authRequired: 'optional' },
       security: {
+        authc: {
+          enabled: 'optional',
+          reason:
+            'Telemetry config is required for both anonymous pages and pages that require authentication.',
+        },
         authz: {
           enabled: false,
-          reason: 'This route is opted out from authorization',
+          reason:
+            'Telemetry config is retrieved by the Kibana service account but does not expose sensitive information requiring authorization.',
         },
       },
     })
@@ -121,7 +126,8 @@ export function registerTelemetryConfigRoutes({
         security: {
           authz: {
             enabled: false,
-            reason: 'This route is opted out from authorization',
+            reason:
+              'Telemetry config is retrieved by the Kibana service account but does not expose sensitive information requiring authorization.',
           },
         },
         validate: v2Validations,
@@ -138,7 +144,8 @@ export function registerTelemetryConfigRoutes({
       security: {
         authz: {
           enabled: false,
-          reason: 'This route is opted out from authorization',
+          reason:
+            'Telemetry config is retrieved by the Kibana service account but does not expose sensitive information requiring authorization.',
         },
       },
     })

--- a/src/platform/plugins/shared/usage_collection/server/routes/stats/stats.ts
+++ b/src/platform/plugins/shared/usage_collection/server/routes/stats/stats.ts
@@ -51,13 +51,22 @@ export function registerStatsRoute({
     {
       path: '/api/stats',
       security: {
+        authc: {
+          ...(config.allowAnonymous === false
+            ? {
+                enabled: false,
+                reason:
+                  'If `status.allowAnonymous` is set to `true`, this route should return the Kibana stat for the unauthenticated requests.',
+              }
+            : { enabled: true }),
+        },
         authz: {
           enabled: false,
-          reason: 'This route is opted out from authorization',
+          reason:
+            'This route is opted out from authorization because any authenticated user is allowed to access Kibana stat.',
         },
       },
       options: {
-        authRequired: !config.allowAnonymous,
         excludeFromRateLimiter: true,
         // The `api` tag ensures that unauthenticated calls receive a 401 rather than a 302 redirect to login page.
         // The `security:acceptJWT` tag allows route to be accessed with JWT credentials. It points to

--- a/x-pack/platform/plugins/private/banners/server/routes/info.ts
+++ b/x-pack/platform/plugins/private/banners/server/routes/info.ts
@@ -16,15 +16,18 @@ export const registerInfoRoute = (router: BannersRouter, config: BannersConfigTy
     {
       path: '/api/banners/info',
       security: {
+        authc: {
+          enabled: 'optional',
+          reason:
+            'Banner config should be available for authenticated and unauthenticated requests.',
+        },
         authz: {
           enabled: false,
-          reason: 'This route is opted out from authorization',
+          reason:
+            'Unauthenticated users get a default banner config without sensitive info, while authenticated users get config from advanced settings with authorization handled by the UiSettings client.',
         },
       },
       validate: false,
-      options: {
-        authRequired: 'optional',
-      },
     },
     async (ctx, req, res) => {
       const allowed = isValidLicense((await ctx.licensing).license);

--- a/x-pack/platform/plugins/private/custom_branding/server/routes/info.ts
+++ b/x-pack/platform/plugins/private/custom_branding/server/routes/info.ts
@@ -14,6 +14,11 @@ export const registerInfoRoute = (router: CustomBrandingRouter) => {
     {
       path: '/api/custom_branding/info',
       security: {
+        authc: {
+          enabled: 'optional',
+          reason:
+            'Custom branding availability info should be available for authenticated and unauthenticated requests.',
+        },
         authz: {
           enabled: false,
           reason:
@@ -21,9 +26,6 @@ export const registerInfoRoute = (router: CustomBrandingRouter) => {
         },
       },
       validate: false,
-      options: {
-        authRequired: 'optional',
-      },
     },
     async (ctx, req, res) => {
       const allowed = isValidLicense((await ctx.licensing).license);

--- a/x-pack/platform/plugins/private/monitoring_collection/server/routes/api/v1/dynamic_route/get_metrics_by_type.ts
+++ b/x-pack/platform/plugins/private/monitoring_collection/server/routes/api/v1/dynamic_route/get_metrics_by_type.ts
@@ -45,7 +45,6 @@ export function registerDynamicRoute({
       },
       options: {
         access: 'public',
-        authRequired: true,
         tags: ['api'], // ensures that unauthenticated calls receive a 401 rather than a 302 redirect to login page
       },
       validate: {

--- a/x-pack/platform/plugins/private/monitoring_collection/server/routes/api/v1/prometheus/get_metrics.ts
+++ b/x-pack/platform/plugins/private/monitoring_collection/server/routes/api/v1/prometheus/get_metrics.ts
@@ -28,7 +28,6 @@ export function registerV1PrometheusRoute({
         },
       },
       options: {
-        authRequired: true,
         tags: ['api'], // ensures that unauthenticated calls receive a 401 rather than a 302 redirect to login page
       },
       validate: {},

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.ts
@@ -89,7 +89,7 @@ function isSAMLResponseQuery(query: any): query is { SAMLResponse: string } {
 function canStartNewSession(request: KibanaRequest) {
   // We should try to establish new session only if request requires authentication and client
   // can be redirected to the Identity Provider where they can authenticate.
-  return canRedirectRequest(request) && request.route.options.authRequired === true;
+  return canRedirectRequest(request) && request.route.options.security.authc.enabled === true;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/security/server/routes/analytics/record_violations.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/analytics/record_violations.ts
@@ -136,6 +136,18 @@ export function defineRecordViolations({ router, analyticsService }: RouteDefini
     {
       path: '/internal/security/analytics/_record_violations',
       security: {
+        /**
+         * Browsers will stop sending reports for the duration of the browser session and without
+         * further retries once this endpoint has returned a single 403. This would effectively
+         * prevent us from capture any reports. To work around this behaviour we optionally
+         * authenticate users but silently ignore any reports that have been received from
+         * unauthenticated users.
+         */
+        authc: {
+          enabled: 'optional',
+          reason:
+            'This route is used by browsers to report CSP and Permission Policy violations. These requests are sent without authentication per the browser spec.',
+        },
         authz: {
           enabled: false,
           reason:
@@ -156,14 +168,6 @@ export function defineRecordViolations({ router, analyticsService }: RouteDefini
         ]),
       },
       options: {
-        /**
-         * Browsers will stop sending reports for the duration of the browser session and without
-         * further retries once this endpoint has returned a single 403. This would effectively
-         * prevent us from capture any reports. To work around this behaviour we optionally
-         * authenticate users but silently ignore any reports that have been received from
-         * unauthenticated users.
-         */
-        authRequired: 'optional',
         /**
          * This endpoint is called by the browser in the background so `kbn-xsrf` header is not sent.
          */

--- a/x-pack/platform/plugins/shared/security/server/routes/views/login.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/views/login.test.ts
@@ -56,11 +56,8 @@ describe('Login view routes', () => {
 
       expect(routeConfig.security).toEqual(
         expect.objectContaining({
-          authc: { enabled: 'optional' },
-          authz: {
-            enabled: false,
-            reason: expect.any(String),
-          },
+          authc: { enabled: 'optional', reason: expect.any(String) },
+          authz: { enabled: false, reason: expect.any(String) },
         })
       );
 

--- a/x-pack/platform/plugins/shared/security/server/routes/views/login.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/views/login.ts
@@ -43,6 +43,7 @@ export function defineLoginRoutes({
       security: {
         authc: {
           enabled: 'optional',
+          reason: 'This route is used to render login page for anonymous users.',
         },
         authz: {
           enabled: false,

--- a/x-pack/platform/plugins/shared/task_manager/server/routes/background_task_utilization.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/routes/background_task_utilization.test.ts
@@ -57,13 +57,13 @@ describe('backgroundTaskUtilizationRoute', () => {
     expect(config1.path).toMatchInlineSnapshot(
       `"/internal/task_manager/_background_task_utilization"`
     );
-    expect(config1.options?.authRequired).toEqual(true);
+    expect(config1.security.authc?.enabled).toEqual(true);
     expect(config1.options?.tags).toEqual(['security:acceptJWT']);
 
     const [config2] = router.get.mock.calls[1];
 
     expect(config2.path).toMatchInlineSnapshot(`"/api/task_manager/_background_task_utilization"`);
-    expect(config2.options?.authRequired).toEqual(true);
+    expect(config1.security.authc?.enabled).toEqual(true);
     expect(config2.options?.tags).toEqual(['security:acceptJWT']);
   });
 
@@ -89,12 +89,12 @@ describe('backgroundTaskUtilizationRoute', () => {
     expect(config1.path).toMatchInlineSnapshot(
       `"/internal/task_manager/_background_task_utilization"`
     );
-    expect(config1.options?.authRequired).toEqual(true);
+    expect(config1.security.authc?.enabled).toEqual(true);
 
     const [config2] = router.get.mock.calls[1];
 
     expect(config2.path).toMatchInlineSnapshot(`"/api/task_manager/_background_task_utilization"`);
-    expect(config2.options?.authRequired).toEqual(false);
+    expect(config1.security.authc?.enabled).toEqual(false);
   });
 
   it('checks user privileges and increments usage counter when API is accessed', async () => {

--- a/x-pack/platform/plugins/shared/task_manager/server/routes/background_task_utilization.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/routes/background_task_utilization.ts
@@ -113,10 +113,19 @@ export function backgroundTaskUtilizationRoute(
       {
         path: `/${routeOption.basePath}/task_manager/_background_task_utilization`,
         security: {
+          authc: {
+            ...(routeOption.isAuthenticated === false
+              ? {
+                  enabled: false,
+                  reason:
+                    'If `xpack.task_manager.unsafe.authenticate_background_task_utilization` is set to `false`, this route should return background task utilization information for the unauthenticated requests.',
+                }
+              : { enabled: true }),
+          },
           authz: {
             enabled: false,
             reason:
-              'This route is opted out from authorization. It can be accessed with JWT credentials.',
+              'Unauthenticated requests get a reduced version of background task utilization information, while authenticated ones can get extended version with authorization handled by the ES client.',
           },
         },
         // Uncomment when we determine that we can restrict API usage to Global admins based on telemetry
@@ -128,7 +137,6 @@ export function backgroundTaskUtilizationRoute(
         validate: false,
         options: {
           access: 'public', // access must be public to allow "system" users, like metrics collectors, to access these routes
-          authRequired: routeOption.isAuthenticated ?? true,
           // The `security:acceptJWT` tag allows route to be accessed with JWT credentials. It points to
           // ROUTE_TAG_ACCEPT_JWT from '@kbn/security-plugin/server' that cannot be imported here directly.
           tags: ['security:acceptJWT'],

--- a/x-pack/solutions/search/plugins/enterprise_search/server/lib/route_config_helpers.test.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/lib/route_config_helpers.test.ts
@@ -24,25 +24,25 @@ describe('skipBodyValidation', () => {
     expect(
       skipBodyValidation({
         path: '/example/path',
-        validate: {},
         security: {
           authz: {
             enabled: false,
             reason: '',
           },
         },
+        validate: {},
       })
     ).toEqual({
-      path: '/example/path',
-      validate: {
-        body: mockBuffer,
-      },
       options: { body: { parse: false } },
+      path: '/example/path',
       security: {
         authz: {
           enabled: false,
           reason: '',
         },
+      },
+      validate: {
+        body: mockBuffer,
       },
     });
   });
@@ -51,34 +51,30 @@ describe('skipBodyValidation', () => {
     expect(
       skipBodyValidation({
         path: '/example/path',
-        validate: {
-          params: mockSchema,
-        },
-        options: {
-          authRequired: true,
-        },
         security: {
           authz: {
             enabled: false,
             reason: '',
           },
         },
+        validate: {
+          params: mockSchema,
+        },
       })
     ).toEqual({
-      path: '/example/path',
-      validate: {
-        params: mockSchema,
-        body: mockBuffer,
-      },
       options: {
-        authRequired: true,
         body: { parse: false },
       },
+      path: '/example/path',
       security: {
         authz: {
           enabled: false,
           reason: '',
         },
+      },
+      validate: {
+        body: mockBuffer,
+        params: mockSchema,
       },
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/custom_scripts_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/custom_scripts_handler.ts
@@ -40,7 +40,6 @@ export const registerCustomScriptsRoute = (
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/details.ts
@@ -37,7 +37,6 @@ export const registerActionDetailsRoutes = (
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/file_download_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/file_download_handler.ts
@@ -43,7 +43,6 @@ export const registerActionFileDownloadRoutes = (
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/file_info_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/file_info_handler.ts
@@ -84,7 +84,6 @@ export const registerActionFileInfoRoute = (
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/list.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/list.ts
@@ -35,7 +35,6 @@ export function registerActionListRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/orphan_actions_space_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/orphan_actions_space_handler.ts
@@ -113,7 +113,6 @@ export const registerOrphanActionsSpaceRoute = (
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {
@@ -136,7 +135,6 @@ export const registerOrphanActionsSpaceRoute = (
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/response_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/response_actions.ts
@@ -79,7 +79,6 @@ export function registerResponseActionRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {
@@ -104,7 +103,6 @@ export function registerResponseActionRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {
@@ -129,7 +127,6 @@ export function registerResponseActionRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {
@@ -157,7 +154,6 @@ export function registerResponseActionRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {
@@ -185,7 +181,6 @@ export function registerResponseActionRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {
@@ -210,7 +205,6 @@ export function registerResponseActionRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {
@@ -235,7 +229,6 @@ export function registerResponseActionRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {
@@ -261,8 +254,6 @@ export function registerResponseActionRoutes(
         },
       },
       options: {
-        authRequired: true,
-
         body: {
           accepts: ['multipart/form-data'],
           output: 'stream',
@@ -293,7 +284,6 @@ export function registerResponseActionRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {
@@ -317,7 +307,6 @@ export function registerResponseActionRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/state.ts
@@ -37,7 +37,6 @@ export function registerActionStateRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/status.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/status.ts
@@ -36,7 +36,6 @@ export function registerActionStatusRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/agent/agent_status_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/agent/agent_status_handler.ts
@@ -33,7 +33,6 @@ export const registerAgentStatusRoute = (
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/index.ts
@@ -58,7 +58,6 @@ export function registerEndpointRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {
@@ -78,7 +77,6 @@ export function registerEndpointRoutes(
     .get({
       access: 'public',
       path: HOST_METADATA_GET_ROUTE,
-      options: { authRequired: true },
       security: {
         authz: {
           requiredPrivileges: ['securitySolution'],
@@ -108,7 +106,6 @@ export function registerEndpointRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
@@ -237,9 +237,6 @@ describe('test endpoint routes', () => {
           ],
         },
       });
-      expect(routeConfig.options).toEqual({
-        authRequired: true,
-      });
       expect(routeConfig.security?.authz).toEqual({ requiredPrivileges: ['securitySolution'] });
       expect(mockResponse.ok).toBeCalled();
       const endpointResultList = mockResponse.ok.mock.calls[0][0]?.body as MetadataListResponse;
@@ -324,9 +321,6 @@ describe('test endpoint routes', () => {
       );
 
       expect(esSearchMock).toHaveBeenCalledTimes(1);
-      expect(routeConfig.options).toEqual({
-        authRequired: true,
-      });
       expect(mockResponse.notFound).toBeCalled();
       const message = mockResponse.notFound.mock.calls[0][0]?.body;
       expect(message).toBeInstanceOf(EndpointHostNotFoundError);
@@ -358,9 +352,6 @@ describe('test endpoint routes', () => {
       );
 
       expect(esSearchMock).toHaveBeenCalledTimes(1);
-      expect(routeConfig.options).toEqual({
-        authRequired: true,
-      });
       expect(mockResponse.ok).toBeCalled();
       const result = mockResponse.ok.mock.calls[0][0]?.body as HostInfo;
       expect(result).toHaveProperty('metadata.Endpoint');
@@ -395,9 +386,6 @@ describe('test endpoint routes', () => {
       );
 
       expect(esSearchMock).toHaveBeenCalledTimes(1);
-      expect(routeConfig.options).toEqual({
-        authRequired: true,
-      });
       expect(mockResponse.ok).toBeCalled();
       const result = mockResponse.ok.mock.calls[0][0]?.body as HostInfo;
       expect(result.host_status).toEqual(HostStatus.UNHEALTHY);
@@ -434,9 +422,6 @@ describe('test endpoint routes', () => {
       );
 
       expect(esSearchMock).toHaveBeenCalledTimes(1);
-      expect(routeConfig.options).toEqual({
-        authRequired: true,
-      });
       expect(mockResponse.ok).toBeCalled();
       const result = mockResponse.ok.mock.calls[0][0]?.body as HostInfo;
       expect(result.host_status).toEqual(HostStatus.UNHEALTHY);
@@ -611,9 +596,6 @@ describe('test endpoint routes', () => {
       );
 
       expect(esClientMock.transform.getTransformStats).toHaveBeenCalledTimes(1);
-      expect(routeConfig.options).toEqual({
-        authRequired: true,
-      });
       expect(routeConfig.security?.authz).toEqual({ requiredPrivileges: ['securitySolution'] });
       expect(mockResponse.ok).toBeCalled();
       const response = mockResponse.ok.mock.calls[0][0]?.body as TransformGetTransformStatsResponse;

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/policy/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/policy/index.ts
@@ -24,7 +24,6 @@ export function registerPolicyRoutes(
     .get({
       access: 'public',
       path: BASE_POLICY_RESPONSE_ROUTE,
-      options: { authRequired: true },
       security: {
         authz: {
           requiredPrivileges: ['securitySolution'],

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/protection_updates_note/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/protection_updates_note/index.ts
@@ -30,7 +30,6 @@ export function registerProtectionUpdatesNoteRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {
@@ -55,7 +54,6 @@ export function registerProtectionUpdatesNoteRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/resolver.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/resolver.ts
@@ -41,7 +41,6 @@ export const registerResolverRoutes = (
         },
       },
       validate: validateTree,
-      options: { authRequired: true },
     },
     handleTree(getRuleRegistry, getLicensing)
   );
@@ -55,7 +54,6 @@ export const registerResolverRoutes = (
         },
       },
       validate: validateEvents,
-      options: { authRequired: true },
     },
     handleEvents(getRuleRegistry)
   );
@@ -72,7 +70,6 @@ export const registerResolverRoutes = (
         },
       },
       validate: validateEntities,
-      options: { authRequired: true },
     },
     handleEntities(config.experimentalFeatures)
   );

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/suggestions/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/suggestions/index.ts
@@ -48,7 +48,6 @@ export function registerEndpointSuggestionsRoutes(
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/get_insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/get_insights.ts
@@ -35,7 +35,6 @@ export const registerGetInsightsRoute = (
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/update_insight.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/update_insight.ts
@@ -37,7 +37,6 @@ export const registerUpdateInsightsRoute = (
           requiredPrivileges: ['securitySolution'],
         },
       },
-      options: { authRequired: true },
     })
     .addVersion(
       {


### PR DESCRIPTION
## Summary

Get rid of the deprecaed `authRequired` route option in favor of `security.authc.*`.


