### PR TITLE
[8.18] [Vega] remove VEGA_DEBUG (#234477)

### DIFF
--- a/src/platform/plugins/private/vis_types/vega/public/vega_view/vega_base_view.js
+++ b/src/platform/plugins/private/vis_types/vega/public/vega_view/vega_base_view.js
@@ -9,9 +9,8 @@
 
 import moment from 'moment';
 import dateMath from '@kbn/datemath';
-import { scheme, loader, logger, Warn, version as vegaVersion, expressionFunction } from 'vega';
+import { scheme, loader, logger, Warn, expressionFunction } from 'vega';
 import { expressionInterpreter } from 'vega-interpreter';
-import { version as vegaLiteVersion } from 'vega-lite';
 import { Utils } from '../data_model/utils';
 import { euiPaletteColorBlind } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -497,33 +496,6 @@ export class VegaBaseView {
       view,
       spec: vlspec || spec,
     });
-
-    if (window) {
-      if (window.VEGA_DEBUG === undefined && console) {
-        console.log('%cWelcome to Kibana Vega Plugin!', 'font-size: 16px; font-weight: bold;');
-        console.log(
-          'You can access the Vega view with VEGA_DEBUG. ' +
-            'Learn more at https://vega.github.io/vega/docs/api/debugging/.'
-        );
-      }
-      const debugObj = {};
-      window.VEGA_DEBUG = debugObj;
-      window.VEGA_DEBUG.VEGA_VERSION = vegaVersion;
-      window.VEGA_DEBUG.VEGA_LITE_VERSION = vegaLiteVersion;
-      window.VEGA_DEBUG.view = view;
-      window.VEGA_DEBUG.vega_spec = spec;
-      window.VEGA_DEBUG.vegalite_spec = vlspec;
-
-      // On dispose, clean up, but don't use undefined to prevent repeated debug statements
-      this._addDestroyHandler(() => {
-        if (debugObj === window.VEGA_DEBUG) {
-          window.VEGA_DEBUG.view = null;
-          window.VEGA_DEBUG.vega_spec = null;
-          window.VEGA_DEBUG.vegalite_spec = null;
-          window.VEGA_DEBUG = null;
-        }
-      });
-    }
   }
 
   destroy() {

--- a/src/platform/plugins/private/vis_types/vega/public/vega_visualization.test.tsx
+++ b/src/platform/plugins/private/vis_types/vega/public/vega_visualization.test.tsx
@@ -82,9 +82,6 @@ describe('VegaVisualizations', () => {
     });
 
     test('should show vegalite graph and update on resize (may fail in dev env)', async () => {
-      const mockedConsoleLog = jest.spyOn(console, 'log'); // mocked console.log to avoid messages in the console when running tests
-      mockedConsoleLog.mockImplementation(() => {}); //  comment this line when console logging for debugging comment this line
-
       let vegaVis: InstanceType<VegaVisType>;
       try {
         vegaVis = new VegaVisualization(domNode, jest.fn());
@@ -114,9 +111,6 @@ describe('VegaVisualizations', () => {
       } finally {
         vegaVis.destroy();
       }
-      // eslint-disable-next-line no-console
-      expect(console.log).toBeCalledTimes(2);
-      mockedConsoleLog.mockRestore();
     });
 
     test('should show vega graph (may fail in dev env)', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Vega] remove VEGA_DEBUG (#234477)](https://github.com/elastic/kibana/pull/234477)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2025-09-17T11:51:01Z","message":"[Vega] remove VEGA_DEBUG (#234477)\n\nThis commit removes the VEGA_DEBUG variable from window object.","sha":"03f47de4412ec686ef5a09e035949639776c6489","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Vega","Team:Visualizations","release_note:skip","backport:all-open","v9.2.0","v9.1.4","v9.0.7","v8.19.4"],"title":"[Vega] remove VEGA_DEBUG","number":234477,"url":"https://github.com/elastic/kibana/pull/234477","mergeCommit":{"message":"[Vega] remove VEGA_DEBUG (#234477)\n\nThis commit removes the VEGA_DEBUG variable from window object.","sha":"03f47de4412ec686ef5a09e035949639776c6489"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/234477","number":234477,"mergeCommit":{"message":"[Vega] remove VEGA_DEBUG (#234477)\n\nThis commit removes the VEGA_DEBUG variable from window object.","sha":"03f47de4412ec686ef5a09e035949639776c6489"}},{"branch":"9.1","label":"v9.1.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/235353","number":235353,"state":"MERGED","mergeCommit":{"sha":"3f77c7e51c9910198d2041c2b655ec7db96c33e4","message":"[9.1] [Vega] remove VEGA_DEBUG (#234477) (#235353)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Vega] remove VEGA_DEBUG\n(#234477)](https://github.com/elastic/kibana/pull/234477)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>"}},{"branch":"9.0","label":"v9.0.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/235352","number":235352,"state":"MERGED","mergeCommit":{"sha":"d940f7267527ae279e00154f35f427d1c30d9526","message":"[9.0] [Vega] remove VEGA_DEBUG (#234477) (#235352)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Vega] remove VEGA_DEBUG\n(#234477)](https://github.com/elastic/kibana/pull/234477)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>"}},{"branch":"8.19","label":"v8.19.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/235351","number":235351,"state":"MERGED","mergeCommit":{"sha":"48e544d25bc6a940f17ff321cd4601e86bb9f180","message":"[8.19] [Vega] remove VEGA_DEBUG (#234477) (#235351)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Vega] remove VEGA_DEBUG\n(#234477)](https://github.com/elastic/kibana/pull/234477)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>"}}]}] BACKPORT-->