### PR TITLE
[Fleet] Catch errors in Fleet setup when getting remote info 

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_synced_integrations.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_synced_integrations.test.ts
@@ -18,6 +18,7 @@ jest.mock('../app_context', () => ({
     getLogger: jest.fn().mockReturnValue({
       error: jest.fn(),
       debug: jest.fn(),
+      warn: jest.fn(),
     }),
     getConfig: jest.fn().mockReturnValue({
       enableManagedLogsAndMetricsDataviews: true,
@@ -143,6 +144,15 @@ describe('fleet_synced_integrations', () => {
         ['*'],
         []
       );
+    });
+
+    it('should not create index patterns if remote info throws error', async () => {
+      esClientMock.cluster.remoteInfo = jest.fn().mockRejectedValue(new Error('Test error'));
+
+      await createCCSIndexPatterns(esClientMock, soClientMock, soImporterMock);
+
+      expect(soImporterMock.import).not.toHaveBeenCalled();
+      expect(soClientMock.updateObjectsSpaces).not.toHaveBeenCalled();
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_synced_integrations.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_synced_integrations.ts
@@ -143,8 +143,14 @@ export async function createCCSIndexPatterns(
     return;
   }
 
-  const remoteInfo = await esClient.cluster.remoteInfo();
-  const remoteClusterNames = Object.keys(remoteInfo);
+  let remoteClusterNames: string[] = [];
+  try {
+    const remoteInfo = await esClient.cluster.remoteInfo();
+    remoteClusterNames = Object.keys(remoteInfo);
+  } catch (error) {
+    appContextService.getLogger().warn(`Error fetching remote cluster info: ${error.message}`);
+    return;
+  }
 
   if (remoteClusterNames.length === 0) {
     return;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/234873

Catching errors of the `remoteInfo` call when creating CCS index patterns to prevent Fleet setup errors when there are missing privileges.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->