### PR TITLE
[Entity Store] Add new `entity` and `asset` fields

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -880,8 +880,8 @@ x-pack/platform/packages/private/security/ui_components @elastic/kibana-security
 x-pack/platform/packages/private/upgrade-assistant/common @elastic/kibana-management
 x-pack/platform/packages/private/upgrade-assistant/public @elastic/kibana-management
 x-pack/platform/packages/private/upgrade-assistant/server @elastic/kibana-management
-x-pack/platform/packages/shared/ai-assistant/ai-assistant-cta @elastic/appex-sharedux
 x-pack/platform/packages/shared/ai-assistant/ai-assistant-connector-selector-action @elastic/appex-sharedux
+x-pack/platform/packages/shared/ai-assistant/ai-assistant-cta @elastic/appex-sharedux
 x-pack/platform/packages/shared/ai-assistant/common @elastic/search-kibana
 x-pack/platform/packages/shared/ai-assistant/icon @elastic/appex-sharedux
 x-pack/platform/packages/shared/ai-infra/inference-common @elastic/appex-ai-infra

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -71571,6 +71571,28 @@ components:
           type: array
         - minLength: 1
           type: string
+    Security_Entity_Analytics_API_Asset:
+      additionalProperties: false
+      type: object
+      properties:
+        business_unit:
+          type: string
+        criticality:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel'
+        environment:
+          type: string
+        id:
+          type: string
+        model:
+          type: string
+        name:
+          type: string
+        owner:
+          type: string
+        serial_number:
+          type: string
+        vendor:
+          type: string
     Security_Entity_Analytics_API_AssetCriticalityBulkUploadErrorItem:
       type: object
       properties:
@@ -71941,11 +71963,24 @@ components:
           additionalProperties: false
           type: object
           properties:
+            asset:
+              type: boolean
+            managed:
+              type: boolean
+            mfa_enabled:
+              type: boolean
             privileged:
               type: boolean
-        behavior:
+        behaviors:
           additionalProperties: false
           type: object
+          properties:
+            brute_force_victim:
+              type: boolean
+            new_country_login:
+              type: boolean
+            used_usb_device:
+              type: boolean
         EngineMetadata:
           $ref: '#/components/schemas/Security_Entity_Analytics_API_EngineMetadata'
         id:
@@ -71957,8 +71992,69 @@ components:
             first_seen:
               format: date-time
               type: string
+            last_activity:
+              format: date-time
+              type: string
         name:
           type: string
+        relationships:
+          additionalProperties: false
+          type: object
+          properties:
+            accessed_frequently_by:
+              items:
+                type: string
+              type: array
+            accesses_frequently:
+              items:
+                type: string
+              type: array
+            communicates_with:
+              items:
+                type: string
+              type: array
+            dependent_of:
+              items:
+                type: string
+              type: array
+            depends_on:
+              items:
+                type: string
+              type: array
+            owned_by:
+              items:
+                type: string
+              type: array
+            owns:
+              items:
+                type: string
+              type: array
+            supervised_by:
+              items:
+                type: string
+              type: array
+            supervises:
+              items:
+                type: string
+              type: array
+        risk:
+          additionalProperties: false
+          type: object
+          properties:
+            calculated_level:
+              $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityRiskLevels'
+              description: Lexical description of the entity's risk.
+              example: Critical
+            calculated_score:
+              description: The raw numeric value of the given entity's risk score.
+              format: double
+              type: number
+            calculated_score_norm:
+              description: The normalized numeric value of the given entity's risk score. Useful for comparing with other entities.
+              format: double
+              maximum: 100
+              minimum: 0
+              type: number
         source:
           type: string
         sub_type:
@@ -72057,13 +72153,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityField'
       required:
@@ -72076,13 +72167,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityField'
         event:
@@ -72333,13 +72419,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityField'
         event:
@@ -72444,13 +72525,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityField'
         event:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -84633,6 +84633,28 @@ components:
           type: array
         - minLength: 1
           type: string
+    Security_Entity_Analytics_API_Asset:
+      additionalProperties: false
+      type: object
+      properties:
+        business_unit:
+          type: string
+        criticality:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel'
+        environment:
+          type: string
+        id:
+          type: string
+        model:
+          type: string
+        name:
+          type: string
+        owner:
+          type: string
+        serial_number:
+          type: string
+        vendor:
+          type: string
     Security_Entity_Analytics_API_AssetCriticalityBulkUploadErrorItem:
       type: object
       properties:
@@ -85003,11 +85025,24 @@ components:
           additionalProperties: false
           type: object
           properties:
+            asset:
+              type: boolean
+            managed:
+              type: boolean
+            mfa_enabled:
+              type: boolean
             privileged:
               type: boolean
-        behavior:
+        behaviors:
           additionalProperties: false
           type: object
+          properties:
+            brute_force_victim:
+              type: boolean
+            new_country_login:
+              type: boolean
+            used_usb_device:
+              type: boolean
         EngineMetadata:
           $ref: '#/components/schemas/Security_Entity_Analytics_API_EngineMetadata'
         id:
@@ -85019,8 +85054,69 @@ components:
             first_seen:
               format: date-time
               type: string
+            last_activity:
+              format: date-time
+              type: string
         name:
           type: string
+        relationships:
+          additionalProperties: false
+          type: object
+          properties:
+            accessed_frequently_by:
+              items:
+                type: string
+              type: array
+            accesses_frequently:
+              items:
+                type: string
+              type: array
+            communicates_with:
+              items:
+                type: string
+              type: array
+            dependent_of:
+              items:
+                type: string
+              type: array
+            depends_on:
+              items:
+                type: string
+              type: array
+            owned_by:
+              items:
+                type: string
+              type: array
+            owns:
+              items:
+                type: string
+              type: array
+            supervised_by:
+              items:
+                type: string
+              type: array
+            supervises:
+              items:
+                type: string
+              type: array
+        risk:
+          additionalProperties: false
+          type: object
+          properties:
+            calculated_level:
+              $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityRiskLevels'
+              description: Lexical description of the entity's risk.
+              example: Critical
+            calculated_score:
+              description: The raw numeric value of the given entity's risk score.
+              format: double
+              type: number
+            calculated_score_norm:
+              description: The normalized numeric value of the given entity's risk score. Useful for comparing with other entities.
+              format: double
+              maximum: 100
+              minimum: 0
+              type: number
         source:
           type: string
         sub_type:
@@ -85119,13 +85215,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityField'
       required:
@@ -85138,13 +85229,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityField'
         event:
@@ -85395,13 +85481,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityField'
         event:
@@ -85506,13 +85587,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityField'
         event:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/common.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/common.gen.ts
@@ -104,12 +104,7 @@ export const Asset = z
     vendor: z.string().optional(),
     environment: z.string().optional(),
     criticality: AssetCriticalityLevel.optional(),
-    business: z
-      .object({
-        unit: z.string().optional(),
-      })
-      .strict()
-      .optional(),
+    business_unit: z.string().optional(),
   })
   .strict();
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/common.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/common.schema.yaml
@@ -39,9 +39,22 @@ components:
           properties:
             privileged:
               type: boolean
-        behavior: 
+            asset:
+              type: boolean
+            managed:
+              type: boolean
+            mfa_enabled:
+              type: boolean
+        behaviors: 
           type: object
           additionalProperties: false
+          properties:
+            brute_force_victim:
+              type: boolean
+            new_country_login:
+              type: boolean
+            used_usb_device:
+              type: boolean
         lifecycle:
           type: object
           additionalProperties: false
@@ -49,6 +62,94 @@ components:
             first_seen:
               type: string
               format: date-time
+            last_activity:
+              type: string
+              format: date-time
+        relationships:
+          type: object
+          additionalProperties: false
+          properties:
+            communicates_with:
+              type: array
+              items:
+                type: string
+            depends_on:
+              type: array
+              items:
+                type: string
+            dependent_of:
+              type: array
+              items:
+                type: string
+            owns:
+              type: array
+              items:
+                type: string
+            owned_by:
+              type: array
+              items:
+                type: string
+            accesses_frequently:
+              type: array
+              items:
+                type: string
+            accessed_frequently_by:
+              type: array
+              items:
+                type: string
+            supervises:
+              type: array
+              items:
+                type: string
+            supervised_by:
+              type: array
+              items:
+                type: string
+        risk:
+          type: object
+          additionalProperties: false
+          properties:
+            calculated_level:
+              $ref: '../../common/common.schema.yaml#/components/schemas/EntityRiskLevels'
+              example: 'Critical'
+              description: Lexical description of the entity's risk.
+            calculated_score:
+              type: number
+              format: double
+              description: The raw numeric value of the given entity's risk score.
+            calculated_score_norm:
+              type: number
+              format: double
+              minimum: 0
+              maximum: 100
+              description: The normalized numeric value of the given entity's risk score. Useful for comparing with other entities.
+
+    Asset:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        owner:
+          type: string
+        serial_number:
+          type: string
+        model:
+          type: string
+        vendor:
+          type: string
+        environment:
+          type: string
+        criticality:
+          $ref: '../../asset_criticality/common.schema.yaml#/components/schemas/AssetCriticalityLevel'
+        business:
+          type: object
+          additionalProperties: false
+          properties:
+            unit:
+              type: string
 
     UserEntity:
       type: object
@@ -97,13 +198,8 @@ components:
           required:
             - name
         asset:
-          type: object
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          properties:
-            criticality:
-              $ref: '../../asset_criticality/common.schema.yaml#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
         event:
           type: object
           additionalProperties: false
@@ -164,13 +260,8 @@ components:
           required:
             - name
         asset:
-          type: object
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          properties:
-            criticality:
-              $ref: '../../asset_criticality/common.schema.yaml#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
         event:
           type: object
           additionalProperties: false
@@ -203,13 +294,8 @@ components:
           required:
             - name
         asset:
-          type: object
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          properties:
-            criticality:
-              $ref: '../../asset_criticality/common.schema.yaml#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
         event:
           type: object
           additionalProperties: false
@@ -236,13 +322,8 @@ components:
         entity:
           $ref: '#/components/schemas/EntityField'
         asset:
-          type: object
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          properties:
-            criticality:
-              $ref: '../../asset_criticality/common.schema.yaml#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
     
     # These entities represent the API of Entity Store
     # where entity is a root field, as it's in the final

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/common.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/common.schema.yaml
@@ -144,12 +144,8 @@ components:
           type: string
         criticality:
           $ref: '../../asset_criticality/common.schema.yaml#/components/schemas/AssetCriticalityLevel'
-        business:
-          type: object
-          additionalProperties: false
-          properties:
-            unit:
-              type: string
+        business_unit:
+          type: string
 
     UserEntity:
       type: object

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -1252,6 +1252,28 @@ paths:
         - Security Entity Analytics API
 components:
   schemas:
+    Asset:
+      additionalProperties: false
+      type: object
+      properties:
+        business_unit:
+          type: string
+        criticality:
+          $ref: '#/components/schemas/AssetCriticalityLevel'
+        environment:
+          type: string
+        id:
+          type: string
+        model:
+          type: string
+        name:
+          type: string
+        owner:
+          type: string
+        serial_number:
+          type: string
+        vendor:
+          type: string
     AssetCriticalityBulkUploadErrorItem:
       type: object
       properties:
@@ -1625,11 +1647,24 @@ components:
           additionalProperties: false
           type: object
           properties:
+            asset:
+              type: boolean
+            managed:
+              type: boolean
+            mfa_enabled:
+              type: boolean
             privileged:
               type: boolean
-        behavior:
+        behaviors:
           additionalProperties: false
           type: object
+          properties:
+            brute_force_victim:
+              type: boolean
+            new_country_login:
+              type: boolean
+            used_usb_device:
+              type: boolean
         EngineMetadata:
           $ref: '#/components/schemas/EngineMetadata'
         id:
@@ -1641,8 +1676,71 @@ components:
             first_seen:
               format: date-time
               type: string
+            last_activity:
+              format: date-time
+              type: string
         name:
           type: string
+        relationships:
+          additionalProperties: false
+          type: object
+          properties:
+            accessed_frequently_by:
+              items:
+                type: string
+              type: array
+            accesses_frequently:
+              items:
+                type: string
+              type: array
+            communicates_with:
+              items:
+                type: string
+              type: array
+            dependent_of:
+              items:
+                type: string
+              type: array
+            depends_on:
+              items:
+                type: string
+              type: array
+            owned_by:
+              items:
+                type: string
+              type: array
+            owns:
+              items:
+                type: string
+              type: array
+            supervised_by:
+              items:
+                type: string
+              type: array
+            supervises:
+              items:
+                type: string
+              type: array
+        risk:
+          additionalProperties: false
+          type: object
+          properties:
+            calculated_level:
+              $ref: '#/components/schemas/EntityRiskLevels'
+              description: Lexical description of the entity's risk.
+              example: Critical
+            calculated_score:
+              description: The raw numeric value of the given entity's risk score.
+              format: double
+              type: number
+            calculated_score_norm:
+              description: >-
+                The normalized numeric value of the given entity's risk score.
+                Useful for comparing with other entities.
+              format: double
+              maximum: 100
+              minimum: 0
+              type: number
         source:
           type: string
         sub_type:
@@ -1753,13 +1851,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/EntityField'
       required:
@@ -1772,13 +1865,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/EntityField'
         event:
@@ -2034,13 +2122,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/EntityField'
         event:
@@ -2145,13 +2228,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/EntityField'
         event:

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -1252,6 +1252,28 @@ paths:
         - Security Entity Analytics API
 components:
   schemas:
+    Asset:
+      additionalProperties: false
+      type: object
+      properties:
+        business_unit:
+          type: string
+        criticality:
+          $ref: '#/components/schemas/AssetCriticalityLevel'
+        environment:
+          type: string
+        id:
+          type: string
+        model:
+          type: string
+        name:
+          type: string
+        owner:
+          type: string
+        serial_number:
+          type: string
+        vendor:
+          type: string
     AssetCriticalityBulkUploadErrorItem:
       type: object
       properties:
@@ -1625,11 +1647,24 @@ components:
           additionalProperties: false
           type: object
           properties:
+            asset:
+              type: boolean
+            managed:
+              type: boolean
+            mfa_enabled:
+              type: boolean
             privileged:
               type: boolean
-        behavior:
+        behaviors:
           additionalProperties: false
           type: object
+          properties:
+            brute_force_victim:
+              type: boolean
+            new_country_login:
+              type: boolean
+            used_usb_device:
+              type: boolean
         EngineMetadata:
           $ref: '#/components/schemas/EngineMetadata'
         id:
@@ -1641,8 +1676,71 @@ components:
             first_seen:
               format: date-time
               type: string
+            last_activity:
+              format: date-time
+              type: string
         name:
           type: string
+        relationships:
+          additionalProperties: false
+          type: object
+          properties:
+            accessed_frequently_by:
+              items:
+                type: string
+              type: array
+            accesses_frequently:
+              items:
+                type: string
+              type: array
+            communicates_with:
+              items:
+                type: string
+              type: array
+            dependent_of:
+              items:
+                type: string
+              type: array
+            depends_on:
+              items:
+                type: string
+              type: array
+            owned_by:
+              items:
+                type: string
+              type: array
+            owns:
+              items:
+                type: string
+              type: array
+            supervised_by:
+              items:
+                type: string
+              type: array
+            supervises:
+              items:
+                type: string
+              type: array
+        risk:
+          additionalProperties: false
+          type: object
+          properties:
+            calculated_level:
+              $ref: '#/components/schemas/EntityRiskLevels'
+              description: Lexical description of the entity's risk.
+              example: Critical
+            calculated_score:
+              description: The raw numeric value of the given entity's risk score.
+              format: double
+              type: number
+            calculated_score_norm:
+              description: >-
+                The normalized numeric value of the given entity's risk score.
+                Useful for comparing with other entities.
+              format: double
+              maximum: 100
+              minimum: 0
+              type: number
         source:
           type: string
         sub_type:
@@ -1753,13 +1851,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/EntityField'
       required:
@@ -1772,13 +1865,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/EntityField'
         event:
@@ -2034,13 +2122,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/EntityField'
         event:
@@ -2145,13 +2228,8 @@ components:
           format: date-time
           type: string
         asset:
+          $ref: '#/components/schemas/Asset'
           additionalProperties: false
-          type: object
-          properties:
-            criticality:
-              $ref: '#/components/schemas/AssetCriticalityLevel'
-          required:
-            - criticality
         entity:
           $ref: '#/components/schemas/EntityField'
         event:

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/elasticsearch_assets/__snapshots__/updates_component_template.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/elasticsearch_assets/__snapshots__/updates_component_template.test.ts.snap
@@ -9,7 +9,7 @@ Object {
         "@timestamp": Object {
           "type": "date",
         },
-        "asset.business.unit": Object {
+        "asset.business_unit": Object {
           "type": "keyword",
         },
         "asset.criticality": Object {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/elasticsearch_assets/__snapshots__/updates_component_template.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/elasticsearch_assets/__snapshots__/updates_component_template.test.ts.snap
@@ -9,7 +9,31 @@ Object {
         "@timestamp": Object {
           "type": "date",
         },
+        "asset.business.unit": Object {
+          "type": "keyword",
+        },
         "asset.criticality": Object {
+          "type": "keyword",
+        },
+        "asset.environment": Object {
+          "type": "keyword",
+        },
+        "asset.id": Object {
+          "type": "keyword",
+        },
+        "asset.model": Object {
+          "type": "keyword",
+        },
+        "asset.name": Object {
+          "type": "keyword",
+        },
+        "asset.owner": Object {
+          "type": "keyword",
+        },
+        "asset.serial_number": Object {
+          "type": "keyword",
+        },
+        "asset.vendor": Object {
           "type": "keyword",
         },
         "host.architecture": Object {
@@ -18,14 +42,59 @@ Object {
         "host.domain": Object {
           "type": "keyword",
         },
+        "host.entity.attributes.Asset": Object {
+          "type": "boolean",
+        },
+        "host.entity.attributes.Managed": Object {
+          "type": "boolean",
+        },
+        "host.entity.attributes.Mfa_enabled": Object {
+          "type": "boolean",
+        },
         "host.entity.attributes.Privileged": Object {
+          "type": "boolean",
+        },
+        "host.entity.behaviors.Brute_force_victim": Object {
+          "type": "boolean",
+        },
+        "host.entity.behaviors.New_country_login": Object {
+          "type": "boolean",
+        },
+        "host.entity.behaviors.Used_usb_device": Object {
           "type": "boolean",
         },
         "host.entity.lifecycle.First_seen": Object {
           "type": "date",
         },
+        "host.entity.lifecycle.Last_activity": Object {
+          "type": "date",
+        },
         "host.entity.name": Object {
           "type": "keyword",
+        },
+        "host.entity.relationships.Accessed_frequently_by": Object {
+          "type": "keyword",
+        },
+        "host.entity.relationships.Communicates_with": Object {
+          "type": "keyword",
+        },
+        "host.entity.relationships.Dependent_of": Object {
+          "type": "keyword",
+        },
+        "host.entity.relationships.Depends_on": Object {
+          "type": "keyword",
+        },
+        "host.entity.relationships.Owned_by": Object {
+          "type": "keyword",
+        },
+        "host.entity.risk.calculated_level": Object {
+          "type": "keyword",
+        },
+        "host.entity.risk.calculated_score": Object {
+          "type": "float",
+        },
+        "host.entity.risk.calculated_score_norm": Object {
+          "type": "float",
         },
         "host.entity.source": Object {
           "type": "keyword",

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/common.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/common.ts
@@ -60,23 +60,28 @@ export const getEntityFieldsDescriptions = (rootField?: EntityType) => {
       source: `${prefix}.attributes.Privileged`,
       destination: 'entity.attributes.Privileged',
       mapping: { type: 'boolean' },
+      allowAPIUpdate: true,
     }),
     newestValue({
       source: `${prefix}.attributes.Asset`,
       destination: 'entity.attributes.Asset',
       mapping: { type: 'boolean' },
+      allowAPIUpdate: true,
     }),
     newestValue({
       source: `${prefix}.attributes.Managed`,
       destination: 'entity.attributes.Managed',
       mapping: { type: 'boolean' },
+      allowAPIUpdate: true,
     }),
     newestValue({
       source: `${prefix}.attributes.Mfa_enabled`,
       destination: 'entity.attributes.Mfa_enabled',
       mapping: { type: 'boolean' },
+      allowAPIUpdate: true,
     }),
 
+    /* Lifecycle fields should not allow update via the API */
     newestValue({
       source: `${prefix}.lifecycle.First_seen`,
       destination: 'entity.lifecycle.First_seen',
@@ -92,16 +97,19 @@ export const getEntityFieldsDescriptions = (rootField?: EntityType) => {
       source: `${prefix}.behaviors.Brute_force_victim`,
       destination: 'entity.behaviors.Brute_force_victim',
       mapping: { type: 'boolean' },
+      allowAPIUpdate: true,
     }),
     newestValue({
       source: `${prefix}.behaviors.New_country_login`,
       destination: 'entity.behaviors.New_country_login',
       mapping: { type: 'boolean' },
+      allowAPIUpdate: true,
     }),
     newestValue({
       source: `${prefix}.behaviors.Used_usb_device`,
       destination: 'entity.behaviors.Used_usb_device',
       mapping: { type: 'boolean' },
+      allowAPIUpdate: true,
     }),
 
     newestValue({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/common.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/common.ts
@@ -27,7 +27,7 @@ export const getCommonFieldDescriptions = (ecsField: BaseECSEntityField): FieldD
     newestValue({ source: 'asset.vendor' }),
     newestValue({ source: 'asset.environment' }),
     newestValue({ source: 'asset.criticality' }),
-    newestValue({ source: 'asset.business.unit' }),
+    newestValue({ source: 'asset.business_unit' }),
     newestValue({
       source: `${ecsField}.risk.calculated_level`,
     }),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/common.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/common.ts
@@ -19,7 +19,15 @@ export const getCommonFieldDescriptions = (ecsField: BaseECSEntityField): FieldD
       source: '_index',
       destination: 'entity.source',
     }),
+    newestValue({ source: 'asset.id' }),
+    newestValue({ source: 'asset.name' }),
+    newestValue({ source: 'asset.owner' }),
+    newestValue({ source: 'asset.serial_number' }),
+    newestValue({ source: 'asset.model' }),
+    newestValue({ source: 'asset.vendor' }),
+    newestValue({ source: 'asset.environment' }),
     newestValue({ source: 'asset.criticality' }),
+    newestValue({ source: 'asset.business.unit' }),
     newestValue({
       source: `${ecsField}.risk.calculated_level`,
     }),
@@ -47,15 +55,72 @@ export const getEntityFieldsDescriptions = (rootField?: EntityType) => {
     newestValue({ source: `${prefix}.type`, destination: 'entity.type' }),
     newestValue({ source: `${prefix}.sub_type`, destination: 'entity.sub_type' }),
     newestValue({ source: `${prefix}.url`, destination: 'entity.url' }),
+
     newestValue({
       source: `${prefix}.attributes.Privileged`,
       destination: 'entity.attributes.Privileged',
       mapping: { type: 'boolean' },
     }),
     newestValue({
+      source: `${prefix}.attributes.Asset`,
+      destination: 'entity.attributes.Asset',
+      mapping: { type: 'boolean' },
+    }),
+    newestValue({
+      source: `${prefix}.attributes.Managed`,
+      destination: 'entity.attributes.Managed',
+      mapping: { type: 'boolean' },
+    }),
+    newestValue({
+      source: `${prefix}.attributes.Mfa_enabled`,
+      destination: 'entity.attributes.Mfa_enabled',
+      mapping: { type: 'boolean' },
+    }),
+
+    newestValue({
       source: `${prefix}.lifecycle.First_seen`,
       destination: 'entity.lifecycle.First_seen',
       mapping: { type: 'date' },
+    }),
+    newestValue({
+      source: `${prefix}.lifecycle.Last_activity`,
+      destination: 'entity.lifecycle.Last_activity',
+      mapping: { type: 'date' },
+    }),
+
+    newestValue({
+      source: `${prefix}.behaviors.Brute_force_victim`,
+      destination: 'entity.behaviors.Brute_force_victim',
+      mapping: { type: 'boolean' },
+    }),
+    newestValue({
+      source: `${prefix}.behaviors.New_country_login`,
+      destination: 'entity.behaviors.New_country_login',
+      mapping: { type: 'boolean' },
+    }),
+    newestValue({
+      source: `${prefix}.behaviors.Used_usb_device`,
+      destination: 'entity.behaviors.Used_usb_device',
+      mapping: { type: 'boolean' },
+    }),
+
+    newestValue({
+      source: `${prefix}.risk.calculated_level`,
+      destination: 'entity.risk.calculated_level',
+    }),
+    newestValue({
+      source: `${prefix}.risk.calculated_score`,
+      destination: 'entity.risk.calculated_score',
+      mapping: {
+        type: 'float',
+      },
+    }),
+    newestValue({
+      source: `${prefix}.risk.calculated_score_norm`,
+      destination: 'entity.risk.calculated_score_norm',
+      mapping: {
+        type: 'float',
+      },
     }),
   ];
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/field_utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/field_utils.ts
@@ -13,11 +13,13 @@ export const collectValues = ({
   source,
   fieldHistoryLength = 10,
   mapping = { type: 'keyword' },
+  allowAPIUpdate = false,
 }: {
   source: string;
   destination?: string;
   mapping?: MappingProperty;
   fieldHistoryLength?: number;
+  allowAPIUpdate?: boolean;
 }): FieldDescription => ({
   destination: destination ?? source,
   source,
@@ -30,6 +32,7 @@ export const collectValues = ({
     limit: fieldHistoryLength,
   },
   mapping,
+  allowAPIUpdate,
 });
 
 export const newestValue = ({
@@ -37,11 +40,13 @@ export const newestValue = ({
   mapping = { type: 'keyword' },
   source,
   sort,
+  allowAPIUpdate,
 }: {
   source: string;
   destination?: string;
   mapping?: MappingProperty;
   sort?: Record<string, 'asc' | 'desc'>;
+  allowAPIUpdate?: boolean;
 }): FieldDescription => ({
   destination: destination ?? source,
   source,
@@ -53,6 +58,7 @@ export const newestValue = ({
     },
   },
   mapping,
+  allowAPIUpdate,
 });
 
 export const oldestValue = ({
@@ -76,4 +82,5 @@ export const oldestValue = ({
     },
   },
   mapping,
+  allowAPIUpdate: false, // oldest value should never be updated
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/host.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/host.ts
@@ -62,27 +62,32 @@ export const hostEntityEngineDescription: EntityDescription = {
       source: `host.entity.relationships.Communicates_with`,
       destination: 'entity.relationships.Communicates_with',
       mapping: { type: 'keyword' },
+      allowAPIUpdate: true,
     }),
     collect({
       source: `host.entity.relationships.Depends_on`,
       destination: 'entity.relationships.Depends_on',
       mapping: { type: 'keyword' },
+      allowAPIUpdate: true,
     }),
     collect({
       source: `host.entity.relationships.Dependent_of`,
       destination: 'entity.relationships.Dependent_of',
       mapping: { type: 'keyword' },
+      allowAPIUpdate: true,
     }),
 
     collect({
       source: `host.entity.relationships.Owned_by`,
       destination: 'entity.relationships.Owned_by',
       mapping: { type: 'keyword' },
+      allowAPIUpdate: true,
     }),
     collect({
       source: `host.entity.relationships.Accessed_frequently_by`,
       destination: 'entity.relationships.Accessed_frequently_by',
       mapping: { type: 'keyword' },
+      allowAPIUpdate: true,
     }),
   ],
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/host.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/host.ts
@@ -57,5 +57,32 @@ export const hostEntityEngineDescription: EntityDescription = {
     collect({ source: 'host.architecture' }),
     ...getCommonFieldDescriptions('host'),
     ...getEntityFieldsDescriptions('host'),
+
+    collect({
+      source: `host.entity.relationships.Communicates_with`,
+      destination: 'entity.relationships.Communicates_with',
+      mapping: { type: 'keyword' },
+    }),
+    collect({
+      source: `host.entity.relationships.Depends_on`,
+      destination: 'entity.relationships.Depends_on',
+      mapping: { type: 'keyword' },
+    }),
+    collect({
+      source: `host.entity.relationships.Dependent_of`,
+      destination: 'entity.relationships.Dependent_of',
+      mapping: { type: 'keyword' },
+    }),
+
+    collect({
+      source: `host.entity.relationships.Owned_by`,
+      destination: 'entity.relationships.Owned_by',
+      mapping: { type: 'keyword' },
+    }),
+    collect({
+      source: `host.entity.relationships.Accessed_frequently_by`,
+      destination: 'entity.relationships.Accessed_frequently_by',
+      mapping: { type: 'keyword' },
+    }),
   ],
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/service.ts
@@ -43,5 +43,21 @@ export const serviceEntityEngineDescription: EntityDescription = {
     newestValue({ source: 'service.version' }),
     ...getCommonFieldDescriptions('service'),
     ...getEntityFieldsDescriptions('service'),
+
+    collect({
+      source: `service.entity.relationships.Communicates_with`,
+      destination: 'entity.relationships.Communicates_with',
+      mapping: { type: 'date' },
+    }),
+    collect({
+      source: `service.entity.relationships.Depends_on`,
+      destination: 'entity.relationships.Depends_on',
+      mapping: { type: 'date' },
+    }),
+    collect({
+      source: `service.entity.relationships.Dependent_of`,
+      destination: 'entity.relationships.Dependent_of',
+      mapping: { type: 'date' },
+    }),
   ],
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/service.ts
@@ -48,16 +48,19 @@ export const serviceEntityEngineDescription: EntityDescription = {
       source: `service.entity.relationships.Communicates_with`,
       destination: 'entity.relationships.Communicates_with',
       mapping: { type: 'date' },
+      allowAPIUpdate: true,
     }),
     collect({
       source: `service.entity.relationships.Depends_on`,
       destination: 'entity.relationships.Depends_on',
       mapping: { type: 'date' },
+      allowAPIUpdate: true,
     }),
     collect({
       source: `service.entity.relationships.Dependent_of`,
       destination: 'entity.relationships.Dependent_of',
       mapping: { type: 'date' },
+      allowAPIUpdate: true,
     }),
   ],
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/user.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/user.ts
@@ -61,22 +61,26 @@ export const userEntityEngineDescription: EntityDescription = {
       source: `user.entity.relationships.Accesses_frequently`,
       destination: 'entity.relationships.Accesses_frequently',
       mapping: { type: 'keyword' },
+      allowAPIUpdate: true,
     }),
     collect({
       source: `user.entity.relationships.Owns`,
       destination: 'entity.relationships.Owns',
       mapping: { type: 'keyword' },
+      allowAPIUpdate: true,
     }),
 
     collect({
       source: `user.entity.relationships.Supervises`,
       destination: 'entity.relationships.Supervises',
       mapping: { type: 'keyword' },
+      allowAPIUpdate: true,
     }),
     collect({
       source: `user.entity.relationships.Supervised_by`,
       destination: 'entity.relationships.Supervised_by',
       mapping: { type: 'keyword' },
+      allowAPIUpdate: true,
     }),
   ],
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/user.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/user.ts
@@ -56,5 +56,27 @@ export const userEntityEngineDescription: EntityDescription = {
     collect({ source: 'user.roles' }),
     ...getCommonFieldDescriptions('user'),
     ...getEntityFieldsDescriptions('user'),
+
+    collect({
+      source: `user.entity.relationships.Accesses_frequently`,
+      destination: 'entity.relationships.Accesses_frequently',
+      mapping: { type: 'keyword' },
+    }),
+    collect({
+      source: `user.entity.relationships.Owns`,
+      destination: 'entity.relationships.Owns',
+      mapping: { type: 'keyword' },
+    }),
+
+    collect({
+      source: `user.entity.relationships.Supervises`,
+      destination: 'entity.relationships.Supervises',
+      mapping: { type: 'keyword' },
+    }),
+    collect({
+      source: `user.entity.relationships.Supervised_by`,
+      destination: 'entity.relationships.Supervised_by',
+      mapping: { type: 'keyword' },
+    }),
   ],
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.test.ts
@@ -107,8 +107,8 @@ describe('EntityStoreCrudClient', () => {
           attributes: {
             privileged: true,
           },
-          lifecycle: {
-            first_seen: new Date().toISOString(),
+          behaviors: {
+            brute_force_victim: true,
           },
         },
       };
@@ -137,8 +137,8 @@ describe('EntityStoreCrudClient', () => {
           attributes: {
             privileged: true,
           },
-          lifecycle: {
-            first_seen: '1995-12-17T03:24:00',
+          behaviors: {
+            brute_force_victim: true,
           },
         },
       };
@@ -163,8 +163,8 @@ describe('EntityStoreCrudClient', () => {
             `ctx._source['entity'] = ctx._source['entity'] == null ? [:] : ctx._source['entity'];` +
             `ctx._source['entity']['attributes'] = ctx._source['entity']['attributes'] == null ? [:] : ctx._source['entity']['attributes'];` +
             `ctx._source['entity']['attributes']['Privileged'] = true;` +
-            `ctx._source['entity']['lifecycle'] = ctx._source['entity']['lifecycle'] == null ? [:] : ctx._source['entity']['lifecycle'];` +
-            `ctx._source['entity']['lifecycle']['First_seen'] = '1995-12-17T03:24:00';`,
+            `ctx._source['entity']['behaviors'] = ctx._source['entity']['behaviors'] == null ? [:] : ctx._source['entity']['behaviors'];` +
+            `ctx._source['entity']['behaviors']['Brute_force_victim'] = true;`,
         },
       });
 
@@ -180,9 +180,9 @@ describe('EntityStoreCrudClient', () => {
               attributes: {
                 Privileged: true,
               },
-              lifecycle: {
+              behaviors: {
                 // eslint-disable-next-line @typescript-eslint/naming-convention
-                First_seen: '1995-12-17T03:24:00',
+                Brute_force_victim: true,
               },
             },
           },
@@ -212,8 +212,8 @@ describe('EntityStoreCrudClient', () => {
           attributes: {
             privileged: false,
           },
-          lifecycle: {
-            first_seen: '1995-12-17T03:24:00',
+          behaviors: {
+            brute_force_victim: true,
           },
         },
       };
@@ -239,8 +239,8 @@ describe('EntityStoreCrudClient', () => {
             `ctx._source['entity']['name'] = 'mysql-db';` +
             `ctx._source['entity']['attributes'] = ctx._source['entity']['attributes'] == null ? [:] : ctx._source['entity']['attributes'];` +
             `ctx._source['entity']['attributes']['Privileged'] = false;` +
-            `ctx._source['entity']['lifecycle'] = ctx._source['entity']['lifecycle'] == null ? [:] : ctx._source['entity']['lifecycle'];` +
-            `ctx._source['entity']['lifecycle']['First_seen'] = '1995-12-17T03:24:00';`,
+            `ctx._source['entity']['behaviors'] = ctx._source['entity']['behaviors'] == null ? [:] : ctx._source['entity']['behaviors'];` +
+            `ctx._source['entity']['behaviors']['Brute_force_victim'] = true;`,
         },
       });
 
@@ -255,9 +255,9 @@ describe('EntityStoreCrudClient', () => {
             attributes: {
               Privileged: false,
             },
-            lifecycle: {
+            behaviors: {
               // eslint-disable-next-line @typescript-eslint/naming-convention
-              First_seen: '1995-12-17T03:24:00',
+              Brute_force_victim: true,
             },
           },
         },
@@ -289,8 +289,8 @@ describe('EntityStoreCrudClient', () => {
           attributes: {
             privileged: true,
           },
-          lifecycle: {
-            first_seen: '1995-12-17T03:24:00',
+          behaviors: {
+            brute_force_victim: true,
           },
         },
       };
@@ -318,8 +318,8 @@ describe('EntityStoreCrudClient', () => {
             `ctx._source['entity'] = ctx._source['entity'] == null ? [:] : ctx._source['entity'];` +
             `ctx._source['entity']['attributes'] = ctx._source['entity']['attributes'] == null ? [:] : ctx._source['entity']['attributes'];` +
             `ctx._source['entity']['attributes']['Privileged'] = true;` +
-            `ctx._source['entity']['lifecycle'] = ctx._source['entity']['lifecycle'] == null ? [:] : ctx._source['entity']['lifecycle'];` +
-            `ctx._source['entity']['lifecycle']['First_seen'] = '1995-12-17T03:24:00';`,
+            `ctx._source['entity']['behaviors'] = ctx._source['entity']['behaviors'] == null ? [:] : ctx._source['entity']['behaviors'];` +
+            `ctx._source['entity']['behaviors']['Brute_force_victim'] = true;`,
         },
       });
 
@@ -336,9 +336,9 @@ describe('EntityStoreCrudClient', () => {
               attributes: {
                 Privileged: true,
               },
-              lifecycle: {
+              behaviors: {
                 // eslint-disable-next-line @typescript-eslint/naming-convention
-                First_seen: '1995-12-17T03:24:00',
+                Brute_force_victim: true,
               },
             },
           },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.test.ts
@@ -76,7 +76,6 @@ describe('EntityStoreCrudClient', () => {
       const doc: Entity = {
         user: {
           name: 'not-allowed',
-          id: ['123'],
         },
         entity: {
           id: 'host-1',
@@ -88,10 +87,10 @@ describe('EntityStoreCrudClient', () => {
         },
       };
 
-      await expect(async () => client.upsertEntity('host', doc)).rejects.toThrow(
+      await expect(async () => client.upsertEntity('user', doc)).rejects.toThrow(
         new BadCRUDRequestError(
           `The following attributes are not allowed to be ` +
-            `updated without forcing it (?force=true): user.name, user.id, entity.type, entity.sub_type`
+            `updated without forcing it (?force=true): entity.type, entity.sub_type`
         )
       );
     });
@@ -106,9 +105,6 @@ describe('EntityStoreCrudClient', () => {
           id: 'host-1',
           attributes: {
             privileged: true,
-          },
-          behaviors: {
-            brute_force_victim: true,
           },
         },
       };
@@ -137,9 +133,6 @@ describe('EntityStoreCrudClient', () => {
           attributes: {
             privileged: true,
           },
-          behaviors: {
-            brute_force_victim: true,
-          },
         },
       };
 
@@ -162,9 +155,7 @@ describe('EntityStoreCrudClient', () => {
           source:
             `ctx._source['entity'] = ctx._source['entity'] == null ? [:] : ctx._source['entity'];` +
             `ctx._source['entity']['attributes'] = ctx._source['entity']['attributes'] == null ? [:] : ctx._source['entity']['attributes'];` +
-            `ctx._source['entity']['attributes']['Privileged'] = true;` +
-            `ctx._source['entity']['behaviors'] = ctx._source['entity']['behaviors'] == null ? [:] : ctx._source['entity']['behaviors'];` +
-            `ctx._source['entity']['behaviors']['Brute_force_victim'] = true;`,
+            `ctx._source['entity']['attributes']['Privileged'] = true;`,
         },
       });
 
@@ -179,10 +170,6 @@ describe('EntityStoreCrudClient', () => {
               id: 'host-1',
               attributes: {
                 Privileged: true,
-              },
-              behaviors: {
-                // eslint-disable-next-line @typescript-eslint/naming-convention
-                Brute_force_victim: true,
               },
             },
           },
@@ -212,8 +199,8 @@ describe('EntityStoreCrudClient', () => {
           attributes: {
             privileged: false,
           },
-          behaviors: {
-            brute_force_victim: true,
+          lifecycle: {
+            first_seen: '1995-12-17T03:24:00',
           },
         },
       };
@@ -239,8 +226,8 @@ describe('EntityStoreCrudClient', () => {
             `ctx._source['entity']['name'] = 'mysql-db';` +
             `ctx._source['entity']['attributes'] = ctx._source['entity']['attributes'] == null ? [:] : ctx._source['entity']['attributes'];` +
             `ctx._source['entity']['attributes']['Privileged'] = false;` +
-            `ctx._source['entity']['behaviors'] = ctx._source['entity']['behaviors'] == null ? [:] : ctx._source['entity']['behaviors'];` +
-            `ctx._source['entity']['behaviors']['Brute_force_victim'] = true;`,
+            `ctx._source['entity']['lifecycle'] = ctx._source['entity']['lifecycle'] == null ? [:] : ctx._source['entity']['lifecycle'];` +
+            `ctx._source['entity']['lifecycle']['First_seen'] = '1995-12-17T03:24:00';`,
         },
       });
 
@@ -255,9 +242,9 @@ describe('EntityStoreCrudClient', () => {
             attributes: {
               Privileged: false,
             },
-            behaviors: {
+            lifecycle: {
               // eslint-disable-next-line @typescript-eslint/naming-convention
-              Brute_force_victim: true,
+              First_seen: '1995-12-17T03:24:00',
             },
           },
         },
@@ -281,7 +268,7 @@ describe('EntityStoreCrudClient', () => {
 
       const doc: Entity = {
         host: {
-          name: 'not-allowed',
+          name: 'should not be there',
           id: ['123'],
         },
         entity: {
@@ -289,8 +276,8 @@ describe('EntityStoreCrudClient', () => {
           attributes: {
             privileged: true,
           },
-          behaviors: {
-            brute_force_victim: true,
+          lifecycle: {
+            first_seen: '1995-12-17T03:24:00',
           },
         },
       };
@@ -313,13 +300,22 @@ describe('EntityStoreCrudClient', () => {
           lang: 'painless',
           source:
             `ctx._source['host'] = ctx._source['host'] == null ? [:] : ctx._source['host'];` +
-            `ctx._source['host']['name'] = 'not-allowed';` +
-            `ctx._source['host']['id'] = ['123'];` +
+            `def collectMap = [:];` +
+            `collectMap['host.id'] = new HashSet();` +
+            `collectMap['host.id'].addAll(['123']);` +
+            `if (!(ctx?._source['host']['id'] == null || ((ctx._source['host']['id'] instanceof Collection || ctx._source['host']['id'] instanceof String || ctx._source['host']['id'] instanceof Map) && ctx._source['host']['id'].isEmpty()))) {` +
+            `  if(ctx._source['host']['id'] instanceof Collection) {` +
+            `    collectMap['host.id'].addAll(ctx._source['host']['id']);` +
+            `  } else {` +
+            `    collectMap['host.id'].add(ctx._source['host']['id']);` +
+            `  }` +
+            `}` +
+            `ctx._source['host']['id'] = new ArrayList(collectMap['host.id']).subList(0, (int) Math.min(10, collectMap['host.id'].size()));` +
             `ctx._source['entity'] = ctx._source['entity'] == null ? [:] : ctx._source['entity'];` +
             `ctx._source['entity']['attributes'] = ctx._source['entity']['attributes'] == null ? [:] : ctx._source['entity']['attributes'];` +
             `ctx._source['entity']['attributes']['Privileged'] = true;` +
-            `ctx._source['entity']['behaviors'] = ctx._source['entity']['behaviors'] == null ? [:] : ctx._source['entity']['behaviors'];` +
-            `ctx._source['entity']['behaviors']['Brute_force_victim'] = true;`,
+            `ctx._source['entity']['lifecycle'] = ctx._source['entity']['lifecycle'] == null ? [:] : ctx._source['entity']['lifecycle'];` +
+            `ctx._source['entity']['lifecycle']['First_seen'] = '1995-12-17T03:24:00';`,
         },
       });
 
@@ -336,9 +332,9 @@ describe('EntityStoreCrudClient', () => {
               attributes: {
                 Privileged: true,
               },
-              behaviors: {
+              lifecycle: {
                 // eslint-disable-next-line @typescript-eslint/naming-convention
-                Brute_force_victim: true,
+                First_seen: '1995-12-17T03:24:00',
               },
             },
           },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.ts
@@ -29,7 +29,8 @@ import { getEntityUpdatesDataStreamName } from './elasticsearch_assets/updates_e
 interface CustomEntityFieldsAttributesHolder {
   attributes?: Record<string, unknown>;
   lifecycle?: Record<string, unknown>;
-  behavior?: Record<string, unknown>;
+  behaviors?: Record<string, unknown>;
+  relationships?: Record<string, unknown>;
 }
 
 type CustomECSEntityField = EntityField & CustomEntityFieldsAttributesHolder;
@@ -48,7 +49,8 @@ const ID_FIELD = 'entity.id';
 const nonForcedAttributesPathRegex = [
   /entity\.attributes\..*/,
   /entity\.lifecycle\..*/,
-  /entity\.behavior\..*/,
+  /entity\.behaviors\..*/,
+  /entity\.relationships\..*/,
 ];
 
 export class EntityStoreCrudClient {
@@ -162,8 +164,8 @@ function isPropAllowed(prop: string) {
 function normalizeToECS(doc: Entity): CustomECSDocument {
   const normalizedDoc = { ...doc }; // create copy
 
-  const { attributes, lifecycle, behavior } = doc.entity;
-  const objsToCheck = { attributes, lifecycle, behavior };
+  const { attributes, lifecycle, behaviors, relationships } = doc.entity;
+  const objsToCheck = { attributes, lifecycle, behaviors, relationships };
   for (const key of Object.keys(objsToCheck)) {
     const typedKey = key as keyof typeof objsToCheck;
     const value = objsToCheck[typedKey];

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.ts
@@ -25,6 +25,9 @@ import {
 import { getEntitiesIndexName } from './utils';
 import { buildUpdateEntityPainlessScript } from './painless/build_update_script';
 import { getEntityUpdatesDataStreamName } from './elasticsearch_assets/updates_entity_data_stream';
+import { engineDescriptionRegistry } from './installation/engine_description';
+import type { EntityDescription } from './entity_definitions/types';
+import type { FieldDescription } from './installation/types';
 
 interface CustomEntityFieldsAttributesHolder {
   attributes?: Record<string, unknown>;
@@ -44,13 +47,7 @@ interface EntityStoreClientOpts {
   dataClient: EntityStoreDataClient;
 }
 
-const ID_FIELD = 'entity.id';
-
-const nonForcedAttributesPathRegex = [
-  /entity\.attributes\..*/,
-  /entity\.behaviors\..*/,
-  /entity\.relationships\..*/,
-];
+const ENTITY_ID_FIELD = 'entity.id';
 
 export class EntityStoreCrudClient {
   private esClient: ElasticsearchClient;
@@ -72,13 +69,15 @@ export class EntityStoreCrudClient {
     const normalizedDocToECS = normalizeToECS(doc);
     const flatProps = getFlattenedObject(normalizedDocToECS);
 
+    const entityTypeDescription = engineDescriptionRegistry[type];
+    const fieldDescriptions = getFieldDescriptions(flatProps, entityTypeDescription);
     if (!force) {
-      assertOnlyNonForcedAttributesInReq(flatProps);
+      assertOnlyNonForcedAttributesInReq(fieldDescriptions);
     }
 
     this.logger.info(`Updating entity '${doc.entity.id}' (type ${type})`);
 
-    const painlessUpdate = buildUpdateEntityPainlessScript(flatProps);
+    const painlessUpdate = buildUpdateEntityPainlessScript(fieldDescriptions);
 
     if (!painlessUpdate) {
       throw new BadCRUDRequestError(`The request doesn't contain any update`);
@@ -128,12 +127,12 @@ export class EntityStoreCrudClient {
   }
 }
 
-function assertOnlyNonForcedAttributesInReq(flatProps: Record<string, unknown>) {
+function assertOnlyNonForcedAttributesInReq(fields: Record<string, FieldDescription>) {
   const notAllowedProps = [];
-  const keys = Object.keys(flatProps);
-  for (const key of keys) {
-    if (!isPropAllowed(key)) {
-      notAllowedProps.push(key);
+
+  for (const [name, description] of Object.entries(fields)) {
+    if (!description.allowAPIUpdate && name !== ENTITY_ID_FIELD) {
+      notAllowedProps.push(name);
     }
   }
 
@@ -144,20 +143,6 @@ function assertOnlyNonForcedAttributesInReq(flatProps: Record<string, unknown>) 
         `updated without forcing it (?force=true): ${notAllowedPropsString}`
     );
   }
-}
-
-function isPropAllowed(prop: string) {
-  if (prop === ID_FIELD) {
-    return true;
-  }
-
-  for (const regex of nonForcedAttributesPathRegex) {
-    if (regex.test(prop)) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 function normalizeToECS(doc: Entity): CustomECSDocument {
@@ -228,4 +213,43 @@ function buildDocumentToUpdate(type: APIEntityType, data: Partial<CustomECSDocum
   doc[type as keyof typeof doc] = typeData;
 
   return doc;
+}
+function getFieldDescriptions(
+  flatProps: Record<string, unknown>,
+  description: EntityDescription
+): Record<string, FieldDescription & { value: unknown }> {
+  const allFieldDescriptions = description.fields.reduce((obj, field) => {
+    obj[field.destination || field.source] = field;
+    return obj;
+  }, {} as Record<string, FieldDescription>);
+
+  const invalid: string[] = [];
+  const descriptions: Record<string, FieldDescription & { value: unknown }> = {};
+
+  for (const [key, value] of Object.entries(flatProps)) {
+    if (key === ENTITY_ID_FIELD || key === description.identityField) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    if (!allFieldDescriptions[key]) {
+      invalid.push(key);
+    } else {
+      descriptions[key] = {
+        ...allFieldDescriptions[key],
+        value,
+      };
+    }
+  }
+
+  // This will catch differences between
+  // API and entity store definition
+  if (invalid.length > 0) {
+    const invalidString = invalid.join(', ');
+    throw new BadCRUDRequestError(
+      `The following attributes are not allowed to be updated: ${invalidString}`
+    );
+  }
+
+  return descriptions;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.ts
@@ -48,7 +48,6 @@ const ID_FIELD = 'entity.id';
 
 const nonForcedAttributesPathRegex = [
   /entity\.attributes\..*/,
-  /entity\.lifecycle\..*/,
   /entity\.behaviors\..*/,
   /entity\.relationships\..*/,
 ];

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/__snapshots__/engine_description.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/__snapshots__/engine_description.test.ts.snap
@@ -818,8 +818,8 @@ Object {
         },
         "type": "top_value",
       },
-      "destination": "asset.business.unit",
-      "source": "asset.business.unit",
+      "destination": "asset.business_unit",
+      "source": "asset.business_unit",
     },
     Object {
       "aggregation": Object {
@@ -864,7 +864,7 @@ Object {
     "@timestamp": Object {
       "type": "date",
     },
-    "asset.business.unit": Object {
+    "asset.business_unit": Object {
       "type": "keyword",
     },
     "asset.criticality": Object {
@@ -1312,8 +1312,8 @@ Object {
         },
         "type": "top_value",
       },
-      "destination": "asset.business.unit",
-      "source": "asset.business.unit",
+      "destination": "asset.business_unit",
+      "source": "asset.business_unit",
     },
     Object {
       "aggregation": Object {
@@ -1568,7 +1568,7 @@ Object {
     "@timestamp": Object {
       "type": "date",
     },
-    "asset.business.unit": Object {
+    "asset.business_unit": Object {
       "type": "keyword",
     },
     "asset.criticality": Object {
@@ -1921,8 +1921,8 @@ Object {
         },
         "type": "top_value",
       },
-      "destination": "asset.business.unit",
-      "source": "asset.business.unit",
+      "destination": "asset.business_unit",
+      "source": "asset.business_unit",
     },
     Object {
       "aggregation": Object {
@@ -2161,7 +2161,7 @@ Object {
     "@timestamp": Object {
       "type": "date",
     },
-    "asset.business.unit": Object {
+    "asset.business_unit": Object {
       "type": "keyword",
     },
     "asset.criticality": Object {
@@ -2470,8 +2470,8 @@ Object {
         },
         "type": "top_value",
       },
-      "destination": "asset.business.unit",
-      "source": "asset.business.unit",
+      "destination": "asset.business_unit",
+      "source": "asset.business_unit",
     },
     Object {
       "aggregation": Object {
@@ -2718,7 +2718,7 @@ Object {
     "@timestamp": Object {
       "type": "date",
     },
-    "asset.business.unit": Object {
+    "asset.business_unit": Object {
       "type": "keyword",
     },
     "asset.criticality": Object {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/__snapshots__/engine_description.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/__snapshots__/engine_description.test.ts.snap
@@ -98,8 +98,108 @@ Object {
         },
         "type": "top_value",
       },
+      "destination": "entity.attributes.Asset",
+      "source": "entity.attributes.Asset",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.attributes.Managed",
+      "source": "entity.attributes.Managed",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.attributes.Mfa_enabled",
+      "source": "entity.attributes.Mfa_enabled",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
       "destination": "entity.lifecycle.First_seen",
       "source": "entity.lifecycle.First_seen",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.lifecycle.Last_activity",
+      "source": "entity.lifecycle.Last_activity",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.Brute_force_victim",
+      "source": "entity.behaviors.Brute_force_victim",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.New_country_login",
+      "source": "entity.behaviors.New_country_login",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.Used_usb_device",
+      "source": "entity.behaviors.Used_usb_device",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_level",
+      "source": "entity.risk.calculated_level",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_score",
+      "source": "entity.risk.calculated_score",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_score_norm",
+      "source": "entity.risk.calculated_score_norm",
     },
     Object {
       "aggregation": Object {
@@ -638,8 +738,88 @@ Object {
         },
         "type": "top_value",
       },
+      "destination": "asset.id",
+      "source": "asset.id",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.name",
+      "source": "asset.name",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.owner",
+      "source": "asset.owner",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.serial_number",
+      "source": "asset.serial_number",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.model",
+      "source": "asset.model",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.vendor",
+      "source": "asset.vendor",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.environment",
+      "source": "asset.environment",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
       "destination": "asset.criticality",
       "source": "asset.criticality",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.business.unit",
+      "source": "asset.business.unit",
     },
     Object {
       "aggregation": Object {
@@ -684,7 +864,31 @@ Object {
     "@timestamp": Object {
       "type": "date",
     },
+    "asset.business.unit": Object {
+      "type": "keyword",
+    },
     "asset.criticality": Object {
+      "type": "keyword",
+    },
+    "asset.environment": Object {
+      "type": "keyword",
+    },
+    "asset.id": Object {
+      "type": "keyword",
+    },
+    "asset.model": Object {
+      "type": "keyword",
+    },
+    "asset.name": Object {
+      "type": "keyword",
+    },
+    "asset.owner": Object {
+      "type": "keyword",
+    },
+    "asset.serial_number": Object {
+      "type": "keyword",
+    },
+    "asset.vendor": Object {
       "type": "keyword",
     },
     "cloud.account.id": Object {
@@ -720,13 +924,34 @@ Object {
     "cloud.service.name": Object {
       "type": "keyword",
     },
+    "entity.attributes.Asset": Object {
+      "type": "boolean",
+    },
+    "entity.attributes.Managed": Object {
+      "type": "boolean",
+    },
+    "entity.attributes.Mfa_enabled": Object {
+      "type": "boolean",
+    },
     "entity.attributes.Privileged": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.Brute_force_victim": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.New_country_login": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.Used_usb_device": Object {
       "type": "boolean",
     },
     "entity.id": Object {
       "type": "keyword",
     },
     "entity.lifecycle.First_seen": Object {
+      "type": "date",
+    },
+    "entity.lifecycle.Last_activity": Object {
       "type": "date",
     },
     "entity.name": Object {
@@ -1007,8 +1232,88 @@ Object {
         },
         "type": "top_value",
       },
+      "destination": "asset.id",
+      "source": "asset.id",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.name",
+      "source": "asset.name",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.owner",
+      "source": "asset.owner",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.serial_number",
+      "source": "asset.serial_number",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.model",
+      "source": "asset.model",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.vendor",
+      "source": "asset.vendor",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.environment",
+      "source": "asset.environment",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
       "destination": "asset.criticality",
       "source": "asset.criticality",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.business.unit",
+      "source": "asset.business.unit",
     },
     Object {
       "aggregation": Object {
@@ -1107,8 +1412,148 @@ Object {
         },
         "type": "top_value",
       },
+      "destination": "entity.attributes.Asset",
+      "source": "host.entity.attributes.Asset",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.attributes.Managed",
+      "source": "host.entity.attributes.Managed",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.attributes.Mfa_enabled",
+      "source": "host.entity.attributes.Mfa_enabled",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
       "destination": "entity.lifecycle.First_seen",
       "source": "host.entity.lifecycle.First_seen",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.lifecycle.Last_activity",
+      "source": "host.entity.lifecycle.Last_activity",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.Brute_force_victim",
+      "source": "host.entity.behaviors.Brute_force_victim",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.New_country_login",
+      "source": "host.entity.behaviors.New_country_login",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.Used_usb_device",
+      "source": "host.entity.behaviors.Used_usb_device",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_level",
+      "source": "host.entity.risk.calculated_level",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_score",
+      "source": "host.entity.risk.calculated_score",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_score_norm",
+      "source": "host.entity.risk.calculated_score_norm",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Communicates_with",
+      "source": "host.entity.relationships.Communicates_with",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Depends_on",
+      "source": "host.entity.relationships.Depends_on",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Dependent_of",
+      "source": "host.entity.relationships.Dependent_of",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Owned_by",
+      "source": "host.entity.relationships.Owned_by",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Accessed_frequently_by",
+      "source": "host.entity.relationships.Accessed_frequently_by",
     },
   ],
   "name": "Security 'host' Entity Store Definition",
@@ -1123,17 +1568,86 @@ Object {
     "@timestamp": Object {
       "type": "date",
     },
+    "asset.business.unit": Object {
+      "type": "keyword",
+    },
     "asset.criticality": Object {
       "type": "keyword",
     },
+    "asset.environment": Object {
+      "type": "keyword",
+    },
+    "asset.id": Object {
+      "type": "keyword",
+    },
+    "asset.model": Object {
+      "type": "keyword",
+    },
+    "asset.name": Object {
+      "type": "keyword",
+    },
+    "asset.owner": Object {
+      "type": "keyword",
+    },
+    "asset.serial_number": Object {
+      "type": "keyword",
+    },
+    "asset.vendor": Object {
+      "type": "keyword",
+    },
+    "entity.attributes.Asset": Object {
+      "type": "boolean",
+    },
+    "entity.attributes.Managed": Object {
+      "type": "boolean",
+    },
+    "entity.attributes.Mfa_enabled": Object {
+      "type": "boolean",
+    },
     "entity.attributes.Privileged": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.Brute_force_victim": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.New_country_login": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.Used_usb_device": Object {
       "type": "boolean",
     },
     "entity.lifecycle.First_seen": Object {
       "type": "date",
     },
+    "entity.lifecycle.Last_activity": Object {
+      "type": "date",
+    },
     "entity.name": Object {
       "type": "keyword",
+    },
+    "entity.relationships.Accessed_frequently_by": Object {
+      "type": "keyword",
+    },
+    "entity.relationships.Communicates_with": Object {
+      "type": "keyword",
+    },
+    "entity.relationships.Dependent_of": Object {
+      "type": "keyword",
+    },
+    "entity.relationships.Depends_on": Object {
+      "type": "keyword",
+    },
+    "entity.relationships.Owned_by": Object {
+      "type": "keyword",
+    },
+    "entity.risk.calculated_level": Object {
+      "type": "keyword",
+    },
+    "entity.risk.calculated_score": Object {
+      "type": "float",
+    },
+    "entity.risk.calculated_score_norm": Object {
+      "type": "float",
     },
     "entity.source": Object {
       "type": "keyword",
@@ -1327,8 +1841,88 @@ Object {
         },
         "type": "top_value",
       },
+      "destination": "asset.id",
+      "source": "asset.id",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.name",
+      "source": "asset.name",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.owner",
+      "source": "asset.owner",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.serial_number",
+      "source": "asset.serial_number",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.model",
+      "source": "asset.model",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.vendor",
+      "source": "asset.vendor",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.environment",
+      "source": "asset.environment",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
       "destination": "asset.criticality",
       "source": "asset.criticality",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.business.unit",
+      "source": "asset.business.unit",
     },
     Object {
       "aggregation": Object {
@@ -1427,8 +2021,132 @@ Object {
         },
         "type": "top_value",
       },
+      "destination": "entity.attributes.Asset",
+      "source": "service.entity.attributes.Asset",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.attributes.Managed",
+      "source": "service.entity.attributes.Managed",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.attributes.Mfa_enabled",
+      "source": "service.entity.attributes.Mfa_enabled",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
       "destination": "entity.lifecycle.First_seen",
       "source": "service.entity.lifecycle.First_seen",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.lifecycle.Last_activity",
+      "source": "service.entity.lifecycle.Last_activity",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.Brute_force_victim",
+      "source": "service.entity.behaviors.Brute_force_victim",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.New_country_login",
+      "source": "service.entity.behaviors.New_country_login",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.Used_usb_device",
+      "source": "service.entity.behaviors.Used_usb_device",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_level",
+      "source": "service.entity.risk.calculated_level",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_score",
+      "source": "service.entity.risk.calculated_score",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_score_norm",
+      "source": "service.entity.risk.calculated_score_norm",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Communicates_with",
+      "source": "service.entity.relationships.Communicates_with",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Depends_on",
+      "source": "service.entity.relationships.Depends_on",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Dependent_of",
+      "source": "service.entity.relationships.Dependent_of",
     },
   ],
   "name": "Security 'service' Entity Store Definition",
@@ -1443,17 +2161,80 @@ Object {
     "@timestamp": Object {
       "type": "date",
     },
+    "asset.business.unit": Object {
+      "type": "keyword",
+    },
     "asset.criticality": Object {
       "type": "keyword",
     },
+    "asset.environment": Object {
+      "type": "keyword",
+    },
+    "asset.id": Object {
+      "type": "keyword",
+    },
+    "asset.model": Object {
+      "type": "keyword",
+    },
+    "asset.name": Object {
+      "type": "keyword",
+    },
+    "asset.owner": Object {
+      "type": "keyword",
+    },
+    "asset.serial_number": Object {
+      "type": "keyword",
+    },
+    "asset.vendor": Object {
+      "type": "keyword",
+    },
+    "entity.attributes.Asset": Object {
+      "type": "boolean",
+    },
+    "entity.attributes.Managed": Object {
+      "type": "boolean",
+    },
+    "entity.attributes.Mfa_enabled": Object {
+      "type": "boolean",
+    },
     "entity.attributes.Privileged": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.Brute_force_victim": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.New_country_login": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.Used_usb_device": Object {
       "type": "boolean",
     },
     "entity.lifecycle.First_seen": Object {
       "type": "date",
     },
+    "entity.lifecycle.Last_activity": Object {
+      "type": "date",
+    },
     "entity.name": Object {
       "type": "keyword",
+    },
+    "entity.relationships.Communicates_with": Object {
+      "type": "date",
+    },
+    "entity.relationships.Dependent_of": Object {
+      "type": "date",
+    },
+    "entity.relationships.Depends_on": Object {
+      "type": "date",
+    },
+    "entity.risk.calculated_level": Object {
+      "type": "keyword",
+    },
+    "entity.risk.calculated_score": Object {
+      "type": "float",
+    },
+    "entity.risk.calculated_score_norm": Object {
+      "type": "float",
     },
     "entity.source": Object {
       "type": "keyword",
@@ -1609,8 +2390,88 @@ Object {
         },
         "type": "top_value",
       },
+      "destination": "asset.id",
+      "source": "asset.id",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.name",
+      "source": "asset.name",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.owner",
+      "source": "asset.owner",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.serial_number",
+      "source": "asset.serial_number",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.model",
+      "source": "asset.model",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.vendor",
+      "source": "asset.vendor",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.environment",
+      "source": "asset.environment",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
       "destination": "asset.criticality",
       "source": "asset.criticality",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "asset.business.unit",
+      "source": "asset.business.unit",
     },
     Object {
       "aggregation": Object {
@@ -1709,8 +2570,140 @@ Object {
         },
         "type": "top_value",
       },
+      "destination": "entity.attributes.Asset",
+      "source": "user.entity.attributes.Asset",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.attributes.Managed",
+      "source": "user.entity.attributes.Managed",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.attributes.Mfa_enabled",
+      "source": "user.entity.attributes.Mfa_enabled",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
       "destination": "entity.lifecycle.First_seen",
       "source": "user.entity.lifecycle.First_seen",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.lifecycle.Last_activity",
+      "source": "user.entity.lifecycle.Last_activity",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.Brute_force_victim",
+      "source": "user.entity.behaviors.Brute_force_victim",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.New_country_login",
+      "source": "user.entity.behaviors.New_country_login",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.behaviors.Used_usb_device",
+      "source": "user.entity.behaviors.Used_usb_device",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_level",
+      "source": "user.entity.risk.calculated_level",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_score",
+      "source": "user.entity.risk.calculated_score",
+    },
+    Object {
+      "aggregation": Object {
+        "sort": Object {
+          "@timestamp": "desc",
+        },
+        "type": "top_value",
+      },
+      "destination": "entity.risk.calculated_score_norm",
+      "source": "user.entity.risk.calculated_score_norm",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Accesses_frequently",
+      "source": "user.entity.relationships.Accesses_frequently",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Owns",
+      "source": "user.entity.relationships.Owns",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Supervises",
+      "source": "user.entity.relationships.Supervises",
+    },
+    Object {
+      "aggregation": Object {
+        "limit": 10,
+        "type": "terms",
+      },
+      "destination": "entity.relationships.Supervised_by",
+      "source": "user.entity.relationships.Supervised_by",
     },
   ],
   "name": "Security 'user' Entity Store Definition",
@@ -1725,17 +2718,83 @@ Object {
     "@timestamp": Object {
       "type": "date",
     },
+    "asset.business.unit": Object {
+      "type": "keyword",
+    },
     "asset.criticality": Object {
       "type": "keyword",
     },
+    "asset.environment": Object {
+      "type": "keyword",
+    },
+    "asset.id": Object {
+      "type": "keyword",
+    },
+    "asset.model": Object {
+      "type": "keyword",
+    },
+    "asset.name": Object {
+      "type": "keyword",
+    },
+    "asset.owner": Object {
+      "type": "keyword",
+    },
+    "asset.serial_number": Object {
+      "type": "keyword",
+    },
+    "asset.vendor": Object {
+      "type": "keyword",
+    },
+    "entity.attributes.Asset": Object {
+      "type": "boolean",
+    },
+    "entity.attributes.Managed": Object {
+      "type": "boolean",
+    },
+    "entity.attributes.Mfa_enabled": Object {
+      "type": "boolean",
+    },
     "entity.attributes.Privileged": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.Brute_force_victim": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.New_country_login": Object {
+      "type": "boolean",
+    },
+    "entity.behaviors.Used_usb_device": Object {
       "type": "boolean",
     },
     "entity.lifecycle.First_seen": Object {
       "type": "date",
     },
+    "entity.lifecycle.Last_activity": Object {
+      "type": "date",
+    },
     "entity.name": Object {
       "type": "keyword",
+    },
+    "entity.relationships.Accesses_frequently": Object {
+      "type": "keyword",
+    },
+    "entity.relationships.Owns": Object {
+      "type": "keyword",
+    },
+    "entity.relationships.Supervised_by": Object {
+      "type": "keyword",
+    },
+    "entity.relationships.Supervises": Object {
+      "type": "keyword",
+    },
+    "entity.risk.calculated_level": Object {
+      "type": "keyword",
+    },
+    "entity.risk.calculated_score": Object {
+      "type": "float",
+    },
+    "entity.risk.calculated_score_norm": Object {
+      "type": "float",
     },
     "entity.source": Object {
       "type": "keyword",

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/engine_description.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/engine_description.ts
@@ -25,7 +25,7 @@ import type { EntityEngineInstallationDescriptor } from './types';
 import { merge } from '../../../../../common/utils/objects/merge';
 import { defaultOptions } from '../constants';
 
-const engineDescriptionRegistry: Record<EntityType, EntityDescription> = {
+export const engineDescriptionRegistry: Record<EntityType, EntityDescription> = {
   host: hostEntityEngineDescription,
   user: userEntityEngineDescription,
   service: serviceEntityEngineDescription,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/types.ts
@@ -102,6 +102,7 @@ export interface EntityEngineInstallationDescriptor {
 export type FieldDescription = EntityDefinitionMetadataElement & {
   mapping: MappingProperty;
   retention: FieldRetentionOp;
+  allowAPIUpdate?: boolean;
 };
 
 export type FieldRetentionOp =

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/painless/build_update_script.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/painless/build_update_script.test.ts
@@ -5,31 +5,24 @@
  * 2.0.
  */
 
-import { getFlattenedObject } from '@kbn/std';
 import { buildUpdateEntityPainlessScript } from './build_update_script';
+import type { FieldDescription } from '../installation/types';
+import { collectValues, newestValue } from '../entity_definitions/entity_descriptions/field_utils';
 
 describe('buildUpdateEntityPainlessScript', () => {
   it('returns empty if no update', () => {
-    const script = buildUpdateEntityPainlessScript(
-      getFlattenedObject({
-        entity: {
-          id: '1',
-        },
-      })
-    );
+    const script = buildUpdateEntityPainlessScript(toMap([newest('entity.id', 'abc')]));
 
     expect(script).toBe('');
   });
 
   it('assigns entity fields', () => {
     const script = buildUpdateEntityPainlessScript(
-      getFlattenedObject({
-        entity: {
-          id: '1',
-          type: 'test-type',
-          sub_type: 'test-sub_type',
-        },
-      })
+      toMap([
+        newest('entity.id', '1'),
+        newest('entity.type', 'test-type'),
+        newest('entity.sub_type', 'test-sub_type'),
+      ])
     );
 
     expect(script).toBe(
@@ -41,15 +34,11 @@ describe('buildUpdateEntityPainlessScript', () => {
 
   it('assigns nested entity fields', () => {
     const script = buildUpdateEntityPainlessScript(
-      getFlattenedObject({
-        entity: {
-          id: '1',
-          attributes: {
-            storage_class: 'cold',
-            managed: true,
-          },
-        },
-      })
+      toMap([
+        newest('entity.id', '1'),
+        newest('entity.attributes.storage_class', 'cold'),
+        newest('entity.attributes.managed', true),
+      ])
     );
 
     expect(script).toBe(
@@ -60,69 +49,159 @@ describe('buildUpdateEntityPainlessScript', () => {
     );
   });
 
+  it('handles collect with arrays', () => {
+    const script = buildUpdateEntityPainlessScript(
+      toMap([
+        newest('entity.id', '1'),
+        newest('entity.attributes.storage_class', 'cold'),
+        newest('entity.attributes.managed', true),
+        collect('entity.relationships.depends_on', ['okta', 'jamf']),
+      ])
+    );
+
+    expect(script).toBe(
+      `ctx._source['entity'] = ctx._source['entity'] == null ? [:] : ctx._source['entity'];` +
+        `ctx._source['entity']['attributes'] = ctx._source['entity']['attributes'] == null ? [:] : ctx._source['entity']['attributes'];` +
+        `ctx._source['entity']['attributes']['storage_class'] = 'cold';` +
+        `ctx._source['entity']['attributes']['managed'] = true;` +
+        `ctx._source['entity']['relationships'] = ctx._source['entity']['relationships'] == null ? [:] : ctx._source['entity']['relationships'];` +
+        `def collectMap = [:];` +
+        `collectMap['entity.relationships.depends_on'] = new HashSet();` +
+        `collectMap['entity.relationships.depends_on'].addAll(['okta', 'jamf']);` +
+        `if (!(ctx?._source['entity']['relationships']['depends_on'] == null || ((ctx._source['entity']['relationships']['depends_on'] instanceof Collection || ctx._source['entity']['relationships']['depends_on'] instanceof String || ctx._source['entity']['relationships']['depends_on'] instanceof Map) && ctx._source['entity']['relationships']['depends_on'].isEmpty()))) {` +
+        `  if(ctx._source['entity']['relationships']['depends_on'] instanceof Collection) {` +
+        `    collectMap['entity.relationships.depends_on'].addAll(ctx._source['entity']['relationships']['depends_on']);` +
+        `  } else {` +
+        `    collectMap['entity.relationships.depends_on'].add(ctx._source['entity']['relationships']['depends_on']);` +
+        `  }` +
+        `}` +
+        `ctx._source['entity']['relationships']['depends_on'] = new ArrayList(collectMap['entity.relationships.depends_on']).subList(0, (int) Math.min(10, collectMap['entity.relationships.depends_on'].size()));`
+    );
+  });
+
+  it('handles collect with single values', () => {
+    const script = buildUpdateEntityPainlessScript(
+      toMap([
+        newest('entity.id', '1'),
+        newest('entity.attributes.storage_class', 'cold'),
+        newest('entity.attributes.managed', true),
+        collect('entity.relationships.depends_on', 'okta'),
+      ])
+    );
+
+    expect(script).toBe(
+      `ctx._source['entity'] = ctx._source['entity'] == null ? [:] : ctx._source['entity'];` +
+        `ctx._source['entity']['attributes'] = ctx._source['entity']['attributes'] == null ? [:] : ctx._source['entity']['attributes'];` +
+        `ctx._source['entity']['attributes']['storage_class'] = 'cold';` +
+        `ctx._source['entity']['attributes']['managed'] = true;` +
+        `ctx._source['entity']['relationships'] = ctx._source['entity']['relationships'] == null ? [:] : ctx._source['entity']['relationships'];` +
+        `def collectMap = [:];` +
+        `collectMap['entity.relationships.depends_on'] = new HashSet();` +
+        `collectMap['entity.relationships.depends_on'].add('okta');` +
+        `if (!(ctx?._source['entity']['relationships']['depends_on'] == null || ((ctx._source['entity']['relationships']['depends_on'] instanceof Collection || ctx._source['entity']['relationships']['depends_on'] instanceof String || ctx._source['entity']['relationships']['depends_on'] instanceof Map) && ctx._source['entity']['relationships']['depends_on'].isEmpty()))) {` +
+        `  if(ctx._source['entity']['relationships']['depends_on'] instanceof Collection) {` +
+        `    collectMap['entity.relationships.depends_on'].addAll(ctx._source['entity']['relationships']['depends_on']);` +
+        `  } else {` +
+        `    collectMap['entity.relationships.depends_on'].add(ctx._source['entity']['relationships']['depends_on']);` +
+        `  }` +
+        `}` +
+        `ctx._source['entity']['relationships']['depends_on'] = new ArrayList(collectMap['entity.relationships.depends_on']).subList(0, (int) Math.min(10, collectMap['entity.relationships.depends_on'].size()));`
+    );
+  });
+
   it('full example', () => {
     const script = buildUpdateEntityPainlessScript(
-      getFlattenedObject({
-        user: {
-          domain: ['val1', 'val2'],
-        },
-        entity: {
-          id: '1',
-          type: 'test-type',
-          sub_type: 'test-sub_type',
-          attributes: {
-            storage_class: 'cold',
-            managed: true,
-          },
-          lifecycle: {
-            first_seen: '2024-08-30T11:03:33.594Z',
-          },
-          behavior: {
-            brute_force_victim: false,
-            used_usb_device: true,
-          },
-        },
-        host: {
-          macAddress: 'cf:45:2e:a3:20:96',
-        },
-      })
+      toMap([
+        collect('user.domain', ['val1', 'val2']),
+        newest('entity.id', '1'),
+        newest('entity.type', 'test-type'),
+        newest('entity.sub_type', 'test-sub_type'),
+        newest('entity.attributes.storage_class', 'cold'),
+        newest('entity.attributes.managed', true),
+        collect('entity.relationships.depends_on', ['okta', 'jamf']),
+        collect('entity.relationships.owned_by', 'rmf'),
+        newest('entity.lifecyle.first_seen', '2024-08-30T11:03:33.594Z'),
+        newest('entity.behaviors.used_usb_device', false),
+        newest('host.macAddress', 'cf:45:2e:a3:20:96'),
+      ])
     );
 
     expect(script).toBe(
       `ctx._source['user'] = ctx._source['user'] == null ? [:] : ctx._source['user'];` +
-        `ctx._source['user']['domain'] = ['val1', 'val2'];` +
+        `def collectMap = [:];` +
+        `collectMap['user.domain'] = new HashSet();` +
+        `collectMap['user.domain'].addAll(['val1', 'val2']);` +
+        `if (!(ctx?._source['user']['domain'] == null || ((ctx._source['user']['domain'] instanceof Collection || ctx._source['user']['domain'] instanceof String || ctx._source['user']['domain'] instanceof Map) && ctx._source['user']['domain'].isEmpty()))) {` +
+        `  if(ctx._source['user']['domain'] instanceof Collection) {` +
+        `    collectMap['user.domain'].addAll(ctx._source['user']['domain']);` +
+        `  } else {` +
+        `    collectMap['user.domain'].add(ctx._source['user']['domain']);` +
+        `  }` +
+        `}` +
+        `ctx._source['user']['domain'] = new ArrayList(collectMap['user.domain']).subList(0, (int) Math.min(10, collectMap['user.domain'].size()));` +
         `ctx._source['entity'] = ctx._source['entity'] == null ? [:] : ctx._source['entity'];` +
         `ctx._source['entity']['type'] = 'test-type';` +
         `ctx._source['entity']['sub_type'] = 'test-sub_type';` +
         `ctx._source['entity']['attributes'] = ctx._source['entity']['attributes'] == null ? [:] : ctx._source['entity']['attributes'];` +
         `ctx._source['entity']['attributes']['storage_class'] = 'cold';` +
         `ctx._source['entity']['attributes']['managed'] = true;` +
-        `ctx._source['entity']['lifecycle'] = ctx._source['entity']['lifecycle'] == null ? [:] : ctx._source['entity']['lifecycle'];` +
-        `ctx._source['entity']['lifecycle']['first_seen'] = '2024-08-30T11:03:33.594Z';` +
-        `ctx._source['entity']['behavior'] = ctx._source['entity']['behavior'] == null ? [:] : ctx._source['entity']['behavior'];` +
-        `ctx._source['entity']['behavior']['brute_force_victim'] = false;` +
-        `ctx._source['entity']['behavior']['used_usb_device'] = true;` +
+        `ctx._source['entity']['relationships'] = ctx._source['entity']['relationships'] == null ? [:] : ctx._source['entity']['relationships'];` +
+        `collectMap['entity.relationships.depends_on'] = new HashSet();` +
+        `collectMap['entity.relationships.depends_on'].addAll(['okta', 'jamf']);` +
+        `if (!(ctx?._source['entity']['relationships']['depends_on'] == null || ((ctx._source['entity']['relationships']['depends_on'] instanceof Collection || ctx._source['entity']['relationships']['depends_on'] instanceof String || ctx._source['entity']['relationships']['depends_on'] instanceof Map) && ctx._source['entity']['relationships']['depends_on'].isEmpty()))) {` +
+        `  if(ctx._source['entity']['relationships']['depends_on'] instanceof Collection) {` +
+        `    collectMap['entity.relationships.depends_on'].addAll(ctx._source['entity']['relationships']['depends_on']);` +
+        `  } else {` +
+        `    collectMap['entity.relationships.depends_on'].add(ctx._source['entity']['relationships']['depends_on']);` +
+        `  }` +
+        `}` +
+        `ctx._source['entity']['relationships']['depends_on'] = new ArrayList(collectMap['entity.relationships.depends_on']).subList(0, (int) Math.min(10, collectMap['entity.relationships.depends_on'].size()));` +
+        `collectMap['entity.relationships.owned_by'] = new HashSet();` +
+        `collectMap['entity.relationships.owned_by'].add('rmf');` +
+        `if (!(ctx?._source['entity']['relationships']['owned_by'] == null || ((ctx._source['entity']['relationships']['owned_by'] instanceof Collection || ctx._source['entity']['relationships']['owned_by'] instanceof String || ctx._source['entity']['relationships']['owned_by'] instanceof Map) && ctx._source['entity']['relationships']['owned_by'].isEmpty()))) {` +
+        `  if(ctx._source['entity']['relationships']['owned_by'] instanceof Collection) {` +
+        `    collectMap['entity.relationships.owned_by'].addAll(ctx._source['entity']['relationships']['owned_by']);` +
+        `  } else {` +
+        `    collectMap['entity.relationships.owned_by'].add(ctx._source['entity']['relationships']['owned_by']);` +
+        `  }` +
+        `}` +
+        `ctx._source['entity']['relationships']['owned_by'] = new ArrayList(collectMap['entity.relationships.owned_by']).subList(0, (int) Math.min(10, collectMap['entity.relationships.owned_by'].size()));` +
+        `ctx._source['entity']['lifecyle'] = ctx._source['entity']['lifecyle'] == null ? [:] : ctx._source['entity']['lifecyle'];` +
+        `ctx._source['entity']['lifecyle']['first_seen'] = '2024-08-30T11:03:33.594Z';` +
+        `ctx._source['entity']['behaviors'] = ctx._source['entity']['behaviors'] == null ? [:] : ctx._source['entity']['behaviors'];` +
+        `ctx._source['entity']['behaviors']['used_usb_device'] = false;` +
         `ctx._source['host'] = ctx._source['host'] == null ? [:] : ctx._source['host'];` +
         `ctx._source['host']['macAddress'] = 'cf:45:2e:a3:20:96';`
     );
   });
-
-  it('small example', () => {
-    const script = buildUpdateEntityPainlessScript(
-      getFlattenedObject({
-        entity: {
-          id: 'entity-test',
-          attributes: {
-            Privileged: true,
-          },
-        },
-      })
-    );
-
-    expect(script).toBe(
-      `ctx._source['entity'] = ctx._source['entity'] == null ? [:] : ctx._source['entity'];` +
-        `ctx._source['entity']['attributes'] = ctx._source['entity']['attributes'] == null ? [:] : ctx._source['entity']['attributes'];` +
-        `ctx._source['entity']['attributes']['Privileged'] = true;`
-    );
-  });
 });
+
+function collect(
+  name: string,
+  value: unknown
+): FieldDescription & {
+  value: unknown;
+} {
+  return {
+    value,
+    ...collectValues({
+      source: name,
+    }),
+  };
+}
+
+function newest(name: string, value: unknown): FieldDescription & { value: unknown } {
+  return {
+    value,
+    ...newestValue({
+      source: name,
+    }),
+  };
+}
+
+function toMap(fields: (FieldDescription & { value: unknown })[]) {
+  return fields.reduce((obj, field) => {
+    obj[field.source] = field;
+    return obj;
+  }, {} as Record<string, FieldDescription & { value: unknown }>);
+}

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/upsert_crud_api.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/upsert_crud_api.ts
@@ -106,7 +106,7 @@ export default function (providerContext: FtrProviderContext) {
             expect(hit._source?.user?.domain).toEqual(['domain.com']);
             expect(hit._source?.entity?.id).toEqual(userName);
             expect(hit._source?.entity?.attributes?.Privileged).toBeTruthy();
-            expect(hit._source?.entity?.behaviors?.First_seen).toBeTruthy();
+            expect(hit._source?.entity?.behaviors?.Brute_force_victim).toBeTruthy();
           });
 
           return true;
@@ -132,7 +132,7 @@ export default function (providerContext: FtrProviderContext) {
             expect(hit._source?.user?.domain).toContain('domain.com updated');
             expect(hit._source?.entity?.id).toEqual(userName);
             expect(hit._source?.entity?.attributes?.Privileged).toBeTruthy();
-            expect(hit._source?.entity?.behaviors?.First_seen).toBeTruthy();
+            expect(hit._source?.entity?.behaviors?.Brute_force_victim).toBeTruthy();
           });
           return true;
         });

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/upsert_crud_api.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/upsert_crud_api.ts
@@ -58,7 +58,6 @@ export default function (providerContext: FtrProviderContext) {
 
       it('Should update an existing user', async () => {
         log.info('Creating user as test subject...');
-        const date = new Date().toISOString();
         const userName = 'test-user-1';
         const testDocs = [{ user: { name: userName, domain: 'domain.com' } }];
 
@@ -89,8 +88,8 @@ export default function (providerContext: FtrProviderContext) {
               attributes: {
                 privileged: true,
               },
-              lifecycle: {
-                first_seen: date,
+              behaviors: {
+                brute_force_victim: true,
               },
             },
           },
@@ -107,7 +106,7 @@ export default function (providerContext: FtrProviderContext) {
             expect(hit._source?.user?.domain).toEqual(['domain.com']);
             expect(hit._source?.entity?.id).toEqual(userName);
             expect(hit._source?.entity?.attributes?.Privileged).toBeTruthy();
-            expect(hit._source?.entity?.lifecycle?.First_seen).toEqual(date);
+            expect(hit._source?.entity?.behaviors?.First_seen).toBeTruthy();
           });
 
           return true;
@@ -133,7 +132,7 @@ export default function (providerContext: FtrProviderContext) {
             expect(hit._source?.user?.domain).toContain('domain.com updated');
             expect(hit._source?.entity?.id).toEqual(userName);
             expect(hit._source?.entity?.attributes?.Privileged).toBeTruthy();
-            expect(hit._source?.entity?.lifecycle?.First_seen).toEqual(date);
+            expect(hit._source?.entity?.behaviors?.First_seen).toBeTruthy();
           });
           return true;
         });


### PR DESCRIPTION
## Changes to logic:

- Update by query painless now supports collect
- Detection of fields that must be updated changed from a regex list to being part of the Entity Definition

## Added Fields
Best described on this [issue](https://github.com/elastic/security-team/issues/13820#issuecomment-3305604266).

Fields were added both on transform and CRUD API

Added the following fields to all definitions.
| Field | ES Mapping | API Type | Transform Operation |
|--------|--------|--------|--------|
| `entity.attributes.Privileged` | `boolean` | `boolean` | newest value |
| `entity.attributes.Asset` | `boolean` | `boolean` | newest value |
| `entity.attributes.Managed` | `boolean` | `boolean` | newest value |
| `entity.attributes.Mfa_enabled` | `boolean` | `boolean` | newest value |
| `entity.lifecycle.First_seen` | `date` | `string` | newest value |
| `entity.lifecycle.Last_activity` | `date` | `string` | newest value |
| `entity.behaviors.Brute_force_victim` | `boolean` | `boolean` | newest value |
| `entity.behaviors.New_country_login` | `boolean` | `boolean` | newest value |
| `entity.behaviors.Used_usb_device` | `boolean` | `boolean` | newest value |
| `entity.risk.calculated_level` | `keyword` | `keyword` | newest value |
| `entity.risk.calculated_score` | `float` | `float` | newest value |
| `entity.risk.calculated_score_norm` | `float` | `float` | newest value |
| `asset.id` | `keyword` | `string` | newest value |
| `asset.name` | `keyword` | `string` | newest value |
| `asset.owner` | `keyword` | `string` | newest value |
| `asset.serial_number` | `keyword` | `string` | newest value |
| `asset.model` | `keyword` | `string` | newest value |
| `asset.vendor` | `keyword` | `string` | newest value |
| `asset.environment` | `keyword` | `string` | newest value |
| `asset.criticality` | `keyword` | `string` | newest value |
| `asset.business_unit` | `keyword` | `string` | newest value |

Added the following fields to host only:
| Field | ES Mapping | API Type | Transform Operation |
|--------|--------|--------|--------|
| `entity.relationships.Communicates_with` | `keyword` | `array of string` | collect |
| `entity.relationships.Depends_on` | `keyword` | `array of string` | collect |
| `entity.relationships.Dependent_of` | `keyword` | `array of string` | collect |
| `entity.relationships.Owned_by` | `keyword` | `array of string` | collect |
| `entity.relationships.Accessed_frequently_by` | `keyword` | `array of string` | collect |

Added the following fields to service only:
| Field | ES Mapping | API Type | Transform Operation |
|--------|--------|--------|--------|
| `entity.relationships.Communicates_with` | `keyword` | `array of string` | collect |
| `entity.relationships.Depends_on` | `keyword` | `array of string` | collect |
| `entity.relationships.Dependent_of` | `keyword` | `array of string` | collect |

Added the following fields to user only:
| Field | ES Mapping | API Type | Transform Operation |
|--------|--------|--------|--------|
| `entity.relationships.Accesses_frequently` | `keyword` | `array of string` | collect |
| `entity.relationships.Owns` | `keyword` | `array of string` | collect |
| `entity.relationships.Supervises` | `keyword` | `array of string` | collect |
| `entity.relationships.Supervised_by` | `keyword` | `array of string` | collect |


### Testing from the API

Request example for a host:

```
PUT kbn:/api/entity_store/entities/host?force=true
{
    "entity": {
        "id": "host-1",
        "attributes": {
          "privileged": true,
          "asset": true,
          "managed": true,
          "mfa_enabled": false
        },
        "behaviors": {
          "brute_force_victim": true,
          "new_country_login": false,
          "used_usb_device": false
        },
        "lifecycle": {
          "first_seen": "2025-09-23T12:17:00Z",
          "last_activity": "2025-09-23T12:17:00Z"
        },
        "relationships": {
          "depends_on": ["okta", "jamf"]
        },
        "risk": {
          "calculated_level": "Moderate",
          "calculated_score": 123.2,
          "calculated_score_norm": 50.2
        }
    },

    "asset": {
      "id": "123",
      "name": "asset-name",
      "owner": "romulo",
      "serial_number": "AAAAA",
      "model": "DELL Super X",
      "vendor": "DELL",
      "environment": "production",
      "criticality": "medium_impact",
      "business": {
        "unit": "sec_ops"
      }
    }
}
```