### PR TITLE
[Agent builder] Add serverless FTR config for agent builder tests

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -402,7 +402,6 @@ enabled:
   - x-pack/platform/test/encrypted_saved_objects_api_integration/config.ts
   - x-pack/platform/test/fleet_multi_cluster/config.ts
   - x-pack/platform/test/monitoring_api_integration/config.ts
-  - x-pack/platform/test/onechat_api_integration/configs/config.stateful.ts
   - x-pack/platform/test/plugin_api_integration/config.ts
   - x-pack/platform/test/saved_object_api_integration/security_and_spaces/config_basic.ts
   - x-pack/platform/test/saved_object_api_integration/security_and_spaces/config_trial.ts

--- a/.buildkite/ftr_search_serverless_configs.yml
+++ b/.buildkite/ftr_search_serverless_configs.yml
@@ -27,3 +27,5 @@ enabled:
   - x-pack/platform/test/serverless/functional/configs/search/config.group10.ts
   - x-pack/platform/test/serverless/functional/configs/search/config.group11.ts
   - x-pack/platform/test/serverless/functional/configs/search/config.group12.ts
+  - x-pack/platform/test/onechat_api_integration/configs/config.serverless.ts
+

--- a/.buildkite/ftr_search_stateful_configs.yml
+++ b/.buildkite/ftr_search_stateful_configs.yml
@@ -12,3 +12,4 @@ enabled:
   - x-pack/solutions/search/test/functional_solution_sidenav/config.ts
   - x-pack/solutions/search/test/functional_solution_sidenav/config.nav_v2.ts
   - x-pack/solutions/search/test/accessibility/config.ts
+  - x-pack/platform/test/onechat_api_integration/configs/config.stateful.ts

--- a/x-pack/platform/test/onechat_api_integration/apis/builtin_tools_internal.ts
+++ b/x-pack/platform/test/onechat_api_integration/apis/builtin_tools_internal.ts
@@ -21,6 +21,7 @@ export default function ({ getService }: FtrProviderContext) {
         const response = await supertest
           .post('/internal/agent_builder/tools/_bulk_delete')
           .set('kbn-xsrf', 'kibana')
+          .set('x-elastic-internal-origin', 'kibana')
           .send({ ids: toolIds })
           .expect(200);
 
@@ -62,6 +63,7 @@ export default function ({ getService }: FtrProviderContext) {
         const response = await supertest
           .post('/internal/agent_builder/tools/_bulk_delete')
           .set('kbn-xsrf', 'kibana')
+          .set('x-elastic-internal-origin', 'kibana')
           .send({ ids: mixedToolIds })
           .expect(200);
 

--- a/x-pack/platform/test/onechat_api_integration/configs/config.serverless.ts
+++ b/x-pack/platform/test/onechat_api_integration/configs/config.serverless.ts
@@ -13,6 +13,6 @@ export default createServerlessTestConfig({
   services: oneChatServices,
   testFiles: [require.resolve('../apis')],
   junit: {
-    reportName: 'X-Pack Agent Builder API Integration Tests',
+    reportName: 'X-Pack Agent Builder Serverless API Integration Tests',
   },
 });

--- a/x-pack/platform/test/onechat_api_integration/configs/config.serverless.ts
+++ b/x-pack/platform/test/onechat_api_integration/configs/config.serverless.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerlessTestConfig } from '../../api_integration_deployment_agnostic/default_configs/serverless.config.base';
+import { oneChatServices } from './ftr_provider_context';
+
+export default createServerlessTestConfig({
+  serverlessProject: 'chat',
+  services: oneChatServices,
+  testFiles: [require.resolve('../apis')],
+  junit: {
+    reportName: 'X-Pack Agent Builder API Integration Tests',
+  },
+});

--- a/x-pack/platform/test/onechat_api_integration/configs/config.serverless.ts
+++ b/x-pack/platform/test/onechat_api_integration/configs/config.serverless.ts
@@ -9,7 +9,7 @@ import { createServerlessTestConfig } from '../../api_integration_deployment_agn
 import { oneChatServices } from './ftr_provider_context';
 
 export default createServerlessTestConfig({
-  serverlessProject: 'chat',
+  serverlessProject: 'es',
   services: oneChatServices,
   testFiles: [require.resolve('../apis')],
   junit: {

--- a/x-pack/platform/test/onechat_api_integration/configs/config.stateful.ts
+++ b/x-pack/platform/test/onechat_api_integration/configs/config.stateful.ts
@@ -12,7 +12,7 @@ export default createStatefulTestConfig({
   services: oneChatServices,
   testFiles: [require.resolve('../apis')],
   junit: {
-    reportName: 'X-Pack Agent Builder API Integration Tests',
+    reportName: 'X-Pack Agent Builder Stateful API Integration Tests',
   },
   // @ts-expect-error
   kbnTestServer: {

--- a/x-pack/platform/test/onechat_api_integration/utils/llm_proxy/llm_proxy_action_connector.ts
+++ b/x-pack/platform/test/onechat_api_integration/utils/llm_proxy/llm_proxy_action_connector.ts
@@ -16,7 +16,7 @@ export async function createLlmProxyActionConnector(
   const logger = getService('log');
 
   const internalReqHeader = samlAuth.getInternalRequestHeader();
-  const roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('editor');
+  const roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('admin');
 
   try {
     const res = await supertestWithoutAuth
@@ -52,7 +52,7 @@ export async function deleteActionConnector(
   const samlAuth = getService('samlAuth');
 
   const internalReqHeader = samlAuth.getInternalRequestHeader();
-  const roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('editor');
+  const roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('admin');
   return supertestWithoutAuth
     .delete(`/api/actions/connector/${actionId}`)
     .set(roleAuthc.apiKeyHeader)


### PR DESCRIPTION
## Summary

relates to https://github.com/elastic/search-team/issues/11086

- Enables existing onechat FTR tests to run on serverless



