### PR TITLE
Re-enables Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabled": false,
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests",
@@ -165,7 +164,8 @@
         "backport:skip",
         "release_note:skip"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/appex-ai-infra dependencies",
@@ -202,7 +202,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/appex-qa dependencies",
@@ -242,7 +243,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "axe-core",
@@ -260,7 +262,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "sinon",
@@ -279,7 +282,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "Enzyme dependencies",
@@ -303,7 +307,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchDepNames": [
@@ -320,7 +325,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchDepNames": [
@@ -337,7 +343,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "base64-js dependencies",
@@ -356,7 +363,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchDepNames": [
@@ -373,7 +381,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "classnames dependencies",
@@ -392,7 +401,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "deep-freeze-strict dependencies",
@@ -411,7 +421,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "lz-string dependencies",
@@ -430,7 +441,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchDepNames": [
@@ -447,7 +459,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "styled-components dependencies",
@@ -470,7 +483,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "Emotion dependencies",
@@ -493,7 +507,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "React dependencies",
@@ -523,7 +538,8 @@
         "upgrade-risk:high",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchDepNames": [
@@ -540,7 +556,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchDepNames": [
@@ -557,7 +574,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "react-router dependencies",
@@ -589,7 +607,8 @@
         "effort:high",
         "upgrade-risk:high"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "react-markdown",
@@ -607,7 +626,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "markdown-it",
@@ -626,7 +646,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "moment",
@@ -645,7 +666,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "monaco",
@@ -664,7 +686,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "polished",
@@ -682,7 +705,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "query-string",
@@ -700,7 +724,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@reduxjs/toolkit",
@@ -719,7 +744,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/ml-ui dependencies",
@@ -743,7 +769,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/fleet dependencies",
@@ -769,7 +796,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "tar",
@@ -787,7 +815,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "unified - ESM Required",
@@ -807,7 +836,8 @@
         "blocked",
         "effort:low"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "use-resize-observer",
@@ -825,7 +855,8 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/kibana-cloud-security-posture dependencies",
@@ -848,7 +879,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "formatjs dependencies",
@@ -870,7 +901,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/kibana-core dependencies",
@@ -913,7 +944,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "ansi related",
@@ -934,7 +965,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "deepmerge",
@@ -953,7 +984,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "lru-cache",
@@ -972,7 +1003,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "mime related",
@@ -994,7 +1025,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "semver",
@@ -1014,7 +1045,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/kibana-data-discovery dependencies",
@@ -1037,7 +1068,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/kibana-management dependencies",
@@ -1056,7 +1087,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/kibana-management - file-saver",
@@ -1076,7 +1107,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "moment-duration-format",
@@ -1098,7 +1129,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "react-virtualized",
@@ -1120,7 +1151,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "react-window",
@@ -1142,7 +1173,7 @@
         "backport:all-open"
       ],
       "enabled": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/charts",
@@ -1162,7 +1193,8 @@
         "release_note:skip",
         "backport:prev-minor"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/ecs",
@@ -1180,7 +1212,8 @@
         "backport:all-open",
         "Team:obs-ux-logs"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/elasticsearch",
@@ -1200,7 +1233,8 @@
         "Team:Operations",
         "Team:Core"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/elasticsearch (CI clients)",
@@ -1287,7 +1321,7 @@
         "backport:prev-minor",
         "backport:prev-major"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1310,7 +1344,7 @@
         "backport:prev-minor",
         "backport:prev-major"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1334,7 +1368,7 @@
         "backport:prev-minor",
         "backport:prev-major"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1357,7 +1391,8 @@
         "backport:prev-minor",
         "backport:prev-major"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "io-ts",
@@ -1375,7 +1410,8 @@
         "Team:Core",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "RxJS",
@@ -1393,7 +1429,8 @@
         "Team:Core",
         "backport:prev-minor"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "stack traces",
@@ -1412,7 +1449,8 @@
         "Team:Core",
         "backport:skip"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "@elastic/ebt",
@@ -1430,7 +1468,8 @@
         "Team:Core",
         "backport:prev-minor"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "lodash",
@@ -1449,7 +1488,8 @@
         "Team:Core",
         "backport:prev-minor"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "OpenAPI Spec",
@@ -1470,7 +1510,7 @@
         "Team:Core",
         "backport:prev-minor"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1499,7 +1539,7 @@
         "Team:Core",
         "backport:prev-minor"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1523,7 +1563,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1543,7 +1583,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1561,7 +1601,7 @@
         "Team:Operations",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": false
     },
     {
@@ -1581,7 +1621,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1601,7 +1641,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1621,7 +1661,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1643,7 +1683,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1662,7 +1702,7 @@
         "Team:Operations",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1683,7 +1723,7 @@
         "Team:Operations",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "allowedVersions": "<3.0",
       "enabled": true
     },
@@ -1725,7 +1765,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1745,7 +1785,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1764,7 +1804,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1783,7 +1823,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1806,7 +1846,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1826,7 +1866,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1857,7 +1897,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1877,7 +1917,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1897,7 +1937,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1916,7 +1956,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1940,7 +1980,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1959,7 +1999,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1979,7 +2019,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -1999,7 +2039,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2019,7 +2059,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2038,7 +2078,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2059,7 +2099,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2079,7 +2119,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2098,7 +2138,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2118,7 +2158,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2137,7 +2177,7 @@
         "Team:Visualizations",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2155,7 +2195,7 @@
         "Team:Visualizations",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2175,7 +2215,7 @@
         "release_note:skip",
         "backport:prev-minor"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2196,7 +2236,7 @@
         "release_note:skip",
         "backport:prev-minor"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2224,7 +2264,7 @@
         "backport:prev-minor"
       ],
       "dependencyDashboardApproval": true,
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2259,7 +2299,7 @@
         "release_note:skip",
         "backport:prev-minor"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2283,7 +2323,7 @@
         "Team:Enterprise Search",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2303,7 +2343,7 @@
         "Team:Enterprise Search",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2325,7 +2365,7 @@
         "effort:high",
         "upgrade-risk:medium"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2345,7 +2385,7 @@
         "Team:Enterprise Search",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2368,7 +2408,7 @@
         "Team:Enterprise Search",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2390,7 +2430,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2410,7 +2450,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2430,7 +2470,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2452,7 +2492,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2473,7 +2513,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2492,7 +2532,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2511,7 +2551,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2530,7 +2570,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2550,7 +2590,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2569,7 +2609,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2590,7 +2630,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2609,7 +2649,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2630,7 +2670,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2657,7 +2697,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2679,7 +2719,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2702,7 +2742,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2723,7 +2763,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2748,7 +2788,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2773,7 +2813,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2801,7 +2841,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2820,7 +2860,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2839,7 +2879,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2858,7 +2898,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2877,7 +2917,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2896,7 +2936,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2915,7 +2955,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2934,7 +2974,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2953,7 +2993,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2972,7 +3012,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -2991,7 +3031,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3010,7 +3050,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3029,7 +3069,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3048,7 +3088,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3067,7 +3107,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3087,7 +3127,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3107,7 +3147,7 @@
         "release_note:skip",
         "ci:all-cypress-suites"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3126,7 +3166,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3145,7 +3185,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3165,7 +3205,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3185,7 +3225,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3205,7 +3245,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3239,7 +3279,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3260,7 +3300,7 @@
         "effort:low",
         "blocked"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3281,7 +3321,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3301,7 +3341,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3323,7 +3363,7 @@
         "effort:low",
         "blocked"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3345,7 +3385,7 @@
         "blocked",
         "effort:low"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3363,7 +3403,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3383,7 +3423,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3401,7 +3441,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3421,7 +3461,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3439,7 +3479,7 @@
         "backport:all-open",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3481,7 +3521,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3501,7 +3541,7 @@
         "backport:all-open",
         "blocked"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3524,7 +3564,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3550,7 +3590,7 @@
         "release_note:skip",
         "backport:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true,
       "matchUpdateTypes": [
         "major",
@@ -3578,7 +3618,7 @@
         "release_note:skip",
         "backport:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3597,7 +3637,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3617,7 +3657,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3641,7 +3681,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3664,7 +3704,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3703,7 +3743,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3728,7 +3768,7 @@
         "ci:build-storybooks",
         "backport:prev-minor"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3753,7 +3793,7 @@
         "backport:skip",
         "ci:all-cypress-suites"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3773,7 +3813,7 @@
         "ci:all-cypress-suites",
         "Team:obs-ux-management"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3794,7 +3834,7 @@
         "ci:all-cypress-suites",
         "Team:obs-ux-management"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3814,7 +3854,7 @@
         "ci:all-cypress-suites",
         "Team:obs-ux-management"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3834,7 +3874,7 @@
         "ci:all-cypress-suites",
         "Team:obs-ux-management"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3854,7 +3894,7 @@
         "ci:all-cypress-suites",
         "Team:obs-ux-management"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3874,7 +3914,7 @@
         "ci:all-cypress-suites",
         "Team:obs-ux-management"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3892,7 +3932,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3912,7 +3952,7 @@
         "ci:all-cypress-suites",
         "Team:obs-ux-management"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3939,7 +3979,7 @@
         "effort:high",
         "upgrade-risk:high"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3958,7 +3998,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3977,7 +4017,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -3995,7 +4035,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4014,7 +4054,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4050,7 +4090,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4070,7 +4110,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4089,7 +4129,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4109,7 +4149,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4128,7 +4168,7 @@
         "release_note:skip",
         "backport:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4147,7 +4187,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4166,7 +4206,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4184,7 +4224,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4202,7 +4242,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4221,7 +4261,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4239,7 +4279,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4259,7 +4299,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "separateMajorMinor": true,
       "allowedVersions": "<5.0.0",
       "enabled": true
@@ -4281,7 +4321,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "separateMajorMinor": true,
       "enabled": true
     },
@@ -4301,7 +4341,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4320,7 +4360,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4358,7 +4398,7 @@
         "backport:prev-minor",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4378,7 +4418,7 @@
         "backport:skip",
         "ci:serverless-test-all"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4397,7 +4437,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4421,7 +4461,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4445,7 +4485,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4464,7 +4504,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4483,7 +4523,7 @@
         "Team:ESQL",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4521,7 +4561,8 @@
         "release_note:skip",
         "backport:prev-minor"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "Serve swagger docs",
@@ -4543,7 +4584,8 @@
         "team:obs-entities",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "Security Engineering Productivity",
@@ -4561,7 +4603,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4580,7 +4622,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4599,7 +4641,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4619,6 +4661,7 @@
         "Team:Kibana Management",
         "Feature:Console"
       ],
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4637,7 +4680,7 @@
         "backport:prev-minor",
         "release_note:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4658,7 +4701,7 @@
         "release_note:skip",
         "backport:skip"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4677,7 +4720,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
@@ -4697,6 +4740,7 @@
         "release_note:skip",
         "backport:current-major"
       ],
+      "minimumReleaseAge": "14 days",
       "enabled": true
     }
   ],


### PR DESCRIPTION
## Summary

A revert of https://github.com/elastic/kibana/pull/235263, which was always temporary.
Additionally, this updates that third-party deps have `"minimumReleaseAge": "14 days"` defined to reduce PR churn.