### PR TITLE
[Cases][Security Solution] Hide cases events behind feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -323,6 +323,11 @@ export const allowedExperimentalValues = Object.freeze({
    * Enables the SIEM Readiness Dashboard feature
    */
   siemReadinessDashboard: false,
+
+  /**
+   * Enables events integration with the Cases plugin
+   */
+  caseEventsIntegration: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/case_events/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/case_events/constants.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// NOTE: remove this flag post serverless deploy
+export const CASE_EVENTS_ENABLED = false;

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/pages/index.tsx
@@ -38,6 +38,7 @@ import { useFetchNotes } from '../../notes/hooks/use_fetch_notes';
 import { DocumentEventTypes } from '../../common/lib/telemetry';
 import { AiForSOCAlertsTable } from '../components/ai_for_soc/wrapper';
 import { EventsTableForCases } from '../components/case_events/table';
+import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 
 const CaseContainerComponent: React.FC = () => {
   const {
@@ -138,6 +139,8 @@ const CaseContainerComponent: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const caseEventsIntegrationEnabled = useIsExperimentalFeatureEnabled('caseEventsIntegration');
+
   return (
     <SecuritySolutionPageWrapper noPadding>
       <CaseDetailsRefreshContext.Provider value={refreshRef}>
@@ -153,7 +156,7 @@ const CaseContainerComponent: React.FC = () => {
               CaseMetricsFeature.LIFESPAN,
             ],
             alerts: { isExperimental: false },
-            events: { enabled: true },
+            events: { enabled: caseEventsIntegrationEnabled },
           },
           refreshRef,
           actionsNavigation: {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.test.tsx
@@ -17,6 +17,8 @@ import { mockCasesContract } from '@kbn/cases-plugin/public/mocks';
 import { useAlertsPrivileges } from '../../../containers/detection_engine/alerts/use_alerts_privileges';
 import userEvent from '@testing-library/user-event';
 
+jest.mock('../../../../common/hooks/use_experimental_features');
+
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../../../containers/detection_engine/alerts/use_alerts_privileges');
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.test.tsx
@@ -18,6 +18,10 @@ import { allCasesPermissions } from '../../../../cases_test_utils';
 
 jest.mock('../../../../common/lib/kibana');
 
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+
+jest.mock('../../../../common/hooks/use_experimental_features');
+
 const refetch = jest.fn();
 const submit = jest.fn();
 const open = jest.fn().mockImplementation(() => {
@@ -94,14 +98,36 @@ describe('useAddToCaseActions', () => {
     );
   });
 
-  it('should render case options when event is not alert ', () => {
-    const { result } = renderHook(
-      () => useAddToCaseActions({ ...defaultProps, ecsData: { _id: '123' } }),
-      {
-        wrapper: TestProviders,
-      }
-    );
-    expect(result.current.addToCaseActionItems.length).toEqual(2);
+  describe('when cases integration feature is enabled', () => {
+    beforeAll(() => {
+      jest.mocked(useIsExperimentalFeatureEnabled).mockReturnValue(true);
+    });
+
+    it('should render case options when event is not alert ', () => {
+      const { result } = renderHook(
+        () => useAddToCaseActions({ ...defaultProps, ecsData: { _id: '123' } }),
+        {
+          wrapper: TestProviders,
+        }
+      );
+      expect(result.current.addToCaseActionItems.length).toEqual(2);
+    });
+  });
+
+  describe('when cases integration feature is disabled', () => {
+    beforeAll(() => {
+      jest.mocked(useIsExperimentalFeatureEnabled).mockReturnValue(false);
+    });
+
+    it('should not render case options when event is not alert ', () => {
+      const { result } = renderHook(
+        () => useAddToCaseActions({ ...defaultProps, ecsData: { _id: '123' } }),
+        {
+          wrapper: TestProviders,
+        }
+      );
+      expect(result.current.addToCaseActionItems.length).toEqual(0);
+    });
   });
 
   it('should call useCasesAddToNewCaseFlyout with attachments only when step is not active', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/take_action_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/take_action_button.test.tsx
@@ -18,6 +18,8 @@ jest.mock('../../../common/lib/kibana');
 jest.mock('../../../detections/containers/detection_engine/alerts/use_alerts_privileges');
 jest.mock('../context');
 
+jest.mock('../../../common/hooks/use_experimental_features');
+
 describe('TakeActionButton', () => {
   it('should render component with all options', async () => {
     (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasIndexWrite: true });


### PR DESCRIPTION
## Summary

This PR introduces feature flag to allow us to disable case events UI conditonally. 
This would allow the serverless deployment to kick in with the migrations first, before we allow our users to modify case related SO's.


