### PR TITLE
[Agent Builder] FTR UI tests for simple conversation

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -405,6 +405,7 @@ enabled:
   - x-pack/platform/test/encrypted_saved_objects_api_integration/config.ts
   - x-pack/platform/test/fleet_multi_cluster/config.ts
   - x-pack/platform/test/monitoring_api_integration/config.ts
+  - x-pack/platform/test/onechat_functional/config.ts
   - x-pack/platform/test/plugin_api_integration/config.ts
   - x-pack/platform/test/saved_object_api_integration/security_and_spaces/config_basic.ts
   - x-pack/platform/test/saved_object_api_integration/security_and_spaces/config_trial.ts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2287,7 +2287,7 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /x-pack/solutions/chat/test/serverless/api_integration/configs/config.ts @elastic/search-kibana @elastic/appex-qa
 /x-pack/solutions/chat/test/serverless/functional/configs/config.ts @elastic/search-kibana @elastic/appex-qa
 /x-pack/platform/test/onechat_api_integration @elastic/search-kibana @elastic/workchat-eng
-
+/x-pack/platform/test/onechat_functional @elastic/search-kibana @elastic/workchat-eng
 
 # Management Experience - Deployment Management
 /src/platform/test/functional/fixtures/kbn_archiver/management.json @elastic/kibana-management @elastic/kibana-data-discovery # Assigned per 2 uses: test/functional/apps/management/_import_objects.ts && test/functional/apps/management/data_views/_scripted_fields_filter.ts

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/agent_select_dropdown.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/agent_select_dropdown.tsx
@@ -40,6 +40,7 @@ const AgentSelectButton: React.FC<AgentSelectButtonProps> = ({ selectedAgentName
     onClick={onClick}
     aria-haspopup="menu"
     aria-labelledby={agentSelectId}
+    data-test-subj="agentBuilderAgentSelectorButton"
   >
     {selectedAgentName}
   </EuiButtonEmpty>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_form.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_form.tsx
@@ -72,6 +72,7 @@ export const ConversationInputForm: React.FC<ConversationInputFormProps> = ({ on
       responsive={false}
       alignItems="stretch"
       justifyContent="center"
+      data-test-subj="agentBuilderConversationInputForm"
       aria-label={i18n.translate('xpack.onechat.conversationInputForm', {
         defaultMessage: 'Message input form',
       })}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_response.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_response.tsx
@@ -38,6 +38,7 @@ export const RoundResponse: React.FC<RoundResponseProps> = ({
       aria-label={i18n.translate('xpack.onechat.round.assistantResponse', {
         defaultMessage: 'Assistant response',
       })}
+      data-test-subj="agentBuilderRoundResponse"
     >
       {showThinking && (
         <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/round_thinking.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/round_thinking.tsx
@@ -77,6 +77,7 @@ export const RoundThinking: React.FC<RoundThinkingProps> = ({ steps, isLoading, 
       id={thinkingAccordionId}
       arrowDisplay="left"
       css={accordionStyles}
+      data-test-subj="agentBuilderThinkingToggle"
       buttonProps={{
         css: thinkingButtonStyles,
       }}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_sidebar/conversation_sections.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_sidebar/conversation_sections.tsx
@@ -58,6 +58,7 @@ export const ConversationSections: React.FC<ConversationSectionsProps> = ({ conv
                 values: { sectionLabel: label },
               })}
               flush
+              data-test-subj="agentBuilderConversationList"
             >
               {sectionConversations.map((conversation) => (
                 <ConversationItem key={conversation.id} conversation={conversation} />

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_sidebar/no_conversations_prompt.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_sidebar/no_conversations_prompt.tsx
@@ -16,7 +16,11 @@ export const NoConversationsPrompt: React.FC = () => {
         <EuiIcon type="newChat" size="l" />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiText color="subdued" textAlign="center">
+        <EuiText
+          color="subdued"
+          textAlign="center"
+          data-test-subj="agentBuilderNoConversationsMessage"
+        >
           <p>
             {i18n.translate('xpack.onechat.conversationSidebar.noConversations', {
               defaultMessage: "You haven't started any conversations yet.",

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_title.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_title.tsx
@@ -65,7 +65,11 @@ export const ConversationTitle: React.FC<{}> = () => {
   return (
     <EuiPageHeaderSection css={sectionStyles}>
       {!isLoading && (
-        <EuiTitle aria-label={labels.ariaLabel} size="xxs">
+        <EuiTitle
+          aria-label={labels.ariaLabel}
+          size="xxs"
+          data-test-subj="agentBuilderConversationTitle"
+        >
           <h1>{titleDisplayText}</h1>
         </EuiTitle>
       )}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/new_conversation_button.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/new_conversation_button.tsx
@@ -52,6 +52,7 @@ export const NewConversationButton: React.FC<{}> = () => {
       iconSide="left"
       aria-label={labels.ariaLabel}
       onClick={handleClick}
+      data-test-subj="agentBuilderNewConversationButton"
       {...buttonProps}
     >
       {labels.display}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/new_conversation_prompt.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/new_conversation_prompt.tsx
@@ -262,7 +262,7 @@ export const NewConversationPrompt: React.FC<{}> = () => {
   `;
   return (
     <ConversationContentWithMargins css={fullHeightStyles}>
-      <div css={gridStyles}>
+      <div css={gridStyles} data-test-subj="agentBuilderWelcomePage">
         <MainContainer>
           <WelcomeText />
         </MainContainer>

--- a/x-pack/platform/test/onechat_functional/config.ts
+++ b/x-pack/platform/test/onechat_functional/config.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const xpackFunctionalConfig = await readConfigFile(
+    require.resolve('../functional/config.base.ts')
+  );
+
+  return {
+    ...xpackFunctionalConfig.getAll(),
+    testFiles: [require.resolve('./tests')],
+    junit: {
+      reportName: 'X-Pack Agent Builder Functional Tests',
+    },
+    kbnTestServer: {
+      ...xpackFunctionalConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...xpackFunctionalConfig.get('kbnTestServer.serverArgs'),
+        '--uiSettings.overrides.agentBuilder:enabled=true',
+        `--logging.loggers=${JSON.stringify([
+          { name: 'plugins.onechat', level: 'debug', appenders: ['console'] },
+        ])}`,
+      ],
+    },
+  };
+}

--- a/x-pack/platform/test/onechat_functional/tests/converse/simple_conversation.ts
+++ b/x-pack/platform/test/onechat_functional/tests/converse/simple_conversation.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../../../functional/ftr_provider_context';
+
+const APP_ID = 'agent_builder';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const { common } = getPageObjects(['common']);
+  const testSubjects = getService('testSubjects');
+
+  describe('Agent Builder Simple Conversation', function () {
+    it('navigates to new conversation page and shows initial state', async () => {
+      await common.navigateToApp(APP_ID, { path: 'conversations/new' });
+
+      // Assert the conversation list is empty and shows the no conversations message
+      const dataTestSubj = 'agentBuilderNoConversationsMessage';
+      await testSubjects.existOrFail(dataTestSubj);
+      const noConversationsElement = await testSubjects.find(dataTestSubj);
+      const noConversationsText = await noConversationsElement.getVisibleText();
+      expect(noConversationsText).to.contain("You haven't started any conversations yet.");
+
+      // Assert the text input box renders
+      await testSubjects.existOrFail('agentBuilderConversationInputForm');
+
+      // Assert the default agent is "Elastic AI Agent"
+      await testSubjects.existOrFail('agentBuilderAgentSelectorButton');
+      const agentButton = await testSubjects.find('agentBuilderAgentSelectorButton');
+      const agentText = await agentButton.getVisibleText();
+      expect(agentText).to.contain('Elastic AI Agent');
+    });
+  });
+}

--- a/x-pack/platform/test/onechat_functional/tests/converse/simple_conversation.ts
+++ b/x-pack/platform/test/onechat_functional/tests/converse/simple_conversation.ts
@@ -6,15 +6,72 @@
  */
 
 import expect from '@kbn/expect';
+import type { LlmProxy } from '../../../onechat_api_integration/utils/llm_proxy';
+import { createLlmProxy } from '../../../onechat_api_integration/utils/llm_proxy';
+import { toolCallMock } from '../../../onechat_api_integration/utils/llm_proxy/mocks';
 import type { FtrProviderContext } from '../../../functional/ftr_provider_context';
+
+// Basic auth connector functions
+async function createConnector(proxy: LlmProxy, supertest: any) {
+  await supertest
+    .post('/api/actions/connector')
+    .set('kbn-xsrf', 'foo')
+    .send({
+      name: 'foo',
+      config: {
+        apiProvider: 'OpenAI',
+        apiUrl: `http://localhost:${proxy.getPort()}`,
+        defaultModel: 'gpt-4',
+      },
+      secrets: { apiKey: 'myApiKey' },
+      connector_type_id: '.gen-ai',
+    })
+    .expect(200);
+}
+
+async function deleteConnectors(supertest: any) {
+  const connectors = await supertest.get('/api/actions/connectors').expect(200);
+  const promises = connectors.body.map((connector: { id: string }) => {
+    return supertest
+      .delete(`/api/actions/connector/${connector.id}`)
+      .set('kbn-xsrf', 'foo')
+      .expect(204);
+  });
+
+  return Promise.all(promises);
+}
 
 const APP_ID = 'agent_builder';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { common } = getPageObjects(['common']);
   const testSubjects = getService('testSubjects');
+  const log = getService('log');
+  const supertest = getService('supertest');
+  const retry = getService('retry');
+  const es = getService('es');
 
   describe('Agent Builder Simple Conversation', function () {
+    let llmProxy: LlmProxy;
+
+    before(async () => {
+      llmProxy = await createLlmProxy(log);
+      await createConnector(llmProxy, supertest);
+    });
+
+    after(async () => {
+      llmProxy.close();
+      await deleteConnectors(supertest);
+      // Clean up all conversations
+      await es.deleteByQuery({
+        index: '.chat-conversations',
+        query: { match_all: {} },
+        wait_for_completion: true,
+        refresh: true,
+        conflicts: 'proceed',
+      });
+    });
+
     it('navigates to new conversation page and shows initial state', async () => {
       await common.navigateToApp(APP_ID, { path: 'conversations/new' });
 
@@ -25,6 +82,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       const noConversationsText = await noConversationsElement.getVisibleText();
       expect(noConversationsText).to.contain("You haven't started any conversations yet.");
 
+      // Assert the welcome page is displayed
+      await testSubjects.existOrFail('agentBuilderWelcomePage');
+
       // Assert the text input box renders
       await testSubjects.existOrFail('agentBuilderConversationInputForm');
 
@@ -33,6 +93,64 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       const agentButton = await testSubjects.find('agentBuilderAgentSelectorButton');
       const agentText = await agentButton.getVisibleText();
       expect(agentText).to.contain('Elastic AI Agent');
+    });
+
+    it('sends a message, receives response, and can start new conversation', async () => {
+      const MOCKED_INPUT = 'hello world';
+      const MOCKED_LLM_RESPONSE = 'hello world received';
+      const MOCKED_LLM_TITLE = 'Test Conversation 1';
+
+      await common.navigateToApp(APP_ID, { path: 'conversations/new' });
+
+      const inputField = await testSubjects.find('onechatAppConversationInputFormTextArea');
+      await inputField.click();
+      await inputField.type(MOCKED_INPUT);
+
+      // Set up LLM proxy interceptors
+      void llmProxy.interceptors.toolChoice({
+        name: 'set_title',
+        response: toolCallMock('set_title', { title: MOCKED_LLM_TITLE }),
+      });
+
+      void llmProxy.interceptors.userMessage({ response: MOCKED_LLM_RESPONSE });
+
+      // Send the message
+      const submitTextButton = await testSubjects.find(
+        'onechatAppConversationInputFormSubmitButton'
+      );
+      await submitTextButton.click();
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      // Wait for the response, title, and conversation list to appear in the UI
+      await retry.try(async () => {
+        const responseElement = await testSubjects.find('agentBuilderRoundResponse');
+        const responseText = await responseElement.getVisibleText();
+        expect(responseText).to.contain(MOCKED_LLM_RESPONSE);
+
+        const titleElement = await testSubjects.find('agentBuilderConversationTitle');
+        const titleText = await titleElement.getVisibleText();
+        expect(titleText).to.contain(MOCKED_LLM_TITLE);
+
+        const conversationList = await testSubjects.find('agentBuilderConversationList');
+        const conversationText = await conversationList.getVisibleText();
+        expect(conversationText).to.contain(MOCKED_LLM_TITLE);
+      });
+
+      // Clicking the "new" button to start a new conversation
+      const newButton = await testSubjects.find('agentBuilderNewConversationButton');
+      await newButton.click();
+
+      // Wait for navigation to complete and assert we're back to the initial state
+      await retry.try(async () => {
+        // The conversation list should still contain our previous conversation
+        const conversationList = await testSubjects.find('agentBuilderConversationList');
+        const conversationText = await conversationList.getVisibleText();
+        expect(conversationText).to.contain(MOCKED_LLM_TITLE);
+
+        // Assert the welcome page is displayed
+        await testSubjects.existOrFail('agentBuilderWelcomePage');
+      });
     });
   });
 }

--- a/x-pack/platform/test/onechat_functional/tests/converse/simple_conversation.ts
+++ b/x-pack/platform/test/onechat_functional/tests/converse/simple_conversation.ts
@@ -6,6 +6,7 @@
  */
 
 import expect from '@kbn/expect';
+import { last } from 'lodash';
 import type { LlmProxy } from '../../../onechat_api_integration/utils/llm_proxy';
 import { createLlmProxy } from '../../../onechat_api_integration/utils/llm_proxy';
 import { toolCallMock } from '../../../onechat_api_integration/utils/llm_proxy/mocks';
@@ -95,26 +96,49 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       expect(agentText).to.contain('Elastic AI Agent');
     });
 
-    it('sends a message, receives response, and can start new conversation', async () => {
-      const MOCKED_INPUT = 'hello world';
-      const MOCKED_LLM_RESPONSE = 'hello world received';
-      const MOCKED_LLM_TITLE = 'Test Conversation 1';
-
+    // Helper function to create a conversation
+    async function createConversation(
+      input: string,
+      title: string,
+      response: string,
+      withToolCall = false
+    ) {
       await common.navigateToApp(APP_ID, { path: 'conversations/new' });
 
       const inputField = await testSubjects.find('onechatAppConversationInputFormTextArea');
       await inputField.click();
-      await inputField.type(MOCKED_INPUT);
+      await inputField.type(input);
 
-      // Set up LLM proxy interceptors
       void llmProxy.interceptors.toolChoice({
         name: 'set_title',
-        response: toolCallMock('set_title', { title: MOCKED_LLM_TITLE }),
+        response: toolCallMock('set_title', { title }),
       });
 
-      void llmProxy.interceptors.userMessage({ response: MOCKED_LLM_RESPONSE });
+      if (withToolCall) {
+        // First interceptor: respond to user message with tool call
+        void llmProxy.interceptors.userMessage({
+          when: ({ messages }) => {
+            const lastMessage = last(messages)?.content as string;
+            return lastMessage.includes(input);
+          },
+          response: toolCallMock('platform_core_search', {
+            query: 'test data',
+          }),
+        });
 
-      // Send the message
+        // Second interceptor: respond to tool message with final response
+        void llmProxy.interceptors.toolMessage({
+          when: ({ messages }) => {
+            const lastMessage = last(messages);
+            const contentParsed = JSON.parse(lastMessage?.content as string);
+            return contentParsed?.results;
+          },
+          response,
+        });
+      } else {
+        void llmProxy.interceptors.userMessage({ response });
+      }
+
       const submitTextButton = await testSubjects.find(
         'onechatAppConversationInputFormSubmitButton'
       );
@@ -122,31 +146,60 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
 
-      // Wait for the response, title, and conversation list to appear in the UI
+      return { title, response };
+    }
+
+    it('sends a message with tool call and receives response with thinking', async () => {
+      const MOCKED_INPUT = 'search for test data';
+      const MOCKED_RESPONSE = 'I found test data using the search tool';
+      const MOCKED_TITLE = 'Test Search Conversation';
+
+      const { title, response } = await createConversation(
+        MOCKED_INPUT,
+        MOCKED_TITLE,
+        MOCKED_RESPONSE,
+        true
+      );
+
+      // Wait for response with thinking to appear
       await retry.try(async () => {
         const responseElement = await testSubjects.find('agentBuilderRoundResponse');
         const responseText = await responseElement.getVisibleText();
-        expect(responseText).to.contain(MOCKED_LLM_RESPONSE);
+        expect(responseText).to.contain(response);
 
         const titleElement = await testSubjects.find('agentBuilderConversationTitle');
         const titleText = await titleElement.getVisibleText();
-        expect(titleText).to.contain(MOCKED_LLM_TITLE);
+        expect(titleText).to.contain(title);
 
         const conversationList = await testSubjects.find('agentBuilderConversationList');
         const conversationText = await conversationList.getVisibleText();
-        expect(conversationText).to.contain(MOCKED_LLM_TITLE);
+        expect(conversationText).to.contain(title);
       });
 
-      // Clicking the "new" button to start a new conversation
+      // Click on "Thinking completed" to expand the thinking details
+      const thinkingToggle = await testSubjects.find('agentBuilderThinkingToggle');
+      await thinkingToggle.click();
+
+      // Wait for the expanded thinking details to appear
+      await retry.try(async () => {
+        const responseElement = await testSubjects.find('agentBuilderRoundResponse');
+        const responseText = await responseElement.getVisibleText();
+
+        // Check that the tool call details are visible
+        expect(responseText).to.contain('Calling tool platform.core.search');
+        expect(responseText).to.contain('Selecting the best target for this query');
+      });
+
+      // Now test clicking the "new" button
       const newButton = await testSubjects.find('agentBuilderNewConversationButton');
       await newButton.click();
 
-      // Wait for navigation to complete and assert we're back to the initial state
+      // Wait for navigation to complete and assert we're back to the initial state with a populated conversation list
       await retry.try(async () => {
         // The conversation list should still contain our previous conversation
         const conversationList = await testSubjects.find('agentBuilderConversationList');
         const conversationText = await conversationList.getVisibleText();
-        expect(conversationText).to.contain(MOCKED_LLM_TITLE);
+        expect(conversationText).to.contain(title);
 
         // Assert the welcome page is displayed
         await testSubjects.existOrFail('agentBuilderWelcomePage');

--- a/x-pack/platform/test/onechat_functional/tests/index.ts
+++ b/x-pack/platform/test/onechat_functional/tests/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../functional/ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('onechat', function () {
+    describe('tools', function () {
+      loadTestFile(require.resolve('./converse/simple_conversation.ts'));
+    });
+  });
+}

--- a/x-pack/platform/test/onechat_functional/tests/index.ts
+++ b/x-pack/platform/test/onechat_functional/tests/index.ts
@@ -8,8 +8,8 @@
 import type { FtrProviderContext } from '../../functional/ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('onechat', function () {
-    describe('tools', function () {
+  describe('Agent Builder', function () {
+    describe('converse', function () {
       loadTestFile(require.resolve('./converse/simple_conversation.ts'));
     });
   });

--- a/x-pack/platform/test/onechat_functional/utils/connector_helpers.ts
+++ b/x-pack/platform/test/onechat_functional/utils/connector_helpers.ts
@@ -5,17 +5,17 @@
  * 2.0.
  */
 
+import type SuperTest from 'supertest';
 import type { LlmProxy } from '../../onechat_api_integration/utils/llm_proxy';
-
 /**
  * Creates a basic auth connector for the LLM proxy
  */
-export async function createConnector(proxy: LlmProxy, supertest: any) {
+export async function createConnector(proxy: LlmProxy, supertest: SuperTest.Agent) {
   await supertest
     .post('/api/actions/connector')
-    .set('kbn-xsrf', 'foo')
+    .set('kbn-xsrf', 'llm-proxy')
     .send({
-      name: 'foo',
+      name: 'llm-proxy',
       config: {
         apiProvider: 'OpenAI',
         apiUrl: `http://localhost:${proxy.getPort()}`,
@@ -30,12 +30,12 @@ export async function createConnector(proxy: LlmProxy, supertest: any) {
 /**
  * Deletes all existing connectors
  */
-export async function deleteConnectors(supertest: any) {
+export async function deleteConnectors(supertest: SuperTest.Agent) {
   const connectors = await supertest.get('/api/actions/connectors').expect(200);
   const promises = connectors.body.map((connector: { id: string }) => {
     return supertest
       .delete(`/api/actions/connector/${connector.id}`)
-      .set('kbn-xsrf', 'foo')
+      .set('kbn-xsrf', 'llm-proxy')
       .expect(204);
   });
 

--- a/x-pack/platform/test/onechat_functional/utils/connector_helpers.ts
+++ b/x-pack/platform/test/onechat_functional/utils/connector_helpers.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LlmProxy } from '../../onechat_api_integration/utils/llm_proxy';
+
+/**
+ * Creates a basic auth connector for the LLM proxy
+ */
+export async function createConnector(proxy: LlmProxy, supertest: any) {
+  await supertest
+    .post('/api/actions/connector')
+    .set('kbn-xsrf', 'foo')
+    .send({
+      name: 'foo',
+      config: {
+        apiProvider: 'OpenAI',
+        apiUrl: `http://localhost:${proxy.getPort()}`,
+        defaultModel: 'gpt-4',
+      },
+      secrets: { apiKey: 'myApiKey' },
+      connector_type_id: '.gen-ai',
+    })
+    .expect(200);
+}
+
+/**
+ * Deletes all existing connectors
+ */
+export async function deleteConnectors(supertest: any) {
+  const connectors = await supertest.get('/api/actions/connectors').expect(200);
+  const promises = connectors.body.map((connector: { id: string }) => {
+    return supertest
+      .delete(`/api/actions/connector/${connector.id}`)
+      .set('kbn-xsrf', 'foo')
+      .expect(204);
+  });
+
+  return Promise.all(promises);
+}


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/search-team/issues/11384

- Adds config setup for UI FTR tests for _converse_
- Adds functional UI FTR tests for a simple conversation flow.
- Creates custom connector with basic auth to work with the `llmProxy` implementation

**ACs:**

**Asking a basic question which invokes a tool and response**
- [x] test to check thinking has tool result
- [x] check raw response
- [x] title is updated
- [x] that the conversation is in the conversation history
- [x] can click to a new conversation

https://github.com/user-attachments/assets/1563168a-8367-4d92-81b3-288437f1e71c

Future tests that need to be written (not included in this PR):
- deleting a conversation
- navigating between conversations in the conversation history panel
- error handling



