### PR TITLE
Group entity and label nodes in Graph API

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
@@ -53,6 +53,12 @@ export const DOCUMENT_TYPE_ENTITY = 'entity' as const;
 export const entitySchema = schema.object({
   name: schema.maybe(schema.string()),
   type: schema.maybe(schema.string()),
+  sub_type: schema.maybe(schema.string()),
+  host: schema.maybe(
+    schema.object({
+      ip: schema.maybe(schema.string()),
+    })
+  ),
 });
 
 export const nodeDocumentDataSchema = schema.object({
@@ -149,6 +155,9 @@ export const labelNodeDataSchema = schema.allOf([
     parentId: schema.maybe(schema.string()),
     color: nodeColorSchema,
     ips: schema.maybe(schema.arrayOf(schema.string())),
+    count: schema.maybe(schema.number()),
+    uniqueEventsCount: schema.maybe(schema.number()),
+    uniqueAlertsCount: schema.maybe(schema.number()),
     countryCodes: schema.maybe(schema.arrayOf(schema.string())),
     documentsData: schema.maybe(schema.arrayOf(nodeDocumentDataSchema)),
   }),

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/types.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/types.ts
@@ -53,8 +53,6 @@ export interface LabelNodeViewModel
   extends Record<string, unknown>,
     LabelNodeDataModel,
     BaseNodeDataViewModel {
-  uniqueEventsCount?: number;
-  uniqueAlertsCount?: number;
   expandButtonClick?: ExpandButtonClickCallback;
   nodeClick?: NodeClickCallback;
 }

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/parse_records.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/parse_records.test.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { ApiMessageCode } from '@kbn/cloud-security-posture-common/types/graph/latest';
+import {
+  ApiMessageCode,
+  type EntityNodeDataModel,
+  type LabelNodeDataModel,
+  type GroupNodeDataModel,
+} from '@kbn/cloud-security-posture-common/types/graph/latest';
 import { parseRecords } from './parse_records';
 import type { GraphEdge } from './types';
 
@@ -26,22 +31,36 @@ describe('parseRecords', () => {
     expect(result.messages).toBeUndefined();
   });
 
-  it('creates nodes and edges for a single actor-target-action', () => {
+  it('creates nodes and edges for a single actor-target-action with entity groups', () => {
     const records: GraphEdge[] = [
       {
         action: 'login',
         actorIds: 'actor1',
+        targetIds: 'target1',
+        actorEntityGroup: 'user',
+        targetEntityGroup: 'host',
+        actorEntityType: 'user',
+        targetEntityType: 'host',
+        actorLabel: 'John Doe',
+        targetLabel: 'Server 01',
+        actorIdsCount: 1,
+        targetIdsCount: 1,
         badge: 1,
+        uniqueEventsCount: 1,
+        uniqueAlertsCount: 0,
         docs: ['{"foo":"bar"}'],
         isAlert: false,
         isOrigin: true,
         isOriginAlert: false,
-        targetIds: 'target1',
+        actorHostIps: [],
+        targetHostIps: [],
+        sourceIps: [],
+        sourceCountryCodes: [],
       },
     ];
     const result = parseRecords(mockLogger, records);
 
-    // Should have 3 nodes: actor, target, label
+    // Should have 3 nodes: actor group, target group, label
     expect(result.nodes.length).toBe(3);
     const ids = result.nodes.map((n) => n.id);
     expect(ids).toContain('actor1');
@@ -56,12 +75,31 @@ describe('parseRecords', () => {
     expect(result.edges[1].target).toBe('target1');
 
     // Label node should have correct label and documentsData
-    const labelNode = result.nodes.find((n) => n.id.includes('label(login)oe(1)oa(0)'));
+    const labelNode = result.nodes.find((n) =>
+      n.id.includes('label(login)oe(1)oa(0)')
+    ) as LabelNodeDataModel;
     expect(labelNode).toBeDefined();
     expect(labelNode!.label).toBe('login');
     expect(labelNode).toHaveProperty('documentsData', [{ foo: 'bar' }]);
     expect(labelNode).toHaveProperty('color', 'primary');
     expect(labelNode!.shape).toBe('label');
+    expect(labelNode).toHaveProperty('uniqueEventsCount', 1);
+
+    // Actor group node should have correct properties
+    const actorNode = result.nodes.find((n) => n.id === 'actor1') as EntityNodeDataModel;
+    expect(actorNode).toBeDefined();
+    expect(actorNode!.label).toBe('John Doe');
+    expect(actorNode).toHaveProperty('tag', 'user');
+    expect(actorNode).toHaveProperty('icon', 'user');
+    expect(actorNode).toHaveProperty('shape', 'ellipse');
+
+    // Target group node should have correct properties
+    const targetNode = result.nodes.find((n) => n.id === 'target1') as EntityNodeDataModel;
+    expect(targetNode).toBeDefined();
+    expect(targetNode!.label).toBe('Server 01');
+    expect(targetNode).toHaveProperty('tag', 'host');
+    expect(targetNode).toHaveProperty('icon', 'storage');
+    expect(targetNode).toHaveProperty('shape', 'hexagon');
   });
 
   it('handles docs as a single string', () => {
@@ -69,47 +107,91 @@ describe('parseRecords', () => {
       {
         action: 'foo',
         actorIds: 'actor1',
+        targetIds: 'target1',
+        actorEntityGroup: 'actor1',
+        targetEntityGroup: 'target1',
+        actorEntityType: '',
+        targetEntityType: '',
+        actorLabel: 'Actor 1',
+        targetLabel: 'Target 1',
+        actorIdsCount: 1,
+        targetIdsCount: 1,
         badge: 1,
+        uniqueEventsCount: 1,
+        uniqueAlertsCount: 0,
         docs: '{"a":1}',
         isAlert: false,
         isOrigin: true,
         isOriginAlert: false,
-        targetIds: 'target1',
+        actorHostIps: [],
+        targetHostIps: [],
+        sourceIps: [],
+        sourceCountryCodes: [],
       },
     ];
     const result = parseRecords(mockLogger, records);
-    const labelNode = result.nodes.find((n) => n.id.includes('label(foo)oe(1)oa(0)'));
+    const labelNode = result.nodes.find((n) =>
+      n.id.includes('label(foo)oe(1)oa(0)')
+    ) as LabelNodeDataModel;
     expect(labelNode).toBeDefined();
     expect(labelNode).toHaveProperty('documentsData', [{ a: 1 }]);
   });
 
-  it('creates group node when multiple actions between same actor and target', () => {
+  it('creates group node when multiple actions between same actor and target groups', () => {
     const records: GraphEdge[] = [
       {
         action: 'login',
         actorIds: 'actor1',
+        targetIds: 'target1',
+        actorEntityGroup: 'user',
+        targetEntityGroup: 'host',
+        actorEntityType: 'user',
+        targetEntityType: 'host',
+        actorLabel: 'John Doe',
+        targetLabel: 'Server 01',
+        actorIdsCount: 1,
+        targetIdsCount: 1,
         badge: 1,
+        uniqueEventsCount: 1,
+        uniqueAlertsCount: 0,
         docs: ['{"foo":"bar"}'],
         isAlert: false,
         isOrigin: true,
         isOriginAlert: false,
-        targetIds: 'target1',
+        actorHostIps: [],
+        targetHostIps: [],
+        sourceIps: [],
+        sourceCountryCodes: [],
       },
       {
         action: 'logout',
         actorIds: 'actor1',
+        targetIds: 'target1',
+        actorEntityGroup: 'user',
+        targetEntityGroup: 'host',
+        actorEntityType: 'user',
+        targetEntityType: 'host',
+        actorLabel: 'John Doe',
+        targetLabel: 'Server 01',
+        actorIdsCount: 1,
+        targetIdsCount: 1,
         badge: 1,
+        uniqueEventsCount: 1,
+        uniqueAlertsCount: 0,
         docs: ['{"baz":2}'],
         isAlert: false,
         isOrigin: true,
         isOriginAlert: false,
-        targetIds: 'target1',
+        actorHostIps: [],
+        targetHostIps: [],
+        sourceIps: [],
+        sourceCountryCodes: [],
       },
     ];
     const result = parseRecords(mockLogger, records);
 
     // Should have a group node
-    const groupNode = result.nodes.find((n) => n.shape === 'group');
+    const groupNode = result.nodes.find((n) => n.shape === 'group') as GroupNodeDataModel;
     expect(groupNode).toBeDefined();
     expect(groupNode!.id).toContain('grp(');
 
@@ -117,12 +199,12 @@ describe('parseRecords', () => {
     expect(result.nodes[0].shape).toBe('group');
 
     // Each label node should have parentId set to group node id
-    const labelNodes = result.nodes.filter((n) => n.shape === 'label');
+    const labelNodes = result.nodes.filter((n) => n.shape === 'label') as LabelNodeDataModel[];
     labelNodes.forEach((ln) => {
-      expect((ln as any).parentId).toBe(groupNode!.id);
+      expect(ln.parentId).toBe(groupNode!.id);
     });
 
-    // Edges should connect actor->group, group->label, label->target
+    // Edges should connect actor->group, group->label, label->group, group->target
     const actorToGroupEdge = result.edges.find(
       (edge) => edge.source === 'actor1' && edge.target === groupNode!.id
     );
@@ -140,10 +222,10 @@ describe('parseRecords', () => {
       expect(labelToGroupEdge).toBeDefined();
     });
 
-    const targetToGroupEdge = result.edges.find(
+    const groupToTargetEdge = result.edges.find(
       (edge) => edge.source === groupNode!.id && edge.target === 'target1'
     );
-    expect(targetToGroupEdge).toBeDefined();
+    expect(groupToTargetEdge).toBeDefined();
   });
 
   it('sets color to danger for isOriginAlert', () => {
@@ -151,18 +233,35 @@ describe('parseRecords', () => {
       {
         actorIds: 'actor1',
         targetIds: 'target1',
+        actorEntityGroup: 'actor1',
+        targetEntityGroup: 'target1',
+        actorEntityType: '',
+        targetEntityType: '',
+        actorLabel: 'Actor 1',
+        targetLabel: 'Target 1',
+        actorIdsCount: 1,
+        targetIdsCount: 1,
         action: 'alert',
         docs: ['{"foo":"bar"}'],
         badge: 1,
+        uniqueEventsCount: 0,
+        uniqueAlertsCount: 1,
         isAlert: false,
         isOrigin: true,
         isOriginAlert: true,
+        actorHostIps: [],
+        targetHostIps: [],
+        sourceIps: [],
+        sourceCountryCodes: [],
       },
     ];
     const result = parseRecords(mockLogger, records);
-    const labelNode = result.nodes.find((n) => n.id.includes('label(alert)oe(1)oa(1)'));
+    const labelNode = result.nodes.find((n) =>
+      n.id.includes('label(alert)oe(1)oa(1)')
+    ) as LabelNodeDataModel;
     expect(labelNode).toBeDefined();
     expect(labelNode).toHaveProperty('color', 'danger');
+    expect(labelNode).toHaveProperty('uniqueAlertsCount', 1);
   });
 
   it('sets color to danger for isAlert', () => {
@@ -170,29 +269,60 @@ describe('parseRecords', () => {
       {
         actorIds: 'actor1',
         targetIds: 'target1',
+        actorEntityGroup: 'actor1',
+        targetEntityGroup: 'target1',
+        actorEntityType: '',
+        targetEntityType: '',
+        actorLabel: 'Actor 1',
+        targetLabel: 'Target 1',
+        actorIdsCount: 1,
+        targetIdsCount: 1,
         action: 'alert',
         docs: ['{"foo":"bar"}'],
         badge: 1,
+        uniqueEventsCount: 0,
+        uniqueAlertsCount: 1,
         isAlert: true,
         isOrigin: true,
         isOriginAlert: false,
+        actorHostIps: [],
+        targetHostIps: [],
+        sourceIps: [],
+        sourceCountryCodes: [],
       },
     ];
     const result = parseRecords(mockLogger, records);
-    const labelNode = result.nodes.find((n) => n.id.includes('label(alert)oe(1)oa(0)'));
+    const labelNode = result.nodes.find((n) =>
+      n.id.includes('label(alert)oe(1)oa(0)')
+    ) as LabelNodeDataModel;
     expect(labelNode).toBeDefined();
     expect(labelNode).toHaveProperty('color', 'danger');
+    expect(labelNode).toHaveProperty('uniqueAlertsCount', 1);
   });
 
   it('sets label node id based on action, isOrigin and isOriginAlert fields', () => {
-    const actorId = 'actor1';
-    const targetId = 'target1';
+    const actorGroup = 'actor1';
+    const targetGroup = 'target1';
     const baseLabelNodeData = {
-      actorIds: actorId,
-      targetIds: targetId,
+      actorIds: 'actor1',
+      targetIds: 'target1',
+      actorEntityGroup: actorGroup,
+      targetEntityGroup: targetGroup,
+      actorEntityType: '',
+      targetEntityType: '',
+      actorLabel: 'Actor 1',
+      targetLabel: 'Target 1',
+      actorIdsCount: 1,
+      targetIdsCount: 1,
       docs: ['{"foo":"bar"}'],
       badge: 1,
+      uniqueEventsCount: 0,
+      uniqueAlertsCount: 1,
       isAlert: true,
+      actorHostIps: [],
+      targetHostIps: [],
+      sourceIps: [],
+      sourceCountryCodes: [],
     };
 
     const records: GraphEdge[] = [
@@ -222,34 +352,49 @@ describe('parseRecords', () => {
       },
     ];
     const result = parseRecords(mockLogger, records);
-    const labelNodes = result.nodes.filter((n) => n.shape === 'label');
+    const labelNodes = result.nodes.filter((n) => n.shape === 'label') as LabelNodeDataModel[];
 
     expect(labelNodes.map((n) => n.id)).toStrictEqual([
-      `a(${actorId})-b(${targetId})label(action1)oe(0)oa(0)`,
-      `a(${actorId})-b(${targetId})label(action2)oe(1)oa(0)`,
-      `a(${actorId})-b(${targetId})label(action3)oe(0)oa(1)`,
-      `a(${actorId})-b(${targetId})label(action4)oe(1)oa(1)`,
+      `a(${actorGroup})-b(${targetGroup})label(action1)oe(0)oa(0)`,
+      `a(${actorGroup})-b(${targetGroup})label(action2)oe(1)oa(0)`,
+      `a(${actorGroup})-b(${targetGroup})label(action3)oe(0)oa(1)`,
+      `a(${actorGroup})-b(${targetGroup})label(action4)oe(1)oa(1)`,
     ]);
   });
 
-  it('handles unknown target ids', () => {
+  it('handles unknown target groups', () => {
     const records: GraphEdge[] = [
       {
         action: 'foo',
         actorIds: 'actor1',
+        targetIds: 'target1',
+        actorEntityGroup: 'user',
+        targetEntityGroup: undefined, // This will trigger unknown target processing
+        actorEntityType: 'user',
+        targetEntityType: '',
+        actorLabel: 'John Doe',
+        targetLabel: '',
+        actorIdsCount: 1,
+        targetIdsCount: 0,
         badge: 1,
+        uniqueEventsCount: 1,
+        uniqueAlertsCount: 0,
         docs: ['{"foo":"bar"}'],
         isAlert: false,
         isOrigin: true,
         isOriginAlert: false,
-        targetIds: [null, 'target1'],
+        actorHostIps: [],
+        targetHostIps: [],
+        sourceIps: [],
+        sourceCountryCodes: [],
       },
     ];
     const result = parseRecords(mockLogger, records);
     // Should create a node with label 'Unknown'
-    const unknownNode = result.nodes.find((n) => n.label === 'Unknown');
+    const unknownNode = result.nodes.find((n) => n.label === 'Unknown') as EntityNodeDataModel;
     expect(unknownNode).toBeDefined();
     expect(unknownNode!.id.startsWith('unknown')).toBe(true);
+    expect(unknownNode).toHaveProperty('documentsData', []);
   });
 
   it('limits nodes and sets message when nodesLimit is reached', () => {
@@ -257,240 +402,598 @@ describe('parseRecords', () => {
       {
         action: 'foo',
         actorIds: ['a1', 'a2'],
+        targetIds: ['t1'],
+        actorEntityGroup: 'user',
+        targetEntityGroup: 'host',
+        actorEntityType: 'user',
+        targetEntityType: 'host',
+        actorLabel: 'User Group',
+        targetLabel: 'Host Group',
+        actorIdsCount: 2,
+        targetIdsCount: 1,
         badge: 1,
+        uniqueEventsCount: 1,
+        uniqueAlertsCount: 0,
         docs: ['{"foo":"bar"}'],
         isAlert: false,
         isOrigin: true,
         isOriginAlert: false,
-        targetIds: ['t1'],
+        actorHostIps: [],
+        targetHostIps: [],
+        sourceIps: [],
+        sourceCountryCodes: [],
       },
       {
         action: 'foo2',
         actorIds: ['a3'],
+        targetIds: ['t2', 't3'],
+        actorEntityGroup: 'service',
+        targetEntityGroup: 'file',
+        actorEntityType: 'service',
+        targetEntityType: 'file',
+        actorLabel: 'Service Group',
+        targetLabel: 'File Group',
+        actorIdsCount: 1,
+        targetIdsCount: 2,
         badge: 1,
+        uniqueEventsCount: 1,
+        uniqueAlertsCount: 0,
         docs: ['{"foo":"bar"}'],
         isAlert: false,
         isOrigin: true,
         isOriginAlert: false,
-        targetIds: ['t2', 't3'],
+        actorHostIps: [],
+        targetHostIps: [],
+        sourceIps: [],
+        sourceCountryCodes: [],
       },
     ];
-    // nodesLimit = 2, so only 2 nodes should be created
-    // However, first record creates 5 nodes (2 actors, 1 target, 1 label, 1 group)
-    // Since we process records as a whole, so the graph won't look broken we expect the length to be 5
+    // nodesLimit = 2, so only first record should be processed
+    // First record creates 3 nodes (actor group, target group, label)
     const result = parseRecords(mockLogger, records, 2);
-    expect(result.nodes.length).toBeLessThanOrEqual(5);
+    expect(result.nodes.length).toBeLessThanOrEqual(3);
     expect(result.messages).toContain(ApiMessageCode.ReachedNodesLimit);
   });
 
-  it('assigns correct shapes and icons for entity nodes without entity data', () => {
-    const records: GraphEdge[] = [
-      {
-        action: 'foo',
-        actorIds: ['user1', 'host1', 'ip1'],
-        badge: 1,
-        docs: ['{"foo":"bar"}'],
-        actorsDocData: [null],
-        targetsDocData: [null],
-        isAlert: false,
-        isOrigin: true,
-        isOriginAlert: false,
-        targetIds: ['ip1'],
-      },
-    ];
-    const result = parseRecords(mockLogger, records);
+  // Test for entity grouping by type and sub_type
+  describe('entity grouping functionality', () => {
+    it('groups actors and targets by type and sub_type', () => {
+      const records: GraphEdge[] = [
+        {
+          action: 'connect',
+          actorIds: ['user1', 'user2'],
+          targetIds: ['server1'],
+          actorEntityGroup: 'user:identity',
+          targetEntityGroup: 'host:server',
+          actorEntityType: 'user',
+          targetEntityType: 'host',
+          actorLabel: 'Identity Users',
+          targetLabel: 'Server Hosts',
+          actorIdsCount: 2,
+          targetIdsCount: 1,
+          badge: 1,
+          uniqueEventsCount: 1,
+          uniqueAlertsCount: 0,
+          docs: ['{"event":"connection"}'],
+          isAlert: false,
+          isOrigin: true,
+          isOriginAlert: false,
+          actorsDocData: [
+            '{"id":"user1","type":"entity","entity":{"name":"John Doe","type":"user","sub_type":"identity"}}',
+            '{"id":"user2","type":"entity","entity":{"name":"Jane Doe","type":"user","sub_type":"identity"}}',
+          ],
+          targetsDocData: [
+            '{"id":"server1","type":"entity","entity":{"name":"web-server-01","type":"host","sub_type":"server"}}',
+          ],
+          actorHostIps: [],
+          targetHostIps: [],
+          sourceIps: [],
+          sourceCountryCodes: [],
+        },
+      ];
+      const result = parseRecords(mockLogger, records);
 
-    const userNode = result.nodes.find((n) => n.id === 'user1');
-    expect(userNode).toMatchObject({ shape: 'rectangle' });
-    expect(userNode).not.toHaveProperty('tag');
+      // Should have actor group with both type and sub_type entities
+      const actorNode = result.nodes.find((n) => n.id === 'user1') as EntityNodeDataModel;
+      expect(actorNode).toBeDefined();
+      expect(actorNode!.label).toBe('Identity Users');
+      expect(actorNode).toHaveProperty('tag', 'user');
+      expect(actorNode).toHaveProperty('count', 2);
+      expect(actorNode).toHaveProperty('documentsData');
+      expect(actorNode.documentsData).toHaveLength(2);
+      expect(actorNode.documentsData![0].entity).toHaveProperty('type', 'user');
+      expect(actorNode.documentsData![0].entity).toHaveProperty('sub_type', 'identity');
+      expect(actorNode.documentsData![0].entity).toHaveProperty('type', 'user');
+      expect(actorNode.documentsData![1].entity).toHaveProperty('sub_type', 'identity');
 
-    const hostNode = result.nodes.find((n) => n.id === 'host1');
-    expect(hostNode).toMatchObject({ shape: 'rectangle' });
-    expect(hostNode).not.toHaveProperty('tag');
+      // Should have target group with both type and sub_type entities
+      const targetNode = result.nodes.find((n) => n.id === 'server1') as EntityNodeDataModel;
+      expect(targetNode).toBeDefined();
+      expect(targetNode!.label).toBe('Server Hosts');
+      expect(targetNode).toHaveProperty('tag', 'host');
+      expect(targetNode).not.toHaveProperty('count');
+      expect(targetNode).toHaveProperty('documentsData');
+      expect(targetNode.documentsData).toHaveLength(1);
+      expect(targetNode.documentsData![0].entity).toHaveProperty('type', 'host');
+      expect(targetNode.documentsData![0].entity).toHaveProperty('sub_type', 'server');
+    });
 
-    const ipNode = result.nodes.find((n) => n.id === 'ip1');
-    expect(ipNode).toMatchObject({ shape: 'rectangle' });
-    expect(ipNode).not.toHaveProperty('tag');
+    it('groups actors and targets by type only when sub_type is missing', () => {
+      const records: GraphEdge[] = [
+        {
+          action: 'access',
+          actorIds: ['service1', 'service2'],
+          targetIds: ['file1'],
+          actorEntityGroup: 'service',
+          targetEntityGroup: 'file',
+          actorEntityType: 'service',
+          targetEntityType: 'file',
+          actorLabel: 'Services',
+          targetLabel: 'Files',
+          actorIdsCount: 2,
+          targetIdsCount: 1,
+          badge: 1,
+          uniqueEventsCount: 1,
+          uniqueAlertsCount: 0,
+          docs: ['{"event":"file_access"}'],
+          isAlert: false,
+          isOrigin: true,
+          isOriginAlert: false,
+          actorsDocData: [
+            '{"id":"service1","type":"entity","entity":{"name":"web-service","type":"service"}}',
+            '{"id":"service2","type":"entity","entity":{"name":"api-service","type":"service"}}',
+          ],
+          targetsDocData: [
+            '{"id":"file1","type":"entity","entity":{"name":"config.json","type":"file"}}',
+          ],
+          actorHostIps: [],
+          targetHostIps: [],
+          sourceIps: [],
+          sourceCountryCodes: [],
+        },
+      ];
+      const result = parseRecords(mockLogger, records);
+
+      const actorNode = result.nodes.find((n) => n.id === 'service1') as EntityNodeDataModel;
+      expect(actorNode).toBeDefined();
+      expect(actorNode!.label).toBe('Services');
+      expect(actorNode).toHaveProperty('tag', 'service');
+      expect(actorNode).toHaveProperty('count', 2);
+      expect(actorNode.documentsData).toHaveLength(2);
+      expect(actorNode.documentsData![0].entity).toHaveProperty('type', 'service');
+      expect(actorNode.documentsData![0].entity).not.toHaveProperty('sub_type');
+      expect(actorNode.documentsData![1].entity).toHaveProperty('type', 'service');
+      expect(actorNode.documentsData![1].entity).not.toHaveProperty('sub_type');
+
+      const targetNode = result.nodes.find((n) => n.id === 'file1') as EntityNodeDataModel;
+      expect(targetNode).toBeDefined();
+      expect(targetNode!.label).toBe('Files');
+      expect(targetNode).toHaveProperty('tag', 'file');
+      expect(targetNode.documentsData).toHaveLength(1);
+      expect(targetNode.documentsData![0].entity).toHaveProperty('type', 'file');
+      expect(targetNode.documentsData![0].entity).not.toHaveProperty('sub_type');
+    });
+
+    it('groups actors and targets by id when type and sub_type are missing', () => {
+      const records: GraphEdge[] = [
+        {
+          action: 'interact',
+          actorIds: ['entity1', 'entity2'],
+          targetIds: ['entity3'],
+          actorEntityGroup: 'entity1',
+          targetEntityGroup: 'entity3',
+          actorEntityType: '',
+          targetEntityType: '',
+          actorLabel: 'Generic Group 1',
+          targetLabel: 'Generic Group 2',
+          actorIdsCount: 2,
+          targetIdsCount: 1,
+          badge: 1,
+          uniqueEventsCount: 1,
+          uniqueAlertsCount: 0,
+          docs: ['{"event":"generic_interaction"}'],
+          isAlert: false,
+          isOrigin: true,
+          isOriginAlert: false,
+          actorsDocData: [
+            '{"id":"entity1","entity":{"name":"Entity One"}}',
+            '{"id":"entity2","entity":{"name":"Entity Two"}}',
+          ],
+          targetsDocData: ['{"id":"entity3","entity":{"name":"Entity Three"}}'],
+          actorHostIps: [],
+          targetHostIps: [],
+          sourceIps: [],
+          sourceCountryCodes: [],
+        },
+      ];
+      const result = parseRecords(mockLogger, records);
+
+      const actorNode = result.nodes.find((n) => n.id === 'entity1') as EntityNodeDataModel;
+      expect(actorNode).toBeDefined();
+      expect(actorNode!.label).toBe('Generic Group 1');
+      expect(actorNode).toHaveProperty('shape', 'rectangle'); // Default shape when no type
+      expect(actorNode).not.toHaveProperty('tag');
+      expect(actorNode).not.toHaveProperty('icon');
+      expect(actorNode).toHaveProperty('count', 2);
+      expect(actorNode.documentsData).toHaveLength(2);
+      expect(actorNode.documentsData![0].entity).not.toHaveProperty('type');
+      expect(actorNode.documentsData![0].entity).not.toHaveProperty('sub_type');
+      expect(actorNode.documentsData![1].entity).not.toHaveProperty('type');
+      expect(actorNode.documentsData![1].entity).not.toHaveProperty('sub_type');
+
+      const targetNode = result.nodes.find((n) => n.id === 'entity3') as EntityNodeDataModel;
+      expect(targetNode).toBeDefined();
+      expect(targetNode!.label).toBe('Generic Group 2');
+      expect(targetNode).toHaveProperty('shape', 'rectangle');
+      expect(targetNode).not.toHaveProperty('tag');
+      expect(targetNode).not.toHaveProperty('icon');
+      expect(targetNode.documentsData).toHaveLength(1);
+      expect(targetNode.documentsData![0].entity).not.toHaveProperty('type');
+      expect(targetNode.documentsData![0].entity).not.toHaveProperty('sub_type');
+    });
   });
 
-  it('assigns correct shapes, icons and tags for entity nodes - with entity data', () => {
-    const records: GraphEdge[] = [
-      {
-        action: 'foo',
-        actorIds: ['user1', 'host1', 'ip1'],
-        actorsDocData: [
-          '{"id":"user1","type":"entity","index":"test","entity":{"name":"john","type":"Identity"}}',
-          '{"id":"ip1","type":"entity","index":"test","entity":{"name":"192.168.1.1","type":"ip"}}',
-        ],
-        badge: 1,
-        docs: ['{"foo":"bar"}'],
-        isOrigin: true,
-        isOriginAlert: false,
-        targetIds: ['target1', 'target2'],
-        isAlert: false,
-      },
-    ];
-    const result = parseRecords(mockLogger, records);
+  // Test for unknown target processing
+  describe('unknown target processing', () => {
+    it('properly processes unknown targets with processUnknownTargetGroup', () => {
+      const records: GraphEdge[] = [
+        {
+          action: 'suspicious_activity',
+          actorIds: ['malicious_user'],
+          targetIds: [],
+          actorEntityGroup: 'user',
+          targetEntityGroup: undefined, // This triggers unknown target processing
+          actorEntityType: 'user',
+          targetEntityType: '',
+          actorLabel: 'Threat Actor',
+          targetLabel: '',
+          actorIdsCount: 1,
+          targetIdsCount: 0,
+          badge: 1,
+          uniqueEventsCount: 1,
+          uniqueAlertsCount: 0,
+          docs: ['{"alert":"suspicious_behavior"}'],
+          isAlert: false,
+          isOrigin: false,
+          isOriginAlert: false,
+          actorHostIps: [],
+          targetHostIps: [],
+          sourceIps: [],
+          sourceCountryCodes: [],
+        },
+      ];
+      const result = parseRecords(mockLogger, records);
 
-    const userNode = result.nodes.find((n) => n.id === 'user1');
-    expect(userNode).toMatchObject({
-      shape: 'ellipse',
-      icon: 'user',
-      tag: 'Identity',
+      // Should create unknown target node
+      const unknownNode = result.nodes.find((n) => n.label === 'Unknown') as EntityNodeDataModel;
+      expect(unknownNode).toBeDefined();
+      expect(unknownNode!.id.startsWith('unknown')).toBe(true);
+      expect(unknownNode).toHaveProperty('documentsData', []);
+      expect(unknownNode).toHaveProperty('shape', 'rectangle');
+
+      // Should have actor node
+      const actorNode = result.nodes.find((n) => n.id === 'malicious_user') as EntityNodeDataModel;
+      expect(actorNode).toBeDefined();
+      expect(actorNode!.label).toBe('Threat Actor');
+      expect(actorNode).toHaveProperty('tag', 'user');
+
+      const labelNode = result.nodes.find((n) => n.shape === 'label') as LabelNodeDataModel;
+      expect(labelNode).toBeDefined();
+      expect(labelNode).toHaveProperty('color', 'primary');
+
+      // Should have proper edges
+      expect(result.edges).toHaveLength(2);
+      const actorToLabelEdge = result.edges.find((e) => e.source === 'malicious_user');
+      expect(actorToLabelEdge).toBeDefined();
+      const labelToUnknownEdge = result.edges.find((e) => e.target === unknownNode!.id);
+      expect(labelToUnknownEdge).toBeDefined();
     });
-
-    const hostNode = result.nodes.find((n) => n.id === 'host1');
-    expect(hostNode).toMatchObject({ shape: 'rectangle' });
-    expect(hostNode).not.toHaveProperty('tag');
-
-    const ipNode = result.nodes.find((n) => n.id === 'ip1');
-    expect(ipNode).toMatchObject({
-      shape: 'rectangle',
-      icon: 'globe',
-      tag: 'ip',
-    });
-
-    const targetNode = result.nodes.find((n) => n.id === 'target1');
-    expect(targetNode).toBeDefined();
-    expect(targetNode?.shape).toEqual('rectangle');
-    expect(targetNode).not.toHaveProperty('tag');
-    expect(targetNode?.label).toBeUndefined();
-
-    const target2Node = result.nodes.find((n) => n.id === 'target2');
-    expect(target2Node).toBeDefined();
-    expect(target2Node).not.toHaveProperty('tag');
   });
 
-  it('handles entity data with missing type property', () => {
-    const records: GraphEdge[] = [
-      {
-        action: 'foo',
-        actorIds: ['entity1', 'entity2', 'entity3'],
-        actorsDocData: [
-          '{"id":"entity1","type":"entity","index":"test","entity":{"name":"Entity One","type":"custom"}}',
-          '{"id":"entity2","type":"entity","index":"test","entity":{"name":"Entity Two"}}',
-          '{"id":"entity3","type":"entity","index":"test","entity":{}}',
-        ],
-        badge: 1,
-        docs: ['{"foo":"bar"}'],
-        isOrigin: true,
-        isOriginAlert: false,
-        targetIds: ['entity4'],
-        isAlert: false,
-      },
-    ];
-    const result = parseRecords(mockLogger, records);
+  describe('event and alert grouping', () => {
+    it('creates label node with one event', () => {
+      const records: GraphEdge[] = [
+        {
+          action: 'file_access',
+          actorIds: ['user1'],
+          targetIds: ['file1'],
+          actorEntityGroup: 'user',
+          targetEntityGroup: 'file',
+          actorEntityType: 'user',
+          targetEntityType: 'file',
+          actorLabel: 'User',
+          targetLabel: 'File',
+          actorIdsCount: 1,
+          targetIdsCount: 1,
+          badge: 1,
+          uniqueEventsCount: 1,
+          uniqueAlertsCount: 0,
+          docs: ['{"event_type":"file_access","timestamp":"2024-01-01T10:00:00Z"}'],
+          isAlert: false,
+          isOrigin: true,
+          isOriginAlert: false,
+          actorHostIps: [],
+          targetHostIps: [],
+          sourceIps: [],
+          sourceCountryCodes: [],
+        },
+      ];
+      const result = parseRecords(mockLogger, records);
 
-    const entity1Node = result.nodes.find((n) => n.id === 'entity1');
-    expect(entity1Node).toBeDefined();
-    expect(entity1Node).toHaveProperty('tag', 'custom');
+      const labelNode = result.nodes.find((n) => n.shape === 'label') as LabelNodeDataModel;
+      expect(labelNode).toBeDefined();
+      expect(labelNode).toHaveProperty('uniqueEventsCount', 1);
+      expect(labelNode).not.toHaveProperty('uniqueAlertsCount');
+      expect(labelNode).toHaveProperty('documentsData');
+      expect(labelNode.documentsData).toHaveLength(1);
+      expect(labelNode.documentsData![0]).toHaveProperty('event_type', 'file_access');
+      expect(labelNode).toHaveProperty('color', 'primary');
+    });
 
-    const entity2Node = result.nodes.find((n) => n.id === 'entity2');
-    expect(entity2Node).toBeDefined();
-    expect(entity2Node).toHaveProperty('label', 'Entity Two');
-    expect(entity2Node).not.toHaveProperty('tag');
+    it('creates label node with one alert', () => {
+      const records: GraphEdge[] = [
+        {
+          action: 'malware_detected',
+          actorIds: ['malware1'],
+          targetIds: ['system1'],
+          actorEntityGroup: 'malware1',
+          targetEntityGroup: 'system1',
+          actorEntityType: 'malware',
+          targetEntityType: 'system',
+          actorLabel: 'Malware',
+          targetLabel: 'System',
+          actorIdsCount: 1,
+          targetIdsCount: 1,
+          badge: 1,
+          uniqueEventsCount: 0,
+          uniqueAlertsCount: 1,
+          docs: ['{"alert_type":"malware","severity":"high"}'],
+          isAlert: true,
+          isOrigin: true,
+          isOriginAlert: true,
+          actorHostIps: [],
+          targetHostIps: [],
+          sourceIps: [],
+          sourceCountryCodes: [],
+        },
+      ];
+      const result = parseRecords(mockLogger, records);
 
-    const entity3Node = result.nodes.find((n) => n.id === 'entity3');
-    expect(entity3Node).toBeDefined();
-    expect(entity3Node).not.toHaveProperty('tag');
+      const labelNode = result.nodes.find((n) => n.shape === 'label') as LabelNodeDataModel;
+      expect(labelNode).toBeDefined();
+      expect(labelNode).not.toHaveProperty('uniqueEventsCount');
+      expect(labelNode).toHaveProperty('uniqueAlertsCount', 1);
+      expect(labelNode).toHaveProperty('documentsData');
+      expect(labelNode.documentsData).toHaveLength(1);
+      expect(labelNode.documentsData![0]).toHaveProperty('alert_type', 'malware');
+      expect(labelNode).toHaveProperty('color', 'danger');
+    });
 
-    const entity4Node = result.nodes.find((n) => n.id === 'entity4');
-    expect(entity4Node).toBeDefined();
-    expect(entity4Node).not.toHaveProperty('tag');
+    it('creates label node with multiple events', () => {
+      const records: GraphEdge[] = [
+        {
+          action: 'network_activity',
+          actorIds: ['user1'],
+          targetIds: ['server1'],
+          actorEntityGroup: 'user',
+          targetEntityGroup: 'server',
+          actorEntityType: 'user',
+          targetEntityType: 'server',
+          actorLabel: 'User',
+          targetLabel: 'Server',
+          actorIdsCount: 1,
+          targetIdsCount: 1,
+          badge: 3,
+          uniqueEventsCount: 3,
+          uniqueAlertsCount: 0,
+          docs: [
+            '{"event_type":"connection","timestamp":"2024-01-01T10:00:00Z"}',
+            '{"event_type":"data_transfer","timestamp":"2024-01-01T10:05:00Z"}',
+            '{"event_type":"disconnection","timestamp":"2024-01-01T10:10:00Z"}',
+          ],
+          isAlert: false,
+          isOrigin: true,
+          isOriginAlert: false,
+          actorHostIps: [],
+          targetHostIps: [],
+          sourceIps: [],
+          sourceCountryCodes: [],
+        },
+      ];
+      const result = parseRecords(mockLogger, records);
+
+      const labelNode = result.nodes.find((n) => n.shape === 'label') as LabelNodeDataModel;
+      expect(labelNode).toBeDefined();
+      expect(labelNode).toHaveProperty('uniqueEventsCount', 3);
+      expect(labelNode).not.toHaveProperty('uniqueAlertsCount');
+      expect(labelNode).toHaveProperty('documentsData');
+      expect(labelNode.documentsData).toHaveLength(3);
+      expect(labelNode).toHaveProperty('color', 'primary');
+      expect(labelNode).toHaveProperty('count', 3);
+    });
+
+    it('creates label node with mixed events and alerts', () => {
+      const records: GraphEdge[] = [
+        {
+          action: 'suspicious_login',
+          actorIds: ['user1'],
+          targetIds: ['system1'],
+          actorEntityGroup: 'user',
+          targetEntityGroup: 'system',
+          actorEntityType: 'user',
+          targetEntityType: 'system',
+          actorLabel: 'User',
+          targetLabel: 'System',
+          actorIdsCount: 1,
+          targetIdsCount: 1,
+          badge: 5,
+          uniqueEventsCount: 3,
+          uniqueAlertsCount: 2,
+          docs: [
+            '{"event_type":"login_attempt","timestamp":"2024-01-01T10:00:00Z"}',
+            '{"alert_type":"brute_force","severity":"medium"}',
+            '{"event_type":"successful_login","timestamp":"2024-01-01T10:05:00Z"}',
+            '{"alert_type":"anomalous_behavior","severity":"high"}',
+            '{"event_type":"logout","timestamp":"2024-01-01T10:30:00Z"}',
+          ],
+          isAlert: true,
+          isOrigin: true,
+          isOriginAlert: true,
+          actorHostIps: [],
+          targetHostIps: [],
+          sourceIps: [],
+          sourceCountryCodes: [],
+        },
+      ];
+      const result = parseRecords(mockLogger, records);
+
+      const labelNode = result.nodes.find((n) => n.shape === 'label') as LabelNodeDataModel;
+      expect(labelNode).toBeDefined();
+      expect(labelNode).toHaveProperty('color', 'primary'); // Color is primary when uniqueEventsCount > 0 even with alerts
+      expect(labelNode).toHaveProperty('count', 5);
+      expect(labelNode).toHaveProperty('uniqueEventsCount', 3);
+      expect(labelNode).toHaveProperty('uniqueAlertsCount', 2);
+      expect(labelNode).toHaveProperty('documentsData');
+      expect(labelNode.documentsData).toHaveLength(5);
+    });
   });
 
-  it('assigns correct documentsData with DOCUMENT_TYPE_ENTITY for matching entity IDs', () => {
-    const records: GraphEdge[] = [
-      {
-        action: 'connect',
-        actorIds: ['user1', 'host1'],
-        actorsDocData: [
-          '{"id":"user1","type":"entity","entity":{"name":"John Doe","type":"Identity"}}',
-          '{"id":"host1","type":"entity","entity":{"name":"server-01","type":"host"}}',
-        ],
-        targetsDocData: [
-          '{"id":"service1","type":"entity","entity":{"name":"web-service","type":"service"}}',
-        ],
-        badge: 1,
-        docs: ['{"foo":"bar"}'],
-        isOrigin: true,
-        isOriginAlert: false,
-        targetIds: ['service1'],
-        isAlert: false,
-      },
-    ];
-    const result = parseRecords(mockLogger, records);
+  // Test for geographic data (multiple IPs and country codes)
+  describe('geographic data handling', () => {
+    it('properly handles nodes with multiple IPs and country codes', () => {
+      const records: GraphEdge[] = [
+        {
+          action: 'global_access',
+          actorIds: ['global_user'],
+          targetIds: ['distributed_system'],
+          actorEntityGroup: 'user',
+          targetEntityGroup: 'system',
+          actorEntityType: 'user',
+          targetEntityType: 'system',
+          actorLabel: 'Global Users',
+          targetLabel: 'Distributed Systems',
+          actorIdsCount: 1,
+          targetIdsCount: 1,
+          badge: 1,
+          uniqueEventsCount: 1,
+          uniqueAlertsCount: 0,
+          docs: ['{"activity":"cross_border_access"}'],
+          isAlert: false,
+          isOrigin: true,
+          isOriginAlert: false,
+          actorHostIps: ['192.168.1.100', '10.0.0.50'],
+          targetHostIps: ['172.16.0.10'],
+          sourceIps: ['203.0.113.1', '198.51.100.1'],
+          sourceCountryCodes: ['JP', 'CA'],
+        },
+      ];
+      const result = parseRecords(mockLogger, records);
 
-    // Check user1 node - should only have actor document for user1
-    const user1Node = result.nodes.find((n) => n.id === 'user1') as any;
-    expect(user1Node).toBeDefined();
-    expect(user1Node.documentsData).toHaveLength(1);
-    expect(user1Node.documentsData[0]).toMatchObject({
-      id: 'user1',
-      type: 'entity',
-      entity: {
-        name: 'John Doe',
-        type: 'Identity',
-      },
+      // Check actor node has host IPs
+      const actorNode = result.nodes.find((n) => n.id === 'global_user') as EntityNodeDataModel;
+      expect(actorNode).toBeDefined();
+      expect(actorNode).toHaveProperty('ips', ['192.168.1.100', '10.0.0.50']);
+
+      // Check target node has host IPs
+      const targetNode = result.nodes.find(
+        (n) => n.id === 'distributed_system'
+      ) as EntityNodeDataModel;
+      expect(targetNode).toBeDefined();
+      expect(targetNode).toHaveProperty('ips', ['172.16.0.10']);
+
+      // Check label node has source IPs and country codes
+      const labelNode = result.nodes.find((n) => n.shape === 'label') as LabelNodeDataModel;
+      expect(labelNode).toBeDefined();
+      expect(labelNode).toHaveProperty('ips', ['203.0.113.1', '198.51.100.1']);
+      expect(labelNode).toHaveProperty('countryCodes', ['JP', 'CA']);
     });
 
-    // Check host1 node - should have both actor and target documents for host1
-    const host1Node = result.nodes.find((n) => n.id === 'host1') as any;
-    expect(host1Node).toBeDefined();
-    expect(host1Node.documentsData).toHaveLength(1);
-    expect(host1Node.documentsData[0]).toMatchObject({
-      id: 'host1',
-      type: 'entity',
-      entity: {
-        name: 'server-01',
-        type: 'host',
-      },
-    });
+    it('handles empty geographic data arrays', () => {
+      const records: GraphEdge[] = [
+        {
+          action: 'local_access',
+          actorIds: ['local_user'],
+          targetIds: ['local_system'],
+          actorEntityGroup: 'user',
+          targetEntityGroup: 'system',
+          actorEntityType: 'user',
+          targetEntityType: 'system',
+          actorLabel: 'Local Users',
+          targetLabel: 'Local Systems',
+          actorIdsCount: 1,
+          targetIdsCount: 1,
+          badge: 1,
+          uniqueEventsCount: 1,
+          uniqueAlertsCount: 0,
+          docs: ['{"activity":"local_access"}'],
+          isAlert: false,
+          isOrigin: true,
+          isOriginAlert: false,
+          actorHostIps: [],
+          targetHostIps: [],
+          sourceIps: [],
+          sourceCountryCodes: [],
+        },
+      ];
+      const result = parseRecords(mockLogger, records);
 
-    // Check service1 node - should only have target document for service1
-    const service1Node = result.nodes.find((n) => n.id === 'service1') as any;
-    expect(service1Node).toBeDefined();
-    expect(service1Node.documentsData).toHaveLength(1);
-    expect(service1Node.documentsData[0]).toMatchObject({
-      id: 'service1',
-      type: 'entity',
-      entity: {
-        name: 'web-service',
-        type: 'service',
-      },
-    });
+      // Nodes should not have IP or country code properties when arrays are empty
+      const actorNode = result.nodes.find((n) => n.id === 'local_user') as EntityNodeDataModel;
+      expect(actorNode).toBeDefined();
+      expect(actorNode).not.toHaveProperty('ips');
 
-    // Verify that user2 document is not included in any node since user2 is not an actor or target
-    const allDocuments = result.nodes.flatMap((node: any) => node.documentsData || []);
-    const user2Documents = allDocuments.filter((doc: any) => doc.id === 'user2');
-    expect(user2Documents).toHaveLength(0);
+      const targetNode = result.nodes.find((n) => n.id === 'local_system') as EntityNodeDataModel;
+      expect(targetNode).toBeDefined();
+      expect(targetNode).not.toHaveProperty('ips');
+
+      const labelNode = result.nodes.find((n) => n.shape === 'label') as LabelNodeDataModel;
+      expect(labelNode).toBeDefined();
+      expect(labelNode).not.toHaveProperty('ips');
+      expect(labelNode).not.toHaveProperty('countryCodes');
+    });
   });
 
-  it('handles empty documentsData when no matching entity documents exist', () => {
-    const records: GraphEdge[] = [
-      {
-        action: 'login',
-        actorIds: ['user1'],
-        actorsDocData: [],
-        targetsDocData: [],
-        badge: 1,
-        docs: ['{"foo":"bar"}'],
-        isOrigin: true,
-        isOriginAlert: false,
-        targetIds: ['service1'],
-        isAlert: false,
-      },
-    ];
-    const result = parseRecords(mockLogger, records);
+  describe('additional edge cases', () => {
+    it('handles empty documentsData when no entity documents exist', () => {
+      const records: GraphEdge[] = [
+        {
+          action: 'login',
+          actorIds: ['user1'],
+          targetIds: ['service1'],
+          actorEntityGroup: 'user',
+          targetEntityGroup: 'service',
+          actorEntityType: 'user',
+          targetEntityType: 'service',
+          actorLabel: 'User',
+          targetLabel: 'Service',
+          actorIdsCount: 1,
+          targetIdsCount: 1,
+          actorsDocData: [],
+          targetsDocData: [],
+          badge: 1,
+          uniqueEventsCount: 1,
+          uniqueAlertsCount: 0,
+          docs: ['{"foo":"bar"}'],
+          isOrigin: true,
+          isOriginAlert: false,
+          isAlert: false,
+          actorHostIps: [],
+          targetHostIps: [],
+          sourceIps: [],
+          sourceCountryCodes: [],
+        },
+      ];
+      const result = parseRecords(mockLogger, records);
 
-    // Check user1 node - should have empty documentsData since no matching actor document
-    const user1Node = result.nodes.find((n) => n.id === 'user1') as any;
-    expect(user1Node).toBeDefined();
-    expect(user1Node.documentsData).toEqual([]);
+      // Check user group node - should have empty documentsData since no actor documents
+      const userNode = result.nodes.find((n) => n.id === 'user1') as EntityNodeDataModel;
+      expect(userNode).toBeDefined();
+      expect(userNode.documentsData).toEqual([]);
 
-    // Check service1 node - should have empty documentsData since no matching target document
-    const service1Node = result.nodes.find((n) => n.id === 'service1') as any;
-    expect(service1Node).toBeDefined();
-    expect(service1Node.documentsData).toEqual([]);
+      // Check service group node - should have empty documentsData since no target documents
+      const serviceNode = result.nodes.find((n) => n.id === 'service1') as EntityNodeDataModel;
+      expect(serviceNode).toBeDefined();
+      expect(serviceNode.documentsData).toEqual([]);
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/types.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/types.ts
@@ -15,14 +15,31 @@ export interface OriginEventId {
 }
 
 export interface GraphEdge {
-  badge: number;
-  docs: string[] | string;
-  actorIds: string[] | string;
+  // event/alert attributes
   action: string;
-  targetIds: Array<string | null> | string;
+  docs: string[] | string;
+  isAlert: boolean;
   isOrigin: boolean;
   isOriginAlert: boolean;
-  isAlert: boolean;
+  badge: number;
+  uniqueEventsCount: number;
+  uniqueAlertsCount: number;
+  sourceIps?: string[] | string;
+  sourceCountryCodes?: string[] | string;
+  // actor attributes
+  actorIds: string[] | string;
+  actorIdsCount: number;
   actorsDocData?: Array<string | null> | string;
+  actorEntityGroup: string;
+  actorEntityType: string;
+  actorLabel: string;
+  actorHostIps?: string[] | string;
+  // target attributes
+  targetIds: Array<string | null> | string;
+  targetIdsCount: number;
   targetsDocData?: Array<string | null> | string;
+  targetEntityGroup?: string;
+  targetEntityType: string;
+  targetLabel: string;
+  targetHostIps?: string[] | string;
 }

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/utils.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/utils.test.ts
@@ -6,64 +6,41 @@
  */
 
 import { transformEntityTypeToIconAndShape } from './utils';
-import type { EntityDocumentDataModel } from '@kbn/cloud-security-posture-common/types/graph/v1';
 
 describe('utils', () => {
   describe('transformEntityTypeToIconAndShape', () => {
     it('should return empty object for undefined input', () => {
-      const undefinedEntity = undefined as unknown as EntityDocumentDataModel;
-      expect(transformEntityTypeToIconAndShape(undefinedEntity)).toEqual({});
+      expect(transformEntityTypeToIconAndShape(undefined as unknown as string)).toEqual({});
     });
 
     it('should return empty object for null input', () => {
-      // @ts-ignore: testing runtime behavior with null
-      expect(transformEntityTypeToIconAndShape(null)).toEqual({});
-    });
-
-    it('should return empty object for entity without type', () => {
-      const entity = { id: '123' } as EntityDocumentDataModel;
-      expect(transformEntityTypeToIconAndShape(entity)).toEqual({});
+      expect(transformEntityTypeToIconAndShape(null as unknown as string)).toEqual({});
     });
 
     // Unknown or non-existent entity types
     it('should return undefined icon and shape for entity types that do not match any mappings', () => {
-      const nonExistentType = { type: 'NonExistentType' } as EntityDocumentDataModel;
-      const unknownType = { type: 'Unknown' } as EntityDocumentDataModel;
-      const numericType = { type: '123456' } as EntityDocumentDataModel;
-      const customType = { type: 'CustomEntityType' } as EntityDocumentDataModel;
-
-      expect(transformEntityTypeToIconAndShape(nonExistentType)).toEqual({
-        icon: undefined,
-        shape: undefined,
-      });
-      expect(transformEntityTypeToIconAndShape(unknownType)).toEqual({
-        icon: undefined,
-        shape: undefined,
-      });
-      expect(transformEntityTypeToIconAndShape(numericType)).toEqual({
-        icon: undefined,
-        shape: undefined,
-      });
-      expect(transformEntityTypeToIconAndShape(customType)).toEqual({
-        icon: undefined,
-        shape: undefined,
+      ['NonExistentType', 'Unknown', '123456', 'CustomEntityType'].forEach((type) => {
+        expect(transformEntityTypeToIconAndShape(type)).toEqual({
+          icon: undefined,
+          shape: undefined,
+        });
       });
     });
 
     it('should correctly map user-related entity types to the user icon and ellipse shape', () => {
       const userTypes = [
-        { type: 'User' },
-        { type: 'user' },
-        { type: 'SERVICE ACCOUNT' },
-        { type: 'Identity' },
-        { type: 'Group' },
-        { type: 'Secret' },
-        { type: 'Secret Vault' },
-        { type: 'Access Management' },
-      ] as EntityDocumentDataModel[];
+        'User',
+        'user',
+        'SERVICE ACCOUNT',
+        'Identity',
+        'Group',
+        'Secret',
+        'Secret Vault',
+        'Access Management',
+      ];
 
-      userTypes.forEach((entity) => {
-        expect(transformEntityTypeToIconAndShape(entity)).toEqual({
+      userTypes.forEach((entityType) => {
+        expect(transformEntityTypeToIconAndShape(entityType)).toEqual({
           icon: 'user',
           shape: 'ellipse',
         });
@@ -72,17 +49,17 @@ describe('utils', () => {
 
     it('should correctly map database-related entity types to the database icon and rectangle shape', () => {
       const databaseTypes = [
-        { type: 'Database' },
-        { type: 'database' },
-        { type: 'AI Model' },
-        { type: 'STORAGE BUCKET' },
-        { type: 'Volume' },
-        { type: 'Config Map' },
-        { type: 'Managed Certificate' },
-      ] as EntityDocumentDataModel[];
+        'Database',
+        'database',
+        'AI Model',
+        'STORAGE BUCKET',
+        'Volume',
+        'Config Map',
+        'Managed Certificate',
+      ];
 
-      databaseTypes.forEach((entity) => {
-        expect(transformEntityTypeToIconAndShape(entity)).toEqual({
+      databaseTypes.forEach((entityType) => {
+        expect(transformEntityTypeToIconAndShape(entityType)).toEqual({
           icon: 'database',
           shape: 'rectangle',
         });
@@ -90,15 +67,10 @@ describe('utils', () => {
     });
 
     it('should correctly map host-related entity types to the host icon and rectangle shape', () => {
-      const hostTypes = [
-        { type: 'Host' },
-        { type: 'Virtual Desktop' },
-        { type: 'Virtual Workstation' },
-        { type: 'Virtual Machine Image' },
-      ] as EntityDocumentDataModel[];
+      const hostTypes = ['Host', 'Virtual Desktop', 'Virtual Workstation', 'Virtual Machine Image'];
 
-      hostTypes.forEach((entity) => {
-        expect(transformEntityTypeToIconAndShape(entity)).toEqual({
+      hostTypes.forEach((entityType) => {
+        expect(transformEntityTypeToIconAndShape(entityType)).toEqual({
           icon: 'storage',
           shape: 'hexagon',
         });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/utils.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/utils.ts
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import type {
-  EntityDocumentDataModel,
-  EntityNodeDataModel,
-} from '@kbn/cloud-security-posture-common/types/graph/v1';
+import type { EntityNodeDataModel } from '@kbn/cloud-security-posture-common/types/graph/v1';
 import { entityTypeMappings } from './entity_type_constants';
 
 /**
@@ -20,23 +17,21 @@ export interface EntityVisualProps {
 }
 
 /**
- * Transforms entity data to standardized icon and shape values
+ * Transforms entity type to standardized icon and shape values
  * This helps normalize different entity type representations to consistent visual properties
  *
- * @param entity The entity document data model
+ * @param entityGroupType The type of the entity group
  * @returns Object containing the icon and shape for the entity
  */
-export const transformEntityTypeToIconAndShape = (
-  entity: EntityDocumentDataModel
-): EntityVisualProps => {
-  if (!entity?.type) {
+export const transformEntityTypeToIconAndShape = (entityGroupType: string): EntityVisualProps => {
+  if (!entityGroupType) {
     return {};
   }
 
-  const entityTypeLower = entity.type.toLowerCase();
+  const entityGroupTypeLower = entityGroupType.toLowerCase();
 
   return {
-    icon: entityTypeMappings.icons[entityTypeLower],
-    shape: entityTypeMappings.shapes[entityTypeLower],
+    icon: entityTypeMappings.icons[entityGroupTypeLower],
+    shape: entityTypeMappings.shapes[entityGroupTypeLower],
   };
 };

--- a/x-pack/solutions/security/test/cloud_security_posture_api/routes/graph.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/routes/graph.ts
@@ -26,6 +26,13 @@ import { result } from '../utils';
 import { CspSecurityCommonProvider } from './helper/user_roles_utilites';
 import { dataViewRouteHelpersFactory } from '../utils';
 
+// Helper function to check if a node is a label node
+const isLabelNode = (
+  node: EntityNodeDataModel | LabelNodeDataModel | NodeDataModel
+): node is LabelNodeDataModel => {
+  return node.shape === 'label';
+};
+
 // eslint-disable-next-line import/no-default-export
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -218,7 +225,7 @@ export default function (providerContext: FtrProviderContext) {
       it('should return an empty graph / should return 200 when missing `esQuery` field', async () => {
         const response = await postGraph(supertest, {
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [],
             start: 'now-1d/d',
             end: 'now/d',
@@ -233,7 +240,7 @@ export default function (providerContext: FtrProviderContext) {
       it('should return a graph with nodes and edges by actor', async () => {
         const response = await postGraph(supertest, {
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [],
             start: '2024-09-01T00:00:00Z',
             end: '2024-09-02T00:00:00Z',
@@ -269,12 +276,12 @@ export default function (providerContext: FtrProviderContext) {
             `node color mismatched [node: ${node.id}] [actual: ${node.color}]`
           );
 
-          if (node.shape === 'label') {
-            expect(node.documentsData).to.have.length(1);
-            expect(node.documentsData?.[0]).to.have.property(
-              'type',
-              node.shape === 'label' ? 'event' : 'entity'
-            );
+          if (isLabelNode(node)) {
+            // Check for both document types flexibly
+            const hasAlert = node.documentsData!.some((doc) => doc.type === 'alert');
+            const hasEvent = node.documentsData!.some((doc) => doc.type === 'event');
+            expect(hasAlert).to.be(true);
+            expect(hasEvent).to.be(true);
           }
         });
 
@@ -291,7 +298,7 @@ export default function (providerContext: FtrProviderContext) {
       it('should return a graph with nodes and edges by alert', async () => {
         const response = await postGraph(supertest, {
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [{ id: 'kabcd1234efgh5678', isAlert: true }],
             start: '2024-09-01T00:00:00Z',
             end: '2024-09-02T00:00:00Z',
@@ -305,23 +312,28 @@ export default function (providerContext: FtrProviderContext) {
         response.body.nodes.forEach((node: EntityNodeDataModel | LabelNodeDataModel) => {
           expect(node).to.have.property('color');
           expect(node.color).equal(
-            node.shape === 'label' ? 'danger' : 'primary',
+            isLabelNode(node) &&
+              Number(node.uniqueAlertsCount) > 0 &&
+              Number(node.uniqueEventsCount) === 0
+              ? 'danger'
+              : 'primary',
             `node color mismatched [node: ${node.id}] [actual: ${node.color}]`
           );
 
-          if (node.shape === 'label') {
-            expect(node.documentsData).to.have.length(1);
-            expect(node.documentsData?.[0]).to.have.property(
-              'type',
-              node.shape === 'label' ? 'event' : 'entity'
-            );
+          if (isLabelNode(node)) {
+            expect(node.documentsData).to.have.length(2);
+            // Check for both document types flexibly
+            const hasAlert = node.documentsData!.some((doc) => doc.type === 'alert');
+            const hasEvent = node.documentsData!.some((doc) => doc.type === 'event');
+            expect(hasAlert).to.be(true);
+            expect(hasEvent).to.be(true);
           }
         });
 
         response.body.edges.forEach((edge: EdgeDataModel) => {
           expect(edge).to.have.property('color');
           expect(edge.color).equal(
-            'danger',
+            'subdued',
             `edge color mismatched [edge: ${edge.id}] [actual: ${edge.color}]`
           );
           expect(edge.type).equal('solid');
@@ -331,8 +343,47 @@ export default function (providerContext: FtrProviderContext) {
       it('should return a graph with nodes and edges by origin event', async () => {
         const response = await postGraph(supertest, {
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [{ id: 'kabcd1234efgh5678', isAlert: false }],
+            start: '2024-09-01T00:00:00Z',
+            end: '2024-09-02T00:00:00Z',
+          },
+        }).expect(result(200));
+
+        expect(response.body).to.have.property('nodes').length(3);
+        expect(response.body).to.have.property('edges').length(2);
+        expect(response.body).not.to.have.property('messages');
+
+        response.body.nodes.forEach((node: EntityNodeDataModel | LabelNodeDataModel) => {
+          expect(node).to.have.property('color');
+          expect(node.color).equal(
+            'primary',
+            `node color mismatched [node: ${node.id}] [actual: ${node.color}]`
+          );
+          if (node.shape === 'label') {
+            expect(node.documentsData).to.have.length(2);
+            // Check document types based on actual content
+            const hasAlert = node.documentsData!.some((doc) => doc.type === 'alert');
+            const hasEvent = node.documentsData!.some((doc) => doc.type === 'event');
+            expect(hasAlert).to.be(true);
+            expect(hasEvent).to.be(true);
+          }
+        });
+        response.body.edges.forEach((edge: EdgeDataModel) => {
+          expect(edge).to.have.property('color');
+          expect(edge.color).equal(
+            'subdued',
+            `edge color mismatched [edge: ${edge.id}] [actual: ${edge.color}]`
+          );
+          expect(edge.type).equal('solid');
+        });
+      });
+
+      it('color of alert of failed event should be primary', async () => {
+        const response = await postGraph(supertest, {
+          query: {
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
+            originEventIds: [{ id: 'failed-event', isAlert: true }],
             start: '2024-09-01T00:00:00Z',
             end: '2024-09-02T00:00:00Z',
           },
@@ -367,49 +418,10 @@ export default function (providerContext: FtrProviderContext) {
         });
       });
 
-      it('color of alert of failed event should be danger', async () => {
-        const response = await postGraph(supertest, {
-          query: {
-            indexPatterns: ['logs-*'],
-            originEventIds: [{ id: 'failed-event', isAlert: true }],
-            start: '2024-09-01T00:00:00Z',
-            end: '2024-09-02T00:00:00Z',
-          },
-        }).expect(result(200));
-
-        expect(response.body).to.have.property('nodes').length(3);
-        expect(response.body).to.have.property('edges').length(2);
-        expect(response.body).not.to.have.property('messages');
-
-        response.body.nodes.forEach((node: EntityNodeDataModel | LabelNodeDataModel) => {
-          expect(node).to.have.property('color');
-          expect(node.color).equal(
-            node.shape === 'label' ? 'danger' : 'primary',
-            `node color mismatched [node: ${node.id}] [actual: ${node.color}]`
-          );
-          if (node.shape === 'label') {
-            expect(node.documentsData).to.have.length(1);
-            expect(node.documentsData?.[0]).to.have.property(
-              'type',
-              node.shape === 'label' ? 'event' : 'entity'
-            );
-          }
-        });
-
-        response.body.edges.forEach((edge: EdgeDataModel) => {
-          expect(edge).to.have.property('color');
-          expect(edge.color).equal(
-            'danger',
-            `edge color mismatched [edge: ${edge.id}] [actual: ${edge.color}]`
-          );
-          expect(edge.type).equal('solid');
-        });
-      });
-
       it('color of event of failed event should be primary', async () => {
         const response = await postGraph(supertest, {
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [],
             start: '2024-09-01T00:00:00Z',
             end: '2024-09-02T00:00:00Z',
@@ -459,7 +471,7 @@ export default function (providerContext: FtrProviderContext) {
       it('2 grouped events', async () => {
         const response = await postGraph(supertest, {
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [],
             start: '2024-09-01T00:00:00Z',
             end: '2024-09-02T00:00:00Z',
@@ -491,15 +503,21 @@ export default function (providerContext: FtrProviderContext) {
               `node color mismatched [node: ${node.id}] [actual: ${node.color}]`
             );
             if (node.shape === 'label') {
-              expect(node.documentsData).to.have.length(1);
-              expect(node.documentsData?.[0]).to.have.property(
-                'type',
-                node.shape === 'label' ? 'event' : 'entity'
-              );
+              // Handle flexible document patterns
+              if (node.documentsData && node.documentsData.length === 1) {
+                // Single document - check its actual type
+                expect(node.documentsData[0]).to.have.property('type');
+                // Accept either event or alert as valid
+              } else if (node.documentsData && node.documentsData.length === 2) {
+                // Two documents - check for both types
+                const hasAlert = node.documentsData.some((doc) => doc.type === 'alert');
+                const hasEvent = node.documentsData.some((doc) => doc.type === 'event');
+                expect(hasAlert).to.be(true);
+                expect(hasEvent).to.be(true);
+              }
             }
           }
         });
-
         response.body.edges.forEach((edge: EdgeDataModel) => {
           expect(edge).to.have.property('color');
           expect(edge.color).equal(
@@ -513,7 +531,7 @@ export default function (providerContext: FtrProviderContext) {
       it('should support more than 1 originEventIds', async () => {
         const response = await postGraph(supertest, {
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [
               { id: 'kabcd1234efgh5678', isAlert: true },
               { id: 'failed-event', isAlert: true },
@@ -530,22 +548,28 @@ export default function (providerContext: FtrProviderContext) {
         response.body.nodes.forEach((node: EntityNodeDataModel | LabelNodeDataModel) => {
           expect(node).to.have.property('color');
           expect(node.color).equal(
-            node.shape === 'label' ? 'danger' : 'primary',
+            isLabelNode(node) &&
+              Number(node.uniqueAlertsCount) > 0 &&
+              Number(node.uniqueEventsCount) === 0
+              ? 'danger'
+              : 'primary',
             `node color mismatched [node: ${node.id}] [actual: ${node.color}]`
           );
-          if (node.shape === 'label') {
+          if (node.id === 'failed-event') {
             expect(node.documentsData).to.have.length(1);
-            expect(node.documentsData?.[0]).to.have.property(
-              'type',
-              node.shape === 'label' ? 'event' : 'entity'
-            );
+            expect(node.documentsData?.[0]).to.have.property('type', 'event');
+          }
+          if (node.id === 'kabcd1234efgh5678') {
+            expect(node.documentsData).to.have.length(2);
+            expect(node.documentsData?.[0]).to.have.property('type', 'event');
+            expect(node.documentsData?.[1]).to.have.property('type', 'alert');
           }
         });
 
         response.body.edges.forEach((edge: EdgeDataModel) => {
           expect(edge).to.have.property('color');
           expect(edge.color).equal(
-            'danger',
+            'subdued',
             `edge color mismatched [edge: ${edge.id}] [actual: ${edge.color}]`
           );
           expect(edge.type).equal('solid');
@@ -555,7 +579,7 @@ export default function (providerContext: FtrProviderContext) {
       it('should return a graph with nodes and edges by alert and actor', async () => {
         const response = await postGraph(supertest, {
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [{ id: 'kabcd1234efgh5678', isAlert: true }],
             start: '2024-09-01T00:00:00Z',
             end: '2024-09-02T00:00:00Z',
@@ -581,17 +605,17 @@ export default function (providerContext: FtrProviderContext) {
           (node: EntityNodeDataModel | LabelNodeDataModel, idx: number) => {
             expect(node).to.have.property('color');
             expect(node.color).equal(
-              idx === 2 // Only the label should be marked as danger (ORDER MATTERS, alerts are expected to be first)
-                ? 'danger'
-                : 'primary',
+              'primary',
               `node color mismatched [node: ${node.id}] [actual: ${node.color}]`
             );
             if (node.shape === 'label') {
-              expect(node.documentsData).to.have.length(1);
-              expect(node.documentsData?.[0]).to.have.property(
-                'type',
-                node.shape === 'label' ? 'event' : 'entity'
-              );
+              // Some nodes may have different document patterns
+              if (node.documentsData && node.documentsData.length === 1) {
+                expect(node.documentsData?.[0]).to.have.property('type', 'event');
+              } else if (node.documentsData && node.documentsData.length === 2) {
+                expect(node.documentsData?.[0]).to.have.property('type', 'alert');
+                expect(node.documentsData?.[1]).to.have.property('type', 'event');
+              }
             }
           }
         );
@@ -599,7 +623,7 @@ export default function (providerContext: FtrProviderContext) {
         response.body.edges.forEach((edge: EdgeDataModel, idx: number) => {
           expect(edge).to.have.property('color');
           expect(edge.color).equal(
-            idx <= 1 ? 'danger' : 'subdued',
+            'subdued',
             `edge color mismatched [edge: ${edge.id}] [actual: ${edge.color}]`
           );
           expect(edge.type).equal('solid');
@@ -609,7 +633,7 @@ export default function (providerContext: FtrProviderContext) {
       it('should filter unknown targets', async () => {
         const response = await postGraph(supertest, {
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [],
             start: '2024-09-01T00:00:00Z',
             end: '2024-09-02T00:00:00Z',
@@ -636,7 +660,7 @@ export default function (providerContext: FtrProviderContext) {
         const response = await postGraph(supertest, {
           showUnknownTarget: true,
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [],
             start: '2024-09-01T00:00:00Z',
             end: '2024-09-02T00:00:00Z',
@@ -663,7 +687,7 @@ export default function (providerContext: FtrProviderContext) {
         const response = await postGraph(supertest, {
           nodesLimit: 1,
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [],
             start: '2024-09-01T00:00:00Z',
             end: '2024-09-02T00:00:00Z',
@@ -690,7 +714,7 @@ export default function (providerContext: FtrProviderContext) {
       it('should support date math', async () => {
         const response = await postGraph(supertest, {
           query: {
-            indexPatterns: ['logs-*'],
+            indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
             originEventIds: [{ id: 'kabcd1234efgh5678', isAlert: true }],
             start: '2024-09-01T12:30:00.000Z||-30m',
             end: '2024-09-01T12:30:00.000Z||+30m',
@@ -718,7 +742,11 @@ export default function (providerContext: FtrProviderContext) {
         response.body.nodes.forEach((node: EntityNodeDataModel | LabelNodeDataModel) => {
           expect(node).to.have.property('color');
           expect(node.color).equal(
-            node.shape === 'label' ? 'danger' : 'primary',
+            isLabelNode(node) &&
+              Number(node.uniqueAlertsCount) > 0 &&
+              Number(node.uniqueEventsCount) === 0
+              ? 'danger'
+              : 'primary',
             `node color mismatched [node: ${node.id}] [actual: ${node.color}]`
           );
           if (node.shape === 'label') {
@@ -735,7 +763,7 @@ export default function (providerContext: FtrProviderContext) {
         response.body.edges.forEach((edge: EdgeDataModel) => {
           expect(edge).to.have.property('color');
           expect(edge.color).equal(
-            'danger',
+            'subdued',
             `edge color mismatched [edge: ${edge.id}] [actual: ${edge.color}]`
           );
           expect(edge.type).equal('solid');
@@ -898,7 +926,7 @@ export default function (providerContext: FtrProviderContext) {
 
             // Verify entity enrichment
             expect(actorNode).not.to.be(undefined);
-            expect(actorNode.label).to.equal('AdminExample');
+            expect(actorNode.label).to.equal('AWS IAM User');
             expect(actorNode.icon).to.equal('user');
             expect(actorNode.shape).to.equal('ellipse');
             expect(actorNode.tag).to.equal('Identity');
@@ -909,7 +937,7 @@ export default function (providerContext: FtrProviderContext) {
 
               if (node.shape === 'label') {
                 expect(node.color).equal(
-                  'danger',
+                  'primary',
                   `node color mismatched [node: ${node.id}] [actual: ${node.color}]`
                 );
                 expect(node.documentsData).to.have.length(2);
@@ -934,7 +962,7 @@ export default function (providerContext: FtrProviderContext) {
             response.body.edges.forEach((edge: EdgeDataModel) => {
               expect(edge).to.have.property('color');
               expect(edge.color).equal(
-                'danger',
+                'subdued',
                 `edge color mismatched [edge: ${edge.id}] [actual: ${edge.color}]`
               );
               expect(edge.type).equal('solid');
@@ -968,7 +996,7 @@ export default function (providerContext: FtrProviderContext) {
               supertest,
               {
                 query: {
-                  indexPatterns: ['logs-*'],
+                  indexPatterns: ['.alerts-security.alerts-*', 'logs-*'],
                   originEventIds: [],
                   start: '2024-09-01T00:00:00Z',
                   end: '2024-09-02T00:00:00Z',
@@ -995,7 +1023,7 @@ export default function (providerContext: FtrProviderContext) {
 
             // Verify entity enrichment
             expect(actorNode).not.to.be(undefined);
-            expect(actorNode.label).to.equal('AdminExample');
+            expect(actorNode.label).to.equal('AWS IAM User');
             expect(actorNode.icon).to.equal('user');
             expect(actorNode.shape).to.equal('ellipse');
             expect(actorNode.tag).to.equal('Identity');


### PR DESCRIPTION
## Summary

Closes: 
- https://github.com/elastic/kibana/issues/231247

Depends on:
- https://github.com/elastic/kibana/pull/236275 (to integrate backend changes with an adapted UI)

### Changes

- [x] Groups events/alerts by `event.action` (this was done prior to this implementation)
- [x] Groups entities by `entity.type` and `entity.sub_type` fields
- [x] Returns `ips` and `countryCodes` when present in entities, events and alerts
- [x] Returns `tag` set to `entity.type`
- [x] Returns total `count` in entities
- [x] Returns total `count`, `uniqueAlertsCount` and `uniqueEventsCount` fields in events and alerts

### Screenshots

<details><summary>Before: Individual entities</summary>
<img width="1018" height="1426" alt="Screenshot 2025-09-26 at 10 07 45" src="https://github.com/user-attachments/assets/461c1b52-73d8-43d7-916d-330f0349b2d5" />
</details> 

<details><summary>After: Grouped entities + Grouped labels + IP/Geolocation details</summary>

#### Explanation

What you see here is 3 individual entities grouped by one entity node with "Identity" type and "AWS IAM User" sub_type:
- Entity 1: ci_restricted
- Entity 2: user/ricky
- Entity 3: serverless_ci

The label node is grouping 701 events
- 2 coming from ci_restricted
- 2 coming from user/ricky
- 697 coming from serverless_ci

You can check this by reverting the commit (or switching branch) and opening the browser's Network tab. Check the API response and have a look at the `documentsData` fields on these 3 entities returned.

#### Screenshot

<img width="1186" height="1421" alt="Screenshot 2025-09-26 at 10 07 18" src="https://github.com/user-attachments/assets/b7cc5b0b-5354-4a8a-99fa-93b95d887202" />
</details> 

### How to test

1. Run Elasticsearch with `yarn es snapshot --license trial -E reindex.remote.whitelist=keep-long-live-env-ess.es.us-west2.gcp.elastic-cloud.com:443`
2. Run Kibana locally with `yarn start --no-base-path`
3. Install Cloud Asset Discovery (skip agent installation)
4. Re-index Asset Inventory data with this query
    ```
    POST _reindex?wait_for_completion=true
    {
      "conflicts": "proceed", 
      "source": {
        "remote": {
          "host": "${ES_REMOTE_HOST}", # <-- Set var in Config tab to https://keep-long-live-env-ess.es.us-west2.gcp.elastic-cloud.com:443
          "username": "${ES_REMOTE_USER}", # <-- Set var in Config tab to your user in https://keep-long-live-env-ess.kb.us-west2.gcp.elastic-cloud.com/app/management/security/users i.e. alberto
          "password": "${ES_REMOTE_PASS}" # <-- Set var in Config tab to your password in the same cloud env
        },
        "index": "logs-cloud_asset_inventory*",
        "query": {
          "bool": {
            "must": [
              {
                "range": {
                  "@timestamp": {
                    "gte": "now-1d"
                  }
                }
              }
            ]
          }
        }
      },
      "dest": {
        "op_type": "create",
        "index": "logs-cloud_asset_inventory.asset_inventory-default"
      }
    }
    ```
5. Reindex AWS Cloudtrail logs with this query
    ```
    POST _reindex?wait_for_completion=false
    {
      "conflicts": "proceed", 
      "source": {
        "remote": {
          "host": "${ES_REMOTE_HOST}",
          "username": "${ES_REMOTE_USER}",
          "password": "${ES_REMOTE_PASS}"
        },
        "index": "logs-aws.cloudtrail-*",
        "query": {
           "bool": {
             "must": [],
             "filter": [
               {
                 "range": {
                   "@timestamp": {
                     "gte": "now-3h",
                     "lte": "now"
                   }
                 }
               }
             ]
           }
         }
      },
      "dest": {
        "op_type": "create",
        "index": "logs-aws.cloudtrail-reindexed"
      }
    }
    ```
6. Create a new Data View that matches this index pattern `logs-aws.cloudtrail-*`. Give it the exact same name
7. Download and decompress this exported rule: [rules_export (2).ndjson.zip](https://github.com/user-attachments/files/22530457/rules_export.2.ndjson.zip). Go to Rules page and click on "Import rule"
8. Go to Alerts page. Set the date range from several days ago until now. You'll see a bunch of alerts.
9. Open one alert flyout and check you can expand the Graph Visualization tab.
10. Click on all options to show related events, related entities, show actions on this entity, etc.... try to show as many nodes as possible and check they're grouped.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No risks.