### PR TITLE
[Search] remove connectors from classic navigation

### DIFF
--- a/x-pack/solutions/search/plugins/search_navigation/public/base_classic_navigation_items.tsx
+++ b/x-pack/solutions/search/plugins/search_navigation/public/base_classic_navigation_items.tsx
@@ -49,14 +49,6 @@ export const BaseClassicNavItems: ClassicNavItem[] = [
         id: 'playground',
       },
       {
-        'data-test-subj': 'searchSideNav-Connectors',
-        deepLink: {
-          link: 'enterpriseSearchContent:connectors',
-          shouldShowActiveForSubroutes: true,
-        },
-        id: 'connectors',
-      },
-      {
         'data-test-subj': 'searchSideNav-SearchApplications',
         deepLink: {
           link: 'enterpriseSearchApplications:searchApplications',

--- a/x-pack/solutions/search/plugins/search_navigation/public/classic_navigation.test.ts
+++ b/x-pack/solutions/search/plugins/search_navigation/public/classic_navigation.test.ts
@@ -28,6 +28,11 @@ describe('classicNavigationFactory', function () {
       title: 'Web Crawlers',
       url: '/app/elasticsearch/content/crawlers',
     },
+    {
+      id: 'elasticsearchIndexManagement',
+      url: '/app/elasticsearch/index_management',
+      title: 'Index Management',
+    },
   ];
   const mockedCoreStart = {
     chrome: {
@@ -106,10 +111,11 @@ describe('classicNavigationFactory', function () {
         name: 'Content',
         items: [
           {
-            id: 'searchConnectors',
+            'data-test-subj': 'searchSideNav-Indices',
             deepLink: {
-              link: 'enterpriseSearchContent:connectors',
+              link: 'elasticsearchIndexManagement',
             },
+            id: 'search_indices',
           },
         ],
       },
@@ -121,10 +127,11 @@ describe('classicNavigationFactory', function () {
         id: 'searchContent',
         items: [
           {
-            href: '/app/elasticsearch/content/connectors',
-            id: 'searchConnectors',
+            'data-test-subj': 'searchSideNav-Indices',
+            href: '/app/elasticsearch/index_management',
+            id: 'search_indices',
             isSelected: false,
-            name: 'Connectors',
+            name: 'Index Management',
             onClick: expect.any(Function),
           },
         ],
@@ -135,20 +142,20 @@ describe('classicNavigationFactory', function () {
   it('returns name if provided over the deeplink title', () => {
     const items: ClassicNavItem[] = [
       {
-        id: 'searchConnectors',
+        id: 'search_indices',
         deepLink: {
-          link: 'enterpriseSearchContent:connectors',
+          link: 'elasticsearchIndexManagement',
         },
-        name: 'Date connectors',
+        name: 'Indices',
       },
     ];
     const solutionNav = classicNavigationFactory(items, core, history);
     expect(solutionNav!.items).toEqual([
       {
-        href: '/app/elasticsearch/content/connectors',
-        id: 'searchConnectors',
+        href: '/app/elasticsearch/index_management',
+        id: 'search_indices',
         isSelected: false,
-        name: 'Date connectors',
+        name: 'Indices',
         onClick: expect.any(Function),
       },
     ]);

--- a/x-pack/solutions/search/test/functional_search/tests/classic_navigation.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/classic_navigation.ts
@@ -46,7 +46,6 @@ export default function searchSolutionNavigation({
         { id: 'Build', label: 'Build' },
         { id: 'Indices', label: 'Index Management' },
         { id: 'Playground', label: 'Playground' },
-        { id: 'Connectors', label: 'Connectors' },
         { id: 'SearchApplications', label: 'Search applications' },
         { id: 'Relevance', label: 'Relevance' },
         { id: 'Synonyms', label: 'Synonyms' },
@@ -68,11 +67,6 @@ export default function searchSolutionNavigation({
           navItem: 'Indices',
           breadcrumbs: ['Build', 'Index Management'],
           pageTestSubject: 'indexManagementHeaderContent',
-        },
-        {
-          navItem: 'Connectors',
-          breadcrumbs: ['Build', 'Connectors'],
-          pageTestSubject: 'searchCreateConnectorPage',
         },
         {
           navItem: 'Playground',


### PR DESCRIPTION
## Summary

Removes Connectors from the Elasticsearch classic navigation.

### Screenshots

**TODO**

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release note

**TODO**