### PR TITLE
[Discover] show both temporary and managed label for specific data views

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.styles.ts
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.styles.ts
@@ -11,7 +11,7 @@ import type { EuiThemeComputed } from '@elastic/eui';
 import { calculateWidthFromEntries } from '@kbn/calculate-width-from-char-count';
 import type { DataViewListItemEnhanced } from './dataview_list';
 
-const DEFAULT_WIDTH = 350;
+const DEFAULT_WIDTH = 425;
 
 export const changeDataViewStyles = ({
   fullWidth,

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/dataview_list.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/dataview_list.tsx
@@ -8,14 +8,14 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import type { EuiSelectableProps, Direction } from '@elastic/eui';
+import type { Direction, EuiSelectableProps } from '@elastic/eui';
 import {
-  EuiSelectable,
   EuiBadge,
+  EuiButtonGroup,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
-  EuiButtonGroup,
+  EuiSelectable,
   toSentenceCase,
 } from '@elastic/eui';
 import type { DataViewListItem } from '@kbn/data-views-plugin/public';
@@ -65,6 +65,22 @@ const strings = {
     },
   },
 };
+
+function ManagedLabel({ name }: { name: string | undefined }) {
+  return (
+    <EuiBadge color="hollow" data-test-subj={`dataViewItemManagedBadge-${name}`}>
+      {strings.editorAndPopover.managed.getManagedDataviewLabel()}
+    </EuiBadge>
+  );
+}
+
+function AdHocLabel({ name }: { name: string | undefined }) {
+  return (
+    <EuiBadge color="hollow" data-test-subj={`dataViewItemTempBadge-${name}`}>
+      {strings.editorAndPopover.adhoc.getTemporaryDataviewLabel()}
+    </EuiBadge>
+  );
+}
 
 export interface DataViewListItemEnhanced extends DataViewListItem {
   isAdhoc?: boolean;
@@ -141,15 +157,17 @@ export function DataViewsList({
         label: name ? name : title,
         value: id,
         checked: id === currentDataViewId ? 'on' : undefined,
-        append: managed ? (
-          <EuiBadge color="hollow" data-test-subj={`dataViewItemManagedBadge-${name}`}>
-            {strings.editorAndPopover.managed.getManagedDataviewLabel()}
-          </EuiBadge>
-        ) : isAdhoc ? (
-          <EuiBadge color="hollow" data-test-subj={`dataViewItemTempBadge-${name}`}>
-            {strings.editorAndPopover.adhoc.getTemporaryDataviewLabel()}
-          </EuiBadge>
-        ) : null,
+        append:
+          managed && isAdhoc ? (
+            <>
+              <ManagedLabel name={name} />
+              <AdHocLabel name={name} />
+            </>
+          ) : managed ? (
+            <ManagedLabel name={name} />
+          ) : isAdhoc ? (
+            <AdHocLabel name={name} />
+          ) : null,
       }))}
       onChange={(choices) => {
         const choice = choices.find(({ checked }) => checked) as unknown as {


### PR DESCRIPTION
## Summary

This PR makes a small UI change to the data view picker. We currently show a `Managed` label for data views that are `managed`. We show a `Temporary` label for the `adhoc` data views.
But we do not show both labels for the data views that are both `managed` and `adhoc`. Instead we just show the `Managed` label.

To ensure transparency to the users, this PR displays both labels for the data views that are impacted. In order to not impact the width available to the data view name, this PR increases the width of the overall popover by `75px` (as the `Temporary` label is around `60px` wide plus padding...).

| Before  | after |
| ------------- | ------------- |
| <img width="385" height="394" alt="Screenshot 2025-09-23 at 4 34 12 PM" src="https://github.com/user-attachments/assets/71598748-6a6c-4c53-b959-53bcadd6e3ac" /> | <img width="454" height="398" alt="Screenshot 2025-09-23 at 4 31 27 PM" src="https://github.com/user-attachments/assets/bbaab024-5235-48fd-b09f-e19886e47680" /> |

> [!NOTE]
> If this is approved by the @elastic/kibana-presentation team, I'll write some unit tests.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.