### PR TITLE
Skip serverless Discover get_doc_viewer tests for MKI

### DIFF
--- a/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_doc_viewer.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_doc_viewer.ts
@@ -19,7 +19,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataViews = getService('dataViews');
   const dataGrid = getService('dataGrid');
 
-  describe('extension getDocViewer', () => {
+  describe('extension getDocViewer', function () {
+    // flaky on MKI, see https://github.com/elastic/kibana/issues/235841
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       await svlCommonPage.loginAsAdmin();
     });


### PR DESCRIPTION
## Summary

This PR skips the serverless Discover `_get_doc_viewer` tests for MKI.
More details about the failure / flakiness in #235841.
