### PR TITLE
[@kbn/config-schema] Schema `input` type with chained `default`s

### DIFF
--- a/src/core/packages/plugins/server-internal/src/plugins_config.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_config.ts
@@ -8,7 +8,7 @@
  */
 
 import type { TypeOf } from '@kbn/config-schema';
-import { schema, type Type } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
 import { get } from 'lodash';
 import type { Env } from '@kbn/config';
 import type { ServiceConfigDescriptor } from '@kbn/core-base-server-internal';
@@ -27,15 +27,7 @@ const configSchema = schema.object({
    * Defines an array of groups to include when loading plugins.
    * Plugins from all groups will be taken into account if the parameter is not provided.
    */
-  allowlistPluginGroups: schema.maybe(
-    schema.arrayOf(
-      schema.oneOf(
-        KIBANA_GROUPS.map((groupName) => schema.literal(groupName)) as [
-          Type<KibanaGroup> // This cast is needed because it's different to Type<T>[] :sight:
-        ]
-      )
-    )
-  ),
+  allowlistPluginGroups: schema.maybe(schema.arrayOf(schema.enum<KibanaGroup>(KIBANA_GROUPS))),
   /**
    * Internal config, not intended to be used by end users. Only for specific
    * internal purposes.

--- a/src/core/packages/root/server-internal/src/root/serverless_config.ts
+++ b/src/core/packages/root/server-internal/src/root/serverless_config.ts
@@ -8,7 +8,7 @@
  */
 
 import type { TypeOf } from '@kbn/config-schema';
-import { schema, type Type } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
 import type { ServiceConfigDescriptor } from '@kbn/core-base-server-internal';
 import { KIBANA_PROJECTS, type KibanaProject } from '@kbn/projects-solutions-groups';
 
@@ -20,13 +20,7 @@ import { KIBANA_PROJECTS, type KibanaProject } from '@kbn/projects-solutions-gro
 // BWC can be ensured by adding the object definition as another alternative to `schema.oneOf`.
 
 // BOOKMARK - List of Kibana project types
-const serverlessConfigSchema = schema.maybe(
-  schema.oneOf(
-    KIBANA_PROJECTS.map((projectName) => schema.literal(projectName)) as [
-      Type<KibanaProject> // This cast is needed because it's different to Type<T>[] :sight:
-    ]
-  )
-);
+const serverlessConfigSchema = schema.maybe(schema.enum<KibanaProject>(KIBANA_PROJECTS));
 
 export type ServerlessConfigType = TypeOf<typeof serverlessConfigSchema>;
 

--- a/src/platform/packages/shared/kbn-config-schema/README.md
+++ b/src/platform/packages/shared/kbn-config-schema/README.md
@@ -69,7 +69,7 @@ Every schema instance has a `validate` method that is used to perform a validati
 ```typescript
 const valueSchema = schema.object({
   isEnabled: schema.boolean(),
-  env: schema.string({ defaultValue: schema.contextRef('envName') }),
+  env: schema.string().default(schema.contextRef('envName')),
 });
 
 expect(valueSchema.validate({ isEnabled: true, env: 'prod' })).toEqual({
@@ -159,7 +159,7 @@ __Options:__
 
 __Usage:__
 ```typescript
-const valueSchema = schema.boolean({ defaultValue: false });
+const valueSchema = schema.boolean().default(false);
 ```
 
 __Notes:__
@@ -196,7 +196,7 @@ __Options:__
 
 __Usage:__
 ```typescript
-const valueSchema = schema.buffer({ defaultValue: Buffer.from('Hi, there!') });
+const valueSchema = schema.buffer().default(Buffer.from('Hi, there!'));
 ```
 
 ### `schema.stream()`
@@ -211,7 +211,7 @@ __Options:__
 
 __Usage:__
 ```typescript
-const valueSchema = schema.stream({ defaultValue: new Stream() });
+const valueSchema = schema.stream().default(new Stream());
 ```
 
 ## Composite types
@@ -251,7 +251,7 @@ __Options:__
 __Usage:__
 ```typescript
 const valueSchema = schema.object({
-  isEnabled: schema.boolean({ defaultValue: false }),
+  isEnabled: schema.boolean().default(false),
   name: schema.string({ minLength: 10 }),
 });
 ```
@@ -307,7 +307,7 @@ __Notes:__
 
 ### `schema.intersection()` / `schema.allOf()`
 
-Creates an `object` schema being the intersection of the provided `object` schemas. 
+Creates an `object` schema being the intersection of the provided `object` schemas.
 Note that schema construction will throw an error if some of the intersection schema share the same key(s).
 
 See the documentation for [schema.object](#schemaobject).
@@ -463,7 +463,7 @@ __Options:__
 
 __Usage:__
 ```typescript
-const valueSchema = schema.duration({ defaultValue: '70ms' });
+const valueSchema = schema.duration().default('70ms');
 ```
 
 __Notes:__
@@ -554,7 +554,7 @@ __Output type:__ `TReferenceValue`
 __Usage:__
 ```typescript
 const valueSchema = schema.object({
-  env: schema.string({ defaultValue: schema.contextRef('envName') }),
+  env: schema.string().default(schema.contextRef('envName')),
 });
 valueSchema.validate({}, { envName: 'dev' });
 ```
@@ -573,7 +573,7 @@ __Usage:__
 ```typescript
 const valueSchema = schema.object({
   node: schema.object({ tag: schema.string() }),
-  env: schema.string({ defaultValue: schema.siblingRef('node.tag') }),
+  env: schema.string().default(schema.siblingRef('node.tag')),
 });
 ```
 
@@ -628,9 +628,9 @@ deal with "defined or undefined"-like checks all over the place in your code. Yo
 * function that is invoked at the validation time and returns a plain value
 
 ```typescript
-const valueSchemaWithPlainValueDefault = schema.string({ defaultValue: 'n/a' });
-const valueSchemaWithReferencedValueDefault = schema.string({ defaultValue: schema.contextRef('env') });
-const valueSchemaWithFunctionEvaluatedDefault = schema.string({ defaultValue: () => Math.random().toString() });
+const valueSchemaWithPlainValueDefault = schema.string().default('n/a');
+const valueSchemaWithReferencedValueDefault = schema.string().default(schema.contextRef('env'));
+const valueSchemaWithFunctionEvaluatedDefault = schema.string().default(() => Math.random().toString());
 ```
 
 __Notes:__

--- a/src/platform/packages/shared/kbn-config-schema/deprecated.ts
+++ b/src/platform/packages/shared/kbn-config-schema/deprecated.ts
@@ -7,6 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Reference } from './reference';
+import type { SomeObjectType } from './src/types/object_type';
+import type { SchemaOf } from './src/types/schema_of';
 
-export class SiblingReference<T = any> extends Reference<T> {}
+/**
+ * @deprecated Use `SomeObjectType` instead.
+ */
+export type ObjectType = SomeObjectType;
+/**
+ * @deprecated Use `SchemaOf` instead.
+ */
+export type Type<T> = SchemaOf<T>;

--- a/src/platform/packages/shared/kbn-config-schema/deprecated.ts
+++ b/src/platform/packages/shared/kbn-config-schema/deprecated.ts
@@ -8,13 +8,14 @@
  */
 
 import type { SomeObjectType } from './src/types/object_type';
-import type { SchemaOf } from './src/types/schema_of';
+import type { SchemaOf } from './src/helpers/types/schema_of';
 
 /**
  * @deprecated Use `SomeObjectType` instead.
  */
 export type ObjectType = SomeObjectType;
+
 /**
  * @deprecated Use `SchemaOf` instead.
  */
-export type Type<T> = SchemaOf<T>;
+export type Type<T> = SchemaOf<T, any>;

--- a/src/platform/packages/shared/kbn-config-schema/index.ts
+++ b/src/platform/packages/shared/kbn-config-schema/index.ts
@@ -170,8 +170,8 @@ function maybe<T extends SomeType>(
  *
  * @note wrapping with `nullable` ignores the `defaultValue` from the `type` when validating.
  */
-function nullable<T extends SomeType>(type: T): Type<T['_output'] | null, T['_input'] | null> {
-  return union([type, literal(null)], { defaultValue: null });
+function nullable<T extends SomeType>(type: T) {
+  return union([type, literal(null)]).default(null);
 }
 
 function object<P extends ObjectProps>(

--- a/src/platform/packages/shared/kbn-config-schema/index.ts
+++ b/src/platform/packages/shared/kbn-config-schema/index.ts
@@ -20,7 +20,6 @@ import type {
   MapOfOptions,
   NumberOptions,
   ObjectTypeOptions,
-  PreciseObjectProps,
   RecordOfOptions,
   StringOptions,
   TypeOptions,
@@ -51,76 +50,51 @@ import {
   StreamType,
   Lazy,
 } from './src/types';
-import type { DurationDefaultValue } from './src/types/duration_type';
-import type { ByteSizeValueType } from './src/types/byte_size_type';
 
-import type { DefaultValue, SomeType } from './src/types/type';
-import type { ObjectInputType, ObjectOutputType, SomeObjectType } from './src/types/object_type';
+import type { SomeType } from './src/types/type';
+import type {
+  ObjectInputType,
+  ObjectOutputType,
+  ObjectProps,
+  SomeObjectType,
+} from './src/types/object_type';
 import type { IntersectionInput, IntersectionOutput } from './src/types/intersection_type';
 
-export type { SomeType, SomeObjectType };
-export type { SchemaOf, TypeOf, TypeOfOutput, TypeOfInput } from './src/types';
+// bucket export to avoid naming collisions
+export type * from './deprecated';
+
+export type { SomeType, SomeObjectType, ObjectProps };
+export type { SchemaOf, TypeOf, TypeOfOutput, TypeOfInput } from './src/helpers/types';
 export { ByteSizeValue } from './src/byte_size_value';
 export { SchemaTypeError, ValidationError } from './src/errors';
 export { isConfigSchema } from './src/typeguards';
 export { offeringBasedSchema } from './src/helpers';
 
-// bucket export to avoid naming collisions
-export type * from './deprecated';
-
-/**
- * Used to define props to pass to `schema.object`.
- *
- * @note should *only* be used with `satisfies` to ensure the correct type is inferred.
- *
- * @example
- * ```ts
- * const mySchemaProps = {
- *   name: schema.string(),
- *   age: schema.number(),
- * } satisfies ObjectProps;
- * const mySchema = schema.object(mySchemaProps);
- * ```
- */
-export type ObjectProps = PreciseObjectProps;
-
-function any<D extends DefaultValue<any> = never>(
-  options?: TypeOptions<any, any, D>
-): Type<any, any, D> {
+function any(options?: TypeOptions<any>): Type<any> {
   return new AnyType(options);
 }
 
-function boolean<D extends DefaultValue<boolean> = never>(
-  options?: TypeOptions<boolean, boolean, D>
-): Type<boolean, boolean, D> {
+function boolean(options?: TypeOptions<boolean>): BooleanType {
   return new BooleanType(options);
 }
 
-function buffer<D extends DefaultValue<Buffer> = never>(
-  options?: TypeOptions<Buffer, Buffer, D>
-): Type<Buffer, Buffer, D> {
+function buffer(options?: TypeOptions<Buffer>): Type<Buffer> {
   return new BufferType(options);
 }
 
-function stream<D extends DefaultValue<Stream> = never>(
-  options?: TypeOptions<Stream, Stream, D>
-): Type<Stream, Stream, D> {
+function stream(options?: TypeOptions<Stream>): Type<Stream> {
   return new StreamType(options);
 }
 
-function string<D extends DefaultValue<string> = never>(
-  options?: StringOptions<D>
-): Type<string, string, D> {
+function string(options?: StringOptions): Type<string> {
   return new StringType(options);
 }
 
-function uri<D extends DefaultValue<string> = never>(
-  options?: URIOptions<D>
-): Type<string, string, D> {
+function uri(options?: URIOptions): Type<string> {
   return new URIType(options);
 }
 
-function literal<T extends string | number | boolean | null>(value: T): Type<T, T, never> {
+function literal<T extends string | number | boolean | null>(value: T): LiteralType<T> {
   return new LiteralType(value);
 }
 
@@ -142,49 +116,41 @@ function literal<T extends string | number | boolean | null>(value: T): Type<T, 
  * const myEnumType = schema.enum(status);
  * ```
  */
-function enumeration<U extends string, D extends DefaultValue<U> = never>(
+function enumeration<U extends string>(
   enumObj: Record<string, U>,
-  options?: TypeOptions<U, U, D>
-): Type<U, U, D>;
-function enumeration<U extends string, D extends DefaultValue<U> = never>(
+  options?: TypeOptions<U>
+): Type<U>;
+function enumeration<U extends string>(
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   values: [U, ...U[]] | readonly [U, ...U[]] | U[] | readonly U[],
-  options?: TypeOptions<U, U, D>
-): Type<U, U, D>;
-function enumeration<U extends string, D extends DefaultValue<U> = never>(
+  options?: TypeOptions<U>
+): Type<U>;
+function enumeration<U extends string>(
   enumObj: Record<string, U> | U[],
-  options?: TypeOptions<U, U, D>
-): Type<U, U, D> {
+  options?: TypeOptions<U>
+): Type<U> {
   const values = Array.isArray(enumObj) ? enumObj : Object.values(enumObj);
   const literalTypes = values.map((value) => literal(value)) as any;
   return union(literalTypes, options);
 }
 
-function number<D extends DefaultValue<number> = never>(
-  options?: NumberOptions<D>
-): Type<number, number, D> {
+function number(options?: NumberOptions): Type<number> {
   return new NumberType(options);
 }
 
-function byteSize<D extends ByteSizeValueType = never>(
-  options?: ByteSizeOptions<D>
-): Type<ByteSizeValue, ByteSizeValue, [D] extends [never] ? never : ByteSizeValue> {
+function byteSize(options?: ByteSizeOptions): ByteSizeType {
   return new ByteSizeType(options);
 }
 
-function duration<D extends DurationDefaultValue = never>(
-  options?: DurationOptions<D>
-): Type<Duration, Duration, [D] extends [never] ? never : Duration> {
+function duration(options?: DurationOptions): DurationType {
   return new DurationType(options);
 }
 
-function never(): Type<never, never, never> {
+function never(): Type<never> {
   return new NeverType();
 }
 
-function ip<D extends DefaultValue<string> = never>(
-  options?: IpOptions<D>
-): Type<string, string, D> {
+function ip(options?: IpOptions): Type<string> {
   return new IpType(options);
 }
 
@@ -195,7 +161,7 @@ function ip<D extends DefaultValue<string> = never>(
  */
 function maybe<T extends SomeType>(
   type: T
-): Type<T['_output'] | undefined, T['_input'] | undefined, any> {
+): Type<T['_output'] | undefined, T['_input'] | undefined> {
   return new MaybeType(type);
 }
 
@@ -204,52 +170,44 @@ function maybe<T extends SomeType>(
  *
  * @note wrapping with `nullable` ignores the `defaultValue` from the `type` when validating.
  */
-function nullable<T extends SomeType>(type: T) {
+function nullable<T extends SomeType>(type: T): Type<T['_output'] | null, T['_input'] | null> {
   return union([type, literal(null)], { defaultValue: null });
 }
 
-function object<
-  T extends SomeObjectType,
-  P extends T['props'], // must derive props from general type to infer precise types
-  D extends DefaultValue<ObjectInputType<P>> = never
->(
+function object<P extends ObjectProps>(
   props: P,
-  options?: ObjectTypeOptions<ObjectOutputType<P>, ObjectInputType<P>, D>
-): ObjectType<P, ObjectOutputType<P>, ObjectInputType<P>, D> {
+  options?: ObjectTypeOptions<ObjectOutputType<P>, ObjectInputType<P>>
+): ObjectType<P, ObjectOutputType<P>, ObjectInputType<P>> {
   return new ObjectType(props, options);
 }
 
-function arrayOf<T extends SomeType, D extends DefaultValue<T['_input'][]> = never>(
+function arrayOf<T extends SomeType>(
   itemType: T,
-  options?: ArrayOptions<T, D>
-): Type<T['_output'][], T['_input'][], D> {
+  options?: ArrayOptions<T>
+): Type<T['_output'][], T['_input'][]> {
   return new ArrayType(itemType, options);
 }
 
-function mapOf<K, T extends SomeType, D extends DefaultValue<Map<K, T['_input']>> = never>(
+function mapOf<K, T extends SomeType>(
   keyType: Type<K>,
   valueType: T,
-  options?: MapOfOptions<K, T, D>
-): Type<Map<K, T['_output']>, Map<K, T['_input']>, D> {
+  options?: MapOfOptions<K, T>
+): Type<Map<K, T['_output']>, Map<K, T['_input']>> {
   return new MapOfType(keyType, valueType, options);
 }
 
-function recordOf<
-  K extends string,
-  T extends SomeType,
-  D extends DefaultValue<Record<K, T['_input']>> = never
->(
+function recordOf<K extends string, T extends SomeType>(
   keyType: Type<K>,
   valueType: T,
-  options?: RecordOfOptions<K, T['_input'], D>
-): Type<Record<K, T['_output']>, Record<K, T['_input']>, D> {
+  options?: RecordOfOptions<K, T['_input']>
+): Type<Record<K, T['_output']>, Record<K, T['_input']>> {
   return new RecordOfType(keyType, valueType, options);
 }
 
-function union<
-  T extends Readonly<[SomeType, ...SomeType[]]>,
-  D extends DefaultValue<T[number]['_input']> = never
->(types: T, options?: UnionTypeOptions<T, D>): Type<T[number]['_output'], T[number]['_input'], D> {
+function union<T extends Readonly<[SomeType, ...SomeType[]]>>(
+  types: T,
+  options?: UnionTypeOptions<T>
+): Type<T[number]['_output'], T[number]['_input']> {
   return new UnionType(types, options);
 }
 
@@ -268,44 +226,33 @@ function intersection<
   T1 extends SomeObjectType,
   T2 extends SomeObjectType,
   T3 extends SomeObjectType,
-  T4 extends SomeObjectType,
-  D extends DefaultValue<T1['_input'] & T2['_input'] & T3['_input'] & T4['_input']> = never
+  T4 extends SomeObjectType
 >(
   types: [T1, T2, T3, T4],
   options?: ObjectTypeOptions<
     T1['_output'] & T2['_output'] & T3['_output'] & T4['_output'],
-    T1['_input'] & T2['_input'] & T3['_input'] & T4['_input'],
-    D
+    T1['_input'] & T2['_input'] & T3['_input'] & T4['_input']
   >
-): IntersectionType<[T1, T2, T3, T4], D>;
+): IntersectionType<[T1, T2, T3, T4]>;
 function intersection<
   T1 extends SomeObjectType,
   T2 extends SomeObjectType,
-  T3 extends SomeObjectType,
-  D extends DefaultValue<T1['_input'] & T2['_input'] & T3['_input']> = never
+  T3 extends SomeObjectType
 >(
   types: [T1, T2, T3],
   options?: ObjectTypeOptions<
     T1['_output'] & T2['_output'] & T3['_output'],
-    T1['_input'] & T2['_input'] & T3['_input'],
-    D
+    T1['_input'] & T2['_input'] & T3['_input']
   >
-): IntersectionType<[T1, T2, T3], D>;
-function intersection<
-  T1 extends SomeObjectType,
-  T2 extends SomeObjectType,
-  D extends DefaultValue<T1['_input'] & T2['_input']> = never
->(
+): IntersectionType<[T1, T2, T3]>;
+function intersection<T1 extends SomeObjectType, T2 extends SomeObjectType>(
   types: [T1, T2],
-  options?: ObjectTypeOptions<T1['_output'] & T2['_output'], T1['_input'] & T2['_input'], D>
-): IntersectionType<[T1, T2], D>;
-function intersection<
-  T extends Readonly<[SomeObjectType, ...SomeObjectType[]]>,
-  D extends DefaultValue<IntersectionInput<T>> = never
->(
+  options?: ObjectTypeOptions<T1['_output'] & T2['_output'], T1['_input'] & T2['_input']>
+): IntersectionType<[T1, T2]>;
+function intersection<T extends Readonly<[SomeObjectType, ...SomeObjectType[]]>>(
   types: T,
-  options?: ObjectTypeOptions<IntersectionOutput<T>, IntersectionInput<T>, D>
-): IntersectionType<T, D> {
+  options?: ObjectTypeOptions<IntersectionOutput<T>, IntersectionInput<T>>
+): IntersectionType<T> {
   return new IntersectionType(types, options);
 }
 
@@ -317,25 +264,20 @@ function siblingRef<T = any>(key: string): SiblingReference<T> {
   return new SiblingReference(key);
 }
 
-function conditional<
-  T extends ConditionalTypeValue,
-  A extends SomeType,
-  B extends SomeType,
-  D extends DefaultValue<A['_input'] | B['_input']> = never
->(
+function conditional<T extends ConditionalTypeValue, A extends SomeType, B extends SomeType>(
   leftOperand: Reference<T>,
   rightOperand: Reference<T> | T | Type<unknown>,
   equalType: A,
   notEqualType: B,
-  options?: ConditionalTypeOptions<A, B, D>
-): Type<A['_output'] | B['_output'], A['_input'] | B['_input'], D> {
+  options?: ConditionalTypeOptions<A, B>
+): Type<A['_output'] | B['_output'], A['_input'] | B['_input']> {
   return new ConditionalType(leftOperand, rightOperand, equalType, notEqualType, options);
 }
 
 /**
  * Useful for creating recursive schemas.
  */
-function lazy<T>(id: string): Type<T, T> {
+function lazy<T>(id: string): Type<T> {
   return new Lazy<T>(id);
 }
 
@@ -381,8 +323,6 @@ import {
   META_FIELD_X_OAS_GET_ADDITIONAL_PROPERTIES,
 } from './src/oas_meta_fields';
 import type { ConditionalTypeOptions } from './src/types/conditional_type';
-import type { ByteSizeValue } from './src/byte_size_value';
-import type { Duration } from './src/duration';
 
 export const metaFields = Object.freeze({
   META_FIELD_X_OAS_DISCONTINUED,

--- a/src/platform/packages/shared/kbn-config-schema/src/duration/index.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/duration/index.ts
@@ -40,7 +40,7 @@ function stringToDuration(text: string): Duration {
   return duration;
 }
 
-function numberToDuration(numberMs: number) {
+function numberToDuration(numberMs: number): Duration {
   if (!Number.isSafeInteger(numberMs) || numberMs < 0) {
     throw new Error(`Value in milliseconds is expected to be a safe positive integer.`);
   }
@@ -48,7 +48,7 @@ function numberToDuration(numberMs: number) {
   return momentDuration(numberMs);
 }
 
-export function ensureDuration(value: Duration | string | number) {
+export function ensureDuration(value: Duration | string | number): Duration {
   if (typeof value === 'string') {
     return stringToDuration(value);
   }

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/offering_based_schema.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/offering_based_schema.test.ts
@@ -218,6 +218,17 @@ describe('Helper: offeringBasedSchema()', () => {
     expectType<boolean>(testSchema._output);
     expectType<boolean | undefined>(testSchema._input);
   });
+  test('TS resolves correct top-level default type', () => {
+    const testSchema = offeringBasedSchema({
+      serverless: schema.string(),
+      traditional: schema.literal('traditional'),
+    }).default('other');
+
+    expectType<string>(testSchema._output);
+    // @ts-expect-error
+    expectType<string>(testSchema._input);
+    expectType<string | undefined>(testSchema._input);
+  });
 
   test('TS enforces the same types on both entries', () => {
     schema.object({

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/offering_based_schema.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/offering_based_schema.test.ts
@@ -14,7 +14,7 @@ import { offeringBasedSchema } from './offering_based_schema';
 describe('Helper: offeringBasedSchema()', () => {
   describe('Example: Only allow the setting on Serverless', () => {
     const validation = schema.object({
-      myProp: offeringBasedSchema({ serverless: schema.boolean({ defaultValue: true }) }),
+      myProp: offeringBasedSchema({ serverless: schema.boolean().default(true) }),
     });
 
     test('it uses the non-serverless validation when the context is not present', () => {
@@ -44,7 +44,7 @@ describe('Helper: offeringBasedSchema()', () => {
 
   describe('Example: Only allow the setting on Traditional', () => {
     const validation = schema.object({
-      myProp: offeringBasedSchema({ traditional: schema.boolean({ defaultValue: true }) }),
+      myProp: offeringBasedSchema({ traditional: schema.boolean().default(true) }),
     });
 
     test('it uses the non-serverless validation when the context is not present', () => {
@@ -75,9 +75,8 @@ describe('Helper: offeringBasedSchema()', () => {
   describe('Example: Fixed setting on Traditional, configurable on Serverless', () => {
     const validation = schema.object({
       myProp: offeringBasedSchema({
-        serverless: schema.string({ defaultValue: 'serverless' }),
-        options: { defaultValue: 'top-default' },
-      }),
+        serverless: schema.string().default('serverless'),
+      }).default('top-default'),
     });
 
     test('it uses the non-serverless validation when the context is not present', () => {
@@ -108,7 +107,7 @@ describe('Helper: offeringBasedSchema()', () => {
   describe('Example: Fixed setting on Traditional (though settable), configurable on Serverless', () => {
     const validation = schema.object({
       myProp: offeringBasedSchema({
-        serverless: schema.boolean({ defaultValue: true }),
+        serverless: schema.boolean().default(true),
         traditional: schema.literal(false),
         options: { defaultValue: false },
       }),
@@ -143,7 +142,7 @@ describe('Helper: offeringBasedSchema()', () => {
     const validation = schema.object({
       myProp: offeringBasedSchema({
         serverless: schema.literal(false),
-        traditional: schema.boolean({ defaultValue: true }),
+        traditional: schema.boolean().default(true),
         options: { defaultValue: false },
       }),
     });
@@ -176,8 +175,8 @@ describe('Helper: offeringBasedSchema()', () => {
   describe('Example: Setting is changeable on all offerings but with different defaults', () => {
     const validation = schema.object({
       myProp: offeringBasedSchema({
-        serverless: schema.boolean({ defaultValue: true }),
-        traditional: schema.boolean({ defaultValue: false }),
+        serverless: schema.boolean().default(true),
+        traditional: schema.boolean().default(false),
       }),
     });
 
@@ -208,12 +207,12 @@ describe('Helper: offeringBasedSchema()', () => {
 
   test('TS resolves correct type with nested conditional', () => {
     const testSchema = offeringBasedSchema({
-      serverless: schema.boolean({ defaultValue: true }),
+      serverless: schema.boolean().default(true),
       traditional: schema.conditional(
         schema.contextRef('dev'),
         false,
-        schema.boolean({ defaultValue: true }),
-        schema.boolean({ defaultValue: false })
+        schema.boolean().default(true),
+        schema.boolean().default(false)
       ),
     });
     expectType<boolean>(testSchema._output);
@@ -223,9 +222,9 @@ describe('Helper: offeringBasedSchema()', () => {
   test('TS enforces the same types on both entries', () => {
     schema.object({
       myProp: offeringBasedSchema({
-        serverless: schema.boolean({ defaultValue: true }),
+        serverless: schema.boolean().default(true),
         // @ts-expect-error
-        traditional: schema.string({ defaultValue: 'not on serverless' }),
+        traditional: schema.string().default('not on serverless'),
       }),
     });
   });

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/offering_based_schema.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/offering_based_schema.ts
@@ -46,8 +46,7 @@ import type { TypeOptions } from '../types/type';
  *   myProp: offeringBasedSchema({
  *     serverless: schema.boolean().default(true),
  *     traditional: schema.literal(false), // this can be skipped if users can't specify it in the config
- *     options: { defaultValue: false },
- *   }),
+ *   }).default(false),
  * });
  * ```
  *

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/offering_based_schema.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/offering_based_schema.ts
@@ -8,7 +8,8 @@
  */
 
 import { schema } from '../..';
-import type { Type, TypeOptions } from '../types';
+import type { Type } from '../types';
+import type { DefaultValue, TypeOptions } from '../types/type';
 
 /**
  * Helper to apply different validations depending on whether Kibana is running the Serverless or Traditional offering.
@@ -23,17 +24,24 @@ import type { Type, TypeOptions } from '../types';
  * const schema = env.packageInfo.buildFlavor === 'serverless' ? baseSchema.extend(a) : baseSchema.extend(b);
  * ```
  *
- * @example Only allow the setting on Serverless
+ * @example
+ * Only allow the setting on Serverless
+ * ```ts
  * const config = schema.object({
  *   myProp: offeringBasedSchema({ serverless: schema.boolean({ defaultValue: true }) }),
  * });
+ * ```
  *
- * @example Only allow the setting on Traditional
+ * @example
+ * Only allow the setting on Traditional
+ * ```ts
  * const config = schema.object({
  *   myProp: offeringBasedSchema({ fullyManaged: schema.boolean({ defaultValue: true }) }),
  * });
- *
- * @example Fixed value on Traditional, configurable on Serverless
+ * ```
+ * @example
+ * Fixed value on Traditional, configurable on Serverless
+ * ```ts
  * const config = schema.object({
  *   myProp: offeringBasedSchema({
  *     serverless: schema.boolean({ defaultValue: true }),
@@ -41,27 +49,38 @@ import type { Type, TypeOptions } from '../types';
  *     options: { defaultValue: false },
  *   }),
  * });
+ * ```
  *
- * @example Setting is changeable on all offerings but with different defaults
+ *
+ * @example
+ * Setting is changeable on all offerings but with different defaults
+ * ```ts
  * const config = schema.object({
  *   myProp: offeringBasedSchema({
  *     serverless: schema.boolean({ defaultValue: true }),
  *     traditional: schema.boolean({ defaultValue: false }),
  *   }),
  * });
+ * ```
  *
  * @param opts.serverless The validation to apply in the Serverless offering. If not provided, it doesn't allow the setting to be set in this offering.
  * @param opts.traditional The validation to apply in the Traditional offering. If not provided, it doesn't allow the setting to be set in this offering.
  * @param opts.options Any options to pass down in the types.
  */
-export function offeringBasedSchema<V>(opts: {
-  serverless?: Type<V>;
-  traditional?: Type<V>;
-  options?: TypeOptions<V>;
+export function offeringBasedSchema<
+  Output,
+  Input = Output,
+  SLD extends DefaultValue<Input> = never,
+  TRD extends DefaultValue<Input> = never,
+  DV extends DefaultValue<Input> = never
+>(opts: {
+  serverless?: Type<Output, Input, SLD>;
+  traditional?: Type<Output, Input, TRD>;
+  options?: TypeOptions<Output, Input, DV>;
 }) {
   const { serverless = schema.never(), traditional = schema.never(), options } = opts;
   return schema.conditional(
-    schema.contextRef('serverless'),
+    schema.contextRef<boolean>('serverless'),
     true,
     serverless,
     traditional,

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/offering_based_schema.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/offering_based_schema.ts
@@ -9,7 +9,7 @@
 
 import { schema } from '../..';
 import type { Type } from '../types';
-import type { DefaultValue, TypeOptions } from '../types/type';
+import type { TypeOptions } from '../types/type';
 
 /**
  * Helper to apply different validations depending on whether Kibana is running the Serverless or Traditional offering.
@@ -28,7 +28,7 @@ import type { DefaultValue, TypeOptions } from '../types/type';
  * Only allow the setting on Serverless
  * ```ts
  * const config = schema.object({
- *   myProp: offeringBasedSchema({ serverless: schema.boolean({ defaultValue: true }) }),
+ *   myProp: offeringBasedSchema({ serverless: schema.boolean().default(true) }),
  * });
  * ```
  *
@@ -36,7 +36,7 @@ import type { DefaultValue, TypeOptions } from '../types/type';
  * Only allow the setting on Traditional
  * ```ts
  * const config = schema.object({
- *   myProp: offeringBasedSchema({ fullyManaged: schema.boolean({ defaultValue: true }) }),
+ *   myProp: offeringBasedSchema({ fullyManaged: schema.boolean().default(true) }),
  * });
  * ```
  * @example
@@ -44,7 +44,7 @@ import type { DefaultValue, TypeOptions } from '../types/type';
  * ```ts
  * const config = schema.object({
  *   myProp: offeringBasedSchema({
- *     serverless: schema.boolean({ defaultValue: true }),
+ *     serverless: schema.boolean().default(true),
  *     traditional: schema.literal(false), // this can be skipped if users can't specify it in the config
  *     options: { defaultValue: false },
  *   }),
@@ -57,8 +57,8 @@ import type { DefaultValue, TypeOptions } from '../types/type';
  * ```ts
  * const config = schema.object({
  *   myProp: offeringBasedSchema({
- *     serverless: schema.boolean({ defaultValue: true }),
- *     traditional: schema.boolean({ defaultValue: false }),
+ *     serverless: schema.boolean().default(true),
+ *     traditional: schema.boolean().default(false),
  *   }),
  * });
  * ```
@@ -67,16 +67,10 @@ import type { DefaultValue, TypeOptions } from '../types/type';
  * @param opts.traditional The validation to apply in the Traditional offering. If not provided, it doesn't allow the setting to be set in this offering.
  * @param opts.options Any options to pass down in the types.
  */
-export function offeringBasedSchema<
-  Output,
-  Input = Output,
-  SLD extends DefaultValue<Input> = never,
-  TRD extends DefaultValue<Input> = never,
-  DV extends DefaultValue<Input> = never
->(opts: {
-  serverless?: Type<Output, Input, SLD>;
-  traditional?: Type<Output, Input, TRD>;
-  options?: TypeOptions<Output, Input, DV>;
+export function offeringBasedSchema<Output, Input = Output>(opts: {
+  serverless?: Type<Output, Input>;
+  traditional?: Type<Output, Input>;
+  options?: TypeOptions<Output, Input>;
 }) {
   const { serverless = schema.never(), traditional = schema.never(), options } = opts;
   return schema.conditional(

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/types.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/types.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expectType } from 'tsd';
+import type { Simplify } from './types';
+
+const types = {
+  string: 'some-string',
+  number: 123,
+};
+
+describe('helper types', () => {
+  describe('Simplify', () => {
+    it('should only be used on objects', () => {
+      // @ts-expect-error
+      expectType<Simplify<number>>();
+    });
+    it('should work on simple objects', () => {
+      interface Test {
+        str: string;
+        num: number;
+      }
+      expectType<Simplify<Test>>({ str: types.string, num: types.number });
+    });
+    it('should work on complex objects', () => {
+      interface Test {
+        str: string;
+        num: number;
+        deep: Omit<Test, 'deep'>;
+      }
+      expectType<Simplify<Test>>({
+        str: types.string,
+        num: types.number,
+        deep: {
+          str: types.string,
+          num: types.number,
+        },
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/types.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/types.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export type OptionalKeys<T extends object> = {
+  [k in keyof T]: undefined extends T[k] ? k : never;
+}[keyof T];
+
+export type RequiredKeys<T extends object> = {
+  [k in keyof T]: undefined extends T[k] ? never : k;
+}[keyof T];
+
+/**
+ * Makes all `undefined` values optional.
+ *
+ * Otherwise, explicitly passing `undefined` will throw a type error.
+ *
+ * @example
+ * ```ts
+ * type A = OptionalizeObject<{
+ *   a: string;
+ *   b: number | undefined;
+ * }>;
+ * // A -> { a: string; b?: number | undefined }
+ * ```
+ */
+export type OptionalizeObject<T extends object> = Simplify<
+  {
+    [K in RequiredKeys<T>]: T[K];
+  } & {
+    [K in OptionalKeys<T>]?: T[K];
+  }
+>;
+
+/**
+ * Simplifies complex object types
+ */
+export type Simplify<T extends object> = { [k in keyof T]: T[k] } & {};

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/types/index.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/types/index.ts
@@ -7,22 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { internals } from '../internals';
-import { Type } from './type';
-
-export class NeverType extends Type<never> {
-  constructor() {
-    super(internals.any().forbidden());
-  }
-
-  protected getDefault() {
-    return undefined;
-  }
-
-  protected handleError(type: string) {
-    switch (type) {
-      case 'any.unknown':
-        return "a value wasn't expected to be present";
-    }
-  }
-}
+export * from './utils';
+export * from './type_of';
+export * from './schema_of';

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/types/schema_of.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/types/schema_of.test.ts
@@ -9,7 +9,7 @@
 
 import { expectType } from 'tsd';
 
-import { schema } from '../..';
+import { schema } from '../../..';
 import type { SchemaOf } from './schema_of';
 
 describe('SchemaOf', () => {
@@ -67,8 +67,8 @@ describe('SchemaOf', () => {
 
     expectType<Expected>(
       schema.object({
-        name: schema.string({ defaultValue: 'John' }),
-        age: schema.number({ defaultValue: 1 }),
+        name: schema.string().default('John'),
+        age: schema.number().default(1),
       })
     );
   });

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/types/schema_of.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/types/schema_of.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Type } from './type';
+import type { Type } from '../../types/type';
 
 /*
  * This `SchemaOf` is meant to allow driving schemas based on TS types.
@@ -37,4 +37,4 @@ import type { Type } from './type';
  *  }) satisfies SchemaOf<MySchemaOutput>;
  * ```
  */
-export type SchemaOf<T> = Omit<Type<T, T, any>, '_input' | 'extendsDeep'>;
+export type SchemaOf<Output, Input = any> = Type<Output, Input>;

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/types/type_of.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/types/type_of.test.ts
@@ -21,9 +21,8 @@ import { duration } from 'moment';
 import { Stream } from 'stream';
 
 import type { TypeOfOutput, TypeOfInput } from './type_of';
-import { ByteSizeValue, schema } from '../..';
-import type { IpOptions } from './ip_type';
-import type { ContextReference } from '../references';
+import { ByteSizeValue, schema } from '../../..';
+import type { ContextReference } from '../../references';
 
 function expectNever<T extends never>() {}
 
@@ -64,7 +63,7 @@ describe('schema types', () => {
         expectType<SchemaType>(types.string);
       });
       test('should output boolean value with default', () => {
-        const testSchema = schema.boolean({ defaultValue: true });
+        const testSchema = schema.boolean().default(true);
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(true);
@@ -106,7 +105,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should output string value with default', () => {
-        const testSchema = schema.string({ defaultValue: types.string });
+        const testSchema = schema.string().default(types.string);
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(types.string);
@@ -125,7 +124,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should output uri value with default', () => {
-        const testSchema = schema.uri({ defaultValue: types.uri });
+        const testSchema = schema.uri().default(types.uri);
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(types.uri);
@@ -144,7 +143,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should output number value with default', () => {
-        const testSchema = schema.number({ defaultValue: types.number });
+        const testSchema = schema.number().default(types.number);
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(types.number);
@@ -163,7 +162,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should output byteSize value with default', () => {
-        const testSchema = schema.byteSize({ defaultValue: types.byteSize });
+        const testSchema = schema.byteSize().default(types.byteSize);
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(types.byteSize);
@@ -171,7 +170,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should output byteSize value with string default', () => {
-        const testSchema = schema.byteSize({ defaultValue: '1gb' });
+        const testSchema = schema.byteSize().default('1gb');
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(types.byteSize);
@@ -179,7 +178,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should output byteSize value with number default', () => {
-        const testSchema = schema.byteSize({ defaultValue: types.number });
+        const testSchema = schema.byteSize().default(types.number);
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(types.byteSize);
@@ -198,7 +197,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should output duration value with default', () => {
-        const testSchema = schema.duration({ defaultValue: types.duration });
+        const testSchema = schema.duration().default(types.duration);
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(types.duration);
@@ -206,7 +205,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should output duration value with string default', () => {
-        const testSchema = schema.duration({ defaultValue: '1h' });
+        const testSchema = schema.duration().default('1h');
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(types.duration);
@@ -214,7 +213,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should output duration value with number default', () => {
-        const testSchema = schema.duration({ defaultValue: types.number });
+        const testSchema = schema.duration().default(types.number);
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(types.duration);
@@ -235,8 +234,6 @@ describe('schema types', () => {
     });
 
     describe('ip', () => {
-      const baseOptions: IpOptions<string> = { versions: ['ipv4'] };
-
       test('should output ip value', () => {
         const testSchema = schema.ip();
         type SchemaType = TypeOfOutput<typeof testSchema>;
@@ -246,7 +243,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should output ip value with default', () => {
-        const testSchema = schema.ip({ ...baseOptions, defaultValue: types.ip });
+        const testSchema = schema.ip().default(types.ip);
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(types.ip);
@@ -268,7 +265,7 @@ describe('schema types', () => {
         expectType<SchemaType>(types.number);
       });
       test('should permit but ignore inner default', () => {
-        const testSchema = schema.nullable(schema.string({ defaultValue: types.string }));
+        const testSchema = schema.nullable(schema.string().default(types.string));
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(null);
@@ -300,7 +297,7 @@ describe('schema types', () => {
       });
       test('should output object types with property defaults', () => {
         const testSchema = schema.object({
-          str: schema.string({ defaultValue: types.string }),
+          str: schema.string().default(types.string),
           num: schema.number(),
         });
         type SchemaType = TypeOfOutput<typeof testSchema>;
@@ -358,7 +355,7 @@ describe('schema types', () => {
         expectType<SchemaType>(types.number);
       });
       test('should permit but ignore inner default', () => {
-        const testSchema = schema.maybe(schema.string({ defaultValue: types.string }));
+        const testSchema = schema.maybe(schema.string().default(types.string));
         type SchemaType = TypeOfOutput<typeof testSchema>;
 
         expectType<SchemaType>(undefined);
@@ -423,7 +420,7 @@ describe('schema types', () => {
         expectType<SchemaType>(types.string);
       });
       test('should input boolean value with default', () => {
-        const testSchema = schema.boolean({ defaultValue: true });
+        const testSchema = schema.boolean().default(true);
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(true);
@@ -464,7 +461,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should input string value with default', () => {
-        const testSchema = schema.string({ defaultValue: types.string });
+        const testSchema = schema.string().default(types.string);
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(types.string);
@@ -482,7 +479,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should input uri value with default', () => {
-        const testSchema = schema.uri({ defaultValue: types.string });
+        const testSchema = schema.uri().default(types.string);
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(types.uri);
@@ -500,7 +497,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should input number value with default', () => {
-        const testSchema = schema.number({ defaultValue: types.number });
+        const testSchema = schema.number().default(types.number);
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(types.number);
@@ -518,14 +515,14 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should input byteSize value with default', () => {
-        const testSchema = schema.byteSize({ defaultValue: types.byteSize });
+        const testSchema = schema.byteSize().default(types.byteSize);
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(types.byteSize);
         expectType<SchemaType>(undefined);
       });
       test('should input byteSize value with string default', () => {
-        const testSchema = schema.byteSize({ defaultValue: '1gb' });
+        const testSchema = schema.byteSize().default('1gb');
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(types.byteSize);
@@ -534,7 +531,7 @@ describe('schema types', () => {
         expectType<SchemaType>(types.string);
       });
       test('should input byteSize value with number default', () => {
-        const testSchema = schema.byteSize({ defaultValue: types.number });
+        const testSchema = schema.byteSize().default(types.number);
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(types.byteSize);
@@ -554,14 +551,14 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should input duration value with default', () => {
-        const testSchema = schema.duration({ defaultValue: types.duration });
+        const testSchema = schema.duration().default(types.duration);
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(types.duration);
         expectType<SchemaType>(undefined);
       });
       test('should input duration value with string default', () => {
-        const testSchema = schema.duration({ defaultValue: '1h' });
+        const testSchema = schema.duration().default('1h');
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(types.duration);
@@ -570,7 +567,7 @@ describe('schema types', () => {
         expectType<SchemaType>(types.string);
       });
       test('should input duration value with number default', () => {
-        const testSchema = schema.duration({ defaultValue: types.number });
+        const testSchema = schema.duration().default(types.number);
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(types.duration);
@@ -603,7 +600,7 @@ describe('schema types', () => {
         expectType<SchemaType>(types.number);
       });
       test('should permit but ignore inner default', () => {
-        const testSchema = schema.nullable(schema.string({ defaultValue: types.string }));
+        const testSchema = schema.nullable(schema.string().default(types.string));
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(null);
@@ -634,13 +631,10 @@ describe('schema types', () => {
       });
       test('should input object types with property defaults', () => {
         const testSchema = schema.object({
-          str: schema.string({ defaultValue: types.string }),
+          str: schema.string().default(types.string),
           num: schema.number(),
         });
         type SchemaType = TypeOfInput<typeof testSchema>;
-
-        const nick = null! as SchemaType;
-        nick.num;
 
         expectType<SchemaType>({
           str: types.string,
@@ -681,8 +675,6 @@ describe('schema types', () => {
     });
 
     describe('ip', () => {
-      const baseOptions: IpOptions<string> = { versions: ['ipv4'] };
-
       test('should input ip value', () => {
         const testSchema = schema.ip();
         type SchemaType = TypeOfInput<typeof testSchema>;
@@ -692,7 +684,7 @@ describe('schema types', () => {
         expectType<SchemaType>(undefined);
       });
       test('should input ip value with default', () => {
-        const testSchema = schema.ip({ ...baseOptions, defaultValue: types.ip });
+        const testSchema = schema.ip().default(types.ip);
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(types.ip);
@@ -713,7 +705,7 @@ describe('schema types', () => {
         expectType<SchemaType>(types.number);
       });
       test('should permit but ignore inner default', () => {
-        const testSchema = schema.maybe(schema.string({ defaultValue: types.string }));
+        const testSchema = schema.maybe(schema.string().default(types.string));
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>(undefined);

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/types/type_of.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/types/type_of.test.ts
@@ -649,15 +649,10 @@ describe('schema types', () => {
         expectType<SchemaType>({});
       });
       test('should input object types with object default', () => {
-        const testSchema = schema.object(
-          { str: schema.string(), num: schema.number() },
-          {
-            defaultValue: {
-              str: types.string,
-              num: types.number,
-            },
-          }
-        );
+        const testSchema = schema.object({ str: schema.string(), num: schema.number() }).default({
+          str: types.string,
+          num: types.number,
+        });
         type SchemaType = TypeOfInput<typeof testSchema>;
 
         expectType<SchemaType>({

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/types/type_of.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/types/type_of.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { SomeType, TypeOrLazyType } from './type';
+import type { SomeType, TypeOrLazyType } from '../../types/type';
 
 /**
  * Resulting schema type.
@@ -48,4 +48,8 @@ export type TypeOfOutput<RT extends TypeOrLazyType> = RT extends () => SomeType
  * const MySchemaType = TypeOfOutput<typeof mySchema>;
  * ```
  */
-export type TypeOfInput<RT extends TypeOrLazyType> = RT extends SomeType ? RT['_input'] : never;
+export type TypeOfInput<RT extends TypeOrLazyType> = RT extends () => SomeType
+  ? ReturnType<RT>['_input']
+  : RT extends SomeType
+  ? RT['_input']
+  : never;

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/types/utils.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/types/utils.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { expectType } from 'tsd';
-import type { Simplify } from './types';
+import type { Simplify } from './utils';
 
 const types = {
   string: 'some-string',

--- a/src/platform/packages/shared/kbn-config-schema/src/helpers/types/utils.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/helpers/types/utils.ts
@@ -7,14 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type OptionalKeys<T extends object> = {
-  [k in keyof T]: undefined extends T[k] ? k : never;
-}[keyof T];
-
-export type RequiredKeys<T extends object> = {
-  [k in keyof T]: undefined extends T[k] ? never : k;
-}[keyof T];
-
 /**
  * Makes all `undefined` values optional.
  *
@@ -30,10 +22,11 @@ export type RequiredKeys<T extends object> = {
  * ```
  */
 export type OptionalizeObject<T extends object> = Simplify<
+  // Do not extract key logic or will break VSCode prop definition linking
   {
-    [K in RequiredKeys<T>]: T[K];
+    [K in keyof T as undefined extends T[K] ? K : never]?: T[K];
   } & {
-    [K in OptionalKeys<T>]?: T[K];
+    [K in keyof T as undefined extends T[K] ? never : K]: T[K];
   }
 >;
 

--- a/src/platform/packages/shared/kbn-config-schema/src/references/context_reference.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/references/context_reference.ts
@@ -9,7 +9,7 @@
 
 import { Reference } from './reference';
 
-export class ContextReference<T> extends Reference<T> {
+export class ContextReference<T = any> extends Reference<T> {
   constructor(key: string) {
     super(`$${key}`);
   }

--- a/src/platform/packages/shared/kbn-config-schema/src/references/reference.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/references/reference.ts
@@ -10,7 +10,10 @@
 import type { Reference as InternalReference } from 'joi';
 import { internals } from '../internals';
 
-export class Reference<T> {
+export class Reference<T = any> {
+  // @ts-expect-error
+  #type: T; // preserve type otherwise it's completely ignored and allows loose typings
+
   public static isReference<V>(value: V | Reference<V> | undefined): value is Reference<V> {
     return (
       value != null &&

--- a/src/platform/packages/shared/kbn-config-schema/src/types/any_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/any_type.test.ts
@@ -41,20 +41,20 @@ test('meta', () => {
 
 describe('#defaultValue', () => {
   test('returns default when undefined', () => {
-    expect(schema.any({ defaultValue: true }).validate(undefined)).toBe(true);
-    expect(schema.any({ defaultValue: 200 }).validate(undefined)).toBe(200);
-    expect(schema.any({ defaultValue: 'bar' }).validate(undefined)).toBe('bar');
-    expect(schema.any({ defaultValue: { baz: 'foo' } }).validate(undefined)).toEqual({
+    expect(schema.any().default(true).validate(undefined)).toBe(true);
+    expect(schema.any().default(200).validate(undefined)).toBe(200);
+    expect(schema.any().default('bar').validate(undefined)).toBe('bar');
+    expect(schema.any().default({ baz: 'foo' }).validate(undefined)).toEqual({
       baz: 'foo',
     });
   });
 
   test('returns value when specified', () => {
-    expect(schema.any({ defaultValue: true }).validate(false)).toBe(false);
-    expect(schema.any({ defaultValue: 200 }).validate(100)).toBe(100);
-    expect(schema.any({ defaultValue: 'bar' }).validate('foo')).toBe('foo');
-    expect(schema.any({ defaultValue: 'not-null' }).validate(null)).toBe(null);
-    expect(schema.any({ defaultValue: { baz: 'foo' } }).validate({ foo: 'bar', baz: 2 })).toEqual({
+    expect(schema.any().default(true).validate(false)).toBe(false);
+    expect(schema.any().default(200).validate(100)).toBe(100);
+    expect(schema.any().default('bar').validate('foo')).toBe('foo');
+    expect(schema.any().default('not-null').validate(null)).toBe(null);
+    expect(schema.any().default({ baz: 'foo' }).validate({ foo: 'bar', baz: 2 })).toEqual({
       foo: 'bar',
       baz: 2,
     });

--- a/src/platform/packages/shared/kbn-config-schema/src/types/any_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/any_type.ts
@@ -10,11 +10,11 @@
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
 import { META_FIELD_X_OAS_ANY } from '../oas_meta_fields';
-import type { TypeOptions } from './type';
+import type { DefaultValue, TypeOptions } from './type';
 import { Type } from './type';
 
-export class AnyType extends Type<any> {
-  constructor(options?: TypeOptions<any>) {
+export class AnyType<D extends DefaultValue<any> = never> extends Type<any, any, D> {
+  constructor(options?: TypeOptions<any, any, D>) {
     super(internals.any().meta({ [META_FIELD_X_OAS_ANY]: true }), options);
   }
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/any_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/any_type.ts
@@ -10,12 +10,16 @@
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
 import { META_FIELD_X_OAS_ANY } from '../oas_meta_fields';
-import type { DefaultValue, TypeOptions } from './type';
+import type { TypeOptions } from './type';
 import { Type } from './type';
 
-export class AnyType<D extends DefaultValue<any> = never> extends Type<any, any, D> {
-  constructor(options?: TypeOptions<any, any, D>) {
+export class AnyType extends Type<any> {
+  constructor(options?: TypeOptions<any>) {
     super(internals.any().meta({ [META_FIELD_X_OAS_ANY]: true }), options);
+  }
+
+  protected getDefault(defaultValue?: any): any {
+    return defaultValue;
   }
 
   protected handleError(type: string, { value }: Record<string, any>) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/array_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/array_type.test.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { expectType } from 'tsd';
+
 import { schema } from '../..';
 
 test('returns value if it matches the type', () => {
@@ -187,6 +189,37 @@ describe('#maxSize', () => {
     expect(() =>
       schema.arrayOf(schema.string(), { maxSize: 1 }).validate(['foo', 'bar'])
     ).toThrowErrorMatchingInlineSnapshot(`"array size is [2], but cannot be greater than [1]"`);
+  });
+});
+
+describe('#validate', () => {
+  test('should validate with correct type', () => {
+    schema.arrayOf(
+      schema.object({
+        foo: schema.string(),
+      }),
+      {
+        validate: (value) => {
+          expectType<typeof value>([{ foo: 'test' }]);
+        },
+      }
+    );
+  });
+});
+
+describe('#defaultValue', () => {
+  // TODO: The defaultValue should be respected
+  test.failing('should validate with correct defaultValue', () => {
+    const defaultValue = [{ foo: 'test' }];
+    const type = schema.arrayOf(
+      schema.object({
+        foo: schema.string(),
+      }),
+      {
+        defaultValue,
+      }
+    );
+    expect(type.validate(undefined)).toEqual(defaultValue);
   });
 });
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/array_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/array_type.test.ts
@@ -110,7 +110,7 @@ test('fails for null values if optional', () => {
 });
 
 test('returns empty array if input is empty but type has default value', () => {
-  const type = schema.arrayOf(schema.string({ defaultValue: 'test' }));
+  const type = schema.arrayOf(schema.string().default('test'));
   expect(type.validate([])).toEqual([]);
 });
 
@@ -141,7 +141,7 @@ test('array within array', () => {
 test('object within array', () => {
   const type = schema.arrayOf(
     schema.object({
-      foo: schema.string({ defaultValue: 'foo' }),
+      foo: schema.string().default('foo'),
     })
   );
 
@@ -208,8 +208,7 @@ describe('#validate', () => {
 });
 
 describe('#defaultValue', () => {
-  // TODO: The defaultValue should be respected
-  test.failing('should validate with correct defaultValue', () => {
+  test('should validate with correct defaultValue', () => {
     const defaultValue = [{ foo: 'test' }];
     const type = schema.arrayOf(
       schema.object({

--- a/src/platform/packages/shared/kbn-config-schema/src/types/array_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/array_type.ts
@@ -9,32 +9,20 @@
 
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
-import type {
-  TypeOptions,
-  ExtendsDeepOptions,
-  UnknownOptions,
-  DefaultValue,
-  SomeType,
-} from './type';
+import type { TypeOptions, ExtendsDeepOptions, UnknownOptions, SomeType } from './type';
 import { Type } from './type';
 
-export type ArrayOptions<
-  T extends SomeType,
-  D extends DefaultValue<T['_input'][]> = never
-> = TypeOptions<T['_output'][], T['_input'][], D> &
+export type ArrayOptions<T extends SomeType> = TypeOptions<T['_output'][], T['_input'][]> &
   UnknownOptions & {
     minSize?: number;
     maxSize?: number;
   };
 
-export class ArrayType<
-  T extends SomeType,
-  D extends DefaultValue<T['_input'][]> = never
-> extends Type<T['_output'][], T['_input'][], D> {
+export class ArrayType<T extends SomeType> extends Type<T['_output'][], T['_input'][]> {
   private readonly itemType: T;
-  private readonly arrayOptions: ArrayOptions<T, D>;
+  private readonly arrayOptions: ArrayOptions<T>;
 
-  constructor(type: T, options: ArrayOptions<T, D> = {}) {
+  constructor(type: T, options: ArrayOptions<T> = {}) {
     let schema = internals.array().items(type.getSchema().optional()).sparse(false);
 
     if (options.minSize !== undefined) {
@@ -56,8 +44,12 @@ export class ArrayType<
     this.arrayOptions = options;
   }
 
-  public extendsDeep(options: ExtendsDeepOptions): ArrayType<T, D> {
+  public extendsDeep(options: ExtendsDeepOptions): ArrayType<T> {
     return new ArrayType(this.itemType.extendsDeep(options) as T, this.arrayOptions);
+  }
+
+  protected getDefault(defaultValue?: T['_input'][]): T['_input'][] | undefined {
+    return defaultValue;
   }
 
   protected handleError(type: string, { limit, reason, value }: Record<string, any>) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/boolean_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/boolean_type.test.ts
@@ -40,11 +40,11 @@ test('includes namespace in failure', () => {
 
 describe('#defaultValue', () => {
   test('returns default when undefined', () => {
-    expect(schema.boolean({ defaultValue: true }).validate(undefined)).toBe(true);
+    expect(schema.boolean().default(true).validate(undefined)).toBe(true);
   });
 
   test('returns value when specified', () => {
-    expect(schema.boolean({ defaultValue: true }).validate(false)).toBe(false);
+    expect(schema.boolean().default(true).validate(false)).toBe(false);
   });
 });
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/boolean_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/boolean_type.ts
@@ -9,11 +9,15 @@
 
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
-import type { TypeOptions } from './type';
+import type { DefaultValue, TypeOptions } from './type';
 import { Type } from './type';
 
-export class BooleanType extends Type<boolean> {
-  constructor(options?: TypeOptions<boolean>) {
+export class BooleanType<D extends DefaultValue<boolean> = never> extends Type<
+  boolean,
+  boolean,
+  D
+> {
+  constructor(options?: TypeOptions<boolean, boolean, D>) {
     super(internals.boolean(), options);
   }
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/boolean_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/boolean_type.ts
@@ -9,16 +9,16 @@
 
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
-import type { DefaultValue, TypeOptions } from './type';
+import type { TypeOptions } from './type';
 import { Type } from './type';
 
-export class BooleanType<D extends DefaultValue<boolean> = never> extends Type<
-  boolean,
-  boolean,
-  D
-> {
-  constructor(options?: TypeOptions<boolean, boolean, D>) {
+export class BooleanType extends Type<boolean> {
+  constructor(options?: TypeOptions<boolean>) {
     super(internals.boolean(), options);
+  }
+
+  protected getDefault(defaultValue?: boolean): boolean | undefined {
+    return defaultValue;
   }
 
   protected handleError(type: string, { value }: Record<string, any>) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/buffer_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/buffer_type.test.ts
@@ -35,12 +35,12 @@ test('coerces strings to buffer', () => {
 describe('#defaultValue', () => {
   test('returns default when undefined', () => {
     const value = Buffer.from('Hi!');
-    expect(schema.buffer({ defaultValue: value }).validate(undefined)).toStrictEqual(value);
+    expect(schema.buffer().default(value).validate(undefined)).toStrictEqual(value);
   });
 
   test('returns value when specified', () => {
     const value = Buffer.from('Hi!');
-    expect(schema.buffer({ defaultValue: Buffer.from('Bye!') }).validate(value)).toStrictEqual(
+    expect(schema.buffer().default(Buffer.from('Bye!')).validate(value)).toStrictEqual(
       value
     );
   });

--- a/src/platform/packages/shared/kbn-config-schema/src/types/buffer_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/buffer_type.ts
@@ -9,11 +9,11 @@
 
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
-import type { TypeOptions } from './type';
+import type { DefaultValue, TypeOptions } from './type';
 import { Type } from './type';
 
-export class BufferType extends Type<Buffer> {
-  constructor(options?: TypeOptions<Buffer>) {
+export class BufferType<D extends DefaultValue<Buffer> = never> extends Type<Buffer, Buffer, D> {
+  constructor(options?: TypeOptions<Buffer, Buffer, D>) {
     super(internals.binary(), options);
   }
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/buffer_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/buffer_type.ts
@@ -9,12 +9,16 @@
 
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
-import type { DefaultValue, TypeOptions } from './type';
+import type { TypeOptions } from './type';
 import { Type } from './type';
 
-export class BufferType<D extends DefaultValue<Buffer> = never> extends Type<Buffer, Buffer, D> {
-  constructor(options?: TypeOptions<Buffer, Buffer, D>) {
+export class BufferType extends Type<Buffer> {
+  constructor(options?: TypeOptions<Buffer>) {
     super(internals.binary(), options);
+  }
+
+  protected getDefault(defaultValue?: Buffer): Buffer | undefined {
+    return defaultValue;
   }
 
   protected handleError(type: string, { value }: Record<string, any>) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/byte_size_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/byte_size_type.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { expectType } from 'tsd';
 import { schema } from '../..';
 import { ByteSizeValue } from '../byte_size_value';
 
@@ -88,6 +89,28 @@ describe('#defaultValue', () => {
   });
 });
 
+describe('#validate', () => {
+  test('should pass only ByteSizeValue to validate', () => {
+    byteSize({
+      defaultValue: ByteSizeValue.parse('1kb'),
+      validate(value) {
+        expectType<ByteSizeValue>(value);
+      },
+    });
+    byteSize({
+      defaultValue: 1024,
+      validate(value) {
+        expectType<ByteSizeValue>(value);
+      },
+    });
+    byteSize({
+      defaultValue: '1024',
+      validate(value) {
+        expectType<ByteSizeValue>(value);
+      },
+    });
+  });
+});
 describe('#min', () => {
   test('returns value when larger', () => {
     expect(

--- a/src/platform/packages/shared/kbn-config-schema/src/types/byte_size_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/byte_size_type.ts
@@ -14,16 +14,24 @@ import { SchemaTypeError } from '../errors';
 import { internals } from '../internals';
 import { Type } from './type';
 
-export interface ByteSizeOptions {
-  // we need to special-case defaultValue as we want to handle string inputs too
+export type ByteSizeValueType = ByteSizeValue | string | number;
+
+/**
+ * Does not support function or `Reference` as `defaultValue`
+ */
+export interface ByteSizeOptions<D extends ByteSizeValueType> {
+  defaultValue?: D;
   validate?: (value: ByteSizeValue) => string | void;
-  defaultValue?: ByteSizeValue | string | number;
   min?: ByteSizeValue | string | number;
   max?: ByteSizeValue | string | number;
 }
 
-export class ByteSizeType extends Type<ByteSizeValue> {
-  constructor(options: ByteSizeOptions = {}) {
+export class ByteSizeType<D extends ByteSizeValueType> extends Type<
+  ByteSizeValue,
+  ByteSizeValue,
+  [D] extends [never] ? never : ByteSizeValue
+> {
+  constructor(options: ByteSizeOptions<D> = {}) {
     let schema = internals.bytes();
 
     if (options.min !== undefined) {
@@ -35,7 +43,9 @@ export class ByteSizeType extends Type<ByteSizeValue> {
     }
 
     super(schema, {
-      defaultValue: ensureByteSizeValue(options.defaultValue),
+      defaultValue: ensureByteSizeValue(options.defaultValue) as [D] extends [never]
+        ? never
+        : ByteSizeValue,
       validate: options.validate,
     });
   }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/byte_size_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/byte_size_type.ts
@@ -19,19 +19,15 @@ export type ByteSizeValueType = ByteSizeValue | string | number;
 /**
  * Does not support function or `Reference` as `defaultValue`
  */
-export interface ByteSizeOptions<D extends ByteSizeValueType> {
-  defaultValue?: D;
+export interface ByteSizeOptions {
+  defaultValue?: ByteSizeValueType;
   validate?: (value: ByteSizeValue) => string | void;
   min?: ByteSizeValue | string | number;
   max?: ByteSizeValue | string | number;
 }
 
-export class ByteSizeType<D extends ByteSizeValueType> extends Type<
-  ByteSizeValue,
-  ByteSizeValue,
-  [D] extends [never] ? never : ByteSizeValue
-> {
-  constructor(options: ByteSizeOptions<D> = {}) {
+export class ByteSizeType extends Type<ByteSizeValue, ByteSizeValue, ByteSizeValueType> {
+  constructor(options: ByteSizeOptions = {}) {
     let schema = internals.bytes();
 
     if (options.min !== undefined) {
@@ -43,11 +39,13 @@ export class ByteSizeType<D extends ByteSizeValueType> extends Type<
     }
 
     super(schema, {
-      defaultValue: ensureByteSizeValue(options.defaultValue) as [D] extends [never]
-        ? never
-        : ByteSizeValue,
+      defaultValue: options.defaultValue,
       validate: options.validate,
     });
+  }
+
+  getDefault(defaultValue?: ByteSizeValueType): ByteSizeValue | undefined {
+    return ensureByteSizeValue(defaultValue);
   }
 
   protected handleError(

--- a/src/platform/packages/shared/kbn-config-schema/src/types/conditional_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/conditional_type.test.ts
@@ -48,8 +48,8 @@ test('properly handles nested types with defaults', () => {
   const type = schema.conditional(
     schema.contextRef<number>('context_value_1'),
     schema.contextRef<number>('context_value_2'),
-    schema.string({ defaultValue: 'equal' }),
-    schema.string({ defaultValue: 'not equal' })
+    schema.string().default('equal'),
+    schema.string().default('not equal')
   );
 
   expect(
@@ -386,8 +386,8 @@ describe('#validate', () => {
         value: schema.conditional(
           schema.siblingRef('key'),
           'number',
-          schema.number({ defaultValue: 100 }),
-          schema.string({ defaultValue: 'some-string' })
+          schema.number().default(100),
+          schema.string().default('some-string')
         ),
       },
       {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/conditional_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/conditional_type.test.ts
@@ -11,8 +11,8 @@ import { schema } from '../..';
 
 test('required by default', () => {
   const type = schema.conditional(
-    schema.contextRef('context_value_1'),
-    schema.contextRef('context_value_2'),
+    schema.contextRef<number>('context_value_1'),
+    schema.contextRef<number>('context_value_2'),
     schema.string(),
     schema.string()
   );
@@ -27,8 +27,8 @@ test('required by default', () => {
 
 test('returns default', () => {
   const type = schema.conditional(
-    schema.contextRef('context_value_1'),
-    schema.contextRef('context_value_2'),
+    schema.contextRef<number>('context_value_1'),
+    schema.contextRef<number>('context_value_2'),
     schema.string(),
     schema.string(),
     {
@@ -46,8 +46,8 @@ test('returns default', () => {
 
 test('properly handles nested types with defaults', () => {
   const type = schema.conditional(
-    schema.contextRef('context_value_1'),
-    schema.contextRef('context_value_2'),
+    schema.contextRef<number>('context_value_1'),
+    schema.contextRef<number>('context_value_2'),
     schema.string({ defaultValue: 'equal' }),
     schema.string({ defaultValue: 'not equal' })
   );
@@ -67,10 +67,26 @@ test('properly handles nested types with defaults', () => {
   ).toEqual('not equal');
 });
 
+test('properly handles oneOf types with defaults', () => {
+  const type = schema.conditional(
+    schema.contextRef<number>('context_value_1'),
+    schema.contextRef<number>('context_value_2'),
+    schema.never(),
+    schema.oneOf([schema.literal('good'), schema.literal('bad')], { defaultValue: 'good' })
+  );
+
+  expect(
+    type.validate(undefined, {
+      context_value_1: 0,
+      context_value_2: 1,
+    })
+  ).toEqual('good');
+});
+
 test('properly validates types according chosen schema', () => {
   const type = schema.conditional(
-    schema.contextRef('context_value_1'),
-    schema.contextRef('context_value_2'),
+    schema.contextRef<number>('context_value_1'),
+    schema.contextRef<number>('context_value_2'),
     schema.string({ minLength: 2 }),
     schema.string({ maxLength: 1 })
   );
@@ -110,7 +126,7 @@ test('properly validates types according chosen schema', () => {
 
 test('properly validates when compares with Schema', () => {
   const type = schema.conditional(
-    schema.contextRef('context_value_1'),
+    schema.contextRef<number | string>('context_value_1'),
     schema.number(),
     schema.string({ minLength: 2 }),
     schema.string({ minLength: 3 })
@@ -184,8 +200,8 @@ test('properly validates when compares with "null" literal Schema', () => {
 
 test('properly handles schemas with incompatible types', () => {
   const type = schema.conditional(
-    schema.contextRef('context_value_1'),
-    schema.contextRef('context_value_2'),
+    schema.contextRef<number>('context_value_1'),
+    schema.contextRef<number>('context_value_2'),
     schema.string(),
     schema.boolean()
   );
@@ -267,7 +283,7 @@ test('works with both context and sibling references', () => {
     key: schema.string(),
     value: schema.conditional(
       schema.siblingRef('key'),
-      schema.contextRef('context_key'),
+      schema.contextRef<number>('context_key'),
       schema.number(),
       schema.string()
     ),

--- a/src/platform/packages/shared/kbn-config-schema/src/types/conditional_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/conditional_type.ts
@@ -10,24 +10,35 @@
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
 import { Reference } from '../references';
-import type { ExtendsDeepOptions, TypeOptions } from './type';
+import type { DefaultValue, ExtendsDeepOptions, SomeType, TypeOptions } from './type';
 import { Type } from './type';
 
 export type ConditionalTypeValue = string | number | boolean | object | null;
 
-export class ConditionalType<A extends ConditionalTypeValue, B, C> extends Type<B | C> {
-  private readonly leftOperand: Reference<A>;
-  private readonly rightOperand: Reference<A> | A | Type<unknown>;
-  private readonly equalType: Type<B>;
-  private readonly notEqualType: Type<C>;
-  private readonly options?: TypeOptions<B | C>;
+export type ConditionalTypeOptions<
+  A extends SomeType,
+  B extends SomeType,
+  D extends DefaultValue<A['_input'] | B['_input']> = never
+> = TypeOptions<A['_output'] | B['_output'], A['_input'] | B['_input'] | B, D>;
+
+export class ConditionalType<
+  T extends ConditionalTypeValue,
+  A extends SomeType,
+  B extends SomeType,
+  D extends DefaultValue<A['_input'] | B['_input']> = never
+> extends Type<A['_output'] | B['_output'], A['_input'] | B['_input'], D> {
+  private readonly leftOperand: Reference<T>;
+  private readonly rightOperand: Reference<T> | T | Type<unknown>;
+  private readonly equalType: A;
+  private readonly notEqualType: B;
+  private readonly options?: ConditionalTypeOptions<A, B, D>;
 
   constructor(
-    leftOperand: Reference<A>,
-    rightOperand: Reference<A> | A | Type<unknown>,
-    equalType: Type<B>,
-    notEqualType: Type<C>,
-    options?: TypeOptions<B | C>
+    leftOperand: Reference<T>,
+    rightOperand: Reference<T> | T | Type<unknown>,
+    equalType: A,
+    notEqualType: B,
+    options?: ConditionalTypeOptions<A, B, D>
   ) {
     const schema = internals.when(leftOperand.getSchema(), {
       is:
@@ -39,6 +50,7 @@ export class ConditionalType<A extends ConditionalTypeValue, B, C> extends Type<
     });
 
     super(schema, options);
+
     this.leftOperand = leftOperand;
     this.rightOperand = rightOperand;
     this.equalType = equalType;

--- a/src/platform/packages/shared/kbn-config-schema/src/types/conditional_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/conditional_type.ts
@@ -10,35 +10,33 @@
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
 import { Reference } from '../references';
-import type { DefaultValue, ExtendsDeepOptions, SomeType, TypeOptions } from './type';
+import type { ExtendsDeepOptions, SomeType, TypeOptions } from './type';
 import { Type } from './type';
 
 export type ConditionalTypeValue = string | number | boolean | object | null;
 
-export type ConditionalTypeOptions<
-  A extends SomeType,
-  B extends SomeType,
-  D extends DefaultValue<A['_input'] | B['_input']> = never
-> = TypeOptions<A['_output'] | B['_output'], A['_input'] | B['_input'] | B, D>;
+export type ConditionalTypeOptions<A extends SomeType, B extends SomeType> = TypeOptions<
+  A['_output'] | B['_output'],
+  A['_input'] | B['_input'] | B
+>;
 
 export class ConditionalType<
   T extends ConditionalTypeValue,
   A extends SomeType,
-  B extends SomeType,
-  D extends DefaultValue<A['_input'] | B['_input']> = never
-> extends Type<A['_output'] | B['_output'], A['_input'] | B['_input'], D> {
+  B extends SomeType
+> extends Type<A['_output'] | B['_output'], A['_input'] | B['_input']> {
   private readonly leftOperand: Reference<T>;
   private readonly rightOperand: Reference<T> | T | Type<unknown>;
   private readonly equalType: A;
   private readonly notEqualType: B;
-  private readonly options?: ConditionalTypeOptions<A, B, D>;
+  private readonly options?: ConditionalTypeOptions<A, B>;
 
   constructor(
     leftOperand: Reference<T>,
     rightOperand: Reference<T> | T | Type<unknown>,
     equalType: A,
     notEqualType: B,
-    options?: ConditionalTypeOptions<A, B, D>
+    options?: ConditionalTypeOptions<A, B>
   ) {
     const schema = internals.when(leftOperand.getSchema(), {
       is:
@@ -66,6 +64,12 @@ export class ConditionalType<
       this.notEqualType.extendsDeep(options),
       this.options
     );
+  }
+
+  protected getDefault(
+    defaultValue?: A['_input'] | B['_input']
+  ): A['_input'] | B['_input'] | undefined {
+    return defaultValue;
   }
 
   protected handleError(type: string, { value }: Record<string, any>) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/duration_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/duration_type.test.ts
@@ -7,9 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Duration } from 'moment';
 import { duration as momentDuration } from 'moment';
 import { schema } from '../..';
 import { ensureDuration } from '../duration';
+import { expectType } from 'tsd';
 
 const { duration, object, contextRef, siblingRef } = schema;
 
@@ -150,6 +152,29 @@ describe('#defaultValue', () => {
         "target": "PT1H",
       }
     `);
+  });
+});
+
+describe('#validate', () => {
+  test('should pass only Duration to validate', () => {
+    duration({
+      defaultValue: momentDuration(1, 'second'),
+      validate(value) {
+        expectType<Duration>(value);
+      },
+    });
+    duration({
+      defaultValue: 123,
+      validate(value) {
+        expectType<Duration>(value);
+      },
+    });
+    duration({
+      defaultValue: '1h',
+      validate(value) {
+        expectType<Duration>(value);
+      },
+    });
   });
 });
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/duration_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/duration_type.test.ts
@@ -113,9 +113,9 @@ describe('#defaultValue', () => {
   test('can be a reference to a moment.Duration', () => {
     expect(
       object({
-        source: duration({ defaultValue: 600 }),
-        target: duration({ defaultValue: siblingRef('source') }),
-        fromContext: duration({ defaultValue: contextRef('val') }),
+        source: duration().default(600),
+        target: duration().default(siblingRef('source')),
+        fromContext: duration().default(contextRef('val')),
       }).validate({}, { val: momentDuration(700, 'ms') })
     ).toMatchInlineSnapshot(`
       Object {
@@ -127,9 +127,9 @@ describe('#defaultValue', () => {
 
     expect(
       object({
-        source: duration({ defaultValue: '1h' }),
-        target: duration({ defaultValue: siblingRef('source') }),
-        fromContext: duration({ defaultValue: contextRef('val') }),
+        source: duration().default('1h'),
+        target: duration().default(siblingRef('source')),
+        fromContext: duration().default(contextRef('val')),
       }).validate({}, { val: momentDuration(2, 'hour') })
     ).toMatchInlineSnapshot(`
       Object {
@@ -141,9 +141,9 @@ describe('#defaultValue', () => {
 
     expect(
       object({
-        source: duration({ defaultValue: momentDuration(1, 'hour') }),
-        target: duration({ defaultValue: siblingRef('source') }),
-        fromContext: duration({ defaultValue: contextRef('val') }),
+        source: duration().default(momentDuration(1, 'hour')),
+        target: duration().default(siblingRef('source')),
+        fromContext: duration().default(contextRef('val')),
       }).validate({}, { val: momentDuration(2, 'hour') })
     ).toMatchInlineSnapshot(`
       Object {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/duration_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/duration_type.ts
@@ -12,32 +12,42 @@ import type { Duration } from '../duration';
 import { ensureDuration } from '../duration';
 import { SchemaTypeError } from '../errors';
 import { internals } from '../internals';
+import { Type, type DefaultValue } from './type';
 import type { Reference } from '../references';
-import { Type } from './type';
 
 export type DurationValueType = Duration | string | number;
 
-export interface DurationOptions {
-  // we need to special-case defaultValue as we want to handle string inputs too
-  defaultValue?: DurationValueType | Reference<DurationValueType> | (() => DurationValueType);
+export type DurationDefaultValue =
+  | DurationValueType
+  | (() => DurationValueType)
+  | Reference<Duration>; // references must only be a Duration
+
+export interface DurationOptions<D extends DurationDefaultValue = never> {
+  defaultValue?: D;
   validate?: (value: Duration) => string | void;
   min?: DurationValueType;
   max?: DurationValueType;
 }
 
-export class DurationType extends Type<Duration> {
-  constructor(options: DurationOptions = {}) {
-    let defaultValue;
-    if (typeof options.defaultValue === 'function') {
-      const originalDefaultValue = options.defaultValue;
+export class DurationType<D extends DurationDefaultValue = never> extends Type<
+  Duration,
+  Duration,
+  [D] extends [never] ? never : Duration
+> {
+  constructor(options: DurationOptions<D> = {}) {
+    let defaultValue: DefaultValue<Duration> | undefined;
+
+    const originalDefaultValue = options.defaultValue;
+
+    if (typeof originalDefaultValue === 'function') {
       defaultValue = () => ensureDuration(originalDefaultValue());
     } else if (
-      typeof options.defaultValue === 'string' ||
-      typeof options.defaultValue === 'number'
+      typeof originalDefaultValue === 'string' ||
+      typeof originalDefaultValue === 'number'
     ) {
-      defaultValue = ensureDuration(options.defaultValue);
+      defaultValue = ensureDuration(originalDefaultValue);
     } else {
-      defaultValue = options.defaultValue;
+      defaultValue = originalDefaultValue;
     }
 
     let schema = internals.duration();
@@ -48,7 +58,10 @@ export class DurationType extends Type<Duration> {
       schema = schema.max(options.max);
     }
 
-    super(schema, { validate: options.validate, defaultValue });
+    super(schema, {
+      validate: options.validate,
+      defaultValue: defaultValue as [D] extends [never] ? never : Duration,
+    });
   }
 
   protected handleError(

--- a/src/platform/packages/shared/kbn-config-schema/src/types/enum_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/enum_type.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema } from '../..';
+
+enum Status {
+  PENDING = 'pending',
+  WAITING = 'waiting',
+  COMPLETED = 'completed',
+}
+
+const myEnums = ['foo', 'bar', 'baz'] as const;
+
+describe('schema.enum', () => {
+  test('returns enum string value when passed string', () => {
+    const type = schema.enum(myEnums);
+    expect(type.validate('foo')).toBe('foo');
+  });
+
+  test('returns enum string value when passed value from enum', () => {
+    const type = schema.enum<Status>(Status);
+    expect(type.validate(Status.PENDING)).toBe(Status.PENDING);
+  });
+
+  test('returns null if wrapped in nullable for undefined', () => {
+    const type = schema.nullable(schema.enum(myEnums));
+    expect(type.validate(undefined)).toBe(null);
+  });
+
+  test('returns default value if provided', () => {
+    const type = schema.enum(myEnums, {
+      defaultValue: 'foo',
+    });
+
+    expect(type.validate(undefined)).toBe('foo');
+  });
+
+  test('validates basic type', () => {
+    const type = schema.enum(myEnums);
+
+    expect(() => type.validate('bad')).toThrowErrorMatchingInlineSnapshot(`
+      "types that failed validation:
+      - [0]: expected value to equal [foo]
+      - [1]: expected value to equal [bar]
+      - [2]: expected value to equal [baz]"
+    `);
+  });
+
+  test('validates enum type', () => {
+    const type = schema.enum(Status);
+
+    expect(() => type.validate('bad')).toThrowErrorMatchingInlineSnapshot(`
+      "types that failed validation:
+      - [0]: expected value to equal [pending]
+      - [1]: expected value to equal [waiting]
+      - [2]: expected value to equal [completed]"
+    `);
+  });
+
+  test('validates type in object', () => {
+    const type = schema.object({
+      enum1: schema.enum(myEnums),
+      enum2: schema.enum(myEnums, { defaultValue: 'bar' }),
+    });
+
+    expect(type.validate({ enum1: 'foo' })).toEqual({ enum1: 'foo', enum2: 'bar' });
+    expect(type.validate({ enum1: 'foo', enum2: 'baz' })).toEqual({ enum1: 'foo', enum2: 'baz' });
+  });
+
+  test('validates type errors in object', () => {
+    const type = schema.object({
+      enum: schema.enum(myEnums),
+    });
+
+    expect(() => type.validate({ enum: 'not-an-enum' })).toThrowErrorMatchingInlineSnapshot(`
+      "[enum]: types that failed validation:
+      - [enum.0]: expected value to equal [foo]
+      - [enum.1]: expected value to equal [bar]
+      - [enum.2]: expected value to equal [baz]"
+    `);
+  });
+});

--- a/src/platform/packages/shared/kbn-config-schema/src/types/index.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/index.ts
@@ -27,14 +27,7 @@ export type { MapOfOptions } from './map_type';
 export { MapOfType } from './map_type';
 export type { NumberOptions } from './number_type';
 export { NumberType } from './number_type';
-export type {
-  ObjectTypeOptions,
-  PreciseObjectProps,
-  NullableProps,
-  ObjectResultType,
-} from './object_type';
-export type { TypeOf, TypeOfOutput, TypeOfInput } from './type_of';
-export type { SchemaOf } from './schema_of';
+export type { ObjectTypeOptions, NullableProps, ObjectResultType } from './object_type';
 export { ObjectType } from './object_type';
 export type { RecordOfOptions } from './record_type';
 export { RecordOfType } from './record_type';

--- a/src/platform/packages/shared/kbn-config-schema/src/types/index.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/index.ts
@@ -20,7 +20,6 @@ export type { ConditionalTypeValue } from './conditional_type';
 export { ConditionalType } from './conditional_type';
 export type { DurationOptions } from './duration_type';
 export { DurationType } from './duration_type';
-export type { IntersectionTypeOptions } from './intersection_type';
 export { IntersectionType } from './intersection_type';
 export { LiteralType } from './literal_type';
 export { MaybeType } from './maybe_type';
@@ -30,11 +29,12 @@ export type { NumberOptions } from './number_type';
 export { NumberType } from './number_type';
 export type {
   ObjectTypeOptions,
-  Props,
+  PreciseObjectProps,
   NullableProps,
-  TypeOf,
   ObjectResultType,
 } from './object_type';
+export type { TypeOf, TypeOfOutput, TypeOfInput } from './type_of';
+export type { SchemaOf } from './schema_of';
 export { ObjectType } from './object_type';
 export type { RecordOfOptions } from './record_type';
 export { RecordOfType } from './record_type';

--- a/src/platform/packages/shared/kbn-config-schema/src/types/intersection_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/intersection_type.test.ts
@@ -34,7 +34,7 @@ describe('schema.allOf', () => {
   it('supports default value', () => {
     const type = schema.allOf([
       schema.object({ foo: schema.string() }),
-      schema.object({ bar: schema.string({ defaultValue: 'default' }) }),
+      schema.object({ bar: schema.string().default('default') }),
     ]);
 
     expect(type.validate({ foo: 'hello' })).toEqual({ foo: 'hello', bar: 'default' });

--- a/src/platform/packages/shared/kbn-config-schema/src/types/intersection_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/intersection_type.ts
@@ -9,7 +9,7 @@
 
 import type { ObjectTypeOptions, SomeObjectType } from './object_type';
 import { ObjectType } from './object_type';
-import type { DefaultValue, SomeType } from './type';
+import type { SomeType } from './type';
 
 export type IntersectionInput<T extends Readonly<[SomeObjectType, ...SomeObjectType[]]>> =
   T extends readonly [infer First, ...infer Rest]
@@ -30,13 +30,9 @@ export type IntersectionOutput<T extends Readonly<[SomeObjectType, ...SomeObject
     : never;
 
 export class IntersectionType<
-  T extends Readonly<[SomeObjectType, ...SomeObjectType[]]>,
-  D extends DefaultValue<IntersectionInput<T>> = never
-> extends ObjectType<IntersectionOutput<T>, IntersectionInput<T>, D> {
-  constructor(
-    types: T,
-    options?: ObjectTypeOptions<IntersectionOutput<T>, IntersectionInput<T>, D>
-  ) {
+  T extends Readonly<[SomeObjectType, ...SomeObjectType[]]>
+> extends ObjectType<IntersectionOutput<T>, IntersectionInput<T>> {
+  constructor(types: T, options?: ObjectTypeOptions<IntersectionOutput<T>, IntersectionInput<T>>) {
     const props = types.reduce((mergedProps, type) => {
       const typeProps = type.props as Record<string, SomeType>;
       Object.entries(typeProps).forEach(([key, value]) => {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/intersection_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/intersection_type.ts
@@ -7,27 +7,48 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Props, ObjectTypeOptions } from './object_type';
+import type { ObjectTypeOptions, SomeObjectType } from './object_type';
 import { ObjectType } from './object_type';
+import type { DefaultValue, SomeType } from './type';
 
-export type IntersectionTypeOptions<T extends Props = any> = ObjectTypeOptions<T>;
+export type IntersectionInput<T extends Readonly<[SomeObjectType, ...SomeObjectType[]]>> =
+  T extends readonly [infer First, ...infer Rest]
+    ? First extends SomeObjectType
+      ? Rest extends readonly [SomeObjectType, ...SomeObjectType[]]
+        ? First['_input'] & IntersectionInput<Rest>
+        : First['_input']
+      : never
+    : never;
+
+export type IntersectionOutput<T extends Readonly<[SomeObjectType, ...SomeObjectType[]]>> =
+  T extends readonly [infer First, ...infer Rest]
+    ? First extends SomeObjectType
+      ? Rest extends readonly [SomeObjectType, ...SomeObjectType[]]
+        ? First['_output'] & IntersectionOutput<Rest>
+        : First['_output']
+      : never
+    : never;
 
 export class IntersectionType<
-  RTS extends Array<ObjectType<any>>,
-  T extends Props
-> extends ObjectType<T> {
-  constructor(types: RTS, options?: IntersectionTypeOptions<T>) {
+  T extends Readonly<[SomeObjectType, ...SomeObjectType[]]>,
+  D extends DefaultValue<IntersectionInput<T>> = never
+> extends ObjectType<IntersectionOutput<T>, IntersectionInput<T>, D> {
+  constructor(
+    types: T,
+    options?: ObjectTypeOptions<IntersectionOutput<T>, IntersectionInput<T>, D>
+  ) {
     const props = types.reduce((mergedProps, type) => {
-      Object.entries(type.getPropSchemas() as Record<string, any>).forEach(([key, value]) => {
+      const typeProps = type.props as Record<string, SomeType>;
+      Object.entries(typeProps).forEach(([key, value]) => {
         if (mergedProps[key] !== undefined) {
           throw new Error(`Duplicate key found in intersection: '${key}'`);
         }
-        mergedProps[key as keyof T] = value;
+        mergedProps[key] = value;
       });
 
       return mergedProps;
-    }, {} as T);
+    }, {} as Record<string, SomeType>) as IntersectionOutput<T>;
 
-    super(props, options);
+    super(props, options as any);
   }
 }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/ip_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/ip_type.ts
@@ -9,22 +9,26 @@
 
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
-import type { DefaultValue, TypeOptions } from './type';
+import type { TypeOptions } from './type';
 import { Type } from './type';
 
 export type IpVersion = 'ipv4' | 'ipv6';
-export type IpOptions<D extends DefaultValue<string> = never> = TypeOptions<string, string, D> & {
+export type IpOptions = TypeOptions<string> & {
   /**
    * IP versions to accept, defaults to ['ipv4', 'ipv6'].
    */
   versions?: IpVersion[];
 };
 
-export class IpType<D extends DefaultValue<string> = never> extends Type<string, string, D> {
-  constructor(options: IpOptions<D> = {}) {
+export class IpType extends Type<string> {
+  constructor(options: IpOptions = {}) {
     const versions = options.versions ?? ['ipv4', 'ipv6'];
     const schema = internals.string().ip({ version: versions, cidr: 'forbidden' });
     super(schema, options);
+  }
+
+  protected getDefault(defaultValue?: string): string | undefined {
+    return defaultValue;
   }
 
   protected handleError(type: string, { value, version }: Record<string, any>) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/ip_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/ip_type.ts
@@ -9,20 +9,21 @@
 
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
-import type { TypeOptions } from './type';
+import type { DefaultValue, TypeOptions } from './type';
 import { Type } from './type';
 
 export type IpVersion = 'ipv4' | 'ipv6';
-export type IpOptions = TypeOptions<string> & {
+export type IpOptions<D extends DefaultValue<string> = never> = TypeOptions<string, string, D> & {
   /**
    * IP versions to accept, defaults to ['ipv4', 'ipv6'].
    */
-  versions: IpVersion[];
+  versions?: IpVersion[];
 };
 
-export class IpType extends Type<string> {
-  constructor(options: IpOptions = { versions: ['ipv4', 'ipv6'] }) {
-    const schema = internals.string().ip({ version: options.versions, cidr: 'forbidden' });
+export class IpType<D extends DefaultValue<string> = never> extends Type<string, string, D> {
+  constructor(options: IpOptions<D> = {}) {
+    const versions = options.versions ?? ['ipv4', 'ipv6'];
+    const schema = internals.string().ip({ version: versions, cidr: 'forbidden' });
     super(schema, options);
   }
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/lazy.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/lazy.ts
@@ -13,8 +13,12 @@ import { internals } from '../internals';
 /**
  * Use this type to construct recursive runtime schemas.
  */
-export class Lazy<T> extends Type<T, T> {
+export class Lazy<T> extends Type<T> {
   constructor(id: string) {
     super(internals.link(`#${id}`));
+  }
+
+  protected getDefault(defaultValue?: T): T | undefined {
+    return defaultValue;
   }
 }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/lazy.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/lazy.ts
@@ -13,7 +13,7 @@ import { internals } from '../internals';
 /**
  * Use this type to construct recursive runtime schemas.
  */
-export class Lazy<T> extends Type<T> {
+export class Lazy<T> extends Type<T, T> {
   constructor(id: string) {
     super(internals.link(`#${id}`));
   }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/literal_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/literal_type.ts
@@ -10,7 +10,7 @@
 import { internals } from '../internals';
 import { Type } from './type';
 
-export class LiteralType<T> extends Type<T> {
+export class LiteralType<T> extends Type<T, T, never> {
   private expectedValue: T;
 
   constructor(value: T) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/literal_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/literal_type.ts
@@ -10,12 +10,16 @@
 import { internals } from '../internals';
 import { Type } from './type';
 
-export class LiteralType<T> extends Type<T, T, never> {
+export class LiteralType<T> extends Type<T> {
   private expectedValue: T;
 
   constructor(value: T) {
     super(internals.any().valid(value));
     this.expectedValue = value;
+  }
+
+  protected getDefault(defaultValue?: T): T | undefined {
+    return defaultValue;
   }
 
   protected handleError(type: string) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/map_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/map_type.test.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { expectType } from 'tsd';
+
 import { schema } from '../..';
 import { META_FIELD_X_OAS_GET_ADDITIONAL_PROPERTIES } from '../oas_meta_fields';
 
@@ -221,6 +223,27 @@ describe('#extendsDeep', () => {
         forbidSchema.validate({ key: { foo: 'test', bar: 'test' } })
       ).toThrowErrorMatchingInlineSnapshot(`"[key.bar]: definition for this key is missing"`);
     });
+  });
+});
+
+describe('#validate', () => {
+  test('should validate with correct type', () => {
+    schema.mapOf(schema.string(), schema.string(), {
+      validate: (value) => {
+        expectType<typeof value>(new Map<string, string>());
+      },
+    });
+  });
+});
+
+describe('#defaultValue', () => {
+  // TODO: The defaultValue should be respected
+  test.failing('should validate with correct defaultValue', () => {
+    const defaultValue = new Map<string, string>([['foo', 'test']]);
+    const type = schema.mapOf(schema.string(), schema.string(), {
+      defaultValue,
+    });
+    expect(type.validate(undefined)).toEqual(defaultValue);
   });
 });
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/map_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/map_type.test.ts
@@ -237,8 +237,7 @@ describe('#validate', () => {
 });
 
 describe('#defaultValue', () => {
-  // TODO: The defaultValue should be respected
-  test.failing('should validate with correct defaultValue', () => {
+  test('should validate with correct defaultValue', () => {
     const defaultValue = new Map<string, string>([['foo', 'test']]);
     const type = schema.mapOf(schema.string(), schema.string(), {
       defaultValue,
@@ -393,12 +392,12 @@ test('handles references', () => {
       schema.contextRef('scenario'),
       'context',
       schema.object({
-        value: schema.string({ defaultValue: schema.contextRef('context_value') }),
-        sibling: schema.string({ defaultValue: 'sibling#1' }),
+        value: schema.string().default(schema.contextRef('context_value')),
+        sibling: schema.string().default('sibling#1'),
       }),
       schema.object({
-        value: schema.string({ defaultValue: schema.siblingRef('sibling') }),
-        sibling: schema.string({ defaultValue: 'sibling#1' }),
+        value: schema.string().default(schema.siblingRef('sibling')),
+        sibling: schema.string().default('sibling#1'),
       })
     )
   );

--- a/src/platform/packages/shared/kbn-config-schema/src/types/map_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/map_type.ts
@@ -11,17 +11,31 @@ import typeDetect from 'type-detect';
 import { SchemaTypeError, SchemaTypesError } from '../errors';
 import { internals } from '../internals';
 import { META_FIELD_X_OAS_GET_ADDITIONAL_PROPERTIES } from '../oas_meta_fields';
-import type { TypeOptions, ExtendsDeepOptions, UnknownOptions } from './type';
+import type {
+  TypeOptions,
+  ExtendsDeepOptions,
+  UnknownOptions,
+  DefaultValue,
+  SomeType,
+} from './type';
 import { Type } from './type';
 
-export type MapOfOptions<K, V> = TypeOptions<Map<K, V>> & UnknownOptions;
+export type MapOfOptions<
+  K,
+  T extends SomeType,
+  D extends DefaultValue<Map<K, T['_input']>> = never
+> = TypeOptions<Map<K, T['_output']>, Map<K, T['_input']>, D> & UnknownOptions;
 
-export class MapOfType<K, V> extends Type<Map<K, V>> {
+export class MapOfType<
+  K,
+  T extends SomeType,
+  D extends DefaultValue<Map<K, T['_input']>> = never
+> extends Type<Map<K, T['_output']>, Map<K, T['_input']>, D> {
   private readonly keyType: Type<K>;
-  private readonly valueType: Type<V>;
-  private readonly mapOptions: MapOfOptions<K, V>;
+  private readonly valueType: T;
+  private readonly mapOptions: MapOfOptions<K, T, D>;
 
-  constructor(keyType: Type<K>, valueType: Type<V>, options: MapOfOptions<K, V> = {}) {
+  constructor(keyType: Type<K>, valueType: T, options: MapOfOptions<K, T, D> = {}) {
     const defaultValue = options.defaultValue;
     let schema = internals
       .map()
@@ -42,17 +56,17 @@ export class MapOfType<K, V> extends Type<Map<K, V>> {
       // of Map/Set/Promise/Error: https://github.com/hapijs/hoek/issues/228.
       // The only way to avoid cloning and hence the bug is to use function for
       // default value instead.
-      defaultValue: defaultValue instanceof Map ? () => defaultValue : defaultValue,
+      defaultValue: (defaultValue instanceof Map ? () => defaultValue : defaultValue) as D,
     });
     this.keyType = keyType;
     this.valueType = valueType;
     this.mapOptions = options;
   }
 
-  public extendsDeep(options: ExtendsDeepOptions) {
+  public extendsDeep(options: ExtendsDeepOptions): MapOfType<K, T, D> {
     return new MapOfType(
       this.keyType.extendsDeep(options),
-      this.valueType.extendsDeep(options),
+      this.valueType.extendsDeep(options) as T,
       this.mapOptions
     );
   }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/maybe_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/maybe_type.ts
@@ -7,14 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ExtendsDeepOptions } from './type';
+import { META_FIELD_X_OAS_OPTIONAL } from '../oas_meta_fields';
+import type { ExtendsDeepOptions, SomeType } from './type';
 import { Type } from './type';
 
-import { META_FIELD_X_OAS_OPTIONAL } from '../oas_meta_fields';
-export class MaybeType<V> extends Type<V | undefined> {
-  private readonly maybeType: Type<V>;
+export class MaybeType<T extends SomeType> extends Type<
+  T['_output'] | undefined,
+  T['_input'] | undefined
+> {
+  private readonly maybeType: Type<T['_output'] | undefined, T['_input'] | undefined, any>;
 
-  constructor(type: Type<V>) {
+  constructor(type: T) {
     super(
       type
         .getSchema()
@@ -25,7 +28,9 @@ export class MaybeType<V> extends Type<V | undefined> {
     this.maybeType = type;
   }
 
-  public extendsDeep(options: ExtendsDeepOptions) {
+  public extendsDeep(
+    options: ExtendsDeepOptions
+  ): Type<T['_output'] | undefined, T['_input'] | undefined> {
     return new MaybeType(this.maybeType.extendsDeep(options));
   }
 }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/maybe_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/maybe_type.ts
@@ -8,14 +8,14 @@
  */
 
 import { META_FIELD_X_OAS_OPTIONAL } from '../oas_meta_fields';
-import type { ExtendsDeepOptions, SomeType } from './type';
+import type { DefaultValue, ExtendsDeepOptions, SomeType } from './type';
 import { Type } from './type';
 
 export class MaybeType<T extends SomeType> extends Type<
   T['_output'] | undefined,
   T['_input'] | undefined
 > {
-  private readonly maybeType: Type<T['_output'] | undefined, T['_input'] | undefined, any>;
+  private readonly maybeType: Type<T['_output'] | undefined, T['_input'] | undefined>;
 
   constructor(type: T) {
     super(
@@ -26,6 +26,12 @@ export class MaybeType<T extends SomeType> extends Type<
         .default(() => undefined)
     );
     this.maybeType = type;
+  }
+
+  protected getDefault(
+    defaultValue?: DefaultValue<T['_input']>
+  ): DefaultValue<T['_input']> | undefined {
+    return defaultValue;
   }
 
   public extendsDeep(

--- a/src/platform/packages/shared/kbn-config-schema/src/types/never_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/never_type.ts
@@ -10,7 +10,7 @@
 import { internals } from '../internals';
 import { Type } from './type';
 
-export class NeverType extends Type<never> {
+export class NeverType extends Type<never, never, never> {
   constructor() {
     super(internals.any().forbidden());
   }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/nullable_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/nullable_type.test.ts
@@ -41,6 +41,11 @@ test('returns object value when passed object', () => {
   expect(type.validate(object)).toEqual(object);
 });
 
+test('returns null if null for literal', () => {
+  const type = schema.nullable(schema.literal('string literal'));
+  expect(type.validate(null)).toBe(null);
+});
+
 test('returns null if null for string', () => {
   const type = schema.nullable(schema.string());
   expect(type.validate(null)).toBe(null);
@@ -54,6 +59,11 @@ test('returns null if null for number', () => {
 test('returns null if null for boolean', () => {
   const type = schema.nullable(schema.boolean());
   expect(type.validate(null)).toBe(null);
+});
+
+test('returns null if undefined for literal', () => {
+  const type = schema.nullable(schema.literal('string literal'));
+  expect(type.validate(undefined)).toBe(null);
 });
 
 test('returns null if undefined for string', () => {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/number_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/number_type.test.ts
@@ -96,6 +96,7 @@ describe('#defaultValue', () => {
 
   test('should allow only number defaults', () => {
     schema.number().default(123);
+    // @ts-expect-error
     schema.number().default(undefined);
     // @ts-expect-error
     schema.number().default('some-string');

--- a/src/platform/packages/shared/kbn-config-schema/src/types/number_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/number_type.test.ts
@@ -93,6 +93,17 @@ describe('#defaultValue', () => {
   test('returns value when specified', () => {
     expect(schema.number({ defaultValue: 2 }).validate(3)).toBe(3);
   });
+
+  test('should allow only number defaults', () => {
+    schema.number({ defaultValue: 123 });
+    schema.number({ defaultValue: undefined });
+    // @ts-expect-error
+    schema.number({ defaultValue: 'some-string' });
+    // @ts-expect-error
+    schema.number({ defaultValue: false });
+    // @ts-expect-error
+    schema.number({ defaultValue: null });
+  });
 });
 
 test('returns error when not number or numeric string', () => {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/number_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/number_type.test.ts
@@ -87,22 +87,22 @@ describe('#unsafe', () => {
 
 describe('#defaultValue', () => {
   test('returns default when number is undefined', () => {
-    expect(schema.number({ defaultValue: 2 }).validate(undefined)).toBe(2);
+    expect(schema.number().default(2).validate(undefined)).toBe(2);
   });
 
   test('returns value when specified', () => {
-    expect(schema.number({ defaultValue: 2 }).validate(3)).toBe(3);
+    expect(schema.number().default(2).validate(3)).toBe(3);
   });
 
   test('should allow only number defaults', () => {
-    schema.number({ defaultValue: 123 });
-    schema.number({ defaultValue: undefined });
+    schema.number().default(123);
+    schema.number().default(undefined);
     // @ts-expect-error
-    schema.number({ defaultValue: 'some-string' });
+    schema.number().default('some-string');
     // @ts-expect-error
-    schema.number({ defaultValue: false });
+    schema.number().default(false);
     // @ts-expect-error
-    schema.number({ defaultValue: null });
+    schema.number().default(null);
   });
 });
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/number_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/number_type.ts
@@ -9,10 +9,14 @@
 
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
-import type { TypeOptions } from './type';
+import type { DefaultValue, TypeOptions } from './type';
 import { Type } from './type';
 
-export type NumberOptions = TypeOptions<number> & {
+export type NumberOptions<D extends DefaultValue<number> = never> = TypeOptions<
+  number,
+  number,
+  D
+> & {
   min?: number;
   max?: number;
   /**
@@ -23,8 +27,8 @@ export type NumberOptions = TypeOptions<number> & {
   unsafe?: boolean;
 };
 
-export class NumberType extends Type<number> {
-  constructor(options: NumberOptions = {}) {
+export class NumberType<D extends DefaultValue<number> = never> extends Type<number, number, D> {
+  constructor(options: NumberOptions<D> = {}) {
     let schema = internals.number();
     if (options.min !== undefined) {
       schema = schema.min(options.min);

--- a/src/platform/packages/shared/kbn-config-schema/src/types/number_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/number_type.ts
@@ -12,11 +12,7 @@ import { internals } from '../internals';
 import type { DefaultValue, TypeOptions } from './type';
 import { Type } from './type';
 
-export type NumberOptions<D extends DefaultValue<number> = never> = TypeOptions<
-  number,
-  number,
-  D
-> & {
+export type NumberOptions = TypeOptions<number> & {
   min?: number;
   max?: number;
   /**
@@ -27,8 +23,8 @@ export type NumberOptions<D extends DefaultValue<number> = never> = TypeOptions<
   unsafe?: boolean;
 };
 
-export class NumberType<D extends DefaultValue<number> = never> extends Type<number, number, D> {
-  constructor(options: NumberOptions<D> = {}) {
+export class NumberType extends Type<number> {
+  constructor(options: NumberOptions = {}) {
     let schema = internals.number();
     if (options.min !== undefined) {
       schema = schema.min(options.min);
@@ -41,6 +37,10 @@ export class NumberType<D extends DefaultValue<number> = never> extends Type<num
     }
 
     super(schema, options);
+  }
+
+  protected getDefault(defaultValue?: DefaultValue<number>): DefaultValue<number> | undefined {
+    return defaultValue;
   }
 
   protected handleError(type: string, { limit, value }: Record<string, any>) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/object_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/object_type.test.ts
@@ -9,9 +9,9 @@
 
 import { get } from 'lodash';
 import { expectType } from 'tsd';
-import type { TypeOf, TypeOfOutput } from './type_of';
+import type { TypeOf, TypeOfOutput } from '../helpers/types/type_of';
 import { offeringBasedSchema, schema } from '../..';
-import type { PreciseObjectProps } from './object_type';
+import type { ObjectProps } from './object_type';
 
 const types = {
   string: 'some-string',
@@ -84,7 +84,7 @@ test('fails if missing required value', () => {
 
 test('returns value if undefined string with default', () => {
   const type = schema.object({
-    name: schema.string({ defaultValue: 'test' }),
+    name: schema.string().default('test'),
   });
   const value = {};
 
@@ -108,7 +108,7 @@ test('fails if key does not exist in schema', () => {
 test('defined object within object', () => {
   const type = schema.object({
     foo: schema.object({
-      bar: schema.string({ defaultValue: 'hello world' }),
+      bar: schema.string().default('hello world'),
     }),
   });
 
@@ -122,7 +122,7 @@ test('defined object within object', () => {
 test('undefined object within object', () => {
   const type = schema.object({
     foo: schema.object({
-      bar: schema.string({ defaultValue: 'hello world' }),
+      bar: schema.string().default('hello world'),
     }),
   });
 
@@ -168,7 +168,7 @@ describe('#validate', () => {
     const type = schema.object(
       {
         foo: schema.object({
-          bar: schema.string({ defaultValue: 'baz' }),
+          bar: schema.string().default('baz'),
         }),
       },
       {
@@ -207,11 +207,11 @@ describe('#validate', () => {
     const mySchema = schema.object(
       {
         str: schema.string(),
-        num: schema.number({ defaultValue: types.number }),
+        num: schema.number().default(types.number),
         strMaybe: schema.maybe(schema.string()),
         obj: schema.object({
           str: schema.string(),
-          num: schema.number({ defaultValue: types.number }),
+          num: schema.number().default(types.number),
           strMaybe: schema.maybe(schema.string()),
         }),
       },
@@ -237,7 +237,7 @@ describe('#getPropSchemas', () => {
     const props = {
       str: schema.string(),
       num: schema.number(),
-    } satisfies PreciseObjectProps;
+    } satisfies ObjectProps;
     const type = schema.object(props);
 
     expect(type.props).not.toBe(props);
@@ -311,7 +311,7 @@ test('handles references', () => {
       defaultValue: schema.contextRef('context_value'),
     }),
     key: schema.string(),
-    value: schema.string({ defaultValue: schema.siblingRef('key') }),
+    value: schema.string().default(schema.siblingRef('key')),
   });
 
   expect(type.validate({ key: 'key#1' }, { context_value: 'context#1' })).toEqual({
@@ -331,8 +331,8 @@ test('handles conditionals', () => {
     value: schema.conditional(
       schema.siblingRef('key'),
       'some-key',
-      schema.string({ defaultValue: 'some-value' }),
-      schema.string({ defaultValue: 'unknown-value' })
+      schema.string().default('some-value'),
+      schema.string().default('unknown-value')
     ),
   });
 
@@ -382,10 +382,7 @@ test('individual keys can validated', () => {
 });
 
 test('allow unknown keys when unknowns = `allow`', () => {
-  const type = schema.object(
-    { foo: schema.string({ defaultValue: 'test' }) },
-    { unknowns: 'allow' }
-  );
+  const type = schema.object({ foo: schema.string().default('test') }, { unknowns: 'allow' });
 
   expect(
     type.validate({
@@ -414,10 +411,7 @@ test('unknowns = `allow` affects only own keys', () => {
 });
 
 test('does not allow unknown keys when unknowns = `forbid`', () => {
-  const type = schema.object(
-    { foo: schema.string({ defaultValue: 'test' }) },
-    { unknowns: 'forbid' }
-  );
+  const type = schema.object({ foo: schema.string().default('test') }, { unknowns: 'forbid' });
   expect(() =>
     type.validate({
       bar: 'baz',
@@ -426,10 +420,7 @@ test('does not allow unknown keys when unknowns = `forbid`', () => {
 });
 
 test('allow and remove unknown keys when unknowns = `ignore`', () => {
-  const type = schema.object(
-    { foo: schema.string({ defaultValue: 'test' }) },
-    { unknowns: 'ignore' }
-  );
+  const type = schema.object({ foo: schema.string().default('test') }, { unknowns: 'ignore' });
 
   expect(
     type.validate({
@@ -479,7 +470,7 @@ test('unknowns = `ignore` respects local preferences in sub-keys', () => {
 describe('nested unknowns', () => {
   test('allow unknown keys when unknowns = `allow`', () => {
     const type = schema.object({
-      myObj: schema.object({ foo: schema.string({ defaultValue: 'test' }) }, { unknowns: 'allow' }),
+      myObj: schema.object({ foo: schema.string().default('test') }, { unknowns: 'allow' }),
     });
 
     expect(
@@ -515,10 +506,7 @@ describe('nested unknowns', () => {
 
   test('does not allow unknown keys when unknowns = `forbid`', () => {
     const type = schema.object({
-      myObj: schema.object(
-        { foo: schema.string({ defaultValue: 'test' }) },
-        { unknowns: 'forbid' }
-      ),
+      myObj: schema.object({ foo: schema.string().default('test') }, { unknowns: 'forbid' }),
     });
     expect(() =>
       type.validate({
@@ -531,10 +519,7 @@ describe('nested unknowns', () => {
 
   test('allow and remove unknown keys when unknowns = `ignore`', () => {
     const type = schema.object({
-      myObj: schema.object(
-        { foo: schema.string({ defaultValue: 'test' }) },
-        { unknowns: 'ignore' }
-      ),
+      myObj: schema.object({ foo: schema.string().default('test') }, { unknowns: 'ignore' }),
     });
 
     expect(
@@ -598,10 +583,7 @@ describe('nested unknowns', () => {
   test('parent `allow`, child `ignore` should be honored', () => {
     const type = schema.object(
       {
-        myObj: schema.object(
-          { foo: schema.string({ defaultValue: 'test' }) },
-          { unknowns: 'ignore' }
-        ),
+        myObj: schema.object({ foo: schema.string().default('test') }, { unknowns: 'ignore' }),
       },
       { unknowns: 'allow' }
     );
@@ -623,7 +605,7 @@ describe('nested unknowns', () => {
     test('should strip unknown keys', () => {
       const type = schema.object({
         myObj: schema.object({
-          foo: schema.string({ defaultValue: 'test' }),
+          foo: schema.string().default('test'),
           nested: schema.object({
             a: schema.number(),
           }),
@@ -1044,107 +1026,106 @@ describe('#defaultValue', () => {
       num: schema.number(),
     };
 
-    schema.object(simpleProps, {
-      // @ts-expect-error
-      defaultValue: {},
-    });
-    schema.object(simpleProps, {
-      defaultValue: {
-        str: types.string,
-        num: types.number,
-      },
+    // @ts-expect-error
+    schema.object(simpleProps).default({});
+    schema.object(simpleProps).default({
+      str: types.string,
+      num: types.number,
     });
   });
-  test('should pass property default types to object default', () => {
+  test('should pass property default types to object defaultValue', () => {
     const simpleProps = {
-      str: schema.string({ defaultValue: types.string }),
+      str: schema.string().default(types.string),
       num: schema.number(),
-    } satisfies PreciseObjectProps;
+    } satisfies ObjectProps;
 
     schema.object(simpleProps, {
       // @ts-expect-error
       defaultValue: {},
     });
-    schema.object(simpleProps, {
-      defaultValue: {
-        num: types.number,
-      },
+    schema.object(simpleProps).default({
+      num: types.number,
     });
-    schema.object(simpleProps, {
-      defaultValue: {
-        str: types.string,
-        num: types.number,
-      },
+    schema.object(simpleProps).default({
+      str: types.string,
+      num: types.number,
+    });
+  });
+  test('should pass property default types to object.default()', () => {
+    const simpleProps = {
+      str: schema.string().default(types.string),
+      num: schema.number(),
+    } satisfies ObjectProps;
+
+    schema
+      .object(simpleProps)
+      // @ts-expect-error
+      .default({});
+    schema.object(simpleProps).default({
+      num: types.number,
+    });
+    schema.object(simpleProps).default({
+      str: types.string,
+      num: types.number,
     });
   });
   test('should handle nested schemas with defaults in object default', () => {
     const nestedProps = {
-      str: schema.string({ defaultValue: types.string }),
+      str: schema.string().default(types.string),
       num: schema.number(),
       obj: schema.object({
         str: schema.string(),
-        num: schema.number({ defaultValue: types.number }),
+        num: schema.number().default(types.number),
       }),
-      objMaybe: schema.object(
-        {
+      objMaybe: schema
+        .object({
           bool: schema.boolean(),
-        },
-        { defaultValue: { bool: false } }
-      ),
-    } satisfies PreciseObjectProps;
+        })
+        .default({ bool: false }),
+    } satisfies ObjectProps;
 
     // full
-    schema.object(nestedProps, {
-      defaultValue: {
+    schema.object(nestedProps).default({
+      str: types.string,
+      num: types.number,
+      obj: {
         str: types.string,
         num: types.number,
-        obj: {
-          str: types.string,
-          num: types.number,
-        },
-        objMaybe: {
-          bool: true,
-        },
+      },
+      objMaybe: {
+        bool: true,
       },
     });
     // sparse
-    schema.object(nestedProps, {
-      defaultValue: {
-        num: types.number,
-        obj: {
-          str: types.string,
-        },
+    schema.object(nestedProps).default({
+      num: types.number,
+      obj: {
+        str: types.string,
       },
     });
     // bad types
-    schema.object(nestedProps, {
-      defaultValue: {
+    schema.object(nestedProps).default({
+      // @ts-expect-error
+      str: types.number,
+      // @ts-expect-error
+      num: types.string,
+      obj: {
         // @ts-expect-error
         str: types.number,
         // @ts-expect-error
         num: types.string,
-        obj: {
-          // @ts-expect-error
-          str: types.number,
-          // @ts-expect-error
-          num: types.string,
-        },
-        objMaybe: {
-          // @ts-expect-error
-          bool: types.string,
-        },
+      },
+      objMaybe: {
+        // @ts-expect-error
+        bool: types.string,
       },
     });
-    schema.object(nestedProps, {
-      defaultValue: {
-        // @ts-expect-error
-        objMaybe: types.string,
-      },
+    schema.object(nestedProps).default({
+      // @ts-expect-error
+      objMaybe: types.string,
     });
     // empty
-    schema.object(nestedProps, {
-      // @ts-expect-error
-      defaultValue: {},
-    });
+    // @ts-expect-error
+    schema.object(nestedProps).default({});
   });
 });

--- a/src/platform/packages/shared/kbn-config-schema/src/types/object_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/object_type.test.ts
@@ -9,8 +9,14 @@
 
 import { get } from 'lodash';
 import { expectType } from 'tsd';
+import type { TypeOf, TypeOfOutput } from './type_of';
 import { offeringBasedSchema, schema } from '../..';
-import type { Props, TypeOf } from './object_type';
+import type { PreciseObjectProps } from './object_type';
+
+const types = {
+  string: 'some-string',
+  number: 123,
+};
 
 test('returns value by default', () => {
   const type = schema.object({
@@ -156,7 +162,7 @@ test('object within object with key without defaultValue', () => {
 });
 
 describe('#validate', () => {
-  test('is called after all content is processed', () => {
+  test('should be called after all content is processed', () => {
     const mockValidate = jest.fn();
 
     const type = schema.object(
@@ -178,6 +184,52 @@ describe('#validate', () => {
       },
     });
   });
+  test('should not be called if validation fails', () => {
+    const mockValidate = jest.fn();
+
+    const type = schema.object(
+      {
+        bar: schema.string(),
+      },
+      {
+        validate: mockValidate,
+      }
+    );
+
+    expect(() => {
+      type.validate({});
+    }).toThrowError('expected value of type [string] but got [undefined]');
+
+    expect(mockValidate).not.toHaveBeenCalled();
+  });
+  test('should be called with validated schema object', () => {
+    type MySchemaOutput = TypeOfOutput<typeof mySchema>;
+    const mySchema = schema.object(
+      {
+        str: schema.string(),
+        num: schema.number({ defaultValue: types.number }),
+        strMaybe: schema.maybe(schema.string()),
+        obj: schema.object({
+          str: schema.string(),
+          num: schema.number({ defaultValue: types.number }),
+          strMaybe: schema.maybe(schema.string()),
+        }),
+      },
+      {
+        validate: (type) => {
+          expectType<MySchemaOutput>(type);
+          expectType<typeof type.num>(types.number);
+          expectType<typeof type.str>(types.string);
+          expectType<typeof type.strMaybe>(types.string);
+          expectType<typeof type.strMaybe>(undefined);
+          expectType<typeof type.obj.num>(types.number);
+          expectType<typeof type.obj.str>(types.string);
+          expectType<typeof type.obj.strMaybe>(types.string);
+          expectType<typeof type.obj.strMaybe>(undefined);
+        },
+      }
+    );
+  });
 });
 
 describe('#getPropSchemas', () => {
@@ -185,11 +237,11 @@ describe('#getPropSchemas', () => {
     const props = {
       str: schema.string(),
       num: schema.number(),
-    } satisfies Props;
+    } satisfies PreciseObjectProps;
     const type = schema.object(props);
 
-    expect(type.getPropSchemas()).not.toBe(props);
-    expect(type.getPropSchemas()).toEqual(props);
+    expect(type.props).not.toBe(props);
+    expect(type.props).toEqual(props);
   });
 
   test('should be spreadable into new schema type', () => {
@@ -198,7 +250,7 @@ describe('#getPropSchemas', () => {
       num: schema.number(),
     });
     const newType = schema.object({
-      ...type.getPropSchemas(),
+      ...type.props,
       bool: schema.boolean(),
     });
 
@@ -218,7 +270,7 @@ describe('#getPropSchemas', () => {
     });
 
     const newType = schema.object({
-      ...type.getPropSchemas(),
+      ...type.props,
       bool: schema.boolean(),
     });
 
@@ -982,5 +1034,117 @@ describe('#extendsDeep', () => {
     expect(() =>
       forbidSchema.validate({ test: { foo: 'test', bar: 'test' } })
     ).toThrowErrorMatchingInlineSnapshot(`"[test.bar]: definition for this key is missing"`);
+  });
+});
+
+describe('#defaultValue', () => {
+  test('should enforce properties in object default', () => {
+    const simpleProps = {
+      str: schema.string(),
+      num: schema.number(),
+    };
+
+    schema.object(simpleProps, {
+      // @ts-expect-error
+      defaultValue: {},
+    });
+    schema.object(simpleProps, {
+      defaultValue: {
+        str: types.string,
+        num: types.number,
+      },
+    });
+  });
+  test('should pass property default types to object default', () => {
+    const simpleProps = {
+      str: schema.string({ defaultValue: types.string }),
+      num: schema.number(),
+    } satisfies PreciseObjectProps;
+
+    schema.object(simpleProps, {
+      // @ts-expect-error
+      defaultValue: {},
+    });
+    schema.object(simpleProps, {
+      defaultValue: {
+        num: types.number,
+      },
+    });
+    schema.object(simpleProps, {
+      defaultValue: {
+        str: types.string,
+        num: types.number,
+      },
+    });
+  });
+  test('should handle nested schemas with defaults in object default', () => {
+    const nestedProps = {
+      str: schema.string({ defaultValue: types.string }),
+      num: schema.number(),
+      obj: schema.object({
+        str: schema.string(),
+        num: schema.number({ defaultValue: types.number }),
+      }),
+      objMaybe: schema.object(
+        {
+          bool: schema.boolean(),
+        },
+        { defaultValue: { bool: false } }
+      ),
+    } satisfies PreciseObjectProps;
+
+    // full
+    schema.object(nestedProps, {
+      defaultValue: {
+        str: types.string,
+        num: types.number,
+        obj: {
+          str: types.string,
+          num: types.number,
+        },
+        objMaybe: {
+          bool: true,
+        },
+      },
+    });
+    // sparse
+    schema.object(nestedProps, {
+      defaultValue: {
+        num: types.number,
+        obj: {
+          str: types.string,
+        },
+      },
+    });
+    // bad types
+    schema.object(nestedProps, {
+      defaultValue: {
+        // @ts-expect-error
+        str: types.number,
+        // @ts-expect-error
+        num: types.string,
+        obj: {
+          // @ts-expect-error
+          str: types.number,
+          // @ts-expect-error
+          num: types.string,
+        },
+        objMaybe: {
+          // @ts-expect-error
+          bool: types.string,
+        },
+      },
+    });
+    schema.object(nestedProps, {
+      defaultValue: {
+        // @ts-expect-error
+        objMaybe: types.string,
+      },
+    });
+    // empty
+    schema.object(nestedProps, {
+      // @ts-expect-error
+      defaultValue: {},
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-config-schema/src/types/object_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/object_type.ts
@@ -10,39 +10,64 @@
 import type { AnySchema } from 'joi';
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
-import type { TypeOptions, ExtendsDeepOptions, UnknownOptions } from './type';
+import type {
+  TypeOptions,
+  ExtendsDeepOptions,
+  UnknownOptions,
+  SomeType,
+  DefaultValue,
+  TypeOrLazyType,
+} from './type';
 import { Type } from './type';
 import { ValidationError } from '../errors';
+import type { OptionalizeObject } from '../helpers/types';
 
-export type Props = Record<string, Type<any>>;
+export type SomeObjectType = ObjectType<any, any, any, any>;
 
-export type NullableProps = Record<string, Type<any> | undefined | null>;
+/**
+ * Needed to constrain the object raw props to preserve the exact type for D
+ *
+ * Without this the defaults will be stripped away when defined directly in the object.
+ */
+export type PreciseObjectProps = {
+  [K in keyof ObjectRawProps]: ObjectRawProps[K] extends Type<infer O, infer I, infer D>
+    ? D
+    : never;
+};
 
-export type TypeOrLazyType = Type<any> | (() => Type<any>);
+export type ObjectRawProps = Record<string, SomeType>;
 
-export type TypeOf<RT extends TypeOrLazyType> = RT extends () => Type<any>
+export type ObjectOutputType<Props extends ObjectRawProps> = OptionalizeObject<{
+  [k in keyof Props]: Props[k]['_output'];
+}>;
+
+export type ObjectInputType<Props extends ObjectRawProps> = OptionalizeObject<{
+  [k in keyof Props]: Props[k]['_input'];
+}>;
+
+export type NullableProps = Record<string, SomeType | undefined | null>;
+
+type TypeOf<RT extends TypeOrLazyType> = RT extends () => SomeType
   ? ReturnType<RT>['type']
-  : RT extends Type<any>
+  : RT extends SomeType
   ? RT['type']
   : never;
 
-type OptionalProperties<Base extends Props> = Pick<
+type OptionalProperties<Base extends ObjectRawProps> = Pick<
   Base,
   {
     [Key in keyof Base]: undefined extends TypeOf<Base[Key]> ? Key : never;
   }[keyof Base]
 >;
 
-type RequiredProperties<Base extends Props> = Pick<
+type RequiredProperties<Base extends ObjectRawProps> = Pick<
   Base,
   {
     [Key in keyof Base]: undefined extends TypeOf<Base[Key]> ? never : Key;
   }[keyof Base]
 >;
 
-// Because of https://github.com/Microsoft/TypeScript/issues/14041
-// this might not have perfect _rendering_ output, but it will be typed.
-export type ObjectResultType<P extends Props> = Readonly<
+export type ObjectResultType<P extends ObjectRawProps> = Readonly<
   { [K in keyof OptionalProperties<P>]?: TypeOf<P[K]> } & {
     [K in keyof RequiredProperties<P>]: TypeOf<P[K]>;
   }
@@ -55,17 +80,9 @@ type DefinedProperties<Base extends NullableProps> = Pick<
   }[keyof Base]
 >;
 
-type ExtendedProps<P extends Props, NP extends NullableProps> = Omit<P, keyof NP> & {
+type ExtendedProps<P extends ObjectRawProps, NP extends NullableProps> = Omit<P, keyof NP> & {
   [K in keyof DefinedProperties<NP>]: NP[K];
 };
-
-type ExtendedObjectType<P extends Props, NP extends NullableProps> = ObjectType<
-  ExtendedProps<P, NP>
->;
-
-type ExtendedObjectTypeOptions<P extends Props, NP extends NullableProps> = ObjectTypeOptions<
-  ExtendedProps<P, NP>
->;
 
 interface ObjectTypeOptionsMeta {
   /**
@@ -75,15 +92,24 @@ interface ObjectTypeOptionsMeta {
   id?: string;
 }
 
-export type ObjectTypeOptions<P extends Props = any> = TypeOptions<ObjectResultType<P>> &
-  UnknownOptions & { meta?: TypeOptions<ObjectResultType<P>>['meta'] & ObjectTypeOptionsMeta };
+export type ObjectTypeOptions<
+  Output,
+  Input = Output,
+  D extends DefaultValue<Input> = never
+> = TypeOptions<Output, Input, D> &
+  UnknownOptions & { meta?: TypeOptions<Output, Input, D>['meta'] & ObjectTypeOptionsMeta };
 
-export class ObjectType<P extends Props = any> extends Type<ObjectResultType<P>> {
-  private props: P;
-  private options: ObjectTypeOptions<P>;
-  private propSchemas: Record<string, AnySchema>;
+export class ObjectType<
+  P extends ObjectRawProps,
+  Output = ObjectOutputType<P>,
+  Input = ObjectInputType<P>,
+  D extends DefaultValue<Input> = never
+> extends Type<Output, Input, D> {
+  #props: P;
+  #options: ObjectTypeOptions<Output, Input, D>;
+  #propSchemas: Record<string, AnySchema>;
 
-  constructor(props: P, options: ObjectTypeOptions<P> = {}) {
+  constructor(props: P, options: ObjectTypeOptions<Output, Input, D> = {}) {
     const schemaKeys = {} as Record<string, AnySchema>;
     const { unknowns, ...typeOptions } = options;
     for (const [key, value] of Object.entries(props)) {
@@ -107,9 +133,9 @@ export class ObjectType<P extends Props = any> extends Type<ObjectResultType<P>>
     }
 
     super(schema, typeOptions);
-    this.props = props;
-    this.propSchemas = schemaKeys;
-    this.options = options;
+    this.#props = props;
+    this.#propSchemas = schemaKeys;
+    this.#options = options;
   }
 
   /**
@@ -149,6 +175,7 @@ export class ObjectType<P extends Props = any> extends Type<ObjectResultType<P>>
    * const extended = origin.extends({
    *   added: schema.number(),
    * }, { defaultValue: { initial: 'foo', added: 'bar' }});
+   * ```
    *
    * @remarks
    * `extends` only support extending first-level properties. It's currently not possible to perform deep/nested extensions.
@@ -168,15 +195,28 @@ export class ObjectType<P extends Props = any> extends Type<ObjectResultType<P>>
    *   }),
    * });
    *
-   * // TypeOf<typeof extended> is `{ foo: string; nested: { c: string } }`
+   * // TypeOf<typeof extended> -> { foo: string; nested: { c: string } }
    * ```
    */
-  public extends<NP extends NullableProps>(
+  public extends<
+    T extends SomeObjectType,
+    NP extends T['props'], // must derive props from general type to infer precise types
+    ND extends DefaultValue<ObjectInputType<ExtendedProps<P, NP>>> = never
+  >(
     newProps: NP,
-    newOptions?: ExtendedObjectTypeOptions<P, NP>
-  ): ExtendedObjectType<P, NP> {
+    newOptions?: ObjectTypeOptions<
+      ObjectOutputType<ExtendedProps<P, NP>>,
+      ObjectInputType<ExtendedProps<P, NP>>,
+      ND
+    >
+  ): ObjectType<
+    ExtendedProps<P, NP>,
+    ObjectOutputType<ExtendedProps<P, NP>>,
+    ObjectInputType<ExtendedProps<P, NP>>,
+    ND
+  > {
     const extendedProps = Object.entries({
-      ...this.props,
+      ...this.#props,
       ...newProps,
     }).reduce((memo, [key, value]) => {
       if (value !== null && value !== undefined) {
@@ -186,15 +226,19 @@ export class ObjectType<P extends Props = any> extends Type<ObjectResultType<P>>
     }, {} as ExtendedProps<P, NP>);
 
     const extendedOptions = {
-      ...this.options,
+      ...this.#options,
       ...newOptions,
-    } as ExtendedObjectTypeOptions<P, NP>;
+    } as ObjectTypeOptions<
+      ObjectOutputType<ExtendedProps<P, NP>>,
+      ObjectInputType<ExtendedProps<P, NP>>,
+      ND
+    >;
 
     return new ObjectType(extendedProps, extendedOptions);
   }
 
-  public extendsDeep(options: ExtendsDeepOptions) {
-    const extendedProps = Object.entries(this.props).reduce((memo, [key, value]) => {
+  public extendsDeep(options: ExtendsDeepOptions): Type<Output, Input, D> {
+    const extendedProps = Object.entries(this.#props).reduce((memo, [key, value]) => {
       if (value !== null && value !== undefined) {
         return {
           ...memo,
@@ -204,8 +248,8 @@ export class ObjectType<P extends Props = any> extends Type<ObjectResultType<P>>
       return memo;
     }, {} as P);
 
-    const extendedOptions: ObjectTypeOptions<P> = {
-      ...this.options,
+    const extendedOptions: ObjectTypeOptions<Output, Input, D> = {
+      ...this.#options,
       ...(options.unknowns ? { unknowns: options.unknowns } : {}),
     };
 
@@ -228,16 +272,36 @@ export class ObjectType<P extends Props = any> extends Type<ObjectResultType<P>>
 
   /**
    * Return the schema for this object's underlying properties
+   *
+   * @example
+   * ```ts
+   * const schema1 = schema.object({
+   *   str: schema.string(),
+   *   num: schema.number(),
+   * });
+   *
+   * const schema2 = schema.object({
+   *   ...schema1.props,
+   *   bool: schema.boolean(),
+   * });
+   * ```
+   */
+  public get props(): P {
+    return { ...this.#props };
+  }
+
+  /**
+   * @deprecated use `schema.props` instead
    */
   public getPropSchemas(): P {
-    return { ...this.props };
+    return { ...this.#props };
   }
 
   validateKey(key: string, value: any) {
-    if (!this.propSchemas[key]) {
+    if (!this.#propSchemas[key]) {
       throw new Error(`${key} is not a valid part of this schema`);
     }
-    const { value: validatedValue, error } = this.propSchemas[key].validate(value);
+    const { value: validatedValue, error } = this.#propSchemas[key].validate(value);
     if (error) {
       throw new ValidationError(error as any, key);
     }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/object_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/object_type.ts
@@ -181,11 +181,11 @@ export class ObjectType<
    * ```ts
    * const origin = schema.object({
    *   initial: schema.string(),
-   * }, { defaultValue: { initial: 'foo' }});
+   * }).default({ initial: 'foo' });
    *
    * const extended = origin.extends({
    *   added: schema.number(),
-   * }, { defaultValue: { initial: 'foo', added: 'bar' }});
+   * }).default({ initial: 'foo', added: 'bar' });
    * ```
    *
    * @remarks

--- a/src/platform/packages/shared/kbn-config-schema/src/types/record_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/record_type.test.ts
@@ -225,8 +225,7 @@ describe('#validate', () => {
 });
 
 describe('#defaultValue', () => {
-  // TODO: The defaultValue should be respected
-  test.failing('should validate with correct defaultValue', () => {
+  test('should validate with correct defaultValue', () => {
     const defaultValue = { foo: 'test' };
     const type = schema.recordOf(schema.string(), schema.string(), {
       defaultValue,
@@ -394,12 +393,12 @@ test('handles references', () => {
       schema.contextRef('scenario'),
       'context',
       schema.object({
-        value: schema.string({ defaultValue: schema.contextRef('context_value') }),
-        sibling: schema.string({ defaultValue: 'sibling#1' }),
+        value: schema.string().default(schema.contextRef('context_value')),
+        sibling: schema.string().default('sibling#1'),
       }),
       schema.object({
-        value: schema.string({ defaultValue: schema.siblingRef('sibling') }),
-        sibling: schema.string({ defaultValue: 'sibling#1' }),
+        value: schema.string().default(schema.siblingRef('sibling')),
+        sibling: schema.string().default('sibling#1'),
       })
     )
   );

--- a/src/platform/packages/shared/kbn-config-schema/src/types/record_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/record_type.test.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { expectType } from 'tsd';
+
 import { schema } from '../..';
 import { META_FIELD_X_OAS_GET_ADDITIONAL_PROPERTIES } from '../oas_meta_fields';
 
@@ -208,6 +210,28 @@ describe('#extendsDeep', () => {
     expect(() =>
       forbidSchema.validate({ key: { foo: 'test', bar: 'test' } })
     ).toThrowErrorMatchingInlineSnapshot(`"[key.bar]: definition for this key is missing"`);
+  });
+});
+
+describe('#validate', () => {
+  test('should validate with correct type', () => {
+    schema.recordOf(schema.string(), schema.string(), {
+      validate: (value) => {
+        const expected: Record<string, string> = { foo: 'test' };
+        expectType<typeof value>(expected);
+      },
+    });
+  });
+});
+
+describe('#defaultValue', () => {
+  // TODO: The defaultValue should be respected
+  test.failing('should validate with correct defaultValue', () => {
+    const defaultValue = { foo: 'test' };
+    const type = schema.recordOf(schema.string(), schema.string(), {
+      defaultValue,
+    });
+    expect(type.validate(undefined)).toEqual(defaultValue);
   });
 });
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/record_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/record_type.ts
@@ -10,18 +10,32 @@
 import typeDetect from 'type-detect';
 import { SchemaTypeError, SchemaTypesError } from '../errors';
 import { internals } from '../internals';
-import type { TypeOptions, ExtendsDeepOptions, UnknownOptions } from './type';
+import type {
+  TypeOptions,
+  ExtendsDeepOptions,
+  UnknownOptions,
+  DefaultValue,
+  SomeType,
+} from './type';
 import { Type } from './type';
 import { META_FIELD_X_OAS_GET_ADDITIONAL_PROPERTIES } from '../oas_meta_fields';
 
-export type RecordOfOptions<K extends string, V> = TypeOptions<Record<K, V>> & UnknownOptions;
+export type RecordOfOptions<
+  K extends string,
+  T extends SomeType,
+  D extends DefaultValue<Record<K, T['_input']>> = never
+> = TypeOptions<Record<K, T['_output']>, Record<K, T['_input']>, D> & UnknownOptions;
 
-export class RecordOfType<K extends string, V> extends Type<Record<K, V>> {
+export class RecordOfType<
+  K extends string,
+  T extends SomeType,
+  D extends DefaultValue<Record<K, T['_input']>> = never
+> extends Type<Record<K, T['_output']>, Record<K, T['_input']>, D> {
   private readonly keyType: Type<K>;
-  private readonly valueType: Type<V>;
-  private readonly options: RecordOfOptions<K, V>;
+  private readonly valueType: T;
+  private readonly options: RecordOfOptions<K, T, D>;
 
-  constructor(keyType: Type<K>, valueType: Type<V>, options: RecordOfOptions<K, V> = {}) {
+  constructor(keyType: Type<K>, valueType: T, options: RecordOfOptions<K, T, D> = {}) {
     let schema = internals
       .record()
       .entries(keyType.getSchema(), valueType.getSchema())
@@ -41,10 +55,10 @@ export class RecordOfType<K extends string, V> extends Type<Record<K, V>> {
     this.options = options;
   }
 
-  public extendsDeep(options: ExtendsDeepOptions) {
+  public extendsDeep(options: ExtendsDeepOptions): RecordOfType<K, T, D> {
     return new RecordOfType(
       this.keyType.extendsDeep(options),
-      this.valueType.extendsDeep(options),
+      this.valueType.extendsDeep(options) as T,
       this.options
     );
   }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/record_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/record_type.ts
@@ -14,28 +14,27 @@ import type {
   TypeOptions,
   ExtendsDeepOptions,
   UnknownOptions,
-  DefaultValue,
   SomeType,
+  DefaultValue,
 } from './type';
 import { Type } from './type';
 import { META_FIELD_X_OAS_GET_ADDITIONAL_PROPERTIES } from '../oas_meta_fields';
 
-export type RecordOfOptions<
-  K extends string,
-  T extends SomeType,
-  D extends DefaultValue<Record<K, T['_input']>> = never
-> = TypeOptions<Record<K, T['_output']>, Record<K, T['_input']>, D> & UnknownOptions;
+export type RecordOfOptions<K extends string, T extends SomeType> = TypeOptions<
+  Record<K, T['_output']>,
+  Record<K, T['_input']>
+> &
+  UnknownOptions;
 
-export class RecordOfType<
-  K extends string,
-  T extends SomeType,
-  D extends DefaultValue<Record<K, T['_input']>> = never
-> extends Type<Record<K, T['_output']>, Record<K, T['_input']>, D> {
+export class RecordOfType<K extends string, T extends SomeType> extends Type<
+  Record<K, T['_output']>,
+  Record<K, T['_input']>
+> {
   private readonly keyType: Type<K>;
   private readonly valueType: T;
-  private readonly options: RecordOfOptions<K, T, D>;
+  private readonly options: RecordOfOptions<K, T>;
 
-  constructor(keyType: Type<K>, valueType: T, options: RecordOfOptions<K, T, D> = {}) {
+  constructor(keyType: Type<K>, valueType: T, options: RecordOfOptions<K, T> = {}) {
     let schema = internals
       .record()
       .entries(keyType.getSchema(), valueType.getSchema())
@@ -55,12 +54,18 @@ export class RecordOfType<
     this.options = options;
   }
 
-  public extendsDeep(options: ExtendsDeepOptions): RecordOfType<K, T, D> {
+  public extendsDeep(options: ExtendsDeepOptions): RecordOfType<K, T> {
     return new RecordOfType(
       this.keyType.extendsDeep(options),
       this.valueType.extendsDeep(options) as T,
       this.options
     );
+  }
+
+  protected getDefault(
+    defaultValue?: DefaultValue<Record<K, T['_input']>>
+  ): DefaultValue<Record<K, T['_input']>> | undefined {
+    return defaultValue;
   }
 
   protected handleError(

--- a/src/platform/packages/shared/kbn-config-schema/src/types/schema_of.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/schema_of.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expectType } from 'tsd';
+
+import { schema } from '../..';
+import type { SchemaOf } from './schema_of';
+
+describe('SchemaOf', () => {
+  it('should create basic schema type from output', () => {
+    interface MySchemaOutput {
+      name: string;
+      age?: number | undefined;
+    }
+
+    type Expected = SchemaOf<MySchemaOutput>;
+
+    expectType<Expected>(
+      schema.object({
+        name: schema.string(),
+        age: schema.maybe(schema.number()),
+      })
+    );
+  });
+
+  it('should error on missing property definitions', () => {
+    interface MySchemaOutput {
+      name: string;
+      age: number;
+      maybe?: number;
+    }
+
+    type Expected = SchemaOf<MySchemaOutput>;
+
+    expectType<Expected>(
+      // @ts-expect-error
+      schema.object({
+        name: schema.string(),
+        age: schema.string(),
+        maybe: schema.maybe(schema.number()),
+      })
+    );
+
+    // unable to enforce presence of optional types
+    expectType<Expected>(
+      schema.object({
+        name: schema.string(),
+        age: schema.number(),
+        // maybe: schema.maybe(schema.number()),
+      })
+    );
+  });
+
+  it('should create basic schema type that allows defaults', () => {
+    interface MySchemaOutput {
+      name: string;
+      age: number;
+    }
+
+    type Expected = SchemaOf<MySchemaOutput>;
+
+    expectType<Expected>(
+      schema.object({
+        name: schema.string({ defaultValue: 'John' }),
+        age: schema.number({ defaultValue: 1 }),
+      })
+    );
+  });
+
+  it('should create schema with array of objects', () => {
+    interface ArrayItem {
+      name: string;
+      age: number | string;
+    }
+    interface MySchemaOutput {
+      arr: ArrayItem[];
+    }
+
+    type Expected = SchemaOf<MySchemaOutput>;
+
+    expectType<Expected>(
+      schema.object({
+        arr: schema.arrayOf(
+          schema.object({
+            name: schema.string(),
+            age: schema.string(),
+          })
+        ),
+      })
+    );
+  });
+
+  it('should create nested schema type', () => {
+    interface MySchemaOutput {
+      name: string;
+      age: number;
+      obj: {
+        bool: boolean;
+      };
+    }
+
+    type Expected = SchemaOf<MySchemaOutput>;
+
+    expectType<Expected>(
+      schema.object({
+        name: schema.string(),
+        age: schema.number(),
+        obj: schema.object({
+          bool: schema.boolean(),
+        }),
+      })
+    );
+  });
+});

--- a/src/platform/packages/shared/kbn-config-schema/src/types/schema_of.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/schema_of.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Type } from './type';
+
+/*
+ * This `SchemaOf` is meant to allow driving schemas based on TS types.
+ * The difficulty is that it's hard to build up the shape of the schema perfectly,
+ * in order to match the expected schema.
+ *
+ * This is a loose type to derive a schema that mostly matches the expected type.
+ */
+
+/**
+ * Schema type derived from *output* type. Should be used with `satisfies` to infer the correct schema type.
+ *
+ * Limitations:
+ * - Does **not** support input types (i.e. input === output).
+ * - May not cover all cases perfectly.
+ *
+ * @example
+ * ```ts
+ * interface MySchemaOutput {
+ *    name: string;
+ *    age: number;
+ *  }
+ *
+ *  const mySchema = schema.object({
+ *    name: schema.string(),
+ *    age: schema.number(),
+ *  }) satisfies SchemaOf<MySchemaOutput>;
+ * ```
+ */
+export type SchemaOf<T> = Omit<Type<T, T, any>, '_input' | 'extendsDeep'>;

--- a/src/platform/packages/shared/kbn-config-schema/src/types/stream_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/stream_type.test.ts
@@ -47,12 +47,12 @@ test('includes namespace in failure', () => {
 describe('#defaultValue', () => {
   test('returns default when undefined', () => {
     const value = new Stream();
-    expect(schema.stream({ defaultValue: value }).validate(undefined)).toBeInstanceOf(Stream);
+    expect(schema.stream().default(value).validate(undefined)).toBeInstanceOf(Stream);
   });
 
   test('returns value when specified', () => {
     const value = new Stream();
-    expect(schema.stream({ defaultValue: new PassThrough() }).validate(value)).toStrictEqual(value);
+    expect(schema.stream().default(new PassThrough()).validate(value)).toStrictEqual(value);
   });
 });
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/stream_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/stream_type.ts
@@ -10,11 +10,11 @@
 import typeDetect from 'type-detect';
 import type { Stream } from 'stream';
 import { internals } from '../internals';
-import type { TypeOptions } from './type';
+import type { DefaultValue, TypeOptions } from './type';
 import { Type } from './type';
 
-export class StreamType extends Type<Stream> {
-  constructor(options?: TypeOptions<Stream>) {
+export class StreamType<D extends DefaultValue<Stream> = never> extends Type<Stream, Stream, D> {
+  constructor(options?: TypeOptions<Stream, Stream, D>) {
     super(internals.stream(), options);
   }
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/stream_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/stream_type.ts
@@ -13,9 +13,13 @@ import { internals } from '../internals';
 import type { DefaultValue, TypeOptions } from './type';
 import { Type } from './type';
 
-export class StreamType<D extends DefaultValue<Stream> = never> extends Type<Stream, Stream, D> {
-  constructor(options?: TypeOptions<Stream, Stream, D>) {
+export class StreamType extends Type<Stream> {
+  constructor(options?: TypeOptions<Stream>) {
     super(internals.stream(), options);
+  }
+
+  protected getDefault(defaultValue?: DefaultValue<Stream>): DefaultValue<Stream> | undefined {
+    return defaultValue;
   }
 
   protected handleError(type: string, { value }: Record<string, any>) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/string_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/string_type.test.ts
@@ -169,6 +169,7 @@ describe('#defaultValue', () => {
 
   test('should allow only string defaults', () => {
     schema.string().default('some-string');
+    // @ts-expect-error
     schema.string().default(undefined);
     // @ts-expect-error
     schema.string().default(123);

--- a/src/platform/packages/shared/kbn-config-schema/src/types/string_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/string_type.test.ts
@@ -166,6 +166,17 @@ describe('#defaultValue', () => {
       })
     ).toBe('some');
   });
+
+  test('should allow only string defaults', () => {
+    schema.string({ defaultValue: 'some-string' });
+    schema.string({ defaultValue: undefined });
+    // @ts-expect-error
+    schema.string({ defaultValue: 123 });
+    // @ts-expect-error
+    schema.string({ defaultValue: false });
+    // @ts-expect-error
+    schema.string({ defaultValue: null });
+  });
 });
 
 test('meta', () => {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/string_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/string_type.test.ts
@@ -152,30 +152,30 @@ describe('#hostname', () => {
 
 describe('#defaultValue', () => {
   test('returns default when string is undefined', () => {
-    expect(schema.string({ defaultValue: 'foo' }).validate(undefined)).toBe('foo');
+    expect(schema.string().default('foo').validate(undefined)).toBe('foo');
   });
 
   test('returns value when specified', () => {
-    expect(schema.string({ defaultValue: 'foo' }).validate('bar')).toBe('bar');
+    expect(schema.string().default('foo').validate('bar')).toBe('bar');
   });
 
   test('returns value from context when context reference is specified', () => {
     expect(
-      schema.string({ defaultValue: schema.contextRef('some_value') }).validate(undefined, {
+      schema.string().default(schema.contextRef('some_value')).validate(undefined, {
         some_value: 'some',
       })
     ).toBe('some');
   });
 
   test('should allow only string defaults', () => {
-    schema.string({ defaultValue: 'some-string' });
-    schema.string({ defaultValue: undefined });
+    schema.string().default('some-string');
+    schema.string().default(undefined);
     // @ts-expect-error
-    schema.string({ defaultValue: 123 });
+    schema.string().default(123);
     // @ts-expect-error
-    schema.string({ defaultValue: false });
+    schema.string().default(false);
     // @ts-expect-error
-    schema.string({ defaultValue: null });
+    schema.string().default(null);
   });
 });
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/string_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/string_type.ts
@@ -14,19 +14,15 @@ import { Type, convertValidationFunction } from './type';
 
 import { META_FIELD_X_OAS_MIN_LENGTH, META_FIELD_X_OAS_MAX_LENGTH } from '../oas_meta_fields';
 
-export type StringOptions<D extends DefaultValue<string> = never> = TypeOptions<
-  string,
-  string,
-  D
-> & {
+export type StringOptions = TypeOptions<string> & {
   minLength?: number;
   maxLength?: number;
   hostname?: boolean;
   coerceFromNumber?: boolean;
 };
 
-export class StringType<D extends DefaultValue<string> = never> extends Type<string, string, D> {
-  constructor(options: StringOptions<D> = {}) {
+export class StringType extends Type<string> {
+  constructor(options: StringOptions = {}) {
     // We want to allow empty strings, however calling `allow('')` causes
     // Joi to allow the value and skip any additional validation.
     // Instead, we reimplement the string validator manually except in the
@@ -72,6 +68,10 @@ export class StringType<D extends DefaultValue<string> = never> extends Type<str
 
     schema.type = 'string';
     super(schema, options);
+  }
+
+  protected getDefault(defaultValue?: DefaultValue<string>): DefaultValue<string> | undefined {
+    return defaultValue;
   }
 
   protected handleError(type: string, { value }: Record<string, any>) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/type.test.ts
@@ -14,7 +14,7 @@ import { Type } from './type';
 import { META_FIELD_X_OAS_DEPRECATED, META_FIELD_X_OAS_DISCONTINUED } from '../oas_meta_fields';
 
 class MyType extends Type<any> {
-  constructor(opts: TypeOptions<any> = {}) {
+  constructor(opts: TypeOptions<any, any, never> = {}) {
     super(internals.any(), opts);
   }
 }

--- a/src/platform/packages/shared/kbn-config-schema/src/types/type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/type.test.ts
@@ -17,6 +17,10 @@ class MyType extends Type<any> {
   constructor(opts: TypeOptions<any, any, never> = {}) {
     super(internals.any(), opts);
   }
+
+  protected getDefault(defaultValue?: any): any {
+    return defaultValue;
+  }
 }
 
 describe('meta', () => {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/type_of.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/type_of.test.ts
@@ -1,0 +1,785 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v types.number"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v types.number".
+ */
+
+import { expectType } from 'tsd';
+import { duration } from 'moment';
+import { Stream } from 'stream';
+
+import type { TypeOfOutput, TypeOfInput } from './type_of';
+import { ByteSizeValue, schema } from '../..';
+import type { IpOptions } from './ip_type';
+import type { ContextReference } from '../references';
+
+function expectNever<T extends never>() {}
+
+const types = {
+  string: 'some-string',
+  number: 123,
+  uri: 'some-uri',
+  ip: 'some-ip',
+  buffer: Buffer.from('test'),
+  stream: new Stream(),
+  duration: duration(1, 'second'),
+  byteSize: new ByteSizeValue(1024),
+};
+
+describe('schema types', () => {
+  describe('TypeOfOutput', () => {
+    describe('any', () => {
+      test('should output any value', () => {
+        const testSchema = schema.any();
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.string);
+      });
+    });
+
+    describe('boolean', () => {
+      test('should output boolean value', () => {
+        const testSchema = schema.boolean();
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(true);
+        expectType<SchemaType>(false);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.string);
+      });
+      test('should output boolean value with default', () => {
+        const testSchema = schema.boolean({ defaultValue: true });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(true);
+        expectType<SchemaType>(false);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.string);
+      });
+    });
+
+    describe('buffer', () => {
+      test('should output buffer value', () => {
+        const testSchema = schema.buffer();
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.buffer);
+      });
+    });
+
+    describe('stream', () => {
+      test('should input stream value', () => {
+        const testSchema = schema.stream();
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.stream);
+      });
+    });
+
+    describe('string', () => {
+      test('should output string value', () => {
+        const testSchema = schema.string();
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should output string value with default', () => {
+        const testSchema = schema.string({ defaultValue: types.string });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('uri', () => {
+      test('should output uri value', () => {
+        const testSchema = schema.uri();
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.uri);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should output uri value with default', () => {
+        const testSchema = schema.uri({ defaultValue: types.uri });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.uri);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('number', () => {
+      test('should output number value', () => {
+        const testSchema = schema.number();
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.number);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should output number value with default', () => {
+        const testSchema = schema.number({ defaultValue: types.number });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.number);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('byteSize', () => {
+      test('should output byteSize value', () => {
+        const testSchema = schema.byteSize();
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.byteSize);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should output byteSize value with default', () => {
+        const testSchema = schema.byteSize({ defaultValue: types.byteSize });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.byteSize);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should output byteSize value with string default', () => {
+        const testSchema = schema.byteSize({ defaultValue: '1gb' });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.byteSize);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should output byteSize value with number default', () => {
+        const testSchema = schema.byteSize({ defaultValue: types.number });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.byteSize);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('duration', () => {
+      test('should output duration value', () => {
+        const testSchema = schema.duration();
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.duration);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should output duration value with default', () => {
+        const testSchema = schema.duration({ defaultValue: types.duration });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.duration);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should output duration value with string default', () => {
+        const testSchema = schema.duration({ defaultValue: '1h' });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.duration);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should output duration value with number default', () => {
+        const testSchema = schema.duration({ defaultValue: types.number });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.duration);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('never', () => {
+      test('should input never value', () => {
+        const testSchema = schema.never();
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectNever<SchemaType>();
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('ip', () => {
+      const baseOptions: IpOptions<string> = { versions: ['ipv4'] };
+
+      test('should output ip value', () => {
+        const testSchema = schema.ip();
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.ip);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should output ip value with default', () => {
+        const testSchema = schema.ip({ ...baseOptions, defaultValue: types.ip });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.ip);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('nullable', () => {
+      test('should output simple type or null', () => {
+        const testSchema = schema.nullable(schema.string());
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(null);
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+      test('should permit but ignore inner default', () => {
+        const testSchema = schema.nullable(schema.string({ defaultValue: types.string }));
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(null);
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+    });
+
+    describe('object', () => {
+      test('should output object types', () => {
+        const testSchema = schema.object({ str: schema.string(), num: schema.number() });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>({
+          str: types.string,
+          num: types.number,
+        });
+        // @ts-expect-error
+        expectType<SchemaType>({
+          num: types.number,
+        });
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>({});
+      });
+      test('should output object types with property defaults', () => {
+        const testSchema = schema.object({
+          str: schema.string({ defaultValue: types.string }),
+          num: schema.number(),
+        });
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>({
+          str: types.string,
+          num: types.number,
+        });
+        // @ts-expect-error
+        expectType<SchemaType>({
+          num: types.number,
+        });
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>({});
+      });
+      test('should output object types with object default', () => {
+        const testSchema = schema.object(
+          { str: schema.string(), num: schema.number() },
+          {
+            defaultValue: {
+              str: types.string,
+              num: types.number,
+            },
+          }
+        );
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>({
+          str: types.string,
+          num: types.number,
+        });
+        // @ts-expect-error
+        expectType<SchemaType>({
+          num: types.number,
+        });
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>({});
+      });
+    });
+
+    describe('maybe', () => {
+      test('should output simple type or undefined', () => {
+        const testSchema = schema.maybe(schema.string());
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(undefined);
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+      test('should permit but ignore inner default', () => {
+        const testSchema = schema.maybe(schema.string({ defaultValue: types.string }));
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(undefined);
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+    });
+
+    describe('lazy', () => {
+      test('should output simple pass-through schema types', () => {
+        const testSchema = schema.lazy<string>('id');
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+      test('should output simple pass-through schema types with default', () => {
+        const testSchema = schema.lazy<string>('id');
+        type SchemaType = TypeOfOutput<typeof testSchema>;
+
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+    });
+  });
+
+  describe('TypeOfInput', () => {
+    describe('any', () => {
+      test('should input any value', () => {
+        const testSchema = schema.any();
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.string);
+      });
+    });
+
+    describe('boolean', () => {
+      test('should input boolean value', () => {
+        const testSchema = schema.boolean();
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(true);
+        expectType<SchemaType>(false);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.string);
+      });
+      test('should input boolean value with default', () => {
+        const testSchema = schema.boolean({ defaultValue: true });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(true);
+        expectType<SchemaType>(false);
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.string);
+      });
+    });
+
+    describe('buffer', () => {
+      test('should input buffer value', () => {
+        const testSchema = schema.buffer();
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.buffer);
+      });
+    });
+
+    describe('stream', () => {
+      test('should input stream value', () => {
+        const testSchema = schema.stream();
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.stream);
+      });
+    });
+
+    describe('string', () => {
+      test('should input string value', () => {
+        const testSchema = schema.string();
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should input string value with default', () => {
+        const testSchema = schema.string({ defaultValue: types.string });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.string);
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('uri', () => {
+      test('should input string value', () => {
+        const testSchema = schema.uri();
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.uri);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should input uri value with default', () => {
+        const testSchema = schema.uri({ defaultValue: types.string });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.uri);
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('number', () => {
+      test('should input string value', () => {
+        const testSchema = schema.number();
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.number);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should input number value with default', () => {
+        const testSchema = schema.number({ defaultValue: types.number });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.number);
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('byteSize', () => {
+      test('should input byteSize value', () => {
+        const testSchema = schema.byteSize();
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.byteSize);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should input byteSize value with default', () => {
+        const testSchema = schema.byteSize({ defaultValue: types.byteSize });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.byteSize);
+        expectType<SchemaType>(undefined);
+      });
+      test('should input byteSize value with string default', () => {
+        const testSchema = schema.byteSize({ defaultValue: '1gb' });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.byteSize);
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(types.string);
+      });
+      test('should input byteSize value with number default', () => {
+        const testSchema = schema.byteSize({ defaultValue: types.number });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.byteSize);
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+    });
+
+    describe('duration', () => {
+      test('should input duration value', () => {
+        const testSchema = schema.duration();
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.duration);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should input duration value with default', () => {
+        const testSchema = schema.duration({ defaultValue: types.duration });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.duration);
+        expectType<SchemaType>(undefined);
+      });
+      test('should input duration value with string default', () => {
+        const testSchema = schema.duration({ defaultValue: '1h' });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.duration);
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(types.string);
+      });
+      test('should input duration value with number default', () => {
+        const testSchema = schema.duration({ defaultValue: types.number });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.duration);
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+    });
+
+    describe('never', () => {
+      test('should input never value', () => {
+        const testSchema = schema.never();
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectNever<SchemaType>();
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('nullable', () => {
+      test('should input simple type, undefined or null', () => {
+        const testSchema = schema.nullable(schema.string());
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(null);
+        expectType<SchemaType>(types.string);
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+      test('should permit but ignore inner default', () => {
+        const testSchema = schema.nullable(schema.string({ defaultValue: types.string }));
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(null);
+        expectType<SchemaType>(types.string);
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+    });
+
+    describe('object', () => {
+      test('should input object types', () => {
+        const testSchema = schema.object({ str: schema.string(), num: schema.number() });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>({
+          str: types.string,
+          num: types.number,
+        });
+        // @ts-expect-error
+        expectType<SchemaType>({
+          num: types.number,
+        });
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>({});
+      });
+      test('should input object types with property defaults', () => {
+        const testSchema = schema.object({
+          str: schema.string({ defaultValue: types.string }),
+          num: schema.number(),
+        });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        const nick = null! as SchemaType;
+        nick.num;
+
+        expectType<SchemaType>({
+          str: types.string,
+          num: types.number,
+        });
+        expectType<SchemaType>({
+          num: types.number,
+        });
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>({});
+      });
+      test('should input object types with object default', () => {
+        const testSchema = schema.object(
+          { str: schema.string(), num: schema.number() },
+          {
+            defaultValue: {
+              str: types.string,
+              num: types.number,
+            },
+          }
+        );
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>({
+          str: types.string,
+          num: types.number,
+        });
+        // @ts-expect-error
+        expectType<SchemaType>({
+          num: types.number,
+        });
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>({});
+      });
+    });
+
+    describe('ip', () => {
+      const baseOptions: IpOptions<string> = { versions: ['ipv4'] };
+
+      test('should input ip value', () => {
+        const testSchema = schema.ip();
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.ip);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+      });
+      test('should input ip value with default', () => {
+        const testSchema = schema.ip({ ...baseOptions, defaultValue: types.ip });
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.ip);
+        expectType<SchemaType>(undefined);
+      });
+    });
+
+    describe('maybe', () => {
+      test('should input simple type, undefined or null', () => {
+        const testSchema = schema.maybe(schema.string());
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(undefined);
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+      test('should permit but ignore inner default', () => {
+        const testSchema = schema.maybe(schema.string({ defaultValue: types.string }));
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(undefined);
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+    });
+
+    describe('lazy', () => {
+      test('should input simple pass-through schema types', () => {
+        const testSchema = schema.lazy<string>('id');
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(undefined);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+      test('should input simple pass-through schema types with default', () => {
+        const testSchema = schema.lazy<string>('id');
+        type SchemaType = TypeOfInput<typeof testSchema>;
+
+        expectType<SchemaType>(types.string);
+        // @ts-expect-error
+        expectType<SchemaType>(null);
+        // @ts-expect-error
+        expectType<SchemaType>(types.number);
+      });
+    });
+  });
+
+  describe('References', () => {
+    describe('contextRef', () => {
+      test('should default type to unknown', () => {
+        const testRef = schema.contextRef('serverless');
+
+        expectType<ContextReference<unknown>>(testRef);
+      });
+      test('should pass explicit type', () => {
+        const testRef = schema.contextRef<string>('serverless');
+
+        expectType<ContextReference<string>>(testRef);
+        // @ts-expect-error
+        expectType<ContextReference<number>>(testRef);
+      });
+    });
+
+    describe('siblingRef', () => {
+      test('should default type to unknown', () => {
+        const testRef = schema.siblingRef('foo');
+
+        expectType<ContextReference<unknown>>(testRef);
+      });
+      test('should pass explicit type', () => {
+        const testRef = schema.siblingRef<string>('foo');
+
+        expectType<ContextReference<string>>(testRef);
+        // @ts-expect-error
+        expectType<ContextReference<number>>(testRef);
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-config-schema/src/types/type_of.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/type_of.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SomeType, TypeOrLazyType } from './type';
+
+/**
+ * Resulting schema type.
+ *
+ * @alias `TypeOfOutput`
+ * @example
+ * ```ts
+ * const mySchema = schema.object({ num: schema.number() });
+ *
+ * const MySchemaType = TypeOf<typeof mySchema>;
+ * ```
+ */
+export type TypeOf<RT extends TypeOrLazyType> = TypeOfOutput<RT>;
+
+/**
+ * Output type of schema after all defaults are applied.
+ *
+ * @example
+ * ```ts
+ * const mySchema = schema.object({ num: schema.number() });
+ *
+ * const MySchemaType = TypeOfOutput<typeof mySchema>;
+ * ```
+ */
+export type TypeOfOutput<RT extends TypeOrLazyType> = RT extends () => SomeType
+  ? ReturnType<RT>['_output']
+  : RT extends SomeType
+  ? RT['_output']
+  : never;
+
+/**
+ * Output type of schema after all defaults are applied.
+ *
+ * @example
+ * ```ts
+ * const mySchema = schema.object({ num: schema.number() });
+ *
+ * const MySchemaType = TypeOfOutput<typeof mySchema>;
+ * ```
+ */
+export type TypeOfInput<RT extends TypeOrLazyType> = RT extends SomeType ? RT['_input'] : never;

--- a/src/platform/packages/shared/kbn-config-schema/src/types/union_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/union_type.ts
@@ -13,21 +13,21 @@ import { internals } from '../internals';
 import type { DefaultValue, ExtendsDeepOptions, SomeType } from './type';
 import { Type, type TypeOptions, type TypeMeta } from './type';
 
-export type UnionTypeOptions<
-  T extends Readonly<[SomeType, ...SomeType[]]>,
-  D extends DefaultValue<T[number]['_input']> = never
-> = TypeOptions<T[number]['_output'], T[number]['_input'], D> & {
+export type UnionTypeOptions<T extends Readonly<[SomeType, ...SomeType[]]>> = TypeOptions<
+  T[number]['_output'],
+  T[number]['_input']
+> & {
   meta?: Omit<TypeMeta, 'id'>;
 };
 
-export class UnionType<
-  T extends Readonly<[SomeType, ...SomeType[]]>,
-  D extends DefaultValue<T[number]['_input']> = never
-> extends Type<T[number]['_output'], T[number]['_input'], D> {
+export class UnionType<T extends Readonly<[SomeType, ...SomeType[]]>> extends Type<
+  T[number]['_output'],
+  T[number]['_input']
+> {
   private readonly unionTypes: T;
-  private readonly typeOptions?: UnionTypeOptions<T, D>;
+  private readonly typeOptions?: UnionTypeOptions<T>;
 
-  constructor(types: T, options?: UnionTypeOptions<T, D>) {
+  constructor(types: T, options?: UnionTypeOptions<T>) {
     const schema = internals.alternatives(types.map((type) => type.getSchema())).match('any');
 
     super(schema, options);
@@ -38,6 +38,12 @@ export class UnionType<
   public extendsDeep(options: ExtendsDeepOptions) {
     const newTypes = this.unionTypes.map((t) => t.extendsDeep(options)) as any;
     return new UnionType(newTypes, this.typeOptions);
+  }
+
+  protected getDefault(
+    defaultValue?: DefaultValue<T[number]['_input']>
+  ): DefaultValue<T[number]['_input']> | undefined {
+    return defaultValue;
   }
 
   protected handleError(type: string, { value, details }: Record<string, any>, path: string[]) {

--- a/src/platform/packages/shared/kbn-config-schema/src/types/uri_type.test.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/uri_type.test.ts
@@ -87,20 +87,20 @@ describe('#scheme', () => {
 
 describe('#defaultValue', () => {
   test('returns default when URI is undefined', () => {
-    expect(schema.uri({ defaultValue: 'http://localhost:9200' }).validate(undefined)).toBe(
+    expect(schema.uri().default('http://localhost:9200').validate(undefined)).toBe(
       'http://localhost:9200'
     );
   });
 
   test('returns value when specified', () => {
     expect(
-      schema.uri({ defaultValue: 'http://localhost:9200' }).validate('http://kibana.local')
+      schema.uri().default('http://localhost:9200').validate('http://kibana.local')
     ).toBe('http://kibana.local');
   });
 
   test('returns value from context when context reference is specified', () => {
     expect(
-      schema.uri({ defaultValue: schema.contextRef('some_uri') }).validate(undefined, {
+      schema.uri().default(schema.contextRef('some_uri')).validate(undefined, {
         some_uri: 'http://kibana.local',
       })
     ).toBe('http://kibana.local');

--- a/src/platform/packages/shared/kbn-config-schema/src/types/uri_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/uri_type.ts
@@ -9,15 +9,15 @@
 
 import typeDetect from 'type-detect';
 import { internals } from '../internals';
-import type { TypeOptions } from './type';
+import type { DefaultValue, TypeOptions } from './type';
 import { Type } from './type';
 
-export type URIOptions = TypeOptions<string> & {
+export type URIOptions<D extends DefaultValue<string> = never> = TypeOptions<string, string, D> & {
   scheme?: string | string[];
 };
 
-export class URIType extends Type<string> {
-  constructor(options: URIOptions = {}) {
+export class URIType<D extends DefaultValue<string> = never> extends Type<string, string, D> {
+  constructor(options: URIOptions<D> = {}) {
     super(internals.string().uri({ scheme: options.scheme }), options);
   }
 

--- a/src/platform/packages/shared/kbn-config-schema/src/types/uri_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/uri_type.ts
@@ -12,13 +12,17 @@ import { internals } from '../internals';
 import type { DefaultValue, TypeOptions } from './type';
 import { Type } from './type';
 
-export type URIOptions<D extends DefaultValue<string> = never> = TypeOptions<string, string, D> & {
+export type URIOptions = TypeOptions<string> & {
   scheme?: string | string[];
 };
 
-export class URIType<D extends DefaultValue<string> = never> extends Type<string, string, D> {
-  constructor(options: URIOptions<D> = {}) {
+export class URIType extends Type<string> {
+  constructor(options: URIOptions = {}) {
     super(internals.string().uri({ scheme: options.scheme }), options);
+  }
+
+  protected getDefault(defaultValue?: DefaultValue<string>): DefaultValue<string> | undefined {
+    return defaultValue;
   }
 
   protected handleError(type: string, { value, scheme }: Record<string, unknown>) {

--- a/src/platform/packages/shared/kbn-config-schema/tsconfig.json
+++ b/src/platform/packages/shared/kbn-config-schema/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "target/types",
-    "stripInternal": true,
     "types": [
       "jest",
       "node"

--- a/src/platform/packages/shared/response-ops/rule_params/common/data_view_spec_schema.ts
+++ b/src/platform/packages/shared/response-ops/rule_params/common/data_view_spec_schema.ts
@@ -22,11 +22,7 @@ const serializedFieldFormatSchema = schema.object({
   params: schema.maybe(schema.any()),
 });
 
-const runtimeFieldNonCompositeFieldsSpecTypeSchema = schema.oneOf(
-  RUNTIME_FIELD_TYPES2.map((runtimeFieldType) => schema.literal(runtimeFieldType)) as [
-    Type<RuntimeType>
-  ]
-);
+const runtimeFieldNonCompositeFieldsSpecTypeSchema = schema.enum(RUNTIME_FIELD_TYPES2);
 
 const primitiveRuntimeFieldSchemaShared = {
   script: schema.maybe(

--- a/src/platform/plugins/shared/content_management/server/rpc/routes/routes.ts
+++ b/src/platform/plugins/shared/content_management/server/rpc/routes/routes.ts
@@ -52,9 +52,7 @@ export function initRpcRoutes(
       },
       validate: {
         params: schema.object({
-          // @ts-ignore We validate above that procedureNames has at least one item
-          // so we can ignore the "Target requires 1 element(s) but source may have fewer." TS error
-          name: schema.oneOf(procedureNames.map((fnName) => schema.literal(fnName))),
+          name: schema.enum<ProcedureName>(procedureNames),
         }),
         // Any object payload can be passed, we will validate the input when calling the rpc handler
         body: schema.maybe(schema.object({}, { unknowns: 'allow' })),

--- a/src/platform/plugins/shared/data_views/server/schemas.ts
+++ b/src/platform/plugins/shared/data_views/server/schemas.ts
@@ -27,11 +27,8 @@ export const RUNTIME_FIELD_TYPES2 = [
   'geo_point',
 ] as const;
 
-export const runtimeFieldNonCompositeFieldsSpecTypeSchema = schema.oneOf(
-  RUNTIME_FIELD_TYPES2.map((runtimeFieldType) => schema.literal(runtimeFieldType)) as [
-    Type<RuntimeType>
-  ]
-);
+export const runtimeFieldNonCompositeFieldsSpecTypeSchema =
+  schema.enum<RuntimeType>(RUNTIME_FIELD_TYPES2);
 
 const primitiveRuntimeFieldSchemaShared = {
   script: schema.maybe(

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
@@ -7,14 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { type Type, schema } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
 import type { IRouter, Logger } from '@kbn/core/server';
 import type { SpacesServiceStart } from '@kbn/spaces-plugin/server';
-import type { ExecutionStatus, ExecutionType, WorkflowExecutionEngineModel } from '@kbn/workflows';
+import type { WorkflowExecutionEngineModel } from '@kbn/workflows';
+import { ExecutionStatus, ExecutionType } from '@kbn/workflows';
 import {
   CreateWorkflowCommandSchema,
-  ExecutionStatusValues,
-  ExecutionTypeValues,
   SearchWorkflowCommandSchema,
   UpdateWorkflowCommandSchema,
 } from '@kbn/workflows';
@@ -556,18 +555,8 @@ export function defineRoutes(
           statuses: schema.maybe(
             schema.oneOf(
               [
-                schema.oneOf(
-                  ExecutionStatusValues.map((type) => schema.literal(type)) as [
-                    Type<ExecutionStatus>
-                  ]
-                ),
-                schema.arrayOf(
-                  schema.oneOf(
-                    ExecutionStatusValues.map((type) => schema.literal(type)) as [
-                      Type<ExecutionStatus>
-                    ]
-                  )
-                ),
+                schema.enum<ExecutionStatus>(ExecutionStatus),
+                schema.arrayOf(schema.enum<ExecutionStatus>(ExecutionStatus)),
               ],
               {
                 defaultValue: [],
@@ -577,14 +566,8 @@ export function defineRoutes(
           executionTypes: schema.maybe(
             schema.oneOf(
               [
-                schema.oneOf(
-                  ExecutionTypeValues.map((type) => schema.literal(type)) as [Type<ExecutionType>]
-                ),
-                schema.arrayOf(
-                  schema.oneOf(
-                    ExecutionTypeValues.map((type) => schema.literal(type)) as [Type<ExecutionType>]
-                  )
-                ),
+                schema.enum<ExecutionType>(ExecutionType),
+                schema.arrayOf(schema.enum<ExecutionType>(ExecutionType)),
               ],
               {
                 defaultValue: [],

--- a/x-pack/platform/plugins/private/data_usage/server/services/autoops_api.ts
+++ b/x-pack/platform/plugins/private/data_usage/server/services/autoops_api.ts
@@ -14,7 +14,7 @@ import type { Logger } from '@kbn/logging';
 import type { AxiosError, AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import type { LogMeta } from '@kbn/core/server';
-import type { Type, TypeOf } from '@kbn/config-schema';
+import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { momentDateParser } from '../../common/utils';
 import { METRIC_TYPE_VALUES, type MetricTypes } from '../../common/rest_types';
@@ -212,9 +212,7 @@ export class AutoOpsAPIService {
   };
 }
 
-export const metricTypesSchema = schema.oneOf(
-  METRIC_TYPE_VALUES.map((metricType) => schema.literal(metricType)) as [Type<MetricTypes>] // Create a oneOf schema for the keys
-);
+export const metricTypesSchema = schema.enum<MetricTypes>(METRIC_TYPE_VALUES);
 
 const UsageMetricsAutoOpsResponseSchema = {
   body: () =>

--- a/x-pack/platform/plugins/shared/onechat/server/routes/tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/tools.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import type { ToolType } from '@kbn/onechat-common';
 import { editableToolTypes } from '@kbn/onechat-common';
 import type { RouteDependencies } from './types';
 import { getHandlerWrapper } from './wrap_handler';
@@ -122,8 +123,7 @@ export function registerToolsRoutes({ router, getInternalServices, logger }: Rou
           request: {
             body: schema.object({
               id: schema.string(),
-              // @ts-expect-error schema.oneOf expects at least one element, and `map` returns a list
-              type: schema.oneOf(editableToolTypes.map((type) => schema.literal(type))),
+              type: schema.enum<ToolType>(editableToolTypes),
               description: schema.string({ defaultValue: '' }),
               tags: schema.arrayOf(schema.string(), { defaultValue: [] }),
               // actual config validation is done in the tool service

--- a/x-pack/platform/plugins/shared/spaces/server/config.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/config.ts
@@ -14,9 +14,7 @@ import type { SolutionId } from '@kbn/core-chrome-browser';
 
 const solutions = ['es', 'oblt', 'security'] as const;
 
-const solutionSchemaLiterals = [...solutions].map((s) => schema.literal(s)) as [
-  ReturnType<typeof schema.literal<Exclude<SolutionId, 'chat'>>>
-];
+const solutionSchema = schema.enum<Exclude<SolutionId, 'chat'>>(solutions);
 
 export const ConfigSchema = schema.object({
   enabled: schema.conditional(
@@ -61,7 +59,7 @@ export const ConfigSchema = schema.object({
       defaultValue: true,
     }),
   }),
-  defaultSolution: schema.maybe(schema.oneOf(solutionSchemaLiterals)),
+  defaultSolution: schema.maybe(solutionSchema),
 });
 
 export function createConfig$(context: PluginInitializerContext) {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/common.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/common.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { Type, TypeOf } from '@kbn/config-schema';
+import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { isEmpty } from 'lodash';
 import { escapeQuotes } from '@kbn/es-query';
@@ -21,9 +21,7 @@ const StringOrArraySchema = schema.maybe(
   schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
 );
 
-const UseLogicalAndFieldLiterals = useLogicalAndFields.map((f) => schema.literal(f)) as [
-  Type<string>
-];
+const UseLogicalAndField = schema.enum(useLogicalAndFields);
 
 const CommonQuerySchema = {
   query: schema.maybe(schema.string()),
@@ -37,7 +35,7 @@ const CommonQuerySchema = {
   monitorQueryIds: StringOrArraySchema,
   showFromAllSpaces: schema.maybe(schema.boolean()),
   useLogicalAndFor: schema.maybe(
-    schema.oneOf([schema.string(), schema.arrayOf(schema.oneOf(UseLogicalAndFieldLiterals))])
+    schema.oneOf([schema.string(), schema.arrayOf(UseLogicalAndField)])
   ),
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/list/list.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/list/list.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-// TODO: fix the odd TS error
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import {
@@ -16,20 +15,15 @@ import {
 import { ENDPOINT_DEFAULT_PAGE_SIZE } from '../../../../endpoint/constants';
 import { agentTypesSchema } from '../common/base';
 
-const commandsSchema = schema.oneOf(
-  // @ts-expect-error TS2769: No overload matches this call
-  RESPONSE_ACTION_API_COMMANDS_NAMES.map((command) => schema.literal(command))
-);
+const commandsSchema = schema.enum(RESPONSE_ACTION_API_COMMANDS_NAMES);
 
 const statusesSchema = {
-  // @ts-expect-error TS2769: No overload matches this call
-  schema: schema.oneOf(RESPONSE_ACTION_STATUS.map((status) => schema.literal(status))),
+  schema: schema.enum(RESPONSE_ACTION_STATUS),
   options: { minSize: 1, maxSize: RESPONSE_ACTION_STATUS.length },
 };
 
 const actionTypesSchema = {
-  // @ts-expect-error TS2769: No overload matches this call
-  schema: schema.oneOf(RESPONSE_ACTION_TYPE.map((type) => schema.literal(type))),
+  schema: schema.enum(RESPONSE_ACTION_TYPE),
   options: { minSize: 1, maxSize: RESPONSE_ACTION_TYPE.length },
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/blocklist_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/blocklist_validator.ts
@@ -6,7 +6,7 @@
  */
 
 import { cloneDeep, uniq } from 'lodash';
-import type { Type, TypeOf } from '@kbn/config-schema';
+import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { OperatingSystem } from '@kbn/securitysolution-utils';
@@ -23,13 +23,9 @@ import { EndpointArtifactExceptionValidationError } from './errors';
 const allowedHashes: Readonly<string[]> = ['file.hash.md5', 'file.hash.sha1', 'file.hash.sha256'];
 const allowedFilePaths: Readonly<string[]> = ['file.path', 'file.path.caseless'];
 
-const FileHashField = schema.oneOf(
-  allowedHashes.map((hash) => schema.literal(hash)) as [Type<string>]
-);
+const FileHashField = schema.enum(allowedHashes);
 
-const FilePath = schema.oneOf(
-  allowedFilePaths.map((path) => schema.literal(path)) as [Type<string>]
-);
+const FilePath = schema.enum(allowedFilePaths);
 
 const FileCodeSigner = schema.literal('file.Ext.code_signature');
 


### PR DESCRIPTION
## Summary

⚠️ Rough POC

You can pull down this branch and play around with it. I used `src/platform/packages/shared/kbn-config-schema/testing-defaults.ts` as simple testing file.

## Summary

Adds support for `TypeOfInput` and `TypeOfOutput` types on `@kbn/config-schema`

```ts
import { schema, TypeOf, TypeOfOutput, TypeOfInput } from '@kbn/config-schema';

const mySchema = schema.object(
  {
    id: schema.number(),
    maybe: schema.maybe(schema.number()),
    num: schema.number().default(2),
    obj: schema.object(
      {
        test1: schema.number(),
        test2: schema.number.default(2),
      }
    ).default({ test1: 1 }),
  },
);

type MySchemaType = Simplify<TypeOf<typeof mySchema>>; // same as output
type MySchemaOuput =  Simplify<TypeOfOutput<typeof mySchema>>;

// Printed type
type MySchemaType = MySchemaOuput;
type MySchemaOuput = {
    id: number;
    num: number;
    obj: {
        test1: number;
        test2: number;
    };
    maybe?: number | undefined;
};

type MySchemaInput = Simplify<TypeOfInput<typeof mySchema>>;

// Printed type
type MySchemaInput = {
    id: number;
    maybe?: number | undefined;
    num?: number | undefined;
    obj?: {
        test1: number;
        test2?: number | undefined;
    } | undefined;
}
```

## Details

These types are crazy! It takes a lot to pull the `defaultValue` from the object and correctly apply that to reshape the `defaultValue` of the object and pass the inputs correctly while avoiding circular references.

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Minimal risk, mostly type changes.