### PR TITLE
Failing test: Serverless Observability Functional Tests.x-pack/solutions/observability/test/serverless/functional/test_suites/rules/es_query_consumer·ts - serverless observability UI ES Query rule - consumers both logs and infrastructure privileges should open the rule creation flyout 

### DIFF
--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/rules/es_query_consumer.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/rules/es_query_consumer.ts
@@ -32,6 +32,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     });
 
     it('should open the rule creation flyout', async () => {
+      await testSubjects.existOrFail('createRuleButton');
       await testSubjects.click('createRuleButton');
       const isCreateRuleFlyoutVisible = await testSubjects.exists('ruleTypeModal');
       expect(isCreateRuleFlyoutVisible).toBe(true);


### PR DESCRIPTION
## Summary

It fixes https://github.com/elastic/kibana/issues/233539 by checking the button exists on the DOM (give it a time to load) before clicking it.

