### PR TITLE
[ES|QL] Fixes controls' trigger across various commands

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/autocomplete.test.ts
@@ -36,7 +36,7 @@ const PROMPT_SUGGESTIONS = [
   ...getFunctionSuggestions({
     location: Location.COMPLETION,
     returnTypes: ['text', 'keyword', 'unknown'],
-  }).map((fn) => `${fn.text} `),
+  }).map((fn) => `${fn.text}`),
 ];
 
 describe('COMPLETION Autocomplete', () => {

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/autocomplete.ts
@@ -141,6 +141,8 @@ export async function autocomplete(
         (fragment) => Boolean(columnExists(fragment, context) || getFunctionDefinition(fragment)),
         (_fragment: string, rangeToReplace?: { start: number; end: number }) => {
           return fieldsAndFunctionsSuggestions.map((suggestion) => {
+            // if there is already a command, we don't want to override it
+            if (suggestion.command) return suggestion;
             return {
               ...suggestion,
               text: `${suggestion.text} `,

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/grok/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/grok/autocomplete.ts
@@ -56,9 +56,13 @@ export async function autocomplete(
 
   // GROK /
   const fieldSuggestions = (await callbacks?.getByType?.(ESQL_STRING_TYPES)) || [];
-  return fieldSuggestions.map((sug) => ({
-    ...sug,
-    text: `${sug.text} `,
-    command: TRIGGER_SUGGESTION_COMMAND,
-  }));
+  return fieldSuggestions.map((sug) => {
+    // if there is already a command, we don't want to override it
+    if (sug.command) return sug;
+    return {
+      ...sug,
+      text: `${sug.text} `,
+      command: TRIGGER_SUGGESTION_COMMAND,
+    };
+  });
 }

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/utils.ts
@@ -176,6 +176,8 @@ export const suggestFields = async (
     (_fragment: string, rangeToReplace?: { start: number; end: number }) => {
       // fie<suggest>
       return fieldSuggestions.map((suggestion) => {
+        // if there is already a command, we don't want to override it
+        if (suggestion.command) return suggestion;
         return {
           ...suggestion,
           text: suggestion.text,

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/autocomplete.ts
@@ -168,11 +168,15 @@ async function handleOnFieldList({
         callbacks.getSuggestedUserDefinedColumnName?.() || ''
       );
 
-      return [customFieldSuggestion, ...fieldSuggestions].map((suggestion) => ({
-        ...suggestion,
-        rangeToReplace,
-        command: TRIGGER_SUGGESTION_COMMAND,
-      }));
+      return [customFieldSuggestion, ...fieldSuggestions].map((suggestion) => {
+        // if there is already a command, we don't want to override it
+        if (suggestion.command) return suggestion;
+        return {
+          ...suggestion,
+          rangeToReplace,
+          command: TRIGGER_SUGGESTION_COMMAND,
+        };
+      });
     },
     // complete: get next actions suggestions for completed field
     (fragment: string, rangeToReplace: { start: number; end: number }) => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/236094

This `command: TRIGGER_SUGGESTION_COMMAND,` is cool but unfortunately the way we are mutating it is not optimal. Why? Because it overwrites other commands. This is happening here too. It overwrites the `Creates control` command and it doesnt work.

I had added in the past the same logic in other places too but it is easy to miss. In a follow up we need to create a helper function that adds this `command: TRIGGER_SUGGESTION_COMMAND,` conditionally and will reuse it everywhere.



