### PR TITLE
[Fleet] Fail migrate action if agent has unsupported version (before 9.2.0)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/agent.ts
@@ -67,5 +67,3 @@ export const PRIVILEGED_AGENT_KUERY = `not ${AGENTS_PREFIX}.local_metadata.elast
 
 // Kuery to find fips agents
 export const FIPS_AGENT_KUERY = `${AGENTS_PREFIX}.local_metadata.elastic.agent.fips: true`;
-
-export const MIGRATE_AGENT_VERSION = '9.2.0';

--- a/x-pack/platform/plugins/shared/fleet/common/constants/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/agent.ts
@@ -67,3 +67,5 @@ export const PRIVILEGED_AGENT_KUERY = `not ${AGENTS_PREFIX}.local_metadata.elast
 
 // Kuery to find fips agents
 export const FIPS_AGENT_KUERY = `${AGENTS_PREFIX}.local_metadata.elastic.agent.fips: true`;
+
+export const MIGRATE_AGENT_VERSION = '9.2.0';

--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -29,6 +29,10 @@ export {
   MINIMUM_DIAGNOSTICS_AGENT_VERSION,
 } from './is_agent_request_diagnostics_supported';
 export {
+  isAgentMigrationSupported,
+  MINIMUM_MIGRATE_AGENT_VERSION,
+} from './is_agent_migrate_supported';
+export {
   isInputOnlyPolicyTemplate,
   isIntegrationPolicyTemplate,
   getNormalizedInputs,

--- a/x-pack/platform/plugins/shared/fleet/common/services/is_agent_migrate_supported.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/is_agent_migrate_supported.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import semverGte from 'semver/functions/gte';
+
+import type { Agent } from '../types';
+
+export const MINIMUM_MIGRATE_AGENT_VERSION = '9.2.0';
+
+export const isAgentMigrationSupported = (agent: Agent) => {
+  return !agent.agent?.version || semverGte(agent.agent.version, MINIMUM_MIGRATE_AGENT_VERSION);
+};

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -52,7 +52,7 @@ export interface Props {
   agentPolicies: AgentPolicy[];
   sortField?: string;
   sortOrder?: 'asc' | 'desc';
-  protectedAndFleetAgents: Agent[];
+  unsupportedMigrateAgents: Agent[];
 }
 
 export const AgentBulkActions: React.FunctionComponent<Props> = ({
@@ -67,7 +67,7 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
   agentPolicies,
   sortField,
   sortOrder,
-  protectedAndFleetAgents,
+  unsupportedMigrateAgents,
 }) => {
   const licenseService = useLicense();
   const authz = useAuthz();
@@ -373,7 +373,7 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
           <AgentMigrateFlyout
             agents={agents}
             agentCount={agentCount}
-            protectedAndFleetAgents={protectedAndFleetAgents}
+            unsupportedMigrateAgents={unsupportedMigrateAgents}
             onClose={() => {
               setIsMigrateModalOpen(false);
             }}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/migrate_agent_flyout/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/migrate_agent_flyout/index.test.tsx
@@ -36,7 +36,7 @@ describe('MigrateAgentFlyout', () => {
           },
         ]}
         agentCount={1}
-        protectedAndFleetAgents={[]}
+        unsupportedMigrateAgents={[]}
       />
     );
   });
@@ -96,7 +96,7 @@ describe('MigrateAgentFlyout', () => {
           },
         ]}
         agentCount={2}
-        protectedAndFleetAgents={[]}
+        unsupportedMigrateAgents={[]}
       />
     );
     const replaceTokenButton = component.queryByTestId('migrateAgentFlyoutReplaceTokenButton');
@@ -119,7 +119,7 @@ describe('MigrateAgentFlyout', () => {
           },
         ]}
         agentCount={1}
-        protectedAndFleetAgents={[
+        unsupportedMigrateAgents={[
           {
             active: true,
             status: 'online',

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/migrate_agent_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/migrate_agent_flyout/index.tsx
@@ -53,7 +53,7 @@ interface Props {
   agentCount: number;
   onClose: () => void;
   onSave: () => void;
-  protectedAndFleetAgents: Agent[];
+  unsupportedMigrateAgents: Agent[];
 }
 
 export const AgentMigrateFlyout: React.FC<Props> = ({
@@ -61,7 +61,7 @@ export const AgentMigrateFlyout: React.FC<Props> = ({
   agentCount,
   onClose,
   onSave,
-  protectedAndFleetAgents,
+  unsupportedMigrateAgents,
 }) => {
   const { notifications } = useStartServices();
   const migrateAgent = sendMigrateSingleAgent;
@@ -83,9 +83,9 @@ export const AgentMigrateFlyout: React.FC<Props> = ({
   const filteredAgents = useMemo(
     () =>
       Array.isArray(agents)
-        ? agents.filter((agent) => !protectedAndFleetAgents.some((a) => a.id === agent.id))
+        ? agents.filter((agent) => !unsupportedMigrateAgents.some((a) => a.id === agent.id))
         : agents,
-    [agents, protectedAndFleetAgents]
+    [agents, unsupportedMigrateAgents]
   );
   const filteredAgentCount = useMemo(
     () => (Array.isArray(filteredAgents) ? filteredAgents.length : agentCount),
@@ -199,17 +199,17 @@ export const AgentMigrateFlyout: React.FC<Props> = ({
             />
           </EuiText>
 
-          {Array.isArray(agents) && protectedAndFleetAgents.length > 0 && (
+          {Array.isArray(agents) && unsupportedMigrateAgents.length > 0 && (
             <>
               <EuiSpacer />
               <EuiPanel color="warning" data-test-subj="migrateAgentFlyoutAlertPanel">
                 <EuiText color="warning" className="eui-alignMiddle">
                   <FormattedMessage
                     id="xpack.fleet.agentList.migrateAgentFlyout.warning"
-                    defaultMessage="{icon} {x} of {y} selected agents cannot be migrated as they are tamper protected or Fleet Server agents."
+                    defaultMessage="{icon} {x} of {y} selected agents cannot be migrated as they are tamper protected or Fleet Server agents or unsupported version."
                     values={{
                       icon: <EuiIcon type="warning" />,
-                      x: protectedAndFleetAgents.length,
+                      x: unsupportedMigrateAgents.length,
                       y: agentCount,
                     }}
                   />
@@ -230,7 +230,7 @@ export const AgentMigrateFlyout: React.FC<Props> = ({
                   <EuiSpacer size="s" />
                   <EuiText>
                     <ul>
-                      {protectedAndFleetAgents.map((agent) => (
+                      {unsupportedMigrateAgents.map((agent) => (
                         <li key={agent.id}>{agent.local_metadata?.host?.hostname}</li>
                       ))}
                     </ul>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -63,7 +63,7 @@ export interface SearchAndFilterBarProps {
   latestAgentActionErrors: number;
   sortField?: string;
   sortOrder?: 'asc' | 'desc';
-  protectedAndFleetAgents: Agent[];
+  unsupportedMigrateAgents: Agent[];
 }
 
 export const SearchAndFilterBar: React.FunctionComponent<SearchAndFilterBarProps> = ({
@@ -95,7 +95,7 @@ export const SearchAndFilterBar: React.FunctionComponent<SearchAndFilterBarProps
   latestAgentActionErrors,
   sortField,
   sortOrder,
-  protectedAndFleetAgents,
+  unsupportedMigrateAgents,
 }) => {
   const authz = useAuthz();
 
@@ -231,7 +231,7 @@ export const SearchAndFilterBar: React.FunctionComponent<SearchAndFilterBarProps
                   agentPolicies={agentPolicies}
                   sortField={sortField}
                   sortOrder={sortOrder}
-                  protectedAndFleetAgents={protectedAndFleetAgents}
+                  unsupportedMigrateAgents={unsupportedMigrateAgents}
                 />
               </EuiFlexItem>
             ) : null}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.test.tsx
@@ -148,6 +148,21 @@ describe('TableRowActions', () => {
 
       expect(res).toBe(null);
     });
+    it('should not render an active action button when agent is an unsupported version', async () => {
+      const res = renderAndGetMigrateButton({
+        agent: {
+          active: true,
+          status: 'online',
+          agent: { version: '9.1.0' },
+        } as any,
+        agentPolicy: {
+          is_managed: false,
+          is_protected: false,
+        } as AgentPolicy,
+      });
+
+      expect(res).toBe(null);
+    });
   });
 
   describe('Request Diagnotics action', () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.tsx
@@ -6,11 +6,12 @@
  */
 
 import React, { useState } from 'react';
+import semverLt from 'semver/functions/lt';
 import { EuiContextMenuItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { FLEET_SERVER_PACKAGE } from '../../../../../../../common';
-
+import { MIGRATE_AGENT_VERSION } from '../../../../../../../common/constants';
 import { isAgentRequestDiagnosticsSupported } from '../../../../../../../common/services';
 
 import { isStuckInUpdating } from '../../../../../../../common/services/agent_status';
@@ -59,7 +60,14 @@ export const TableRowActions: React.FunctionComponent<{
       <FormattedMessage id="xpack.fleet.agentList.viewActionText" defaultMessage="View agent" />
     </EuiContextMenuItem>,
   ];
-  if (!agentPolicy?.is_protected && !isFleetServerAgent && agentMigrationsEnabled) {
+  const unsupportedVersion =
+    agent.agent?.version && semverLt(agent.agent.version, MIGRATE_AGENT_VERSION);
+  if (
+    !agentPolicy?.is_protected &&
+    !isFleetServerAgent &&
+    agentMigrationsEnabled &&
+    !unsupportedVersion
+  ) {
     menuItems.push(
       <EuiContextMenuItem
         icon="cluster"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.tsx
@@ -6,13 +6,14 @@
  */
 
 import React, { useState } from 'react';
-import semverLt from 'semver/functions/lt';
 import { EuiContextMenuItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { FLEET_SERVER_PACKAGE } from '../../../../../../../common';
-import { MIGRATE_AGENT_VERSION } from '../../../../../../../common/constants';
-import { isAgentRequestDiagnosticsSupported } from '../../../../../../../common/services';
+import {
+  isAgentMigrationSupported,
+  isAgentRequestDiagnosticsSupported,
+} from '../../../../../../../common/services';
 
 import { isStuckInUpdating } from '../../../../../../../common/services/agent_status';
 
@@ -60,13 +61,11 @@ export const TableRowActions: React.FunctionComponent<{
       <FormattedMessage id="xpack.fleet.agentList.viewActionText" defaultMessage="View agent" />
     </EuiContextMenuItem>,
   ];
-  const unsupportedVersion =
-    agent.agent?.version && semverLt(agent.agent.version, MIGRATE_AGENT_VERSION);
   if (
     !agentPolicy?.is_protected &&
     !isFleetServerAgent &&
     agentMigrationsEnabled &&
-    !unsupportedVersion
+    isAgentMigrationSupported(agent)
   ) {
     menuItems.push(
       <EuiContextMenuItem

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -6,12 +6,11 @@
  */
 import React, { useState, useMemo, useCallback } from 'react';
 import { differenceBy, isEqual } from 'lodash';
-import semverLt from 'semver/functions/lt';
 import { EuiSpacer, EuiPortal } from '@elastic/eui';
 
 import { isStuckInUpdating } from '../../../../../../common/services/agent_status';
 import { FLEET_SERVER_PACKAGE } from '../../../../../../common';
-import { MIGRATE_AGENT_VERSION } from '../../../../../../common/constants/agent';
+import { isAgentMigrationSupported } from '../../../../../../common/services';
 import type { Agent } from '../../../types';
 
 import {
@@ -194,9 +193,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         )
       : [];
     const unsupportedVersionAgents = Array.isArray(selectedAgents)
-      ? selectedAgents.filter((agent) =>
-          agent.agent?.version ? semverLt(agent.agent.version, MIGRATE_AGENT_VERSION) : false
-        )
+      ? selectedAgents.filter((agent) => !isAgentMigrationSupported(agent))
       : [];
     return [...protectedAgents, ...fleetAgents, ...unsupportedVersionAgents];
   }, [selectedAgents, agentPoliciesIndexedById]);

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.test.ts
@@ -168,6 +168,46 @@ describe('Agent migration', () => {
         migrateSingleAgent(esClientMock, soClientMock, agentId, mockedPolicy, mockedAgent, options)
       ).rejects.toThrowError('Agent is protected and cannot be migrated');
     });
+
+    it('should throw an error if the agent is a fleet server', async () => {
+      const agentId = 'agent-123';
+      const options = {
+        policyId: 'policy-456',
+        enrollment_token: 'test-enrollment-token',
+        uri: 'https://test-fleet-server.example.com',
+      };
+      await expect(
+        migrateSingleAgent(
+          esClientMock,
+          soClientMock,
+          agentId,
+          mockedPolicy,
+          { ...mockedAgent, components: [{ type: 'fleet-server' } as any] },
+          options
+        )
+      ).rejects.toThrowError('Fleet server agents cannot be migrated');
+    });
+
+    it('should throw an error if the agent has a not supported version', async () => {
+      const agentId = 'agent-123';
+      const options = {
+        policyId: 'policy-456',
+        enrollment_token: 'test-enrollment-token',
+        uri: 'https://test-fleet-server.example.com',
+      };
+      await expect(
+        migrateSingleAgent(
+          esClientMock,
+          soClientMock,
+          agentId,
+          mockedPolicy,
+          { ...mockedAgent, agent: { version: '9.1.0' } as any },
+          options
+        )
+      ).rejects.toThrowError(
+        'Agent cannot be migrated. Migrate action is supported from version 9.2.0.'
+      );
+    });
   });
 
   // Bulk migrate
@@ -252,6 +292,52 @@ describe('Agent migration', () => {
         {
           'agent-123': new FleetError(
             'Agent agent-123 cannot be migrated because it is protected.'
+          ),
+        },
+        'agent does not support migration action'
+      );
+    });
+
+    it('should record error result if the agent is fleet-server', async () => {
+      const agent = { ...mockedAgent, components: [{ type: 'fleet-server' } as any] };
+      (getAgents as jest.Mock).mockResolvedValue([agent, agent]);
+      const options = {
+        enrollment_token: 'test-enrollment-token',
+        uri: 'https://test-fleet-server.example.com',
+      };
+      await bulkMigrateAgents(esClientMock, soClientMock, {
+        ...options,
+        agentIds: [agent.id, agent.id],
+      });
+      expect(mockedCreateErrorActionResults).toHaveBeenCalledWith(
+        esClientMock,
+        expect.any(String),
+        {
+          'agent-123': new FleetError(
+            'Agent agent-123 cannot be migrated because it is a fleet-server.'
+          ),
+        },
+        'agent does not support migration action'
+      );
+    });
+
+    it('should record error result if the agent is on unsupported version', async () => {
+      const agent = { ...mockedAgent, agent: { version: '9.1.0' } as any };
+      (getAgents as jest.Mock).mockResolvedValue([agent, agent]);
+      const options = {
+        enrollment_token: 'test-enrollment-token',
+        uri: 'https://test-fleet-server.example.com',
+      };
+      await bulkMigrateAgents(esClientMock, soClientMock, {
+        ...options,
+        agentIds: [agent.id, agent.id],
+      });
+      expect(mockedCreateErrorActionResults).toHaveBeenCalledWith(
+        esClientMock,
+        expect.any(String),
+        {
+          'agent-123': new FleetError(
+            'Agent agent-123 cannot be migrated. Migrate action is supported from version 9.2.0.'
           ),
         },
         'agent does not support migration action'

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.ts
@@ -4,10 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import semverLt from 'semver/functions/lt';
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 
-import { MIGRATE_AGENT_VERSION } from '../../../common/constants';
+import { isAgentMigrationSupported, MINIMUM_MIGRATE_AGENT_VERSION } from '../../../common/services';
 import { FleetError, FleetUnauthorizedError } from '../../errors';
 
 import type { AgentPolicy, Agent } from '../../types';
@@ -42,9 +41,9 @@ export async function migrateSingleAgent(
   if (agent.components?.some((c) => c.type === 'fleet-server')) {
     throw new FleetUnauthorizedError(`Fleet server agents cannot be migrated`);
   }
-  if (agent.agent?.version && semverLt(agent.agent.version, MIGRATE_AGENT_VERSION)) {
+  if (!isAgentMigrationSupported(agent)) {
     throw new FleetError(
-      `Agent cannot be migrated. Migrate action is supported from version ${MIGRATE_AGENT_VERSION}.`
+      `Agent cannot be migrated. Migrate action is supported from version ${MINIMUM_MIGRATE_AGENT_VERSION}.`
     );
   }
   const response = await createAgentAction(esClient, soClient, {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate_action_runner.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate_action_runner.ts
@@ -6,8 +6,10 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
+import semverLt from 'semver/functions/lt';
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 
+import { MIGRATE_AGENT_VERSION } from '../../../common/constants';
 import { FleetError } from '../../errors';
 
 import type { Agent } from '../../types';
@@ -63,6 +65,10 @@ export async function bulkMigrateAgentsBatch(
     } else if (agent.components?.some((c) => c.type === 'fleet-server')) {
       errors[agent.id] = new FleetError(
         `Agent ${agent.id} cannot be migrated because it is a fleet-server.`
+      );
+    } else if (agent.agent?.version && semverLt(agent.agent.version, MIGRATE_AGENT_VERSION)) {
+      errors[agent.id] = new FleetError(
+        `Agent ${agent.id} cannot be migrated. Migrate action is supported from version ${MIGRATE_AGENT_VERSION}.`
       );
     } else {
       agentsToAction.push(agent);

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate_action_runner.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate_action_runner.ts
@@ -6,10 +6,9 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import semverLt from 'semver/functions/lt';
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 
-import { MIGRATE_AGENT_VERSION } from '../../../common/constants';
+import { isAgentMigrationSupported, MINIMUM_MIGRATE_AGENT_VERSION } from '../../../common/services';
 import { FleetError } from '../../errors';
 
 import type { Agent } from '../../types';
@@ -66,9 +65,9 @@ export async function bulkMigrateAgentsBatch(
       errors[agent.id] = new FleetError(
         `Agent ${agent.id} cannot be migrated because it is a fleet-server.`
       );
-    } else if (agent.agent?.version && semverLt(agent.agent.version, MIGRATE_AGENT_VERSION)) {
+    } else if (!isAgentMigrationSupported(agent)) {
       errors[agent.id] = new FleetError(
-        `Agent ${agent.id} cannot be migrated. Migrate action is supported from version ${MIGRATE_AGENT_VERSION}.`
+        `Agent ${agent.id} cannot be migrated. Migrate action is supported from version ${MINIMUM_MIGRATE_AGENT_VERSION}.`
       );
     } else {
       agentsToAction.push(agent);

--- a/x-pack/platform/test/fixtures/es_archives/fleet/agents/data.json
+++ b/x-pack/platform/test/fixtures/es_archives/fleet/agents/data.json
@@ -37,7 +37,7 @@
       "enrolled_at": "2022-06-21T12:14:25Z",
       "last_checkin": "2022-06-27T12:27:29Z",
       "tags": ["existingTag"],
-      "agent": {"id": "agent2", "version": "9.0.0"}
+      "agent": {"id": "agent2", "version": "9.2.0"}
     }
   }
 }

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/migrate.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/migrate.ts
@@ -193,6 +193,19 @@ export default function (providerContext: FtrProviderContext) {
       await es.index({
         refresh: 'wait_for',
         index: AGENTS_INDEX,
+        id: 'agent3_91',
+        document: {
+          policy_id: policy3.id,
+          enrolled_at: new Date().toISOString(),
+          agent: {
+            version: '9.1.0',
+          },
+        },
+      });
+
+      await es.index({
+        refresh: 'wait_for',
+        index: AGENTS_INDEX,
         id: 'agent4',
         document: {
           policy_id: policy1.id,
@@ -272,6 +285,17 @@ export default function (providerContext: FtrProviderContext) {
             uri: 'https://example.com',
           })
           .expect(403);
+      });
+
+      it('should return a 400 if the agent is an unsupported version', async () => {
+        const {} = await supertest
+          .post(`/api/fleet/agents/agent3_91/migrate`)
+          .set('kbn-xsrf', 'xx')
+          .send({
+            enrollment_token: '1234',
+            uri: 'https://example.com',
+          })
+          .expect(400);
       });
 
       it('should return a 404 when agent does not exist', async () => {

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/privileges.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/privileges.ts
@@ -316,7 +316,7 @@ export default function (providerContext: FtrProviderContext) {
       },
       {
         method: 'POST',
-        path: '/api/fleet/agents/agent1/migrate',
+        path: '/api/fleet/agents/agent2/migrate',
         scenarios: ALL_SCENARIOS,
         send: {
           enrollment_token: '1234',


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/231178

Hide Migrate agent action if agent is on unsupported version

<img width="1113" height="661" alt="image" src="https://github.com/user-attachments/assets/1e50a3bf-161b-4d97-aa64-f528085ed00c" />

Single API returns error if agent is on unsupported version

```
POST kbn:/api/fleet/agents/613cb6b8-c438-4a31-86c3-d726b8417d3d/migrate
{"enrollment_token":"YTExaGNKa0JnS1BBU1NmWTF0NTE6M0dPc1c5QXp6Zm9jd1ZSMUdBemllQQ==","uri":"https://192.168.65.1:8220","settings":{}}

{
  "statusCode": 400,
  "error": "Bad Request",
  "message": "Agent cannot be migrated. Migrate action is supported from version 9.2.0."
}
```

The bulk migrate UI action shows a warning if some of the selected agents are on unsupported version.

<img width="1107" height="830" alt="image" src="https://github.com/user-attachments/assets/6e174f55-bf4f-41ae-8eab-f6211809f998" />

The bulk migrate API records error action results for agents on unsupported versoin

<img width="581" height="469" alt="image" src="https://github.com/user-attachments/assets/dea65e5a-5d31-488c-88e4-428ee74dee16" />
 


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



