### PR TITLE
[Fleet] Poc create alert rules from template

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
@@ -650,6 +650,7 @@ export enum INSTALL_STATES {
   CREATE_RESTART_INSTALLATION = 'create_restart_installation',
   INSTALL_KIBANA_ASSETS = 'install_kibana_assets',
   INSTALL_ILM_POLICIES = 'install_ilm_policies',
+  INSTALL_ELASTIC_AGENT_RULES = 'install_elastic_agent_rules',
   INSTALL_ML_MODEL = 'install_ml_model',
   INSTALL_INDEX_TEMPLATE_PIPELINES = 'install_index_template_pipelines',
   REMOVE_LEGACY_TEMPLATES = 'remove_legacy_templates',

--- a/x-pack/platform/plugins/shared/fleet/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/fleet/kibana.jsonc
@@ -43,7 +43,8 @@
       "telemetry",
       "discover",
       "ingestPipelines",
-      "automaticImport"
+      "automaticImport",
+      "alerting"
     ],
     "requiredBundles": [
       "kibanaReact",

--- a/x-pack/platform/plugins/shared/fleet/server/services/app_context.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/app_context.ts
@@ -54,6 +54,7 @@ import type { FleetUsage } from '../collectors/register';
 
 import type { BulkActionsResolver } from './agents/bulk_actions_resolver';
 import { type UninstallTokenServiceInterface } from './security/uninstall_token_service';
+import { AlertingServerStart } from '@kbn/alerting-plugin/server';
 
 class AppContextService {
   private encryptedSavedObjects: EncryptedSavedObjectsClient | undefined;
@@ -84,6 +85,7 @@ class AppContextService {
   private taskManagerStart: TaskManagerStartContract | undefined;
   private fetchUsage?: (abortController: AbortController) => Promise<FleetUsage | undefined>;
   private lockManagerService: LockManagerService | undefined;
+  private alertingStart: AlertingServerStart | undefined;
 
   public start(appContext: FleetAppContext) {
     this.data = appContext.data;
@@ -111,6 +113,7 @@ class AppContextService {
     this.taskManagerStart = appContext.taskManagerStart;
     this.fetchUsage = appContext.fetchUsage;
     this.lockManagerService = appContext.lockManagerService;
+    this.alertingStart = appContext.alertingStart;
 
     if (appContext.config$) {
       this.config$ = appContext.config$;
@@ -366,6 +369,10 @@ class AppContextService {
 
   public getLockManagerService() {
     return this.lockManagerService;
+  }
+
+  public getAlertingStart() {
+    return this.alertingStart;
   }
 }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/_state_machine_package_install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/_state_machine_package_install.ts
@@ -60,6 +60,7 @@ import {
 } from './steps';
 import type { StateMachineDefinition, StateMachineStates } from './state_machine';
 import { handleState } from './state_machine';
+import { stepInstallElasticAgentRules } from './steps/step_install_elastic_agent_rules';
 
 export interface InstallContext extends StateContext<StateNames> {
   savedObjectsClient: SavedObjectsClientContract;
@@ -97,6 +98,11 @@ const regularStatesDefinition: StateMachineStates<StateNames> = {
   install_kibana_assets: {
     onPreTransition: cleanUpKibanaAssetsStep,
     onTransition: stepInstallKibanaAssets,
+    nextState: INSTALL_STATES.INSTALL_ELASTIC_AGENT_RULES,
+    onPostTransition: updateLatestExecutedState,
+  },
+  install_elastic_agent_rules: {
+    onTransition: stepInstallElasticAgentRules,
     nextState: INSTALL_STATES.INSTALL_ILM_POLICIES,
     onPostTransition: updateLatestExecutedState,
   },

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_elastic_agent_rules.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_elastic_agent_rules.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { appContextService } from '@kbn/fleet-plugin/server/services/app_context';
+import { withPackageSpan } from '../../utils';
+import type { InstallContext } from '../_state_machine_package_install';
+import { HTTPAuthorizationHeader } from '@kbn/security-plugin/server';
+import { FakeRawRequest } from '@kbn/core/server';
+import { kibanaRequestFactory } from '@kbn/core/packages/http/server-utils';
+
+function createKibanaRequestFromAuth(authorizationHeader: HTTPAuthorizationHeader) {
+  const requestHeaders: Headers = {
+    authorization: authorizationHeader.toString(),
+  };
+  const fakeRawRequest: FakeRawRequest = {
+    headers: requestHeaders,
+    path: '/',
+  };
+
+  // Since we're using API keys and accessing elasticsearch can only be done
+  // via a request, we're faking one with the proper authorization headers.
+  const fakeRequest = kibanaRequestFactory(fakeRawRequest);
+
+  return fakeRequest;
+}
+
+export async function stepInstallElasticAgentRules(context: InstallContext) {
+  const { savedObjectsClient, logger, installedPkg, packageInstallContext, spaceId } = context;
+  const { packageInfo } = packageInstallContext;
+  const { name: pkgName, title: pkgTitle } = packageInfo;
+
+  await withPackageSpan('Install elastic agent rules', async () => {
+    if (pkgName !== 'all_assets') {
+      return;
+    }
+
+    if (!context.authorizationHeader) {
+      // Need authorization to create a rule as it need an api key
+      return;
+    }
+
+    const rulesClient = await appContextService
+      .getAlertingStart()
+      ?.getRulesClientWithRequest(createKibanaRequestFromAuth(context.authorizationHeader));
+
+    if (!rulesClient) {
+      throw new Error('Rules client is not available');
+    }
+
+    await packageInstallContext.archiveIterator.traverseEntries(
+      async (entry) => {
+        if (!entry.buffer) {
+          return;
+        }
+
+        const alert = JSON.parse(entry.buffer.toString('utf8'));
+        const { ruleTypeId, ...rest } = alert.attributes;
+
+        await rulesClient.create({
+          data: { alertTypeId: ruleTypeId, ...rest, enabled: true, consumer: 'alerts' }, // what value for consumer will make sense?
+          options: { id: 'hardcoded-id' },
+        });
+      },
+      (path) => path.match(/\/alerting_rule_template\//) !== null
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Poc to try to automatically create rule from template during a package

You can test this by installing the `all_assets` integration, with the `enableAgentStatusAlerting` feature flag turned on

[all_assets-0.2.0.zip](https://github.com/user-attachments/files/22407791/all_assets-0.2.0.zip)

It surface some issue we may have when creating an alert from Fleet:
* permissions to create rule, rules run with an api key with the permissions of the user that create the rule
* consumer 
* space?  rule are space aware, should we allow to install the rule in multiple space? ids, ... 
