### PR TITLE
[Agent Builder] Add support for specifying chart type in prompt

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/tool_result.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/tool_result.ts
@@ -7,6 +7,7 @@
 
 import type { SearchRequest } from '@elastic/elasticsearch/lib/api/types';
 import type { EsqlEsqlColumnInfo, FieldValue } from '@elastic/elasticsearch/lib/api/types';
+import type { ChartType } from '@kbn/visualization-utils';
 
 export enum ToolResultType {
   resource = 'resource',
@@ -67,9 +68,15 @@ export type ToolResult =
   | OtherResult
   | ErrorResult;
 
+export interface VisualizationElementAttributes {
+  toolResultId?: string;
+  chartType?: ChartType;
+}
+
 export const visualizationElement = {
   tagName: 'visualization',
   attributes: {
     toolResultId: 'tool-result-id',
+    chartType: 'chart-type',
   },
 };

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tsconfig.json
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tsconfig.json
@@ -15,5 +15,6 @@
   ],
   "kbn_references": [
     "@kbn/sse-utils",
+    "@kbn/visualization-utils",
   ]
 }

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/chat_message_text.test.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/chat_message_text.test.tsx
@@ -1,0 +1,277 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { Node, Parent } from 'unist';
+import { render, screen } from '@testing-library/react';
+import { ToolResultType, type TabularDataResult } from '@kbn/onechat-common/tools/tool_result';
+import { cloneDeep } from 'lodash';
+import type { ConversationRoundStep } from '@kbn/onechat-common';
+import { ConversationRoundStepType } from '@kbn/onechat-common';
+import unified from 'unified';
+import remarkParse from 'remark-parse-no-trim';
+import { createVisualizationRenderer, visualizationTagParser } from './markdown_plugins';
+import { ChatMessageText } from './chat_message_text';
+import { useOnechatServices } from '../../../hooks/use_onechat_service';
+import { useStepsFromPrevRounds } from '../../../hooks/use_conversation';
+import { VisualizeESQL } from '../../tools/esql/visualize_esql';
+import type { OnechatStartDependencies } from '../../../../types';
+import { setWith } from '@kbn/safer-lodash-set';
+
+jest.mock('../../tools/esql/visualize_esql', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const _React = require('react'); // Use require to avoid hoisting issues with jest.mock
+  return {
+    VisualizeESQL: jest.fn(() =>
+      _React.createElement('span', { 'data-test-subj': 'visualize-esql' })
+    ),
+  };
+});
+
+jest.mock('../../../hooks/use_onechat_service', () => ({
+  useOnechatServices: jest.fn(),
+}));
+
+jest.mock('../../../hooks/use_conversation', () => ({
+  useStepsFromPrevRounds: jest.fn(),
+}));
+
+const mockVisualizeESQL = VisualizeESQL as jest.MockedFunction<any>;
+const useOnechatServicesMock = useOnechatServices as jest.MockedFunction<typeof useOnechatServices>;
+const useStepsFromPrevRoundsMock = useStepsFromPrevRounds as jest.MockedFunction<
+  typeof useStepsFromPrevRounds
+>;
+
+const toolResult: TabularDataResult = {
+  tool_result_id: '6K4K',
+  type: ToolResultType.tabularData,
+  data: {
+    query:
+      'FROM metrics-apm.transaction.1m-default\n| WHERE @timestamp >= NOW() - 1 hour\n| STATS avg_duration = AVG(transaction.duration.summary) BY minute_bucket = BUCKET(@timestamp, 1 minute)\n| SORT minute_bucket\n| LIMIT 100',
+    columns: [
+      { name: 'avg_duration', type: 'double' },
+      { name: 'minute_bucket', type: 'date' },
+    ],
+    values: [],
+  },
+};
+
+const toolCallStep: ConversationRoundStep = {
+  type: ConversationRoundStepType.toolCall,
+  tool_call_id: 'tool-call-1',
+  tool_id: 'platform.core.search',
+  params: {},
+  results: [toolResult],
+};
+
+function createStartDependencies() {
+  return {
+    lens: {},
+    dataViews: {},
+    cloud: {},
+    share: {},
+  } as OnechatStartDependencies;
+}
+
+function getAST(markdown: string) {
+  const processor = unified().use(remarkParse);
+  const tree = processor.parse(markdown);
+  return processor.runSync(tree) as Parent;
+}
+
+describe('chat_message_text', () => {
+  beforeEach(() => {
+    mockVisualizeESQL.mockClear();
+    useOnechatServicesMock.mockReturnValue({
+      agentService: {},
+      chatService: {},
+      conversationsService: {},
+      toolsService: {},
+      startDependencies: createStartDependencies(),
+    } as ReturnType<typeof useOnechatServices>);
+    useStepsFromPrevRoundsMock.mockReturnValue([]);
+  });
+
+  describe('visualizationTagParser', () => {
+    function recursivelyFindVisualizationNodes(node: Node | Parent, nodes: Node[] = []) {
+      if (node.children) {
+        const parent = node as Parent;
+        parent.children.forEach((child) => recursivelyFindVisualizationNodes(child, nodes));
+      }
+
+      if (node.type === 'visualization') {
+        nodes.push(node);
+      }
+
+      return nodes;
+    }
+
+    function getVisualizationNodes(markdown: string) {
+      const tree = getAST(markdown);
+      visualizationTagParser()(tree);
+      return recursivelyFindVisualizationNodes(tree);
+    }
+
+    it('converts visualization HTML nodes into visualization elements', () => {
+      const toolResultId = 'abcd';
+      const markdown = `Here is a visualization:\n<visualization tool-result-id="${toolResultId}" />`;
+      const visualizationNodes = getVisualizationNodes(markdown);
+
+      expect(visualizationNodes).toHaveLength(1);
+      expect(visualizationNodes[0].toolResultId).toBe(toolResultId);
+    });
+
+    it('sets toolResultId to undefined when the attribute is missing', () => {
+      const markdown = 'Missing attribute test\n<visualization />';
+      const visualizationNodes = getVisualizationNodes(markdown);
+
+      expect(visualizationNodes).toHaveLength(1);
+      expect(visualizationNodes[0].toolResultId).toBeUndefined();
+    });
+
+    it('supports multiple visualization tags in a single markdown', () => {
+      const markdown = `Multiple visualizations\n<visualization tool-result-id="first" />\nMore text
+<visualization tool-result-id="second" />`;
+      const visualizationNodes = getVisualizationNodes(markdown);
+
+      expect(visualizationNodes).toHaveLength(2);
+      const ids = visualizationNodes.map((node) => node.toolResultId);
+      expect(ids).toEqual(['first', 'second']);
+    });
+
+    it('handles mixed-case visualization tags', () => {
+      const markdown = 'Case insensitive\n<VISUALIZATION tool-result-id="cased" />';
+      const visualizationNodes = getVisualizationNodes(markdown);
+
+      expect(visualizationNodes).toHaveLength(1);
+      expect(visualizationNodes[0].toolResultId).toBe('cased');
+    });
+  });
+
+  describe('createVisualizationRenderer', () => {
+    it('returns a renderer that instantiates VisualizeESQL when the tool result exists', () => {
+      const startDependencies = createStartDependencies();
+      const renderer = createVisualizationRenderer({
+        startDependencies,
+        stepsFromCurrentRound: [toolCallStep],
+        stepsFromPrevRounds: [],
+      });
+
+      const element = renderer({ toolResultId: '6K4K' });
+      render(element);
+
+      expect(mockVisualizeESQL).toHaveBeenCalledTimes(1);
+      const props = mockVisualizeESQL.mock.calls[0][0];
+      expect(props).toMatchObject({
+        esqlColumns: toolResult.data.columns,
+        esqlQuery: toolResult.data.query,
+        lens: startDependencies.lens,
+        dataViews: startDependencies.dataViews,
+      });
+    });
+
+    it('returns a fallback when toolResultId is missing', () => {
+      const renderer = createVisualizationRenderer({
+        startDependencies: createStartDependencies(),
+        stepsFromCurrentRound: [toolCallStep],
+        stepsFromPrevRounds: [],
+      });
+
+      const element = renderer({ toolResultId: undefined });
+      render(element);
+
+      expect(screen.getByText(/Visualization missing tool-result-id/i)).toBeInTheDocument();
+      expect(mockVisualizeESQL).not.toHaveBeenCalled();
+    });
+
+    it('returns a fallback when tool result cannot be found', () => {
+      const renderer = createVisualizationRenderer({
+        startDependencies: createStartDependencies(),
+        stepsFromCurrentRound: [toolCallStep],
+        stepsFromPrevRounds: [],
+      });
+
+      const element = renderer({ toolResultId: 'unknown-id' });
+      render(element);
+
+      const fallbackMessages = screen.getAllByText((_, elm) =>
+        Boolean(
+          elm?.textContent?.includes('Unable to find visualization for tool-result-id=unknown-id.')
+        )
+      );
+      expect(fallbackMessages.length).toBeGreaterThan(0);
+      expect(mockVisualizeESQL).not.toHaveBeenCalled();
+    });
+
+    it('returns a fallback when tool result lacks an ES|QL query', () => {
+      const stepWithoutQuery = cloneDeep(toolCallStep) as ConversationRoundStep;
+      setWith(stepWithoutQuery, 'results[0].data.query', undefined); // Remove the query
+
+      const renderer = createVisualizationRenderer({
+        startDependencies: createStartDependencies(),
+        stepsFromCurrentRound: [stepWithoutQuery],
+        stepsFromPrevRounds: [],
+      });
+
+      const element = renderer({ toolResultId: '6K4K' });
+      render(element);
+
+      expect(mockVisualizeESQL).not.toHaveBeenCalled();
+      const fallbacks = screen.getAllByText((_, elm) =>
+        Boolean(elm?.textContent?.includes('Unable to find esql query for tool-result-id=6K4K.'))
+      );
+      expect(fallbacks.length).toBeGreaterThan(0);
+    });
+
+    it('looks through previous rounds when current steps have no matching tool result', () => {
+      const renderer = createVisualizationRenderer({
+        startDependencies: createStartDependencies(),
+        stepsFromCurrentRound: [],
+        stepsFromPrevRounds: [toolCallStep],
+      });
+
+      const element = renderer({ toolResultId: '6K4K' });
+      render(element);
+
+      expect(mockVisualizeESQL).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('<ChatMessageText />', () => {
+    it('renders VisualizeESQL for visualization tags with matching tool results', () => {
+      useStepsFromPrevRoundsMock.mockReturnValue([toolCallStep]);
+
+      const content = 'Here is a visualization:\n<visualization tool-result-id="6K4K" />';
+      render(<ChatMessageText content={content} steps={[toolCallStep]} />);
+
+      expect(screen.getByTestId('visualize-esql')).toBeInTheDocument();
+      const props = mockVisualizeESQL.mock.calls[0][0];
+      expect(props).toEqual(
+        expect.objectContaining({
+          esqlColumns: toolResult.data.columns,
+          esqlQuery: toolResult.data.query,
+        })
+      );
+    });
+
+    it('uses tool results from previous rounds when current steps are empty', () => {
+      useStepsFromPrevRoundsMock.mockReturnValue([toolCallStep]);
+
+      const content = 'Here is a visualization:\n<visualization tool-result-id="6K4K" />';
+      render(<ChatMessageText content={content} steps={[]} />);
+
+      expect(mockVisualizeESQL).toHaveBeenCalledTimes(1);
+      const props = mockVisualizeESQL.mock.calls[0][0];
+      expect(props).toEqual(
+        expect.objectContaining({
+          esqlColumns: toolResult.data.columns,
+          esqlQuery: toolResult.data.query,
+        })
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/chat_message_text.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/chat_message_text.tsx
@@ -22,13 +22,14 @@ import {
 } from '@elastic/eui';
 import { type PluggableList } from 'unified';
 import type { ConversationRoundStep } from '@kbn/onechat-common';
+import { visualizationElement } from '@kbn/onechat-common/tools/tool_result';
 import { useOnechatServices } from '../../../hooks/use_onechat_service';
 import {
   Cursor,
   esqlLanguagePlugin,
-  getVisualizationHandler,
+  createVisualizationRenderer,
   loadingCursorPlugin,
-  visualizationPlugin,
+  visualizationTagParser,
 } from './markdown_plugins';
 import { useStepsFromPrevRounds } from '../../../hooks/use_conversation';
 
@@ -117,7 +118,7 @@ export function ChatMessageText({ content, steps: stepsFromCurrentRound }: Props
           </EuiTableRowCell>
         );
       },
-      visualization: getVisualizationHandler({
+      [visualizationElement.tagName]: createVisualizationRenderer({
         startDependencies,
         stepsFromCurrentRound,
         stepsFromPrevRounds,
@@ -128,7 +129,7 @@ export function ChatMessageText({ content, steps: stepsFromCurrentRound }: Props
       parsingPluginList: [
         loadingCursorPlugin,
         esqlLanguagePlugin,
-        visualizationPlugin,
+        visualizationTagParser,
         ...parsingPlugins,
       ],
       processingPluginList: processingPlugins,

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/markdown_plugins.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/markdown_plugins.tsx
@@ -20,41 +20,96 @@ import { EuiCode, EuiText, useEuiTheme } from '@elastic/eui';
 import type { OnechatStartDependencies } from '../../../../types';
 import { VisualizeESQL } from '../../tools/esql/visualize_esql';
 
+type MutableNode = Node & {
+  value?: string;
+  toolResultId?: string;
+  chartType?: string;
+};
+
 export const visualizationTagParser = () => {
   const extractAttribute = (value: string, attr: string) => {
     const regex = new RegExp(`${attr}="([^"]*)"`, 'i');
     return value.match(regex)?.[1];
   };
 
-  const visitor = (node: Node) => {
-    if ('children' in node) {
-      const parent = node as Parent;
-      parent.children.forEach((child) => visitor(child));
-    }
+  const getVisualizationAttributes = (value: string) => ({
+    toolResultId: extractAttribute(value, visualizationElement.attributes.toolResultId),
+    chartType: extractAttribute(value, visualizationElement.attributes.chartType),
+  });
 
-    if (node.type !== 'html') {
-      return;
-    }
-
-    // find <visualization> nodes
-    const value = node.value as string | undefined;
-    if (!value || !value.trim().toLowerCase().startsWith(`<${visualizationElement.tagName}`)) {
-      return;
-    }
-
-    // extract attributes
-    const toolResultId = extractAttribute(value, visualizationElement.attributes.toolResultId);
-    const chartType = extractAttribute(value, visualizationElement.attributes.chartType);
-
-    // transform the node from type `html` to (custom) type `visualization`
+  const assignVisualizationAttributes = (
+    node: MutableNode,
+    attributes: ReturnType<typeof getVisualizationAttributes>
+  ) => {
     node.type = visualizationElement.tagName;
-    node.toolResultId = toolResultId;
-    node.chartType = chartType;
-    delete node.value; // remove the raw HTML value
+    node.toolResultId = attributes.toolResultId;
+    node.chartType = attributes.chartType;
+    delete node.value;
+  };
+
+  const visualizationTagRegex = new RegExp(`<${visualizationElement.tagName}\\b[^>]*\\/?>`, 'gi');
+
+  const createVisualizationNode = (
+    attributes: ReturnType<typeof getVisualizationAttributes>,
+    position: MutableNode['position']
+  ): MutableNode => ({
+    type: visualizationElement.tagName,
+    toolResultId: attributes.toolResultId,
+    chartType: attributes.chartType,
+    position,
+  });
+
+  const visitParent = (parent: Parent) => {
+    for (let index = 0; index < parent.children.length; index++) {
+      const child = parent.children[index] as MutableNode;
+
+      if ('children' in child) {
+        visitParent(child as Parent);
+      }
+
+      if (child.type !== 'html') {
+        continue; // terminate iteration if not html node
+      }
+
+      const rawValue = child.value;
+      if (!rawValue) {
+        continue; // terminate iteration if no value attribute
+      }
+
+      const trimmedValue = rawValue.trim();
+      if (!trimmedValue.toLowerCase().startsWith(`<${visualizationElement.tagName}`)) {
+        continue; // terminate iteration if not starting with visualization tag
+      }
+
+      const matches = Array.from(trimmedValue.matchAll(visualizationTagRegex));
+      if (matches.length === 0) {
+        continue; // terminate iteration if no matches found
+      }
+
+      const visualizationAttributes = matches.map((match) => getVisualizationAttributes(match[0]));
+      const leftoverContent = trimmedValue.replace(visualizationTagRegex, '').trim();
+
+      assignVisualizationAttributes(child, visualizationAttributes[0]);
+
+      if (visualizationAttributes.length === 1 || leftoverContent.length > 0) {
+        continue;
+      }
+
+      const additionalNodes = visualizationAttributes
+        .slice(1)
+        .map((attributes) => createVisualizationNode(attributes, child.position));
+
+      const siblings = parent.children as Node[];
+      siblings.splice(index + 1, 0, ...additionalNodes);
+      index += additionalNodes.length;
+      continue;
+    }
   };
 
   return (tree: Node) => {
-    visitor(tree);
+    if ('children' in tree) {
+      visitParent(tree as Parent);
+    }
   };
 };
 

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
@@ -13,6 +13,7 @@ import {
 } from '@kbn/onechat-common';
 import { sanitizeToolId } from '@kbn/onechat-genai-utils/langchain';
 import { visualizationElement } from '@kbn/onechat-common/tools/tool_result';
+import { ChartType } from '@kbn/visualization-utils';
 import { customInstructionsBlock, formatDate } from '../utils/prompt_helpers';
 
 const tools = {
@@ -152,6 +153,9 @@ export const getActPrompt = ({
 function renderVisualizationPrompt() {
   const { tabularData } = ToolResultType;
   const { tagName, attributes } = visualizationElement;
+  const chartTypeNames = Object.values(ChartType)
+    .map((chartType) => `\`${chartType}\``)
+    .join(', ');
 
   return `#### Rendering Visualizations with the <${tagName}> Element
       When a tool call returns a result of type "${tabularData}", you may render a visualization in the UI by emitting a custom XML element:
@@ -160,9 +164,11 @@ function renderVisualizationPrompt() {
 
       **Rules**
       * The \`<${tagName}>\` element must only be used to render tool results of type \`${tabularData}\`.
+      * You can specify an optional chart type by adding the \`${attributes.chartType}\` attribute with one of the following values: ${chartTypeNames}.
+      * If no chart type is specified, the system will choose an appropriate default visualization.
       * You must copy the \`tool_result_id\` from the tool's response into the \`${attributes.toolResultId}\` element attribute verbatim.
       * Do not invent, alter, or guess \`tool_result_id\`. You must use the exact id provided in the tool response.
-      * You must not include any other attributes or content within the \`<${tagName}>\` element.
+      * You must not include any other attributes or content within the \`<${tagName}>\` element.      
 
       **Example Usage:**
 
@@ -178,5 +184,8 @@ function renderVisualizationPrompt() {
       }
 
       To visualize this response your reply should be:
-      <${tagName} ${attributes.toolResultId}="LiDo" />`;
+      <${tagName} ${attributes.toolResultId}="LiDo"/>
+            
+      To visualize this response as a bar chart your reply should be:
+      <${tagName} ${attributes.toolResultId}="LiDo" ${attributes.chartType}="${ChartType.Bar}"/>`;
 }

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
@@ -165,7 +165,7 @@ function renderVisualizationPrompt() {
       **Rules**
       * The \`<${tagName}>\` element must only be used to render tool results of type \`${tabularData}\`.
       * You can specify an optional chart type by adding the \`${attributes.chartType}\` attribute with one of the following values: ${chartTypeNames}.
-      * If no chart type is specified, the system will choose an appropriate default visualization.
+      * If the user does not specify a chart type, do NOT assume any. The system will choose an appropriate default visualization.
       * You must copy the \`tool_result_id\` from the tool's response into the \`${attributes.toolResultId}\` element attribute verbatim.
       * Do not invent, alter, or guess \`tool_result_id\`. You must use the exact id provided in the tool response.
       * You must not include any other attributes or content within the \`<${tagName}>\` element.      


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/11116

In https://github.com/elastic/kibana/pull/232182 basic visualization support was added. 
This PR adds support for specifying the chart type in the prompt. 

This is an example of how the LLM can produce an area chart for a specific tool result:
```
<visualization tool-result-id="OE5B" chart-type="Area"/>
```

<img width="420" height="507" alt="image" src="https://github.com/user-attachments/assets/ffd38906-aa92-4661-a783-27a332eb8c86" />
