### PR TITLE
[UII] Remove extra space when building subcategory in integrations URL

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/constants/page_paths.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/constants/page_paths.ts
@@ -133,7 +133,7 @@ export const pagePathGetters: {
   }) => {
     const categoryPath =
       category && subCategory
-        ? `/${category}/${subCategory} `
+        ? `/${category}/${subCategory}`
         : category && !subCategory
         ? `/${category}`
         : ``;


### PR DESCRIPTION
## Summary

In integrations browse experience, when user clicks into a subcategory such as Security > DNS, an extra space is added to the URL: `/app/integrations/browse/security/dns_security%20`

Reloading the page with the extra space causes no results to be returned because we try to do exact matching on `dns_security%20` subcategory.

This PR fixes this bug by removing the extra space.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->