### PR TITLE
[SecuritySolution][Navigation]  V2 sidenav fixes and udpates

### DIFF
--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/cases_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/cases_navigation_tree.ts
@@ -22,6 +22,7 @@ export const createCasesNavigationTree = (
   id: SecurityPageName.case,
   link: securityLink(SecurityPageName.case),
   renderAs: 'item',
+  // TODO: update icon from EUI
   iconV2: LazyIconBriefcase,
   sideNavVersion,
   children: [

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/security_launchpad_navigation_tree.test.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/security_launchpad_navigation_tree.test.ts
@@ -92,14 +92,18 @@ describe('createLaunchpadNavigationTree', () => {
         iconV2: 'launch',
         children: [
           {
-            id: SecurityPageName.landing,
-            link: securityLink(SecurityPageName.landing),
-            renderAs: 'item',
-          },
-          {
-            id: SecurityPageName.aiValue,
-            link: securityLink(SecurityPageName.aiValue),
-            renderAs: 'item',
+            children: [
+              {
+                id: SecurityPageName.landing,
+                link: securityLink(SecurityPageName.landing),
+                renderAs: 'item',
+              },
+              {
+                id: SecurityPageName.aiValue,
+                link: securityLink(SecurityPageName.aiValue),
+                renderAs: 'item',
+              },
+            ],
           },
         ],
       });

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/security_launchpad_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/security_launchpad_navigation_tree.ts
@@ -61,6 +61,6 @@ export const createLaunchpadNavigationTree = (
     icon: 'launch',
     iconV2: 'launch',
     sideNavVersion,
-    children,
+    children: [{ children }],
   };
 };

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/v2_icons/workflow.tsx
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/v2_icons/workflow.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiIconProps } from '@elastic/eui';
+import { EuiIcon } from '@elastic/eui';
+import type { SVGProps } from 'react';
+import React from 'react';
+
+const iconType: React.FC<SVGProps<SVGSVGElement>> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 15 15" {...props}>
+    <path
+      fill="#1D2A3E"
+      d="M6 6v2h2V6H6ZM1 1v2h2V1H1Zm3 .5h7a3 3 0 1 1 0 6H9V8c0 .6-.4 1-1 1H6a1 1 0 0 1-1-1v-.5H3a2 2 0 1 0 0 4h9.3l-1.7-1.6.8-.8 2.8 2.9-2.8 2.9-.8-.8 1.7-1.6H3a3 3 0 1 1 0-6h2V6c0-.6.4-1 1-1h2c.6 0 1 .4 1 1v.5h2a2 2 0 1 0 0-4H4V3c0 .6-.4 1-1 1H1a1 1 0 0 1-1-1V1c0-.6.4-1 1-1h2c.6 0 1 .4 1 1v.5Z"
+    />
+  </svg>
+);
+
+export const iconWorkflow = ({ size = 'm', ...rest }: Omit<EuiIconProps, 'type'>) => {
+  return <EuiIcon {...{ type: iconType, size, ...rest }} />;
+};

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/v2_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/v2_navigation_tree.ts
@@ -16,6 +16,10 @@ const LazyIconBulb = lazy(() =>
   import('./v2_icons/bulb').then(({ iconBulb }) => ({ default: iconBulb }))
 );
 
+const LazyIconWorkflow = lazy(() =>
+  import('./v2_icons/workflow').then(({ iconWorkflow }) => ({ default: iconWorkflow }))
+);
+
 export const createV2NavigationTree = (core: CoreStart): NodeDefinition[] => [
   defaultNavigationTree.dashboards({ sideNavVersion: 'v2' }),
   defaultNavigationTree.rules({ sideNavVersion: 'v2' }),
@@ -26,8 +30,8 @@ export const createV2NavigationTree = (core: CoreStart): NodeDefinition[] => [
     sideNavVersion: 'v2',
   },
   {
-    // TODO: update icon before release
-    iconV2: 'merge',
+    // TODO: update icon from EUI
+    iconV2: LazyIconWorkflow,
     link: 'workflows',
     withBadge: true,
     badgeTypeV2: 'techPreview' as const,
@@ -62,6 +66,7 @@ export const createV2NavigationTree = (core: CoreStart): NodeDefinition[] => [
   },
   {
     id: SecurityPageName.threatIntelligence,
+    // TODO: update icon from EUI
     iconV2: LazyIconBulb,
     link: securityLink(SecurityPageName.threatIntelligence),
     sideNavVersion: 'v2',

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/v2_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/v2_navigation_tree.ts
@@ -10,7 +10,7 @@ import type { NodeDefinition } from '@kbn/core-chrome-browser';
 import { defaultNavigationTree } from '../../navigation_tree';
 
 import { SecurityPageName } from '../..';
-import { securityLink } from '../../links';
+import { i18nStrings, securityLink } from '../../links';
 
 const LazyIconBulb = lazy(() =>
   import('./v2_icons/bulb').then(({ iconBulb }) => ({ default: iconBulb }))
@@ -23,6 +23,18 @@ export const createV2NavigationTree = (core: CoreStart): NodeDefinition[] => [
     id: SecurityPageName.alerts,
     iconV2: 'warning',
     link: securityLink(SecurityPageName.alerts),
+    sideNavVersion: 'v2',
+  },
+  {
+    // TODO: update icon before release
+    iconV2: 'merge',
+    link: 'workflows',
+    withBadge: true,
+    badgeTypeV2: 'techPreview' as const,
+    badgeOptions: {
+      icon: 'beaker',
+      tooltip: i18nStrings.workflows.badgeTooltip,
+    },
     sideNavVersion: 'v2',
   },
   {

--- a/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
@@ -53,6 +53,7 @@ export const createNavigationTree = (services: Services): NavigationTreeDefiniti
                 icon: 'beaker',
                 tooltip: i18nStrings.workflows.badgeTooltip,
               },
+              sideNavVersion: 'v1',
             },
             {
               id: SecurityPageName.attackDiscovery,

--- a/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
@@ -36,8 +36,6 @@ export const createNavigationTree = (services: Services): NavigationTreeDefiniti
           iconV2: 'discoverApp',
         },
         defaultNavigationTree.dashboards({ sideNavVersion: 'v1' }),
-        // version 2 sidenav
-        ...defaultNavigationTree.v2(services),
         {
           breadcrumbStatus: 'hidden',
           children: [
@@ -99,6 +97,8 @@ export const createNavigationTree = (services: Services): NavigationTreeDefiniti
           ],
         },
         defaultNavigationTree.ml({ sideNavVersion: 'v1' }),
+        // version 2 sidenav
+        ...defaultNavigationTree.v2(services),
       ],
     },
   ],
@@ -143,10 +143,12 @@ export const createNavigationTree = (services: Services): NavigationTreeDefiniti
               title: i18nStrings.launchPad.migrations.title,
               children: [
                 {
+                  id: SecurityPageName.siemMigrationsRules,
                   link: securityLink(SecurityPageName.siemMigrationsRules),
                   sideNavVersion: 'v2',
                 },
                 {
+                  id: SecurityPageName.siemMigrationsDashboards,
                   link: securityLink(SecurityPageName.siemMigrationsDashboards),
                   sideNavVersion: 'v2',
                 },

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.test.ts
@@ -88,7 +88,7 @@ describe('Navigation Tree Role-Based Access', () => {
   const findLaunchpadNode = (navigationTree: NavigationTreeDefinition) => {
     const footer = navigationTree.footer?.[0];
     if (footer && 'children' in footer) {
-      return footer.children?.find(
+      return footer.children.find(
         (child) => 'id' in child && child.id === SecurityPageName.landing
       );
     }
@@ -101,8 +101,8 @@ describe('Navigation Tree Role-Based Access', () => {
       const launchpadGroup = footer.children?.find(
         (child) => 'id' in child && child.id === SecurityGroupName.launchpad
       );
-      if (launchpadGroup && 'children' in launchpadGroup) {
-        return launchpadGroup.children?.find(
+      if (launchpadGroup && launchpadGroup.children) {
+        return launchpadGroup.children[0]?.children?.find(
           (child) => 'id' in child && child.id === SecurityPageName.aiValue
         );
       }

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
@@ -59,8 +59,7 @@ export const createNavigationTree = async (
             link: 'discover',
           },
           defaultNavigationTree.dashboards({ sideNavVersion: 'v1' }),
-          // version 2 sidenav
-          ...defaultNavigationTree.v2(services),
+
           {
             breadcrumbStatus: 'hidden',
             children: [
@@ -123,6 +122,8 @@ export const createNavigationTree = async (
             ],
           },
           defaultNavigationTree.ml({ sideNavVersion: 'v1' }),
+          // version 2 sidenav
+          ...defaultNavigationTree.v2(services),
         ],
       },
     ],
@@ -161,10 +162,12 @@ export const createNavigationTree = async (
                 title: i18nStrings.launchPad.migrations.title,
                 children: [
                   {
+                    id: SecurityPageName.siemMigrationsRules,
                     link: securityLink(SecurityPageName.siemMigrationsRules),
                     sideNavVersion: 'v2',
                   },
                   {
+                    id: SecurityPageName.siemMigrationsDashboards,
                     link: securityLink(SecurityPageName.siemMigrationsDashboards),
                     sideNavVersion: 'v2',
                   },


### PR DESCRIPTION
## Summary
Fixes the issue where Translated Dashboards was not visible.

Follow up of https://github.com/elastic/kibana/pull/235048
See https://github.com/elastic/kibana/pull/235048#issuecomment-3317966366

<details open><summary>v2</summary>
<img width="1921" height="1218" alt="Screenshot 2025-09-24 at 11 38 24" src="https://github.com/user-attachments/assets/159561c8-8dfa-48a3-8467-82d7d0071e82" />
<img width="569" height="1032" alt="Screenshot 2025-09-24 at 13 20 03" src="https://github.com/user-attachments/assets/1d8b0223-7e00-4916-979b-6acf4e296f4f" />

</details> 

<details><summary>v1 and v2</summary>
<img width="1279" height="1166" alt="Screenshot 2025-09-24 at 12 21 57" src="https://github.com/user-attachments/assets/fe1d3836-02b8-4cef-b113-8c8088e402c2" />
</details> 

<details><summary>clip (v1 and v2 launchpad)</summary>
<p>
  <img src="https://github.com/user-attachments/assets/b6e3206f-d4ea-470c-a042-0a738ed4212b" />
</p>
</details> 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



