### PR TITLE
Parameterize CodeQL alerting

### DIFF
--- a/.github/workflows/codeql-stats.yml
+++ b/.github/workflows/codeql-stats.yml
@@ -22,6 +22,7 @@ jobs:
       working-directory: ./kibana-operations/triage
       env:
         GITHUB_TOKEN: ${{secrets.KIBANAMACHINE_TOKEN}}
+        GITHUB_REPO: kibana
         SLACK_TOKEN: ${{secrets.CODE_SCANNING_SLACK_TOKEN}}
         SLACK_CHANNEL: ${{secrets.CODE_SCANNING_SLACK_CHANNEL_ID}}
         CODE_SCANNING_BRANCHES: main,8.19

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,6 +81,7 @@ jobs:
       working-directory: ./kibana-operations/triage
       env:
         GITHUB_TOKEN: ${{secrets.KIBANAMACHINE_TOKEN}}
+        GITHUB_REPO: kibana
         SLACK_TOKEN: ${{secrets.CODE_SCANNING_SLACK_TOKEN}}
         SLACK_CHANNEL: ${{secrets.CODE_SCANNING_SLACK_CHANNEL_ID}}
         CODE_SCANNING_ES_HOST: ${{secrets.CODE_SCANNING_ES_HOST}}


### PR DESCRIPTION
## Summary

Adds a `GITHUB_REPO` env variable to the CodeQL alerting workflow, in support of scanning additional repositories.