### PR TITLE
[Security solutions][Explore] Integrate dataview logic into host KPIs charts

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/stat_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/stat_items.tsx
@@ -14,6 +14,8 @@ import type { StatItemsProps } from './types';
 import { FlexItem, ChartHeight } from './utils';
 import { MetricEmbeddable } from './metric_embeddable';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
+import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
+import { DataViewManagerScopeName } from '../../../data_view_manager/constants';
 
 export const StatItemsComponent = React.memo<StatItemsProps>(({ statItems, from, id, to }) => {
   const timerange = useMemo(
@@ -34,6 +36,7 @@ export const StatItemsComponent = React.memo<StatItemsProps>(({ statItems, from,
   } = statItems;
 
   const { isToggleExpanded, onToggle } = useToggleStatus({ id });
+  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
   return (
     <FlexItem grow={1} data-test-subj={key}>
@@ -64,6 +67,11 @@ export const StatItemsComponent = React.memo<StatItemsProps>(({ statItems, from,
                     id={`${id}-bar-embeddable`}
                     height={ChartHeight}
                     inspectTitle={description}
+                    scopeId={
+                      newDataViewPickerEnabled
+                        ? DataViewManagerScopeName.explore
+                        : DataViewManagerScopeName.default
+                    }
                   />
                 </FlexItem>
               )}
@@ -78,6 +86,11 @@ export const StatItemsComponent = React.memo<StatItemsProps>(({ statItems, from,
                       id={`${id}-area-embeddable`}
                       height={ChartHeight}
                       inspectTitle={description}
+                      scopeId={
+                        newDataViewPickerEnabled
+                          ? DataViewManagerScopeName.explore
+                          : DataViewManagerScopeName.default
+                      }
                     />
                   </FlexItem>
                 </>


### PR DESCRIPTION
## Summary

Fixes #232375

## 🛑  Problem overview

The new dataView logic was not properly integrated in the KPI charts in the host page as the KPI numeric values would change, but the charts would stay the same.
Here's the video from the ticket that show cases the issue:

<details>
<summary> 🎥  Expand for the video</summary>

https://github.com/user-attachments/assets/3309ea30-3c53-4b14-8bd7-cc5c9f0b32e8
</details>

## 💡 Solution overview

Apparently, we were not passing the correct scope id to the chart components (actually, we were not passing any scope at all!).
This contribution just passes the correct scope based on the value of the dataView feature flag.

Here's a video of the page working correctly after applying the fix:

<details>
<summary> 🎥  Expand for the video</summary>

https://github.com/user-attachments/assets/b6c182e0-3dd2-4986-9164-34d675209e16
</details>