### PR TITLE
[9.1] [Controls] Add ESQL control types to options list (#233126)

### DIFF
--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/constants.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/constants.ts
@@ -8,7 +8,7 @@
  */
 
 import { ALERT_RULE_NAME, ALERT_STATUS } from '@kbn/rule-data-utils';
-import type { OptionsListControlState } from '@kbn/controls-plugin/public';
+import type { OptionsListDSLControlState } from '@kbn/controls-plugin/public';
 import { i18n } from '@kbn/i18n';
 import type { FilterControlConfig } from './types';
 
@@ -65,7 +65,7 @@ export const TEST_IDS = {
   },
 };
 
-export const COMMON_OPTIONS_LIST_CONTROL_INPUTS: Partial<OptionsListControlState> = {
+export const COMMON_OPTIONS_LIST_CONTROL_INPUTS: Partial<OptionsListDSLControlState> = {
   hideExclude: true,
   hideSort: true,
   placeholder: '',

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/mocks/data.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/mocks/data.ts
@@ -9,7 +9,7 @@
 
 import type {
   ControlGroupRuntimeState,
-  OptionsListControlState,
+  OptionsListDSLControlState,
 } from '@kbn/controls-plugin/public';
 import type { Filter } from '@kbn/es-query';
 import { ALERT_DURATION, ALERT_RULE_NAME, ALERT_START, ALERT_STATUS } from '@kbn/rule-data-utils';
@@ -41,7 +41,7 @@ export const sampleOutputData: ControlGroupOutput = {
   ],
 };
 
-export const initialInputData: ControlGroupRuntimeState<OptionsListControlState> = {
+export const initialInputData: ControlGroupRuntimeState<OptionsListDSLControlState> = {
   initialChildControlState: {
     '0': {
       type: 'optionsListControl',

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/types.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/types.ts
@@ -10,7 +10,7 @@
 import type { Filter, Query, TimeRange } from '@kbn/es-query';
 import type {
   ControlGroupRenderer,
-  OptionsListControlState,
+  OptionsListDSLControlState,
   ControlGroupRuntimeState,
   ControlGroupRendererApi,
 } from '@kbn/controls-plugin/public';
@@ -19,7 +19,7 @@ import type { Storage } from '@kbn/kibana-utils-plugin/public';
 export type FilterUrlFormat = Record<
   string,
   Pick<
-    OptionsListControlState,
+    OptionsListDSLControlState,
     'selectedOptions' | 'title' | 'fieldName' | 'existsSelected' | 'exclude'
   >
 >;
@@ -29,7 +29,7 @@ export interface FilterContextType {
   addControl: (controls: FilterControlConfig) => void;
 }
 
-export type FilterControlConfig = Omit<OptionsListControlState, 'dataViewId'> & {
+export type FilterControlConfig = Omit<OptionsListDSLControlState, 'dataViewId'> & {
   /*
    * Determines the presence and order of a control
    * */

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/utils.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/utils.ts
@@ -9,7 +9,7 @@
 
 import type {
   ControlGroupRuntimeState,
-  OptionsListControlState,
+  OptionsListDSLControlState,
   ControlPanelState,
 } from '@kbn/controls-plugin/public';
 
@@ -25,7 +25,7 @@ export const getFilterItemObjListFromControlState = (controlState: ControlGroupR
   const panels = getPanelsInOrderFromControlsState(controlState);
   return panels.map((panel) => {
     const { fieldName, selectedOptions, title, existsSelected, exclude, hideActionBar } =
-      panel as ControlPanelState<OptionsListControlState>;
+      panel as ControlPanelState<OptionsListDSLControlState>;
 
     return {
       fieldName: fieldName as string,

--- a/src/platform/plugins/shared/controls/common/options_list/index.ts
+++ b/src/platform/plugins/shared/controls/common/options_list/index.ts
@@ -13,6 +13,8 @@ export type { OptionsListSearchTechnique } from './suggestions_searching';
 export type { OptionsListSortingType } from './suggestions_sorting';
 export type {
   OptionsListControlState,
+  OptionsListESQLControlState,
+  OptionsListDSLControlState,
   OptionsListDisplaySettings,
   OptionsListFailureResponse,
   OptionsListRequest,

--- a/src/platform/plugins/shared/controls/common/options_list/types.ts
+++ b/src/platform/plugins/shared/controls/common/options_list/types.ts
@@ -10,10 +10,11 @@
 import { DataView, FieldSpec, RuntimeFieldSpec } from '@kbn/data-views-plugin/common';
 import type { AggregateQuery, BoolQuery, Filter, Query, TimeRange } from '@kbn/es-query';
 
-import { OptionsListSelection } from './options_list_selections';
-import { OptionsListSortingType } from './suggestions_sorting';
-import { DefaultDataControlState } from '../types';
-import { OptionsListSearchTechnique } from './suggestions_searching';
+import type { ESQLControlState } from '@kbn/esql-types';
+import type { OptionsListSelection } from './options_list_selections';
+import type { OptionsListSortingType } from './suggestions_sorting';
+import type { DefaultDataControlState } from '../types';
+import type { OptionsListSearchTechnique } from './suggestions_searching';
 
 /**
  * ----------------------------------------------------------------
@@ -29,9 +30,7 @@ export interface OptionsListDisplaySettings {
   hideSort?: boolean;
 }
 
-export interface OptionsListControlState
-  extends DefaultDataControlState,
-    OptionsListDisplaySettings {
+type OptionsListBaseControlState = OptionsListDisplaySettings & {
   searchTechnique?: OptionsListSearchTechnique;
   sort?: OptionsListSortingType;
   selectedOptions?: OptionsListSelection[];
@@ -39,7 +38,19 @@ export interface OptionsListControlState
   runPastTimeout?: boolean;
   singleSelect?: boolean;
   exclude?: boolean;
-}
+};
+export type OptionsListDSLControlState = DefaultDataControlState & OptionsListBaseControlState;
+export type OptionsListESQLControlState = ESQLControlState & OptionsListBaseControlState;
+
+export type OptionsListControlState = OptionsListDSLControlState | OptionsListESQLControlState;
+
+export const isOptionsListESQLControlState = (
+  state: OptionsListControlState | undefined
+): state is OptionsListESQLControlState =>
+  typeof state !== 'undefined' &&
+  Object.hasOwn(state, 'esqlQuery') &&
+  Object.hasOwn(state, 'controlType') &&
+  !Object.hasOwn(state, 'fieldName');
 
 /**
  * ----------------------------------------------------------------
@@ -92,7 +103,7 @@ export type OptionsListRequest = Omit<
  */
 export interface OptionsListRequestBody
   extends Pick<
-    OptionsListControlState,
+    OptionsListDSLControlState,
     'fieldName' | 'searchTechnique' | 'sort' | 'selectedOptions'
   > {
   runtimeFieldMap?: Record<string, RuntimeFieldSpec>;

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_editor_options.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_editor_options.tsx
@@ -87,8 +87,8 @@ export const OptionsListEditorOptions = ({
   );
 
   const compatibleSearchTechniques = useMemo(
-    () => getCompatibleSearchTechniques(field.type),
-    [field.type]
+    () => getCompatibleSearchTechniques(field?.type),
+    [field?.type]
   );
 
   const searchOptions = useMemo(() => {

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
@@ -25,6 +25,7 @@ import { PublishingSubject } from '@kbn/presentation-publishing';
 
 import { initializeUnsavedChanges } from '@kbn/presentation-containers';
 import { OPTIONS_LIST_CONTROL } from '../../../../common';
+import { isOptionsListESQLControlState } from '../../../../common/options_list/types';
 import type {
   OptionsListControlState,
   OptionsListSortingType,
@@ -73,6 +74,10 @@ export const getOptionsListControlFactory = (): DataControlFactory<
     },
     CustomOptionsComponent: OptionsListEditorOptions,
     buildControl: async ({ initialState, finalizeApi, uuid, controlGroupApi }) => {
+      if (isOptionsListESQLControlState(initialState)) {
+        throw new Error('ES|QL control state handling not yet implemented');
+      }
+
       /** Serializable state - i.e. the state that is saved with the control */
       const editorStateManager = initializeEditorStateManager(initialState);
 
@@ -299,6 +304,9 @@ export const getOptionsListControlFactory = (): DataControlFactory<
           existsSelected: false,
         },
         onReset: (lastSaved) => {
+          if (isOptionsListESQLControlState(lastSaved?.rawState)) {
+            throw new Error('ES|QL control state handling not yet implemented');
+          }
           dataControlManager.reinitializeState(lastSaved?.rawState);
           selectionsManager.reinitializeState(lastSaved?.rawState);
           editorStateManager.reinitializeState(lastSaved?.rawState);

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/types.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/types.ts
@@ -12,8 +12,6 @@ import { Subject } from 'rxjs';
 import type { PublishesTitle, PublishingSubject } from '@kbn/presentation-publishing';
 import { SubjectsOf, SettersOf } from '@kbn/presentation-publishing/state_manager/types';
 import type {
-  OptionsListControlState,
-  OptionsListDisplaySettings,
   OptionsListSelection,
   OptionsListSortingType,
   OptionsListSuggestions,
@@ -28,32 +26,33 @@ export type OptionsListControlApi = DataControlApi & {
   setSelectedOptions: (options: OptionsListSelection[] | undefined) => void;
 };
 
-export interface OptionsListComponentState
-  extends Omit<OptionsListControlState, keyof OptionsListDisplaySettings> {
-  searchString: string;
-  searchStringValid: boolean;
-  requestSize: number;
-}
-
 interface PublishesOptions {
   availableOptions$: PublishingSubject<OptionsListSuggestions | undefined>;
   invalidSelections$: PublishingSubject<Set<OptionsListSelection>>;
   totalCardinality$: PublishingSubject<number>;
 }
-export type OptionsListState = Pick<DefaultDataControlState, 'fieldName'> &
+
+/**
+ * A type consisting of only the properties that the options list control puts into state managers
+ * and then passes to the UI component. Excludes any managed state properties that don't end up being used
+ * by the component
+ */
+export type OptionsListComponentState = Pick<DefaultDataControlState, 'fieldName'> &
   SelectionsState &
   EditorState &
-  TemporaryState & { sort: OptionsListSortingType | undefined };
+  TemporaryState & {
+    sort: OptionsListSortingType | undefined;
+  };
 
-type PublishesOptionsListState = SubjectsOf<OptionsListState>;
-type OptionsListStateSetters = Partial<SettersOf<OptionsListState>> &
-  SettersOf<Pick<OptionsListState, 'sort' | 'searchString' | 'requestSize' | 'exclude'>>;
+type PublishesOptionsListComponentState = SubjectsOf<OptionsListComponentState>;
+type OptionsListComponentStateSetters = Partial<SettersOf<OptionsListComponentState>> &
+  SettersOf<Pick<OptionsListComponentState, 'sort' | 'searchString' | 'requestSize' | 'exclude'>>;
 
 export type OptionsListComponentApi = PublishesField &
   PublishesOptions &
-  PublishesOptionsListState &
+  PublishesOptionsListComponentState &
   Pick<PublishesTitle, 'title$'> &
-  OptionsListStateSetters & {
+  OptionsListComponentStateSetters & {
     deselectOption: (key: string | undefined) => void;
     makeSelection: (key: string | undefined, showOnlySelected: boolean) => void;
     loadMoreSubject: Subject<void>;

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/types.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/types.ts
@@ -16,10 +16,10 @@ import {
   PublishingSubject,
 } from '@kbn/presentation-publishing';
 
-import { DefaultDataControlState } from '../../../common';
-import { ControlGroupApi } from '../../control_group/types';
-import { ControlFactory, DefaultControlApi } from '../types';
-import { PublishesAsyncFilters } from './publishes_async_filters';
+import type { DefaultControlState } from '../../../common';
+import type { ControlGroupApi } from '../../control_group/types';
+import type { ControlFactory, DefaultControlApi } from '../types';
+import type { PublishesAsyncFilters } from './publishes_async_filters';
 
 export type DataControlFieldFormatter = FieldFormatConvertFunction | ((toFormat: any) => string);
 
@@ -36,17 +36,17 @@ export type DataControlApi = DefaultControlApi &
   PublishesAsyncFilters;
 
 export interface CustomOptionsComponentProps<
-  State extends DefaultDataControlState = DefaultDataControlState
+  State extends DefaultControlState = DefaultControlState
 > {
   initialState: Partial<State>;
-  field: DataViewField;
+  field?: DataViewField;
   updateState: (newState: Partial<State>) => void;
   setControlEditorValid: (valid: boolean) => void;
   controlGroupApi: ControlGroupApi;
 }
 
 export interface DataControlFactory<
-  State extends DefaultDataControlState = DefaultDataControlState,
+  State extends DefaultControlState = DefaultControlState,
   Api extends DataControlApi = DataControlApi
 > extends ControlFactory<State, Api> {
   isFieldCompatible: (field: DataViewField) => boolean;

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/types.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/types.ts
@@ -13,7 +13,7 @@ import type {
   PublishesTitle,
 } from '@kbn/presentation-publishing';
 import type { DefaultControlApi } from '../types';
-import { OptionsListState } from '../data_controls/options_list_control/types';
+import type { OptionsListComponentState } from '../data_controls/options_list_control/types';
 
 export type ESQLControlApi = DefaultControlApi &
   PublishesESQLVariable &
@@ -21,15 +21,15 @@ export type ESQLControlApi = DefaultControlApi &
   Pick<Required<PublishesTitle>, 'defaultTitle$'> &
   PublishesDataLoading;
 
-type HideExcludeUnusedState = Pick<OptionsListState, 'exclude'>;
-type HideExistsUnusedState = Pick<OptionsListState, 'existsSelected'>;
-type HideSortUnusedState = Pick<OptionsListState, 'sort'>;
+type HideExcludeUnusedState = Pick<OptionsListComponentState, 'exclude'>;
+type HideExistsUnusedState = Pick<OptionsListComponentState, 'existsSelected'>;
+type HideSortUnusedState = Pick<OptionsListComponentState, 'sort'>;
 type DisableLoadSuggestionsUnusedState = Pick<
-  OptionsListState,
+  OptionsListComponentState,
   'dataLoading' | 'requestSize' | 'runPastTimeout'
 >;
-type DisableMultiSelectUnusedState = Pick<OptionsListState, 'singleSelect'>;
-type DisableInvalidSelectionsUnusedState = Pick<OptionsListState, 'invalidSelections'>;
+type DisableMultiSelectUnusedState = Pick<OptionsListComponentState, 'singleSelect'>;
+type DisableInvalidSelectionsUnusedState = Pick<OptionsListComponentState, 'invalidSelections'>;
 
 export type OptionsListESQLUnusedState = HideExcludeUnusedState &
   HideExistsUnusedState &
@@ -37,4 +37,4 @@ export type OptionsListESQLUnusedState = HideExcludeUnusedState &
   DisableLoadSuggestionsUnusedState &
   DisableMultiSelectUnusedState &
   DisableInvalidSelectionsUnusedState &
-  Pick<OptionsListState, 'fieldName'>;
+  Pick<OptionsListComponentState, 'fieldName'>;

--- a/src/platform/plugins/shared/controls/public/index.ts
+++ b/src/platform/plugins/shared/controls/public/index.ts
@@ -49,7 +49,7 @@ export type {
   ControlPanelsState,
   DefaultDataControlState,
 } from '../common';
-export type { OptionsListControlState } from '../common/options_list';
+export type { OptionsListControlState, OptionsListDSLControlState } from '../common/options_list';
 
 export { serializeRuntimeState } from './control_group/utils/serialize_runtime_state';
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Zac Xeper","email":"Zacqary@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-09-10T16:23:53Z","message":"[Controls] Add ESQL control types to options list (#233126)\n\n## Summary\n\nPart of #227062\n\nThis adds types for ES|QL control properties and API methods to the\noptions list control factory in preparation to unify the factories. It\ndoes not actually yet make the control function with ES|QL data sources\nor variables, but lays the groundwork for adding this functionality in a\nsecond PR.\n\n- Options list control now optionally accepts all the properties in\n`ESQLControlState` as a possible input state. The input state must now\nbe either `ESQLControlState` or `DefaultDataControlState`.\n- The options list control and component APIs now publish `esqlQuery# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT ,\n`esqlVariable# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT , and `esqlControlType# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT . `esqlVariable# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  is an\n`ESQLControlVariable` derived from the ES|QL control's\n`variableType`/`variableName`, and the other two subjects are simply\nrenamed properties to reduce ambiguity downstream in the control\nfactory.\n- `esqlVariable# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  will publish from the control API and be read by the\ncontrol group. This is how current ES|QL controls already publish their\nvariables and make them available to the dashboard. In this PR, it will\nalways publish `undefined` and therefore do nothing.\n- `esqlControlType# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  can be used to determine whether to fetch available\noptions list suggestions, or to pull them from the `availableOptions`\ninput state\n- `esqlQuery# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  can be used to fetch available options if the control\ntype is `VALUES_FROM_QUERY`\n- Options list suggestions data requests to be passed to\n`fetchAndValidate` now have types for possible ES|QL requests. See [this\npart of the initial draft unification\nPR](https://github.com/elastic/kibana/pull/230132/files#diff-338ef52d0d7391e8b3fb6cbd90747d33f3a93b0389a8fa586f4f94e86fbc1916)\nfor an example of what this enables us to do.\n- An ESQL state manager has been added to the options list factory, even\nthough it's not fully implemented yet. This generates all the needed\npublishing subjects and allows the component and control APIs to pass\nthe new type checks.\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"493cd58a58f85e97e0b99bba17a4930e0366212d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Dashboard","Team:Presentation","loe:small","release_note:skip","impact:medium","backport missing","Project:Controls","backport:version","v9.2.0","v9.1.5"],"title":"[Controls] Add ESQL control types to options list","number":233126,"url":"https://github.com/elastic/kibana/pull/233126","mergeCommit":{"message":"[Controls] Add ESQL control types to options list (#233126)\n\n## Summary\n\nPart of #227062\n\nThis adds types for ES|QL control properties and API methods to the\noptions list control factory in preparation to unify the factories. It\ndoes not actually yet make the control function with ES|QL data sources\nor variables, but lays the groundwork for adding this functionality in a\nsecond PR.\n\n- Options list control now optionally accepts all the properties in\n`ESQLControlState` as a possible input state. The input state must now\nbe either `ESQLControlState` or `DefaultDataControlState`.\n- The options list control and component APIs now publish `esqlQuery# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT ,\n`esqlVariable# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT , and `esqlControlType# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT . `esqlVariable# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  is an\n`ESQLControlVariable` derived from the ES|QL control's\n`variableType`/`variableName`, and the other two subjects are simply\nrenamed properties to reduce ambiguity downstream in the control\nfactory.\n- `esqlVariable# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  will publish from the control API and be read by the\ncontrol group. This is how current ES|QL controls already publish their\nvariables and make them available to the dashboard. In this PR, it will\nalways publish `undefined` and therefore do nothing.\n- `esqlControlType# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  can be used to determine whether to fetch available\noptions list suggestions, or to pull them from the `availableOptions`\ninput state\n- `esqlQuery# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  can be used to fetch available options if the control\ntype is `VALUES_FROM_QUERY`\n- Options list suggestions data requests to be passed to\n`fetchAndValidate` now have types for possible ES|QL requests. See [this\npart of the initial draft unification\nPR](https://github.com/elastic/kibana/pull/230132/files#diff-338ef52d0d7391e8b3fb6cbd90747d33f3a93b0389a8fa586f4f94e86fbc1916)\nfor an example of what this enables us to do.\n- An ESQL state manager has been added to the options list factory, even\nthough it's not fully implemented yet. This generates all the needed\npublishing subjects and allows the component and control APIs to pass\nthe new type checks.\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"493cd58a58f85e97e0b99bba17a4930e0366212d"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/233126","number":233126,"mergeCommit":{"message":"[Controls] Add ESQL control types to options list (#233126)\n\n## Summary\n\nPart of #227062\n\nThis adds types for ES|QL control properties and API methods to the\noptions list control factory in preparation to unify the factories. It\ndoes not actually yet make the control function with ES|QL data sources\nor variables, but lays the groundwork for adding this functionality in a\nsecond PR.\n\n- Options list control now optionally accepts all the properties in\n`ESQLControlState` as a possible input state. The input state must now\nbe either `ESQLControlState` or `DefaultDataControlState`.\n- The options list control and component APIs now publish `esqlQuery# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT ,\n`esqlVariable# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT , and `esqlControlType# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT . `esqlVariable# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  is an\n`ESQLControlVariable` derived from the ES|QL control's\n`variableType`/`variableName`, and the other two subjects are simply\nrenamed properties to reduce ambiguity downstream in the control\nfactory.\n- `esqlVariable# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  will publish from the control API and be read by the\ncontrol group. This is how current ES|QL controls already publish their\nvariables and make them available to the dashboard. In this PR, it will\nalways publish `undefined` and therefore do nothing.\n- `esqlControlType# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  can be used to determine whether to fetch available\noptions list suggestions, or to pull them from the `availableOptions`\ninput state\n- `esqlQuery# Backport

This will backport the following commits from `main` to `9.1`:
{{{{raw}}}} - [[Controls] Add ESQL control types to options list (#233126)](https://github.com/elastic/kibana/pull/233126){{{{/raw}}}}

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  can be used to fetch available options if the control\ntype is `VALUES_FROM_QUERY`\n- Options list suggestions data requests to be passed to\n`fetchAndValidate` now have types for possible ES|QL requests. See [this\npart of the initial draft unification\nPR](https://github.com/elastic/kibana/pull/230132/files#diff-338ef52d0d7391e8b3fb6cbd90747d33f3a93b0389a8fa586f4f94e86fbc1916)\nfor an example of what this enables us to do.\n- An ESQL state manager has been added to the options list factory, even\nthough it's not fully implemented yet. This generates all the needed\npublishing subjects and allows the component and control APIs to pass\nthe new type checks.\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"493cd58a58f85e97e0b99bba17a4930e0366212d"}},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->