### PR TITLE
[9.1] [ResponseOps][Connectors] Fix problem saving rule with index connector (#234624)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/es_index/es_index_params.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/es_index/es_index_params.tsx
@@ -61,7 +61,7 @@ export const IndexParamsFields = ({
         ? // if non-empty object, stringify it into format that JSON editor expects
           JSON.stringify(docs[0], null, 2)
         : null
-      : undefined;
+      : '';
   };
 
   const [documentToIndex, setDocumentToIndex] = useState<string | undefined | null>(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ResponseOps][Connectors] Fix problem saving rule with index connector (#234624)](https://github.com/elastic/kibana/pull/234624)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Antonio","email":"antonio.coelho@elastic.co"},"sourceCommit":{"committedDate":"2025-09-15T09:34:57Z","message":"[ResponseOps][Connectors] Fix problem saving rule with index connector (#234624)\n\nFixes #179144\n\n## Summary\n\nThe default value was undefined, which was not triggering the form\nvalidation.\n\nSetting it to an empty string triggers it when the form is opened.+\n\nThe default `{}` would also trigger the error but I found it more\nmisleading. What validation does is check if it is a json object **and\nif it has fields.**","sha":"c1819c52571be05a68d45f5a23736e77e785d662","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Actions","Team:ResponseOps","backport missing","backport:version","v9.2.0"],"title":"[ResponseOps][Connectors] Fix problem saving rule with index connector","number":234624,"url":"https://github.com/elastic/kibana/pull/234624","mergeCommit":{"message":"[ResponseOps][Connectors] Fix problem saving rule with index connector (#234624)\n\nFixes #179144\n\n## Summary\n\nThe default value was undefined, which was not triggering the form\nvalidation.\n\nSetting it to an empty string triggers it when the form is opened.+\n\nThe default `{}` would also trigger the error but I found it more\nmisleading. What validation does is check if it is a json object **and\nif it has fields.**","sha":"c1819c52571be05a68d45f5a23736e77e785d662"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/234624","number":234624,"mergeCommit":{"message":"[ResponseOps][Connectors] Fix problem saving rule with index connector (#234624)\n\nFixes #179144\n\n## Summary\n\nThe default value was undefined, which was not triggering the form\nvalidation.\n\nSetting it to an empty string triggers it when the form is opened.+\n\nThe default `{}` would also trigger the error but I found it more\nmisleading. What validation does is check if it is a json object **and\nif it has fields.**","sha":"c1819c52571be05a68d45f5a23736e77e785d662"}}]}] BACKPORT-->