### PR TITLE
[8.18] ESLint Rule for non-kbn-handlebars detection (#233190)

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -331,6 +331,7 @@ module.exports = {
     '@kbn/imports/no_group_crossing_manifests': 'error',
     '@kbn/imports/no_group_crossing_imports': 'error',
     '@kbn/css/no_css_color': 'warn',
+    '@kbn/imports/no_direct_handlebars_import': 'error',
     'no-new-func': 'error',
     'no-implied-eval': 'error',
     'no-prototype-builtins': 'error',

--- a/packages/kbn-eslint-plugin-imports/index.ts
+++ b/packages/kbn-eslint-plugin-imports/index.ts
@@ -16,6 +16,7 @@ import { NoBoundaryCrossingRule } from './src/rules/no_boundary_crossing';
 import { NoGroupCrossingImportsRule } from './src/rules/no_group_crossing_imports';
 import { NoGroupCrossingManifestsRule } from './src/rules/no_group_crossing_manifests';
 import { RequireImportRule } from './src/rules/require_import';
+import { NoDirectHandlebarsImportRule } from './src/rules/no_direct_handlebars_import';
 
 /**
  * Custom ESLint rules, add `'@kbn/eslint-plugin-imports'` to your eslint config to use them
@@ -30,4 +31,5 @@ export const rules = {
   no_group_crossing_imports: NoGroupCrossingImportsRule,
   no_group_crossing_manifests: NoGroupCrossingManifestsRule,
   require_import: RequireImportRule,
+  no_direct_handlebars_import: NoDirectHandlebarsImportRule,
 };

--- a/packages/kbn-eslint-plugin-imports/src/rules/no_direct_handlebars_import.test.ts
+++ b/packages/kbn-eslint-plugin-imports/src/rules/no_direct_handlebars_import.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { RuleTester } from 'eslint';
+import { NoDirectHandlebarsImportRule } from './no_direct_handlebars_import';
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('@kbn/imports/no_direct_handlebars_import', NoDirectHandlebarsImportRule, {
+  valid: [
+    {
+      code: 'import Handlebars from "@kbn/handlebars";',
+    },
+    {
+      code: 'import { compile } from "@kbn/handlebars";',
+    },
+    {
+      code: 'import * as Handlebars from "@kbn/handlebars";',
+    },
+    {
+      code: 'import something from "other-package";',
+    },
+    {
+      code: 'const foo = require("@kbn/handlebars");',
+    },
+  ],
+
+  invalid: [
+    {
+      code: 'import Handlebars from "handlebars";',
+      errors: [
+        {
+          message:
+            'Do not import directly from "handlebars". Use the custom Handlebars from "@kbn/handlebars" instead.',
+        },
+      ],
+      output: "import Handlebars from '@kbn/handlebars';",
+    },
+    {
+      code: 'import { compile } from "handlebars";',
+      errors: [
+        {
+          message:
+            'Do not import directly from "handlebars". Use the custom Handlebars from "@kbn/handlebars" instead.',
+        },
+      ],
+      output: "import { compile } from '@kbn/handlebars';",
+    },
+    {
+      code: 'import * as Handlebars from "handlebars";',
+      errors: [
+        {
+          message:
+            'Do not import directly from "handlebars". Use the custom Handlebars from "@kbn/handlebars" instead.',
+        },
+      ],
+      output: "import * as Handlebars from '@kbn/handlebars';",
+    },
+    {
+      code: 'import "handlebars/lib/handlebars";',
+      errors: [
+        {
+          message:
+            'Do not import directly from "handlebars". Use the custom Handlebars from "@kbn/handlebars" instead.',
+        },
+      ],
+      output: "import '@kbn/handlebars/lib/handlebars';",
+    },
+    {
+      code: 'const Handlebars = require("handlebars");',
+      errors: [
+        {
+          message:
+            'Do not import directly from "handlebars". Use the custom Handlebars from "@kbn/handlebars" instead.',
+        },
+      ],
+      output: "const Handlebars = require('@kbn/handlebars');",
+    },
+  ],
+});

--- a/packages/kbn-eslint-plugin-imports/src/rules/no_direct_handlebars_import.ts
+++ b/packages/kbn-eslint-plugin-imports/src/rules/no_direct_handlebars_import.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Rule } from 'eslint';
+import { visitAllImportStatements } from '../helpers/visit_all_import_statements';
+import { report } from '../helpers/report';
+
+export const NoDirectHandlebarsImportRule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+    docs: {
+      description: 'Disallow direct imports from handlebars package. Use @kbn/handlebars instead.',
+      url: 'https://github.com/elastic/kibana/blob/main/packages/kbn-eslint-plugin-imports/README.mdx#kbnimportsno_direct_handlebars_import',
+    },
+    messages: {
+      noDirectHandlebarsImport:
+        'Do not import directly from "handlebars". Use the custom Handlebars from "@kbn/handlebars" instead.',
+    },
+  },
+
+  create(context) {
+    return visitAllImportStatements((req, { node }) => {
+      if (!req) {
+        return;
+      }
+
+      // Skip the rule for files within the kbn-handlebars package itself
+      const filename = context.getFilename();
+      if (filename.includes('/kbn-handlebars/') || filename.includes('\\kbn-handlebars\\')) {
+        return;
+      }
+
+      // Check for direct imports from 'handlebars' package
+      if (req === 'handlebars' || req.startsWith('handlebars/')) {
+        // Replace 'handlebars' with '@kbn/handlebars' in the import request
+        const correctImport = req.replace(/^handlebars/, '@kbn/handlebars');
+
+        report(context, {
+          node,
+          message:
+            'Do not import directly from "handlebars". Use the custom Handlebars from "@kbn/handlebars" instead.',
+          correctImport,
+        });
+      }
+    });
+  },
+};

--- a/src/dev/eslint/security_eslint_rule_tests.ts
+++ b/src/dev/eslint/security_eslint_rule_tests.ts
@@ -50,6 +50,16 @@ require('lodash/fp/assoc'); // eslint-disable-line no-restricted-modules
 require('lodash/fp/assocPath'); // eslint-disable-line no-restricted-modules
 require('lodash/fp/template'); // eslint-disable-line no-restricted-modules
 
+// Adding some additional tests for Handlebars here, for more tests, see packages/kbn-eslint-plugin-imports/src/rules/no_direct_handlebars_import.test.ts
+import * as hb from 'handlebars'; // eslint-disable-line @kbn/imports/no_direct_handlebars_import
+import Handlebars from 'handlebars'; // eslint-disable-line @kbn/imports/no_direct_handlebars_import
+import { compile as hc } from 'handlebars'; // eslint-disable-line @kbn/imports/no_direct_handlebars_import
+import { precompile as hp } from 'handlebars'; // eslint-disable-line @kbn/imports/no_direct_handlebars_import
+import { template as ht } from 'handlebars'; // eslint-disable-line @kbn/imports/no_direct_handlebars_import
+import { SafeString as hs } from 'handlebars'; // eslint-disable-line @kbn/imports/no_direct_handlebars_import
+
+require('handlebars'); // eslint-disable-line @kbn/imports/no_direct_handlebars_import
+
 const lodash = {
   set() {},
   setWith() {},
@@ -71,4 +81,4 @@ _.assocPath(); // eslint-disable-line no-restricted-properties
 _.template(); // eslint-disable-line no-restricted-properties
 
 // hack to ensure all imported variables are used
-module.exports = [a, b, c, d, e, f, g, h, i, j];
+module.exports = [a, b, c, d, e, f, g, h, i, j, hb, Handlebars, hc, hp, ht, hs];

--- a/src/platform/packages/shared/kbn-openapi-generator/src/template_service/register_helpers.ts
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/template_service/register_helpers.ts
@@ -6,9 +6,8 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-
 import type Handlebars from '@kbn/handlebars';
-import { HelperOptions } from 'handlebars';
+import type { HelperOptions } from '@kbn/handlebars';
 import { snakeCase, camelCase, upperCase } from 'lodash';
 
 export function registerHelpers(handlebarsInstance: typeof Handlebars) {

--- a/src/platform/packages/shared/kbn-openapi-generator/src/template_service/template_service.ts
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/template_service/template_service.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+// eslint-disable-next-line @kbn/imports/no_direct_handlebars_import
 import Handlebars from 'handlebars';
 import { resolve } from 'path';
 import { BundleGenerationContext, GenerationContext } from '../parser/get_generation_context';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [ESLint Rule for non-kbn-handlebars detection (#233190)](https://github.com/elastic/kibana/pull/233190)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kurt","email":"kc13greiner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-09-19T19:08:27Z","message":"ESLint Rule for non-kbn-handlebars detection (#233190)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/229853\n\nThis adds an ESLint rule to prevent teams from directly importing\n\"Handlebars\" into their files and instead using @kbn-handlebars.\n\nThe @kbn-handlebars package is allows to directly import \"Handlebars\"\nfor patching\n\n## Testing\n\nOpen up a file of your choice and try to import Handlebars, check that\nESLint recognizes it:\n\n<img width=\"334\" height=\"103\" alt=\"Screenshot 2025-09-02 at 8 04 23 AM\"\nsrc=\"https://github.com/user-attachments/assets/20d0cc4b-d353-47a5-bf29-444c63425eda\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1525cead4835f03330e9c0681556ee2aed64e138","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport missing","backport:version","v9.2.0","v9.1.4","v9.0.7","v8.18.7","v8.19.4"],"title":"ESLint Rule for non-kbn-handlebars detection","number":233190,"url":"https://github.com/elastic/kibana/pull/233190","mergeCommit":{"message":"ESLint Rule for non-kbn-handlebars detection (#233190)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/229853\n\nThis adds an ESLint rule to prevent teams from directly importing\n\"Handlebars\" into their files and instead using @kbn-handlebars.\n\nThe @kbn-handlebars package is allows to directly import \"Handlebars\"\nfor patching\n\n## Testing\n\nOpen up a file of your choice and try to import Handlebars, check that\nESLint recognizes it:\n\n<img width=\"334\" height=\"103\" alt=\"Screenshot 2025-09-02 at 8 04 23 AM\"\nsrc=\"https://github.com/user-attachments/assets/20d0cc4b-d353-47a5-bf29-444c63425eda\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1525cead4835f03330e9c0681556ee2aed64e138"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.0","8.18","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/233190","number":233190,"mergeCommit":{"message":"ESLint Rule for non-kbn-handlebars detection (#233190)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/229853\n\nThis adds an ESLint rule to prevent teams from directly importing\n\"Handlebars\" into their files and instead using @kbn-handlebars.\n\nThe @kbn-handlebars package is allows to directly import \"Handlebars\"\nfor patching\n\n## Testing\n\nOpen up a file of your choice and try to import Handlebars, check that\nESLint recognizes it:\n\n<img width=\"334\" height=\"103\" alt=\"Screenshot 2025-09-02 at 8 04 23 AM\"\nsrc=\"https://github.com/user-attachments/assets/20d0cc4b-d353-47a5-bf29-444c63425eda\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1525cead4835f03330e9c0681556ee2aed64e138"}},{"branch":"9.1","label":"v9.1.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->