### PR TITLE
[Response Ops][Connectors] Enable webhook oauth2 option in ui

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/webhook/webhook_connectors.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/webhook/webhook_connectors.tsx
@@ -78,7 +78,7 @@ const WebhookActionConnectorFields: React.FunctionComponent<ActionConnectorField
         <LazyLoadedAuthConfig
           readOnly={readOnly}
           isPfxEnabled={isPfxEnabled}
-          isOAuth2Enabled={false} // intermediate release: temporarily disabled, will be enabled in a follow-up PR
+          isOAuth2Enabled={true}
         />
       </React.Suspense>
     </>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/235748