### PR TITLE
[9.1] [ML] [Data Frame Analytics] Fixing Job details fly-out in Analytics Map page (#236131)

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -22,6 +22,8 @@ import { MlPageHeader } from '../../../components/page_header';
 import type { AnalyticsSelectorIds } from '../components/analytics_selector';
 import { AnalyticsIdSelector, AnalyticsIdSelectorControls } from '../components/analytics_selector';
 import { AnalyticsEmptyPrompt } from '../analytics_management/components/empty_prompt';
+import { JobInfoFlyoutsProvider } from '../../../jobs/components/job_details_flyout/job_details_flyout_context';
+import { AnalyticsDetailFlyout } from '../analytics_exploration/components/analytics_detail_flyout';
 
 export const Page: FC = () => {
   const [globalState, setGlobalState] = useUrlState('_g');
@@ -101,7 +103,8 @@ export const Page: FC = () => {
   };
 
   return (
-    <>
+    <JobInfoFlyoutsProvider>
+      <AnalyticsDetailFlyout />
       <AnalyticsIdSelectorControls
         setIsIdSelectorFlyoutVisible={setIsIdSelectorFlyoutVisible}
         selectedId={jobId ?? modelId}
@@ -158,6 +161,6 @@ export const Page: FC = () => {
         getEmptyState()
       )}
       <HelpMenu docLink={helpLink} />
-    </>
+    </JobInfoFlyoutsProvider>
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ML] [Data Frame Analytics] Fixing Job details fly-out in Analytics Map page (#236131)](https://github.com/elastic/kibana/pull/236131)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Krasocki","email":"104936644+KodeRad@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-09-24T07:49:11Z","message":"[ML] [Data Frame Analytics] Fixing Job details fly-out in Analytics Map page (#236131)\n\n## Summary\n\nFixes #235819\n\nAnalytics Map page was missing provider and job details fly-out\ncomponent. That was causing `JobInfoFlyoutsContext` to fallback to\ndefault values and it never reached a point where the Job Details Flyout\nis properly displayed.\n\n#### Recording with fix:\n\n\nhttps://github.com/user-attachments/assets/d2accf62-7c34-4430-bcd5-82768ee502d6\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"b92a9ab6c63e6e4727afc1f00bfce82a3ee9b88f","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix",":ml","Feature:Data Frame Analytics","Team:ML","backport:all-open","v9.2.0"],"title":"[ML] [Data Frame Analytics] Fixing Job details fly-out in Analytics Map page","number":236131,"url":"https://github.com/elastic/kibana/pull/236131","mergeCommit":{"message":"[ML] [Data Frame Analytics] Fixing Job details fly-out in Analytics Map page (#236131)\n\n## Summary\n\nFixes #235819\n\nAnalytics Map page was missing provider and job details fly-out\ncomponent. That was causing `JobInfoFlyoutsContext` to fallback to\ndefault values and it never reached a point where the Job Details Flyout\nis properly displayed.\n\n#### Recording with fix:\n\n\nhttps://github.com/user-attachments/assets/d2accf62-7c34-4430-bcd5-82768ee502d6\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"b92a9ab6c63e6e4727afc1f00bfce82a3ee9b88f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236131","number":236131,"mergeCommit":{"message":"[ML] [Data Frame Analytics] Fixing Job details fly-out in Analytics Map page (#236131)\n\n## Summary\n\nFixes #235819\n\nAnalytics Map page was missing provider and job details fly-out\ncomponent. That was causing `JobInfoFlyoutsContext` to fallback to\ndefault values and it never reached a point where the Job Details Flyout\nis properly displayed.\n\n#### Recording with fix:\n\n\nhttps://github.com/user-attachments/assets/d2accf62-7c34-4430-bcd5-82768ee502d6\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"b92a9ab6c63e6e4727afc1f00bfce82a3ee9b88f"}}]}] BACKPORT-->