### PR TITLE
[Maps] Fix flaky functional test: handle Integrations redirect from hash to path

### DIFF
--- a/x-pack/platform/test/functional/apps/maps/group4/geofile_wizard_auto_open.ts
+++ b/x-pack/platform/test/functional/apps/maps/group4/geofile_wizard_auto_open.ts
@@ -14,12 +14,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const browser = getService('browser');
   const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/173095
-  // Failing: See https://github.com/elastic/kibana/issues/173095
-  describe.skip('Auto open file upload wizard in maps app', () => {
+  describe('Auto open file upload wizard in maps app', () => {
     before(async () => {
       await common.navigateToUrl('integrations', 'browse', {
         useActualUrl: true,
+        shouldUseHashForSubUrl: false,
       });
       const searchInput = await find.byCssSelector('[data-test-subj="epmList.searchBar"]');
       await searchInput.type('GeoJSON');


### PR DESCRIPTION
Closes #173095

Flaky test runner task for this PR - https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9350

Below the video with the changing paths before the fix:
- initially: /app/integrations?_t=...#browse
- redirected to: /app/integrations/browse?_t=...


https://github.com/user-attachments/assets/ede84be3-7287-49e2-8c95-b79ef75da063



Also, there’s a video showing the consistent path after the fix.  Just to clarify, I didn’t change anything besides the test itself - it directly navigates to: /app/integrations/browse?_t=...


https://github.com/user-attachments/assets/c4ff2a6c-c43b-4dbf-a213-310d508b6413


By default, when you call navigateToUrl('integrations', 'browse'), it adds #browse because shouldUseHashForSubUrl is true.

What I did in the test was force shouldUseHashForSubUrl: false, so instead of starting with #browse, the test goes directly to /browse.

That way, we skip the intermediate redirect from #browse to /browse, the test gets the final URL immediately, and it stops being flaky.

So my fix is entirely in the test—it just changes how the helper builds the URL.

In the real application, Integrations already redirects from #browse to /browse. Even if you open #browse, the app will send you to /browse.

So in practice, the production code always ends up on /browse.

The focus here is: tests should reflect how the app actually behaves. What I did was stabilize the test by matching the real behavior. The test doesn’t need to check the redirect itself—it just wants to verify that selecting GeoJSON opens the Maps wizard.

By adjusting the test to use the final path directly, we avoid false negatives caused by flaky redirects.

