### PR TITLE
Add `.cursor` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ target
 .jruby
 .idea
 .claude
+.cursor
 .windsurf
 *.iml
 *.log


### PR DESCRIPTION
While we don't have any Kibana-wide settings for cursor, I think it's worth ignoring this directory. It's used for project-specific cursor rules.