### PR TITLE
[Controls Anywhere] Add use global filters to range slider

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/data_controls/components/custom_options_additional_settings.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/components/custom_options_additional_settings.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiFormRow, EuiSpacer, EuiSwitch } from '@elastic/eui';
+import React, { useState } from 'react';
+import { DataControlEditorStrings } from '../data_control_constants';
+import type { CustomOptionsComponentProps } from '../types';
+
+type Props = React.PropsWithChildren<
+  Pick<CustomOptionsComponentProps, 'initialState' | 'updateState'>
+>;
+
+export const CustomOptionsAdditionalSettings: React.FC<Props> = ({
+  children,
+  initialState,
+  updateState,
+}) => {
+  const [useGlobalFilters, setUseGlobalFilters] = useState<boolean>(
+    initialState.useGlobalFilters ?? true
+  );
+  return (
+    <EuiFormRow label={DataControlEditorStrings.manageControl.getAdditionalSettingsTitle()}>
+      <>
+        <EuiSwitch
+          compressed
+          label={DataControlEditorStrings.manageControl.getUseGlobalFiltersTitle()}
+          checked={useGlobalFilters}
+          onChange={() => {
+            const newUseGlobalFilters = !useGlobalFilters;
+            setUseGlobalFilters(newUseGlobalFilters);
+            updateState({ useGlobalFilters: newUseGlobalFilters });
+          }}
+          data-test-subj={'optionsListControl__useGlobalFiltersAdditionalSetting'}
+        />
+        {children ? (
+          <>
+            <EuiSpacer size="s" />
+            {children}
+          </>
+        ) : null}
+      </>
+    </EuiFormRow>
+  );
+};

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/components/index.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/components/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { CustomOptionsAdditionalSettings } from './custom_options_additional_settings';

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/data_control_constants.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/data_control_constants.tsx
@@ -108,5 +108,13 @@ export const DataControlEditorStrings = {
       i18n.translate('controls.controlGroup.management.delete', {
         defaultMessage: 'Delete control',
       }),
+    getAdditionalSettingsTitle: () =>
+      i18n.translate('controls.controlGroup.manageControl.additionalSettingsTitle', {
+        defaultMessage: `Additional settings`,
+      }),
+    getUseGlobalFiltersTitle: () =>
+      i18n.translate('controls.controlGroup.manageControl.useGlobalFilters', {
+        defaultMessage: 'Use global filters',
+      }),
   },
 };

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/data_control_manager.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/data_control_manager.ts
@@ -29,7 +29,7 @@ export const defaultDataControlComparators: StateComparators<DataControlState> =
   ...titleComparators,
   dataViewId: 'referenceEquality',
   fieldName: 'referenceEquality',
-  useGlobalFilters: (a, b) => a === b,
+  useGlobalFilters: (a, b) => (a ?? true) === (b ?? true),
 };
 
 export type DataControlStateManager = Omit<StateManager<DataControlState>, 'api'> & {

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/data_control_manager.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/data_control_manager.ts
@@ -29,7 +29,7 @@ export const defaultDataControlComparators: StateComparators<DataControlState> =
   ...titleComparators,
   dataViewId: 'referenceEquality',
   fieldName: 'referenceEquality',
-  useGlobalFilters: (a, b) => a ?? true === b ?? true,
+  useGlobalFilters: (a, b) => a === b,
 };
 
 export type DataControlStateManager = Omit<StateManager<DataControlState>, 'api'> & {

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_editor_options.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_editor_options.tsx
@@ -9,14 +9,15 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 
-import { EuiFormRow, EuiRadioGroup, EuiSpacer, EuiSwitch } from '@elastic/eui';
-import type { OptionsListControlState, OptionsListSearchTechnique } from '@kbn/controls-schemas';
+import { EuiFormRow, EuiRadioGroup, EuiSwitch } from '@elastic/eui';
+import type { OptionsListDSLControlState, OptionsListSearchTechnique } from '@kbn/controls-schemas';
 
 import { getCompatibleSearchTechniques } from '../../../../../common/options_list/suggestions_searching';
 import { ControlSettingTooltipLabel } from '../../../../control_group/components/control_setting_tooltip_label';
 import type { CustomOptionsComponentProps } from '../../types';
 import { DEFAULT_SEARCH_TECHNIQUE } from '../constants';
 import { OptionsListStrings } from '../options_list_strings';
+import { CustomOptionsAdditionalSettings } from '../../components';
 
 const selectionOptions = [
   {
@@ -68,7 +69,7 @@ export const OptionsListEditorOptions = ({
   initialState,
   field,
   updateState,
-}: CustomOptionsComponentProps<OptionsListControlState>) => {
+}: CustomOptionsComponentProps<OptionsListDSLControlState>) => {
   // const allowExpensiveQueries = useStateFromPublishingSubject(
   //   controlGroupApi.allowExpensiveQueries$
   // );
@@ -77,9 +78,7 @@ export const OptionsListEditorOptions = ({
   const [runPastTimeout, setRunPastTimeout] = useState<boolean>(
     initialState.runPastTimeout ?? false
   );
-  const [useGlobalFilters, setUseGlobalFilters] = useState<boolean>(
-    initialState.useGlobalFilters ?? true
-  );
+
   const [searchTechnique, setSearchTechnique] = useState<OptionsListSearchTechnique>(
     initialState.searchTechnique ?? DEFAULT_SEARCH_TECHNIQUE
   );
@@ -159,38 +158,24 @@ export const OptionsListEditorOptions = ({
           />
         </EuiFormRow>
       )}
-      <EuiFormRow label={OptionsListStrings.editor.getAdditionalSettingsTitle()}>
-        <>
-          <EuiSwitch
-            compressed
-            label={OptionsListStrings.editor.getUseGlobalFiltersTitle()}
-            checked={useGlobalFilters}
-            onChange={() => {
-              const newUseGlobalFilters = !useGlobalFilters;
-              setUseGlobalFilters(newUseGlobalFilters);
-              updateState({ useGlobalFilters: newUseGlobalFilters });
-            }}
-            data-test-subj={'optionsListControl__useGlobalFiltersAdditionalSetting'}
-          />
-          <EuiSpacer size="s" />
-          <EuiSwitch
-            compressed
-            label={
-              <ControlSettingTooltipLabel
-                label={OptionsListStrings.editor.getRunPastTimeoutTitle()}
-                tooltip={OptionsListStrings.editor.getRunPastTimeoutTooltip()}
-              />
-            }
-            checked={runPastTimeout}
-            onChange={() => {
-              const newRunPastTimeout = !runPastTimeout;
-              setRunPastTimeout(newRunPastTimeout);
-              updateState({ runPastTimeout: newRunPastTimeout });
-            }}
-            data-test-subj={'optionsListControl__runPastTimeoutAdditionalSetting'}
-          />
-        </>
-      </EuiFormRow>
+      <CustomOptionsAdditionalSettings initialState={initialState} updateState={updateState}>
+        <EuiSwitch
+          compressed
+          label={
+            <ControlSettingTooltipLabel
+              label={OptionsListStrings.editor.getRunPastTimeoutTitle()}
+              tooltip={OptionsListStrings.editor.getRunPastTimeoutTooltip()}
+            />
+          }
+          checked={runPastTimeout}
+          onChange={() => {
+            const newRunPastTimeout = !runPastTimeout;
+            setRunPastTimeout(newRunPastTimeout);
+            updateState({ runPastTimeout: newRunPastTimeout });
+          }}
+          data-test-subj={'optionsListControl__runPastTimeoutAdditionalSetting'}
+        />
+      </CustomOptionsAdditionalSettings>
     </>
   );
 };

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/fetch_and_validate.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/fetch_and_validate.tsx
@@ -21,6 +21,7 @@ import { isValidSearch } from '../../../../common/options_list/is_valid_search';
 import type { OptionsListSuccessResponse } from '../../../../common/options_list/types';
 import { OptionsListFetchCache } from './options_list_fetch_cache';
 import type { OptionsListComponentApi, OptionsListControlApi } from './types';
+import { getFetchContextFilters } from '../utils';
 
 export function fetchAndValidate$({
   api,
@@ -87,11 +88,7 @@ export function fetchAndValidate$({
 
         /** Fetch the suggestions list + perform validation */
         api.loadingSuggestions$.next(true);
-        if (!useGlobalFilters) {
-          fetchContext.filters = fetchContext.filters?.filter(
-            (currentFilter) => Boolean(currentFilter.meta.controlledBy) // filters without `controlledBy` are coming from unified search
-          );
-        }
+        fetchContext.filters = getFetchContextFilters(fetchContext, useGlobalFilters);
 
         const request = {
           sort,

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/options_list_strings.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/options_list_strings.ts
@@ -109,10 +109,6 @@ export const OptionsListStrings = {
           }),
       },
     },
-    getAdditionalSettingsTitle: () =>
-      i18n.translate('controls.optionsList.editor.additionalSettingsTitle', {
-        defaultMessage: `Additional settings`,
-      }),
     getRunPastTimeoutTitle: () =>
       i18n.translate('controls.optionsList.editor.runPastTimeout', {
         defaultMessage: 'Ignore timeout for results',
@@ -121,10 +117,6 @@ export const OptionsListStrings = {
       i18n.translate('controls.optionsList.editor.runPastTimeout.tooltip', {
         defaultMessage:
           'Wait to display results until the list is complete. This setting is useful for large data sets, but the results might take longer to populate.',
-      }),
-    getUseGlobalFiltersTitle: () =>
-      i18n.translate('controls.optionsList.editor.useGlobalFilters', {
-        defaultMessage: 'Use global filters',
       }),
   },
   popover: {

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/components/editor/range_slider_editor_options.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/components/editor/range_slider_editor_options.tsx
@@ -12,6 +12,7 @@ import React, { useState } from 'react';
 import type { RangeSliderControlState } from '@kbn/controls-schemas';
 import { RangeSliderStrings } from '../../range_slider_strings';
 import type { CustomOptionsComponentProps } from '../../../types';
+import { CustomOptionsAdditionalSettings } from '../../../components';
 
 export const RangeSliderEditorOptions = ({
   initialState,
@@ -21,20 +22,23 @@ export const RangeSliderEditorOptions = ({
   const [step, setStep] = useState(initialState.step ?? 1);
 
   return (
-    <EuiFormRow fullWidth label={RangeSliderStrings.editor.getStepTitle()}>
-      <EuiFieldNumber
-        compressed
-        value={step}
-        onChange={(event) => {
-          const newStep = event.target.valueAsNumber;
-          setStep(newStep);
-          updateState({ step: newStep });
-          setControlEditorValid(newStep > 0);
-        }}
-        min={0}
-        isInvalid={step === undefined || step <= 0}
-        data-test-subj="rangeSliderControl__stepAdditionalSetting"
-      />
-    </EuiFormRow>
+    <>
+      <EuiFormRow fullWidth label={RangeSliderStrings.editor.getStepTitle()}>
+        <EuiFieldNumber
+          compressed
+          value={step}
+          onChange={(event) => {
+            const newStep = event.target.valueAsNumber;
+            setStep(newStep);
+            updateState({ step: newStep });
+            setControlEditorValid(newStep > 0);
+          }}
+          min={0}
+          isInvalid={step === undefined || step <= 0}
+          data-test-subj="rangeSliderControl__stepAdditionalSetting"
+        />
+      </EuiFormRow>
+      <CustomOptionsAdditionalSettings initialState={initialState} updateState={updateState} />
+    </>
   );
 };

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/get_range_slider_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/get_range_slider_control_factory.tsx
@@ -140,6 +140,7 @@ export const getRangesliderControlFactory = (): EmbeddableFactory<
         controlFetch$,
         dataViews$: dataControlManager.api.dataViews$,
         fieldName$: dataControlManager.api.fieldName$,
+        useGlobalFilters$: dataControlManager.api.useGlobalFilters$,
         setIsLoading: (isLoading: boolean) => {
           // clear previous loading error on next loading start
           if (isLoading && dataControlManager.api.blockingError$.value) {
@@ -199,6 +200,7 @@ export const getRangesliderControlFactory = (): EmbeddableFactory<
         controlFetch$,
         dataViews$: dataControlManager.api.dataViews$,
         rangeFilters$: dataControlManager.api.appliedFilters$,
+        useGlobalFilters$: dataControlManager.api.useGlobalFilters$,
         setIsLoading: (isLoading: boolean) => {
           loadingHasNoResults$.next(isLoading);
         },

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/utils/filter_utils.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/utils/filter_utils.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FetchContext } from '@kbn/presentation-publishing';
+
+export const getFetchContextFilters = (fetchContext: FetchContext, useGlobalFilters?: boolean) => {
+  if (!useGlobalFilters) {
+    return fetchContext.filters?.filter(
+      (currentFilter) => Boolean(currentFilter.meta.controlledBy) // filters without `controlledBy` are coming from unified search
+    );
+  }
+  return fetchContext.filters;
+};

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/utils/index.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/utils/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export * from './filter_utils';


### PR DESCRIPTION
## Summary

Closes #235865 

- Adds the Use Global Filters setting to the Range Slider control
- Makes the Use Global Filters setting work on the Range Slider control
- Abstracts out the "Additional Settings" section of the custom options component so that it's easy to reuse across both types of data control
- Fixes a bug in the `useGlobalFilters` comparator that didn't actually allow you to disable it in the editor and save changes