### PR TITLE
[Agent builder] Save viz to dashboard

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/visualize_esql.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/visualize_esql.tsx
@@ -60,7 +60,6 @@ export function VisualizeESQL({
 
   const [lensInput, setLensInput] = useState<TypedLensByValueInput | undefined>();
 
-  // initialization
   useEffect(() => {
     if (lensHelpersAsync.value && dataViewAsync.value && !lensInput) {
       const context = {
@@ -85,7 +84,7 @@ export function VisualizeESQL({
         const attrs = getLensAttributesFromSuggestion({
           filters: [],
           query: {
-            esql: '',
+            esql: esqlQuery,
           },
           suggestion,
           dataView: dataViewAsync.value,
@@ -95,6 +94,7 @@ export function VisualizeESQL({
           attributes: attrs,
           id: uuidv4(),
         };
+
         setLensInput(lensEmbeddableInput);
       }
     }

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/visualize_esql.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/visualize_esql.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { EuiLoadingSpinner } from '@elastic/eui';
+import { EuiButtonIcon, EuiLoadingSpinner, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { v4 as uuidv4 } from 'uuid';
 import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public/types';
 import { getESQLAdHocDataview } from '@kbn/esql-utils';
@@ -110,6 +111,8 @@ export function VisualizeESQL({
 
   return (
     <div style={{ height: VISUALIZATION_HEIGHT }}>
+      <SaveVisualization lens={lens} lensInput={lensInput} />
+
       {isLoading ? (
         <EuiLoadingSpinner />
       ) : (
@@ -121,5 +124,42 @@ export function VisualizeESQL({
         />
       )}
     </div>
+  );
+}
+
+function SaveVisualization({
+  lens,
+  lensInput,
+}: {
+  lens: LensPublicStart;
+  lensInput: TypedLensByValueInput | undefined;
+}) {
+  const saveVisualizationLabel = i18n.translate('xpack.onechat.conversation.visualization.save', {
+    defaultMessage: 'Save visualization',
+  });
+
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
+  return (
+    <>
+      <EuiToolTip content={saveVisualizationLabel} disableScreenReaderOutput>
+        <EuiButtonIcon
+          size="xs"
+          iconType="save"
+          onClick={() => setIsSaveModalOpen(true)}
+          data-test-subj="observabilityAiAssistantLensESQLSaveButton"
+          aria-label={saveVisualizationLabel}
+        />
+      </EuiToolTip>
+
+      {isSaveModalOpen ? (
+        <lens.SaveModalComponent
+          initialInput={lensInput}
+          onClose={() => {
+            setIsSaveModalOpen(() => false);
+          }}
+          isSaveable={false} // prevent saving ESQL visualizations to the library
+        />
+      ) : null}
+    </>
   );
 }


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/11319

This add a small "save" icon that makes it possible to save a visualisation generated from chat to a dashboard.
Design is not final - ideas are welcome!

https://github.com/user-attachments/assets/63b785a0-a6df-489b-9273-ae19e3a20a13

