### PR TITLE
[POC][Write restricted objects] SavedObjects supporting access control telemetry

### DIFF
--- a/src/core/packages/saved-objects/base-server-internal/src/saved_objects_type_registry.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/saved_objects_type_registry.ts
@@ -125,6 +125,12 @@ export class SavedObjectTypeRegistry implements ISavedObjectTypeRegistry {
   public supportsAccessControl(type: string): boolean {
     return this.types.get(type)?.supportsAccessControl ?? false;
   }
+
+  public getAllTypesWithAccessControl() {
+    return this.getAllTypes()
+      .filter((type) => type.supportsAccessControl)
+      .map(({ name }) => name);
+  }
 }
 
 const validateType = ({ name, management, hidden, hiddenFromHttpApis }: SavedObjectsType) => {

--- a/src/core/packages/saved-objects/server/src/type_registry.ts
+++ b/src/core/packages/saved-objects/server/src/type_registry.ts
@@ -98,4 +98,9 @@ export interface ISavedObjectTypeRegistry {
    * the property/type is not registered.
    */
   getNameAttribute(type: string): string;
+
+  /**
+   * Returns all {@link SavedObjectsType | types} currently registered that support access control.
+   */
+  getAllTypesWithAccessControl(): string[];
 }

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts/get_saved_object_counts.test.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts/get_saved_object_counts.test.ts
@@ -27,7 +27,13 @@ describe('getSavedObjectsCounts', () => {
     const results = await getSavedObjectsCounts(soClient, ['type-a']);
     // Make sure ES.search is triggered (we'll test the actual params in other specific tests)
     expect(soClient.find).toHaveBeenCalledTimes(1);
-    expect(results).toStrictEqual({ total: 0, per_type: [], non_expected_types: [], others: 0 });
+    expect(results).toStrictEqual({
+      total: 0,
+      per_type: [],
+      non_expected_types: [],
+      others: 0,
+      by_access_control_type: [],
+    });
   });
 
   test('should match all and request the `missing` bucket (size + 1) when `exclusive === false`', async () => {
@@ -45,6 +51,9 @@ describe('getSavedObjectsCounts', () => {
             missing: 'missing_so_type',
           },
         },
+        has_access_control: {
+          filter: { exists: { field: 'accessControl' } },
+        },
       },
     });
   });
@@ -56,7 +65,10 @@ describe('getSavedObjectsCounts', () => {
       type: ['type_one', 'type_two'],
       namespaces: ['*'],
       perPage: 0,
-      aggs: { types: { terms: { field: 'type', size: 2 } } },
+      aggs: {
+        types: { terms: { field: 'type', size: 2 } },
+        has_access_control: { filter: { exists: { field: 'accessControl' } } },
+      },
     });
   });
 
@@ -81,6 +93,7 @@ describe('getSavedObjectsCounts', () => {
       ],
       non_expected_types: [],
       others: 10,
+      by_access_control_type: [],
     });
   });
 
@@ -109,6 +122,7 @@ describe('getSavedObjectsCounts', () => {
       ],
       non_expected_types: ['type-3', 'type-four'],
       others: 6,
+      by_access_control_type: [],
     });
   });
 });

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts/get_saved_object_counts.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts/get_saved_object_counts.ts
@@ -107,7 +107,9 @@ export async function getSavedObjectsCounts(
     void,
     {
       types: estypes.AggregationsStringTermsAggregate;
-      access_control_types: estypes.AggregationsStringTermsAggregate;
+      access_control_types: estypes.AggregationsFilterAggregate & {
+        by_type: estypes.AggregationsStringTermsAggregate;
+      };
     }
   >({
     type: soTypes,
@@ -120,7 +122,7 @@ export async function getSavedObjectsCounts(
     (body.aggregations?.types?.buckets as estypes.AggregationsStringTermsBucketKeys[]) || [];
 
   const accessControlBucket =
-    (body.aggregations?.access_control_types
+    (body.aggregations?.access_control_types?.by_type
       ?.buckets as estypes.AggregationsStringTermsBucketKeys[]) || [];
 
   const nonExpectedTypes: string[] = [];

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/saved_objects_counts/saved_objects_count_collector.test.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/saved_objects_counts/saved_objects_count_collector.test.ts
@@ -23,7 +23,8 @@ describe('saved_objects_count_collector', () => {
     registerSavedObjectsCountUsageCollector(
       usageCollectionMock,
       () => Promise.resolve(['type_one', 'type_two', 'type-three', 'type-four']),
-      mockGetSoClientWithHiddenIndices
+      mockGetSoClientWithHiddenIndices,
+      () => Promise.resolve(['type_one', 'type-three'])
     )
   );
   afterAll(() => jest.clearAllTimers());

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/saved_objects_counts/saved_objects_count_collector.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/saved_objects_counts/saved_objects_count_collector.ts
@@ -21,6 +21,7 @@ interface SavedObjectsCountUsage {
   others: number;
   by_type: SavedObjectsCountUsageByType[];
   non_registered_types: string[];
+  by_access_control_type: SavedObjectsCountUsageByType[];
 }
 
 export function registerSavedObjectsCountUsageCollector(
@@ -43,6 +44,22 @@ export function registerSavedObjectsCountUsageCollector(
           type: 'array',
           items: {
             type: { type: 'keyword', _meta: { description: 'The SavedObjects type' } },
+            count: {
+              type: 'long',
+              _meta: {
+                description:
+                  'How many SavedObjects of that type are stored in the cluster across all Spaces',
+              },
+            },
+          },
+        },
+        by_access_control_type: {
+          type: 'array',
+          items: {
+            type: {
+              type: 'keyword',
+              _meta: { description: 'The SavedObjects types supporting access control' },
+            },
             count: {
               type: 'long',
               _meta: {
@@ -78,15 +95,21 @@ export function registerSavedObjectsCountUsageCollector(
           total,
           per_type: buckets,
           non_expected_types: nonRegisteredTypes,
+          by_access_control_type: accessControlBuckets,
           others,
         } = await getSavedObjectsCounts(soClient, allRegisteredSOTypes, {
           namespaces,
           exclusive: false,
         });
+
         return {
           total,
           by_type: buckets.map(({ key: type, doc_count: count }) => ({ type, count })),
           non_registered_types: nonRegisteredTypes,
+          by_access_control_type: accessControlBuckets.map(({ key: type, doc_count: count }) => ({
+            type,
+            count,
+          })),
           others,
         };
       },

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/saved_objects_counts/saved_objects_count_collector.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/saved_objects_counts/saved_objects_count_collector.ts
@@ -27,7 +27,8 @@ interface SavedObjectsCountUsage {
 export function registerSavedObjectsCountUsageCollector(
   usageCollection: UsageCollectionSetup,
   getAllSavedObjectTypes: () => Promise<string[]>,
-  getSoClientWithHiddenIndices: () => Promise<SavedObjectsClientContract>
+  getSoClientWithHiddenIndices: () => Promise<SavedObjectsClientContract>,
+  getAllTypesWithAccessControl: () => Promise<string[]>
 ) {
   usageCollection.registerCollector(
     usageCollection.makeUsageCollector<SavedObjectsCountUsage>({
@@ -90,6 +91,7 @@ export function registerSavedObjectsCountUsageCollector(
       async fetch() {
         const soClient = await getSoClientWithHiddenIndices();
         const allRegisteredSOTypes = await getAllSavedObjectTypes();
+        const allTypesWithAccessControl = await getAllTypesWithAccessControl();
         const namespaces = ['*'];
         const {
           total,
@@ -100,6 +102,7 @@ export function registerSavedObjectsCountUsageCollector(
         } = await getSavedObjectsCounts(soClient, allRegisteredSOTypes, {
           namespaces,
           exclusive: false,
+          typesSupportingAccessControl: allTypesWithAccessControl,
         });
 
         return {

--- a/src/platform/plugins/private/kibana_usage_collection/server/plugin.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/plugin.ts
@@ -159,10 +159,16 @@ export class KibanaUsageCollectionPlugin implements Plugin {
       return coreStart.savedObjects.createInternalRepository(allSoTypes);
     };
 
+    const getAllTypesWithAccessControl = async () => {
+      const coreStart = await coreStartPromise;
+      return coreStart.savedObjects.getTypeRegistry().getAllTypesWithAccessControl();
+    };
+
     registerSavedObjectsCountUsageCollector(
       usageCollection,
       getAllSavedObjectTypes,
-      getSoClientWithHiddenIndices
+      getSoClientWithHiddenIndices,
+      getAllTypesWithAccessControl
     );
     registerManagementUsageCollector(usageCollection, getUiSettingsClient);
     registerUiMetricUsageCollector(usageCollection, registerType, getSavedObjectsClient);

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -10156,6 +10156,25 @@
             }
           }
         },
+        "by_access_control_type": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "type": {
+                "type": "keyword",
+                "_meta": {
+                  "description": "The SavedObjects types supporting access control"
+                }
+              },
+              "count": {
+                "type": "long",
+                "_meta": {
+                  "description": "How many SavedObjects of that type are stored in the cluster across all Spaces"
+                }
+              }
+            }
+          }
+        },
         "others": {
           "type": "long",
           "_meta": {


### PR DESCRIPTION
## Summary
This PR adds basic SavedObject usage data aggregation for counts of SOs with `accessControl` fields per `type`. 

This implementation doesn't cover the usage of SO specific telemetry which will be implemented at the RPC layer. 


Added a simple aggregate filter to the SO Count collection that filters on `All registered SO types` and then aggregates for `access_control` for types supporting access control. 


Screenshot showing doc count for per type SO registration. 
<img width="1622" height="619" alt="Screenshot 2025-09-22 at 12 18 57" src="https://github.com/user-attachments/assets/62060d5e-da6a-494a-92f8-7ab51d736999" />


### Checklist
Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



