### PR TITLE
[Failure store modal] Remove small unit options and add visual improvements

### DIFF
--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/constants.ts
@@ -10,43 +10,46 @@ export const timeUnits = [
   {
     value: 'd',
     text: i18n.translate('xpack.failureStoreModal.timeUnits.daysLabel', {
-      defaultMessage: 'days',
+      defaultMessage: 'Days',
     }),
   },
   {
     value: 'h',
     text: i18n.translate('xpack.failureStoreModal.timeUnits.hoursLabel', {
-      defaultMessage: 'hours',
+      defaultMessage: 'Hours',
     }),
   },
   {
     value: 'm',
     text: i18n.translate('xpack.failureStoreModal.timeUnits.minutesLabel', {
-      defaultMessage: 'minutes',
+      defaultMessage: 'Minutes',
     }),
   },
   {
     value: 's',
     text: i18n.translate('xpack.failureStoreModal.timeUnits.secondsLabel', {
-      defaultMessage: 'seconds',
+      defaultMessage: 'Seconds',
     }),
   },
+];
+
+export const extraTimeUnits = [
   {
     value: 'ms',
     text: i18n.translate('xpack.failureStoreModal.timeUnits.msLabel', {
-      defaultMessage: 'milliseconds',
+      defaultMessage: 'Milliseconds',
     }),
   },
   {
     value: 'micros',
     text: i18n.translate('xpack.failureStoreModal.timeUnits.microsLabel', {
-      defaultMessage: 'microseconds',
+      defaultMessage: 'Microseconds',
     }),
   },
   {
     value: 'nanos',
     text: i18n.translate('xpack.failureStoreModal.timeUnits.nanosLabel', {
-      defaultMessage: 'nanoseconds',
+      defaultMessage: 'Nanoseconds',
     }),
   },
 ];

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.test.tsx
@@ -110,7 +110,7 @@ describe('FailureStoreModal', () => {
       expect(getByTestId('selectFailureStoreRetentionPeriodUnit')).toBeInTheDocument();
 
       expect(getByTestId('selectFailureStorePeriodValue')).toHaveValue(15);
-      expect(getByTestId('selectFailureStoreRetentionPeriodUnit')).toHaveValue('d');
+      expect(getByTestId('selectFailureStoreRetentionPeriodUnit')).toHaveTextContent('Days');
 
       fireEvent.click(getByTestId('enableFailureStoreToggle'));
 
@@ -159,9 +159,9 @@ describe('FailureStoreModal', () => {
       expect(valueSelector).toBeDisabled();
       expect(unitSelector).toBeDisabled();
 
-      // The default retention period in the props is 40m, so the value should be 40 and unit 'm'
+      // The default retention period in the props is 40m, so the value should be 40 and unit 'Minutes'
       expect(valueSelector).toHaveValue(40);
-      expect(unitSelector).toHaveValue('m');
+      expect(unitSelector).toHaveTextContent('Minutes');
 
       fireEvent.click(customButton);
 
@@ -171,16 +171,15 @@ describe('FailureStoreModal', () => {
       expect(valueSelector).not.toBeDisabled();
       expect(unitSelector).not.toBeDisabled();
 
-      // The custom retention period by default is the default period, so the value should be 40 and unit 'm'
+      // The custom retention period by default is the default period, so the value should be 40 and unit 'Minutes'
       expect(valueSelector).toHaveValue(40);
-      expect(unitSelector).toHaveValue('m');
+      expect(unitSelector).toHaveTextContent('Minutes');
 
-      fireEvent.change(unitSelector, {
-        target: { value: 's' },
-      });
+      fireEvent.click(unitSelector);
+      fireEvent.click(getByTestId('retentionPeriodUnit-s'));
       fireEvent.change(valueSelector, { target: { value: '15' } });
 
-      expect(unitSelector).toHaveValue('s');
+      expect(unitSelector).toHaveTextContent('Seconds');
       expect(valueSelector).toHaveValue(15);
 
       fireEvent.click(getByTestId('failureStoreModalSaveButton'));

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.tsx
@@ -89,14 +89,14 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
   const retentionPeriodUnit = customRetentionPeriod
     ? customRetentionPeriod.unit
     : defaultRetentionPeriod
-      ? defaultRetentionPeriod.unit
-      : 'd';
+    ? defaultRetentionPeriod.unit
+    : 'd';
 
   const retentionPeriodValue = customRetentionPeriod
     ? customRetentionPeriod.size
     : defaultRetentionPeriod
-      ? defaultRetentionPeriod.size
-      : '30';
+    ? defaultRetentionPeriod.size
+    : '30';
 
   const { form } = useForm({
     defaultValue: {
@@ -125,16 +125,16 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
       isCustomPeriod && customRetentionPeriod
         ? customRetentionPeriod.size
         : defaultRetentionPeriod
-          ? defaultRetentionPeriod.size
-          : '30'
+        ? defaultRetentionPeriod.size
+        : '30'
     );
     form.setFieldValue(
       'retentionPeriodUnit',
       isCustomPeriod && customRetentionPeriod
         ? customRetentionPeriod.unit
         : defaultRetentionPeriod
-          ? defaultRetentionPeriod.unit
-          : 'd'
+        ? defaultRetentionPeriod.unit
+        : 'd'
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [periodType]);
@@ -201,7 +201,8 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
 
               <EuiFormRow>
                 {isCustomPeriod || defaultRetentionPeriod ? (
-                  <RetentionPeriodField disabled={!isCustomPeriod} />) : (
+                  <RetentionPeriodField disabled={!isCustomPeriod} />
+                ) : (
                   <EuiCallOut
                     announceOnMount
                     typeof="info"

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.tsx
@@ -11,8 +11,6 @@ import {
   EuiButton,
   EuiButtonEmpty,
   EuiCallOut,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiFormRow,
   EuiModal,
   EuiModalBody,
@@ -24,67 +22,18 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-
-import type { FormSchema } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import {
   useForm,
-  FIELD_TYPES,
   Form,
   useFormIsModified,
   UseField,
   useFormData,
 } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
-
-import {
-  ButtonGroupField,
-  NumericField,
-  SelectField,
-  ToggleField,
-} from '@kbn/es-ui-shared-plugin/static/forms/components';
-import { timeUnits, failureStorePeriodOptions } from '../constants';
+import { ButtonGroupField, ToggleField } from '@kbn/es-ui-shared-plugin/static/forms/components';
+import { failureStorePeriodOptions } from '../constants';
 import { splitSizeAndUnits } from '../utils';
-
-const editFailureStoreFormSchema: FormSchema = {
-  failureStore: {
-    type: FIELD_TYPES.TOGGLE,
-    defaultValue: false,
-  },
-  periodType: {
-    type: FIELD_TYPES.SUPER_SELECT,
-    defaultValue: 'default',
-  },
-  retentionPeriodValue: {
-    type: FIELD_TYPES.NUMBER,
-    defaultValue: 30,
-    validations: [
-      {
-        validator: ({ value, formData }) => {
-          // Only validate when failure store is enabled AND period type is custom
-          if (formData.failureStore && formData.periodType === 'custom') {
-            if (!value || value <= 0) {
-              return {
-                message: i18n.translate(
-                  'xpack.failureStoreModal.form.retentionPeriodValue.required',
-                  {
-                    defaultMessage:
-                      'Retention period value is required when failure store is enabled.',
-                  }
-                ),
-              };
-            }
-          }
-          // Explicitly return undefined when validation doesn't apply to clear any previous errors
-          return undefined;
-        },
-      },
-    ],
-    fieldsToValidateOnChange: ['failureStore', 'periodType', 'retentionPeriodValue'],
-  },
-  retentionPeriodUnit: {
-    type: FIELD_TYPES.SELECT,
-    defaultValue: 'd',
-  },
-};
+import { RetentionPeriodField } from '../retention_period_field/retention_period_field';
+import { editFailureStoreFormSchema } from './schema';
 
 export interface FailureStoreFormProps {
   failureStoreEnabled: boolean;
@@ -140,14 +89,14 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
   const retentionPeriodUnit = customRetentionPeriod
     ? customRetentionPeriod.unit
     : defaultRetentionPeriod
-    ? defaultRetentionPeriod.unit
-    : 'd';
+      ? defaultRetentionPeriod.unit
+      : 'd';
 
   const retentionPeriodValue = customRetentionPeriod
     ? customRetentionPeriod.size
     : defaultRetentionPeriod
-    ? defaultRetentionPeriod.size
-    : '30';
+      ? defaultRetentionPeriod.size
+      : '30';
 
   const { form } = useForm({
     defaultValue: {
@@ -176,16 +125,16 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
       isCustomPeriod && customRetentionPeriod
         ? customRetentionPeriod.size
         : defaultRetentionPeriod
-        ? defaultRetentionPeriod.size
-        : '30'
+          ? defaultRetentionPeriod.size
+          : '30'
     );
     form.setFieldValue(
       'retentionPeriodUnit',
       isCustomPeriod && customRetentionPeriod
         ? customRetentionPeriod.unit
         : defaultRetentionPeriod
-        ? defaultRetentionPeriod.unit
-        : 'd'
+          ? defaultRetentionPeriod.unit
+          : 'd'
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [periodType]);
@@ -252,34 +201,7 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
 
               <EuiFormRow>
                 {isCustomPeriod || defaultRetentionPeriod ? (
-                  <EuiFlexGroup gutterSize="s">
-                    <EuiFlexItem>
-                      <UseField
-                        path={'retentionPeriodValue'}
-                        component={NumericField}
-                        euiFieldProps={{
-                          options: failureStorePeriodOptions,
-                          disabled: !isCustomPeriod,
-                          min: 0,
-                          placeholder: retentionPeriodValue,
-                          'data-test-subj': 'selectFailureStorePeriodValue',
-                        }}
-                      />
-                    </EuiFlexItem>
-                    <EuiFlexItem>
-                      <UseField
-                        path={'retentionPeriodUnit'}
-                        component={SelectField}
-                        euiFieldProps={{
-                          options: timeUnits,
-                          disabled: !isCustomPeriod,
-                          placeholder: retentionPeriodUnit,
-                          'data-test-subj': 'selectFailureStoreRetentionPeriodUnit',
-                        }}
-                      />
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                ) : (
+                  <RetentionPeriodField disabled={!isCustomPeriod} />) : (
                   <EuiCallOut
                     announceOnMount
                     typeof="info"

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/schema.ts
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/schema.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FIELD_TYPES, type FormSchema } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
+import { i18n } from '@kbn/i18n';
+
+const isInvalidRetention = (value: string) => {
+  const num = Number(value);
+  return isNaN(num) || num < 1 || num % 1 > 0;
+};
+
+export const editFailureStoreFormSchema: FormSchema = {
+  failureStore: {
+    type: FIELD_TYPES.TOGGLE,
+    defaultValue: false,
+  },
+  periodType: {
+    type: FIELD_TYPES.SUPER_SELECT,
+    defaultValue: 'default',
+  },
+  retentionPeriodValue: {
+    type: FIELD_TYPES.NUMBER,
+    defaultValue: 30,
+    validations: [
+      {
+        validator: ({ value, formData }) => {
+          // Only validate when failure store is enabled AND period type is custom
+          if (formData.failureStore && formData.periodType === 'custom') {
+            if (!value || value <= 0) {
+              return {
+                message: i18n.translate(
+                  'xpack.failureStoreModal.form.retentionPeriodValue.required',
+                  {
+                    defaultMessage:
+                      'Retention period value is required when failure store is enabled.',
+                  }
+                ),
+              };
+            }
+            if (isInvalidRetention(value)) {
+              return {
+                message: i18n.translate(
+                  'xpack.failureStoreModal.form.retentionPeriodValue.invalid',
+                  {
+                    defaultMessage: 'A positive integer is required.',
+                  }
+                ),
+              };
+            }
+          }
+          // Explicitly return undefined when validation doesn't apply to clear any previous errors
+          return undefined;
+        },
+      },
+    ],
+    fieldsToValidateOnChange: ['failureStore', 'periodType', 'retentionPeriodValue'],
+  },
+  retentionPeriodUnit: {
+    type: FIELD_TYPES.SELECT,
+    defaultValue: 'd',
+  },
+};

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/retention_period_field/retention_period_field.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/retention_period_field/retention_period_field.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { fireEvent, render } from '@testing-library/react';
+import { Form, useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
+import { RetentionPeriodField } from './retention_period_field';
+
+const TestWrapper = ({
+  disabled,
+  retentionPeriod,
+}: {
+  disabled: boolean;
+  retentionPeriod: { value: number; unit: string };
+}) => {
+  const { form } = useForm({
+    defaultValue: {
+      retentionPeriodValue: retentionPeriod.value,
+      retentionPeriodUnit: retentionPeriod.unit,
+    },
+  });
+
+  return (
+    <Form form={form}>
+      <RetentionPeriodField disabled={disabled} />
+    </Form>
+  );
+};
+
+const renderField = ({
+  disabled = false,
+  retentionPeriod = { value: 15, unit: 'd' },
+}: {
+  disabled?: boolean;
+  retentionPeriod?: { value: number; unit: string };
+}) => {
+  return render(
+    <IntlProvider>
+      <TestWrapper disabled={disabled} retentionPeriod={retentionPeriod} />
+    </IntlProvider>
+  );
+};
+
+describe('RetentionPeriodField', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders value and unit fields', () => {
+    const { getByTestId } = renderField({});
+
+    expect(getByTestId('selectFailureStorePeriodValue')).toBeInTheDocument();
+    expect(getByTestId('selectFailureStorePeriodValue')).toHaveValue(15);
+    expect(getByTestId('selectFailureStoreRetentionPeriodUnit')).toBeInTheDocument();
+    expect(getByTestId('selectFailureStoreRetentionPeriodUnit')).toHaveTextContent('Days');
+  });
+
+  it('renders unit label if it exists', () => {
+    const { getByTestId } = renderField({
+      retentionPeriod: { value: 15, unit: 'ms' },
+    });
+
+    expect(getByTestId('selectFailureStorePeriodValue')).toBeInTheDocument();
+    expect(getByTestId('selectFailureStorePeriodValue')).toHaveValue(15);
+    expect(getByTestId('selectFailureStoreRetentionPeriodUnit')).toBeInTheDocument();
+    expect(getByTestId('selectFailureStoreRetentionPeriodUnit')).toHaveTextContent('Milliseconds');
+  });
+
+  it('renders unit if label does not exist', () => {
+    const { getByTestId } = renderField({
+      retentionPeriod: { value: 15, unit: 'otherUnit' },
+    });
+
+    expect(getByTestId('selectFailureStorePeriodValue')).toBeInTheDocument();
+    expect(getByTestId('selectFailureStorePeriodValue')).toHaveValue(15);
+    expect(getByTestId('selectFailureStoreRetentionPeriodUnit')).toBeInTheDocument();
+    expect(getByTestId('selectFailureStoreRetentionPeriodUnit')).toHaveTextContent('otherUnit');
+  });
+
+  it('disables fields when disabled prop is true', () => {
+    const { getByTestId } = renderField({
+      disabled: true,
+    });
+
+    expect(getByTestId('selectFailureStorePeriodValue')).toBeDisabled();
+    expect(getByTestId('selectFailureStoreRetentionPeriodUnit')).toBeDisabled();
+  });
+
+  it('renders only days, hours, minutes and seconds options', () => {
+    const { queryByTestId, getByTestId } = renderField({});
+
+    fireEvent.click(getByTestId('selectFailureStoreRetentionPeriodUnit'));
+    expect(queryByTestId('retentionPeriodUnit-d')).toBeInTheDocument();
+    expect(queryByTestId('retentionPeriodUnit-h')).toBeInTheDocument();
+    expect(queryByTestId('retentionPeriodUnit-m')).toBeInTheDocument();
+    expect(queryByTestId('retentionPeriodUnit-s')).toBeInTheDocument();
+    expect(queryByTestId('retentionPeriodUnit-ms')).not.toBeInTheDocument();
+    expect(queryByTestId('retentionPeriodUnit-micros')).not.toBeInTheDocument();
+    expect(queryByTestId('retentionPeriodUnit-nanos')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/retention_period_field/retention_period_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/retention_period_field/retention_period_field.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FunctionComponent } from 'react';
+import React, { useState } from 'react';
+import { EuiButton, EuiPopover, EuiSelectable } from '@elastic/eui';
+
+import { UseField } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
+
+import { NumericField } from '@kbn/es-ui-shared-plugin/static/forms/components';
+import { timeUnits, extraTimeUnits } from '../constants';
+
+export const RetentionPeriodField: FunctionComponent<{ disabled: boolean }> = ({ disabled }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <UseField
+      path="retentionPeriodValue"
+      component={NumericField}
+      componentProps={{
+        fullWidth: true,
+        euiFieldProps: {
+          disabled,
+          'data-test-subj': `selectFailureStorePeriodValue`,
+          min: 1,
+          append: (
+            <UseField key={'retentionPeriodUnit'} path={'retentionPeriodUnit'}>
+              {(field) => {
+                const onSelect = (option: string) => {
+                  field.setValue(option);
+                  setOpen(false);
+                };
+
+                return (
+                  <EuiPopover
+                    isOpen={open}
+                    panelPaddingSize="none"
+                    closePopover={() => setOpen(false)}
+                    button={
+                      <EuiButton
+                        data-test-subj="selectFailureStoreRetentionPeriodUnit"
+                        disabled={disabled}
+                        iconType="arrowDown"
+                        iconSide="right"
+                        color="text"
+                        onClick={() => setOpen((isOpen) => !isOpen)}
+                      >
+                        {[...timeUnits, ...extraTimeUnits].find(
+                          (option) => option.value === field.value
+                        )?.text ?? `${field.value}`}
+                      </EuiButton>
+                    }
+                  >
+                    <EuiSelectable
+                      singleSelection="always"
+                      listProps={{
+                        onFocusBadge: false,
+                        style: {
+                          minWidth: 130,
+                        },
+                      }}
+                      options={timeUnits.map((item) => ({
+                        key: item.value,
+                        label: item.text,
+                        checked: field.value === item.value ? 'on' : undefined,
+                        'data-test-subj': `retentionPeriodUnit-${item.value}`,
+                      }))}
+                      onChange={(newOptions, event, changedOption) => {
+                        if (changedOption) {
+                          onSelect(changedOption.key);
+                        }
+                      }}
+                    >
+                      {(list) => list}
+                    </EuiSelectable>
+                  </EuiPopover>
+                );
+              }}
+            </UseField>
+          ),
+        },
+      }}
+    />
+  );
+};

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/retention_period_field/retention_period_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/retention_period_field/retention_period_field.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FunctionComponent } from 'react';
-import React, { useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { EuiButton, EuiPopover, EuiSelectable } from '@elastic/eui';
 
 import { UseField } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
@@ -16,6 +16,11 @@ import { timeUnits, extraTimeUnits } from '../constants';
 
 export const RetentionPeriodField: FunctionComponent<{ disabled: boolean }> = ({ disabled }) => {
   const [open, setOpen] = useState(false);
+  const allUnits = useMemo(() => [...timeUnits, ...extraTimeUnits], []);
+  const labelFor = useCallback(
+    (value: string) => allUnits.find((unit) => unit.value === value)?.text ?? value,
+    [allUnits]
+  );
   return (
     <UseField
       path="retentionPeriodValue"
@@ -48,9 +53,7 @@ export const RetentionPeriodField: FunctionComponent<{ disabled: boolean }> = ({
                         color="text"
                         onClick={() => setOpen((isOpen) => !isOpen)}
                       >
-                        {[...timeUnits, ...extraTimeUnits].find(
-                          (option) => option.value === field.value
-                        )?.text ?? `${field.value}`}
+                        {labelFor(String(field.value))}
                       </EuiButton>
                     }
                   >


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/235540
Fixes: https://github.com/elastic/kibana/issues/235510

## Summary
This PR introduces a set of improvements in the Failure Store Modal:
* Adds validation for positive integer
* Modify the drop down in order to make it more similar to the edit retention modal one in Streams.
* Removes small unit options. If the Failure Store has a retention unit smaller than a second set via API, we'll show the label when the modal is open for consistency.

### Desired look
<img width="590" height="407" alt="image" src="https://github.com/user-attachments/assets/bf45cdbb-9df3-4ed2-8612-05d162b267a2" />

### Demo

https://github.com/user-attachments/assets/6f9e906e-24f7-4410-8802-0e96cf98db1c


