### PR TITLE
[8.19] [Security Solution] [GenAi] Use default LLM setting for security GenAi features (#234480)

### DIFF
--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/components/default_ai_connector.tsx
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/components/default_ai_connector.tsx
@@ -313,8 +313,10 @@ export const DefaultAIConnector: React.FC<Props> = ({ connectors, settings }) =>
                   onChange={onChangeDefaultLlm}
                   isDisabled={fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]?.isReadOnly}
                   isLoading={connectors.loading}
-                  isInvalid={(selectedOptions.length === 0 && !connectors.loading) ||
-            (defaultLlmOnlyValue && selectedOptions[0]?.value === NO_DEFAULT_CONNECTOR)}
+                  isInvalid={
+                    (selectedOptions.length === 0 && !connectors.loading) ||
+                    (defaultLlmOnlyValue && selectedOptions[0]?.value === NO_DEFAULT_CONNECTOR)
+                  }
                 />
               </EuiFormRow>
 

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/components/default_ai_connector.tsx
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/components/default_ai_connector.tsx
@@ -313,7 +313,8 @@ export const DefaultAIConnector: React.FC<Props> = ({ connectors, settings }) =>
                   onChange={onChangeDefaultLlm}
                   isDisabled={fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]?.isReadOnly}
                   isLoading={connectors.loading}
-                  isInvalid={selectedOptions.length === 0 && !connectors.loading}
+                  isInvalid={(selectedOptions.length === 0 && !connectors.loading) ||
+            (defaultLlmOnlyValue && selectedOptions[0]?.value === NO_DEFAULT_CONNECTOR)}
                 />
               </EuiFormRow>
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/chat_complete/use_chat_complete.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/chat_complete/use_chat_complete.ts
@@ -26,10 +26,10 @@ interface UseChatComplete {
 // useChatComplete uses the same api as useSendMessage (post_actions_connector_execute) but without requiring conversationId/apiConfig
 // it is meant to be used for one-off messages that don't require a conversation
 export const useChatComplete = ({ connectorId }: { connectorId: string }): UseChatComplete => {
-  const { alertsIndexPattern, http, traceOptions } = useAssistantContext();
+  const { alertsIndexPattern, http, traceOptions, settings } = useAssistantContext();
   const [isLoading, setIsLoading] = useState(false);
   const abortController = useRef(new AbortController());
-  const { data: connectors } = useLoadConnectors({ http, inferenceEnabled: true });
+  const { data: connectors } = useLoadConnectors({ http, inferenceEnabled: true, settings });
   const actionTypeId = useMemo(
     () => connectors?.find(({ id }) => id === connectorId)?.actionTypeId ?? '.gen-ai',
     [connectors, connectorId]

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings_editor.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings_editor.tsx
@@ -11,12 +11,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { HttpSetup } from '@kbn/core-http-browser';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/public/common';
-import type { PromptResponse, User } from '@kbn/elastic-assistant-common';
-import {
-  getCurrentConversationOwner,
-  ConversationSharedState,
-} from '@kbn/elastic-assistant-common';
-import { ShareSelect } from '../../share_conversation/share_select';
+import type { PromptResponse } from '@kbn/elastic-assistant-common';
 import { useAssistantContext, type Conversation } from '../../../..';
 import * as i18n from './translations';
 import * as i18nModel from '../../../connectorland/models/model_selector/translations';

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings_editor.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings_editor.tsx
@@ -11,8 +11,13 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { HttpSetup } from '@kbn/core-http-browser';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/public/common';
-import { PromptResponse } from '@kbn/elastic-assistant-common';
-import { Conversation } from '../../../..';
+import type { PromptResponse, User } from '@kbn/elastic-assistant-common';
+import {
+  getCurrentConversationOwner,
+  ConversationSharedState,
+} from '@kbn/elastic-assistant-common';
+import { ShareSelect } from '../../share_conversation/share_select';
+import { useAssistantContext, type Conversation } from '../../../..';
 import * as i18n from './translations';
 import * as i18nModel from '../../../connectorland/models/model_selector/translations';
 
@@ -49,8 +54,10 @@ export const ConversationSettingsEditor: React.FC<ConversationSettingsEditorProp
     selectedConversation,
     setConversationsSettingsBulkActions,
   }) => {
+    const { settings } = useAssistantContext();
     const { data: connectors, isSuccess: areConnectorsFetched } = useLoadConnectors({
       http,
+      settings,
     });
     const [conversationUpdates, setConversationUpdates] =
       useState<Conversation>(selectedConversation);

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/helpers.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/helpers.test.ts
@@ -6,7 +6,9 @@
  */
 
 import { getDefaultConnector, getOptionalRequestParams } from './helpers';
-import { AIConnector } from '../connectorland/connector_selector';
+import type { AIConnector } from '../connectorland/connector_selector';
+import type { SettingsStart } from '@kbn/core-ui-settings-browser';
+import { GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR } from '@kbn/management-settings-ids';
 
 describe('helpers', () => {
   describe('getDefaultConnector', () => {
@@ -25,41 +27,97 @@ describe('helpers', () => {
         apiUrl: 'https://api.openai.com/v1/chat/completions',
       },
     };
+
+    const connector2: AIConnector = {
+      ...defaultConnector,
+      id: 'c7f91dc0-2197-11ee-aded-897192c5d633',
+      name: 'OpenAI',
+      config: {
+        apiProvider: 'OpenAI 2',
+        apiUrl: 'https://api.openai.com/v1/chat/completions',
+      },
+    };
+
+    const clientGet = jest.fn();
+
+    const settings = {
+      client: {
+        get: clientGet,
+      },
+    } as unknown as SettingsStart;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      clientGet.mockImplementation((key: string) => {
+        return undefined;
+      });
+    });
+
     it('should return undefined if connectors array is undefined', () => {
       const connectors = undefined;
-      const result = getDefaultConnector(connectors);
+      const result = getDefaultConnector(connectors, settings);
 
       expect(result).toBeUndefined();
     });
 
     it('should return undefined if connectors array is empty', () => {
       const connectors: AIConnector[] = [];
-      const result = getDefaultConnector(connectors);
+      const result = getDefaultConnector(connectors, settings);
 
       expect(result).toBeUndefined();
     });
 
-    it('should return the connector id if there is only one connector', () => {
+    it('should return the first connector if there is only one connector available', () => {
       const connectors: AIConnector[] = [defaultConnector];
-      const result = getDefaultConnector(connectors);
+      const result = getDefaultConnector(connectors, settings);
 
       expect(result).toBe(connectors[0]);
     });
 
-    it('should return the connector id if there are multiple connectors', () => {
-      const connectors: AIConnector[] = [
-        defaultConnector,
-        {
-          ...defaultConnector,
-          id: 'c7f91dc0-2197-11ee-aded-897192c5d633',
-          name: 'OpenAI',
-          config: {
-            apiProvider: 'OpenAI 2',
-            apiUrl: 'https://api.openai.com/v1/chat/completions',
-          },
-        },
-      ];
-      const result = getDefaultConnector(connectors);
+    it('should return the default connector if there are multiple connectors and default connector is defined', () => {
+      clientGet.mockImplementation((key: string) => {
+        if (key === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR) {
+          return defaultConnector.id;
+        }
+        return undefined;
+      });
+      const connectors: AIConnector[] = [defaultConnector, connector2];
+      const result = getDefaultConnector(connectors, settings);
+      expect(result).toBe(defaultConnector);
+    });
+
+    it('should return the default connector if there are multiple connectors and default connector is defined but they are in a different order', () => {
+      clientGet.mockImplementation((key: string) => {
+        if (key === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR) {
+          return defaultConnector.id;
+        }
+        return undefined;
+      });
+      const connectors: AIConnector[] = [connector2, defaultConnector];
+      const result = getDefaultConnector(connectors, settings);
+      expect(result).toBe(defaultConnector);
+    });
+
+    it('should return the first connector if there are multiple connectors and no default connector is defined', () => {
+      clientGet.mockImplementation(() => {
+        return undefined;
+      });
+
+      const connectors: AIConnector[] = [connector2, defaultConnector];
+      const result = getDefaultConnector(connectors, settings);
+      expect(result).toBe(connectors[0]);
+    });
+
+    it('should return the first connector if there are multiple connectors and a default connector is defined but it does not exist', () => {
+      clientGet.mockImplementation((key: string) => {
+        if (key === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR) {
+          return 'randomConnectorIdThatDoesNotExist';
+        }
+        return undefined;
+      });
+
+      const connectors: AIConnector[] = [connector2, defaultConnector];
+      const result = getDefaultConnector(connectors, settings);
       expect(result).toBe(connectors[0]);
     });
   });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -99,6 +99,7 @@ const AssistantComponent: React.FC<Props> = ({
     showAnonymizedValues,
     setContentReferencesVisible,
     setShowAnonymizedValues,
+    settings,
   } = useAssistantContext();
 
   const [selectedPromptContexts, setSelectedPromptContexts] = useState<
@@ -131,8 +132,12 @@ const AssistantComponent: React.FC<Props> = ({
   // Connector details
   const { data: connectors, isFetchedAfterMount: isFetchedConnectors } = useLoadConnectors({
     http,
+    settings,
   });
-  const defaultConnector = useMemo(() => getDefaultConnector(connectors), [connectors]);
+  const defaultConnector = useMemo(
+    () => getDefaultConnector(connectors, settings),
+    [connectors, settings]
+  );
   const spaceId = useAssistantSpaceId();
   const { getLastConversation, setLastConversation } = useAssistantLastConversation({ spaceId });
   const lastConversationFromLocalStorage = useMemo(

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings.tsx
@@ -68,6 +68,7 @@ export const AssistantSettings: React.FC<Props> = React.memo(
       selectedSettingsTab,
       setSelectedSettingsTab,
       toasts,
+      settings,
     } = useAssistantContext();
 
     useEffect(() => {
@@ -80,6 +81,7 @@ export const AssistantSettings: React.FC<Props> = React.memo(
 
     const { data: connectors } = useLoadConnectors({
       http,
+      settings,
     });
     const {
       conversationsSettingsBulkActions,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
@@ -72,7 +72,6 @@ const testProps = {
   dataViews: mockDataViews,
   onTabChange,
   currentTab: CONNECTORS_TAB,
-  settings: {} as SettingsStart,
 };
 jest.mock('../../assistant_context');
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
@@ -24,8 +24,12 @@ import {
   QUICK_PROMPTS_TAB,
   SYSTEM_PROMPTS_TAB,
 } from './const';
-import { DataViewsContract } from '@kbn/data-views-plugin/public';
 import { SettingsStart } from '@kbn/core-ui-settings-browser';
+import type { DataViewsContract } from '@kbn/data-views-plugin/public';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
 
 const mockSetSelectedSettingsTab = jest.fn();
 
@@ -39,6 +43,19 @@ const mockContext = {
     isAssistantEnabled: true,
     isAssistantManagementEnabled: true,
     hasConnectorsAllPrivilege: true,
+  },
+  settings: {
+    client: {
+      get: jest.fn((key) => {
+        if (key === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR) {
+          return 'c5f91dc0-2197-11ee-aded-897192c5d6f5';
+        }
+        if (key === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY) {
+          return false;
+        }
+        return undefined;
+      }),
+    },
   },
   selectedSettingsTab: null,
   setSelectedSettingsTab: mockSetSelectedSettingsTab,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
@@ -24,7 +24,6 @@ import {
   QUICK_PROMPTS_TAB,
   SYSTEM_PROMPTS_TAB,
 } from './const';
-import { SettingsStart } from '@kbn/core-ui-settings-browser';
 import type { DataViewsContract } from '@kbn/data-views-plugin/public';
 import {
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
@@ -35,7 +35,6 @@ import { ManagementSettingsTabs } from './types';
 
 interface Props {
   dataViews: DataViewsContract;
-  settings: SettingsStart;
   onTabChange?: (tabId: string) => void;
   currentTab: ManagementSettingsTabs;
 }
@@ -45,7 +44,7 @@ interface Props {
  * anonymization, knowledge base, and evaluation via the `isModelEvaluationEnabled` feature flag.
  */
 export const AssistantSettingsManagement: React.FC<Props> = React.memo(
-  ({ dataViews, onTabChange, currentTab: selectedSettingsTab, settings }) => {
+  ({ dataViews, onTabChange, currentTab: selectedSettingsTab }) => {
     const {
       assistantFeatures: { assistantModelEvaluation: modelEvaluatorEnabled },
       http,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
@@ -53,6 +53,7 @@ export const AssistantSettingsManagement: React.FC<Props> = React.memo(
       setSelectedSettingsTab,
       navigateToApp,
       assistantAvailability: { isAssistantManagementEnabled },
+      settings,
     } = useAssistantContext();
 
     useEffect(() => {
@@ -65,8 +66,12 @@ export const AssistantSettingsManagement: React.FC<Props> = React.memo(
 
     const { data: connectors } = useLoadConnectors({
       http,
+      settings,
     });
-    const defaultConnector = useMemo(() => getDefaultConnector(connectors), [connectors]);
+    const defaultConnector = useMemo(
+      () => getDefaultConnector(connectors, settings),
+      [connectors, settings]
+    );
 
     const { euiTheme } = useEuiTheme();
     const headerIconShadow = useEuiShadow('s');

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
@@ -9,7 +9,6 @@ import React, { useEffect, useMemo } from 'react';
 import { EuiAvatar, EuiPageTemplate, EuiTitle, useEuiShadow, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { DataViewsContract } from '@kbn/data-views-plugin/public';
-import { SettingsStart } from '@kbn/core-ui-settings-browser';
 import * as i18n from './translations';
 import { useAssistantContext } from '../../assistant_context';
 import { useLoadConnectors } from '../../connectorland/use_load_connectors';

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/evaluation_settings/evaluation_settings.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/evaluation_settings/evaluation_settings.tsx
@@ -50,8 +50,9 @@ const AS_PLAIN_TEXT: EuiComboBoxSingleSelectionShape = { asPlainText: true };
  * Evaluation Settings -- development-only feature for evaluating models
  */
 export const EvaluationSettings: React.FC = React.memo(() => {
-  const { actionTypeRegistry, http, setTraceOptions, toasts, traceOptions } = useAssistantContext();
-  const { data: connectors } = useLoadConnectors({ http, inferenceEnabled: true });
+  const { actionTypeRegistry, http, setTraceOptions, toasts, traceOptions, settings } =
+    useAssistantContext();
+  const { data: connectors } = useLoadConnectors({ http, inferenceEnabled: true, settings });
   const { mutate: performEvaluation, isLoading: isPerformingEvaluation } = usePerformEvaluation({
     http,
     toasts,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.test.tsx
@@ -24,7 +24,6 @@ import {
   SYSTEM_PROMPTS_TAB,
 } from './const';
 import type { DataViewsContract } from '@kbn/data-views-plugin/public';
-import { SettingsStart } from '@kbn/core-ui-settings-browser';
 import {
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
@@ -64,7 +63,6 @@ const testProps = {
   dataViews: mockDataViews,
   onTabChange,
   currentTab: CONNECTORS_TAB,
-  settings: {} as SettingsStart,
 };
 jest.mock('../../assistant_context');
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.test.tsx
@@ -23,8 +23,12 @@ import {
   QUICK_PROMPTS_TAB,
   SYSTEM_PROMPTS_TAB,
 } from './const';
-import { DataViewsContract } from '@kbn/data-views-plugin/public';
+import type { DataViewsContract } from '@kbn/data-views-plugin/public';
 import { SettingsStart } from '@kbn/core-ui-settings-browser';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
 
 const mockContext = {
   basePromptContexts: MOCK_QUICK_PROMPTS,
@@ -34,6 +38,19 @@ const mockContext = {
   assistantFeatures: { assistantModelEvaluation: true },
   assistantAvailability: {
     isAssistantEnabled: true,
+  },
+  settings: {
+    client: {
+      get: jest.fn((key) => {
+        if (key === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR) {
+          return 'c5f91dc0-2197-11ee-aded-897192c5d6f5';
+        }
+        if (key === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY) {
+          return false;
+        }
+        return undefined;
+      }),
+    },
   },
 };
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.tsx
@@ -43,7 +43,6 @@ interface Props {
   dataViews: DataViewsContract;
   onTabChange?: (tabId: string) => void;
   currentTab: ManagementSettingsTabs;
-  settings: SettingsStart;
 }
 
 /**
@@ -51,7 +50,7 @@ interface Props {
  * anonymization, knowledge base, and evaluation via the `isModelEvaluationEnabled` feature flag.
  */
 export const SearchAILakeConfigurationsSettingsManagement: React.FC<Props> = React.memo(
-  ({ dataViews, onTabChange, currentTab, settings }) => {
+  ({ dataViews, onTabChange, currentTab }) => {
     const {
       assistantFeatures: { assistantModelEvaluation: modelEvaluatorEnabled },
       http,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.tsx
@@ -15,7 +15,6 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { DataViewsContract } from '@kbn/data-views-plugin/public';
-import { SettingsStart } from '@kbn/core-ui-settings-browser';
 import { AIForSOCConnectorSettingsManagement } from '../../connectorland/ai_for_soc_connector_settings_management';
 import * as i18n from './translations';
 import { useAssistantContext } from '../../assistant_context';

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.tsx
@@ -57,6 +57,7 @@ export const SearchAILakeConfigurationsSettingsManagement: React.FC<Props> = Rea
       http,
       selectedSettingsTab,
       setSelectedSettingsTab,
+      settings,
     } = useAssistantContext();
 
     useEffect(() => {
@@ -68,8 +69,12 @@ export const SearchAILakeConfigurationsSettingsManagement: React.FC<Props> = Rea
 
     const { data: connectors } = useLoadConnectors({
       http,
+      settings,
     });
-    const defaultConnector = useMemo(() => getDefaultConnector(connectors), [connectors]);
+    const defaultConnector = useMemo(
+      () => getDefaultConnector(connectors, settings),
+      [connectors, settings]
+    );
 
     const { euiTheme } = useEuiTheme();
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -22,6 +22,7 @@ import {
 } from '@kbn/core/public';
 import type { ProductDocBasePluginStart } from '@kbn/product-doc-base-plugin/public';
 import { useQuery } from '@tanstack/react-query';
+import type { SettingsStart } from '@kbn/core-ui-settings-browser';
 import { updatePromptContexts } from './helpers';
 import type {
   PromptContext,
@@ -87,6 +88,7 @@ export interface AssistantProviderProps {
   nameSpace?: string;
   navigateToApp: ApplicationStart['navigateToApp'];
   title?: string;
+  settings: SettingsStart;
   toasts?: IToasts;
   currentAppId: string;
   productDocBase: ProductDocBasePluginStart;
@@ -128,6 +130,7 @@ export interface UseAssistantContext {
   selectedSettingsTab: ModalSettingsTabs | null;
   contentReferencesVisible: boolean;
   showAnonymizedValues: boolean;
+  settings: SettingsStart;
   setShowAnonymizedValues: React.Dispatch<React.SetStateAction<boolean>>;
   setContentReferencesVisible: React.Dispatch<React.SetStateAction<boolean>>;
   setAssistantStreamingEnabled: React.Dispatch<React.SetStateAction<boolean | undefined>>;
@@ -178,6 +181,7 @@ export const useAssistantContextValue = (props: AssistantProviderProps): UseAssi
     getUrlForApp,
     http,
     inferenceEnabled = false,
+    settings,
     navigateToApp,
     nameSpace = DEFAULT_ASSISTANT_NAMESPACE,
     productDocBase,
@@ -317,6 +321,7 @@ export const useAssistantContextValue = (props: AssistantProviderProps): UseAssi
       getComments,
       getUrlForApp,
       http,
+      settings,
       inferenceEnabled,
       knowledgeBase: {
         ...DEFAULT_KNOWLEDGE_BASE_SETTINGS,
@@ -330,6 +335,7 @@ export const useAssistantContextValue = (props: AssistantProviderProps): UseAssi
       selectedSettingsTab,
       // can be undefined from localStorage, if not defined, default to true
       assistantStreamingEnabled: localStorageStreaming ?? true,
+
       setAssistantStreamingEnabled: setLocalStorageStreaming,
       setKnowledgeBase: setLocalStorageKnowledgeBase,
       contentReferencesVisible: contentReferencesVisible ?? true,
@@ -364,6 +370,7 @@ export const useAssistantContextValue = (props: AssistantProviderProps): UseAssi
       basePromptContexts,
       currentUserAvatar,
       docLinks,
+      settings,
       getComments,
       getUrlForApp,
       http,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
@@ -15,6 +15,7 @@ import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/common/openai/c
 import { euiThemeVars } from '@kbn/ui-theme';
 import { some } from 'lodash';
 import type { AttackDiscoveryStats } from '@kbn/elastic-assistant-common';
+import { GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR } from '@kbn/management-settings-ids';
 import { AttackDiscoveryStatusIndicator } from './attack_discovery_status_indicator';
 import { useLoadConnectors } from '../use_load_connectors';
 import * as i18n from '../translations';
@@ -57,7 +58,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
     setIsOpen,
     stats = null,
   }) => {
-    const { actionTypeRegistry, http, assistantAvailability, inferenceEnabled } =
+    const { actionTypeRegistry, http, assistantAvailability, inferenceEnabled, settings } =
       useAssistantContext();
     // Connector Modal State
     const [isConnectorModalVisible, setIsConnectorModalVisible] = useState<boolean>(false);
@@ -68,6 +69,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
     const { data: aiConnectors, refetch: refetchConnectors } = useLoadConnectors({
       http,
       inferenceEnabled,
+      settings,
     });
 
     const localIsDisabled = isDisabled || !assistantAvailability.hasConnectorsReadPrivilege;
@@ -185,6 +187,11 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
       [cleanupAndCloseModal, onConnectorSelectionChange, refetchConnectors]
     );
 
+    const defaultAIConnectorId = settings.client.get<string | undefined>(
+      GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+      undefined
+    );
+
     return (
       <>
         {!connectorExists && !connectorOptions.length ? (
@@ -208,7 +215,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
             isOpen={modalForceOpen}
             onChange={onChange}
             options={allConnectorOptions}
-            valueOfSelected={selectedConnectorId}
+            valueOfSelected={selectedConnectorId ?? defaultAIConnectorId}
             placeholder={i18n.INLINE_CONNECTOR_PLACEHOLDER}
             popoverProps={{ panelMinWidth: 400, anchorPosition: 'downRight' }}
           />

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_setup/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_setup/index.tsx
@@ -35,9 +35,9 @@ export const ConnectorSetup = ({
   );
   const { setApiConfig } = useConversation();
   // Access all conversations so we can add connector to all on initial setup
-  const { actionTypeRegistry, http, inferenceEnabled } = useAssistantContext();
+  const { actionTypeRegistry, http, inferenceEnabled, settings } = useAssistantContext();
 
-  const { refetch: refetchConnectors } = useLoadConnectors({ http, inferenceEnabled });
+  const { refetch: refetchConnectors } = useLoadConnectors({ http, inferenceEnabled, settings });
 
   const { data: actionTypes } = useLoadActionTypes({ http });
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/use_load_connectors/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/use_load_connectors/index.test.tsx
@@ -9,6 +9,10 @@ import { waitFor, renderHook } from '@testing-library/react';
 import { useLoadConnectors, Props } from '.';
 import { mockConnectors } from '../../mock/connectors';
 import { TestProviders } from '../../mock/test_providers/test_providers';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
 
 const mockConnectorsAndExtras = [
   ...mockConnectors,
@@ -52,7 +56,19 @@ const http = {
 const toasts = {
   addError: jest.fn(),
 };
-const defaultProps = { http, toasts } as unknown as Props;
+const settings = {
+  client: {
+    get: jest.fn().mockImplementation((settingKey) => {
+      if (settingKey === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR) {
+        return undefined;
+      }
+      if (settingKey === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY) {
+        return false;
+      }
+    }),
+  },
+};
+const defaultProps = { http, toasts, settings } as unknown as Props;
 
 describe('useLoadConnectors', () => {
   beforeEach(() => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_providers/test_providers.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_providers/test_providers.tsx
@@ -17,12 +17,10 @@ import { UserProfileService } from '@kbn/core/public';
 import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
 import { of } from 'rxjs';
 import { docLinksServiceMock } from '@kbn/core/public/mocks';
-import {
-  AssistantProvider,
-  AssistantProviderProps,
-  useAssistantContextValue,
-} from '../../assistant_context';
-import { AssistantAvailability } from '../../assistant_context/types';
+import type { SettingsStart } from '@kbn/core-ui-settings-browser';
+import type { AssistantProviderProps } from '../../assistant_context';
+import { AssistantProvider, useAssistantContextValue } from '../../assistant_context';
+import type { AssistantAvailability } from '../../assistant_context/types';
 import { AssistantSpaceIdProvider } from '../../assistant/use_space_aware_context';
 
 interface Props {
@@ -99,7 +97,12 @@ export const TestProvidersComponent: React.FC<Props> = ({
     },
     userProfileService: jest.fn() as unknown as UserProfileService,
     chrome,
-  };
+    settings: {
+      client: {
+        get: jest.fn(),
+      },
+    } as unknown as SettingsStart,
+  } as AssistantProviderProps;
 
   return (
     <I18nProvider>

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/tour/elastic_llm/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/tour/elastic_llm/index.tsx
@@ -41,7 +41,7 @@ const ElasticLLMCostAwarenessTourComponent: React.FC<Props> = ({
   zIndex,
   wrapper = true, // Whether to wrap the children in a div with padding
 }) => {
-  const { http, inferenceEnabled } = useAssistantContext();
+  const { http, inferenceEnabled, settings } = useAssistantContext();
   const { euiTheme } = useEuiTheme();
   const tourStorageKey = useTourStorageKey(storageKey);
   const [tourState, setTourState] = useLocalStorage<EISUsageCostTourState>(
@@ -72,6 +72,7 @@ const ElasticLLMCostAwarenessTourComponent: React.FC<Props> = ({
   const { data: aiConnectors } = useLoadConnectors({
     http,
     inferenceEnabled,
+    settings,
   });
   const isElasticLLMConnectorSelected = useMemo(
     () =>

--- a/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
+++ b/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
@@ -87,7 +87,7 @@ interface ConnectorStepProps {
 
 export const ConnectorStep = React.memo<ConnectorStepProps>(({ connector }) => {
   const { euiTheme } = useEuiTheme();
-  const { http, notifications, triggersActionsUi } = useKibana().services;
+  const { http, notifications, triggersActionsUi, settings } = useKibana().services;
   const { setConnector, completeStep } = useActions();
 
   const [connectors, setConnectors] = useState<AIConnector[]>();
@@ -103,7 +103,7 @@ export const ConnectorStep = React.memo<ConnectorStepProps>(({ connector }) => {
     isLoading,
     data: aiConnectors,
     refetch: refetchConnectors,
-  } = useLoadConnectors({ http, toasts: notifications.toasts, inferenceEnabled });
+  } = useLoadConnectors({ http, toasts: notifications.toasts, inferenceEnabled, settings });
 
   useEffect(() => {
     if (aiConnectors != null) {

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/mock/test_providers/test_providers.tsx
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/mock/test_providers/test_providers.tsx
@@ -20,11 +20,11 @@ import { I18nProvider } from '@kbn/i18n-react';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { EuiThemeProvider } from '@elastic/eui';
 
-import {
-  AssistantProviderProps,
-  useAssistantContextValue,
-} from '@kbn/elastic-assistant/impl/assistant_context';
-import { DataQualityProvider, DataQualityProviderProps } from '../../data_quality_context';
+import type { AssistantProviderProps } from '@kbn/elastic-assistant/impl/assistant_context';
+import { useAssistantContextValue } from '@kbn/elastic-assistant/impl/assistant_context';
+import type { SettingsStart } from '@kbn/core-ui-settings-browser';
+import type { DataQualityProviderProps } from '../../data_quality_context';
+import { DataQualityProvider } from '../../data_quality_context';
 import { ResultsRollupContext } from '../../contexts/results_rollup_context';
 import { IndicesCheckContext } from '../../contexts/indices_check_context';
 import { UseIndicesCheckReturnValue } from '../../hooks/use_indices_check/types';
@@ -98,6 +98,11 @@ const TestExternalProvidersComponent: React.FC<TestExternalProvidersProps> = ({ 
     userProfileService: jest.fn() as unknown as UserProfileService,
     getUrlForApp: jest.fn(),
     chrome,
+    settings: {
+      client: {
+        get: jest.fn(),
+      },
+    } as unknown as SettingsStart,
   };
 
   return (

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/tsconfig.json
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/tsconfig.json
@@ -24,6 +24,7 @@
     "@kbn/core-notifications-browser-mocks",
     "@kbn/core-chrome-browser-mocks",
     "@kbn/ai-assistant-icon",
-    "@kbn/react-kibana-context-render"
+    "@kbn/react-kibana-context-render",
+    "@kbn/core-ui-settings-browser"
   ]
 }

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/context/assistant_context/assistant_provider.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/context/assistant_context/assistant_provider.tsx
@@ -41,6 +41,7 @@ export function AssistantProvider({ children }: { children: React.ReactElement }
     chrome,
     productDocBase,
     elasticAssistantSharedState,
+    settings,
   } = useKibana().services;
 
   const inferenceEnabled = useInferenceEnabled();
@@ -106,6 +107,7 @@ export function AssistantProvider({ children }: { children: React.ReactElement }
     userProfileService: userProfile,
     chrome,
     getUrlForApp,
+    settings,
   });
 
   useEffect(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
@@ -24,7 +24,6 @@ export const ManagementSettings = React.memo(() => {
     data: { dataViews },
     chrome: { docTitle, setBreadcrumbs },
     serverless,
-    settings,
     docLinks,
     featureFlags,
     notifications,
@@ -111,7 +110,6 @@ export const ManagementSettings = React.memo(() => {
         featureFlags={featureFlags}
       >
         <AssistantSettingsManagement
-          settings={settings}
           dataViews={dataViews}
           onTabChange={handleTabChange}
           currentTab={currentTab}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
@@ -55,7 +55,7 @@ export const ID = 'attackDiscoveryQuery';
 
 const AttackDiscoveryPageComponent: React.FC = () => {
   const {
-    services: { uiSettings },
+    services: { uiSettings, settings },
   } = useKibana();
 
   const { attackDiscoveryAlertsEnabled } = useKibanaFeatureFlags();
@@ -64,6 +64,7 @@ const AttackDiscoveryPageComponent: React.FC = () => {
   const { data: aiConnectors } = useLoadConnectors({
     http,
     inferenceEnabled,
+    settings,
   });
 
   // for showing / hiding anonymized data:

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.tsx
@@ -58,9 +58,10 @@ export const CreateFlyout: React.FC<Props> = React.memo(({ onClose }) => {
     services: { uiSettings },
   } = useKibana();
 
-  const { alertsIndexPattern, http } = useAssistantContext();
+  const { alertsIndexPattern, http, settings } = useAssistantContext();
   const { data: aiConnectors, isLoading: isLoadingConnectors } = useLoadConnectors({
     http,
+    settings,
   });
 
   const { sourcererDataView } = useSourcererDataView();

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.tsx
@@ -73,9 +73,10 @@ export const DetailsFlyout: React.FC<Props> = React.memo(({ scheduleId, onClose 
   } = useKibana();
   const { euiTheme } = useEuiTheme();
 
-  const { alertsIndexPattern, http } = useAssistantContext();
+  const { alertsIndexPattern, http, settings } = useAssistantContext();
   const { data: aiConnectors, isLoading: isLoadingConnectors } = useLoadConnectors({
     http,
+    settings,
   });
   const { data: { schedule } = { schedule: undefined }, isLoading: isLoadingSchedule } =
     useGetAttackDiscoverySchedule({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
@@ -74,9 +74,12 @@ export const useAttackDiscovery = ({
   const {
     http,
     notifications: { toasts },
+    settings,
   } = useKibana().services;
+
   const { data: aiConnectors } = useLoadConnectors({
     http,
+    settings,
   });
 
   // generation can take a long time, so we calculate an approximate future time:

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_assistant_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_assistant_provider.tsx
@@ -15,6 +15,7 @@ import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
 import { of } from 'rxjs';
 import { useAssistantContextValue } from '@kbn/elastic-assistant/impl/assistant_context';
 import { docLinksServiceMock } from '@kbn/core/public/mocks';
+import type { SettingsStart } from '@kbn/core-ui-settings-browser';
 
 interface Props {
   assistantAvailability?: AssistantAvailability;
@@ -69,6 +70,11 @@ export const MockAssistantProviderComponent: React.FC<Props> = ({
     userProfileService: mockUserProfileService,
     chrome,
     getUrlForApp: jest.fn(),
+    settings: {
+      client: {
+        get: jest.fn(),
+      },
+    } as unknown as SettingsStart,
   });
 
   return <AssistantProvider value={assistantContextValue}>{children}</AssistantProvider>;

--- a/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/ai_settings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/ai_settings.tsx
@@ -23,7 +23,6 @@ export const AISettings: React.FC = () => {
   const {
     application,
     data: { dataViews },
-    settings,
     docLinks,
     notifications: { toasts },
     featureFlags,
@@ -66,7 +65,6 @@ export const AISettings: React.FC = () => {
           dataViews={dataViews}
           onTabChange={onTabChange}
           currentTab={currentTab}
-          settings={settings}
         />
       </DefaultAiConnectorSettingsContextProvider>
     </AssistantSpaceIdProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_scan.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_scan.tsx
@@ -40,9 +40,10 @@ export const WorkflowInsightsScanSection = ({
   const CONNECTOR_ID_LOCAL_STORAGE_KEY = 'connectorId';
 
   const spaceId = useSpaceId() ?? 'default';
-  const { http } = useKibana().services;
+  const { http, settings } = useKibana().services;
   const { data: aiConnectors } = useLoadConnectors({
     http,
+    settings,
   });
   const { canWriteWorkflowInsights } = useUserPrivileges().endpointPrivileges;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/assistant/assistant_card.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/assistant/assistant_card.tsx
@@ -46,14 +46,19 @@ export const AssistantCard: OnboardingCardComponent<AssistantCardMetadata> = ({
 
   const [selectedConnectorId, setSelectedConnectorId] = useStoredAssistantConnectorId(spaceId);
 
-  const defaultConnector = useMemo(() => getDefaultConnector(connectors), [connectors]);
-
-  const { setApiConfig } = useConversation();
-
   const {
     http,
     assistantAvailability: { isAssistantEnabled },
+    settings,
   } = useAssistantContext();
+
+  const defaultConnector = useMemo(
+    () => getDefaultConnector(connectors, settings),
+    [connectors, settings]
+  );
+
+  const { setApiConfig } = useConversation();
+
   const { getLastConversation, setLastConversation } = useAssistantLastConversation({ spaceId });
   const {
     allSystemPrompts,

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -260,5 +260,6 @@
     "@kbn/elastic-assistant-shared-state-plugin",
     "@kbn/core-metrics-server",
     "@kbn/ai-assistant-default-llm-setting",
+    "@kbn/core-ui-settings-browser",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] [GenAi] Use default LLM setting for security GenAi features (#234480)](https://github.com/elastic/kibana/pull/234480)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kenneth Kreindler","email":"42113355+KDKHD@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-09-25T10:14:26Z","message":"[Security Solution] [GenAi] Use default LLM setting for security GenAi features (#234480)\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\nThis PR integrates the new [default LLM\nsetting](https://github.com/elastic/kibana/pull/231940) with the\nsecurity solution GenAI features (AI assistant and Attack discovery).\nThe default LLM setting allows admins to configure the preferred AI\nconnector. This PR make sure that this setting is actually respected in\nthe AI assistant and Attack discovery.\n\n### How to test: \n- Start Kibana locally from this branch\n- Make sure you have at least 3 LLM connectors configured (can be\npreconfigured ones).\n- Go to stack management > advanced settings and switch the following\nsetting to \"Security AI assistant in other apps\". (This will make\ntesting a little bit easier)\n<img width=\"1954\" height=\"133\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/12fc4313-b2a5-45f7-bca9-8e0e7ee7f19e\"\n/>\n\n- Enable the feature flag by adding the following to kibana.dev.yml: \n\n```\nfeature_flags.overrides.aiAssistant.defaultLlmSettingEnabled: true\n```\n\n- Go to the GenAi Settings page:\nhttp://localhost:5601/app/management/ai/genAiSettings\n- Select a default LLM:\n\n<img width=\"2524\" height=\"775\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d8c51f46-04d2-42bf-871b-735fa3849d30\"\n/>\n\n- Save the setting change using the footer at the bottom of the page.\n- Open the Security AI assistant (if you changed the Assistant\nvisibility setting, you can open the assistant from the GenAi page\ndirectly)\n- Check that the LLM connector for the conversation is the one you\nconfigured as the default LLM. Also, verify that you can still change\nthe connector used in your conversation to one of your other connectors.\n- Change the LLM to a non-default connector for the conversation.\n- Once you select a non-default connector, chat with the assistant and\nthen start a new conversation, your non-default connector should still\nbe active for the new conversation.\n- Now back on the GenAi settings page, check the `Disallow all other\nconnectors` checkbox.\n- Open the AI assistant again and go to the existing conversation that\nhas a few messages inside.\n- You should see a red banner indicating that a connector needs to be\nselected.\n- If you open the connector selector, you should now only see the\ndefault LLM you have configured as an option.\n\n#### Attack Discovery\nIn attack discovery, you should observe the same behavior.\n\n- Go to attack discovery\nhttp://localhost:5601/app/security/attack_discovery\n- Open the manual run config flyout\n<img width=\"3081\" height=\"1184\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a5a11f1e-8b0b-40d9-8937-6fe4497cbf10\"\n/>\n\n- Verify that only the default LLM is available as the connector:\n\n<img width=\"1698\" height=\"833\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/45b68d6c-6f36-487f-ba08-030f41c10545\"\n/>\n\n- Go back to the GenAi settings page\nhttp://localhost:5601/app/management/ai/genAiSettings and deselect the\n`Disallow all other connectors` checkbox and select a different default\nconnector.\n- Go to Attack Discovery and open the manual run config flyout again.\n- Check that by default, your new default connector is used. Also,\nverify that you now again have the option of changing the connector to\nany of the other configured connectors.\n\n### TODO\nThe designs of the connector selector for Attack discovery and the\nAssistant still need to be implemented. That will be done in a separate\nPR.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for feaures that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [X] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b543b8c8fbb0527bd704984946bc240af8104bc2","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Security Generative AI","backport:version","v9.2.0","v9.1.4","v9.0.7","v8.18.7","v8.19.4"],"title":"[Security Solution] [GenAi] Use default LLM setting for security GenAi features","number":234480,"url":"https://github.com/elastic/kibana/pull/234480","mergeCommit":{"message":"[Security Solution] [GenAi] Use default LLM setting for security GenAi features (#234480)\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\nThis PR integrates the new [default LLM\nsetting](https://github.com/elastic/kibana/pull/231940) with the\nsecurity solution GenAI features (AI assistant and Attack discovery).\nThe default LLM setting allows admins to configure the preferred AI\nconnector. This PR make sure that this setting is actually respected in\nthe AI assistant and Attack discovery.\n\n### How to test: \n- Start Kibana locally from this branch\n- Make sure you have at least 3 LLM connectors configured (can be\npreconfigured ones).\n- Go to stack management > advanced settings and switch the following\nsetting to \"Security AI assistant in other apps\". (This will make\ntesting a little bit easier)\n<img width=\"1954\" height=\"133\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/12fc4313-b2a5-45f7-bca9-8e0e7ee7f19e\"\n/>\n\n- Enable the feature flag by adding the following to kibana.dev.yml: \n\n```\nfeature_flags.overrides.aiAssistant.defaultLlmSettingEnabled: true\n```\n\n- Go to the GenAi Settings page:\nhttp://localhost:5601/app/management/ai/genAiSettings\n- Select a default LLM:\n\n<img width=\"2524\" height=\"775\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d8c51f46-04d2-42bf-871b-735fa3849d30\"\n/>\n\n- Save the setting change using the footer at the bottom of the page.\n- Open the Security AI assistant (if you changed the Assistant\nvisibility setting, you can open the assistant from the GenAi page\ndirectly)\n- Check that the LLM connector for the conversation is the one you\nconfigured as the default LLM. Also, verify that you can still change\nthe connector used in your conversation to one of your other connectors.\n- Change the LLM to a non-default connector for the conversation.\n- Once you select a non-default connector, chat with the assistant and\nthen start a new conversation, your non-default connector should still\nbe active for the new conversation.\n- Now back on the GenAi settings page, check the `Disallow all other\nconnectors` checkbox.\n- Open the AI assistant again and go to the existing conversation that\nhas a few messages inside.\n- You should see a red banner indicating that a connector needs to be\nselected.\n- If you open the connector selector, you should now only see the\ndefault LLM you have configured as an option.\n\n#### Attack Discovery\nIn attack discovery, you should observe the same behavior.\n\n- Go to attack discovery\nhttp://localhost:5601/app/security/attack_discovery\n- Open the manual run config flyout\n<img width=\"3081\" height=\"1184\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a5a11f1e-8b0b-40d9-8937-6fe4497cbf10\"\n/>\n\n- Verify that only the default LLM is available as the connector:\n\n<img width=\"1698\" height=\"833\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/45b68d6c-6f36-487f-ba08-030f41c10545\"\n/>\n\n- Go back to the GenAi settings page\nhttp://localhost:5601/app/management/ai/genAiSettings and deselect the\n`Disallow all other connectors` checkbox and select a different default\nconnector.\n- Go to Attack Discovery and open the manual run config flyout again.\n- Check that by default, your new default connector is used. Also,\nverify that you now again have the option of changing the connector to\nany of the other configured connectors.\n\n### TODO\nThe designs of the connector selector for Attack discovery and the\nAssistant still need to be implemented. That will be done in a separate\nPR.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for feaures that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [X] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b543b8c8fbb0527bd704984946bc240af8104bc2"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/234480","number":234480,"mergeCommit":{"message":"[Security Solution] [GenAi] Use default LLM setting for security GenAi features (#234480)\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\nThis PR integrates the new [default LLM\nsetting](https://github.com/elastic/kibana/pull/231940) with the\nsecurity solution GenAI features (AI assistant and Attack discovery).\nThe default LLM setting allows admins to configure the preferred AI\nconnector. This PR make sure that this setting is actually respected in\nthe AI assistant and Attack discovery.\n\n### How to test: \n- Start Kibana locally from this branch\n- Make sure you have at least 3 LLM connectors configured (can be\npreconfigured ones).\n- Go to stack management > advanced settings and switch the following\nsetting to \"Security AI assistant in other apps\". (This will make\ntesting a little bit easier)\n<img width=\"1954\" height=\"133\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/12fc4313-b2a5-45f7-bca9-8e0e7ee7f19e\"\n/>\n\n- Enable the feature flag by adding the following to kibana.dev.yml: \n\n```\nfeature_flags.overrides.aiAssistant.defaultLlmSettingEnabled: true\n```\n\n- Go to the GenAi Settings page:\nhttp://localhost:5601/app/management/ai/genAiSettings\n- Select a default LLM:\n\n<img width=\"2524\" height=\"775\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d8c51f46-04d2-42bf-871b-735fa3849d30\"\n/>\n\n- Save the setting change using the footer at the bottom of the page.\n- Open the Security AI assistant (if you changed the Assistant\nvisibility setting, you can open the assistant from the GenAi page\ndirectly)\n- Check that the LLM connector for the conversation is the one you\nconfigured as the default LLM. Also, verify that you can still change\nthe connector used in your conversation to one of your other connectors.\n- Change the LLM to a non-default connector for the conversation.\n- Once you select a non-default connector, chat with the assistant and\nthen start a new conversation, your non-default connector should still\nbe active for the new conversation.\n- Now back on the GenAi settings page, check the `Disallow all other\nconnectors` checkbox.\n- Open the AI assistant again and go to the existing conversation that\nhas a few messages inside.\n- You should see a red banner indicating that a connector needs to be\nselected.\n- If you open the connector selector, you should now only see the\ndefault LLM you have configured as an option.\n\n#### Attack Discovery\nIn attack discovery, you should observe the same behavior.\n\n- Go to attack discovery\nhttp://localhost:5601/app/security/attack_discovery\n- Open the manual run config flyout\n<img width=\"3081\" height=\"1184\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a5a11f1e-8b0b-40d9-8937-6fe4497cbf10\"\n/>\n\n- Verify that only the default LLM is available as the connector:\n\n<img width=\"1698\" height=\"833\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/45b68d6c-6f36-487f-ba08-030f41c10545\"\n/>\n\n- Go back to the GenAi settings page\nhttp://localhost:5601/app/management/ai/genAiSettings and deselect the\n`Disallow all other connectors` checkbox and select a different default\nconnector.\n- Go to Attack Discovery and open the manual run config flyout again.\n- Check that by default, your new default connector is used. Also,\nverify that you now again have the option of changing the connector to\nany of the other configured connectors.\n\n### TODO\nThe designs of the connector selector for Attack discovery and the\nAssistant still need to be implemented. That will be done in a separate\nPR.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for feaures that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [X] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b543b8c8fbb0527bd704984946bc240af8104bc2"}},{"branch":"9.1","label":"v9.1.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/236461","number":236461,"state":"OPEN"},{"branch":"9.0","label":"v9.0.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->