### PR TITLE
[Fleet] Remove EUI dependencies from common

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/settings/agent_policy_settings.tsx
+++ b/x-pack/platform/plugins/shared/fleet/common/settings/agent_policy_settings.tsx
@@ -7,8 +7,6 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiCode } from '@elastic/eui';
-
 import { z } from '@kbn/zod';
 
 import { AGENT_LOG_LEVELS, DEFAULT_LOG_LEVEL } from '../constants';
@@ -32,9 +30,10 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     title: i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.goMaxProcsTitle', {
       defaultMessage: 'Limit CPU usage',
     }),
-    description: i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.goMaxProcsDescription', {
-      defaultMessage: 'Limits the maximum number of CPUs that can be executing simultaneously.',
-    }),
+    description: () =>
+      i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.goMaxProcsDescription', {
+        defaultMessage: 'Limits the maximum number of CPUs that can be executing simultaneously.',
+      }),
     learnMoreLink:
       'https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-limit-cpu',
     api_field: {
@@ -49,12 +48,10 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     title: i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.downloadTimeoutTitle', {
       defaultMessage: 'Agent binary download timeout',
     }),
-    description: i18n.translate(
-      'xpack.fleet.settings.agentPolicyAdvanced.downloadTimeoutDescription',
-      {
+    description: () =>
+      i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.downloadTimeoutDescription', {
         defaultMessage: 'Timeout for downloading the agent binary.',
-      }
-    ),
+      }),
     learnMoreLink:
       'https://www.elastic.co/guide/en/fleet/current/enable-custom-policy-settings.html#configure-agent-download-timeout',
     api_field: {
@@ -75,12 +72,13 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
         defaultMessage: 'Agent binary target directory',
       }
     ),
-    description: i18n.translate(
-      'xpack.fleet.settings.agentPolicyAdvanced.agentDownloadTargetDirectoryDescription',
-      {
-        defaultMessage: 'The disk path to which the agent binary will be downloaded.',
-      }
-    ),
+    description: () =>
+      i18n.translate(
+        'xpack.fleet.settings.agentPolicyAdvanced.agentDownloadTargetDirectoryDescription',
+        {
+          defaultMessage: 'The disk path to which the agent binary will be downloaded.',
+        }
+      ),
     learnMoreLink:
       'https://www.elastic.co/guide/en/fleet/current/elastic-agent-standalone-download.html',
     schema: z.string(),
@@ -98,12 +96,13 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
         defaultMessage: 'Agent logging metrics period',
       }
     ),
-    description: i18n.translate(
-      'xpack.fleet.settings.agentPolicyAdvanced.agentLoggingMetricsPeriodDescription',
-      {
-        defaultMessage: 'The frequency of logging the internal Elastic Agent metrics.',
-      }
-    ),
+    description: () =>
+      i18n.translate(
+        'xpack.fleet.settings.agentPolicyAdvanced.agentLoggingMetricsPeriodDescription',
+        {
+          defaultMessage: 'The frequency of logging the internal Elastic Agent metrics.',
+        }
+      ),
     learnMoreLink:
       'https://www.elastic.co/guide/en/fleet/current/elastic-agent-standalone-logging-config.html#elastic-agent-standalone-logging-settings',
     schema: zodStringWithDurationValidation,
@@ -114,11 +113,11 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     title: i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.agentLoggingLevelTitle', {
       defaultMessage: 'Agent logging level',
     }),
-    description: (
+    description: ({ renderer }) => (
       <FormattedMessage
         id="xpack.fleet.settings.agentPolicyAdvanced.agentLoggingLevelDescription"
         defaultMessage="Sets the log level for all the agents on the policy. The default log level is {level}."
-        values={{ level: <EuiCode>{DEFAULT_LOG_LEVEL}</EuiCode> }}
+        values={{ level: renderer.renderCode(DEFAULT_LOG_LEVEL) }}
       />
     ),
     api_field: {
@@ -134,7 +133,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     title: i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.agentLoggingToFilesTitle', {
       defaultMessage: 'Agent logging to files',
     }),
-    description: (
+    description: () => (
       <FormattedMessage
         id="xpack.fleet.settings.agentPolicyAdvanced.agentLoggingToFilesDescription"
         defaultMessage="Enables logging to rotating files."
@@ -153,7 +152,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     title: i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.agentLoggingFileSizeTitle', {
       defaultMessage: 'Agent logging file size limit',
     }),
-    description: (
+    description: () => (
       <FormattedMessage
         id="xpack.fleet.settings.agentPolicyAdvanced.agentLoggingFileSizeDescription"
         defaultMessage="Configure log file size limit in bytes. If limit is reached, log file will be automatically rotated."
@@ -172,7 +171,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     title: i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.agentLoggingFileLimitTitle', {
       defaultMessage: 'Agent logging number of files',
     }),
-    description: (
+    description: () => (
       <FormattedMessage
         id="xpack.fleet.settings.agentPolicyAdvanced.agentLoggingFileLimitDescription"
         defaultMessage="Number of rotated log files to keep. Oldest files will be deleted first."
@@ -194,7 +193,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
         defaultMessage: 'Agent logging file rotation interval',
       }
     ),
-    description: (
+    description: () => (
       <FormattedMessage
         id="xpack.fleet.settings.agentPolicyAdvanced.agentLoggingFileIntervalDescription"
         defaultMessage="Enable log file rotation on time intervals in addition to size-based rotation, i.e. 1s, 1m , 1h, 24h."
@@ -213,7 +212,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     title: i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.monitoringRuntimeTitle', {
       defaultMessage: 'Monitoring runtime (experimental)',
     }),
-    description: (
+    description: () => (
       <FormattedMessage
         id="xpack.fleet.settings.agentPolicyAdvanced.monitoringRuntimeDescription"
         defaultMessage="Change how the Beat inputs used for Elastic Agent self-monitored are executed."

--- a/x-pack/platform/plugins/shared/fleet/common/settings/types.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/settings/types.ts
@@ -5,14 +5,24 @@
  * 2.0.
  */
 
+import type React from 'react';
 import type { z } from '@kbn/zod';
 
 export type SettingsSection = 'AGENT_POLICY_ADVANCED_SETTINGS';
 
+/**
+ * Those dependencies are used to not require dependencies not used server side
+ */
+export interface SettingsUIDependencies {
+  renderer: {
+    renderCode: (code: string) => React.ReactNode;
+  };
+}
+
 export interface SettingsConfig {
   name: string;
   title: string;
-  description: string | React.ReactNode;
+  description: (deps: SettingsUIDependencies) => string | React.ReactNode;
   learnMoreLink?: string;
   schema: z.ZodTypeAny;
   api_field: {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/form_settings/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/form_settings/index.test.tsx
@@ -49,7 +49,7 @@ describe('ConfiguredSettings', () => {
       {
         name: 'agent.limits.go_max_procs',
         title: 'GO_MAX_PROCS',
-        description: 'Description',
+        description: () => 'Description',
         learnMoreLink: '',
         api_field: {
           name: 'agent_limits_go_max_procs',
@@ -78,7 +78,7 @@ describe('ConfiguredSettings', () => {
       {
         name: 'test',
         title: 'TEST',
-        description: 'Description',
+        description: () => 'Description',
         learnMoreLink: '',
         api_field: {
           name: 'test',
@@ -111,7 +111,7 @@ describe('ConfiguredSettings', () => {
       {
         name: 'test',
         title: 'TEST',
-        description: 'Description',
+        description: () => 'Description',
         learnMoreLink: '',
         api_field: {
           name: 'test',
@@ -153,7 +153,7 @@ describe('ConfiguredSettings', () => {
       {
         name: 'agent.download.timeout',
         title: 'Agent binary download timeout',
-        description: 'Description',
+        description: () => 'Description',
         learnMoreLink: '',
         api_field: {
           name: 'agent_download_timeout',
@@ -180,7 +180,7 @@ describe('ConfiguredSettings', () => {
       {
         name: 'agent.logging.to_files',
         title: 'Agent logging to files',
-        description: 'Description',
+        description: () => 'Description',
         learnMoreLink: '',
         api_field: {
           name: 'agent_logging_to_files',
@@ -210,7 +210,7 @@ describe('ConfiguredSettings', () => {
         name: 'agent.limits.go_max_procs',
         hidden: true,
         title: 'GO_MAX_PROCS',
-        description: 'Description',
+        description: () => 'Description',
         learnMoreLink: '',
         api_field: {
           name: 'agent_limits_go_max_procs',

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/form_settings/settings_field_wrapper.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/form_settings/settings_field_wrapper.tsx
@@ -8,7 +8,7 @@
 import { z, ZodFirstPartyTypeKind } from '@kbn/zod';
 import React, { useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiDescribedFormGroup, EuiFormRow, EuiLink } from '@elastic/eui';
+import { EuiCode, EuiDescribedFormGroup, EuiFormRow, EuiLink } from '@elastic/eui';
 
 import type { SettingsConfig } from '../../../../../common/settings/types';
 import { useAgentPolicyFormContext } from '../../sections/agent_policy/components/agent_policy_form';
@@ -32,6 +32,10 @@ export const validateSchema = (coercedSchema: z.ZodString, newValue: any): strin
   if (!validationResults.success) {
     return validationResults.error.issues[0].message;
   }
+};
+
+const renderer = {
+  renderCode: (code: string) => <EuiCode>{code}</EuiCode>,
 };
 
 export const SettingsFieldWrapper: React.FC<{
@@ -81,7 +85,7 @@ export const SettingsFieldWrapper: React.FC<{
       title={<h4>{settingsConfig.title}</h4>}
       description={
         <>
-          {settingsConfig.description}{' '}
+          {settingsConfig.description({ renderer })}{' '}
           {settingsConfig.learnMoreLink && (
             <EuiLink href={settingsConfig.learnMoreLink} external>
               <FormattedMessage

--- a/x-pack/platform/plugins/shared/fleet/server/services/form_settings/form_settings.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/form_settings/form_settings.test.ts
@@ -16,7 +16,7 @@ const TEST_SETTINGS: SettingsConfig[] = [
   {
     name: 'test.foo',
     title: 'test',
-    description: 'test',
+    description: () => 'test',
     schema: z.boolean(),
     api_field: {
       name: 'test_foo',
@@ -25,7 +25,7 @@ const TEST_SETTINGS: SettingsConfig[] = [
   {
     name: 'test.foo.default_value',
     title: 'test',
-    description: 'test',
+    description: () => 'test',
     schema: z.string().default('test'),
     api_field: {
       name: 'test_foo_default_value',


### PR DESCRIPTION
## Summary

Requiring EUI server side seems to have a huge impact on kibana start time ~800ms on a recent macbook, that PR remove the dependencies from Fleet server side code 