### PR TITLE
[Discover][UnifiedTabs] Fix closeTabsToTheRight function

### DIFF
--- a/src/platform/packages/shared/kbn-unified-tabs/src/utils/manage_tabs.test.ts
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/utils/manage_tabs.test.ts
@@ -235,5 +235,14 @@ describe('manage_tabs', () => {
       expect(nextState.items).toEqual([items[0]]);
       expect(nextState.selectedItem).toBe(items[0]);
     });
+
+    it('closes tabs to the right if tab-to-be-closed is a currently open one', () => {
+      const prevState = { items, selectedItem: items[4] };
+      const nextState = closeTabsToTheRight(prevState, items[2]);
+
+      expect(nextState.items).not.toBe(items);
+      expect(nextState.items).toEqual([items[0], items[1], items[2]]);
+      expect(nextState.selectedItem).toBe(items[2]);
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-unified-tabs/src/utils/manage_tabs.ts
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/utils/manage_tabs.ts
@@ -157,6 +157,7 @@ export const closeTabsToTheRight = (
   item: TabItem
 ): TabsState => {
   const itemIndex = items.findIndex((i) => i.id === item.id);
+  const selectedTabIndex = selectedItem ? items.findIndex((i) => i.id === selectedItem.id) : -1;
 
   if (itemIndex === -1 || itemIndex === items.length - 1) {
     return {
@@ -166,9 +167,10 @@ export const closeTabsToTheRight = (
   }
 
   const nextItems = items.slice(0, itemIndex + 1);
+  const isSelectedTabClosed = selectedTabIndex > itemIndex;
 
   return {
     items: nextItems,
-    selectedItem,
+    selectedItem: isSelectedTabClosed ? item : selectedItem,
   };
 };


### PR DESCRIPTION
## Summary

Resolves #235771

According to @davismcphee's observation:
> This is likely because we don't update the selected tab ID to a valid value one after closing the tab, and its runtime state no longer exists. Should be a fairly straightforward one to fix.

within this PR I added a check if the currently open tab is in the to-be-closed batch. If so, the tab focus is moved to the tab, where click action occurred.

https://github.com/user-attachments/assets/c088c2c4-13a7-41d8-bef9-9c28500303d2


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



