### PR TITLE
[Search][FTR] Configs clean-up

### DIFF
--- a/.buildkite/ftr_search_serverless_configs.yml
+++ b/.buildkite/ftr_search_serverless_configs.yml
@@ -6,12 +6,13 @@ defaultQueue: 'n2-4-spot'
 enabled:
   - x-pack/solutions/search/test/serverless/api_integration/configs/config.ts
   - x-pack/solutions/search/test/serverless/api_integration/configs/config.feature_flags.ts
-  - x-pack/platform/test/serverless/api_integration/configs/search/config.group1.ts
   - x-pack/solutions/search/test/serverless/functional/configs/config.ts
-  - x-pack/platform/test/serverless/functional/configs/search/config.examples.ts
+  - x-pack/solutions/search/test/serverless/functional/configs/config.search_features.ts
   - x-pack/solutions/search/test/serverless/functional/configs/config.feature_flags.ts
   - x-pack/solutions/search/test/serverless/functional/configs/config.screenshots.ts
   - x-pack/solutions/search/test/serverless/functional/configs/config.nav_v2.ts
+  - x-pack/platform/test/serverless/api_integration/configs/search/config.group1.ts
+  - x-pack/platform/test/serverless/functional/configs/search/config.examples.ts
   - x-pack/platform/test/serverless/functional/configs/search/config.saved_objects_management.ts
   - x-pack/platform/test/serverless/functional/configs/search/config.context_awareness.ts
   - x-pack/platform/test/serverless/functional/configs/search/config.config_compat_mode.ts
@@ -28,4 +29,3 @@ enabled:
   - x-pack/platform/test/serverless/functional/configs/search/config.group11.ts
   - x-pack/platform/test/serverless/functional/configs/search/config.group12.ts
   - x-pack/platform/test/onechat_api_integration/configs/config.serverless.ts
-

--- a/.buildkite/ftr_search_stateful_configs.yml
+++ b/.buildkite/ftr_search_stateful_configs.yml
@@ -5,6 +5,7 @@ disabled:
 defaultQueue: 'n2-4-spot'
 enabled:
   - x-pack/solutions/search/test/functional_search/config.ts
+  - x-pack/solutions/search/test/functional_search/config/config.basic.ts
   - x-pack/solutions/search/test/functional_search/config/config.search_playground.ts
   - x-pack/solutions/search/test/functional_search/config/config.feature_flags.ts
   - x-pack/solutions/search/test/api_integration/apis/search_playground/config.ts

--- a/x-pack/platform/test/serverless/shared/types/index.ts
+++ b/x-pack/platform/test/serverless/shared/types/index.ts
@@ -42,4 +42,5 @@ export interface CreateTestConfigOptions<
   services?: TServices;
   pageObjects?: TPageObjects;
   apps?: Record<string, { pathname: string; hash?: string }>;
+  screenshots?: { directory: string };
 }

--- a/x-pack/solutions/search/test/functional_search/config.ts
+++ b/x-pack/solutions/search/test/functional_search/config.ts
@@ -12,7 +12,7 @@ import { pageObjects } from './page_objects';
 
 /**
  * NOTE: The solution view is currently only available in the cloud environment.
- * This test suite fakes a cloud environement by setting the cloud.id and cloud.base_url
+ * This test suite fakes a cloud environment by setting the cloud.id and cloud.base_url
  */
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
@@ -34,15 +34,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         'xpack.security.enabled=true',
       ],
     },
-    kbnTestServer: {
-      ...functionalConfig.get('kbnTestServer'),
-      serverArgs: [
-        ...functionalConfig.get('kbnTestServer.serverArgs'),
-        '--xpack.searchIndices.enabled=true',
-      ],
-    },
     testFiles: [require.resolve('.')],
-    screenshots: { directory: resolve(__dirname, 'screenshots') },
+    screenshots: { directory: resolve(__dirname, '../screenshots') },
     apps: {
       ...functionalConfig.get('apps'),
       searchInferenceEndpoints: {

--- a/x-pack/solutions/search/test/functional_search/config/config.basic.ts
+++ b/x-pack/solutions/search/test/functional_search/config/config.basic.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const searchFuncationalConfig = await readConfigFile(require.resolve('../config'));
+
+  return {
+    ...searchFuncationalConfig.getAll(),
+    junit: {
+      reportName: 'Search Solution Functional Tests - Basic License',
+    },
+    esTestCluster: {
+      ...searchFuncationalConfig.get('esTestCluster'),
+      license: 'basic',
+      serverArgs: [
+        'xpack.license.self_generated.type=basic',
+        'xpack.security.enabled=true',
+        'xpack.security.authc.api_key.enabled=true',
+      ],
+    },
+    testFiles: [require.resolve('../index.basic.ts')],
+  };
+}

--- a/x-pack/solutions/search/test/functional_search/config/config.feature_flags.ts
+++ b/x-pack/solutions/search/test/functional_search/config/config.feature_flags.ts
@@ -24,6 +24,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         ...searchFuncationalConfig.get('kbnTestServer.serverArgs'),
         '--xpack.spaces.defaultSolution=es', // Default to Search Solution
         `--uiSettings.overrides.searchPlayground:searchModeEnabled=true`,
+        `--uiSettings.overrides.agentBuilder:enabled=true`,
       ],
     },
     // load tests in the index file

--- a/x-pack/solutions/search/test/functional_search/index.basic.ts
+++ b/x-pack/solutions/search/test/functional_search/index.basic.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+/* eslint-disable import/no-default-export */
+
+import type { FtrProviderContext } from './ftr_provider_context';
+
+export default ({ loadTestFile }: FtrProviderContext): void => {
+  describe('Search solution basic license tests', function () {
+    // Copies of nav tests for basic license until we can run a single suite with multiple licenses
+    // currently we hide nav items when on basic license, we can test this in a single suite when we
+    // we update to show nav items on basic license
+    loadTestFile(require.resolve('./tests/classic_navigation.basic'));
+    loadTestFile(require.resolve('./tests/solution_navigation.basic'));
+  });
+};

--- a/x-pack/solutions/search/test/functional_search/index.feature_flags.ts
+++ b/x-pack/solutions/search/test/functional_search/index.feature_flags.ts
@@ -13,5 +13,6 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
     // Shared test file to close the global solution tour
     loadTestFile(require.resolve('./apps/shared/solution_tour'));
     // add tests that require feature flags, defined in config.feature_flags.ts
+    loadTestFile(require.resolve('./tests/agent_builder'));
   });
 };

--- a/x-pack/solutions/search/test/functional_search/tests/agent_builder.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/agent_builder.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const { solutionNavigation } = getPageObjects(['solutionNavigation']);
+  const testSubjects = getService('testSubjects');
+  const searchSpace = getService('searchSpace');
+  const appsMenu = getService('appsMenu');
+
+  describe('Agent Builder', function () {
+    describe('search solution navigation', function () {
+      let cleanUp: () => Promise<unknown>;
+      let spaceCreated: { id: string } = { id: '' };
+      before(async () => {
+        ({ cleanUp, spaceCreated } = await searchSpace.createTestSpace(
+          'agent-builder-solution-nav'
+        ));
+        await searchSpace.navigateTo(spaceCreated.id);
+      });
+      after(async () => {
+        // Clean up space created
+        await cleanUp();
+      });
+
+      it('should have side nav link for agents', async () => {
+        await solutionNavigation.sidenav.expectLinkExists({ deepLinkId: 'agent_builder' });
+        await solutionNavigation.sidenav.clickLink({ deepLinkId: 'agent_builder' });
+        await testSubjects.existOrFail('onechatPageConversations');
+        await solutionNavigation.sidenav.expectLinkActive({ deepLinkId: 'agent_builder' });
+        await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Agent Chat' });
+      });
+    });
+    describe('classic navigation', function () {
+      let cleanUp: () => Promise<unknown>;
+      let spaceCreated: { id: string } = { id: '' };
+      before(async () => {
+        ({ cleanUp, spaceCreated } = await searchSpace.createTestSpace(
+          'agent-builder-classic-nav',
+          'classic'
+        ));
+        await searchSpace.navigateTo(spaceCreated.id);
+      });
+      after(async () => {
+        // Clean up space created
+        await cleanUp();
+      });
+
+      it('should have agent builder in global nav', async () => {
+        await testSubjects.existOrFail('toggleNavButton');
+        await appsMenu.openCollapsibleNav();
+        await appsMenu.linkExists('Agent Builder');
+        await appsMenu.clickLink('Agent Builder');
+        await testSubjects.existOrFail('onechatPageConversations');
+      });
+    });
+  });
+}

--- a/x-pack/solutions/search/test/functional_search/tests/classic_navigation.basic.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/classic_navigation.basic.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default function searchClassicNavigationTests({
+  getPageObjects,
+  getService,
+}: FtrProviderContext) {
+  const { common, searchClassicNavigation } = getPageObjects(['common', 'searchClassicNavigation']);
+  const searchSpace = getService('searchSpace');
+  const testSubjects = getService('testSubjects');
+
+  describe('Search Classic Navigation', () => {
+    let cleanUp: () => Promise<unknown>;
+    let spaceCreated: { id: string } = { id: '' };
+
+    before(async () => {
+      ({ cleanUp, spaceCreated } = await searchSpace.createTestSpace(
+        'search-classic-ftr',
+        'classic'
+      ));
+
+      await searchSpace.navigateTo(spaceCreated.id);
+      await common.navigateToApp('searchHomepage');
+    });
+
+    after(async () => {
+      // Clean up space created
+      await cleanUp();
+    });
+
+    it('renders expected navigation items', async () => {
+      await searchClassicNavigation.expectAllNavItems([
+        { id: 'Home', label: 'Home' },
+        { id: 'Build', label: 'Build' },
+        { id: 'Indices', label: 'Index Management' },
+        { id: 'SearchApplications', label: 'Search applications' },
+        { id: 'Relevance', label: 'Relevance' },
+        { id: 'Synonyms', label: 'Synonyms' },
+        { id: 'QueryRules', label: 'Query rules' },
+      ]);
+    });
+    it('has expected navigation', async () => {
+      const expectNoPageReload = await searchClassicNavigation.createNoPageReloadCheck();
+
+      await searchClassicNavigation.expectNavItemExists('Home');
+
+      const sideNavTestCases: Array<{
+        navItem: string;
+        breadcrumbs: string[];
+        pageTestSubject: string;
+      }> = [
+        {
+          navItem: 'Indices',
+          breadcrumbs: ['Build', 'Index Management'],
+          pageTestSubject: 'indexManagementHeaderContent',
+        },
+        {
+          navItem: 'SearchApplications',
+          breadcrumbs: ['Build', 'Search applications'],
+          pageTestSubject: 'searchApplicationsListPage',
+        },
+        {
+          navItem: 'Synonyms',
+          breadcrumbs: ['Relevance', 'Synonyms'],
+          pageTestSubject: 'searchSynonymsOverviewPage',
+        },
+        {
+          navItem: 'QueryRules',
+          breadcrumbs: ['Relevance', 'Query rules'],
+          pageTestSubject: 'queryRulesBasePage',
+        },
+      ];
+
+      for (const testCase of sideNavTestCases) {
+        await searchClassicNavigation.clickNavItem(testCase.navItem);
+        // Wait for the date test subj to ensure the page is loaded before continuing
+        await testSubjects.existOrFail(testCase.pageTestSubject);
+        await searchClassicNavigation.expectNavItemActive(testCase.navItem);
+        for (const breadcrumb of testCase.breadcrumbs) {
+          await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists(breadcrumb);
+        }
+      }
+
+      await expectNoPageReload();
+    });
+  });
+}

--- a/x-pack/solutions/search/test/functional_search/tests/solution_navigation.basic.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/solution_navigation.basic.ts
@@ -39,7 +39,7 @@ export default function searchSolutionNavigation({
     it('renders expected side nav items', async () => {
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Discover' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dashboards' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
+      // await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Developer Tools' });
       // await solutionNavigation.sidenav.expectLinkExists({ text: 'Agents' }); enable when available
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Machine Learning' });
@@ -59,12 +59,6 @@ export default function searchSolutionNavigation({
         breadcrumbs: string[];
         pageTestSubject: string;
       }> = [
-        // TODO: enable when available
-        // {
-        //   link: { navId: 'agent_builder' },
-        //   breadcrumbs: ['Agent Chat'],
-        //   pageTestSubject: 'onechatPageConversations',
-        // },
         {
           link: { deepLinkId: 'discover' },
           breadcrumbs: ['Discover'],
@@ -75,11 +69,17 @@ export default function searchSolutionNavigation({
           breadcrumbs: ['Dashboards'],
           pageTestSubject: 'noDataViewsPrompt',
         },
-        {
-          link: { deepLinkId: 'searchPlayground' },
-          breadcrumbs: ['Build', 'Playground'],
-          pageTestSubject: 'playgroundsListPage',
-        },
+        // TODO: enable when available
+        // {
+        //   link: { navId: 'agent_builder' },
+        //   breadcrumbs: ['Agent Chat'],
+        //   pageTestSubject: 'onechatPageConversations',
+        // },
+        // {
+        //   link: { deepLinkId: 'searchPlayground' },
+        //   breadcrumbs: ['Build', 'Playground'],
+        //   pageTestSubject: 'playgroundsListPage',
+        // },
         {
           link: { deepLinkId: 'dev_tools' },
           breadcrumbs: ['Developer Tools'],
@@ -105,10 +105,10 @@ export default function searchSolutionNavigation({
       await solutionNavigation.sidenav.expectOnlyDefinedLinks(
         [
           'searchHomepage',
-          // 'agent_builder', enabled when available
           'discover',
           'dashboards',
-          'searchPlayground',
+          // 'agent_builder', enabled when available
+          // 'searchPlayground',
           'machine_learning',
           'dev_tools',
           'ingest_and_data',

--- a/x-pack/solutions/search/test/serverless/functional/configs/config.feature_flags.ts
+++ b/x-pack/solutions/search/test/serverless/functional/configs/config.feature_flags.ts
@@ -5,53 +5,35 @@
  * 2.0.
  */
 
-import { createTestConfig } from '@kbn/test-suites-xpack-platform/serverless/functional/config.base';
-import { services } from '../services';
-import { pageObjects } from '../page_objects';
+import type { FtrConfigProviderContext } from '@kbn/test';
 
 /**
  * Make sure to create a MKI deployment with custom Kibana image, that includes feature flags arguments
  * These tests most likely will fail on default MKI project
  */
-export default createTestConfig({
-  serverlessProject: 'es',
-  pageObjects,
-  services,
-  junit: {
-    reportName: 'Serverless Search Feature Flags Functional Tests',
-  },
-  suiteTags: { exclude: ['skipSvlSearch'] },
-  // add feature flags
-  kbnServerArgs: [
-    `--xpack.cloud.id=ES3_FTR_TESTS:ZmFrZS1kb21haW4uY2xkLmVsc3RjLmNvJGZha2Vwcm9qZWN0aWQuZXMkZmFrZXByb2plY3RpZC5rYg==`,
-    `--uiSettings.overrides.searchPlayground:searchModeEnabled=true`,
-    `--uiSettings.overrides.queryRules:queryRulesEnabled=true`,
-    '--xpack.searchQueryRules.enabled=true',
-  ],
-  // load tests in the index file
-  testFiles: [require.resolve('./index.feature_flags.ts')],
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseConfig = await readConfigFile(require.resolve('./config'));
 
-  // include settings from project controller
-  // https://github.com/elastic/project-controller/blob/main/internal/project/esproject/config/elasticsearch.yml
-  esServerArgs: [],
-  apps: {
-    serverlessConnectors: {
-      pathname: '/app/connectors',
+  return {
+    ...baseConfig.getAll(),
+    junit: {
+      reportName: 'Serverless Search Feature Flags Functional Tests',
     },
-    searchPlayground: {
-      pathname: '/app/search_playground',
+    kbnTestServer: {
+      ...baseConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...baseConfig.get('kbnTestServer.serverArgs'),
+        '--feature_flags.overrides.core.chrome.projectSideNav=v2',
+        `--uiSettings.overrides.agentBuilder:enabled=true`,
+        `--uiSettings.overrides.searchPlayground:searchModeEnabled=true`,
+        `--uiSettings.overrides.queryRules:queryRulesEnabled=true`,
+        '--xpack.searchQueryRules.enabled=true',
+      ],
     },
-    searchSynonyms: {
-      pathname: '/app/elasticsearch/search_synonyms',
+    // load tests in the index file
+    testFiles: [require.resolve('./index.feature_flags.ts')],
+    apps: {
+      ...baseConfig.get('apps'),
     },
-    searchQueryRules: {
-      pathname: '/app/elasticsearch/query_rules',
-    },
-    elasticsearchStart: {
-      pathname: '/app/elasticsearch/start',
-    },
-    elasticsearchIndices: {
-      pathname: '/app/elasticsearch/indices',
-    },
-  },
-});
+  };
+}

--- a/x-pack/solutions/search/test/serverless/functional/configs/config.feature_flags.ts
+++ b/x-pack/solutions/search/test/serverless/functional/configs/config.feature_flags.ts
@@ -26,8 +26,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--feature_flags.overrides.core.chrome.projectSideNav=v2',
         `--uiSettings.overrides.agentBuilder:enabled=true`,
         `--uiSettings.overrides.searchPlayground:searchModeEnabled=true`,
-        `--uiSettings.overrides.queryRules:queryRulesEnabled=true`,
-        '--xpack.searchQueryRules.enabled=true',
       ],
     },
     // load tests in the index file

--- a/x-pack/solutions/search/test/serverless/functional/configs/config.search_features.ts
+++ b/x-pack/solutions/search/test/serverless/functional/configs/config.search_features.ts
@@ -13,16 +13,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseConfig.getAll(),
     junit: {
-      reportName: 'Serverless Search Functional Tests - v2 Solution Navigation',
+      reportName: 'Serverless Search Functional Tests - Search Features',
     },
-    kbnTestServer: {
-      ...baseConfig.get('kbnTestServer'),
-      serverArgs: [
-        ...baseConfig.get('kbnTestServer.serverArgs'),
-        '--feature_flags.overrides.core.chrome.projectSideNav=v2',
-        `--uiSettings.overrides.agentBuilder:enabled=true`,
-      ],
-    },
-    testFiles: [require.resolve('../test_suites/navigation')],
+    testFiles: [require.resolve('./index.search_features.ts')],
   };
 }

--- a/x-pack/solutions/search/test/serverless/functional/configs/config.ts
+++ b/x-pack/solutions/search/test/serverless/functional/configs/config.ts
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
+import { resolve } from 'path';
 import { KBN_CERT_PATH, KBN_KEY_PATH } from '@kbn/dev-utils';
 import { createTestConfig } from '@kbn/test-suites-xpack-platform/serverless/functional/config.base';
 import { services } from '../services';
@@ -18,6 +20,7 @@ export default createTestConfig({
     reportName: 'Serverless Search Functional Tests',
   },
   suiteTags: { exclude: ['skipSvlSearch'] },
+  screenshots: { directory: resolve(__dirname, '../../../screenshots') },
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/esproject/config/elasticsearch.yml
@@ -53,6 +56,12 @@ export default createTestConfig({
     },
     searchHomepage: {
       pathname: '/app/elasticsearch/home',
+    },
+    searchSynonyms: {
+      pathname: '/app/elasticsearch/search_synonyms',
+    },
+    searchQueryRules: {
+      pathname: '/app/elasticsearch/query_rules',
     },
   },
 });

--- a/x-pack/solutions/search/test/serverless/functional/configs/config.ts
+++ b/x-pack/solutions/search/test/serverless/functional/configs/config.ts
@@ -36,7 +36,6 @@ export default createTestConfig({
     '--xpack.dataUsage.autoops.api.url=http://localhost:9000',
     `--xpack.dataUsage.autoops.api.tls.certificate=${KBN_CERT_PATH}`,
     `--xpack.dataUsage.autoops.api.tls.key=${KBN_KEY_PATH}`,
-    '--xpack.searchSynonyms.enabled=true',
   ],
   apps: {
     serverlessConnectors: {

--- a/x-pack/solutions/search/test/serverless/functional/configs/index.feature_flags.ts
+++ b/x-pack/solutions/search/test/serverless/functional/configs/index.feature_flags.ts
@@ -10,6 +10,7 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('serverless search UI - feature flags', function () {
     // add tests that require feature flags, defined in config.feature_flags.ts
+    loadTestFile(require.resolve('../test_suites/agent_builder'));
     loadTestFile(require.resolve('../test_suites/search_playground/search_relevance'));
   });
 }

--- a/x-pack/solutions/search/test/serverless/functional/configs/index.search_features.ts
+++ b/x-pack/solutions/search/test/serverless/functional/configs/index.search_features.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('serverless search UI - search features', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('../test_suites/elasticsearch_start.ts'));
+    loadTestFile(require.resolve('../test_suites/search_homepage'));
+    loadTestFile(require.resolve('../test_suites/search_index_detail.ts'));
+    loadTestFile(require.resolve('../test_suites/connectors/connectors_overview'));
+    loadTestFile(require.resolve('../test_suites/search_playground/playground_overview'));
+    loadTestFile(require.resolve('../test_suites/search_playground/saved_playgrounds'));
+    loadTestFile(require.resolve('../test_suites/inference_management'));
+    loadTestFile(require.resolve('../test_suites/search_query_rules/search_query_rules_overview'));
+    loadTestFile(require.resolve('../test_suites/search_synonyms/search_synonyms_overview'));
+    loadTestFile(require.resolve('../test_suites/search_synonyms/search_synonym_detail'));
+    loadTestFile(require.resolve('../test_suites/console_notebooks'));
+  });
+}

--- a/x-pack/solutions/search/test/serverless/functional/configs/index.ts
+++ b/x-pack/solutions/search/test/serverless/functional/configs/index.ts
@@ -12,11 +12,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     this.tags(['esGate']);
 
     loadTestFile(require.resolve('../test_suites/navigation'));
-    loadTestFile(require.resolve('../test_suites/elasticsearch_start.ts'));
-    loadTestFile(require.resolve('../test_suites/search_homepage'));
-    loadTestFile(require.resolve('../test_suites/search_index_detail.ts'));
     loadTestFile(require.resolve('../test_suites/index_management'));
-    loadTestFile(require.resolve('../test_suites/connectors/connectors_overview'));
     loadTestFile(require.resolve('../test_suites/default_dataview'));
     loadTestFile(require.resolve('../test_suites/pipelines'));
     loadTestFile(require.resolve('../test_suites/cases/attachment_framework'));
@@ -24,14 +20,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('../test_suites/dashboards/import_dashboard'));
     loadTestFile(require.resolve('../test_suites/advanced_settings'));
     loadTestFile(require.resolve('../test_suites/rules/rule_details'));
-    loadTestFile(require.resolve('../test_suites/console_notebooks'));
-    loadTestFile(require.resolve('../test_suites/search_playground/playground_overview'));
-    loadTestFile(require.resolve('../test_suites/search_playground/saved_playgrounds'));
     loadTestFile(require.resolve('../test_suites/ml'));
     loadTestFile(require.resolve('../test_suites/custom_role_access'));
-    loadTestFile(require.resolve('../test_suites/inference_management'));
-    loadTestFile(require.resolve('../test_suites/search_query_rules/search_query_rules_overview'));
-    loadTestFile(require.resolve('../test_suites/search_synonyms/search_synonyms_overview'));
-    loadTestFile(require.resolve('../test_suites/search_synonyms/search_synonym_detail'));
   });
 }

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/agent_builder.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/agent_builder.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const { common, solutionNavigation, svlCommonPage } = getPageObjects([
+    'common',
+    'solutionNavigation',
+    'svlCommonPage',
+  ]);
+  const testSubjects = getService('testSubjects');
+  describe('Agent Builder', function () {
+    function agentsSideNavTest() {
+      it('should have side nav link for agents', async () => {
+        await solutionNavigation.sidenav.expectLinkExists({ deepLinkId: 'agent_builder' });
+        await solutionNavigation.sidenav.clickLink({ deepLinkId: 'agent_builder' });
+        await testSubjects.existOrFail('onechatPageConversations');
+        await solutionNavigation.sidenav.expectLinkActive({ deepLinkId: 'agent_builder' });
+        await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Agent Chat' });
+      });
+    }
+    describe('admin user', function () {
+      before(async () => {
+        await svlCommonPage.loginWithRole('admin');
+        await common.navigateToApp('discover');
+      });
+
+      agentsSideNavTest();
+    });
+    describe('developer user', function () {
+      before(async () => {
+        await svlCommonPage.loginWithRole('developer');
+        await common.navigateToApp('discover');
+      });
+
+      agentsSideNavTest();
+    });
+    describe('viewer user', function () {
+      before(async () => {
+        await svlCommonPage.loginWithRole('viewer');
+        await common.navigateToApp('discover');
+      });
+
+      agentsSideNavTest();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Clean-up search FTR configs to better share the base config for both hosted and serverless.
- introduce a config for a basic license in hosted
- introduced a search features config for serverless to reduce the size of the base config
- introduced tests for agent builder navigation items

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


