### PR TITLE
[scout] disable ES debug level logs for authc

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/run_elasticsearch.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/run_elasticsearch.ts
@@ -13,12 +13,7 @@ import type { ToolingLog } from '@kbn/tooling-log';
 import { REPO_ROOT } from '@kbn/repo-info';
 import type { ArtifactLicense, ServerlessProjectType } from '@kbn/es';
 import { isServerlessProjectType } from '@kbn/es/src/utils';
-import {
-  createTestEsCluster,
-  esTestConfig,
-  cleanupElasticsearch,
-  createEsClientForTesting,
-} from '@kbn/test';
+import { createTestEsCluster, esTestConfig, cleanupElasticsearch } from '@kbn/test';
 import type { Config } from '../config';
 
 interface RunElasticsearchOptions {
@@ -87,25 +82,25 @@ export async function runElasticsearch(
     config,
   });
 
-  // TODO: Remove this once we find out why SAML callback randomly fails with 401
-  log.info('Enable authc debug logs for ES');
-  const clientUrl = new URL(
-    Url.format({
-      protocol: options.config.get('servers.elasticsearch.protocol'),
-      hostname: options.config.get('servers.elasticsearch.hostname'),
-      port: options.config.get('servers.elasticsearch.port'),
-    })
-  );
-  clientUrl.username = options.config.get('servers.kibana.username');
-  clientUrl.password = options.config.get('servers.kibana.password');
-  const esClient = createEsClientForTesting({
-    esUrl: clientUrl.toString(),
-  });
-  await esClient.cluster.putSettings({
-    persistent: {
-      'logger.org.elasticsearch.xpack.security.authc': 'debug',
-    },
-  });
+  // Enable it to debug why SAML callback randomly returns 401
+  // log.info('Enable authc debug logs for ES');
+  // const clientUrl = new URL(
+  //   Url.format({
+  //     protocol: options.config.get('servers.elasticsearch.protocol'),
+  //     hostname: options.config.get('servers.elasticsearch.hostname'),
+  //     port: options.config.get('servers.elasticsearch.port'),
+  //   })
+  // );
+  // clientUrl.username = options.config.get('servers.kibana.username');
+  // clientUrl.password = options.config.get('servers.kibana.password');
+  // const esClient = createEsClientForTesting({
+  //   esUrl: clientUrl.toString(),
+  // });
+  // await esClient.cluster.putSettings({
+  //   persistent: {
+  //     'logger.org.elasticsearch.xpack.security.authc': 'debug',
+  //   },
+  // });
 
   return async () => {
     await cleanupElasticsearch(node, config.serverless, logsDir, log);


### PR DESCRIPTION
## Summary

Disabling debug level `security.authc` logging for stateful ES in scout tests. Related to https://github.com/elastic/kibana/pull/212866

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->