### PR TITLE
Create `alwaysOnline` plugin

### DIFF
--- a/docs/extend/plugin-list.md
+++ b/docs/extend/plugin-list.md
@@ -19,6 +19,7 @@ mapped_pages:
 | --- | --- |
 | [advancedSettings](https://github.com/elastic/kibana/blob/main/src/platform/plugins/private/advanced_settings/README.md) | This plugin registers the management settings application allowing users to configure their advanced settings, also known as uiSettings within the code. |
 | [aiAssistantManagementSelection](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/ai_assistant_management/selection/README.md) | The aiAssistantManagementSelection plugin manages the Ai Assistant management section. |
+| [alwaysOnline](https://github.com/elastic/kibana/blob/main/src/platform/plugins/private/always_online/README.md) | A Kibana plugin that overrides window.navigator.onLine to trick browsers into thinking they are always online (useful for some air-gapped customers). |
 | [charts](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/charts/README.md) | The Charts plugin is a way to create easier integration of shared colors, themes, types and other utilities across all Kibana charts and visualizations. |
 | [console](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/console/README.md) | Console provides the user with tools for storing and executing requests against Elasticsearch. |
 | [contentManagement](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/content_management/README.md) | The content management plugin provides functionality to manage content in Kibana. |

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "@kbn/alerts-grouping": "link:x-pack/solutions/observability/packages/kbn-alerts-grouping",
     "@kbn/alerts-restricted-fixtures-plugin": "link:x-pack/platform/test/alerting_api_integration/common/plugins/alerts_restricted",
     "@kbn/alerts-ui-shared": "link:src/platform/packages/shared/kbn-alerts-ui-shared",
+    "@kbn/always-online": "link:src/platform/plugins/private/always_online",
     "@kbn/analytics": "link:src/platform/packages/shared/kbn-analytics",
     "@kbn/analytics-collection-utils": "link:src/platform/packages/private/analytics/utils/analytics_collection_utils",
     "@kbn/analytics-ftr-helpers-plugin": "link:src/platform/test/analytics/plugins/analytics_ftr_helpers",

--- a/src/platform/plugins/private/always_online/README.md
+++ b/src/platform/plugins/private/always_online/README.md
@@ -1,0 +1,3 @@
+# alwaysOnline
+
+A Kibana plugin that overrides `window.navigator.onLine` to trick browsers into thinking they are always online (useful for some air-gapped customers).

--- a/src/platform/plugins/private/always_online/kibana.jsonc
+++ b/src/platform/plugins/private/always_online/kibana.jsonc
@@ -1,0 +1,16 @@
+{
+  "type": "plugin",
+  "id": "@kbn/always-online",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "private",
+  "description": "Overrides window.navigator.onLine to trick browsers into thinking they are always online (useful for some air-gapped customers).",
+  "plugin": {
+    "id": "alwaysOnline",
+    "configPath": ["alwaysOnline"],
+    "browser": true,
+    "server": true,
+  }
+}

--- a/src/platform/plugins/private/always_online/package.json
+++ b/src/platform/plugins/private/always_online/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kbn/always-online",
-  "version": "0.0.0",
+  "version": "1.0.0",
+  "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
   "private": true,
   "description": "Overrides window.navigator.onLine to trick browsers into thinking they are always online (useful for some air-gapped customers).",
   "scripts": {

--- a/src/platform/plugins/private/always_online/package.json
+++ b/src/platform/plugins/private/always_online/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@kbn/always-online",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Overrides window.navigator.onLine to trick browsers into thinking they are always online (useful for some air-gapped customers).",
+  "scripts": {
+    "bootstrap": "yarn kbn bootstrap && yarn install",
+    "build": "yarn plugin-helpers build",
+    "dev": "yarn plugin-helpers dev",
+    "plugin-helpers": "node ../../scripts/plugin_helpers",
+    "kbn": "node ../../scripts/kbn"
+  }
+}

--- a/src/platform/plugins/private/always_online/public/index.ts
+++ b/src/platform/plugins/private/always_online/public/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PluginInitializerContext } from '@kbn/core/public';
+import { AlwaysOnlinePlugin } from './plugin';
+
+export const plugin = (initializerContext: PluginInitializerContext) => {
+  return new AlwaysOnlinePlugin(initializerContext);
+};

--- a/src/platform/plugins/private/always_online/public/plugin.ts
+++ b/src/platform/plugins/private/always_online/public/plugin.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Plugin, PluginInitializerContext } from '@kbn/core/public';
+
+export interface AlwaysOnlinePluginConfig {
+  enabled: boolean;
+}
+
+export class AlwaysOnlinePlugin implements Plugin {
+  constructor(private initializerContext: PluginInitializerContext<AlwaysOnlinePluginConfig>) {}
+
+  public setup() {
+    const enabled = this.initializerContext.config.get();
+    if (enabled) {
+      Object.defineProperty(window.navigator, 'onLine', {
+        get: () => true,
+      });
+    }
+  }
+  public start() {}
+}

--- a/src/platform/plugins/private/always_online/server/config.ts
+++ b/src/platform/plugins/private/always_online/server/config.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { TypeOf } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
+import type { PluginConfigDescriptor } from '@kbn/core/server';
+
+export const configSchema = schema.object({
+  /** Controls whether alwaysOnline plugin is enabled. */
+  enabled: schema.boolean({ defaultValue: false }),
+});
+
+export type ConfigSchema = TypeOf<typeof configSchema>;
+
+export const config: PluginConfigDescriptor<ConfigSchema> = {
+  schema: configSchema,
+};

--- a/src/platform/plugins/private/always_online/server/index.ts
+++ b/src/platform/plugins/private/always_online/server/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Plugin } from '@kbn/core/server';
+
+export { config } from './config';
+
+export const plugin: () => Plugin = () => ({
+  setup: () => {},
+  start: () => {},
+});

--- a/src/platform/plugins/private/always_online/tsconfig.json
+++ b/src/platform/plugins/private/always_online/tsconfig.json
@@ -1,10 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./target/types"
+    "outDir": "target/types"
   },
   "include": [
     "public/**/*.ts",
   ],
-  "exclude": []
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/core",
+  ]
 }

--- a/src/platform/plugins/private/always_online/tsconfig.json
+++ b/src/platform/plugins/private/always_online/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./target/types"
+  },
+  "include": [
+    "public/**/*.ts",
+  ],
+  "exclude": []
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -72,6 +72,8 @@
       "@kbn/alerts-restricted-fixtures-plugin/*": ["x-pack/platform/test/alerting_api_integration/common/plugins/alerts_restricted/*"],
       "@kbn/alerts-ui-shared": ["src/platform/packages/shared/kbn-alerts-ui-shared"],
       "@kbn/alerts-ui-shared/*": ["src/platform/packages/shared/kbn-alerts-ui-shared/*"],
+      "@kbn/always-online": ["src/platform/plugins/private/always_online"],
+      "@kbn/always-online/*": ["src/platform/plugins/private/always_online/*"],
       "@kbn/ambient-common-types": ["src/platform/packages/private/kbn-ambient-common-types"],
       "@kbn/ambient-common-types/*": ["src/platform/packages/private/kbn-ambient-common-types/*"],
       "@kbn/ambient-ftr-types": ["src/platform/packages/private/kbn-ambient-ftr-types"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4112,6 +4112,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/always-online@link:src/platform/plugins/private/always_online":
+  version "0.0.0"
+  uid ""
+
 "@kbn/ambient-common-types@link:src/platform/packages/private/kbn-ambient-common-types":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/enhancements/issues/25729

Some customers have air-gapped environments with configurations that trick web browsers into thinking they are _offline_. 
This causes some third party libraries to pause network activity until connection is restored.

The goal of this PR is to create a special plugin to alter `window.navigator.onLine` information in the browser, so that they are tricked into believing they are online all the time.

This plugin is disabled by default, so the override can be applied by adding the following in the `kibana.yml` config:

```yaml
alwaysOnline.enabled: true
```