### PR TITLE
[ML UI] Adds a link to the Elastic Inference Service on top of the Inference Endpoints page

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3023,6 +3023,3 @@ x-pack/plugins/observability_solution/synthetics/server/saved_objects/synthetics
 ####
 ## These rules are always last so they take ultimate priority over everything else
 ####
-####
-## These rules are always last so they take ultimate priority over everything else
-####

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -508,6 +508,7 @@ src/platform/packages/shared/kbn-i18n @elastic/kibana-core
 src/platform/packages/shared/kbn-i18n-react @elastic/kibana-core
 src/platform/packages/shared/kbn-interpreter @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-io-ts-utils @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations
 src/platform/packages/shared/kbn-lens-embeddable-utils @elastic/obs-ux-infra_services-team @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-licensing-types @elastic/kibana-core
 src/platform/packages/shared/kbn-logging @elastic/kibana-core
@@ -3019,6 +3020,9 @@ x-pack/plugins/observability_solution/synthetics/server/saved_objects/synthetics
 /.github/workflows/oblt-github-commands   @elastic/observablt-robots @elastic/kibana-operations
 /.github/workflows/undeploy-my-kibana.yml @elastic/observablt-robots @elastic/kibana-operations
 
+####
+## These rules are always last so they take ultimate priority over everything else
+####
 ####
 ## These rules are always last so they take ultimate priority over everything else
 ####

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -156,6 +156,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       deployTrainedModels: `${ELASTIC_DOCS}explore-analyze/machine-learning/nlp/ml-nlp-deploy-models`,
       documentLevelSecurity: `${ELASTIC_DOCS}deploy-manage/users-roles/cluster-or-deployment-auth/controlling-access-at-document-field-level`,
       e5Model: `${ELASTIC_DOCS}explore-analyze/machine-learning/nlp/ml-nlp-e5`,
+      elasticInferenceService: `${ELASTIC_DOCS}explore-analyze/elastic-inference/eis`,
       elser: `${ELASTIC_DOCS}solutions/search/semantic-search/semantic-search-semantic-text`,
       engines: `${ENTERPRISE_SEARCH_DOCS}engines.html`,
       indexApi: isServerless

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -143,6 +143,7 @@ export interface DocLinks {
     readonly deployTrainedModels: string;
     readonly documentLevelSecurity: string;
     readonly e5Model: string;
+    readonly elasticInferenceService: string;
     readonly elser: string;
     readonly engines: string;
     readonly indexApi: string;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/common/doc_links.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/common/doc_links.ts
@@ -9,6 +9,7 @@ import type { DocLinks } from '@kbn/doc-links';
 
 class InferenceEndpointsDocLinks {
   public createInferenceEndpoint: string = '';
+  public elasticInferenceService: string = '';
   public semanticSearchElser: string = '';
   public semanticSearchE5: string = '';
 
@@ -16,6 +17,7 @@ class InferenceEndpointsDocLinks {
 
   setDocLinks(newDocLinks: DocLinks) {
     this.createInferenceEndpoint = newDocLinks.inferenceManagement.inferenceAPIDocumentation;
+    this.elasticInferenceService = newDocLinks.enterpriseSearch.elasticInferenceService;
     this.semanticSearchElser = newDocLinks.enterpriseSearch.elser;
     this.semanticSearchE5 = newDocLinks.enterpriseSearch.e5Model;
   }

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/common/translations.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/common/translations.ts
@@ -26,6 +26,13 @@ export const VIEW_YOUR_MODELS_LINK = i18n.translate(
   }
 );
 
+export const EIS_DOCUMENTATION_LINK = i18n.translate(
+  'xpack.searchInferenceEndpoints.eisDocumentationLink',
+  {
+    defaultMessage: 'Elastic Inference Service',
+  }
+);
+
 export const API_DOCUMENTATION_LINK = i18n.translate(
   'xpack.searchInferenceEndpoints.apiDocumentationLink',
   {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/inference_endpoints_header.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/inference_endpoints_header.tsx
@@ -37,6 +37,7 @@ export const InferenceEndpointsHeader: React.FC<InferenceEndpointsHeaderProps> =
           {i18n.ADD_ENDPOINT_LABEL}
         </EuiButton>,
         <EuiButtonEmpty
+          aria-label={i18n.API_DOCUMENTATION_LINK}
           iconType="popout"
           iconSide="right"
           iconSize="s"
@@ -48,6 +49,7 @@ export const InferenceEndpointsHeader: React.FC<InferenceEndpointsHeaderProps> =
           {i18n.API_DOCUMENTATION_LINK}
         </EuiButtonEmpty>,
         <EuiButtonEmpty
+          aria-label={i18n.VIEW_YOUR_MODELS_LINK}
           href={trainedModelPageUrl}
           iconType="popout"
           iconSide="right"
@@ -57,6 +59,18 @@ export const InferenceEndpointsHeader: React.FC<InferenceEndpointsHeaderProps> =
           data-test-subj="view-your-models"
         >
           {i18n.VIEW_YOUR_MODELS_LINK}
+        </EuiButtonEmpty>,
+        <EuiButtonEmpty
+          aria-label={i18n.EIS_DOCUMENTATION_LINK}
+          href={docLinks.elasticInferenceService}
+          iconType="popout"
+          iconSide="right"
+          iconSize="s"
+          flush="both"
+          target="_blank"
+          data-test-subj="eis-documentation"
+        >
+          {i18n.EIS_DOCUMENTATION_LINK}
         </EuiButtonEmpty>,
       ]}
     />

--- a/x-pack/solutions/search/test/serverless/functional/page_objects/svl_search_inference_management_page.ts
+++ b/x-pack/solutions/search/test/serverless/functional/page_objects/svl_search_inference_management_page.ts
@@ -16,6 +16,7 @@ export function SvlSearchInferenceManagementPageProvider({ getService }: FtrProv
     InferenceTabularPage: {
       async expectHeaderToBeExist() {
         await testSubjects.existOrFail('allInferenceEndpointsPage');
+        await testSubjects.existOrFail('eis-documentation');
         await testSubjects.existOrFail('api-documentation');
         await testSubjects.existOrFail('view-your-models');
         await testSubjects.existOrFail('add-inference-endpoint-header-button');


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/236022

This PR adds a link to the EIS docs page on top of the inference UI page: https://www.elastic.co/docs/explore-analyze/elastic-inference/eis next to the ML Trained Models and API Documentation.

<img width="1771" height="550" alt="image" src="https://github.com/user-attachments/assets/c14a4bb0-a22a-4029-913f-e456924c11c9" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




