### PR TITLE
[Index Management] Fix small bug with unaccessible property

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/required_parameters_forms/index.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/required_parameters_forms/index.ts
@@ -32,7 +32,7 @@ export const getRequiredParametersFormForType = (
   if (subType) {
     const typeDefinition = TYPE_DEFINITION[type];
 
-    return typeDefinition.subTypes?.types.includes(subType)
+    return typeDefinition?.subTypes?.types.includes(subType)
       ? typeToParametersFormMap[subType]
       : undefined;
   }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/235676

## Summary

This bug seems to only happen on serverless, when creating a mapping and then attempting to delete whatever is in the mapping type field by default causes an error due to a property being accessed that isnt there yet.


https://github.com/user-attachments/assets/ea1aa1d1-5b81-4423-be78-e4ae2f08fafc

