### PR TITLE
[8.18] [Infra][Hosts UI] Fix log rate chart (#234441)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/host_charts.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/host_charts.tsx
@@ -29,7 +29,7 @@ export const HostCharts = React.forwardRef<HTMLDivElement, Props>(
   ({ assetId, dataView, dateRange, metric, onShowAll, overview = false }, ref) => {
     const { charts } = useHostCharts({
       metric,
-      dataViewId: dataView?.id,
+      dataViewId: dataView?.getIndexPattern(),
       overview,
     });
 
@@ -103,6 +103,7 @@ export const HostCharts = React.forwardRef<HTMLDivElement, Props>(
               key={chart.id}
               assetId={assetId}
               dateRange={dateRange}
+              dataView={dataView}
               lensAttributes={chart}
               queryField={findInventoryFields('host').id}
             />

--- a/x-pack/solutions/observability/plugins/infra/public/utils/data_view.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/utils/data_view.ts
@@ -26,7 +26,7 @@ interface DataViewAttributes {
   name?: string;
 }
 
-export const resolveDataView = ({
+export const resolveDataView = async ({
   dataViewId,
   dataViewsService,
 }: {
@@ -34,7 +34,7 @@ export const resolveDataView = ({
   dataViewsService: DataViewsContract;
 }) => {
   try {
-    return resolvePersistedDataView({ dataViewsService, dataViewId });
+    return await resolvePersistedDataView({ dataViewsService, dataViewId });
   } catch {
     return resolveAdHocDataView({
       dataViewsService,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Infra][Hosts UI] Fix log rate chart (#234441)](https://github.com/elastic/kibana/pull/234441)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-09-11T13:29:59Z","message":"[Infra][Hosts UI] Fix log rate chart (#234441)\n\nfixes [#233401](https://github.com/elastic/kibana/issues/233401)\n\n## Summary\n\nFixes the loading of the Log Rate chart. The problem was caused because\nthe logs data view id doesn't match the index pattern.\n\n| before | after |\n|-------|-------|\n|<img width=\"800\" height=\"822\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/92820311-232d-47f2-bdfd-23334972c2e7\"\n/>|<img width=\"800\" height=\"818\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ead928d3-2398-45ae-a356-c24fa2b68623\"\n/>|\n\n\n<img width=\"800\" height=\"818\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/394947e0-c02a-4a53-b851-4c528f83ad6e\"\n/>\n\n\n### how to test\n\n- Point your local kibana to an oblt cluster\n- Navigate to `Infrastructure > Hosts`\n- Search for `siem-linux-edge-lite-oblt`\n- Open the detail view and navigate to the Logs tab","sha":"ecc07be5770fb75f17d900de440c549e86ccb72f","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:obs-ux-infra_services","backport:version","v8.18.0","v9.1.0","v8.19.0","v9.2.0"],"title":"[Infra][Hosts UI] Fix log rate chart","number":234441,"url":"https://github.com/elastic/kibana/pull/234441","mergeCommit":{"message":"[Infra][Hosts UI] Fix log rate chart (#234441)\n\nfixes [#233401](https://github.com/elastic/kibana/issues/233401)\n\n## Summary\n\nFixes the loading of the Log Rate chart. The problem was caused because\nthe logs data view id doesn't match the index pattern.\n\n| before | after |\n|-------|-------|\n|<img width=\"800\" height=\"822\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/92820311-232d-47f2-bdfd-23334972c2e7\"\n/>|<img width=\"800\" height=\"818\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ead928d3-2398-45ae-a356-c24fa2b68623\"\n/>|\n\n\n<img width=\"800\" height=\"818\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/394947e0-c02a-4a53-b851-4c528f83ad6e\"\n/>\n\n\n### how to test\n\n- Point your local kibana to an oblt cluster\n- Navigate to `Infrastructure > Hosts`\n- Search for `siem-linux-edge-lite-oblt`\n- Open the detail view and navigate to the Logs tab","sha":"ecc07be5770fb75f17d900de440c549e86ccb72f"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.1","8.19"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/234441","number":234441,"mergeCommit":{"message":"[Infra][Hosts UI] Fix log rate chart (#234441)\n\nfixes [#233401](https://github.com/elastic/kibana/issues/233401)\n\n## Summary\n\nFixes the loading of the Log Rate chart. The problem was caused because\nthe logs data view id doesn't match the index pattern.\n\n| before | after |\n|-------|-------|\n|<img width=\"800\" height=\"822\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/92820311-232d-47f2-bdfd-23334972c2e7\"\n/>|<img width=\"800\" height=\"818\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ead928d3-2398-45ae-a356-c24fa2b68623\"\n/>|\n\n\n<img width=\"800\" height=\"818\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/394947e0-c02a-4a53-b851-4c528f83ad6e\"\n/>\n\n\n### how to test\n\n- Point your local kibana to an oblt cluster\n- Navigate to `Infrastructure > Hosts`\n- Search for `siem-linux-edge-lite-oblt`\n- Open the detail view and navigate to the Logs tab","sha":"ecc07be5770fb75f17d900de440c549e86ccb72f"}}]}] BACKPORT-->