### PR TITLE
[SharedUX] Rewrite feedback snippet README to mdx

### DIFF
--- a/dev_docs/nav-kibana-dev.docnav.json
+++ b/dev_docs/nav-kibana-dev.docnav.json
@@ -298,6 +298,10 @@
         {
           "id": "kibDevDocsChromeRecentlyAccessed",
           "label": "Recently Viewed"
+        },
+        {
+          "id": "kibDevDocsFeedbackSnippet",
+          "label": "Feedback Snippet"
         }
       ]
     },

--- a/dev_docs/shared_ux/shared_ux_landing.mdx
+++ b/dev_docs/shared_ux/shared_ux_landing.mdx
@@ -66,5 +66,10 @@ layout: landing
       title: 'Chrome Recently Viewed',
       description: 'Learn how to add recently viewed items to the side navigation',
     },
+    {
+      pageId: 'kibDevDocsFeedbackSnippet',
+      title: 'Feedback Snippet',
+      description: 'Learn about our feedback snippet that gathers user feedback',
+    },
   ]}
 />

--- a/src/platform/packages/shared/shared-ux/feedback_snippet/README.mdx
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/README.mdx
@@ -1,5 +1,5 @@
 ---
-id: sharedUX/Components/FeedbackSnippet
+id: kibDevDocsFeedbackSnippet
 slug: /shared-ux/components/feedback-snippet
 title: Feedback Snippet
 description: A component to gather user feedback.

--- a/src/platform/packages/shared/shared-ux/feedback_snippet/README.mdx
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/README.mdx
@@ -1,16 +1,15 @@
-# @kbn/shared-ux-feedback-snippet
-
 ---
 id: sharedUX/Components/FeedbackSnippet
-slug: /shared-ux/components/feedback_snippet
+slug: /shared-ux/components/feedback-snippet
 title: Feedback Snippet
-summary: A component to gather user feedback that initially renders as a panel and becomes a button after interaction.
+description: A component to gather user feedback.
 tags: ['shared-ux', 'component']
 date: 2025-09-11
 ---
- 
-# Feedback Snippet
-A snippet to gather user feedback. It initially renders as a panel, and once interacted with, it becomes a persistent button. It manages its own state (panel vs. button) based on user interaction tracked in `localStorage`.
+
+## @kbn/shared-ux-feedback-snippet
+
+It initially renders as a panel, and once interacted with, it becomes a persistent button. It manages its own state (panel vs. button) based on user interaction tracked in `localStorage`.
 
 ## Behavior
 The component has two main states:


### PR DESCRIPTION
## Summary

- Moved from `md` to `mdx` to leverage `docs.elastic` and for the feedback snippet documentation to be included there. 

## Testing

Tested via docs-elastic at `http://localhost:3000/shared-ux/components/feedback-snippet`:

<img width="1293" height="1024" alt="Screenshot 2025-09-24 at 13 06 17" src="https://github.com/user-attachments/assets/419387c0-b845-4533-b75a-ab088cc1a50d" />

