### PR TITLE
[9.1] [FTR] Move Scout reporter events upload to pipeline scripts (#220277)

### DIFF
--- a/.buildkite/scripts/steps/code_coverage/jest_parallel.sh
+++ b/.buildkite/scripts/steps/code_coverage/jest_parallel.sh
@@ -86,5 +86,9 @@ mv target/kibana-coverage/jest-combined/coverage-final.json \
 echo "--- Jest [$TEST_TYPE] configs complete"
 printf "%s\n" "${results[@]}"
 
+# Scout reporter
+echo "--- Upload Scout reporter events to AppEx QA's team cluster"
+node scripts/scout upload-events --dontFailOnError
+
 # Force exit 0 to ensure the next build step starts.
 exit 0

--- a/.buildkite/scripts/steps/test/ftr_configs.sh
+++ b/.buildkite/scripts/steps/test/ftr_configs.sh
@@ -114,4 +114,8 @@ echo "--- FTR configs complete"
 printf "%s\n" "${results[@]}"
 echo ""
 
+# Scout reporter
+echo "--- Upload Scout reporter events to AppEx QA's team cluster"
+node scripts/scout upload-events --dontFailOnError
+
 exit $exitCode

--- a/.buildkite/scripts/steps/test/jest_parallel.sh
+++ b/.buildkite/scripts/steps/test/jest_parallel.sh
@@ -114,4 +114,8 @@ echo "--- Jest configs complete"
 printf "%s\n" "${results[@]}"
 echo ""
 
+# Scout reporter
+echo "--- Upload Scout reporter events to AppEx QA's team cluster"
+node scripts/scout upload-events --dontFailOnError
+
 exit $exitCode

--- a/.buildkite/scripts/steps/test/scout_configs.sh
+++ b/.buildkite/scripts/steps/test/scout_configs.sh
@@ -74,7 +74,6 @@ fi
 results=()
 failedConfigs=()
 configWithoutTests=()
-passedConfigs=()
 
 FINAL_EXIT_CODE=0
 
@@ -129,5 +128,8 @@ if [[ ${#failedConfigs[@]} -gt 0 ]]; then
   printf '%s\n' "${failedConfigs[@]}"
   buildkite-agent meta-data set "$FAILED_CONFIGS_KEY" "$failedConfigs"
 fi
+
+echo "--- Upload Scout reporter events to AppEx QA's team cluster"
+node scripts/scout upload-events --dontFailOnError
 
 exit $FINAL_EXIT_CODE  # Exit with 10 only if there were config failures

--- a/src/platform/packages/private/kbn-scout-reporting/src/cli/upload_events.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/cli/upload_events.test.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import fs from 'node:fs';
+
+import { uploadAllEventsFromPath } from './upload_events';
+import { ToolingLog } from '@kbn/tooling-log';
+
+jest.mock('node:fs');
+
+jest.mock('@kbn/scout-info', () => ({
+  SCOUT_REPORT_OUTPUT_ROOT: 'scout/reports/directory',
+}));
+
+jest.mock('../helpers/elasticsearch', () => ({
+  getValidatedESClient: jest.fn(),
+}));
+
+const mockAddEventsFromFile = jest.fn();
+
+jest.mock('../reporting/report/events', () => ({
+  ScoutReportDataStream: jest.fn().mockImplementation(() => {
+    return {
+      addEventsFromFile: mockAddEventsFromFile,
+    };
+  }),
+}));
+
+describe('uploadAllEventsFromPath', () => {
+  let log: jest.Mocked<ToolingLog>;
+
+  beforeEach(() => {
+    log = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warning: jest.fn(),
+    } as any;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw an error if the provided eventLogPath does not exist', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    await expect(
+      uploadAllEventsFromPath('non_existent_path', {
+        esURL: 'esURL',
+        esAPIKey: 'esAPIKey',
+        verifyTLSCerts: true,
+        log,
+      })
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"The provided event log path 'non_existent_path' does not exist."`
+    );
+  });
+
+  it('should throw an error if the provided eventLogPath is a file and it does not end with .ndjson', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'statSync').mockReturnValue({
+      isDirectory: () => false,
+    } as unknown as fs.Stats);
+
+    await expect(
+      uploadAllEventsFromPath('invalid_event_log.txt', {
+        esURL: 'esURL',
+        esAPIKey: 'esAPIKey',
+        verifyTLSCerts: true,
+        log,
+      })
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"The provided event log file 'invalid_event_log.txt' must end with .ndjson."`
+    );
+  });
+
+  it('should log a warning if the provided eventLogPath is a directory and it does not contain any .ndjson file', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    // Simulate directory contents: 1 .txt file
+    (fs.readdirSync as jest.Mock).mockImplementation((directoryPath: string) => {
+      if (directoryPath === 'mocked_directory') {
+        return ['not_events.txt'];
+      }
+      return [];
+    });
+
+    (fs.statSync as jest.Mock).mockImplementation((filePath: string) => {
+      if (filePath === 'mocked_directory') {
+        return { isDirectory: () => true, isFile: () => false };
+      }
+      return { isDirectory: () => false, isFile: () => true };
+    });
+
+    await uploadAllEventsFromPath('mocked_directory', {
+      esURL: 'esURL',
+      esAPIKey: 'esAPIKey',
+      verifyTLSCerts: true,
+      log,
+    });
+
+    expect(log.warning).toHaveBeenCalledWith(
+      `No .ndjson event log files found in directory 'mocked_directory'.`
+    );
+  });
+
+  it('should upload the event log file if the provided eventLogPath if a file and ends with .ndjson', async () => {
+    jest.spyOn(fs, 'statSync').mockReturnValue({
+      isDirectory: () => true,
+    } as unknown as fs.Stats);
+    jest.spyOn(fs, 'readdirSync').mockReturnValue(['file.txt' as unknown as fs.Dirent]);
+
+    // assume the provided event log path exists
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    // the provided event log path is not a directory
+    jest.spyOn(fs, 'statSync').mockReturnValue({
+      isDirectory: () => false,
+    } as unknown as fs.Stats);
+
+    await uploadAllEventsFromPath('existing_event_log.ndjson', {
+      esURL: 'esURL',
+      esAPIKey: 'esAPIKey',
+      verifyTLSCerts: true,
+      log,
+    });
+
+    expect(mockAddEventsFromFile).toHaveBeenCalledWith('existing_event_log.ndjson');
+  });
+
+  it('should find event log files recursively', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    (fs.readdirSync as jest.Mock).mockImplementation((directoryPath: string) => {
+      if (directoryPath === 'mocked_directory') {
+        return ['sub_directory', 'no_events_here.txt'];
+      }
+
+      if (directoryPath === 'mocked_directory/sub_directory') {
+        return ['events.ndjson'];
+      }
+
+      return [];
+    });
+
+    (fs.statSync as jest.Mock).mockImplementation((filePath: string) => {
+      if (filePath === 'mocked_directory') {
+        return { isDirectory: () => true, isFile: () => false } as fs.Stats;
+      }
+      if (filePath === 'mocked_directory/sub_directory') {
+        return { isDirectory: () => true, isFile: () => false } as fs.Stats;
+      }
+      return { isDirectory: () => false, isFile: () => true } as fs.Stats;
+    });
+
+    await uploadAllEventsFromPath('mocked_directory/sub_directory', {
+      esURL: 'esURL',
+      esAPIKey: 'esAPIKey',
+      verifyTLSCerts: true,
+      log,
+    });
+
+    expect(mockAddEventsFromFile).toHaveBeenCalledWith(
+      'mocked_directory/sub_directory/events.ndjson'
+    );
+
+    expect(log.info.mock.calls).toEqual([
+      ['Connecting to Elasticsearch at esURL'],
+      ["Recursively found 1 .ndjson event log file in directory 'mocked_directory/sub_directory'."],
+    ]);
+  });
+
+  it('should upload multiple event log files if the provided eventLogPath is a directory and contains .ndjson files', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    // Simulate directory contents: 2 .ndjson files, 1 .txt file
+    (fs.readdirSync as jest.Mock).mockImplementation((directoryPath: string) => {
+      if (directoryPath === 'mocked_directory') {
+        return ['file1.ndjson', 'file2.ndjson', 'not_events.txt'];
+      }
+      return [];
+    });
+
+    (fs.statSync as jest.Mock).mockImplementation((filePath: string) => {
+      if (filePath === 'mocked_directory') {
+        return { isDirectory: () => true, isFile: () => false };
+      }
+      return { isDirectory: () => false, isFile: () => true };
+    });
+
+    await uploadAllEventsFromPath('mocked_directory', {
+      esURL: 'esURL',
+      esAPIKey: 'esAPIKey',
+      verifyTLSCerts: true,
+      log,
+    });
+
+    expect(mockAddEventsFromFile).toHaveBeenCalledWith('mocked_directory/file1.ndjson');
+    expect(mockAddEventsFromFile).toHaveBeenCalledWith('mocked_directory/file2.ndjson');
+    expect(mockAddEventsFromFile).not.toHaveBeenCalledWith('mocked_directory/not_events.txt');
+
+    expect(log.info.mock.calls).toEqual([
+      ['Connecting to Elasticsearch at esURL'],
+      ["Recursively found 2 .ndjson event log files in directory 'mocked_directory'."],
+    ]);
+  });
+});

--- a/src/platform/packages/private/kbn-scout-reporting/src/cli/upload_events.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/cli/upload_events.ts
@@ -8,60 +8,140 @@
  */
 
 import fs from 'node:fs';
+import path from 'node:path';
+
 import { Command } from '@kbn/dev-cli-runner';
 import { createFlagError } from '@kbn/dev-cli-errors';
+import { ToolingLog } from '@kbn/tooling-log';
+
 import {
   SCOUT_REPORTER_ES_URL,
   SCOUT_REPORTER_ES_API_KEY,
   SCOUT_REPORTER_ES_VERIFY_CERTS,
+  SCOUT_REPORT_OUTPUT_ROOT,
 } from '@kbn/scout-info';
 import { ScoutReportDataStream } from '../reporting/report/events';
 import { getValidatedESClient } from '../helpers/elasticsearch';
+
+const readFilesRecursively = (directory: string, callback: Function) => {
+  const files = fs.readdirSync(directory);
+  files.forEach((file) => {
+    const filePath = path.join(directory, file);
+    const stat = fs.statSync(filePath);
+    if (stat.isDirectory()) {
+      readFilesRecursively(filePath, callback);
+    } else if (stat.isFile()) {
+      callback(filePath);
+    }
+  });
+};
+
+export const uploadAllEventsFromPath = async (
+  eventLogPath: string,
+  options: {
+    esURL: string;
+    esAPIKey: string;
+    verifyTLSCerts: boolean;
+    log: ToolingLog;
+  }
+) => {
+  // Validate CLI options
+  if (!fs.existsSync(eventLogPath)) {
+    throw createFlagError(`The provided event log path '${eventLogPath}' does not exist.`);
+  }
+
+  // If the provided event log path is a file, ensure it ends with .ndjson
+  if (!fs.statSync(eventLogPath).isDirectory()) {
+    if (!eventLogPath.endsWith('.ndjson')) {
+      throw createFlagError(`The provided event log file '${eventLogPath}' must end with .ndjson.`);
+    }
+  }
+
+  // ES connection
+  options.log.info(`Connecting to Elasticsearch at ${options.esURL}`);
+  const es = await getValidatedESClient(
+    {
+      node: options.esURL,
+      auth: { apiKey: options.esAPIKey },
+      tls: {
+        rejectUnauthorized: options.verifyTLSCerts,
+      },
+    },
+    { log: options.log, cli: true }
+  );
+
+  // Event log upload
+  const reportDataStream = new ScoutReportDataStream(es, options.log);
+
+  if (fs.statSync(eventLogPath).isDirectory()) {
+    const ndjsonFilePaths: string[] = [];
+
+    readFilesRecursively(eventLogPath, (filePath: string) => {
+      if (filePath.endsWith('.ndjson')) {
+        ndjsonFilePaths.push(filePath);
+      }
+    });
+
+    if (ndjsonFilePaths.length === 0) {
+      options.log.warning(`No .ndjson event log files found in directory '${eventLogPath}'.`);
+    } else {
+      options.log.info(
+        `Recursively found ${ndjsonFilePaths.length} .ndjson event log file${
+          ndjsonFilePaths.length === 1 ? '' : 's'
+        } in directory '${eventLogPath}'.`
+      );
+
+      for (const filePath of ndjsonFilePaths) {
+        await reportDataStream.addEventsFromFile(filePath);
+      }
+    }
+  } else if (eventLogPath.endsWith('.ndjson')) {
+    await reportDataStream.addEventsFromFile(eventLogPath);
+  }
+};
 
 export const uploadEvents: Command<void> = {
   name: 'upload-events',
   description: 'Upload events recorded by the Scout reporter to Elasticsearch',
   flags: {
     string: ['eventLogPath', 'esURL', 'esAPIKey'],
-    boolean: ['verifyTLSCerts'],
+    boolean: ['verifyTLSCerts', 'dontFailOnError'],
     default: {
       esURL: SCOUT_REPORTER_ES_URL,
       esAPIKey: SCOUT_REPORTER_ES_API_KEY,
       verifyTLSCerts: SCOUT_REPORTER_ES_VERIFY_CERTS,
+      dontFailOnError: false,
     },
     help: `
-    --eventLogPath    (required)  Path to the event log to upload
     --esURL           (required)  Elasticsearch URL [env: SCOUT_REPORTER_ES_URL]
     --esAPIKey        (required)  Elasticsearch API Key [env: SCOUT_REPORTER_ES_API_KEY]
     --verifyTLSCerts  (optional)  Verify TLS certificates [env: SCOUT_REPORTER_ES_VERIFY_CERTS]
+    --eventLogPath    (optional)  Path to an event log file or directory. If omitted, all events in the Scout reports output directory will be uploaded
+    --dontFailOnError (optional)  If present, errors during upload will be logged but not thrown, allowing the process to complete without failure (default: false)
     `,
   },
   run: async ({ flagsReader, log }) => {
-    // Read & validate CLI options
-    const eventLogPath = flagsReader.requiredString('eventLogPath');
-
-    if (!fs.existsSync(eventLogPath)) {
-      throw createFlagError(`Event log path '${eventLogPath}' does not exist.`);
-    }
+    // default to Scout report output directory if no eventLogPath is provided
+    const eventLogPath = flagsReader.string('eventLogPath') || SCOUT_REPORT_OUTPUT_ROOT;
 
     const esURL = flagsReader.requiredString('esURL');
     const esAPIKey = flagsReader.requiredString('esAPIKey');
+    const verifyTLSCerts = flagsReader.boolean('verifyTLSCerts');
+    const dontFailOnError = flagsReader.boolean('dontFailOnError');
 
-    // ES connection
-    log.info(`Connecting to Elasticsearch at ${esURL}`);
-    const es = await getValidatedESClient(
-      {
-        node: esURL,
-        auth: { apiKey: esAPIKey },
-        tls: {
-          rejectUnauthorized: flagsReader.boolean('verifyTLSCerts'),
-        },
-      },
-      { log, cli: true }
-    );
+    try {
+      await uploadAllEventsFromPath(eventLogPath, {
+        esURL,
+        esAPIKey,
+        verifyTLSCerts,
+        log,
+      });
+    } catch (error) {
+      log.error(error);
 
-    // Event log upload
-    const reportDataStream = new ScoutReportDataStream(es, log);
-    await reportDataStream.addEventsFromFile(eventLogPath);
+      if (!dontFailOnError) {
+        throw error;
+      }
+    }
   },
 };

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/jest/reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/jest/reporter.ts
@@ -31,7 +31,6 @@ import {
   ScoutFileInfo,
   ScoutReportEventAction,
   type ScoutTestRunInfo,
-  uploadScoutReportEvents,
 } from '../../..';
 
 /**
@@ -240,7 +239,6 @@ export class ScoutJestReporter extends BaseReporter {
     // Save & conclude the report
     try {
       this.report.save(this.reportRootPath);
-      await uploadScoutReportEvents(this.report.eventLogPath, this.scoutLog);
     } catch (e) {
       // Log the error but don't propagate it
       this.scoutLog.error(e);

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
@@ -36,7 +36,6 @@ import {
   ScoutFileInfo,
   ScoutReportEventAction,
   type ScoutTestRunInfo,
-  uploadScoutReportEvents,
 } from '../../report';
 import { environmentMetadata } from '../../../datasources';
 import type { ScoutPlaywrightReporterOptions } from '../scout_playwright_reporter';
@@ -283,7 +282,6 @@ export class ScoutPlaywrightReporter implements Reporter {
     // Save, upload events & conclude the report
     try {
       this.report.save(this.reportRootPath);
-      await uploadScoutReportEvents(this.report.eventLogPath, this.log);
     } catch (e) {
       // Log the error but don't propagate it
       this.log.error(e);

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/index.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/index.ts
@@ -12,13 +12,7 @@ import path from 'node:path';
 import readline from 'node:readline';
 import { ToolingLog } from '@kbn/tooling-log';
 import { Client as ESClient } from 'elasticsearch-8.x'; // Switch to `@elastic/elasticsearch` when the CI cluster is upgraded.
-import {
-  SCOUT_REPORTER_ES_API_KEY,
-  SCOUT_REPORTER_ES_URL,
-  SCOUT_REPORTER_ES_VERIFY_CERTS,
-  SCOUT_TEST_EVENTS_DATA_STREAM_NAME,
-} from '@kbn/scout-info';
-import { getValidatedESClient } from '../../../../helpers/elasticsearch';
+import { SCOUT_TEST_EVENTS_DATA_STREAM_NAME } from '@kbn/scout-info';
 import { ScoutReportEvent } from '../event';
 import * as componentTemplates from './component_templates';
 import * as indexTemplates from './index_templates';
@@ -146,42 +140,4 @@ export class ScoutReportDataStream {
       this.log.warning(`Failed to upload ${stats.failed} events`);
     }
   }
-}
-
-/**
- * Upload events logged by a Scout reporter to the configured Scout Reporter ES instance
- *
- * @param eventLogPath Path to event log file
- * @param log Logger instance
- */
-export async function uploadScoutReportEvents(eventLogPath: string, log?: ToolingLog) {
-  const logger = log || new ToolingLog();
-
-  const warnSettingWasNotConfigured = (settingName: string) =>
-    logger.warning(`Won't upload Scout reporter events: ${settingName} was not configured`);
-
-  if (SCOUT_REPORTER_ES_URL === undefined) {
-    warnSettingWasNotConfigured('SCOUT_REPORTER_ES_URL');
-    return;
-  }
-
-  if (SCOUT_REPORTER_ES_API_KEY === undefined) {
-    warnSettingWasNotConfigured('SCOUT_REPORTER_ES_API_KEY');
-    return;
-  }
-
-  log?.info(`Connecting to Scout reporter ES URL ${SCOUT_REPORTER_ES_URL}`);
-  const es = await getValidatedESClient(
-    {
-      node: SCOUT_REPORTER_ES_URL,
-      auth: { apiKey: SCOUT_REPORTER_ES_API_KEY },
-      tls: {
-        rejectUnauthorized: SCOUT_REPORTER_ES_VERIFY_CERTS,
-      },
-    },
-    { log }
-  );
-
-  const reportDataStream = new ScoutReportDataStream(es, logger);
-  await reportDataStream.addEventsFromFile(eventLogPath);
 }

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/scout_ftr_reporter.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/scout_ftr_reporter.ts
@@ -18,7 +18,6 @@ import {
   type ScoutTestRunInfo,
   generateTestRunId,
   getTestIDForTitle,
-  uploadScoutReportEvents,
   ScoutFileInfo,
 } from '@kbn/scout-reporting';
 import {
@@ -198,7 +197,7 @@ export class ScoutFTRReporter {
     });
   };
 
-  onRunEnd = async () => {
+  onRunEnd = () => {
     /**
      * Root suite execution has ended
      */
@@ -221,7 +220,6 @@ export class ScoutFTRReporter {
     // Save & conclude the report
     try {
       this.report.save(this.reportRootPath);
-      await uploadScoutReportEvents(this.report.eventLogPath, this.log);
     } catch (e) {
       // Log the error but don't propagate it
       this.log.error(e);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[FTR] Move Scout reporter events upload to pipeline scripts (#220277)](https://github.com/elastic/kibana/pull/220277)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tre","email":"wayne.seymour@elastic.co"},"sourceCommit":{"committedDate":"2025-07-28T13:36:46Z","message":"[FTR] Move Scout reporter events upload to pipeline scripts (#220277)\n\nThis PR:\n\n* Refactors the existing `upload-events` Scout CLI command to centralize\nand streamline the event log upload logic.\n* Introduces a new helper function `uploadAllEventsFromPath` that:\n* Accepts a path to either a single `.ndjson` event file or a directory.\n* Recursively scans directories to find and upload all `.ndjson` event\nfiles.\n* Updates the CLI logic to:\n* Default to the `SCOUT_REPORT_OUTPUT_ROOT` path\n(`<KIBANA_ROOT>/.scout/reports`) when `--eventLogPath` is not provided.\n* Log and optionally suppress errors using the `--dontFailOnError` flag,\nallowing flexible handling in CI pipelines.\n\n### Clarifications on `--eventLogPath`:\n\n* The `--eventLogPath` flag supports both file and directory paths.\n  * If the provided does not exist, an error is thrown.\n* If the path points to a file, and the file doesn't end with `.ndjson`,\nan error is thrown.\n* If the path points to a directory, and the directory doesn't contain\nany file ending with `.ndjson`, we exit early and log a warning.\n* If the flag is omitted the CLI defaults to the\n`SCOUT_REPORT_OUTPUT_ROOT` directory.\n\n---------\n\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"3402b5e0fc939300fff33769210b72f96fc41250","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","FTR","v9.2.0"],"title":"[FTR] Move Scout reporter events upload to pipeline scripts","number":220277,"url":"https://github.com/elastic/kibana/pull/220277","mergeCommit":{"message":"[FTR] Move Scout reporter events upload to pipeline scripts (#220277)\n\nThis PR:\n\n* Refactors the existing `upload-events` Scout CLI command to centralize\nand streamline the event log upload logic.\n* Introduces a new helper function `uploadAllEventsFromPath` that:\n* Accepts a path to either a single `.ndjson` event file or a directory.\n* Recursively scans directories to find and upload all `.ndjson` event\nfiles.\n* Updates the CLI logic to:\n* Default to the `SCOUT_REPORT_OUTPUT_ROOT` path\n(`<KIBANA_ROOT>/.scout/reports`) when `--eventLogPath` is not provided.\n* Log and optionally suppress errors using the `--dontFailOnError` flag,\nallowing flexible handling in CI pipelines.\n\n### Clarifications on `--eventLogPath`:\n\n* The `--eventLogPath` flag supports both file and directory paths.\n  * If the provided does not exist, an error is thrown.\n* If the path points to a file, and the file doesn't end with `.ndjson`,\nan error is thrown.\n* If the path points to a directory, and the directory doesn't contain\nany file ending with `.ndjson`, we exit early and log a warning.\n* If the flag is omitted the CLI defaults to the\n`SCOUT_REPORT_OUTPUT_ROOT` directory.\n\n---------\n\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"3402b5e0fc939300fff33769210b72f96fc41250"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220277","number":220277,"mergeCommit":{"message":"[FTR] Move Scout reporter events upload to pipeline scripts (#220277)\n\nThis PR:\n\n* Refactors the existing `upload-events` Scout CLI command to centralize\nand streamline the event log upload logic.\n* Introduces a new helper function `uploadAllEventsFromPath` that:\n* Accepts a path to either a single `.ndjson` event file or a directory.\n* Recursively scans directories to find and upload all `.ndjson` event\nfiles.\n* Updates the CLI logic to:\n* Default to the `SCOUT_REPORT_OUTPUT_ROOT` path\n(`<KIBANA_ROOT>/.scout/reports`) when `--eventLogPath` is not provided.\n* Log and optionally suppress errors using the `--dontFailOnError` flag,\nallowing flexible handling in CI pipelines.\n\n### Clarifications on `--eventLogPath`:\n\n* The `--eventLogPath` flag supports both file and directory paths.\n  * If the provided does not exist, an error is thrown.\n* If the path points to a file, and the file doesn't end with `.ndjson`,\nan error is thrown.\n* If the path points to a directory, and the directory doesn't contain\nany file ending with `.ndjson`, we exit early and log a warning.\n* If the flag is omitted the CLI defaults to the\n`SCOUT_REPORT_OUTPUT_ROOT` directory.\n\n---------\n\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"3402b5e0fc939300fff33769210b72f96fc41250"}}]}] BACKPORT-->