### PR TITLE
[8.19] [scout] discover tests in `packages` dir (#235391)

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -606,6 +606,15 @@ export async function pickTestGroupRunOrder() {
   );
 }
 
+// copied from src/platform/packages/shared/kbn-scout/src/config/discovery/search_configs.ts
+interface ScoutTestDiscoveryConfig {
+  group: string;
+  path: string;
+  usesParallelWorkers: boolean;
+  configs: string[];
+  type: 'plugin' | 'package';
+}
+
 export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
   const bk = new BuildkiteClient();
   const envFromlabels: Record<string, string> = collectEnvFromLabels();
@@ -614,19 +623,22 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
     throw new Error(`Scout configs file not found at ${scoutConfigsPath}`);
   }
 
-  const rawScoutConfigs = JSON.parse(Fs.readFileSync(scoutConfigsPath, 'utf-8'));
-  const pluginsWithScoutConfigs: string[] = Object.keys(rawScoutConfigs);
+  const rawScoutConfigs = JSON.parse(Fs.readFileSync(scoutConfigsPath, 'utf-8')) as Record<
+    string,
+    ScoutTestDiscoveryConfig
+  >;
+  const pluginsOrPackagesWithScoutTests: string[] = Object.keys(rawScoutConfigs);
 
-  if (pluginsWithScoutConfigs.length === 0) {
+  if (pluginsOrPackagesWithScoutTests.length === 0) {
     // no scout configs found, nothing to need to upload steps
     return;
   }
 
-  const scoutGroups = pluginsWithScoutConfigs.map((plugin) => ({
-    title: plugin,
-    key: plugin,
-    usesParallelWorkers: rawScoutConfigs[plugin].usesParallelWorkers,
-    group: rawScoutConfigs[plugin].group,
+  const scoutCiRunGroups = pluginsOrPackagesWithScoutTests.map((name) => ({
+    label: `Scout: [ ${rawScoutConfigs[name].group} / ${name} ] ${rawScoutConfigs[name].type}`,
+    key: name,
+    agents: expandAgentQueue(rawScoutConfigs[name].usesParallelWorkers ? 'n2-8-spot' : 'n2-4-spot'),
+    group: rawScoutConfigs[name].group,
   }));
 
   // upload the step definitions to Buildkite
@@ -634,13 +646,14 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
     [
       {
         group: 'Scout Configs',
-        depends_on: ['build'],
-        steps: scoutGroups.map(
-          ({ title, key, group, usesParallelWorkers }): BuildkiteStep => ({
-            label: `Scout: [ ${group} / ${title} ] plugin`,
+        key: 'scout-configs',
+        depends_on: ['build_scout_tests'],
+        steps: scoutCiRunGroups.map(
+          ({ label, key, group, agents }): BuildkiteStep => ({
+            label,
             command: getRequiredEnv('SCOUT_CONFIGS_SCRIPT'),
             timeout_in_minutes: 60,
-            agents: expandAgentQueue(usesParallelWorkers ? 'n2-8-spot' : 'n2-4-spot'),
+            agents,
             env: {
               SCOUT_CONFIG_GROUP_KEY: key,
               SCOUT_CONFIG_GROUP_TYPE: group,

--- a/.buildkite/pipelines/pull_request/scout_tests.yml
+++ b/.buildkite/pipelines/pull_request/scout_tests.yml
@@ -3,6 +3,7 @@ steps:
     label: 'Scout Test Run Builder'
     agents:
       machineType: n2-standard-2
+    key: build_scout_tests
     timeout_in_minutes: 10
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'

--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -1,5 +1,5 @@
-# Define which plugins should be run or skipped in Scout CI pipeline
-ui_tests:
+# Define which plugins and packages should be run or skipped in Kibana CI pipeline
+plugins:
   enabled:
     - discover_enhanced
     - maps
@@ -7,4 +7,8 @@ ui_tests:
     - painless_lab
     - security_solution
     - streams_app
+  disabled:
+
+packages:
+  enabled:
   disabled:

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
@@ -37,23 +37,36 @@ describe('runDiscoverPlaywrightConfigs', () => {
   let flagsReader: jest.Mocked<FlagsReader>;
   let log: jest.Mocked<ToolingLog>;
 
-  // 'enabled' plugins
-  const mockPluginsWithRunnableConfigs: Map<string, any> = new Map([
+  // 'enabled' items
+  const mockScoutConfigs: Map<string, any> = new Map([
     [
       'pluginA',
       {
         group: 'groupA',
-        pluginPath: 'plugin/path',
+        path: 'plugin/path',
         configs: ['config1.ts', 'config2.ts'],
         usesParallelWorkers: true,
+        type: 'plugin',
+      },
+    ],
+    [
+      'packageA',
+      {
+        group: 'groupC',
+        path: 'package/path',
+        configs: ['config4.ts'],
+        usesParallelWorkers: false,
+        type: 'package',
       },
     ],
   ]);
 
-  // these are all the plugins found, but only some of them will be enabled (validateWithScoutCiConfig will find out which ones)
-  const mockPluginsWithConfigs = new Map([
-    ['pluginA', { group: 'groupA', configs: ['config1.ts', 'config2.ts'] }], // enabled
-    ['pluginB', { group: 'groupB', configs: ['config3.ts'] }], // disabled
+  // these are all the items found, but only some of them will be enabled (validateWithScoutCiConfig will find out which ones)
+  const mockAllConfigs = new Map([
+    ['pluginA', { group: 'groupA', configs: ['config1.ts', 'config2.ts'], type: 'plugin' }], // enabled
+    ['pluginB', { group: 'groupB', configs: ['config3.ts'], type: 'plugin' }], // disabled
+    ['packageA', { group: 'groupB', configs: ['config4.ts'], type: 'package' }], // enabled
+    ['packageB', { group: 'groupC', configs: ['config5.ts'], type: 'package' }], // disabled
   ]);
 
   beforeAll(() => {
@@ -78,8 +91,8 @@ describe('runDiscoverPlaywrightConfigs', () => {
 
     (measurePerformance as jest.Mock).mockImplementation((_log, _msg, fn) => fn());
 
-    (getScoutPlaywrightConfigs as jest.Mock).mockReturnValue(mockPluginsWithConfigs);
-    (validateWithScoutCiConfig as jest.Mock).mockReturnValue(mockPluginsWithRunnableConfigs);
+    (getScoutPlaywrightConfigs as jest.Mock).mockReturnValue(mockAllConfigs);
+    (validateWithScoutCiConfig as jest.Mock).mockReturnValue(mockScoutConfigs);
   });
 
   it('validates configs when "validate" is true', () => {
@@ -100,7 +113,7 @@ describe('runDiscoverPlaywrightConfigs', () => {
     runDiscoverPlaywrightConfigs(flagsReader, log);
 
     // setting --validate will trigger a validation
-    expect(validateWithScoutCiConfig).toHaveBeenCalledWith(log, mockPluginsWithConfigs);
+    expect(validateWithScoutCiConfig).toHaveBeenCalledWith(log, mockAllConfigs);
   });
 
   it('should correctly parse custom config search paths', () => {
@@ -126,12 +139,16 @@ describe('runDiscoverPlaywrightConfigs', () => {
     runDiscoverPlaywrightConfigs(flagsReader, log);
 
     expect(log.info.mock.calls).toEqual([
-      ["Found Playwright config files in '2' plugins"],
+      ['Found Playwright config files in 2 plugin(s) and 2 package(s)'],
       ['groupA / [pluginA] plugin:'],
       ['- config1.ts'],
       ['- config2.ts'],
       ['groupB / [pluginB] plugin:'],
       ['- config3.ts'],
+      ['groupB / [packageA] package:'],
+      ['- config4.ts'],
+      ['groupC / [packageB] package:'],
+      ['- config5.ts'],
     ]);
   });
 
@@ -164,19 +181,68 @@ describe('runDiscoverPlaywrightConfigs', () => {
     runDiscoverPlaywrightConfigs(flagsReader, log);
 
     // setting --save will trigger a validation
-    expect(validateWithScoutCiConfig).toHaveBeenCalledWith(log, mockPluginsWithConfigs);
+    expect(validateWithScoutCiConfig).toHaveBeenCalledWith(log, mockAllConfigs);
 
     // create directory if it doesn't exist
     expect(fs.mkdirSync).toHaveBeenCalledWith('/path/to', { recursive: true });
 
-    // we should only write the configs of the plugins that are actually enabled
+    // we should only write the configs of the items that are actually enabled
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       '/path/to/scout_playwright_configs.json',
-      JSON.stringify(Object.fromEntries(mockPluginsWithRunnableConfigs), null, 2)
+      JSON.stringify(Object.fromEntries(mockScoutConfigs), null, 2)
     );
 
     expect(log.info).toHaveBeenCalledWith(
-      `Found Playwright config files in '2' plugins.\nSaved '1' plugins to '/path/to/scout_playwright_configs.json'`
+      `Found Playwright config files in 2 plugin(s) and 2 package(s).\nSaved 1 plugin(s) and 1 package(s) to '/path/to/scout_playwright_configs.json'`
     );
+  });
+
+  it('handles both plugins and packages correctly', () => {
+    // Test data with both plugins and packages
+    const mixedConfigs = new Map([
+      ['pluginX', { group: 'solution1', configs: ['plugin.config.ts'], type: 'plugin' }],
+      ['packageY', { group: 'platform', configs: ['package.config.ts'], type: 'package' }],
+    ]);
+
+    (getScoutPlaywrightConfigs as jest.Mock).mockReturnValue(mixedConfigs);
+    (validateWithScoutCiConfig as jest.Mock).mockReturnValue(mixedConfigs);
+
+    flagsReader.boolean.mockReturnValue(false);
+    flagsReader.arrayOfStrings.mockReturnValue([]);
+
+    runDiscoverPlaywrightConfigs(flagsReader, log);
+
+    expect(log.info.mock.calls).toEqual([
+      ['Found Playwright config files in 1 plugin(s) and 1 package(s)'],
+      ['solution1 / [pluginX] plugin:'],
+      ['- plugin.config.ts'],
+      ['platform / [packageY] package:'],
+      ['- package.config.ts'],
+    ]);
+  });
+
+  it('handles package-only scenarios', () => {
+    // Test data with only packages
+    const packageOnlyConfigs = new Map([
+      ['packageA', { group: 'platform', configs: ['config1.ts', 'config2.ts'], type: 'package' }],
+      ['packageB', { group: 'security', configs: ['config3.ts'], type: 'package' }],
+    ]);
+
+    (getScoutPlaywrightConfigs as jest.Mock).mockReturnValue(packageOnlyConfigs);
+    (validateWithScoutCiConfig as jest.Mock).mockReturnValue(packageOnlyConfigs);
+
+    flagsReader.boolean.mockReturnValue(false);
+    flagsReader.arrayOfStrings.mockReturnValue([]);
+
+    runDiscoverPlaywrightConfigs(flagsReader, log);
+
+    expect(log.info.mock.calls).toEqual([
+      ['Found Playwright config files in 0 plugin(s) and 2 package(s)'],
+      ['platform / [packageA] package:'],
+      ['- config1.ts'],
+      ['- config2.ts'],
+      ['security / [packageB] package:'],
+      ['- config3.ts'],
+    ]);
   });
 });

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
@@ -16,23 +16,30 @@ import { getScoutPlaywrightConfigs, DEFAULT_TEST_PATH_PATTERNS } from '../config
 import { measurePerformance } from '../common';
 import { validateWithScoutCiConfig } from '../config/discovery';
 
+const getCountByType = (configs: Map<string, any>, type: 'plugin' | 'package'): number => {
+  return Array.from(configs.values()).filter((config) => config.type === type).length;
+};
+
 export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: ToolingLog) => {
   const searchPaths = flagsReader.arrayOfStrings('searchPaths')!;
 
-  const pluginsWithConfigs = measurePerformance(log, 'Discovering Playwright config files', () =>
+  const scoutConfigs = measurePerformance(log, 'Discovering Playwright config files', () =>
     getScoutPlaywrightConfigs(searchPaths, log)
   );
 
+  const pluginCount = getCountByType(scoutConfigs, 'plugin');
+  const packageCount = getCountByType(scoutConfigs, 'package');
+
   const finalMessage =
-    pluginsWithConfigs.size === 0
+    scoutConfigs.size === 0
       ? 'No Playwright config files found'
-      : `Found Playwright config files in '${pluginsWithConfigs.size}' plugins`;
+      : `Found Playwright config files in ${pluginCount} plugin(s) and ${packageCount} package(s)`;
 
   if (!flagsReader.boolean('save')) {
     log.info(finalMessage);
 
-    pluginsWithConfigs.forEach((data, plugin) => {
-      log.info(`${data.group} / [${plugin}] plugin:`);
+    scoutConfigs.forEach((data, itemName) => {
+      log.info(`${data.group} / [${itemName}] ${data.type}:`);
       data.configs.map((file) => {
         log.info(`- ${file}`);
       });
@@ -40,7 +47,10 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
   }
 
   if (flagsReader.boolean('save')) {
-    const pluginsWithRunnableConfigs = validateWithScoutCiConfig(log, pluginsWithConfigs);
+    const runnableConfigs = validateWithScoutCiConfig(log, scoutConfigs);
+
+    const runnablePluginCount = getCountByType(runnableConfigs, 'plugin');
+    const runnablePackageCount = getCountByType(runnableConfigs, 'package');
 
     const dirPath = path.dirname(SCOUT_PLAYWRIGHT_CONFIGS_PATH);
 
@@ -50,18 +60,18 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
 
     fs.writeFileSync(
       SCOUT_PLAYWRIGHT_CONFIGS_PATH,
-      JSON.stringify(Object.fromEntries(pluginsWithRunnableConfigs), null, 2)
+      JSON.stringify(Object.fromEntries(runnableConfigs), null, 2)
     );
 
     log.info(
-      `${finalMessage}.\nSaved '${pluginsWithRunnableConfigs.size}' plugins to '${SCOUT_PLAYWRIGHT_CONFIGS_PATH}'`
+      `${finalMessage}.\nSaved ${runnablePluginCount} plugin(s) and ${runnablePackageCount} package(s) to '${SCOUT_PLAYWRIGHT_CONFIGS_PATH}'`
     );
 
     return;
   }
 
   if (flagsReader.boolean('validate')) {
-    validateWithScoutCiConfig(log, pluginsWithConfigs);
+    validateWithScoutCiConfig(log, scoutConfigs);
   }
 };
 
@@ -75,8 +85,8 @@ export const discoverPlaywrightConfigsCmd: Command<void> = {
 
   Common usage:
     node scripts/scout discover-playwright-configs --searchPaths <search_paths>
-    node scripts/scout discover-playwright-configs --validate // validate if all plugins are registered in the Scout CI config
-    node scripts/scout discover-playwright-configs --save // validate and save enabled plugins with its config files to '${SCOUT_PLAYWRIGHT_CONFIGS_PATH}'
+    node scripts/scout discover-playwright-configs --validate // validate if all items are registered in the Scout CI config
+    node scripts/scout discover-playwright-configs --save // validate and save enabled items with their config files to '${SCOUT_PLAYWRIGHT_CONFIGS_PATH}'
     node scripts/scout discover-playwright-configs
   `,
   flags: {

--- a/src/platform/packages/shared/kbn-scout/src/config/discovery/search_configs.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/config/discovery/search_configs.test.ts
@@ -31,41 +31,60 @@ describe('getScoutPlaywrightConfigs', () => {
   it('should return an empty map if no matching files are found', () => {
     (fastGlob.sync as jest.Mock).mockReturnValueOnce([]);
 
-    const plugins = getScoutPlaywrightConfigs(['x-pack/plugins'], mockLog);
-    expect(plugins.size).toBe(0);
+    const configs = getScoutPlaywrightConfigs(['x-pack/plugins'], mockLog);
+    expect(configs.size).toBe(0);
   });
 
-  it('should correctly extract plugin names and group config files', () => {
+  it('should correctly extract item names and group config files', () => {
     (fastGlob.sync as jest.Mock).mockReturnValue([
       'x-pack/platform/plugins/private/plugin_a/test/scout/ui/playwright.config.ts',
       'x-pack/platform/plugins/private/plugin_a/test/scout/ui/parallel.playwright.config.ts',
+      'x-pack/platform/packages/shared/package_a/test/scout/api/playwright.config.ts',
       'x-pack/solutions/security/plugins/plugin_b/test/scout/ui/playwright.config.ts',
       'src/platform/plugins/shared/plugin_c/test/scout/ui/playwright.config.ts',
+      'src/platform/packages/private/package_b/test/scout/ui/playwright.config.ts',
     ]);
 
-    const plugins = getScoutPlaywrightConfigs(['x-pack/', 'src/'], mockLog);
+    const configs = getScoutPlaywrightConfigs(['x-pack/', 'src/'], mockLog);
 
-    expect(plugins.size).toBe(3);
-    expect(plugins.get('plugin_a')).toEqual({
+    expect(configs.size).toBe(5);
+    expect(configs.get('plugin_a')).toEqual({
       configs: [
         'x-pack/platform/plugins/private/plugin_a/test/scout/ui/playwright.config.ts',
         'x-pack/platform/plugins/private/plugin_a/test/scout/ui/parallel.playwright.config.ts',
       ],
       usesParallelWorkers: true,
       group: 'platform',
-      pluginPath: 'x-pack/platform/plugins/private/plugin_a',
+      path: 'x-pack/platform/plugins/private/plugin_a',
+      type: 'plugin',
     });
-    expect(plugins.get('plugin_b')).toEqual({
+    expect(configs.get('plugin_b')).toEqual({
       configs: ['x-pack/solutions/security/plugins/plugin_b/test/scout/ui/playwright.config.ts'],
       usesParallelWorkers: false,
       group: 'security',
-      pluginPath: 'x-pack/solutions/security/plugins/plugin_b',
+      path: 'x-pack/solutions/security/plugins/plugin_b',
+      type: 'plugin',
     });
-    expect(plugins.get('plugin_c')).toEqual({
+    expect(configs.get('plugin_c')).toEqual({
       configs: ['src/platform/plugins/shared/plugin_c/test/scout/ui/playwright.config.ts'],
       usesParallelWorkers: false,
       group: 'platform',
-      pluginPath: 'src/platform/plugins/shared/plugin_c',
+      path: 'src/platform/plugins/shared/plugin_c',
+      type: 'plugin',
+    });
+    expect(configs.get('package_a')).toEqual({
+      configs: ['x-pack/platform/packages/shared/package_a/test/scout/api/playwright.config.ts'],
+      usesParallelWorkers: false,
+      group: 'platform',
+      path: 'x-pack/platform/packages/shared/package_a',
+      type: 'package',
+    });
+    expect(configs.get('package_b')).toEqual({
+      configs: ['src/platform/packages/private/package_b/test/scout/ui/playwright.config.ts'],
+      usesParallelWorkers: false,
+      group: 'platform',
+      path: 'src/platform/packages/private/package_b',
+      type: 'package',
     });
   });
 
@@ -74,11 +93,11 @@ describe('getScoutPlaywrightConfigs', () => {
       'x-pack/security/plugins/unknown-path/playwright.config.ts',
     ]);
 
-    const plugins = getScoutPlaywrightConfigs(['x-pack/security'], mockLog);
+    const configs = getScoutPlaywrightConfigs(['x-pack/security'], mockLog);
 
-    expect(plugins.size).toBe(0);
+    expect(configs.size).toBe(0);
     expect(mockLog.warning).toHaveBeenCalledWith(
-      expect.stringContaining('Unable to extract plugin name from path')
+      expect.stringContaining('Unable to extract plugin/package name from path')
     );
   });
 });
@@ -86,9 +105,13 @@ describe('getScoutPlaywrightConfigs', () => {
 describe('validateWithScoutCiConfig', () => {
   let mockLog: ToolingLog;
   const mockScoutCiConfig = {
-    ui_tests: {
+    plugins: {
       enabled: ['pluginA', 'pluginB'],
       disabled: ['pluginC'],
+    },
+    packages: {
+      enabled: ['packageA'],
+      disabled: ['packageB'],
     },
   };
 
@@ -102,79 +125,126 @@ describe('validateWithScoutCiConfig', () => {
     jest.clearAllMocks();
   });
 
-  it('should return only enabled plugins', () => {
-    const pluginsWithConfigs = new Map([
+  it('should return only enabled plugins and packages', () => {
+    const scoutConfigs = new Map([
       [
         'pluginA',
         {
           group: 'group1',
-          pluginPath: 'pluginPathA',
+          path: 'pluginPathA',
           usesParallelWorkers: true,
           configs: ['configA'],
+          type: 'plugin' as const,
         },
       ],
       [
         'pluginB',
         {
           group: 'group1',
-          pluginPath: 'pluginPathB',
+          path: 'pluginPathB',
           usesParallelWorkers: false,
           configs: ['configB1', 'configB2'],
+          type: 'plugin' as const,
         },
       ],
       [
         'pluginC',
         {
           group: 'group2',
-          pluginPath: 'pluginPathC',
+          path: 'pluginPathC',
           usesParallelWorkers: true,
           configs: ['configC'],
+          type: 'plugin' as const,
+        },
+      ],
+      [
+        'packageA',
+        {
+          group: 'group1',
+          path: 'packagePathA',
+          usesParallelWorkers: true,
+          configs: ['configA'],
+          type: 'package' as const,
+        },
+      ],
+      [
+        'packageB',
+        {
+          group: 'group2',
+          path: 'packagePathB',
+          usesParallelWorkers: false,
+          configs: ['configB'],
+          type: 'package' as const,
         },
       ],
     ]);
 
-    const result = validateWithScoutCiConfig(mockLog, pluginsWithConfigs);
-    expect(result.size).toBe(2);
+    const result = validateWithScoutCiConfig(mockLog, scoutConfigs);
+    expect(result.size).toBe(3);
     expect(result.has('pluginA')).toBe(true);
     expect(result.has('pluginB')).toBe(true);
+    expect(result.has('packageA')).toBe(true);
     expect(result.has('pluginC')).toBe(false);
+    expect(result.has('packageB')).toBe(false);
   });
 
-  it('should throw an error if plugins are not registered in Scout CI config', () => {
-    const pluginsWithConfigs = new Map([
+  it('should throw an error if plugins or packages are not registered in Scout CI config', () => {
+    const scoutConfigs = new Map([
       [
         'pluginX',
         {
           group: 'groupX',
-          pluginPath: 'pluginPathX',
+          path: 'pluginPathX',
           usesParallelWorkers: true,
           configs: ['configX'],
+          type: 'plugin' as const,
+        },
+      ],
+      [
+        'packageX',
+        {
+          group: 'groupX',
+          path: 'packagePathX',
+          usesParallelWorkers: true,
+          configs: ['configX'],
+          type: 'package' as const,
         },
       ],
     ]);
 
-    expect(() => validateWithScoutCiConfig(mockLog, pluginsWithConfigs)).toThrow(
-      "The following plugins are not registered in Scout CI config '.buildkite/scout_ci_config.yml':\n- pluginX"
+    expect(() => validateWithScoutCiConfig(mockLog, scoutConfigs)).toThrow(
+      "The following plugin(s)/package(s) are not listed in Scout CI config '.buildkite/scout_ci_config.yml':\n- pluginX (plugin)\n- packageX (package)"
     );
   });
 
-  it('should log a warning for disabled plugins', () => {
-    const pluginsWithConfigs = new Map([
+  it('should log a warning for disabled plugins and packages', () => {
+    const scoutConfigs = new Map([
       [
         'pluginC',
         {
           group: 'group2',
-          pluginPath: 'pluginPathC',
+          path: 'pluginPathC',
           usesParallelWorkers: true,
           configs: ['configC'],
+          type: 'plugin' as const,
+        },
+      ],
+      [
+        'packageB',
+        {
+          group: 'group2',
+          path: 'packagePathB',
+          usesParallelWorkers: false,
+          configs: ['configB'],
+          type: 'package' as const,
         },
       ],
     ]);
 
-    validateWithScoutCiConfig(mockLog, pluginsWithConfigs);
+    validateWithScoutCiConfig(mockLog, scoutConfigs);
 
     expect(mockLog.warning).toHaveBeenCalledWith(
-      `The following plugins are disabled in '.buildkite/scout_ci_config.yml' and will be excluded from CI run\n- pluginC`
+      `The following plugin(s)/package(s) are disabled in '.buildkite/scout_ci_config.yml' and will be excluded from CI run\n- pluginC\n- packageB`
     );
   });
 });

--- a/src/platform/packages/shared/kbn-scout/src/config/discovery/search_configs.ts
+++ b/src/platform/packages/shared/kbn-scout/src/config/discovery/search_configs.ts
@@ -15,13 +15,19 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import { createFailError } from '@kbn/dev-cli-errors';
 
-export const DEFAULT_TEST_PATH_PATTERNS = ['src/platform/plugins', 'x-pack/**/plugins'];
+export const DEFAULT_TEST_PATH_PATTERNS = [
+  'src/platform/plugins',
+  'src/platform/packages',
+  'x-pack/**/plugins',
+  'x-pack/**/packages',
+];
 
-interface PluginScoutConfig {
+interface ScoutTestDiscoveryConfig {
   group: string;
-  pluginPath: string;
+  path: string;
   usesParallelWorkers: boolean;
   configs: string[];
+  type: 'plugin' | 'package';
 }
 
 export const getScoutPlaywrightConfigs = (searchPaths: string[], log: ToolingLog) => {
@@ -43,108 +49,151 @@ export const getScoutPlaywrightConfigs = (searchPaths: string[], log: ToolingLog
     'x-pack/solutions/search': 'search',
     'x-pack/solutions/observability': 'observability',
     'x-pack/platform/plugins': 'platform',
+    'x-pack/platform/packages': 'platform',
     'src/platform/plugins': 'platform',
+    'src/platform/packages': 'platform',
   };
 
-  const matchPluginPath = (filePath: string): { pluginPath: string; pluginName: string } | null => {
+  const matchDirPath = (
+    filePath: string
+  ): { path: string; name: string; type: 'plugin' | 'package' } | null => {
     const regexes = [
-      /(x-pack\/platform\/plugins\/(?:private|shared|[^\/]+)\/([^\/]+))\/test\/scout\//,
-      /(x-pack\/solutions\/[^\/]+\/plugins\/([^\/]+))\/test\/scout\//, // covers all Kibana solutions
-      /(src\/platform\/plugins\/(?:private|shared)?\/?([^\/]+))\/test\/scout\//,
+      // Plugin patterns
+      {
+        regex: /(x-pack\/platform\/plugins\/(?:private|shared|[^\/]+)\/([^\/]+))\/test\/scout\//,
+        type: 'plugin' as const,
+      },
+      {
+        regex: /(x-pack\/solutions\/[^\/]+\/plugins\/([^\/]+))\/test\/scout\//,
+        type: 'plugin' as const,
+      }, // covers all Kibana solutions
+      {
+        regex: /(src\/platform\/plugins\/(?:private|shared)?\/?([^\/]+))\/test\/scout\//,
+        type: 'plugin' as const,
+      },
+      // Package patterns
+      {
+        regex: /(x-pack\/platform\/packages\/(?:private|shared|[^\/]+)\/([^\/]+))\/test\/scout\//,
+        type: 'package' as const,
+      },
+      {
+        regex: /(x-pack\/solutions\/[^\/]+\/packages\/([^\/]+))\/test\/scout\//,
+        type: 'package' as const,
+      }, // covers all Kibana solutions
+      {
+        regex: /(src\/platform\/packages\/(?:private|shared)\/([^\/]+))\/test\/scout\//,
+        type: 'package' as const,
+      },
     ];
 
-    for (const regex of regexes) {
+    for (const { regex, type } of regexes) {
       const match = filePath.match(regex);
       if (match) {
-        return { pluginPath: match[1], pluginName: match[2] };
+        return { path: match[1], name: match[2], type };
       }
     }
     return null;
   };
 
-  const pluginsWithConfigs = new Map<string, PluginScoutConfig>();
+  const scoutConfigMap = new Map<string, ScoutTestDiscoveryConfig>();
 
   files.forEach((filePath) => {
-    const matchResult = matchPluginPath(filePath);
+    const matchResult = matchDirPath(filePath);
     if (!matchResult) {
-      log.warning(`Unable to extract plugin name from path: ${filePath}`);
+      log.warning(`Unable to extract plugin/package name from path: ${filePath}`);
       return;
     }
 
-    const { pluginPath, pluginName } = matchResult;
+    const { path: itemPath, name: itemName, type } = matchResult;
     const group =
       Object.entries(typeMappings).find(([key]) => filePath.includes(key))?.[1] || 'unknown';
 
-    if (!pluginsWithConfigs.has(pluginName)) {
-      pluginsWithConfigs.set(pluginName, {
+    if (!scoutConfigMap.has(itemName)) {
+      scoutConfigMap.set(itemName, {
         group,
-        pluginPath,
+        path: itemPath,
         configs: [],
         usesParallelWorkers: false,
+        type,
       });
     }
 
-    const pluginData = pluginsWithConfigs.get(pluginName)!;
-    if (!pluginData.configs.includes(filePath)) {
-      pluginData.configs.push(filePath);
+    const itemData = scoutConfigMap.get(itemName)!;
+    if (!itemData.configs.includes(filePath)) {
+      itemData.configs.push(filePath);
       if (filePath.endsWith('parallel.playwright.config.ts')) {
-        pluginData.usesParallelWorkers = true;
+        itemData.usesParallelWorkers = true;
       }
     }
   });
 
-  return pluginsWithConfigs;
+  return scoutConfigMap;
 };
 
 export const validateWithScoutCiConfig = (
   log: ToolingLog,
-  pluginsWithConfigs: Map<string, PluginScoutConfig>
+  scoutConfigMap: Map<string, ScoutTestDiscoveryConfig>
 ) => {
   const scoutCiConfigRelPath = path.join('.buildkite', 'scout_ci_config.yml');
   const scoutCiConfigPath = path.resolve(REPO_ROOT, scoutCiConfigRelPath);
   const ciConfig = yaml.load(fs.readFileSync(scoutCiConfigPath, 'utf8')) as {
-    ui_tests: {
+    plugins: {
+      enabled?: string[];
+      disabled?: string[];
+    };
+    packages: {
       enabled?: string[];
       disabled?: string[];
     };
   };
 
-  const enabledPlugins = new Set(ciConfig.ui_tests.enabled || []);
-  const disabledPlugins = new Set(ciConfig.ui_tests.disabled || []);
+  const enabledPlugins = new Set(ciConfig.plugins.enabled || []);
+  const disabledPlugins = new Set(ciConfig.plugins.disabled || []);
+  const enabledPackages = new Set(ciConfig.packages.enabled || []);
+  const disabledPackages = new Set(ciConfig.packages.disabled || []);
+
   const allRegisteredPlugins = new Set([...enabledPlugins, ...disabledPlugins]);
+  const allRegisteredPackages = new Set([...enabledPackages, ...disabledPackages]);
 
-  const unregisteredPlugins: string[] = [];
-  const runnablePlugins = new Map<string, PluginScoutConfig>();
+  const unregisteredItems: string[] = [];
+  const runnableConfigs = new Map<string, ScoutTestDiscoveryConfig>();
 
-  for (const [pluginName, config] of pluginsWithConfigs.entries()) {
-    if (!allRegisteredPlugins.has(pluginName)) {
-      unregisteredPlugins.push(pluginName);
-    } else if (enabledPlugins.has(pluginName)) {
-      runnablePlugins.set(pluginName, config);
+  for (const [title, config] of scoutConfigMap.entries()) {
+    const isPlugin = config.type === 'plugin';
+    const isPackage = config.type === 'package';
+
+    if (isPlugin && !allRegisteredPlugins.has(title)) {
+      unregisteredItems.push(`${title} (plugin)`);
+    } else if (isPackage && !allRegisteredPackages.has(title)) {
+      unregisteredItems.push(`${title} (package)`);
+    } else if (
+      (isPlugin && enabledPlugins.has(title)) ||
+      (isPackage && enabledPackages.has(title))
+    ) {
+      runnableConfigs.set(title, config);
     }
   }
 
-  if (unregisteredPlugins.length > 0) {
+  if (unregisteredItems.length > 0) {
     throw createFailError(
-      `The following plugins are not registered in Scout CI config '${scoutCiConfigRelPath}':\n${unregisteredPlugins
-        .map((plugin) => {
-          return `- ${plugin}`;
+      `The following plugin(s)/package(s) are not listed in Scout CI config '${scoutCiConfigRelPath}':\n${unregisteredItems
+        .map((item) => {
+          return `- ${item}`;
         })
         .join('\n')}\nRead more: src/platform/packages/shared/kbn-scout/README.md`
     );
   }
 
-  if (disabledPlugins.size > 0) {
+  const allDisabled = [...disabledPlugins, ...disabledPackages];
+  if (allDisabled.length > 0) {
     log.warning(
-      `The following plugins are disabled in '${scoutCiConfigRelPath}' and will be excluded from CI run\n${[
-        ...disabledPlugins,
-      ]
-        .map((plugin) => {
-          return `- ${plugin}`;
+      `The following plugin(s)/package(s) are disabled in '${scoutCiConfigRelPath}' and will be excluded from CI run\n${allDisabled
+        .map((item) => {
+          return `- ${item}`;
         })
         .join('\n')}`
     );
   }
 
-  return runnablePlugins;
+  return runnableConfigs;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[scout] discover tests in `packages` dir (#235391)](https://github.com/elastic/kibana/pull/235391)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-09-18T14:26:15Z","message":"[scout] discover tests in `packages` dir (#235391)\n\n## Summary\n\nThis PR extends scout config discovery to support tests, located in\n`packages`.\n\nHow to test:\n\n```bash\nnode scripts/scout discover-playwright-configs\n info Searching for Playwright config files in the following paths:\n info - src/platform/plugins/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info - src/platform/packages/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info - x-pack/**/plugins/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info - x-pack/**/packages/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info\n info Found Playwright config files in 9 plugin(s) and 0 package(s)\n```\n\nrelated to https://github.com/elastic/kibana/pull/234302","sha":"49d82ca69090eeaeab5788b08cf1fecaa50681c5","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","test:scout","v9.2.0"],"title":"[scout] discover tests in `packages` dir","number":235391,"url":"https://github.com/elastic/kibana/pull/235391","mergeCommit":{"message":"[scout] discover tests in `packages` dir (#235391)\n\n## Summary\n\nThis PR extends scout config discovery to support tests, located in\n`packages`.\n\nHow to test:\n\n```bash\nnode scripts/scout discover-playwright-configs\n info Searching for Playwright config files in the following paths:\n info - src/platform/plugins/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info - src/platform/packages/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info - x-pack/**/plugins/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info - x-pack/**/packages/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info\n info Found Playwright config files in 9 plugin(s) and 0 package(s)\n```\n\nrelated to https://github.com/elastic/kibana/pull/234302","sha":"49d82ca69090eeaeab5788b08cf1fecaa50681c5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/235391","number":235391,"mergeCommit":{"message":"[scout] discover tests in `packages` dir (#235391)\n\n## Summary\n\nThis PR extends scout config discovery to support tests, located in\n`packages`.\n\nHow to test:\n\n```bash\nnode scripts/scout discover-playwright-configs\n info Searching for Playwright config files in the following paths:\n info - src/platform/plugins/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info - src/platform/packages/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info - x-pack/**/plugins/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info - x-pack/**/packages/**/test/scout/{ui,api}/{playwright.config.ts,parallel.playwright.config.ts}\n info\n info Found Playwright config files in 9 plugin(s) and 0 package(s)\n```\n\nrelated to https://github.com/elastic/kibana/pull/234302","sha":"49d82ca69090eeaeab5788b08cf1fecaa50681c5"}},{"url":"https://github.com/elastic/kibana/pull/236471","number":236471,"branch":"9.1","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/236476","number":236476,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->