### PR TITLE
fix: internal connectors generic request

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/common/elasticsearch_request_builder.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/elasticsearch_request_builder.ts
@@ -19,6 +19,12 @@ export function buildRequestFromConnector(
 ): { method: string; path: string; body?: any; params?: any } {
   // console.log('DEBUG - Input params:', JSON.stringify(params, null, 2));
 
+  // Special case: elasticsearch.request type uses raw API format at top level
+  if (stepType === 'elasticsearch.request') {
+    const { method = 'GET', path, body } = params;
+    return { method, path, body };
+  }
+
   // Lazy load the generated connectors to avoid main bundle bloat
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { GENERATED_ELASTICSEARCH_CONNECTORS } = require('./generated_es_connectors');

--- a/src/platform/packages/shared/kbn-workflows/common/kibana_request_builder.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/kibana_request_builder.ts
@@ -23,6 +23,12 @@ export function buildKibanaRequestFromAction(
     return { method, path, body, query, headers };
   }
 
+  // Special case: kibana.request type uses raw API format at top level
+  if (actionType === 'kibana.request') {
+    const { method = 'GET', path, body, query, headers } = params;
+    return { method, path, body, query, headers };
+  }
+
   // Lazy load the generated connectors to avoid main bundle bloat
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { GENERATED_KIBANA_CONNECTORS } = require('./generated_kibana_connectors');

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/elasticsearch_action_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/elasticsearch_action_step.ts
@@ -110,6 +110,14 @@ export class ElasticsearchActionStepImpl extends StepBase<ElasticsearchActionSte
         path,
         body,
       });
+    } else if (stepType === 'elasticsearch.request') {
+      // Special case: elasticsearch.request type uses raw API format at top level
+      const { method = 'GET', path, body } = params;
+      return await esClient.transport.request({
+        method,
+        path,
+        body,
+      });
     } else {
       // Use generated connector definitions to determine method and path (covers all 568+ ES APIs)
       const {


### PR DESCRIPTION
close https://github.com/elastic/security-team/issues/14034
- Add support for kibana.request type to use raw API format at top level
- Add support for elasticsearch.request type to use raw API format at top level
- This allows workflows to use generic request types without needing specific connector definitions
- Maintains backward compatibility with existing connector-driven syntax and nested request format



