### PR TITLE
Do not deep freeze SO type definitions in prod

### DIFF
--- a/src/core/packages/saved-objects/base-server-internal/src/saved_objects_type_registry.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/saved_objects_type_registry.ts
@@ -43,7 +43,10 @@ export class SavedObjectTypeRegistry implements ISavedObjectTypeRegistry {
       );
     }
     validateType(type);
-    this.types.set(type.name, deepFreeze(type) as SavedObjectsType);
+    if (process.env.NODE_ENV !== 'production') {
+      deepFreeze(type);
+    }
+    this.types.set(type.name, type);
   }
 
   /** {@inheritDoc ISavedObjectTypeRegistry.getLegacyTypes} */


### PR DESCRIPTION
## Summary

This operation is expensive, and executed for every SO type definition.
Should any modifications occur to SO type definitions, they'll be caught at _dev / CI time_.