### PR TITLE
Increase disk for ES snapshot build

### DIFF
--- a/.buildkite/pipelines/es_snapshots/build.yml
+++ b/.buildkite/pipelines/es_snapshots/build.yml
@@ -9,3 +9,4 @@ steps:
       localSsds: 1
       localSsdInterface: nvme
       machineType: c2-standard-8
+      diskSizeGb: 100


### PR DESCRIPTION
## Summary
Docker image build and push for ES snapshot build fails silently because of disk size issues: https://buildkite.com/elastic/kibana-elasticsearch-snapshot-build/builds/6932

This in turn causes failed Cloud deployments, because of missing images:
https://buildkite.com/elastic/kibana-deploy-cloud-from-pr/builds/435#01997647-fc3d-451b-9cc2-4602bef8ab5c

cc: @jbudz - this section is running with no error propagation - is this still relevant? Can we make the error ignore more specific for the mentioned cases? https://github.com/elastic/kibana/blob/5245f408a88467a3486488357685b183d02565d8/.buildkite/scripts/steps/es_snapshots/build.sh#L92-L108