### PR TITLE
Unflatten doc before applying filterlist

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.test.ts
@@ -27,6 +27,20 @@ describe('Security Solution - Health Diagnostic Queries - utils', () => {
       });
     });
 
+    test('should keep fields marked with KEEP action in flat doc', async () => {
+      const data = [{ 'kibana.alert.rule.name': 'Endpoint Security (Elastic Defend)' }];
+      const rules = {
+        'user.name': Action.KEEP,
+        'kibana.alert.rule.name': Action.KEEP,
+      };
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toEqual([
+        { kibana: { alert: { rule: { name: 'Endpoint Security (Elastic Defend)' } } } },
+      ]);
+    });
+
     test('should keep fields marked with KEEP action', async () => {
       const data = [{ user: { name: 'john', email: 'john@example.com' } }];
       const rules = {
@@ -96,31 +110,6 @@ describe('Security Solution - Health Diagnostic Queries - utils', () => {
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((result[0] as any).meta.host.ip).not.toBe('192.168.1.1');
-    });
-
-    test('should handle arrays of documents', async () => {
-      const data = [
-        [
-          { user: 'alice', token: 'abc123' },
-          { user: 'bob', token: 'xyz789' },
-        ],
-      ];
-      const rules = {
-        user: Action.KEEP,
-        token: Action.MASK,
-      };
-
-      const result = await applyFilterlist(data, rules, mockSalt);
-
-      expect(result).toHaveLength(1);
-      expect(Array.isArray(result[0])).toBe(true);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const docs = result[0] as any[];
-      expect(docs).toHaveLength(2);
-      expect(docs[0].user).toBe('alice');
-      expect(docs[1].user).toBe('bob');
-      expect(docs[0].token).not.toBe('abc123');
-      expect(docs[1].token).not.toBe('xyz789');
     });
 
     test('should handle arrays of complex documents', async () => {
@@ -299,30 +288,6 @@ describe('Security Solution - Health Diagnostic Queries - utils', () => {
           },
         },
       ]);
-    });
-
-    test('should handle mixed document types', async () => {
-      const data = [
-        { type: 'user', name: 'john', password: 'secret' },
-        [{ type: 'admin', name: 'admin', token: 'admin123' }],
-      ];
-      const rules = {
-        name: Action.KEEP,
-        password: Action.MASK,
-        token: Action.MASK,
-      };
-
-      const result = await applyFilterlist(data, rules, mockSalt);
-
-      expect(result).toHaveLength(2);
-      expect(result[0]).toMatchObject({ name: 'john' });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((result[0] as any).password).not.toBe('secret');
-      expect(Array.isArray(result[1])).toBe(true);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const adminDocs = result[1] as any[];
-      expect(adminDocs[0].name).toBe('admin');
-      expect(adminDocs[0].token).not.toBe('admin123');
     });
 
     test('should handle numeric and boolean values', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.ts
@@ -13,6 +13,8 @@ import {
   type HealthDiagnosticQuery,
   type HealthDiagnosticQueryStats,
 } from './health_diagnostic_service.types';
+import { unflatten } from '../helpers';
+import type { AnyObject } from '../types';
 
 export function shouldExecute(startDate: Date, endDate: Date, interval: Interval): boolean {
   const nextDate = intervalFromDate(startDate, interval);
@@ -131,7 +133,8 @@ export async function applyFilterlist(
     }
   };
 
-  for (const doc of data) {
+  for (const rawDoc of data) {
+    const doc = unflatten(rawDoc as AnyObject);
     if (Array.isArray(doc)) {
       const docs = doc as unknown[];
       const result = await Promise.all(


### PR DESCRIPTION
## Summary

Due that some documents have dots in the fieldnames, e.g., `kibana.alert.original_event.kind` is a single field and not `{"kibana": { "alert": ... } }`, we need to unflatten those fields before applying the filterlist.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->