### PR TITLE
[Fleet] make enrollment_token a secret in migrate action

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/types/models/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/agent.ts
@@ -82,6 +82,7 @@ export interface NewAgentAction {
     user_info?: {
       password?: SOSecret;
     };
+    enrollment_token?: SOSecret;
   };
 }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.test.ts
@@ -111,9 +111,11 @@ describe('Agent migration', () => {
         type: 'MIGRATE',
         policyId: options.policyId,
         data: {
-          enrollment_token: options.enrollment_token,
           target_uri: options.uri,
           settings: options.settings,
+        },
+        secrets: {
+          enrollment_token: options.enrollment_token,
         },
       });
 
@@ -144,9 +146,11 @@ describe('Agent migration', () => {
         soClientMock,
         expect.objectContaining({
           data: {
-            enrollment_token: options.enrollment_token,
             target_uri: options.uri,
             settings: undefined,
+          },
+          secrets: {
+            enrollment_token: options.enrollment_token,
           },
         })
       );
@@ -191,9 +195,11 @@ describe('Agent migration', () => {
           agents: [mockedAgent.id, mockedAgent.id],
           type: 'MIGRATE',
           data: {
-            enrollment_token: options.enrollment_token,
             target_uri: options.uri,
             settings: options.settings,
+          },
+          secrets: {
+            enrollment_token: options.enrollment_token,
           },
           total: 2,
           namespaces: ['default'],
@@ -219,9 +225,11 @@ describe('Agent migration', () => {
         soClientMock,
         expect.objectContaining({
           data: {
-            enrollment_token: options.enrollment_token,
             target_uri: options.uri,
             settings: undefined,
+          },
+          secrets: {
+            enrollment_token: options.enrollment_token,
           },
         })
       );

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.ts
@@ -26,7 +26,12 @@ export async function migrateSingleAgent(
   agentId: string,
   agentPolicy: AgentPolicy | undefined,
   agent: Agent,
-  options: any
+  options: {
+    policyId?: string;
+    enrollment_token: string;
+    uri: string;
+    settings?: Record<string, any>;
+  }
 ) {
   //  If the agent belongs to a policy that is protected or has fleet-server as a component meaning its a fleet server agent, throw an error
   if (agentPolicy?.is_protected || agent.components?.some((c) => c.type === 'fleet-server')) {
@@ -38,10 +43,12 @@ export async function migrateSingleAgent(
     type: 'MIGRATE',
     policyId: options.policyId,
     data: {
-      enrollment_token: options.enrollment_token,
       target_uri: options.uri,
       settings: options.settings,
     },
+    ...(options.enrollment_token && {
+      secrets: { enrollment_token: options.enrollment_token },
+    }),
   });
   return { actionId: response.id };
 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate_action_runner.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate_action_runner.ts
@@ -81,10 +81,12 @@ export async function bulkMigrateAgentsBatch(
     type: 'MIGRATE',
     total,
     data: {
-      enrollment_token: options.enrollment_token,
       target_uri: options.uri,
       settings: options.settings,
     },
+    ...(options.enrollment_token && {
+      secrets: { enrollment_token: options.enrollment_token },
+    }),
     namespaces,
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/secrets/actions.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/secrets/actions.test.ts
@@ -45,6 +45,7 @@ describe('Action Secrets', () => {
       user_info: {
         password: 'password1',
       },
+      enrollment_token: 'enrollment_token1',
     },
   };
 
@@ -62,14 +63,26 @@ describe('Action Secrets', () => {
               id: expect.any(String),
             },
           },
+          enrollment_token: {
+            id: expect.any(String),
+          },
         },
       });
-      expect(res.secretReferences).toEqual([{ id: expect.anything() }]);
+      expect(res.secretReferences).toEqual([{ id: expect.anything() }, { id: expect.anything() }]);
       expect(esClientMock.transport.request.mock.calls).toEqual([
         [
           {
             body: {
               value: 'password1',
+            },
+            method: 'POST',
+            path: '/_fleet/secret',
+          },
+        ],
+        [
+          {
+            body: {
+              value: 'enrollment_token1',
             },
             method: 'POST',
             path: '/_fleet/secret',
@@ -89,6 +102,9 @@ describe('Action Secrets', () => {
               id: '7jCKYZUBBY96FE7DX6L1',
             },
           },
+          enrollment_token: {
+            id: '7jCKYZUBBY96FE7DX6L2',
+          },
         },
       } as any;
       await deleteActionSecrets({
@@ -100,6 +116,12 @@ describe('Action Secrets', () => {
           {
             method: 'DELETE',
             path: '/_fleet/secret/7jCKYZUBBY96FE7DX6L1',
+          },
+        ],
+        [
+          {
+            method: 'DELETE',
+            path: '/_fleet/secret/7jCKYZUBBY96FE7DX6L2',
           },
         ],
       ]);

--- a/x-pack/platform/plugins/shared/fleet/server/services/secrets/actions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/secrets/actions.ts
@@ -112,7 +112,6 @@ export async function deleteActionSecrets(opts: {
 
 /**
  * Helper function to get the secret paths for an agent action.
- * Currently only supports user_info.password as a secret.
  */
 function getActionSecretPaths(action: NewAgentAction): SOSecretPath[] {
   const secretPaths: SOSecretPath[] = [];
@@ -121,6 +120,12 @@ function getActionSecretPaths(action: NewAgentAction): SOSecretPath[] {
     secretPaths.push({
       path: 'secrets.user_info.password',
       value: action.secrets.user_info.password,
+    });
+  }
+  if (action?.secrets?.enrollment_token) {
+    secretPaths.push({
+      path: 'secrets.enrollment_token',
+      value: action.secrets.enrollment_token,
     });
   }
 

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/migrate.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/migrate.ts
@@ -242,6 +242,14 @@ export default function (providerContext: FtrProviderContext) {
         expect(action.secret_references[0].id).to.be.a('string');
         // Check that secrets is not stored in the action.
         expect(Object.keys(action)).to.not.contain(['secrets']);
+
+        const secretRes = await es.get({
+          index: '.fleet-secrets',
+          id: action.secret_references[0].id,
+        });
+        expect(secretRes._source).to.eql({
+          value: '1234',
+        });
       });
 
       it('should return a 403 if the agent is tamper protected', async () => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/ingest-dev/issues/6119

Make `enrollment_token` a secret in single and bulk migrate action.
Updated unit and integration tests to cover the API changes.

To verify:
- Enable feature flag `enableAgentMigrations`
- Enroll an agent into Fleet, making sure both Fleet server and the agent are on the latest 9.2.0-SNAPSHOT version.
- Take the Migrate agent action
- Verify that the migrate action is successful, and the agent is reassigned to the new policy
- Verify that the enrollment token is stored as a secret reference in the `.fleet-actions` index

```
POST kbn:/api/fleet/agents/<agent_id>/migrate
{"enrollment_token":"<token>","uri":"https://192.168.64.1:8220","settings":{}}

POST kbn:/api/fleet/agents/bulk_migrate
{"agents":"( fleet-agents.policy_id : (\"<policy_id>\"))","uri":"https://192.168.64.1:8220","enrollment_token":"<token>","settings":{}}

# action doc
      {
        "_index": ".fleet-actions-7",
        "_id": "faaa3e40-1852-4a83-b252-9ccbda6a9a6c",
        "_score": 1,
        "_source": {
          "@timestamp": "2025-09-18T15:14:06.435Z",
          "expiration": "2025-10-18T15:14:06.435Z",
          "agents": [
            "88905475-1f93-4b41-b12c-a18f77adb327",
          ],
          "namespaces": [
            "default"
          ],
          "action_id": "9ecbb72b-6ba8-4141-aa8f-6c4c72c2fdc6",
          "data": {
            "target_uri": "https://192.168.65.1:8220",
            "settings": {},
            "enrollment_token": "$co.elastic.secret{tBdjXZkBL2hPWtRqzyrk}"
          },
          "type": "MIGRATE",
          "total": 1,
          "secret_references": [
            {
              "id": "tBdjXZkBL2hPWtRqzyrk"
            }
          ],
    }

{
        "_index": ".fleet-secrets-7",
        "_id": "tBdjXZkBL2hPWtRqzyrk",
        "_score": 1,
        "_source": {
          "value": "<token>"
        }
      },
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



