### PR TITLE
[SharedUX] Add unit tests for the feedback snippet component

### DIFF
--- a/src/platform/packages/shared/shared-ux/feedback_snippet/README.md
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/README.md
@@ -21,3 +21,8 @@ The component has two main states:
 - **Prompt:** The panel shows a custom `promptViewMessage` to gather feedback from the user.
 - **Positive:** The panel shows a thank you message and then automatically dismisses itself.
 - **Negative:** The panel updates to show a custom `surveyUrl` call-to-action button. The panel remains visible until the user explicitly dismisses it or navigates to the survey (which opens in a new tab).
+
+## Running tests
+You can run tests with:
+
+`node scripts/jest --config=src/platform/packages/shared/shared-ux/feedback_snippet/jest.config.js`

--- a/src/platform/packages/shared/shared-ux/feedback_snippet/jest.config.js
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/jest.config.js
@@ -8,7 +8,7 @@
  */
 
 module.exports = {
-  preset: '@kbn/test/jest_node',
+  preset: '@kbn/test',
   rootDir: '../../../../../..',
   roots: ['<rootDir>/src/platform/packages/shared/shared-ux/feedback_snippet'],
 };

--- a/src/platform/packages/shared/shared-ux/feedback_snippet/src/__snapshots__/feedback_button.test.tsx.snap
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/src/__snapshots__/feedback_button.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FeedbackButton renders with the expected id 1`] = `
+<button
+  aria-label="Feedback button"
+  class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-text-FeedbackButton"
+  data-test-subj="feedbackSnippetButton"
+  id="feedbackSnippetTestIdButtonSurveyLink"
+  type="button"
+>
+  <span
+    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+  >
+    <span
+      class="eui-textTruncate euiButtonEmpty__text"
+    >
+      Got feedback?
+    </span>
+    <span
+      color="inherit"
+      data-euiicon-type="popout"
+    />
+  </span>
+</button>
+`;

--- a/src/platform/packages/shared/shared-ux/feedback_snippet/src/__snapshots__/feedback_panel.test.tsx.snap
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/src/__snapshots__/feedback_panel.test.tsx.snap
@@ -1,0 +1,188 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FeedbackPanel renders with the expected inner components based on the feedback view: negative 1`] = `
+<div
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-m-m-plain-hasShadow-FeedbackPanel"
+  data-test-subj="feedbackSnippetPanel"
+>
+  <div
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-spaceBetween-stretch-row"
+  >
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <div
+        class="euiText emotion-euiText-s-euiTextAlign-left"
+      >
+        Sorry to hear! Please, tell us a little more:
+      </div>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <button
+        aria-label="Close feedback panel"
+        class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+        data-test-subj="feedbackSnippetPanelDismiss"
+        id="feedbackSnippetTestIdPanelDismiss"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="cross"
+        />
+      </button>
+    </div>
+  </div>
+  <div
+    class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
+  />
+  <div
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-center-stretch-row"
+  >
+    <button
+      aria-label="Take quick survey"
+      class="euiButton emotion-euiButtonDisplay-s-fullWidth-defaultMinWidth-fill-primary"
+      id="feedbackSnippetTestIdPanelSurveyLink"
+      type="button"
+    >
+      <span
+        class="emotion-euiButtonDisplayContent"
+      >
+        Take quick survey
+        <span
+          color="inherit"
+          data-euiicon-type="popout"
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`FeedbackPanel renders with the expected inner components based on the feedback view: positive 1`] = `
+<div
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-m-m-plain-hasShadow-FeedbackPanel"
+  data-test-subj="feedbackSnippetPanel"
+>
+  <div
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-center-stretch-row"
+  >
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <div
+        class="euiText emotion-euiText-s-euiTextAlign-center"
+      >
+        Thanks for the feedback!
+        <br />
+        Glad you enjoy it!
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
+  />
+  <div
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-center-stretch-row"
+  >
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <span
+        color="success"
+        data-euiicon-type="faceHappy"
+        data-test-subj="feedbackSnippetPanelPositiveIcon"
+      >
+        Happy face
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FeedbackPanel renders with the expected inner components based on the feedback view: prompt 1`] = `
+<div
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-m-m-plain-hasShadow-FeedbackPanel"
+  data-test-subj="feedbackSnippetPanel"
+>
+  <div
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-spaceBetween-stretch-row"
+  >
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <div
+        class="euiText emotion-euiText-s-euiTextAlign-left"
+      >
+        Was this page helpful?
+      </div>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <button
+        aria-label="Close feedback panel"
+        class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+        data-test-subj="feedbackSnippetPanelDismiss"
+        id="feedbackSnippetTestIdPanelDismiss"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="cross"
+        />
+      </button>
+    </div>
+  </div>
+  <div
+    class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
+  />
+  <div
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-center-stretch-row"
+  >
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <button
+        class="euiButton emotion-euiButtonDisplay-s-defaultMinWidth-base-danger"
+        id="feedbackSnippetTestIdPanelThumbDown"
+        type="button"
+      >
+        <span
+          class="emotion-euiButtonDisplayContent"
+        >
+          <span
+            data-euiicon-type="thumbDown"
+          >
+            Thumb down
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <button
+        class="euiButton emotion-euiButtonDisplay-s-defaultMinWidth-base-success"
+        id="feedbackSnippetTestIdPanelThumbUp"
+        type="button"
+      >
+        <span
+          class="emotion-euiButtonDisplayContent"
+        >
+          <span
+            data-euiicon-type="thumbUp"
+          >
+            Thumb up
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_button.test.tsx
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_button.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import React from 'react';
+import { FeedbackButton } from './feedback_button';
+
+describe('FeedbackButton', () => {
+  const handleOpenSurveyMock = jest.fn();
+  beforeEach(() => {
+    render(
+      <FeedbackButton
+        feedbackButtonMessage={'Got feedback?'}
+        feedbackSnippetId={'feedbackSnippetTestId'}
+        handleOpenSurvey={handleOpenSurveyMock}
+      />
+    );
+  });
+
+  it('renders with the expected id', () => {
+    const button = screen.getByRole('button', { name: 'Feedback button' });
+    expect(button).toHaveAttribute('id', 'feedbackSnippetTestIdButtonSurveyLink');
+    expect(button).toMatchSnapshot();
+  });
+
+  it('calls open survey handler when clicked', async () => {
+    const button = screen.getByRole('button', { name: 'Feedback button' });
+    await userEvent.click(button);
+    expect(handleOpenSurveyMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_panel.test.tsx
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_panel.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { FeedbackPanel } from './feedback_panel';
+import type { FeedbackView } from './feedback_snippet';
+import { I18nProvider } from '@kbn/i18n-react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('./confetti');
+
+describe('FeedbackPanel', () => {
+  const handleDismissPanel = jest.fn();
+  const handleOpenSurveyAndDismissPanel = jest.fn();
+  const handleNegativeFeedback = jest.fn();
+  const handlePositiveFeedback = jest.fn();
+  const testCases: Array<{ view: FeedbackView; expectedElements: Array<() => HTMLElement> }> = [
+    {
+      view: 'prompt',
+      expectedElements: [
+        () => screen.getByRole('button', { name: 'Thumb down' }),
+        () => screen.getByRole('button', { name: 'Thumb up' }),
+        () => screen.getByRole('button', { name: 'Close feedback panel' }),
+      ],
+    },
+    {
+      view: 'positive',
+      expectedElements: [() => screen.getByTestId('feedbackSnippetPanelPositiveIcon')],
+    },
+    {
+      view: 'negative',
+      expectedElements: [() => screen.getByRole('button', { name: 'Take quick survey' })],
+    },
+  ];
+  const renderPanel = (view: FeedbackView) => {
+    return render(
+      <I18nProvider>
+        <FeedbackPanel
+          feedbackSnippetId="feedbackSnippetTestId"
+          feedbackView={view}
+          promptViewMessage="Was this page helpful?"
+          handleDismissPanel={handleDismissPanel}
+          handleOpenSurveyAndDismissPanel={handleOpenSurveyAndDismissPanel}
+          handleNegativeFeedback={handleNegativeFeedback}
+          handlePositiveFeedback={handlePositiveFeedback}
+        />
+      </I18nProvider>
+    );
+  };
+
+  it.each(testCases)(
+    'renders with the expected inner components based on the feedback view: $view',
+    async ({ view, expectedElements }) => {
+      renderPanel(view);
+      const panel = await screen.findByTestId('feedbackSnippetPanel');
+      for (const findElement of expectedElements) {
+        const element = findElement();
+        expect(element).toBeInTheDocument();
+        expect(panel.contains(element)).toBe(true);
+      }
+      expect(panel).toMatchSnapshot();
+    }
+  );
+
+  it('calls handlePositiveFeedback when thumb up is clicked', async () => {
+    renderPanel('prompt');
+    const button = screen.getByRole('button', { name: 'Thumb up' });
+    await userEvent.click(button);
+    expect(handlePositiveFeedback).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls handleNegativeFeedback when thumb down is clicked', async () => {
+    renderPanel('prompt');
+    const button = screen.getByRole('button', { name: 'Thumb down' });
+    await userEvent.click(button);
+    expect(handleNegativeFeedback).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls handleDismissPanel when close is clicked', async () => {
+    renderPanel('prompt');
+    const button = screen.getByRole('button', { name: 'Close feedback panel' });
+    await userEvent.click(button);
+    expect(handleDismissPanel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls handleOpenSurveyAndDismissPanel when survey button is clicked', async () => {
+    renderPanel('negative');
+    const button = screen.getByRole('button', { name: 'Take quick survey' });
+    await userEvent.click(button);
+    expect(handleOpenSurveyAndDismissPanel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_panel.tsx
@@ -137,7 +137,13 @@ export const FeedbackPanel = ({
 
   const positiveFooter = (
     <EuiFlexItem grow={false}>
-      <EuiIcon type="faceHappy" color="success" size="l" aria-label={faceHappyIconLabel} />
+      <EuiIcon
+        data-test-subj="feedbackSnippetPanelPositiveIcon"
+        type="faceHappy"
+        color="success"
+        size="l"
+        aria-label={faceHappyIconLabel}
+      />
     </EuiFlexItem>
   );
 

--- a/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_snippet.test.tsx
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_snippet.test.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { I18nProvider } from '@kbn/i18n-react';
+import { FeedbackSnippet } from './feedback_snippet';
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('./confetti');
+
+describe('FeedbackSnippet', () => {
+  const props = {
+    feedbackButtonMessage: 'Got feedback?',
+    feedbackSnippetId: 'feedbackSnippetTestId',
+    promptViewMessage: 'Was this page helpful?',
+    surveyUrl: 'https://www.elastic.co',
+  };
+
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+    Object.defineProperty(window, 'open', {
+      value: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const renderComponent = () =>
+    render(
+      <I18nProvider>
+        <FeedbackSnippet {...props} />
+      </I18nProvider>
+    );
+
+  /**
+   * GIVEN the localStorage key is set
+   * WHEN the feedback snippet renders
+   * THEN it should take the form of a feedback button
+   */
+  it('renders the feedback button if local storage key is set', () => {
+    localStorage.setItem(props.feedbackSnippetId, Date.now().toString());
+    renderComponent();
+    expect(screen.getByRole('button', { name: 'Feedback button' })).toBeInTheDocument();
+    expect(screen.queryByTestId('feedbackSnippetPanel')).not.toBeInTheDocument();
+  });
+
+  /**
+   * GIVEN the localStorage key is not set
+   * WHEN the feedback snippet renders
+   * THEN it should take the form of a feedback panel
+   */
+  it('renders the feedback panel if local storage key is not set', () => {
+    renderComponent();
+    expect(screen.getByTestId('feedbackSnippetPanel')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Feedback button' })).not.toBeInTheDocument();
+  });
+
+  describe('panel flows', () => {
+    /**
+     * GIVEN the feedback panel is rendered
+     * WHEN I click the positive feedback button
+     * THEN I should see the positive feedback view
+     * AND after a timeout the panel should disappear
+     * AND the feedback button should be shown
+     */
+    it('positive feedback flow: shows positive view, then disappears and shows button', async () => {
+      renderComponent();
+      await user.click(screen.getByRole('button', { name: 'Thumb up' }));
+      expect(await screen.findByTestId('feedbackSnippetPanelPositiveIcon')).toBeInTheDocument();
+      await act(() => {
+        jest.runAllTimers();
+      });
+      expect(screen.queryByTestId('feedbackSnippetPanelPositiveIcon')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Feedback button' })).toBeInTheDocument();
+      expect(localStorage.getItem(props.feedbackSnippetId)).not.toBeNull();
+    });
+
+    /**
+     * GIVEN the feedback panel is rendered
+     * WHEN I click the negative feedback button and then the survey button
+     * THEN the survey should open in a new tab
+     * AND the panel should disappear
+     * AND the feedback button should be shown
+     */
+    it('negative feedback flow: shows negative view with survey button, clicking it opens survey and shows feedback button', async () => {
+      renderComponent();
+      await user.click(screen.getByRole('button', { name: 'Thumb down' }));
+      expect(screen.getByRole('button', { name: 'Take quick survey' })).toBeInTheDocument();
+      expect(localStorage.getItem(props.feedbackSnippetId)).not.toBeNull();
+      await user.click(screen.getByRole('button', { name: 'Take quick survey' }));
+      expect(window.open).toHaveBeenCalledWith(props.surveyUrl, '_blank');
+      expect(screen.getByRole('button', { name: 'Feedback button' })).toBeInTheDocument();
+      expect(screen.queryByTestId('feedbackSnippetPanel')).not.toBeInTheDocument();
+    });
+
+    /**
+     * GIVEN the feedback panel is rendered
+     * WHEN I click the dismiss panel button
+     * THEN the panel should disappear
+     * AND the feedback button should be shown
+     */
+    it('dismiss panel flow: clicking dismiss button hides panel and shows feedback button', async () => {
+      renderComponent();
+      await user.click(screen.getByRole('button', { name: 'Close feedback panel' }));
+      expect(screen.queryByTestId('feedbackSnippetPanel')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Feedback button' })).toBeInTheDocument();
+      expect(localStorage.getItem(props.feedbackSnippetId)).not.toBeNull();
+    });
+  });
+
+  describe('button flows', () => {
+    /**
+     * GIVEN the feedback button is rendered
+     * WHEN I click the survey button
+     * THEN the survey should open in a new tab
+     */
+    it('feedback button flow: clicking the button opens the survey', async () => {
+      localStorage.setItem(props.feedbackSnippetId, Date.now().toString());
+      renderComponent();
+      await user.click(screen.getByRole('button', { name: 'Feedback button' }));
+      expect(window.open).toHaveBeenCalledWith(props.surveyUrl, '_blank');
+    });
+  });
+});

--- a/src/platform/packages/shared/shared-ux/feedback_snippet/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/tsconfig.json
@@ -2,12 +2,6 @@
   "extends": "../../../../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "target/types",
-    "types": [
-      "jest",
-      "node",
-      "react",
-      "@emotion/react/types/css-prop",
-    ]
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/234445

## Summary

- Added unit tests for the feedback snippet component.
- Followed the GIVEN, WHEN, THEN pattern for `feedback_snippet` test file which is the one carrying most of the user interaction logic (inspired by https://github.com/elastic/kibana/pull/232925).
- Included snapshot tests for both the panel and the button test files.

## Testing
You can run them with: `node scripts/jest --config=src/platform/packages/shared/shared-ux/feedback_snippet/jest.config.js`

**Test coverage:** 

(Stories and confetti animation have no tests)

File                                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                        
-----------------------------------------|---------|----------|---------|---------|------------------------------------------
 shared-ux/feedback_snippet/src          |   91.66 |      100 |   92.85 |   91.48 |                                          
  feedback_button.tsx                    |     100 |      100 |     100 |     100 |                                          
  feedback_panel.tsx                     |     100 |      100 |     100 |     100 |                                          
  feedback_snippet.stories.tsx           |       0 |      100 |       0 |       0 | 14-37                                    
  feedback_snippet.tsx                   |     100 |      100 |     100 |     100 |                                          
 shared-ux/feedback_snippet/src/confetti |       0 |        0 |       0 |       0 |                                          
  confetti.component.tsx                 |       0 |        0 |       0 |       0 | 14-38                                    
