### PR TITLE
Adding managed field to get data views response schema

### DIFF
--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/public/get_data_views.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/public/get_data_views.ts
@@ -59,6 +59,7 @@ const getDataViewsRouteFactory =
           typeMeta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
           name: schema.maybe(schema.string()),
           timeFieldName: schema.maybe(schema.string()),
+          managed: schema.maybe(schema.boolean()),
         })
       );
       return schema.object({ [serviceKey]: dataViewListSchema });


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/235975

`managed` was also missing from the response schema and so the public api call fails.

Checking against the type [DataViewListItem](https://github.com/elastic/kibana/blob/2e9bcbb3126389520706ef100813efd47adaee4a/src/platform/plugins/shared/data_views/common/data_views/data_views.ts#L64), this list should now definitely be correct.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->