### PR TITLE
fix dysfunctional `read_jest_help.mjs`

### DIFF
--- a/scripts/read_jest_help.cjs
+++ b/scripts/read_jest_help.cjs
@@ -7,12 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import Fsp from 'fs/promises';
-import Path from 'path';
+require('../src/setup_node_env');
 
-import { createFailError } from '@kbn/dev-cli-errors';
-import { run } from '@kbn/dev-cli-runner';
-import { REPO_ROOT } from '@kbn/repo-info';
+const Fsp = require('fs/promises');
+const Path = require('path');
+
+const { createFailError } = require('@kbn/dev-cli-errors');
+const { run } = require('@kbn/dev-cli-runner');
+const { REPO_ROOT } = require('@kbn/repo-info');
 
 const FLAGS_FILE = 'src/platform/packages/shared/kbn-test/src/jest/jest_flags.json';
 
@@ -21,7 +23,7 @@ function readStdin() {
     let buffer = '';
     let timer = setTimeout(() => {
       reject(
-        createFailError('you must pipe the output of `yarn jest --help` to this script', {
+        new Error('you must pipe the output of `yarn jest --help` to this script', {
           showHelp: true,
         })
       );
@@ -113,7 +115,7 @@ run(
     log.warning('make sure you bootstrap to rebuild @kbn/test');
   },
   {
-    usage: `yarn jest --help | node scripts/read_jest_help.mjs`,
+    usage: `yarn jest --help | node scripts/read_jest_help.cjs`,
     description: `
       Jest no longer exposes the ability to parse CLI flags externally, so we use this
       script to read the help output and convert it into parameters we can pass to getopts()

--- a/src/platform/packages/shared/kbn-test/src/jest/jest_flags.json
+++ b/src/platform/packages/shared/kbn-test/src/jest/jest_flags.json
@@ -24,6 +24,7 @@
     "modulePathIgnorePatterns",
     "modulePaths",
     "notifyMode",
+    "openHandlesTimeout",
     "outputFile",
     "preset",
     "prettierPath",
@@ -88,6 +89,7 @@
     "onlyChanged",
     "onlyFailures",
     "passWithNoTests",
+    "randomize",
     "resetMocks",
     "resetModules",
     "restoreMocks",
@@ -104,7 +106,8 @@
     "version",
     "watch",
     "watchAll",
-    "watchman"
+    "watchman",
+    "workerThreads"
   ],
   "alias": {
     "b": "bail",

--- a/src/platform/packages/shared/kbn-test/src/jest/run.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run.ts
@@ -147,7 +147,7 @@ function parseJestArguments(): ParsedJestArguments {
 
   If this flag is valid you might need to update the flags in "src/platform/packages/shared/kbn-test/src/jest/run.js".
 
-  Run 'yarn jest --help | node scripts/read_jest_help.mjs' to update this scripts knowledge of what
+  Run 'yarn jest --help | node scripts/read_jest_help.cjs' to update this scripts knowledge of what
   flags jest supports
 
 `);


### PR DESCRIPTION
## Summary
`src/platform/packages/shared/kbn-test/src/jest/run.ts` makes a reference to an existing script, `read_jest_help.mjs`. However this file doesn't work as advertised.

```
node:internal/modules/esm/resolve:204
  const resolvedOption = FSLegacyMainResolve(pkgPath, packageConfig.main, baseStringified);
                         ^

Error: Cannot find package '/Users/alex/Git/elastic-kibana/node_modules/@kbn/dev-cli-errors/index.js' imported from /Users/alex/Git/elastic-kibana/scripts/read_jest_help.mjs
    at legacyMainResolve (node:internal/modules/esm/resolve:204:26)
    at packageResolve (node:internal/modules/esm/resolve:778:12)
```

An easy way to fix this was to move it to cjs, updating the imports, and it started working again. 
The update to the `src/platform/packages/shared/kbn-test/src/jest/jest_flags.json` is through running the script.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->