### PR TITLE
[Streams] Add ilm pannel small fixes

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/ilm_summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/ilm_summary.tsx
@@ -195,15 +195,15 @@ function IlmPhase({
           <EuiPanel
             paddingSize="xs"
             css={{
-              marginRight: '-40px',
-              width: '80px',
+              marginRight: minAge ? '-40px' : '-10px',
+              width: minAge ? '80px' : '20px',
             }}
             grow={false}
             hasBorder={false}
             hasShadow={false}
           >
             <EuiText textAlign="center" size="xs" color="subdued">
-              {minAge ? getTimeSizeAndUnitLabel(minAge) + (phase.name === 'hot' ? '*' : '') : '∞'}
+              {minAge ? getTimeSizeAndUnitLabel(minAge) : '∞'}
             </EuiText>
           </EuiPanel>
         ) : undefined}


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/235821

## Summary

Adds a couple of small changes for the ILM panel in the Streams retention tab: removes the asterisk from the ilm policy tier and reduces the box for the forever retention so it doesn't look weird in high contrast mode.

<img width="1246" height="573" alt="Screenshot 2025-09-23 at 14 25 53" src="https://github.com/user-attachments/assets/83cf3bd2-447e-4d63-8196-7af634d7474f" />


<img width="1235" height="455" alt="Screenshot 2025-09-23 at 14 10 58" src="https://github.com/user-attachments/assets/f29e1e25-ee6f-4d90-b23b-efc94dadabfd" />
