### PR TITLE
🌊 Streams: Extend streams settings flyout

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -600,6 +600,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       uptimeDurationAnomaly: `${ELASTIC_DOCS}solutions/observability/incident-management/create-an-uptime-duration-anomaly-rule`,
       monitorLogs: `${ELASTIC_DOCS}solutions/observability/logs/explore-logs`,
       logsStreams: `${ELASTIC_DOCS}solutions/observability/logs/streams/streams`,
+      wiredStreams: `${ELASTIC_DOCS}solutions/observability/streams/wired-streams`,
       analyzeMetrics: `${ELASTIC_DOCS}solutions/observability/infra-and-hosts/analyze-infrastructure-host-metrics`,
       monitorUptimeSynthetics: `${ELASTIC_DOCS}solutions/observability/synthetics`,
       userExperience: `${ELASTIC_DOCS}solutions/observability/applications/user-experience`,

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -599,7 +599,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       tlsCertificate: `${ELASTIC_DOCS}solutions/observability/incident-management/create-tls-certificate-rule`,
       uptimeDurationAnomaly: `${ELASTIC_DOCS}solutions/observability/incident-management/create-an-uptime-duration-anomaly-rule`,
       monitorLogs: `${ELASTIC_DOCS}solutions/observability/logs/explore-logs`,
-      logsStreams: `${ELASTIC_DOCS}solutions/observability/logs/streams/streams`,
+      logsStreams: `${ELASTIC_DOCS}solutions/observability/streams/streams`,
       wiredStreams: `${ELASTIC_DOCS}solutions/observability/streams/wired-streams`,
       analyzeMetrics: `${ELASTIC_DOCS}solutions/observability/infra-and-hosts/analyze-infrastructure-host-metrics`,
       monitorUptimeSynthetics: `${ELASTIC_DOCS}solutions/observability/synthetics`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -417,6 +417,7 @@ export interface DocLinks {
     uptimeDurationAnomaly: string;
     monitorLogs: string;
     logsStreams: string;
+    wiredStreams: string;
     analyzeMetrics: string;
     monitorUptimeSynthetics: string;
     userExperience: string;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.tsx
@@ -30,9 +30,11 @@ import {
   EuiCodeBlock,
   useGeneratedHtmlId,
   EuiText,
+  EuiLink,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useAbortController } from '@kbn/react-hooks';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { useKibana } from '../../hooks/use_kibana';
 import { useStreamsPrivileges } from '../../hooks/use_streams_privileges';
 
@@ -138,6 +140,10 @@ export function StreamsSettingsFlyout({
     {
       id: `${shipperButtonGroupPrefix}__logstash`,
       label: 'Logstash',
+    },
+    {
+      id: `${shipperButtonGroupPrefix}__fleet`,
+      label: 'Fleet',
     },
   ];
   const [selectedShipperId, setSelectedShipperId] = React.useState(
@@ -266,10 +272,22 @@ output.elasticsearch:
             </EuiText>
             <EuiText color="subdued" size="s">
               <p>
-                {i18n.translate('xpack.streams.streamsListView.shipperConfigDescription', {
-                  defaultMessage:
-                    'Send logs data to wired streams. Check the documentation for more info.',
-                })}
+                <FormattedMessage
+                  id="xpack.streams.streamsListView.shipperConfigDescription"
+                  defaultMessage="Send logs data to wired streams. <docLink>Check the documentation</docLink> for more info."
+                  values={{
+                    docLink: (...chunks: React.ReactNode[]) => (
+                      <EuiLink
+                        href={core.docLinks.links.observability.wiredStreams}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        external
+                      >
+                        {chunks}
+                      </EuiLink>
+                    ),
+                  }}
+                />
               </p>
             </EuiText>
             <EuiButtonGroup
@@ -283,14 +301,66 @@ output.elasticsearch:
               isFullWidth={false}
               data-test-subj="streamsShipperButtonGroup"
             />
-            <EuiCodeBlock
-              language="yaml"
-              isCopyable
-              paddingSize="m"
-              data-test-subj="streamsShipperConfigExample"
-            >
-              {shipperConfigExamples[selectedShipperId]}
-            </EuiCodeBlock>
+            {selectedShipperId.endsWith('__fleet') ? (
+              <EuiText size="s">
+                <p>
+                  <FormattedMessage
+                    id="xpack.streams.streamsListView.shipperConfigFleetDescription"
+                    defaultMessage="Use the <b>Custom Logs (Filestream)</b> integration to send data to Wired Streams:"
+                    values={{
+                      b: (chunks) => <b>{chunks}</b>,
+                    }}
+                  />
+                </p>
+                <ul>
+                  <li>
+                    {i18n.translate(
+                      'xpack.streams.streamsListView.shipperConfigFleetDescriptionStep1',
+                      {
+                        defaultMessage:
+                          'Enable "Write to logs streams" for the output you want to use in the Fleet Settings tab.',
+                      }
+                    )}
+                  </li>
+                  <li>
+                    {i18n.translate(
+                      'xpack.streams.streamsListView.shipperConfigFleetDescriptionStep2',
+                      {
+                        defaultMessage:
+                          'Add the Custom Logs (Filestream) integration to an agent policy.',
+                      }
+                    )}
+                  </li>
+                  <li>
+                    {i18n.translate(
+                      'xpack.streams.streamsListView.shipperConfigFleetDescriptionStep3',
+                      {
+                        defaultMessage:
+                          'Enable the \'Use the "logs" data stream\' setting in the integration configuration.',
+                      }
+                    )}
+                  </li>
+                  <li>
+                    {i18n.translate(
+                      'xpack.streams.streamsListView.shipperConfigFleetDescriptionStep4',
+                      {
+                        defaultMessage:
+                          'Make sure the agent policy is using the output you configured in step 1.',
+                      }
+                    )}
+                  </li>
+                </ul>
+              </EuiText>
+            ) : (
+              <EuiCodeBlock
+                language="yaml"
+                isCopyable
+                paddingSize="m"
+                data-test-subj="streamsShipperConfigExample"
+              >
+                {shipperConfigExamples[selectedShipperId]}
+              </EuiCodeBlock>
+            )}
           </EuiFlexGroup>
         </EuiFlyoutBody>
       </EuiFlyout>


### PR DESCRIPTION
<img width="426" height="479" alt="Screenshot 2025-09-23 at 16 32 51" src="https://github.com/user-attachments/assets/09057279-2e91-4e1f-b725-3fad1f4d2061" />

This PR does two things:
* Add a link to the wired streams documentation
* Add a tab for how to send data to wired streams via fleet