### PR TITLE
suggest right operators after a completed boolean expression

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/rerank/autocomplete.ts
@@ -205,7 +205,7 @@ async function handleOnExpression({
   context: ICommandContext | undefined;
   expressionRoot: ESQLSingleAstItem | undefined;
 }): Promise<ISuggestionItem[]> {
-  let suggestions = await suggestForExpression({
+  const suggestions = await suggestForExpression({
     innerText,
     getColumnsByType: callbacks.getByType,
     expressionRoot,
@@ -220,8 +220,6 @@ async function handleOnExpression({
     const expressionType = getExpressionType(expressionRoot, context?.columns);
 
     if (expressionType === 'boolean' && isExpressionComplete(expressionType, innerText)) {
-      const allowed = new Set(['AND', 'OR']); // TODO: this filter should be unnecessary. Need to fix suggestForExpression
-      suggestions = suggestions.filter(({ label }) => allowed.has(label.toUpperCase()));
       suggestions.push(...buildNextActions());
     }
   }

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/where/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/where/autocomplete.test.ts
@@ -248,6 +248,15 @@ describe('WHERE Autocomplete', () => {
       ]);
     });
 
+    test('suggestions after IS', async () => {
+      await whereExpectSuggestions('from index | WHERE keywordField IS ', [
+        'IS NULL',
+        'IS NOT NULL',
+      ]);
+
+      await whereExpectSuggestions('from index | WHERE keywordField IS NU', ['IS NULL']);
+    });
+
     test('suggestions after NOT', async () => {
       await whereExpectSuggestions('from index | WHERE keywordField not ', [
         'LIKE $0',
@@ -260,38 +269,12 @@ describe('WHERE Autocomplete', () => {
         'IN $0',
       ]);
       await whereExpectSuggestions('FROM index | WHERE NOT ENDS_WITH(keywordField, "foo") ', [
-        ...getFunctionSignaturesByReturnType(
-          Location.WHERE,
-          'boolean',
-          { operators: true },
-          ['boolean'],
-          [':']
-        ),
+        'AND $0',
+        'OR $0',
         '| ',
       ]);
-      await whereExpectSuggestions('from index | WHERE keywordField IS NOT', [
-        '!= $0',
-        '== $0',
-        'AND $0',
-        'IN $0',
-        'IS NOT NULL',
-        'IS NULL',
-        'NOT',
-        'NOT IN $0',
-        'OR $0',
-      ]);
-
-      await whereExpectSuggestions('from index | WHERE keywordField IS NOT ', [
-        '!= $0',
-        '== $0',
-        'AND $0',
-        'IN $0',
-        'IS NOT NULL',
-        'IS NULL',
-        'NOT',
-        'NOT IN $0',
-        'OR $0',
-      ]);
+      await whereExpectSuggestions('from index | WHERE keywordField IS NOT ', ['IS NOT NULL']);
+      await whereExpectSuggestions('from index | WHERE keywordField IS NOT      ', ['IS NOT NULL']);
     });
 
     test('suggestions after IN', async () => {

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/types.ts
@@ -230,6 +230,7 @@ export interface FunctionFilterPredicates {
   location: Location;
   returnTypes?: string[];
   ignored?: string[];
+  allowed?: string[];
 }
 
 export interface Literals {

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/autocomplete/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/autocomplete/helpers.ts
@@ -349,6 +349,14 @@ export async function suggestForExpression({
             // so we can only suggest operators that accept any type as a left operand
             leftParamType: isParamExpressionType(expressionType) ? undefined : expressionType,
             ignored: ['='],
+            allowed:
+              expressionType === 'boolean' && position === 'after_literal'
+                ? [
+                    ...logicalOperators
+                      .filter(({ locationsAvailable }) => locationsAvailable.includes(location))
+                      .map(({ name }) => name),
+                  ]
+                : undefined,
           },
           hasMinimumLicenseRequired,
           activeProduct

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/expressions.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/expressions.ts
@@ -330,8 +330,9 @@ export function buildPartialMatcher(str: string) {
   return pattern;
 }
 
-const isNullMatcher = new RegExp('is ' + buildPartialMatcher('nul') + '$', 'i');
-const isNotNullMatcher = new RegExp('is ' + buildPartialMatcher('not nul') + '$', 'i');
+// Handles: "IS ", "IS N", "IS NU", "IS NUL" with flexible whitespace
+const isNullMatcher = new RegExp('is\\s*(' + buildPartialMatcher('nul') + ')?$', 'i');
+const isNotNullMatcher = new RegExp('is\\s*(' + buildPartialMatcher('not nul') + ')?$', 'i');
 
 // --- Expression types helpers ---
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/operators.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/operators.ts
@@ -22,7 +22,7 @@ import {
   isParameterType,
   isReturnType,
 } from '../types';
-import { operatorsDefinitions } from '../all_operators';
+import { operatorsDefinitions, logicalOperators } from '../all_operators';
 import {
   filterFunctionDefinitions,
   checkFunctionInvocationComplete,
@@ -89,6 +89,31 @@ export const getOperatorsSuggestionsAfterNot = (): ISuggestionItem[] => {
     .map(getOperatorSuggestion);
 };
 
+/** Suggest complete "IS [NOT] NULL" operators when the user has started typing "IS ..." */
+export const getOperatorsSuggestionsAfterIs = (
+  queryText: string,
+  location: Location,
+  leftParamType: FunctionParameterType
+): ISuggestionItem[] => {
+  const candidates = ['is null', 'is not null'];
+  const queryLower = queryText.toLowerCase();
+  const queryNormalized = queryLower.replace(/\s+/g, ' ').replace(/\s+$/, ' ');
+  const allowedOperators = candidates.filter((candidate) => {
+    const candidateLower = candidate.toLowerCase();
+    // - "... is " matches candidate "is null" (prefix: "is ")
+    // - "... is n" matches candidate "is not null" (prefix: "is n")
+    return [...candidateLower].some((_, i) =>
+      queryNormalized.endsWith(candidateLower.slice(0, i + 1))
+    );
+  });
+
+  return getOperatorSuggestions({
+    location,
+    leftParamType,
+    allowed: allowedOperators,
+  });
+};
+
 export function isArrayType(type: string): type is ArrayType {
   return type.endsWith('[]');
 }
@@ -101,7 +126,7 @@ function getSupportedTypesForBinaryOperators(
   return fnDef && Array.isArray(fnDef?.signatures)
     ? fnDef.signatures
         .filter(({ params }) => params.find((p) => p.name === 'left' && p.type === previousType))
-        .map(({ params }) => params[1].type)
+        .map(({ params }) => params[1]?.type)
     : [previousType];
 }
 
@@ -134,6 +159,7 @@ export async function getSuggestionsToRightOfOperatorExpression({
 }) {
   const suggestions = [];
   const isFnComplete = checkFunctionInvocationComplete(operator, getExpressionType);
+
   if (isFnComplete.complete) {
     // i.e. ... | <COMMAND> field > 0 <suggest>
     // i.e. ... | <COMMAND> field + otherN <suggest>
@@ -148,6 +174,14 @@ export async function getSuggestionsToRightOfOperatorExpression({
             ? 'any'
             : operatorReturnType,
         ignored: ['=', ':'],
+        allowed:
+          operatorReturnType === 'boolean'
+            ? [
+                ...logicalOperators
+                  .filter(({ locationsAvailable }) => locationsAvailable.includes(location))
+                  .map(({ name }) => name),
+              ]
+            : undefined,
       })
     );
   } else {
@@ -172,7 +206,7 @@ export async function getSuggestionsToRightOfOperatorExpression({
         suggestions.push(listCompleteItem);
       } else {
         const finalType = leftArgType || 'any';
-        const supportedTypes = getSupportedTypesForBinaryOperators(fnDef, finalType as string);
+        const supportedTypes = getSupportedTypesForBinaryOperators(fnDef, finalType);
 
         // this is a special case with AND/OR
         // <COMMAND> expression AND/OR <suggest>
@@ -182,24 +216,36 @@ export async function getSuggestionsToRightOfOperatorExpression({
           finalType === 'boolean' &&
           getFunctionDefinition(operator.name)?.type === FunctionDefinitionTypes.OPERATOR
             ? ['any']
-            : (supportedTypes as string[]);
+            : supportedTypes;
 
-        // TODO replace with fields callback + function suggestions
-        suggestions.push(
-          ...(await getFieldsOrFunctionsSuggestions(
-            typeToUse,
-            location,
-            getColumnsByType,
-            {
-              functions: true,
-              columns: true,
-              values: Boolean(operator.subtype === 'binary-expression'),
-            },
-            {},
-            hasMinimumLicenseRequired,
-            activeProduct
-          ))
-        );
+        // Special case: if we have an incomplete unary operator that starts with "is", suggest the complete forms
+        const isUnaryIs = operator.name.startsWith('is ');
+        if (isUnaryIs) {
+          suggestions.push(
+            ...getOperatorsSuggestionsAfterIs(
+              queryText,
+              location,
+              finalType === 'unknown' || finalType === 'unsupported' ? 'any' : finalType
+            )
+          );
+        } else {
+          // TODO replace with fields callback + function suggestions
+          suggestions.push(
+            ...(await getFieldsOrFunctionsSuggestions(
+              typeToUse,
+              location,
+              getColumnsByType,
+              {
+                functions: true,
+                columns: true,
+                values: Boolean(operator.subtype === 'binary-expression'),
+              },
+              {},
+              hasMinimumLicenseRequired,
+              activeProduct
+            ))
+          );
+        }
       }
     }
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -1030,36 +1030,13 @@ describe('autocomplete', () => {
   describe('Replacement ranges are attached when needed', () => {
     testSuggestions('FROM a | WHERE doubleField IS NOT N/', [
       { text: 'IS NOT NULL', rangeToReplace: { start: 27, end: 35 } },
-      { text: 'IS NULL', rangeToReplace: undefined },
-      '!= $0',
-      '== $0',
-      'IN $0',
-      'AND $0',
-      'NOT',
-      'NOT IN $0',
-      'OR $0',
     ]);
     testSuggestions('FROM a | WHERE doubleField IS N/', [
       { text: 'IS NOT NULL', rangeToReplace: { start: 27, end: 31 } },
       { text: 'IS NULL', rangeToReplace: { start: 27, end: 31 } },
-      { text: '!= $0', rangeToReplace: { start: 30, end: 31 } },
-      '== $0',
-      'IN $0',
-      'AND $0',
-      'NOT',
-      'NOT IN $0',
-      'OR $0',
     ]);
     testSuggestions('FROM a | EVAL doubleField IS NOT N/', [
       { text: 'IS NOT NULL', rangeToReplace: { start: 26, end: 34 } },
-      'IS NULL',
-      '!= $0',
-      '== $0',
-      'IN $0',
-      'AND $0',
-      'NOT',
-      'NOT IN $0',
-      'OR $0',
     ]);
 
     describe('dot-separated field names', () => {


### PR DESCRIPTION
## Summary

 https://github.com/elastic/kibana/issues/235095

- Suggest only AND/OR after a completed boolean expression.
- Correct incomplete IS NULL and IS NOT NULL conditions

Note: 
The handling of is null and not null was not supposed to be included here but was a consequence of some failed tests.

<img width="1002" height="186" alt="after" src="https://github.com/user-attachments/assets/272a328d-b922-4053-8b61-a969bf7cbc3e" />


<img width="945" height="224" alt="after4" src="https://github.com/user-attachments/assets/a95a853a-c0fd-44e6-90d0-18ba54b9600b" />
