### PR TITLE
[Metrics][Discover] Fix performance issues in the metrics grid

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -135,6 +135,7 @@ export async function getDataView(
     dataView = await dataViewsAPI.get(index, false);
   } catch {
     dataView = await dataViewsAPI.create({
+      id: index,
       title: index,
       timeFieldName: timeField || '@timestamp',
     });

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -135,7 +135,6 @@ export async function getDataView(
     dataView = await dataViewsAPI.get(index, false);
   } catch {
     dataView = await dataViewsAPI.create({
-      id: index,
       title: index,
       timeFieldName: timeField || '@timestamp',
     });

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.test.ts
@@ -66,14 +66,8 @@ describe('useChartLayers', () => {
     );
 
     await waitFor(() => {
-      expect(result.current).toHaveLength(1);
+      expect(result.current).toHaveLength(0);
     });
-
-    const layer = result.current[0];
-    expect(layer.xAxis).toStrictEqual({ field: '@timestamp', type: 'dateHistogram' });
-    expect(layer.yAxis).toEqual([]);
-    expect(layer.seriesType).toBe('line');
-    expect(layer.breakdown).toBeUndefined();
   });
 
   it('maps columns correctly to yAxis and uses dimensions for breakdown', async () => {

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts
@@ -49,6 +49,10 @@ export const useChartLayers = ({
   );
 
   const layers = useMemo<LensSeriesLayer[]>(() => {
+    if (columns.length === 0) {
+      return [];
+    }
+
     const xAxisColumn = columns.find((col) => col.meta.type === 'date');
     const xAxis: LensSeriesLayer['xAxis'] = {
       type: 'dateHistogram',

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.test.ts
@@ -39,13 +39,11 @@ describe('useLensProps', () => {
   const discoverFetch$ = new BehaviorSubject<UnifiedHistogramInputMessage>({ type: 'fetch' });
   const getTimeRange = (): TimeRange => ({ from: 'now-1h', to: 'now' });
 
-  // Create mock chart ref
   const createMockChartRef = () => {
     const div = document.createElement('div');
     return { current: div };
   };
 
-  // Create mock IntersectionObserver
   const createIntersectionObserverMock = () => {
     const mockObserve = jest.fn();
     const mockDisconnect = jest.fn();

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
@@ -40,7 +40,6 @@ export type LensProps = Pick<
   | 'onLoad'
 >;
 
-const ROOT_MARGIN = '15px';
 export const useLensProps = ({
   title,
   query,

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
@@ -26,6 +26,7 @@ import {
 } from 'rxjs';
 import type { TimeRange } from '@kbn/data-plugin/common';
 import type { MetricUnit } from '@kbn/metrics-experience-plugin/common/types';
+import { useEuiTheme } from '@elastic/eui';
 import { useChartLayers } from './use_chart_layers';
 export type LensProps = Pick<
   EmbeddableComponentProps,
@@ -63,6 +64,7 @@ export const useLensProps = ({
   chartRef?: React.RefObject<HTMLDivElement>;
   abortController?: AbortController;
 } & Pick<ChartSectionProps, 'services' | 'searchSessionId'>) => {
+  const { euiTheme } = useEuiTheme();
   const chartLayers = useChartLayers({
     query,
     seriesType,
@@ -138,7 +140,7 @@ export const useLensProps = ({
     const intersecting$ = new Observable<boolean>((subscriber) => {
       const observer = new IntersectionObserver(
         ([entry]) => subscriber.next(entry.isIntersecting),
-        { threshold: 0.1, rootMargin: ROOT_MARGIN }
+        { threshold: 0.1, rootMargin: euiTheme.size.base }
       );
 
       if (chartRefCurrent) {
@@ -172,7 +174,7 @@ export const useLensProps = ({
     return () => {
       subscription.unsubscribe();
     };
-  }, [discoverFetch$, updateLensPropsContext, chartRef]);
+  }, [discoverFetch$, updateLensPropsContext, chartRef, euiTheme.size.base]);
 
   return lensPropsContext;
 };

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
@@ -39,7 +39,7 @@ export type LensProps = Pick<
   | 'onLoad'
 >;
 
-const ROOT_MARGIN = '50px';
+const ROOT_MARGIN = '15px';
 export const useLensProps = ({
   title,
   query,
@@ -132,23 +132,24 @@ export const useLensProps = ({
 
   useEffect(() => {
     const attributesCurrent = attributes$.current;
-    const charRefCurrent = chartRef?.current;
+    const chartRefCurrent = chartRef?.current;
 
+    // progressively load Lens when the chart becomes visible
     const intersecting$ = new Observable<boolean>((subscriber) => {
       const observer = new IntersectionObserver(
         ([entry]) => subscriber.next(entry.isIntersecting),
         { threshold: 0.1, rootMargin: ROOT_MARGIN }
       );
 
-      if (charRefCurrent) {
-        observer.observe(charRefCurrent);
+      if (chartRefCurrent) {
+        observer.observe(chartRefCurrent);
       } else {
         subscriber.next(true);
         subscriber.complete();
       }
 
       return () => observer.disconnect();
-    }).pipe(startWith(!!charRefCurrent), distinctUntilChanged());
+    }).pipe(startWith(!!chartRefCurrent), distinctUntilChanged());
 
     const subscription = merge(
       discoverFetch$,

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
@@ -143,12 +143,12 @@ export const useLensProps = ({
       if (charRefCurrent) {
         observer.observe(charRefCurrent);
       } else {
-        subscriber.next(false);
+        subscriber.next(true);
         subscriber.complete();
       }
 
       return () => observer.disconnect();
-    }).pipe(startWith(false), distinctUntilChanged());
+    }).pipe(startWith(!!charRefCurrent), distinctUntilChanged());
 
     const subscription = merge(
       discoverFetch$,

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { css } from '@emotion/react';
 import { useEuiTheme } from '@elastic/eui';
 import type { ChartSectionProps, UnifiedHistogramInputMessage } from '@kbn/unified-histogram/types';
@@ -52,6 +52,7 @@ export const Chart: React.FC<ChartProps> = ({
   filters = [],
 }) => {
   const { euiTheme } = useEuiTheme();
+  const chartRef = useRef<HTMLDivElement>(null);
 
   const { getTimeRange } = requestParams;
 
@@ -80,6 +81,7 @@ export const Chart: React.FC<ChartProps> = ({
     discoverFetch$,
     abortController,
     getTimeRange,
+    chartRef,
   });
 
   return (
@@ -92,6 +94,7 @@ export const Chart: React.FC<ChartProps> = ({
           display: none;
         }
       `}
+      ref={chartRef}
     >
       {lensProps && (
         <LensWrapperMemo


### PR DESCRIPTION
## Summary

This PR tries to improve some aspects related to the performance of the metrics grid.

>[!IMPORTANT]
> The approach adopted is to load charts that are visible in the viewport. Users with large screens, in which all 20 charts are in the viewport, might still experience some slowness - if the performance issue is caused by multiple parallel requests 


### **With charts lazy-loaded**


```bash
INFO: beat.stats.libbeat.output.events.acked chart took, 446.09999990463257ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.active chart took, 479.7000000476837ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.batches chart took, 457.30000019073486ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.active chart took, 435.2000000476837ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.acked chart took, 413.30000019073486ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.acked chart took, 382.90000009536743ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.batches chart took, 559ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.active chart took, 624.7000000476837ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.dropped chart took, 602ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.dropped chart took, 583.7000000476837ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.batches chart took, 583.5ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.dropped chart took, 591.5ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.duplicates chart took, 645.1000001430511ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.failed chart took, 623ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.duplicates chart took, 614.0999999046326ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.duplicates chart took, 653.2999999523163ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.toomany chart took, 526.5ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.failed chart took, 507.7999999523163ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.toomany chart took, 490.5ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.failed chart took, 474.7999999523163ms
```
**Summary**
- Mean: 534.7 ms
- Median: 542.8 ms
- Min: 382.9 ms
- Max: 653.3 ms


### **Without lazy-loading**
```bash
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.acked chart took, 1047.0999999046326ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.active chart took, 1028.3000001907349ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.active chart took, 1115.3999998569489ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.acked chart took, 1098.3000001907349ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.acked chart took, 1073.2000000476837ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.dropped chart took, 1038.1999998092651ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.batches chart took, 1023.7999999523163ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.dropped chart took, 995.7999999523163ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.dropped chart took, 978.2000000476837ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.batches chart took, 960.7999999523163ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.batches chart took, 942.3999998569489ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.duplicates chart took, 915.0999999046326ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.duplicates chart took, 965.5ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.failed chart took, 959ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.duplicates chart took, 945.8000001907349ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.failed chart took, 984ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.failed chart took, 970.6000001430511ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.toomany chart took, 776.2999999523163ms
lens_wrapper.tsx:64 INFO: beat.stats.libbeat.output.events.toomany chart took, 761.3000001907349ms
```
**Summary**
- Mean: 977.8 ms
- Median: 978.2 ms
- Min: 761.3 ms
- Max: 1115.4 ms


**Performance improvement with lazy-loading:**

~45.3% faster on average (mean)
~44.5% faster median case

### Lens config builder not caching adhoc data views

>[!WARNING]
> This change was removed from this PR. An issue has been created for the visualizations team to look into it https://github.com/elastic/kibana/issues/236335

The Lens Config Builder was not properly creating ad-hoc data views, which caused the retrieval of cached data views to fail. Because many requests occur in the UI, these unnecessary requests occupied the browser's request queue (which allows approximately 6 parallel requests over HTTP/1.0).

before
![dataview_not_cached](https://github.com/user-attachments/assets/0c29f7c0-a185-4128-bfa8-f7c77c91831b)

after
![dataview](https://github.com/user-attachments/assets/e78adcfb-db05-40b4-940d-837218ed2a6a)




