### PR TITLE
Update registered rule types test snapshot with the missing props

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap
+++ b/x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap
@@ -6125,6 +6125,24 @@ Object {
             Object {
               "additionalProperties": false,
               "properties": Object {
+                "customizedFields": Object {
+                  "items": Object {
+                    "additionalProperties": false,
+                    "properties": Object {
+                      "fieldName": Object {
+                        "type": "string",
+                      },
+                    },
+                    "required": Array [
+                      "fieldName",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "hasBaseVersion": Object {
+                  "type": "boolean",
+                },
                 "isCustomized": Object {
                   "type": "boolean",
                 },
@@ -6797,6 +6815,24 @@ Object {
             Object {
               "additionalProperties": false,
               "properties": Object {
+                "customizedFields": Object {
+                  "items": Object {
+                    "additionalProperties": false,
+                    "properties": Object {
+                      "fieldName": Object {
+                        "type": "string",
+                      },
+                    },
+                    "required": Array [
+                      "fieldName",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "hasBaseVersion": Object {
+                  "type": "boolean",
+                },
                 "isCustomized": Object {
                   "type": "boolean",
                 },
@@ -7535,6 +7571,24 @@ Object {
             Object {
               "additionalProperties": false,
               "properties": Object {
+                "customizedFields": Object {
+                  "items": Object {
+                    "additionalProperties": false,
+                    "properties": Object {
+                      "fieldName": Object {
+                        "type": "string",
+                      },
+                    },
+                    "required": Array [
+                      "fieldName",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "hasBaseVersion": Object {
+                  "type": "boolean",
+                },
                 "isCustomized": Object {
                   "type": "boolean",
                 },
@@ -8188,6 +8242,24 @@ Object {
             Object {
               "additionalProperties": false,
               "properties": Object {
+                "customizedFields": Object {
+                  "items": Object {
+                    "additionalProperties": false,
+                    "properties": Object {
+                      "fieldName": Object {
+                        "type": "string",
+                      },
+                    },
+                    "required": Array [
+                      "fieldName",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "hasBaseVersion": Object {
+                  "type": "boolean",
+                },
                 "isCustomized": Object {
                   "type": "boolean",
                 },
@@ -8897,6 +8969,24 @@ Object {
             Object {
               "additionalProperties": false,
               "properties": Object {
+                "customizedFields": Object {
+                  "items": Object {
+                    "additionalProperties": false,
+                    "properties": Object {
+                      "fieldName": Object {
+                        "type": "string",
+                      },
+                    },
+                    "required": Array [
+                      "fieldName",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "hasBaseVersion": Object {
+                  "type": "boolean",
+                },
                 "isCustomized": Object {
                   "type": "boolean",
                 },
@@ -9607,6 +9697,24 @@ Object {
             Object {
               "additionalProperties": false,
               "properties": Object {
+                "customizedFields": Object {
+                  "items": Object {
+                    "additionalProperties": false,
+                    "properties": Object {
+                      "fieldName": Object {
+                        "type": "string",
+                      },
+                    },
+                    "required": Array [
+                      "fieldName",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "hasBaseVersion": Object {
+                  "type": "boolean",
+                },
                 "isCustomized": Object {
                   "type": "boolean",
                 },
@@ -10317,6 +10425,24 @@ Object {
             Object {
               "additionalProperties": false,
               "properties": Object {
+                "customizedFields": Object {
+                  "items": Object {
+                    "additionalProperties": false,
+                    "properties": Object {
+                      "fieldName": Object {
+                        "type": "string",
+                      },
+                    },
+                    "required": Array [
+                      "fieldName",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "hasBaseVersion": Object {
+                  "type": "boolean",
+                },
                 "isCustomized": Object {
                   "type": "boolean",
                 },


### PR DESCRIPTION
Adds the missing props added by https://github.com/elastic/kibana/pull/235394 to the registered rule types schema snapshot.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->