### PR TITLE
[Agent Builder] Don't scroll to bottom of conversation if its the first round

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
@@ -33,6 +33,7 @@ export const Conversation: React.FC<{}> = () => {
   const { euiTheme } = useEuiTheme();
   const { isResponseLoading } = useSendMessage();
   const { isFetched } = useConversationStatus();
+  const prevConversationIdRef = useRef<string>();
 
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const {
@@ -48,13 +49,14 @@ export const Conversation: React.FC<{}> = () => {
 
   const scrollContainerHeight = scrollContainerRef.current?.clientHeight ?? 0;
 
-  // Stick to bottom only on initial conversation load or when {conversationId} is changed
+  // Stick to bottom only when user returns to an existing conversation (conversationId is defined and changes)
   useEffect(() => {
-    if (isFetched && conversationId) {
+    if (isFetched && conversationId && prevConversationIdRef.current !== undefined) {
       requestAnimationFrame(() => {
         stickToBottom();
       });
     }
+    prevConversationIdRef.current = conversationId;
   }, [stickToBottom, isFetched, conversationId]);
 
   const scrollContainerStyles = css`

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
@@ -8,6 +8,7 @@
 import { EuiButtonIcon, EuiResizableContainer, useEuiScrollBar, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useHasActiveConversation } from '../../hooks/use_conversation';
 import { ConversationInputForm } from './conversation_input/conversation_input_form';
 import { ConversationRounds } from './conversation_rounds/conversation_rounds';
@@ -18,6 +19,7 @@ import { useSendMessage } from '../../context/send_message_context';
 import { useConversationScrollActions } from '../../hooks/use_conversation_scroll_actions';
 import { useConversationStatus } from '../../hooks/use_conversation';
 import { ConversationContent } from './conversation_grid';
+import type { LocationState } from '../../hooks/use_navigation';
 
 const fullHeightStyles = css`
   height: 100%;
@@ -33,7 +35,9 @@ export const Conversation: React.FC<{}> = () => {
   const { euiTheme } = useEuiTheme();
   const { isResponseLoading } = useSendMessage();
   const { isFetched } = useConversationStatus();
-  const prevConversationIdRef = useRef<string>();
+  const location = useLocation<LocationState>();
+
+  const shouldStickToBottom = location.state?.shouldStickToBottom ?? true;
 
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const {
@@ -51,13 +55,12 @@ export const Conversation: React.FC<{}> = () => {
 
   // Stick to bottom only when user returns to an existing conversation (conversationId is defined and changes)
   useEffect(() => {
-    if (isFetched && conversationId && prevConversationIdRef.current !== undefined) {
+    if (isFetched && conversationId && shouldStickToBottom) {
       requestAnimationFrame(() => {
         stickToBottom();
       });
     }
-    prevConversationIdRef.current = conversationId;
-  }, [stickToBottom, isFetched, conversationId]);
+  }, [stickToBottom, isFetched, conversationId, shouldStickToBottom]);
 
   const scrollContainerStyles = css`
     overflow-y: auto;

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation_actions.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation_actions.ts
@@ -57,7 +57,10 @@ export const useConversationActions = () => {
   const navigateToConversation = ({ nextConversationId }: { nextConversationId: string }) => {
     // Navigate to the new conversation if user is still on the "new" conversation page
     if (!conversationId && shouldAllowConversationRedirectRef.current) {
-      navigateToOnechatUrl(appPaths.chat.conversation({ conversationId: nextConversationId }));
+      const path = appPaths.chat.conversation({ conversationId: nextConversationId });
+      const params = undefined;
+      const state = { shouldStickToBottom: false };
+      navigateToOnechatUrl(path, params, state);
     }
   };
 

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_navigation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_navigation.ts
@@ -9,16 +9,21 @@ import { useCallback } from 'react';
 import { ONECHAT_APP_ID } from '../../../common/features';
 import { useKibana } from './use_kibana';
 
+export interface LocationState {
+  shouldStickToBottom?: boolean;
+}
+
 export const useNavigation = () => {
   const {
     services: { application },
   } = useKibana();
 
   const navigateToOnechatUrl = useCallback(
-    (path: string, params?: Record<string, string>) => {
+    (path: string, params?: Record<string, string>, state?: LocationState) => {
       const queryParams = new URLSearchParams(params);
       application.navigateToApp(ONECHAT_APP_ID, {
         path: queryParams.size ? `${path}?${queryParams}` : path,
+        state,
       });
     },
     [application]


### PR DESCRIPTION
## Summary

This stops the scroll container scrolling to the bottom of the first round when it finishes streaming I.e. the conversationId changes in the url path. 

We should only `scrollToBottom()` when a user lands on an existing conversation.

Solution: Using location.state when navigating the users from a new conversation to a conversationId and passing `shouldStickToBottom: false`


