### PR TITLE
[Security Solutio][Diagnostic Queries] Improve ILM checks for serverless

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3023,6 +3023,3 @@ x-pack/plugins/observability_solution/synthetics/server/saved_objects/synthetics
 ####
 ## These rules are always last so they take ultimate priority over everything else
 ####
-####
-## These rules are always last so they take ultimate priority over everything else
-####

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -508,6 +508,7 @@ src/platform/packages/shared/kbn-i18n @elastic/kibana-core
 src/platform/packages/shared/kbn-i18n-react @elastic/kibana-core
 src/platform/packages/shared/kbn-interpreter @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-io-ts-utils @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations
 src/platform/packages/shared/kbn-lens-embeddable-utils @elastic/obs-ux-infra_services-team @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-licensing-types @elastic/kibana-core
 src/platform/packages/shared/kbn-logging @elastic/kibana-core
@@ -3019,6 +3020,9 @@ x-pack/plugins/observability_solution/synthetics/server/saved_objects/synthetics
 /.github/workflows/oblt-github-commands   @elastic/observablt-robots @elastic/kibana-operations
 /.github/workflows/undeploy-my-kibana.yml @elastic/observablt-robots @elastic/kibana-operations
 
+####
+## These rules are always last so they take ultimate priority over everything else
+####
 ####
 ## These rules are always last so they take ultimate priority over everything else
 ####

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.ts
@@ -203,52 +203,57 @@ export class CircuitBreakingQueryExecutorImpl implements CircuitBreakingQueryExe
     }
     const tiers = query.tiers;
 
-    return (
-      await this.client.ilm
-        .explainLifecycle({
-          index: query.index,
-          only_managed: false,
-          filter_path: ['indices.*.phase'],
-        })
-        .then((response) => {
-          if (response.indices === undefined) {
-            this.logger.debug(
-              'Got an empty response while explaining lifecycle. Asumming serverless.',
-              {
-                index: query.index,
-              } as LogMeta
-            );
-            return [query.index];
-          } else {
-            const indices = Object.entries(response.indices).map(([indexName, stats]) => {
-              if ('phase' in stats && stats.phase) {
-                if (tiers.includes(stats.phase)) {
-                  return indexName;
-                } else {
-                  this.logger.debug('Index is not in the expected phases', {
-                    phase: stats.phase,
-                    index: indexName,
-                    tiers,
-                  } as LogMeta);
-                  return '';
-                }
+    return this.client.ilm
+      .explainLifecycle({
+        index: query.index,
+        only_managed: false,
+        filter_path: ['indices.*.phase'],
+      })
+      .then((response) => {
+        if (response.indices === undefined) {
+          this.logger.debug(
+            'Got an empty response while explaining lifecycle. Asumming serverless.',
+            {
+              index: query.index,
+            } as LogMeta
+          );
+          return [query.index];
+        } else {
+          const indices = Object.entries(response.indices).map(([indexName, stats]) => {
+            if ('phase' in stats && stats.phase) {
+              if (tiers.includes(stats.phase)) {
+                return indexName;
               } else {
-                // should not happen, but just in case
-                this.logger.debug('Index is not managed by an ILM', {
+                this.logger.debug('Index is not in the expected phases', {
+                  phase: stats.phase,
                   index: indexName,
                   tiers,
                 } as LogMeta);
                 return '';
               }
-            });
-            this.logger.debug('Indices managed by ILM', {
-              queryName: query.name,
-              tiers: query.tiers,
-              indices,
-            } as LogMeta);
-            return indices;
-          }
-        })
-    ).filter((indexName) => indexName !== '');
+            } else {
+              // should not happen, but just in case
+              this.logger.debug('Index is not managed by an ILM', {
+                index: indexName,
+                tiers,
+              } as LogMeta);
+              return '';
+            }
+          });
+          this.logger.debug('Indices managed by ILM', {
+            queryName: query.name,
+            tiers: query.tiers,
+            indices,
+          } as LogMeta);
+          return indices;
+        }
+      })
+      .then((indices) => {
+        return indices.filter((indexName) => indexName !== '');
+      })
+      .catch((error) => {
+        this.logger.info('Error while checking ILM status, assuming serverless', { error });
+        return [query.index];
+      });
   }
 }


### PR DESCRIPTION
## Summary

Improve error handling when querying non-existent ILM APIs in serverless.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->