### PR TITLE
[agent builder] add space support for conversations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -880,8 +880,8 @@ x-pack/platform/packages/private/security/ui_components @elastic/kibana-security
 x-pack/platform/packages/private/upgrade-assistant/common @elastic/kibana-management
 x-pack/platform/packages/private/upgrade-assistant/public @elastic/kibana-management
 x-pack/platform/packages/private/upgrade-assistant/server @elastic/kibana-management
-x-pack/platform/packages/shared/ai-assistant/ai-assistant-cta @elastic/appex-sharedux
 x-pack/platform/packages/shared/ai-assistant/ai-assistant-connector-selector-action @elastic/appex-sharedux
+x-pack/platform/packages/shared/ai-assistant/ai-assistant-cta @elastic/appex-sharedux
 x-pack/platform/packages/shared/ai-assistant/common @elastic/search-kibana
 x-pack/platform/packages/shared/ai-assistant/icon @elastic/appex-sharedux
 x-pack/platform/packages/shared/ai-infra/inference-common @elastic/appex-ai-infra

--- a/x-pack/platform/plugins/shared/onechat/server/services/conversation/conversation_service.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/conversation/conversation_service.ts
@@ -11,6 +11,8 @@ import type {
   SecurityServiceStart,
   ElasticsearchServiceStart,
 } from '@kbn/core/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import { getCurrentSpaceId } from '../../utils/spaces';
 import type { ConversationClient } from './client';
 import { createClient } from './client';
 import { createStorage } from './storage';
@@ -19,23 +21,24 @@ export interface ConversationService {
   getScopedClient(options: { request: KibanaRequest }): Promise<ConversationClient>;
 }
 
+interface ConversationServiceDeps {
+  logger: Logger;
+  security: SecurityServiceStart;
+  elasticsearch: ElasticsearchServiceStart;
+  spaces?: SpacesPluginStart;
+}
+
 export class ConversationServiceImpl implements ConversationService {
   private readonly logger: Logger;
   private readonly security: SecurityServiceStart;
   private readonly elasticsearch: ElasticsearchServiceStart;
+  private readonly spaces?: SpacesPluginStart;
 
-  constructor({
-    logger,
-    security,
-    elasticsearch,
-  }: {
-    logger: Logger;
-    security: SecurityServiceStart;
-    elasticsearch: ElasticsearchServiceStart;
-  }) {
+  constructor({ logger, security, elasticsearch, spaces }: ConversationServiceDeps) {
     this.logger = logger;
     this.security = security;
     this.elasticsearch = elasticsearch;
+    this.spaces = spaces;
   }
 
   async getScopedClient({ request }: { request: KibanaRequest }): Promise<ConversationClient> {
@@ -47,7 +50,8 @@ export class ConversationServiceImpl implements ConversationService {
     const esClient = this.elasticsearch.client.asScoped(request).asInternalUser;
     const storage = createStorage({ logger: this.logger, esClient });
     const user = { id: authUser.profile_uid!, username: authUser.username };
+    const space = getCurrentSpaceId({ request, spaces: this.spaces });
 
-    return createClient({ user, storage });
+    return createClient({ user, storage, space });
   }
 }

--- a/x-pack/platform/plugins/shared/onechat/server/services/conversation/converters.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/conversation/converters.test.ts
@@ -23,6 +23,7 @@ describe('conversation model converters', () => {
           title: 'conv_title',
           user_id: 'user_id',
           user_name: 'user_name',
+          space: 'space',
           rounds: [
             {
               id: 'round-1',
@@ -56,7 +57,6 @@ describe('conversation model converters', () => {
         },
         created_at: '2024-09-04T06:44:17.944Z',
         updated_at: '2025-08-04T06:44:19.123Z',
-
         rounds: [
           {
             id: 'round-1',
@@ -142,13 +142,14 @@ describe('conversation model converters', () => {
 
     it('serializes the conversation', () => {
       const conversation = conversationBase();
-      const serialized = toEs(conversation);
+      const serialized = toEs(conversation, 'another-space');
 
       expect(serialized).toEqual({
         agent_id: 'agent_id',
         title: 'conv_title',
         user_id: 'user_id',
         user_name: 'user_name',
+        space: 'another-space',
         rounds: [
           {
             id: 'round-1',
@@ -181,7 +182,7 @@ describe('conversation model converters', () => {
           reasoning: 'reasoning',
         },
       ];
-      const serialized = toEs(conversation);
+      const serialized = toEs(conversation, 'space');
 
       expect(serialized.rounds[0].steps).toEqual([
         {

--- a/x-pack/platform/plugins/shared/onechat/server/services/conversation/converters.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/conversation/converters.ts
@@ -86,11 +86,12 @@ export const fromEsWithoutRounds = (document: Document): ConversationWithoutRoun
   return convertBaseFromEs(document);
 };
 
-export const toEs = (conversation: Conversation): ConversationProperties => {
+export const toEs = (conversation: Conversation, space: string): ConversationProperties => {
   return {
     agent_id: conversation.agent_id,
     user_id: conversation.user.id,
     user_name: conversation.user.username,
+    space,
     title: conversation.title,
     created_at: conversation.created_at,
     updated_at: conversation.updated_at,
@@ -101,15 +102,18 @@ export const toEs = (conversation: Conversation): ConversationProperties => {
 export const updateConversation = ({
   conversation,
   update,
+  space,
   updateDate,
 }: {
   conversation: Conversation;
   update: ConversationUpdateRequest;
+  space: string;
   updateDate: Date;
 }) => {
   const updated = {
     ...conversation,
     ...update,
+    space,
     updatedAt: updateDate.toISOString(),
   };
 
@@ -118,17 +122,20 @@ export const updateConversation = ({
 
 export const createRequestToEs = ({
   conversation,
+  space,
   currentUser,
   creationDate,
 }: {
   conversation: ConversationCreateRequest;
   currentUser: UserIdAndName;
   creationDate: Date;
+  space: string;
 }): ConversationProperties => {
   return {
     agent_id: conversation.agent_id,
     user_id: currentUser.id,
     user_name: currentUser.username,
+    space,
     title: conversation.title,
     created_at: creationDate.toISOString(),
     updated_at: creationDate.toISOString(),

--- a/x-pack/platform/plugins/shared/onechat/server/services/conversation/storage.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/conversation/storage.ts
@@ -20,6 +20,7 @@ const storageSettings = {
       user_id: types.keyword({}),
       user_name: types.keyword({}),
       agent_id: types.keyword({}),
+      space: types.keyword({}),
       title: types.text({}),
       created_at: types.date({}),
       updated_at: types.date({}),
@@ -32,6 +33,7 @@ export interface ConversationProperties {
   user_id: string;
   user_name: string;
   agent_id: string;
+  space: string;
   title: string;
   created_at: string;
   updated_at: string;

--- a/x-pack/platform/plugins/shared/onechat/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/create_services.ts
@@ -92,6 +92,7 @@ export class ServiceManager {
       logger: logger.get('conversations'),
       security,
       elasticsearch,
+      spaces,
     });
 
     const chat = createChatService({


### PR DESCRIPTION
## Summary

Follow-up of https://github.com/elastic/kibana/pull/236074

Add space support for conversations too.

(can't easily add FTR test here given we can't create convos without using the converse API - will have to be done later)

## How to test

```
GET kbn://api/agent_builder/conversations
```

- Generate some conversation in the default space
- Go to another space, confirm the conversations are not listed
- Create some conversation here
- Get back to default space and confirm the new conversation is not listed