### PR TITLE
[ES|QL] [Discover] Runs the histogram with from command for a timeseries query

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -48,6 +48,7 @@ export {
   getKqlSearchQueries,
   getRemoteClustersFromESQLQuery,
   getLookupIndicesFromQuery,
+  convertTimeseriesCommandToFrom,
 } from './src';
 
 export { ENABLE_ESQL, FEEDBACK_LINK } from './constants';

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -29,6 +29,7 @@ export {
   getCategorizeField,
   getKqlSearchQueries,
   getRemoteClustersFromESQLQuery,
+  convertTimeseriesCommandToFrom,
 } from './utils/query_parsing_helpers';
 export { queryCannotBeSampled } from './utils/query_cannot_be_sampled';
 export {

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -27,6 +27,7 @@ import {
   getCategorizeField,
   findClosestColumn,
   getKqlSearchQueries,
+  convertTimeseriesCommandToFrom,
 } from './query_parsing_helpers';
 import type { monaco } from '@kbn/monaco';
 import type { ESQLColumn } from '@kbn/esql-ast';
@@ -257,6 +258,20 @@ describe('esql query helpers', () => {
       expect(code).toEqual(
         'FROM index1 /* cmt */\n  | KEEP field1, field2 /* cmt */\n  | SORT field1 /* cmt */'
       );
+    });
+  });
+
+  describe('convertTimeseriesCommandToFrom', function () {
+    it('should return the query as it is if no TS command is found', function () {
+      const query = convertTimeseriesCommandToFrom(
+        'FROM index1 | KEEP field1, field2 | SORT field1'
+      );
+      expect(query).toEqual('FROM index1 | KEEP field1, field2 | SORT field1');
+    });
+
+    it('should return the query with FROM command if TS command is found', function () {
+      const query = convertTimeseriesCommandToFrom('TS index1 | KEEP field1, field2 | SORT field1');
+      expect(query).toEqual('FROM index1 | KEEP field1, field2 | SORT field1');
     });
   });
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -288,12 +288,6 @@ export const mapVariableToColumn = (
   return columns;
 };
 
-/**
- * Extracts the partial query string up to a specific cursor position
- * @param queryString - The complete query string
- * @param cursorPosition - The cursor position
- * @returns The query string up to the cursor position
- */
 export const getQueryUpToCursor = (queryString: string, cursorPosition?: monaco.Position) => {
   const lines = queryString.split('\n');
   const lineNumber = cursorPosition?.lineNumber ?? lines.length;

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -41,11 +41,6 @@ export function getIndexPatternFromESQLQuery(esql?: string) {
   return indices?.map((index) => index.name).join(',');
 }
 
-/**
- * Extracts remote cluster names from an ES|QL query
- * @param esql - The ES|QL query string
- * @returns Array of remote cluster names, or undefined if none found
- */
 export function getRemoteClustersFromESQLQuery(esql?: string): string[] | undefined {
   if (!esql) return undefined;
   const { root } = Parser.parse(esql);
@@ -95,11 +90,6 @@ export function hasTransformationalCommand(esql?: string) {
   return hasAtLeastOneTransformationalCommand;
 }
 
-/**
- * Extracts the limit value from an ES|QL query
- * @param esql - The ES|QL query string
- * @returns The limit value, or default limit if none specified
- */
 export function getLimitFromESQLQuery(esql: string): number {
   const { ast } = parse(esql);
   const limitCommands = ast.filter(({ name }) => name === 'limit');
@@ -210,11 +200,6 @@ export const getTimeFieldFromESQLQuery = (esql: string) => {
   return columnName;
 };
 
-/**
- * Extracts KQL search queries from KQL functions in an ES|QL query
- * @param esql - The ES|QL query string
- * @returns Array of KQL query strings
- */
 export const getKqlSearchQueries = (esql: string) => {
   const { ast } = parse(esql);
   const functions: ESQLFunction[] = [];
@@ -235,11 +220,6 @@ export const getKqlSearchQueries = (esql: string) => {
     .filter((query) => query !== '');
 };
 
-/**
- * Checks if a query is properly wrapped with pipe separators
- * @param query - The query string to check
- * @returns True if the query is properly wrapped by pipes
- */
 export const isQueryWrappedByPipes = (query: string): boolean => {
   const { ast } = parse(query);
   const numberOfCommands = ast.length;
@@ -247,21 +227,11 @@ export const isQueryWrappedByPipes = (query: string): boolean => {
   return numberOfCommands === pipesWithNewLine?.length;
 };
 
-/**
- * Formats an ES|QL query with proper indentation and line breaks
- * @param src - The source query string
- * @returns The prettified query string
- */
 export const prettifyQuery = (src: string): string => {
   const { root } = Parser.parse(src, { withFormatting: true });
   return WrappingPrettyPrinter.print(root, { multiline: true });
 };
 
-/**
- * Retrieves metadata column names from an ES|QL query
- * @param esql - The ES|QL query string
- * @returns Array of metadata column names
- */
 export const retrieveMetadataColumns = (esql: string): string[] => {
   const { ast } = parse(esql);
   const options: ESQLCommandOption[] = [];
@@ -273,11 +243,6 @@ export const retrieveMetadataColumns = (esql: string): string[] => {
   return metadataOptions?.args.map((column) => (column as ESQLColumn).name) ?? [];
 };
 
-/**
- * Extracts all column names referenced in an ES|QL query
- * @param esql - The ES|QL query string
- * @returns Array of column names
- */
 export const getQueryColumnsFromESQLQuery = (esql: string): string[] => {
   const { root } = parse(esql);
   const columns: ESQLColumn[] = [];
@@ -289,11 +254,6 @@ export const getQueryColumnsFromESQLQuery = (esql: string): string[] => {
   return columns.map((column) => column.name);
 };
 
-/**
- * Extracts variable names used in an ES|QL query
- * @param esql - The ES|QL query string
- * @returns Array of variable names (without ? prefixes)
- */
 export const getESQLQueryVariables = (esql: string): string[] => {
   const { root } = parse(esql);
   const usedVariablesInQuery = Walker.params(root);
@@ -412,12 +372,6 @@ export function findClosestColumn(
   return closestColumn;
 }
 
-/**
- * Extracts field values from a query at a specific cursor position
- * @param queryString - The query string
- * @param cursorPosition - The cursor position
- * @returns The field name at the cursor position, or undefined
- */
 export const getValuesFromQueryField = (queryString: string, cursorPosition?: monaco.Position) => {
   const queryInCursorPosition = getQueryUpToCursor(queryString, cursorPosition);
 
@@ -474,11 +428,6 @@ export const fixESQLQueryWithVariables = (
   return queryString;
 };
 
-/**
- * Extracts CATEGORIZE column names from STATS BY commands in an ES|QL query
- * @param esql - The ES|QL query string
- * @returns Array of categorize column names
- */
 export const getCategorizeColumns = (esql: string): string[] => {
   const { root } = parse(esql);
   const statsCommand = root.commands.find(({ name }) => name === 'stats');

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.suggestions.test.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.suggestions.test.ts
@@ -169,6 +169,44 @@ describe('LensVisService suggestions', () => {
     expect(lensVis.visContext?.attributes.state.query).toStrictEqual(histogramQuery);
   });
 
+  test('should return histogramSuggestion with FROM for a timeseries user query', async () => {
+    const lensVis = await getLensVisMock({
+      filters: [],
+      query: { esql: 'TS metrics*' },
+      dataView: dataViewMock,
+      timeInterval: 'auto',
+      timeRange: {
+        from: '2023-09-03T08:00:00.000Z',
+        to: '2023-09-04T08:56:28.274Z',
+      },
+      breakdownField: undefined,
+      columns: [
+        {
+          id: 'var0',
+          name: 'var0',
+          meta: {
+            type: 'number',
+          },
+        },
+      ],
+      isPlainRecord: true,
+      allSuggestions: [],
+      isTransformationalESQL: false,
+    });
+
+    expect(lensVis.currentSuggestionContext?.type).toBe(
+      UnifiedHistogramSuggestionType.histogramForESQL
+    );
+    expect(lensVis.currentSuggestionContext?.suggestion).toBeDefined();
+
+    const histogramQuery = {
+      esql: `FROM metrics*
+| EVAL timestamp=DATE_TRUNC(30 minute, @timestamp) | stats results = count(*) by timestamp`,
+    };
+
+    expect(lensVis.visContext?.attributes.state.query).toStrictEqual(histogramQuery);
+  });
+
   test('should not return histogramSuggestion if no suggestions returned by the api and transformational commands', async () => {
     const lensVis = await getLensVisMock({
       filters: [],

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
@@ -16,6 +16,7 @@ import {
   isESQLColumnSortable,
   hasTransformationalCommand,
   getCategorizeField,
+  convertTimeseriesCommandToFrom,
 } from '@kbn/esql-utils';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import type {
@@ -617,6 +618,7 @@ export class LensVisService {
     const queryInterval = interval ?? computeInterval(timeRange, this.services.data);
     const language = getAggregateQueryMode(query);
     const safeQuery = removeDropCommandsFromESQLQuery(query[language]);
+    const normalizedQuery = convertTimeseriesCommandToFrom(safeQuery);
     const breakdown = breakdownColumn ? `, \`${breakdownColumn.name}\`` : '';
 
     // sort by breakdown column if it's sortable
@@ -626,7 +628,7 @@ export class LensVisService {
         : '';
 
     return appendToESQLQuery(
-      safeQuery,
+      normalizedQuery,
       `| EVAL ${TIMESTAMP_COLUMN}=DATE_TRUNC(${queryInterval}, ${dataView.timeFieldName}) | stats results = count(*) by ${TIMESTAMP_COLUMN}${breakdown}${sortBy}`
     );
   };


### PR DESCRIPTION
## Summary

The count(*) is not supported by TS command. As a result in main if you type `TS metrics*` the histogram will fail with 

<img width="1763" height="598" alt="image" src="https://github.com/user-attachments/assets/ef12e11a-3d49-4a61-8fd9-f0c61a7ceda6" />


I discussed it with ES and they told me that this is expected:

```
count(*) doesn't work  because the semantics are different, due to how time series are tracked
```

we agreed on this case to run the histogram with the FROM command instead

<img width="1527" height="532" alt="image" src="https://github.com/user-attachments/assets/42aa67ba-2216-4b81-abed-7f52547b5f2d" />


### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



