### PR TITLE
[Security Solution] Fix `context.results_link` passed from detection rules to rule actions

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/notifications/legacy_rules_notification_rule_type.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/notifications/legacy_rules_notification_rule_type.test.ts
@@ -42,7 +42,7 @@ const reported = {
       },
     ],
     results_link:
-      '/app/security/detections/rules/id/rule-id?timerange=(global:(linkTo:!(timeline),timerange:(from:1576255233400,kind:absolute,to:1576341633400)),timeline:(linkTo:!(global),timerange:(from:1576255233400,kind:absolute,to:1576341633400)))',
+      '/app/security/rules/id/rule-id?timerange=(global:(linkTo:!(timeline),timerange:(from:1576255233400,kind:absolute,to:1576341633400)),timeline:(linkTo:!(global),timerange:(from:1576255233400,kind:absolute,to:1576341633400)))',
     rule: {
       alert_suppression: undefined,
       author: ['Elastic'],
@@ -294,7 +294,7 @@ describe('legacyRules_notification_rule_type', () => {
         context: {
           ...reported.context,
           results_link:
-            'http://localhost/detections/rules/id/rule-id?timerange=(global:(linkTo:!(timeline),timerange:(from:1576255233400,kind:absolute,to:1576341633400)),timeline:(linkTo:!(global),timerange:(from:1576255233400,kind:absolute,to:1576341633400)))',
+            'http://localhost/rules/id/rule-id?timerange=(global:(linkTo:!(timeline),timerange:(from:1576255233400,kind:absolute,to:1576341633400)),timeline:(linkTo:!(global),timerange:(from:1576255233400,kind:absolute,to:1576341633400)))',
           rule: {
             ...reported.context.rule,
             meta: {
@@ -347,7 +347,7 @@ describe('legacyRules_notification_rule_type', () => {
             },
           ],
           results_link:
-            '/app/security/detections/rules/id/id?timerange=(global:(linkTo:!(timeline),timerange:(from:1576255233400,kind:absolute,to:1576341633400)),timeline:(linkTo:!(global),timerange:(from:1576255233400,kind:absolute,to:1576341633400)))',
+            '/app/security/rules/id/id?timerange=(global:(linkTo:!(timeline),timerange:(from:1576255233400,kind:absolute,to:1576341633400)),timeline:(linkTo:!(global),timerange:(from:1576255233400,kind:absolute,to:1576341633400)))',
           rule: {
             ...reported.context.rule,
             id: 'id',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/notifications/schedule_throttle_notification_actions.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/notifications/schedule_throttle_notification_actions.test.ts
@@ -210,7 +210,7 @@ describe('schedule_throttle_notification_actions', () => {
     });
 
     expect((scheduleNotificationActions as jest.Mock).mock.calls[0][0].resultsLink).toMatch(
-      'http://www.example.com/detections/rules/id/123'
+      'http://www.example.com/rules/id/123'
     );
     expect(scheduleNotificationActions).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/notifications/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/notifications/utils.test.ts
@@ -21,12 +21,12 @@ describe('utils', () => {
     test('it returns expected link', () => {
       const resultLink = getNotificationResultsLink({
         kibanaSiemAppUrl: 'http://localhost:5601/app/security',
-        id: 'notification-id',
+        id: '721df360-e7f8-402c-9bdb-1bc724667d51', // some rule.id
         from: '00000',
         to: '1111',
       });
       expect(resultLink).toEqual(
-        `http://localhost:5601/app/security/detections/rules/id/notification-id?timerange=(global:(linkTo:!(timeline),timerange:(from:00000,kind:absolute,to:1111)),timeline:(linkTo:!(global),timerange:(from:00000,kind:absolute,to:1111)))`
+        `http://localhost:5601/app/security/rules/id/721df360-e7f8-402c-9bdb-1bc724667d51?timerange=(global:(linkTo:!(timeline),timerange:(from:00000,kind:absolute,to:1111)),timeline:(linkTo:!(global),timerange:(from:00000,kind:absolute,to:1111)))`
       );
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/notifications/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/notifications/utils.ts
@@ -22,7 +22,7 @@ export const getNotificationResultsLink = ({
 }) => {
   if (from == null || to == null) return '';
 
-  return `${kibanaSiemAppUrl}/detections/rules/id/${id}?timerange=(global:(linkTo:!(timeline),timerange:(from:${from},kind:absolute,to:${to})),timeline:(linkTo:!(global),timerange:(from:${from},kind:absolute,to:${to})))`;
+  return `${kibanaSiemAppUrl}/rules/id/${id}?timerange=(global:(linkTo:!(timeline),timerange:(from:${from},kind:absolute,to:${to})),timeline:(linkTo:!(global),timerange:(from:${from},kind:absolute,to:${to})))`;
 };
 
 interface DeconflictOptions {


### PR DESCRIPTION
**Partially addresses:** https://github.com/elastic/kibana/issues/232557

## Summary

This PR fixes the value of the `results_link` variable we pass at the end of a detection rule execution to its rule actions via the `context` object. This variable then can be used from actions via `{{context.results_link}}` template placeholder.

We used to construct the `results_link` like this: `<base-url>/app/security/detections/rules/id/<rule-id>?timerange=<...>`. Which used to be the correct URL to the Rule Details page.

However, the URL structure of detections pages had been changed a long time ago, and now we have this: `<base-url>/app/security/detections/rules/id/<rule-id>`. We had URL redirects from `/app/security/detections/rules/id/<rule-id>` to `/app/security/detections/rules/id/<rule-id>`, but they were broken by https://github.com/elastic/kibana/pull/217890. Some of them have been fixed since then, so now the redirects work as expected in some versions of Kibana, and in some of them they are still broken. See https://github.com/elastic/kibana/issues/232557#issuecomment-3320470840 for details.

This PR adjusts the `results_link` according to the up to date URL structure.

## Release Notes

Fixes the URL passed to detection rule actions via the `{{context.results_link}}` placeholder.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
    - No need for that as the only affected tests are unit tests
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->