### PR TITLE
Re-add renovate to the allow list for CI jobs

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -8,7 +8,7 @@
       "enabled": true,
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
-      "allowed_list": ["elastic-vault-github-plugin-prod[bot]"],
+      "allowed_list": ["elastic-vault-github-plugin-prod[bot]", "elastic-renovate-prod[bot]"],
       "set_commit_status": true,
       "commit_status_context": "kibana-ci",
       "build_on_commit": true,


### PR DESCRIPTION
## Summary

Re-allows Renovate to auto-run CI