### PR TITLE
[CI] Restrict Storybook version in Renovate. Add branch target

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3753,7 +3753,8 @@
         "team:kibana-operations"
       ],
       "matchBaseBranches": [
-        "main"
+        "main",
+        "8.19"
       ],
       "matchDepNames": [
         "@pmmmwh/react-refresh-webpack-plugin",
@@ -3767,8 +3768,9 @@
         "Team:Operations",
         "release_note:skip",
         "ci:build-storybooks",
-        "backport:prev-minor"
+        "backport:skip"
       ],
+      "allowedVersions": "<9.0.0",
       "minimumReleaseAge": "14 days",
       "enabled": true
     },


### PR DESCRIPTION
## Summary

Renovate is targeting the next major (`v9`) for Storybook, but other deps are still the previous major (`v8`). The version mismatch causes issues and SB will require a manual migration to the next major.

https://github.com/elastic/kibana/pull/235591/commits/1937f32c2aa396c7dbbc76c1bf0f6e859d1de90d


