### PR TITLE
[ES|QL] Bug: Rerank validation fail within the ON clause for boolean expressions.

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/validate.test.ts
@@ -20,6 +20,13 @@ describe('RERANK Validation', () => {
       rerankExpectErrors('FROM index | RERANK ?q ON keywordField', []);
     });
 
+    test('Support ON clause validation for boolean expressions', () => {
+      rerankExpectErrors(
+        'FROM index | RERANK col0="some text" ON textField=textField LIKE "a*"',
+        []
+      );
+    });
+
     test('unsupported field type', () => {
       rerankExpectErrors('FROM index | RERANK col0=2 ON keywordField', [
         'RERANK query must be of type text. Found integer',

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/location.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/location.ts
@@ -23,6 +23,8 @@ const commandOptionNameToLocation: Record<string, Location> = {
   by: Location.STATS_BY,
   enrich: Location.ENRICH,
   with: Location.ENRICH_WITH,
+  // Rerank is a special case, because it is the only command that requrire a boolen validation inside the ON Clause
+  on: Location.RERANK,
   dissect: Location.DISSECT,
   rename: Location.RENAME,
   join: Location.JOIN,


### PR DESCRIPTION
## Summary

For Rerank validation, we enabled the mapping in `commandOptionNameToLocation ` to validate the ON clause, since Rerank is the only command that requires validation of boolean expressions within ON.

It seems that this condition no longer exists, so Rerank reports a validation error for:
`RERANK... on col0 = field1 < field2`

Here some proposal:
1)  I recover the old solution **(the current one)**
2)  `getLocationInfo` is the function that retrieve the right ID Location for commands. 
      
We can make a small change to use the **ParentCommand** as a real fallback fallback. This will strengthen the current logic without altering it: 

```javascript 
const displayName = (option ?? parentCommand).name;
  const id = getLocationFromCommandOrOptionName(displayName);
```

to 
 ```javascript 
  const displayName = (option ?? parentCommand).name;

  let id = getLocationFromCommandOrOptionName(displayName);

  if (!id && parentCommand) {
    id = getLocationFromCommandOrOptionName(parentCommand.name);
  }
```

**Why this happen?** 
When we call for Rerank  `const displayName = (option ?? parentCommand).name;`  options = ON and ParentCommand = Rerank 
This information is coming from the AST and follows standard conventions

I suppose other solutions involve to manipolate the AST but it will modify also mutators, visitors, ecc... Here the current set for On.
`const onOption = this.toOption(onToken.getText().toLowerCase(), rerankFieldsCtx);`

