### PR TITLE
[Discover] show temporary and managed labels when necessary in the data view picker

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/assets/adhoc.svg
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/assets/adhoc.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none"><path fill="#07C" d="M12 2H2v12H1V1h12v1zM5 5h5.999V4H5zM3 5V4h1v1zm2 3V7h4v1zM3 8V7h1v1zm2 3v-1h3v1zm-2 0v-1h1v1z"/><path stroke="#07C" stroke-dasharray="2 2" d="M1.5 1.5h11v12h-11z"/></svg>

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.styles.ts
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.styles.ts
@@ -11,7 +11,7 @@ import type { EuiThemeComputed } from '@elastic/eui';
 import { calculateWidthFromEntries } from '@kbn/calculate-width-from-char-count';
 import type { DataViewListItemEnhanced } from './dataview_list';
 
-const DEFAULT_WIDTH = 350;
+const DEFAULT_WIDTH = 450;
 
 export const changeDataViewStyles = ({
   fullWidth,

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
@@ -18,7 +18,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
-  EuiIcon,
   EuiPopover,
   EuiText,
   useEuiTheme,
@@ -27,10 +26,10 @@ import {
 } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
+import { DataViewLabels } from './data_view_labels';
 import type { IUnifiedSearchPluginServices } from '../types';
 import { type DataViewPickerProps } from './data_view_picker';
 import type { DataViewListItemEnhanced } from './dataview_list';
-import adhoc from './assets/adhoc.svg';
 import { changeDataViewStyles } from './change_dataview.styles';
 import { DataViewSelector } from './data_view_selector';
 
@@ -102,9 +101,15 @@ export function ChangeDataView({
     fetchDataViews();
   }, [data, currentDataViewId, adHocDataViews, savedDataViews]);
 
-  const isAdHocSelected = useMemo(() => {
-    return adHocDataViews?.some((dataView) => dataView.id === currentDataViewId);
-  }, [adHocDataViews, currentDataViewId]);
+  const isAdHocSelected = useMemo(
+    () => adHocDataViews?.some((dataView) => dataView.id === currentDataViewId),
+    [adHocDataViews, currentDataViewId]
+  );
+
+  const isManagedSelected = useMemo(
+    () => dataViewsList.find((dataView) => dataView.id === currentDataViewId)?.managed,
+    [currentDataViewId, dataViewsList]
+  );
 
   const closeDataViewEditor = useRef<() => void | undefined>();
 
@@ -136,13 +141,10 @@ export function ChangeDataView({
         {...rest}
       >
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-          {/* we don't want to display the adHoc icon on text based mode */}
-          {isAdHocSelected && (
-            <EuiFlexItem grow={false}>
-              <EuiIcon type={adhoc} color="primary" size="s" />
-            </EuiFlexItem>
-          )}
           <EuiFlexItem grow={false}>{trigger.label}</EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <DataViewLabels isAdhoc={isAdHocSelected} isManaged={isManagedSelected} name={label} />
+          </EuiFlexItem>
         </EuiFlexGroup>
       </EuiButtonEmpty>
     );

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
@@ -141,7 +141,9 @@ export function ChangeDataView({
         {...rest}
       >
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-          <EuiFlexItem grow={false}>{trigger.label}</EuiFlexItem>
+          <EuiFlexItem data-test-subj={`${dataTestSubj}-label`} grow={false}>
+            {trigger.label}
+          </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <DataViewLabels isAdhoc={isAdHocSelected} isManaged={isManagedSelected} name={label} />
           </EuiFlexItem>

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_labels.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_labels.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DataViewLabels } from './data_view_labels';
+
+describe('DataViewLabels', () => {
+  it('should render both labels', () => {
+    const { getByTestId } = render(
+      <DataViewLabels isAdhoc={true} isManaged={true} name={'name'} />
+    );
+    expect(getByTestId('dataViewItemTempBadge-name')).toHaveTextContent('Temporary');
+    expect(getByTestId('dataViewItemManagedBadge-name')).toHaveTextContent('Managed');
+  });
+
+  it('should render only temporary label', () => {
+    const { getByTestId, queryByTestId } = render(
+      <DataViewLabels isAdhoc={true} isManaged={false} name={'name'} />
+    );
+    expect(getByTestId('dataViewItemTempBadge-name')).toBeInTheDocument();
+    expect(queryByTestId('dataViewItemManagedBadge-name')).not.toBeInTheDocument();
+  });
+
+  it('should render only managed label', () => {
+    const { getByTestId, queryByTestId } = render(
+      <DataViewLabels isAdhoc={false} isManaged={true} name={'name'} />
+    );
+    expect(queryByTestId('dataViewItemTempBadge-name')).not.toBeInTheDocument();
+    expect(getByTestId('dataViewItemManagedBadge-name')).toBeInTheDocument();
+  });
+
+  it('should render no labels', () => {
+    const { container } = render(
+      <DataViewLabels isAdhoc={false} isManaged={false} name={'name'} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_labels.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_labels.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import React, { memo } from 'react';
+
+const TEMPORARY_LABEL = i18n.translate(
+  'unifiedSearch.query.queryBar.indexPattern.temporaryDataviewLabel',
+  {
+    defaultMessage: 'Temporary',
+  }
+);
+const MANAGED_LABEL = i18n.translate(
+  'unifiedSearch.query.queryBar.indexPattern.managedDataviewLabel',
+  {
+    defaultMessage: 'Managed',
+  }
+);
+
+const TemporaryDataViewLabel = memo(({ name }: { name: string | undefined }) => {
+  return (
+    <EuiBadge color="hollow" data-test-subj={`dataViewItemTempBadge-${name}`}>
+      {TEMPORARY_LABEL}
+    </EuiBadge>
+  );
+});
+
+const ManagedDataViewLabel = memo(({ name }: { name: string | undefined }) => {
+  return (
+    <EuiBadge color="hollow" data-test-subj={`dataViewItemManagedBadge-${name}`}>
+      {MANAGED_LABEL}
+    </EuiBadge>
+  );
+});
+
+export interface DataViewLabelsProps {
+  /**
+   * True if the data view is temporary (ad-hoc)
+   */
+  isAdhoc: boolean | undefined;
+  /**
+   * True if the data view is managed
+   */
+  isManaged: boolean | undefined;
+  /**
+   * Name of the data view
+   */
+  name: string | undefined;
+}
+
+/**
+ * Renders labels for the data view item, depending on if the data view is managed, adhoc, both or neither.
+ * These are used within the data view picker dropdown as well as the data view picker button.
+ */
+export const DataViewLabels = memo(({ isAdhoc, isManaged, name }: DataViewLabelsProps) => {
+  return (
+    <>
+      {isManaged && isAdhoc ? (
+        <EuiFlexGroup direction="row" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <TemporaryDataViewLabel name={name} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <ManagedDataViewLabel name={name} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ) : isManaged ? (
+        <ManagedDataViewLabel name={name} />
+      ) : isAdhoc ? (
+        <TemporaryDataViewLabel name={name} />
+      ) : null}
+    </>
+  );
+});
+
+DataViewLabels.displayName = 'DataViewLabels';

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/dataview_list.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/dataview_list.tsx
@@ -8,20 +8,20 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import type { EuiSelectableProps, Direction } from '@elastic/eui';
+import type { Direction, EuiSelectableProps } from '@elastic/eui';
 import {
-  EuiSelectable,
-  EuiBadge,
+  EuiButtonGroup,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
-  EuiButtonGroup,
+  EuiSelectable,
   toSentenceCase,
 } from '@elastic/eui';
 import type { DataViewListItem } from '@kbn/data-views-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { ESQL_TYPE } from '@kbn/data-view-utils';
+import { DataViewLabels } from './data_view_labels';
 import { SortingService } from './sorting_service';
 import { MIDDLE_TRUNCATION_PROPS } from '../filter_bar/filter_editor/lib/helpers';
 
@@ -45,18 +45,6 @@ const strings = {
       i18n.translate('unifiedSearch.optionsList.popover.sortDirections', {
         defaultMessage: 'Sort directions',
       }),
-    adhoc: {
-      getTemporaryDataviewLabel: () =>
-        i18n.translate('unifiedSearch.query.queryBar.indexPattern.temporaryDataviewLabel', {
-          defaultMessage: 'Temporary',
-        }),
-    },
-    managed: {
-      getManagedDataviewLabel: () =>
-        i18n.translate('unifiedSearch.query.queryBar.indexPattern.managedDataviewLabel', {
-          defaultMessage: 'Managed',
-        }),
-    },
     search: {
       getSearchPlaceholder: () =>
         i18n.translate('unifiedSearch.query.queryBar.indexPattern.findDataView', {
@@ -141,15 +129,7 @@ export function DataViewsList({
         label: name ? name : title,
         value: id,
         checked: id === currentDataViewId ? 'on' : undefined,
-        append: managed ? (
-          <EuiBadge color="hollow" data-test-subj={`dataViewItemManagedBadge-${name}`}>
-            {strings.editorAndPopover.managed.getManagedDataviewLabel()}
-          </EuiBadge>
-        ) : isAdhoc ? (
-          <EuiBadge color="hollow" data-test-subj={`dataViewItemTempBadge-${name}`}>
-            {strings.editorAndPopover.adhoc.getTemporaryDataviewLabel()}
-          </EuiBadge>
-        ) : null,
+        append: <DataViewLabels isAdhoc={isAdhoc} isManaged={managed} name={name} />,
       }))}
       onChange={(choices) => {
         const choice = choices.find(({ checked }) => checked) as unknown as {

--- a/src/platform/test/functional/services/data_views.ts
+++ b/src/platform/test/functional/services/data_views.ts
@@ -79,7 +79,7 @@ export class DataViewsService extends FtrService {
    * Returns name for the currently selected Data View
    */
   async getSelectedName() {
-    return this.testSubjects.getVisibleText('*dataView-switch-link');
+    return this.testSubjects.getVisibleText('*dataView-switch-link-label');
   }
 
   /**

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/saved_searches.spec.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/saved_searches.spec.ts
@@ -6,8 +6,8 @@
  */
 
 import { expect } from '@kbn/scout';
-import { spaceTest, testData } from '../fixtures';
 import type { ExtParallelRunTestFixtures } from '../fixtures';
+import { spaceTest, testData } from '../fixtures';
 
 const assertNoFilterAndEmptyQuery = async (
   filterBadge: { field: string; value: string },
@@ -27,7 +27,7 @@ const assertNoFilterAndEmptyQuery = async (
 
 const assertDataViewIsSelected = async (page: ExtParallelRunTestFixtures['page'], name: string) =>
   await expect(
-    page.testSubj.locator('*dataView-switch-link'),
+    page.testSubj.locator('*dataView-switch-link-label'),
     'Incorrect data view is selected'
   ).toHaveText(name);
 

--- a/x-pack/platform/test/functional/apps/lens/group1/ad_hoc_data_view.ts
+++ b/x-pack/platform/test/functional/apps/lens/group1/ad_hoc_data_view.ts
@@ -61,7 +61,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     await header.waitUntilLoadingHasFinished();
 
     const actualIndexPattern = await (
-      await testSubjects.find('discover-dataView-switch-link')
+      await testSubjects.find('discover-dataView-switch-link-label')
     ).getVisibleText();
     expect(actualIndexPattern).to.be('*stash*');
 
@@ -206,7 +206,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await header.waitUntilLoadingHasFinished();
 
       const actualIndexPattern = await (
-        await testSubjects.find('discover-dataView-switch-link')
+        await testSubjects.find('discover-dataView-switch-link-label')
       ).getVisibleText();
       expect(actualIndexPattern).to.be('*stash*');
 


### PR DESCRIPTION
## Summary

This PR makes a tiny change to the DataView picker shown in Discover and soon on all the page throughout Security Solution:
- We are currently showing a small icon only for selected data views that are `adhoc` (temporary). This PR replaces the icon with a `Temporary` text label, and also adds the `Managed` text label when appropriate.
- We also currently show on the `Managed` text label in the dropdown, even if the data view is also adhoc. The PR makes sure that we display both `Temporary` and `Managed` labels when necessary

> [!WARNING]
> UIUX has not yet given the correct icon, nor has approved showing 2 icons for data views that are both `adhoc` and `managed`. To be confirmed soon!

For data views that are neither `managed` nor `adhoc`, no visible changes:
| Before  | After |
| ------------- | ------------- |
| <img width="312" height="65" alt="Screenshot 2025-09-23 at 3 46 15 PM" src="https://github.com/user-attachments/assets/84667236-edf5-45d6-909f-c63ebf94f22d" /> | <img width="312" height="65" alt="Screenshot 2025-09-23 at 3 46 15 PM" src="https://github.com/user-attachments/assets/403338fa-553c-4aa3-9605-c942a0687f2f" /> |

For data views that are `managed` only, we now show the label:
| Before  | After |
| ------------- | ------------- |
| <img width="297" height="66" alt="Screenshot 2025-09-23 at 3 46 57 PM" src="https://github.com/user-attachments/assets/4c95eba9-1a1e-4fa0-b31d-cd9b3b476524" /> | <img width="375" height="48" alt="Screenshot 2025-09-29 at 11 45 06 AM" src="https://github.com/user-attachments/assets/bddedb12-00f2-4b06-8571-3d5bbf41f27b" /> |

For data views that are `adhoc` only, we switched the icon for the label:
| Before  | After |
| ------------- | ------------- |
| <img width="210" height="64" alt="Screenshot 2025-09-23 at 3 47 29 PM" src="https://github.com/user-attachments/assets/195df744-02de-44b3-83d3-052ea51f4827" /> | <img width="269" height="44" alt="Screenshot 2025-09-29 at 11 46 32 AM" src="https://github.com/user-attachments/assets/e1a13e08-f520-4354-8a29-8fae099c5e20" /> |

For data views that are both `managed` and `adhoc` only, we show 2 icons:
| Before  | After |
| ------------- | ------------- |
| <img width="336" height="62" alt="Screenshot 2025-09-23 at 3 46 44 PM" src="https://github.com/user-attachments/assets/08c1ee3a-bdc6-45ac-af88-6dd830e8db72" /> | <img width="472" height="42" alt="Screenshot 2025-09-29 at 11 47 08 AM" src="https://github.com/user-attachments/assets/78cc7721-b41c-4e06-9a8a-e4b6d1af82f5" /> |


Now that both labels can be rendered in the dropwdpwn, we need a little bit more width space to ensure enough space for the data view name to be rendered.  This PR increases the width of the overall popover by 100px (as the Temporary label is around 60px wide and we have some padding...).
| Before  | After |
| ------------- | ------------- |
| <img width="368" height="390" alt="Screenshot 2025-09-29 at 11 50 53 AM" src="https://github.com/user-attachments/assets/46551828-0309-4214-96d8-34f373d53648" /> | <img width="466" height="394" alt="Screenshot 2025-09-29 at 11 48 01 AM" src="https://github.com/user-attachments/assets/13d8d0b5-8599-429e-86af-8e4f698ffc75" /> |

> [!NOTE]
> If this is approved by the @elastic/kibana-presentation team, I'll write some unit tests.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/235731