### PR TITLE
[Discover] ensures the data view picker icon is always vertically centered

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -448,6 +448,7 @@ src/platform/packages/shared/kbn-avc-banner @elastic/security-defend-workflows
 src/platform/packages/shared/kbn-axe-config @elastic/appex-qa
 src/platform/packages/shared/kbn-babel-register @elastic/kibana-operations
 src/platform/packages/shared/kbn-background-search @elastic/kibana-data-discovery
+src/platform/packages/shared/kbn-bench @elastic/obs-ui-devex-team
 src/platform/packages/shared/kbn-cache-cli @elastic/kibana-operations
 src/platform/packages/shared/kbn-calculate-auto @elastic/obs-ux-management-team
 src/platform/packages/shared/kbn-calculate-width-from-char-count @elastic/kibana-visualizations
@@ -460,6 +461,7 @@ src/platform/packages/shared/kbn-coloring @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-config @elastic/kibana-core
 src/platform/packages/shared/kbn-config-schema @elastic/kibana-core
 src/platform/packages/shared/kbn-content-management-utils @elastic/kibana-data-discovery
+src/platform/packages/shared/kbn-core-server-benchmarks @elastic/kibana-core
 src/platform/packages/shared/kbn-crypto @elastic/kibana-security
 src/platform/packages/shared/kbn-crypto-browser @elastic/kibana-core
 src/platform/packages/shared/kbn-css-utils @elastic/appex-sharedux
@@ -509,6 +511,7 @@ src/platform/packages/shared/kbn-i18n @elastic/kibana-core
 src/platform/packages/shared/kbn-i18n-react @elastic/kibana-core
 src/platform/packages/shared/kbn-interpreter @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-io-ts-utils @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-jest-benchmarks @elastic/obs-ui-devex-team
 src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations
 src/platform/packages/shared/kbn-lens-embeddable-utils @elastic/obs-ux-infra_services-team @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-licensing-types @elastic/kibana-core
@@ -540,6 +543,7 @@ src/platform/packages/shared/kbn-opentelemetry-utils @elastic/kibana-core
 src/platform/packages/shared/kbn-osquery-io-ts-types @elastic/security-defend-workflows
 src/platform/packages/shared/kbn-otel-semantic-conventions @elastic/obs-ux-logs-team
 src/platform/packages/shared/kbn-palettes @elastic/kibana-visualizations
+src/platform/packages/shared/kbn-profiler @elastic/obs-knowledge-team
 src/platform/packages/shared/kbn-profiling-utils @elastic/obs-ux-infra_services-team
 src/platform/packages/shared/kbn-react-field @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-react-hooks @elastic/obs-ux-logs-team
@@ -611,6 +615,7 @@ src/platform/packages/shared/kbn-utils @elastic/kibana-operations
 src/platform/packages/shared/kbn-visualization-ui-components @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-visualization-utils @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-workflows @elastic/workflows-eng
+src/platform/packages/shared/kbn-workspaces @elastic/obs-ui-devex-team
 src/platform/packages/shared/kbn-xstate-utils @elastic/obs-ux-logs-team
 src/platform/packages/shared/kbn-zod @elastic/kibana-core
 src/platform/packages/shared/kbn-zod-helpers @elastic/security-detection-rule-management

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
@@ -8,22 +8,22 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import type { EuiContextMenuPanelProps } from '@elastic/eui';
 import {
-  EuiPopover,
-  EuiHorizontalRule,
-  EuiContextMenuPanel,
+  EuiButtonEmpty,
   EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiPopover,
+  EuiText,
   useEuiTheme,
   useGeneratedHtmlId,
   useIsWithinBreakpoints,
-  EuiIcon,
-  EuiText,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiButtonEmpty,
 } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
@@ -135,20 +135,15 @@ export function ChangeDataView({
         size="s"
         {...rest}
       >
-        <>
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
           {/* we don't want to display the adHoc icon on text based mode */}
           {isAdHocSelected && (
-            <EuiIcon
-              type={adhoc}
-              color="primary"
-              css={css`
-                margin-right: ${euiTheme.size.s};
-              `}
-              size="s"
-            />
+            <EuiFlexItem grow={false}>
+              <EuiIcon type={adhoc} color="primary" size="s" />
+            </EuiFlexItem>
           )}
-          {trigger.label}
-        </>
+          <EuiFlexItem grow={false}>{trigger.label}</EuiFlexItem>
+        </EuiFlexGroup>
       </EuiButtonEmpty>
     );
   };


### PR DESCRIPTION
## Summary

This PR makes a small change to the data view picker, to fix an issue where the adhoc icon was not always centered.

### Issue

In Security Solution, we use the data view picker in multiple places. One of the place is the navbar where we display the nav icon, the breadcrumbs... This component is using an [EuiHeaderSection](https://eui.elastic.co/docs/components/layout/header/) component to wrap the content. For some reason, the combination of the `EuiHeaderSection` and the current data view picker adds the following css to the EuiButton:
```
.euiHeaderSectionItem .euiButtonEmpty__text {
    display: flex;
}
```
And this messes up the vertical alignment of the icon.

This is not visible in Discover (or in Analyzer) because the picker is not nested under an `EuiHeaderSection` component...

### Solution

To ensure that the data view picker is always rendered the same way, the approach here was to use `EuiFlexGroup` and `EuiFlexItem` to wrap the icon and the text next to it, directly in the data view component itself.
 
The usage in Discover isn't visually impacted by this change:

| Before without icon | After without icon |
| ------------- | ------------- |
| <img width="403" height="233" alt="Screenshot 2025-09-24 at 3 19 46 PM" src="https://github.com/user-attachments/assets/31aba036-692b-4a1f-8306-521f41982c2f" /> | <img width="344" height="234" alt="Screenshot 2025-09-24 at 3 22 24 PM" src="https://github.com/user-attachments/assets/266f226f-5da9-4f5b-a947-da7b63d1b2a1" /> |

| Before with icon | After with icon |
| ------------- | ------------- |
| <img width="373" height="250" alt="Screenshot 2025-09-24 at 3 22 38 PM" src="https://github.com/user-attachments/assets/a12ddd77-6bac-4c61-8651-0f2bd4244bc8" /> | <img width="389" height="230" alt="Screenshot 2025-09-24 at 3 20 01 PM" src="https://github.com/user-attachments/assets/835592d2-5942-4f4e-ae2e-9248585a325a" /> |

But the data view picker now looks better in Security Solution when displaying the adhoc/temporary icon:

| Before without icon | After without icon |
| ------------- | ------------- |
| <img width="443" height="192" alt="Screenshot 2025-09-24 at 3 20 46 PM" src="https://github.com/user-attachments/assets/cc6fb893-e0d2-4f3b-b109-f443e59a608e" /> | <img width="431" height="200" alt="Screenshot 2025-09-24 at 3 22 03 PM" src="https://github.com/user-attachments/assets/43fdfd17-07b1-4d1d-86ef-444fe688d5a6" /> |

| Before with icon | After with icon |
| ------------- | ------------- |
| <img width="419" height="209" alt="Screenshot 2025-09-24 at 3 22 15 PM" src="https://github.com/user-attachments/assets/2e710a8b-3993-4f18-9164-0a584b8580a7" /> | <img width="383" height="212" alt="Screenshot 2025-09-24 at 3 21 01 PM" src="https://github.com/user-attachments/assets/03836ca5-cb70-479d-8003-b2b1dde0475c" /> |

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.