### PR TITLE
[Cloud Security] Support additional parameters for package policy and Agentless API

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -132,6 +132,7 @@ src/core/packages/chrome/layout/core-chrome-layout-components @elastic/appex-sha
 src/core/packages/chrome/layout/core-chrome-layout-constants @elastic/appex-sharedux
 src/core/packages/chrome/layout/core-chrome-layout-feature-flags @elastic/appex-sharedux
 src/core/packages/chrome/navigation @elastic/eui-team
+src/core/packages/chrome/navigation-tour @elastic/appex-sharedux
 src/core/packages/config/server-internal @elastic/kibana-core
 src/core/packages/custom-branding/browser @elastic/appex-sharedux
 src/core/packages/custom-branding/browser-internal @elastic/appex-sharedux

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
@@ -529,6 +529,59 @@ describe('useOnSubmit', () => {
       });
     });
 
+    it('should set cloud_connectors enabled to false and supports_cloud_connector to false for aws when cloud connector input var is false', () => {
+      const setNewAgentPolicy = jest.fn();
+      const setPackagePolicy = jest.fn();
+
+      const packagePolicy = {
+        inputs: [
+          {
+            type: 'aws',
+            enabled: true,
+            streams: [
+              {
+                vars: {
+                  'aws.supports_cloud_connectors': { value: false },
+                },
+              },
+            ],
+          },
+        ],
+      } as any;
+
+      const newAgentPolicy = {
+        supports_agentless: true,
+        agentless: {
+          cloud_connectors: {
+            enabled: true,
+            target_csp: 'aws',
+          },
+        },
+      } as any;
+
+      updateAgentlessCloudConnectorConfig(
+        packagePolicy,
+        newAgentPolicy,
+        setNewAgentPolicy,
+        setPackagePolicy
+      );
+
+      expect(setNewAgentPolicy).toHaveBeenCalledWith({
+        ...newAgentPolicy,
+        agentless: {
+          ...newAgentPolicy.agentless,
+          cloud_connectors: {
+            enabled: false,
+            target_csp: 'aws',
+          },
+        },
+      });
+      expect(setPackagePolicy).toHaveBeenCalledWith({
+        ...packagePolicy,
+        supports_cloud_connector: false,
+      });
+    });
+
     it('should update agentless cloud connector config when enabled and target CSP is azure', () => {
       const setNewAgentPolicy = jest.fn();
       const setPackagePolicy = jest.fn();
@@ -581,6 +634,59 @@ describe('useOnSubmit', () => {
       expect(setPackagePolicy).toHaveBeenCalledWith({
         ...packagePolicy,
         supports_cloud_connector: true,
+      });
+    });
+
+    it('should set cloud_connectors enabled to false and supports_cloud_connector to false for azure when cloud connector input var is false', () => {
+      const setNewAgentPolicy = jest.fn();
+      const setPackagePolicy = jest.fn();
+
+      const packagePolicy = {
+        inputs: [
+          {
+            type: 'azure',
+            enabled: true,
+            streams: [
+              {
+                vars: {
+                  'azure.supports_cloud_connectors': { value: false },
+                },
+              },
+            ],
+          },
+        ],
+      } as any;
+
+      const newAgentPolicy = {
+        supports_agentless: true,
+        agentless: {
+          cloud_connectors: {
+            enabled: true,
+            target_csp: 'azure',
+          },
+        },
+      } as any;
+
+      updateAgentlessCloudConnectorConfig(
+        packagePolicy,
+        newAgentPolicy,
+        setNewAgentPolicy,
+        setPackagePolicy
+      );
+
+      expect(setNewAgentPolicy).toHaveBeenCalledWith({
+        ...newAgentPolicy,
+        agentless: {
+          ...newAgentPolicy.agentless,
+          cloud_connectors: {
+            enabled: false,
+            target_csp: 'azure',
+          },
+        },
+      });
+      expect(setPackagePolicy).toHaveBeenCalledWith({
+        ...packagePolicy,
+        supports_cloud_connector: false,
       });
     });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
@@ -16,7 +16,7 @@ import { sendGetPackagePolicies, useConfig } from '../../../../../hooks';
 
 import { SelectedPolicyTab } from '../../components';
 
-import { useOnSubmit } from './form';
+import { useOnSubmit, updateAgentlessCloudConnectorConfig } from './form';
 
 type MockFn = jest.MockedFunction<any>;
 
@@ -470,6 +470,245 @@ describe('useOnSubmit', () => {
         expect(logsInput?.enabled).toBe(true);
         expect(metricsInput?.enabled).toBe(true);
       });
+    });
+  });
+
+  describe('updateAgentlessCloudConnectorConfig', () => {
+    it('should update agentless cloud connector config when enabled and target CSP is aws', () => {
+      const setNewAgentPolicy = jest.fn();
+      const setPackagePolicy = jest.fn();
+
+      const packagePolicy = {
+        inputs: [
+          {
+            type: 'aws',
+            enabled: true,
+            streams: [
+              {
+                vars: {
+                  'aws.supports_cloud_connectors': { value: true },
+                },
+              },
+            ],
+          },
+        ],
+      } as any;
+
+      const newAgentPolicy = {
+        supports_agentless: true,
+        agentless: {
+          cloud_connectors: {
+            enabled: false,
+            target_csp: 'azure',
+          },
+        },
+      } as any;
+
+      // Should update cloud_connectors to enabled: true, target_csp: 'aws'
+      // and set supports_cloud_connector to true in packagePolicy
+      updateAgentlessCloudConnectorConfig(
+        packagePolicy,
+        newAgentPolicy,
+        setNewAgentPolicy,
+        setPackagePolicy
+      );
+
+      expect(setNewAgentPolicy).toHaveBeenCalledWith({
+        ...newAgentPolicy,
+        agentless: {
+          ...newAgentPolicy.agentless,
+          cloud_connectors: {
+            enabled: true,
+            target_csp: 'aws',
+          },
+        },
+      });
+      expect(setPackagePolicy).toHaveBeenCalledWith({
+        ...packagePolicy,
+        supports_cloud_connector: true,
+      });
+    });
+
+    it('should update agentless cloud connector config when enabled and target CSP is azure', () => {
+      const setNewAgentPolicy = jest.fn();
+      const setPackagePolicy = jest.fn();
+
+      const packagePolicy = {
+        inputs: [
+          {
+            type: 'azure',
+            enabled: true,
+            streams: [
+              {
+                vars: {
+                  'azure.supports_cloud_connectors': { value: true },
+                },
+              },
+            ],
+          },
+        ],
+      } as any;
+
+      const newAgentPolicy = {
+        supports_agentless: true,
+        agentless: {
+          cloud_connectors: {
+            enabled: false,
+            target_csp: 'azure',
+          },
+        },
+      } as any;
+
+      // Should update cloud_connectors to enabled: true, target_csp: 'aws'
+      // and set supports_cloud_connector to true in packagePolicy
+      updateAgentlessCloudConnectorConfig(
+        packagePolicy,
+        newAgentPolicy,
+        setNewAgentPolicy,
+        setPackagePolicy
+      );
+
+      expect(setNewAgentPolicy).toHaveBeenCalledWith({
+        ...newAgentPolicy,
+        agentless: {
+          ...newAgentPolicy.agentless,
+          cloud_connectors: {
+            enabled: true,
+            target_csp: 'azure',
+          },
+        },
+      });
+      expect(setPackagePolicy).toHaveBeenCalledWith({
+        ...packagePolicy,
+        supports_cloud_connector: true,
+      });
+    });
+
+    it('should clear cloud_connectors and set supports_cloud_connector to false for gcp', () => {
+      const setNewAgentPolicy = jest.fn();
+      const setPackagePolicy = jest.fn();
+
+      const packagePolicy = {
+        inputs: [
+          {
+            type: 'gcp',
+            enabled: true,
+            streams: [
+              {
+                vars: {
+                  'gcp.supports_cloud_connectors': { value: true },
+                },
+              },
+            ],
+          },
+        ],
+      } as any;
+
+      const newAgentPolicy = {
+        supports_agentless: true,
+        agentless: {
+          cloud_connectors: {
+            enabled: true,
+            target_csp: 'aws',
+          },
+        },
+      } as any;
+
+      updateAgentlessCloudConnectorConfig(
+        packagePolicy,
+        newAgentPolicy,
+        setNewAgentPolicy,
+        setPackagePolicy
+      );
+
+      expect(setNewAgentPolicy).toHaveBeenCalledWith({
+        ...newAgentPolicy,
+        agentless: {
+          ...newAgentPolicy.agentless,
+          cloud_connectors: undefined,
+        },
+      });
+      expect(setPackagePolicy).toHaveBeenCalledWith({
+        ...packagePolicy,
+        supports_cloud_connector: false,
+      });
+    });
+
+    it('should not update agentless cloud connector config if nothing changed', () => {
+      const setNewAgentPolicy = jest.fn();
+      const setPackagePolicy = jest.fn();
+
+      const packagePolicy = {
+        inputs: [
+          {
+            type: 'aws',
+            enabled: true,
+            streams: [
+              {
+                vars: {
+                  'aws.supports_cloud_connectors': { value: true },
+                },
+              },
+            ],
+          },
+        ],
+      } as any;
+
+      const newAgentPolicy = {
+        supports_agentless: true,
+        agentless: {
+          cloud_connectors: {
+            enabled: true,
+            target_csp: 'aws',
+          },
+        },
+      } as any;
+
+      updateAgentlessCloudConnectorConfig(
+        packagePolicy,
+        newAgentPolicy,
+        setNewAgentPolicy,
+        setPackagePolicy
+      );
+
+      expect(setNewAgentPolicy).not.toHaveBeenCalled();
+      expect(setPackagePolicy).not.toHaveBeenCalled();
+    });
+
+    it('should not update if input is missing or not enabled', () => {
+      const setNewAgentPolicy = jest.fn();
+      const setPackagePolicy = jest.fn();
+
+      const packagePolicy = {
+        inputs: [
+          {
+            type: 'aws',
+            enabled: false,
+            streams: [
+              {
+                vars: {
+                  'aws.supports_cloud_connectors': { value: true },
+                },
+              },
+            ],
+          },
+        ],
+      } as any;
+
+      const newAgentPolicy = {
+        supports_agentless: true,
+        agentless: {},
+      } as any;
+
+      updateAgentlessCloudConnectorConfig(
+        packagePolicy,
+        newAgentPolicy,
+        setNewAgentPolicy,
+        setPackagePolicy
+      );
+
+      expect(setNewAgentPolicy).not.toHaveBeenCalled();
+      expect(setPackagePolicy).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -62,7 +62,6 @@ import {
 import { ensurePackageKibanaAssetsInstalled } from '../../../../../services/ensure_kibana_assets_installed';
 
 import { useAgentless, useSetupTechnology } from './setup_technology';
-import { NewAgentActionSchema } from '@kbn/fleet-plugin/server/types';
 
 const DEFAULT_AGENTLESS_LIMIT = 5;
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/aws_credentials_form/aws_credential_type_selector.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/aws_credentials_form/aws_credential_type_selector.tsx
@@ -9,6 +9,7 @@ import { EuiFormRow, EuiSelect } from '@elastic/eui';
 import { AWS_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ } from '@kbn/cloud-security-posture-common';
 import type { AwsCredentialsTypeOptions } from './get_aws_credentials_form_options';
 import type { AwsCredentialsType } from '../types';
+import { TechnicalPreviewText } from '../common';
 
 export const AwsCredentialTypeSelector = ({
   type,
@@ -32,6 +33,7 @@ export const AwsCredentialTypeSelector = ({
       onChange={(optionElem) => {
         onChange(optionElem.target.value as AwsCredentialsType);
       }}
+      append={type === 'cloud_connectors' ? <TechnicalPreviewText /> : undefined}
       data-test-subj={AWS_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ}
     />
   </EuiFormRow>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/azure_credentials_form/azure_credential_type_selector.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/azure_credentials_form/azure_credential_type_selector.tsx
@@ -10,6 +10,7 @@ import { EuiFormRow, EuiSelect } from '@elastic/eui';
 import { AZURE_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ } from '@kbn/cloud-security-posture-common';
 import { i18n } from '@kbn/i18n';
 import type { AzureCredentialsType } from '../types';
+import { TechnicalPreviewText } from '../common';
 
 export const AzureCredentialTypeSelector = ({
   type,
@@ -36,6 +37,7 @@ export const AzureCredentialTypeSelector = ({
       onChange={(optionElem) => {
         onChange(optionElem.target.value as AzureCredentialsType);
       }}
+      append={type === 'cloud_connectors' ? <TechnicalPreviewText /> : undefined}
       data-test-subj={AZURE_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ}
     />
   </EuiFormRow>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/common.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/common.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiLink, EuiText } from '@elastic/eui';
+import { EuiLink, EuiText, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -41,5 +41,27 @@ export const ReadDocumentation = ({ url }: { url: string }) => {
         }}
       />
     </EuiText>
+  );
+};
+
+export const TechnicalPreviewText = () => {
+  const technicalPreviewLabel = i18n.translate(
+    'securitySolutionPackages.cloudSecurityPosture.cloudSetup.technicalPreviewTextLabel',
+    {
+      defaultMessage: 'Technical preview',
+    }
+  );
+  const technicalPreviewTip = i18n.translate(
+    'securitySolutionPackages.cloudSecurityPosture.cloudSetup.technicalPreviewTextTooltip',
+    {
+      defaultMessage:
+        'This functionality is in technical preview and may be changed in a future release. Please help us by reporting any bugs.',
+    }
+  );
+
+  return (
+    <EuiToolTip content={technicalPreviewTip} title={technicalPreviewLabel}>
+      <span>{technicalPreviewLabel}</span>
+    </EuiToolTip>
   );
 };


### PR DESCRIPTION
## Summary

Introduces Azure support for cloud security package policies, expanding Kibana's cloud connector capabilities. The changes enable more flexible configuration options for different cloud service providers (CSPs), with a specific focus on Azure integration

Adds the `Technical Preview` on the credential selector for Azure and AWS when cloud connector is selected

 ### Testing Considerations:
  - Validate cloud connector policy changes across different cloud providers
  - Test credential handling for various connector types
  - Verify tech preview for Azure and AWS functionality works as expected


https://github.com/user-attachments/assets/899e1787-b116-45d3-9d2d-c5cb56750491

### Checklist
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenario
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




