### PR TITLE
[8.18] [Scout] Log warning instead of error when `--dontFailOnError` is set (#236100)

### DIFF
--- a/src/platform/packages/private/kbn-scout-reporting/src/cli/upload_events.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/cli/upload_events.test.ts
@@ -9,8 +9,9 @@
 
 import fs from 'node:fs';
 
-import { uploadAllEventsFromPath } from './upload_events';
-import { ToolingLog } from '@kbn/tooling-log';
+import type { EventUploadOptions } from './upload_events';
+import { uploadAllEventsFromPath, nonThrowingUploadAllEventsFromPath } from './upload_events';
+import type { ToolingLog } from '@kbn/tooling-log';
 
 jest.mock('node:fs');
 
@@ -35,6 +36,12 @@ jest.mock('../reporting/report/events', () => ({
 describe('uploadAllEventsFromPath', () => {
   let log: jest.Mocked<ToolingLog>;
 
+  const spies = {
+    existsSync: jest.spyOn(fs, 'existsSync'),
+    statSync: jest.spyOn(fs, 'statSync'),
+    readdirSync: jest.spyOn(fs, 'readdirSync'),
+  };
+
   beforeEach(() => {
     log = {
       info: jest.fn(),
@@ -45,10 +52,11 @@ describe('uploadAllEventsFromPath', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    Object.values(spies).forEach((spy) => spy.mockRestore());
   });
 
   it('should throw an error if the provided eventLogPath does not exist', async () => {
-    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    spies.existsSync.mockReturnValue(false);
 
     await expect(
       uploadAllEventsFromPath('non_existent_path', {
@@ -63,8 +71,8 @@ describe('uploadAllEventsFromPath', () => {
   });
 
   it('should throw an error if the provided eventLogPath is a file and it does not end with .ndjson', async () => {
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
-    jest.spyOn(fs, 'statSync').mockReturnValue({
+    spies.existsSync.mockReturnValue(true);
+    spies.statSync.mockReturnValue({
       isDirectory: () => false,
     } as unknown as fs.Stats);
 
@@ -81,7 +89,7 @@ describe('uploadAllEventsFromPath', () => {
   });
 
   it('should log a warning if the provided eventLogPath is a directory and it does not contain any .ndjson file', async () => {
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    spies.existsSync.mockReturnValue(true);
 
     // Simulate directory contents: 1 .txt file
     (fs.readdirSync as jest.Mock).mockImplementation((directoryPath: string) => {
@@ -111,16 +119,16 @@ describe('uploadAllEventsFromPath', () => {
   });
 
   it('should upload the event log file if the provided eventLogPath if a file and ends with .ndjson', async () => {
-    jest.spyOn(fs, 'statSync').mockReturnValue({
+    spies.statSync.mockReturnValue({
       isDirectory: () => true,
     } as unknown as fs.Stats);
-    jest.spyOn(fs, 'readdirSync').mockReturnValue(['file.txt' as unknown as fs.Dirent]);
+    spies.readdirSync.mockReturnValue(['file.txt' as unknown as fs.Dirent]);
 
     // assume the provided event log path exists
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    spies.existsSync.mockReturnValue(true);
 
     // the provided event log path is not a directory
-    jest.spyOn(fs, 'statSync').mockReturnValue({
+    spies.statSync.mockReturnValue({
       isDirectory: () => false,
     } as unknown as fs.Stats);
 
@@ -135,7 +143,7 @@ describe('uploadAllEventsFromPath', () => {
   });
 
   it('should find event log files recursively', async () => {
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    spies.existsSync.mockReturnValue(true);
 
     (fs.readdirSync as jest.Mock).mockImplementation((directoryPath: string) => {
       if (directoryPath === 'mocked_directory') {
@@ -177,7 +185,7 @@ describe('uploadAllEventsFromPath', () => {
   });
 
   it('should upload multiple event log files if the provided eventLogPath is a directory and contains .ndjson files', async () => {
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    spies.existsSync.mockReturnValue(true);
 
     // Simulate directory contents: 2 .ndjson files, 1 .txt file
     (fs.readdirSync as jest.Mock).mockImplementation((directoryPath: string) => {
@@ -208,6 +216,32 @@ describe('uploadAllEventsFromPath', () => {
     expect(log.info.mock.calls).toEqual([
       ['Connecting to Elasticsearch at esURL'],
       ["Recursively found 2 .ndjson event log files in directory 'mocked_directory'."],
+    ]);
+  });
+});
+
+describe('nonThrowingUploadAllEventsFromPath', () => {
+  it('should not throw and only log a warning', async () => {
+    const log: jest.Mocked<ToolingLog> = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warning: jest.fn(),
+    } as any;
+
+    const eventLogPath = '/some/path/that/does/not/exist';
+    const eventUploadOptions: EventUploadOptions = {
+      esURL: 'esURL',
+      esAPIKey: 'esAPIKey',
+      verifyTLSCerts: true,
+      log,
+    };
+
+    await expect(
+      nonThrowingUploadAllEventsFromPath(eventLogPath, eventUploadOptions)
+    ).resolves.toBeUndefined();
+
+    expect(log.warning.mock.calls).toEqual([
+      [`An error was suppressed: The provided event log path '${eventLogPath}' does not exist.`],
     ]);
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Scout] Log warning instead of error when `--dontFailOnError` is set (#236100)](https://github.com/elastic/kibana/pull/236100)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"David Olaru","email":"dolaru@elastic.co"},"sourceCommit":{"committedDate":"2025-09-24T09:18:44Z","message":"[Scout] Log warning instead of error when `--dontFailOnError` is set (#236100)\n\n## Summary\nThe `--dontFailOnError` flag is currently used when uploading Scout\nevents from CI.\n\nBecause the error is still logged at the error level, it's been\nmistakenly identified as the root cause of an issue despite the fact\nthat the return code of the event upload call was zero.\n\nThe error is now logged as a warning, without the stack trace.","sha":"6b49ea8414929102a8a962c896c8feca61d8d8e9","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.2.0"],"title":"[Scout] Log warning instead of error when `--dontFailOnError` is set","number":236100,"url":"https://github.com/elastic/kibana/pull/236100","mergeCommit":{"message":"[Scout] Log warning instead of error when `--dontFailOnError` is set (#236100)\n\n## Summary\nThe `--dontFailOnError` flag is currently used when uploading Scout\nevents from CI.\n\nBecause the error is still logged at the error level, it's been\nmistakenly identified as the root cause of an issue despite the fact\nthat the return code of the event upload call was zero.\n\nThe error is now logged as a warning, without the stack trace.","sha":"6b49ea8414929102a8a962c896c8feca61d8d8e9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236100","number":236100,"mergeCommit":{"message":"[Scout] Log warning instead of error when `--dontFailOnError` is set (#236100)\n\n## Summary\nThe `--dontFailOnError` flag is currently used when uploading Scout\nevents from CI.\n\nBecause the error is still logged at the error level, it's been\nmistakenly identified as the root cause of an issue despite the fact\nthat the return code of the event upload call was zero.\n\nThe error is now logged as a warning, without the stack trace.","sha":"6b49ea8414929102a8a962c896c8feca61d8d8e9"}}]}] BACKPORT-->