### PR TITLE
[Metrics][Discover] Fix the multiselect issue inside the toolbar selector when search is used

### DIFF
--- a/src/platform/packages/shared/shared-ux/toolbar_selector/src/toolbar_selector.test.tsx
+++ b/src/platform/packages/shared/shared-ux/toolbar_selector/src/toolbar_selector.test.tsx
@@ -9,7 +9,8 @@
 
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { SelectableEntry } from './toolbar_selector';
 import { ToolbarSelector } from './toolbar_selector';
 
@@ -21,7 +22,7 @@ const options: SelectableEntry[] = [
 
 describe('ToolbarSelector', () => {
   it('renders button label', () => {
-    const { getByText } = render(
+    render(
       <ToolbarSelector
         data-test-subj="toolbarSelectorTest"
         buttonLabel="Choose"
@@ -30,11 +31,12 @@ describe('ToolbarSelector', () => {
         singleSelection={true}
       />
     );
-    expect(getByText('Choose')).toBeInTheDocument();
+    expect(screen.getByText('Choose')).toBeInTheDocument();
   });
 
-  it('opens popover and shows options', () => {
-    const { getByTestId, getByText } = render(
+  it('opens popover and shows options', async () => {
+    const user = userEvent.setup();
+    render(
       <ToolbarSelector
         data-test-subj="toolbarSelectorTest"
         buttonLabel="Select"
@@ -43,15 +45,16 @@ describe('ToolbarSelector', () => {
         singleSelection={true}
       />
     );
-    fireEvent.click(getByTestId('toolbarSelectorTestButton'));
-    expect(getByText('Option 1')).toBeInTheDocument();
-    expect(getByText('Option 2')).toBeInTheDocument();
-    expect(getByText('Option 3')).toBeInTheDocument();
+    await user.click(screen.getByTestId('toolbarSelectorTestButton'));
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+    expect(screen.getByText('Option 3')).toBeInTheDocument();
   });
 
-  it('calls onChange for single selection', () => {
+  it('calls onChange for single selection', async () => {
+    const user = userEvent.setup();
     const onChange = jest.fn();
-    const { getByTestId, getByText } = render(
+    render(
       <ToolbarSelector
         data-test-subj="toolbarSelectorTest"
         buttonLabel="Select"
@@ -61,18 +64,19 @@ describe('ToolbarSelector', () => {
         onChange={onChange}
       />
     );
-    fireEvent.click(getByTestId('toolbarSelectorTestButton'));
-    fireEvent.click(getByText('Option 2'));
+    await user.click(screen.getByTestId('toolbarSelectorTestButton'));
+    fireEvent.click(screen.getByText('Option 2'));
     expect(onChange).toHaveBeenCalledWith({ label: 'Option 2', value: '2', checked: 'on' });
   });
 
-  it('calls onChange for multi selection', () => {
+  it('calls onChange for multi selection', async () => {
+    const user = userEvent.setup();
     const onChange = jest.fn();
     const multiOptions: SelectableEntry[] = [
       { label: 'A', value: 'a' },
       { label: 'B', value: 'b' },
     ];
-    const { getByTestId, getByText } = render(
+    render(
       <ToolbarSelector
         data-test-subj="toolbarSelectorMultiTest"
         buttonLabel="Multi"
@@ -82,9 +86,9 @@ describe('ToolbarSelector', () => {
         onChange={onChange}
       />
     );
-    fireEvent.click(getByTestId('toolbarSelectorMultiTestButton'));
-    fireEvent.click(getByText('A'));
-    fireEvent.click(getByText('B'));
+    await user.click(screen.getByTestId('toolbarSelectorMultiTestButton'));
+    fireEvent.click(screen.getByText('A'));
+    fireEvent.click(screen.getByText('B'));
 
     expect(onChange).toHaveBeenCalledTimes(2);
     expect(onChange).toHaveBeenNthCalledWith(1, [{ label: 'A', value: 'a', checked: 'on' }]);
@@ -92,7 +96,7 @@ describe('ToolbarSelector', () => {
   });
 
   it('renders with disabled state', () => {
-    const { getByTestId } = render(
+    render(
       <ToolbarSelector
         data-test-subj="toolbarSelectorDisabled"
         buttonLabel="Disabled"
@@ -102,11 +106,12 @@ describe('ToolbarSelector', () => {
         disabled={true}
       />
     );
-    expect(getByTestId('toolbarSelectorDisabledButton')).toBeDisabled();
+    expect(screen.getByTestId('toolbarSelectorDisabledButton')).toBeDisabled();
   });
 
-  it('renders with searchable enabled', () => {
-    const { getByTestId } = render(
+  it('renders with searchable enabled', async () => {
+    const user = userEvent.setup();
+    render(
       <ToolbarSelector
         data-test-subj="toolbarSelectorSearch"
         buttonLabel="Search"
@@ -115,11 +120,12 @@ describe('ToolbarSelector', () => {
         singleSelection={true}
       />
     );
-    fireEvent.click(getByTestId('toolbarSelectorSearchButton'));
-    expect(getByTestId('toolbarSelectorSearchSelectorSearch')).toBeInTheDocument();
+    await user.click(screen.getByTestId('toolbarSelectorSearchButton'));
+    expect(screen.getByTestId('toolbarSelectorSearchSelectorSearch')).toBeInTheDocument();
   });
 
   it('renders with searchable enabled and multi selection and preserves previously selected options', async () => {
+    const user = userEvent.setup();
     const onChange = jest.fn();
 
     // Start with pre-selected options to test preservation
@@ -129,7 +135,7 @@ describe('ToolbarSelector', () => {
       { label: 'C', value: 'c' },
     ];
 
-    const { getByTestId, getByText, queryByText } = render(
+    render(
       <ToolbarSelector
         data-test-subj="toolbarSelectorSearchBasic"
         buttonLabel="Search Test"
@@ -143,32 +149,25 @@ describe('ToolbarSelector', () => {
       />
     );
 
-    // Open the selector
-    fireEvent.click(getByTestId('toolbarSelectorSearchBasicButton'));
+    await user.click(screen.getByTestId('toolbarSelectorSearchBasicButton'));
 
     // Verify all options are initially visible
-    expect(getByText('A')).toBeInTheDocument();
-    expect(getByText('B')).toBeInTheDocument();
-    expect(getByText('C')).toBeInTheDocument();
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText('C')).toBeInTheDocument();
 
-    // Search for "C" which should only show C
-    const searchInput = getByTestId('toolbarSelectorSearchBasicSelectorSearch');
-    fireEvent.change(searchInput, { target: { value: 'C' } });
+    // Search for "C" which should only show C - use fireEvent for search input (EUI compatibility)
+    const searchInput = screen.getByTestId('toolbarSelectorSearchBasicSelectorSearch');
+    await user.type(searchInput, 'C');
 
-    // Wait for debounced search
-    await waitFor(
-      () => {
-        // C should be visible
-        expect(getByText('C')).toBeInTheDocument();
-        // A and B should be hidden
-        expect(queryByText('A')).not.toBeInTheDocument();
-        expect(queryByText('B')).not.toBeInTheDocument();
-      },
-      { timeout: 500 }
-    );
+    await waitFor(() => {
+      expect(screen.getByText('C')).toBeInTheDocument();
+      expect(screen.queryByText('A')).not.toBeInTheDocument();
+      expect(screen.queryByText('B')).not.toBeInTheDocument();
+    });
 
-    // Select C
-    fireEvent.click(getByText('C'));
+    // Select C using fireEvent for EUI selectable compatibility
+    fireEvent.click(screen.getByText('C'));
 
     // The onChange should preserve A and B (hidden but selected) + add C
     expect(onChange).toHaveBeenCalledWith(
@@ -180,8 +179,9 @@ describe('ToolbarSelector', () => {
     );
   });
 
-  it('renders with optional props: popoverTitle, popoverContentBelowSearch, hasArrow', () => {
-    const { getByTestId, getAllByLabelText, getByText } = render(
+  it('renders with optional props: popoverTitle, popoverContentBelowSearch, hasArrow', async () => {
+    const user = userEvent.setup();
+    render(
       <ToolbarSelector
         data-test-subj="toolbarSelectorOptionalProps"
         buttonLabel="Optional"
@@ -193,8 +193,8 @@ describe('ToolbarSelector', () => {
         hasArrow={false}
       />
     );
-    fireEvent.click(getByTestId('toolbarSelectorOptionalPropsButton'));
-    expect(getByText('Maximum selection limit reached')).toBeInTheDocument();
-    expect(getAllByLabelText('My Popover Title')).toHaveLength(3);
+    await user.click(screen.getByTestId('toolbarSelectorOptionalPropsButton'));
+    expect(screen.getByText('Maximum selection limit reached')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('My Popover Title')).toHaveLength(3);
   });
 });

--- a/src/platform/packages/shared/shared-ux/toolbar_selector/src/toolbar_selector.tsx
+++ b/src/platform/packages/shared/shared-ux/toolbar_selector/src/toolbar_selector.tsx
@@ -132,7 +132,17 @@ export const ToolbarSelector = ({
   >(
     (newOptions) => {
       if (singleSelection === false) {
-        onChange?.(newOptions.filter(({ checked }) => checked === 'on'));
+        // For multi-selection, we need to preserve previously selected options
+        const currentlyVisibleSelected = newOptions.filter(({ checked }) => checked === 'on');
+        const currentlyVisibleValues = new Set(newOptions.map((option) => option.value));
+
+        // Find previously selected options that are not currently visible (filtered out)
+        const previouslySelectedButHidden = options.filter(
+          (option) => option.checked === 'on' && !currentlyVisibleValues.has(option.value)
+        );
+
+        const allSelected = [...currentlyVisibleSelected, ...previouslySelectedButHidden];
+        onChange?.(allSelected);
       } else {
         const chosenOption = newOptions.find(({ checked }) => checked === 'on');
         onChange?.(
@@ -142,7 +152,7 @@ export const ToolbarSelector = ({
         disableLabelPopover();
       }
     },
-    [closePopover, disableLabelPopover, onChange, singleSelection]
+    [closePopover, disableLabelPopover, onChange, singleSelection, options]
   );
 
   const searchProps: EuiSelectableProps['searchProps'] = useMemo(


### PR DESCRIPTION
Closes #235792 

## Summary

This PR fixes the multiselect issue inside the toolbar selector when search is used. I first checked the[ eui selectable demo](https://eui.elastic.co/docs/components/forms/selection/selectable/), where the search was working correctly, and then saw that the issue is when we filter the values inside the toolbar selector component. The issue is well described in the ticket - so basically, if we have a selected value and then we put a search term not matching the selection, we should keep the previous selection and also include the new selection. 

## How it works now: 

![dim_ms](https://github.com/user-attachments/assets/65dcc4c1-7aa3-4381-a1c9-d77ddcf922a3)

Same in the second values filter: 

<img width="1359" height="413" alt="image" src="https://github.com/user-attachments/assets/f8642950-7f42-47da-9f2f-235dbf04e171" />

## How to test
- Clone https://github.com/simianhacker/simian-forge/tree/main
- Run ` ./forge --dataset hosts --count 25 --interval 30s`
  - For beats metrics, the system integration package MUST be installed (after installing it, make sure to delete all existing metrics data streams)
- Set the following config to `kibana.dev.yml`
```yml
feature_flags.overrides:
  metricsExperienceEnabled: true
 ```
- Navigate to Discover and Switch to ESQL mode
- Validate if 
   - The dimensions selector allows multiple selections and doesn't remove selected values in case a different search term is used (steps that are shown above in the recording)
