### PR TITLE
[9.1] [scout] disable ES debug level logs for authc (#236106)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/run_elasticsearch.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/run_elasticsearch.ts
@@ -13,13 +13,8 @@ import type { ToolingLog } from '@kbn/tooling-log';
 import { REPO_ROOT } from '@kbn/repo-info';
 import type { ArtifactLicense, ServerlessProjectType } from '@kbn/es';
 import { isServerlessProjectType } from '@kbn/es/src/utils';
-import {
-  createTestEsCluster,
-  esTestConfig,
-  cleanupElasticsearch,
-  createEsClientForTesting,
-} from '@kbn/test';
-import { Config } from '../config';
+import { createTestEsCluster, esTestConfig, cleanupElasticsearch } from '@kbn/test';
+import type { Config } from '../config';
 
 interface RunElasticsearchOptions {
   log: ToolingLog;
@@ -87,25 +82,25 @@ export async function runElasticsearch(
     config,
   });
 
-  // TODO: Remove this once we find out why SAML callback randomly fails with 401
-  log.info('Enable authc debug logs for ES');
-  const clientUrl = new URL(
-    Url.format({
-      protocol: options.config.get('servers.elasticsearch.protocol'),
-      hostname: options.config.get('servers.elasticsearch.hostname'),
-      port: options.config.get('servers.elasticsearch.port'),
-    })
-  );
-  clientUrl.username = options.config.get('servers.kibana.username');
-  clientUrl.password = options.config.get('servers.kibana.password');
-  const esClient = createEsClientForTesting({
-    esUrl: clientUrl.toString(),
-  });
-  await esClient.cluster.putSettings({
-    persistent: {
-      'logger.org.elasticsearch.xpack.security.authc': 'debug',
-    },
-  });
+  // Enable it to debug why SAML callback randomly returns 401
+  // log.info('Enable authc debug logs for ES');
+  // const clientUrl = new URL(
+  //   Url.format({
+  //     protocol: options.config.get('servers.elasticsearch.protocol'),
+  //     hostname: options.config.get('servers.elasticsearch.hostname'),
+  //     port: options.config.get('servers.elasticsearch.port'),
+  //   })
+  // );
+  // clientUrl.username = options.config.get('servers.kibana.username');
+  // clientUrl.password = options.config.get('servers.kibana.password');
+  // const esClient = createEsClientForTesting({
+  //   esUrl: clientUrl.toString(),
+  // });
+  // await esClient.cluster.putSettings({
+  //   persistent: {
+  //     'logger.org.elasticsearch.xpack.security.authc': 'debug',
+  //   },
+  // });
 
   return async () => {
     await cleanupElasticsearch(node, config.serverless, logsDir, log);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[scout] disable ES debug level logs for authc (#236106)](https://github.com/elastic/kibana/pull/236106)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-09-23T15:11:43Z","message":"[scout] disable ES debug level logs for authc (#236106)\n\n## Summary\n\nDisabling debug level `security.authc` logging for stateful ES in scout\ntests. Related to https://github.com/elastic/kibana/pull/212866","sha":"04b23e380c504af8bb407ee2e3d3ccb63b3eaf8a","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.2.0"],"title":"[scout] disable ES debug level logs for authc","number":236106,"url":"https://github.com/elastic/kibana/pull/236106","mergeCommit":{"message":"[scout] disable ES debug level logs for authc (#236106)\n\n## Summary\n\nDisabling debug level `security.authc` logging for stateful ES in scout\ntests. Related to https://github.com/elastic/kibana/pull/212866","sha":"04b23e380c504af8bb407ee2e3d3ccb63b3eaf8a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236106","number":236106,"mergeCommit":{"message":"[scout] disable ES debug level logs for authc (#236106)\n\n## Summary\n\nDisabling debug level `security.authc` logging for stateful ES in scout\ntests. Related to https://github.com/elastic/kibana/pull/212866","sha":"04b23e380c504af8bb407ee2e3d3ccb63b3eaf8a"}}]}] BACKPORT-->