### PR TITLE
[8.19] [ML] AIOps: Log Rate Analysis: Limit msearch usage (#235611)

### DIFF
--- a/x-pack/platform/packages/shared/ml/aiops_log_pattern_analysis/create_category_request.ts
+++ b/x-pack/platform/packages/shared/ml/aiops_log_pattern_analysis/create_category_request.ts
@@ -34,14 +34,15 @@ export function createCategoryRequest(
   intervalMs?: number,
   additionalFilter?: CategorizationAdditionalFilter,
   useStandardTokenizer: boolean = true,
-  includeSparkline: boolean = true
+  includeSparkline: boolean = true,
+  categoryLimit: number = CATEGORY_LIMIT
 ) {
   const query = createDefaultQuery(queryIn, timeField, timeRange);
   const aggs = {
     categories: {
       categorize_text: {
         field,
-        size: CATEGORY_LIMIT,
+        size: categoryLimit,
         ...(useStandardTokenizer ? { categorization_analyzer: categorizationAnalyzer } : {}),
       },
       aggs: {

--- a/x-pack/platform/packages/shared/ml/aiops_log_rate_analysis/queries/fetch_categories.test.ts
+++ b/x-pack/platform/packages/shared/ml/aiops_log_rate_analysis/queries/fetch_categories.test.ts
@@ -98,19 +98,19 @@ describe('getCategoryRequest', () => {
             ],
           },
         },
-      },
-      aggs: {
-        sample: {
-          random_sampler: { probability: 0.1, seed: 1234 },
-          aggs: {
-            categories: {
-              categorize_text: {
-                field: 'the-field-name',
-                size: 100,
-              },
-              aggs: {
-                examples: {
-                  top_hits: { size: 4, sort: ['the-time-field-name'], _source: 'the-field-name' },
+        aggs: {
+          sample: {
+            random_sampler: { probability: 0.1, seed: 1234 },
+            aggs: {
+              categories: {
+                categorize_text: {
+                  field: 'the-field-name',
+                  size: 100,
+                },
+                aggs: {
+                  examples: {
+                    top_hits: { size: 4, sort: ['the-time-field-name'], _source: 'the-field-name' },
+                  },
                 },
               },
             },

--- a/x-pack/platform/packages/shared/ml/aiops_log_rate_analysis/queries/fetch_categories.test.ts
+++ b/x-pack/platform/packages/shared/ml/aiops_log_rate_analysis/queries/fetch_categories.test.ts
@@ -98,19 +98,19 @@ describe('getCategoryRequest', () => {
             ],
           },
         },
-        aggs: {
-          sample: {
-            random_sampler: { probability: 0.1, seed: 1234 },
-            aggs: {
-              categories: {
-                categorize_text: {
-                  field: 'the-field-name',
-                  size: 1000,
-                },
-                aggs: {
-                  examples: {
-                    top_hits: { size: 4, sort: ['the-time-field-name'], _source: 'the-field-name' },
-                  },
+      },
+      aggs: {
+        sample: {
+          random_sampler: { probability: 0.1, seed: 1234 },
+          aggs: {
+            categories: {
+              categorize_text: {
+                field: 'the-field-name',
+                size: 100,
+              },
+              aggs: {
+                examples: {
+                  top_hits: { size: 4, sort: ['the-time-field-name'], _source: 'the-field-name' },
                 },
               },
             },

--- a/x-pack/platform/packages/shared/ml/aiops_log_rate_analysis/queries/fetch_categories.ts
+++ b/x-pack/platform/packages/shared/ml/aiops_log_rate_analysis/queries/fetch_categories.ts
@@ -85,7 +85,9 @@ export const getCategoryRequest = (
     undefined,
     undefined,
     false,
-    false
+    false,
+    // categoryLimit reduced to avoid extensive mSearch requests
+    100
   );
 
   // In this case we're only interested in the aggregation which

--- a/x-pack/platform/packages/shared/ml/aiops_log_rate_analysis/queries/fetch_top_categories.test.ts
+++ b/x-pack/platform/packages/shared/ml/aiops_log_rate_analysis/queries/fetch_top_categories.test.ts
@@ -48,7 +48,7 @@ describe('fetchTopCategories', () => {
                     top_hits: { _source: 'message', size: 4, sort: ['the-time-field-name'] },
                   },
                 },
-                categorize_text: { field: 'message', size: 1000 },
+                categorize_text: { field: 'message', size: 100 },
               },
             },
             query: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] AIOps: Log Rate Analysis: Limit msearch usage (#235611)](https://github.com/elastic/kibana/pull/235611)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Walter M. Rafelsberger","email":"walter.rafelsberger@elastic.co"},"sourceCommit":{"committedDate":"2025-09-24T11:47:27Z","message":"[ML] AIOps: Log Rate Analysis: Limit msearch usage (#235611)\n\n## Summary\n\nPart of #235562\n\n- limit log rate analysis to keyword fields for alert analysis\nf8c3bbb12cd3a12e7653fb72c85b0e3f7abe81e3\n- limit log rate analysis category requests to reduce `msearch` from\n1000 to 100 b4b5ceabf58e88d33839edf0d810591db2791322\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"8ca8cbfe7add6c05de9168d4a38b4e458c9fbbe7","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","backport:version","v9.2.0","v8.18.8","v8.19.5","v9.0.8","v9.1.5"],"title":"[ML] AIOps: Log Rate Analysis: Limit msearch usage","number":235611,"url":"https://github.com/elastic/kibana/pull/235611","mergeCommit":{"message":"[ML] AIOps: Log Rate Analysis: Limit msearch usage (#235611)\n\n## Summary\n\nPart of #235562\n\n- limit log rate analysis to keyword fields for alert analysis\nf8c3bbb12cd3a12e7653fb72c85b0e3f7abe81e3\n- limit log rate analysis category requests to reduce `msearch` from\n1000 to 100 b4b5ceabf58e88d33839edf0d810591db2791322\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"8ca8cbfe7add6c05de9168d4a38b4e458c9fbbe7"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/235611","number":235611,"mergeCommit":{"message":"[ML] AIOps: Log Rate Analysis: Limit msearch usage (#235611)\n\n## Summary\n\nPart of #235562\n\n- limit log rate analysis to keyword fields for alert analysis\nf8c3bbb12cd3a12e7653fb72c85b0e3f7abe81e3\n- limit log rate analysis category requests to reduce `msearch` from\n1000 to 100 b4b5ceabf58e88d33839edf0d810591db2791322\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"8ca8cbfe7add6c05de9168d4a38b4e458c9fbbe7"}},{"branch":"8.18","label":"v8.18.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/236295","number":236295,"state":"OPEN"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/236287","number":236287,"state":"OPEN"}]}] BACKPORT-->