### PR TITLE
[ES|QL] Adds inline docs for the FORK command

### DIFF
--- a/src/platform/packages/private/kbn-language-documentation/scripts/resources/commands/processing_data.ts
+++ b/src/platform/packages/private/kbn-language-documentation/scripts/resources/commands/processing_data.ts
@@ -261,6 +261,91 @@ FROM employees
     },
   },
   {
+    name: 'fork',
+    labelDefaultMessage: 'FORK',
+    descriptionDefaultMessage: `### FORK
+\`FORK\` creates multiple execution branches to operate on the same input data and combines the results in a single output table.
+
+\`\`\` esql
+FORK ( <processing_commands> ) ( <processing_commands> ) ... ( <processing_commands> )
+\`\`\`
+
+**Description**
+
+The \`FORK\` processing command creates multiple execution branches to operate
+on the same input data and combines the results in a single output table. A discriminator column (\`_fork\`) is added to identify which branch each row came from.
+
+**Branch identification:**
+- The \`_fork\` column identifies each branch with values like \`fork1\`, \`fork2\`, \`fork3\`, etc.
+- Values correspond to the order branches are defined
+- \`fork1\` always indicates the first branch
+
+**Column handling:**
+- \`FORK\` branches can output different columns
+- Columns with the same name must have the same data type across all branches
+- Missing columns are filled with \`null\` values
+
+**Row ordering:**
+- \`FORK\` preserves row order within each branch
+- Rows from different branches may be interleaved
+- Use \`SORT _fork\` to group results by branch
+
+NOTE:
+\`FORK\` branches default to \`LIMIT 1000\` if no \`LIMIT\` is provided.
+
+**Limitations**
+
+- \`FORK\` supports at most 8 execution branches.
+- Using remote cluster references and \`FORK\` is not supported.
+- Using more than one \`FORK\` command in a query is not supported.
+
+**Examples**
+
+In the following example, each \`FORK\` branch returns one row.
+Notice how \`FORK\` adds a \`_fork\` column that indicates which row the branch originates from:
+
+\`\`\` esql
+FROM employees
+| FORK ( WHERE emp_no == 10001 )
+       ( WHERE emp_no == 10002 )
+| KEEP emp_no, _fork
+| SORT emp_no
+\`\`\`
+
+| emp_no:integer | _fork:keyword |
+| --- | --- |
+| 10001 | fork1 |
+| 10002 | fork2 |
+
+The next example, returns total number of rows that match the query along with
+the top five rows sorted by score.
+
+\`\`\`esql
+FROM books METADATA _score
+| WHERE author:"Faulkner"
+| EVAL score = round(_score, 2)
+| FORK (SORT score DESC, author | LIMIT 5 | KEEP author, score)
+       (STATS total = COUNT(*))
+| SORT _fork, score DESC, author
+\`\`\`
+
+| author:text | score:double | _fork:keyword | total:long |
+| --- | --- | --- | --- |
+| William Faulkner | 2.39 | fork1 | null |
+| William Faulkner | 2.39 | fork1 | null |
+| Colleen Faulkner | 1.59 | fork1 | null |
+| Danny Faulkner | 1.59 | fork1 | null |
+| Keith Faulkner | 1.59 | fork1 | null |
+| null | null | fork2 | 18 |
+            `,
+    descriptionOptions: {
+      description:
+        'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+    },
+    openLinksInNewTab: true,
+    preview: true,
+  },
+  {
     name: 'grok',
     labelDefaultMessage: 'GROK',
     descriptionDefaultMessage: `### GROK

--- a/src/platform/packages/private/kbn-language-documentation/scripts/resources/commands/processing_data.ts
+++ b/src/platform/packages/private/kbn-language-documentation/scripts/resources/commands/processing_data.ts
@@ -277,7 +277,7 @@ on the same input data and combines the results in a single output table. A disc
 
 **Branch identification:**
 - The \`_fork\` column identifies each branch with values like \`fork1\`, \`fork2\`, \`fork3\`, etc.
-- Values correspond to the order branches are defined
+- Values correspond to the order in which branches are defined
 - \`fork1\` always indicates the first branch
 
 **Column handling:**

--- a/src/platform/packages/private/kbn-language-documentation/scripts/resources/commands/processing_data.ts
+++ b/src/platform/packages/private/kbn-language-documentation/scripts/resources/commands/processing_data.ts
@@ -341,6 +341,7 @@ FROM books METADATA _score
     descriptionOptions: {
       description:
         'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+      ignoreTag: true,
     },
     openLinksInNewTab: true,
     preview: true,

--- a/src/platform/packages/private/kbn-language-documentation/src/sections/generated/processing_commands.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/sections/generated/processing_commands.tsx
@@ -314,6 +314,96 @@ FROM employees
       ),
     },
     {
+      label: i18n.translate('languageDocumentation.documentationESQL.fork', {
+        defaultMessage: 'FORK',
+      }),
+      preview: true,
+      description: (
+        <Markdown
+          openLinksInNewTab={true}
+          markdownContent={i18n.translate('languageDocumentation.documentationESQL.fork.markdown', {
+            defaultMessage: `### FORK
+\`FORK\` creates multiple execution branches to operate on the same input data and combines the results in a single output table.
+
+\`\`\` esql
+FORK ( <processing_commands> ) ( <processing_commands> ) ... ( <processing_commands> )
+\`\`\`
+
+**Description**
+
+The \`FORK\` processing command creates multiple execution branches to operate
+on the same input data and combines the results in a single output table. A discriminator column (\`_fork\`) is added to identify which branch each row came from.
+
+**Branch identification:**
+- The \`_fork\` column identifies each branch with values like \`fork1\`, \`fork2\`, \`fork3\`, etc.
+- Values correspond to the order in which branches are defined
+- \`fork1\` always indicates the first branch
+
+**Column handling:**
+- \`FORK\` branches can output different columns
+- Columns with the same name must have the same data type across all branches
+- Missing columns are filled with \`null\` values
+
+**Row ordering:**
+- \`FORK\` preserves row order within each branch
+- Rows from different branches may be interleaved
+- Use \`SORT _fork\` to group results by branch
+
+NOTE:
+\`FORK\` branches default to \`LIMIT 1000\` if no \`LIMIT\` is provided.
+
+**Limitations**
+
+- \`FORK\` supports at most 8 execution branches.
+- Using remote cluster references and \`FORK\` is not supported.
+- Using more than one \`FORK\` command in a query is not supported.
+
+**Examples**
+
+In the following example, each \`FORK\` branch returns one row.
+Notice how \`FORK\` adds a \`_fork\` column that indicates which row the branch originates from:
+
+\`\`\` esql
+FROM employees
+| FORK ( WHERE emp_no == 10001 )
+       ( WHERE emp_no == 10002 )
+| KEEP emp_no, _fork
+| SORT emp_no
+\`\`\`
+
+| emp_no:integer | _fork:keyword |
+| --- | --- |
+| 10001 | fork1 |
+| 10002 | fork2 |
+
+The next example, returns total number of rows that match the query along with
+the top five rows sorted by score.
+
+\`\`\`esql
+FROM books METADATA _score
+| WHERE author:"Faulkner"
+| EVAL score = round(_score, 2)
+| FORK (SORT score DESC, author | LIMIT 5 | KEEP author, score)
+       (STATS total = COUNT(*))
+| SORT _fork, score DESC, author
+\`\`\`
+
+| author:text | score:double | _fork:keyword | total:long |
+| --- | --- | --- | --- |
+| William Faulkner | 2.39 | fork1 | null |
+| William Faulkner | 2.39 | fork1 | null |
+| Colleen Faulkner | 1.59 | fork1 | null |
+| Danny Faulkner | 1.59 | fork1 | null |
+| Keith Faulkner | 1.59 | fork1 | null |
+| null | null | fork2 | 18 |
+            `,
+            description:
+              'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+          })}
+        />
+      ),
+    },
+    {
       label: i18n.translate('languageDocumentation.documentationESQL.grok', {
         defaultMessage: 'GROK',
       }),

--- a/src/platform/packages/private/kbn-language-documentation/src/sections/generated/processing_commands.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/sections/generated/processing_commands.tsx
@@ -399,6 +399,7 @@ FROM books METADATA _score
             `,
             description:
               'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+            ignoreTag: true,
           })}
         />
       ),


### PR DESCRIPTION
This PR adds inline docs for the FORK command. It mimics the content currently at https://www.elastic.co/docs/reference/query-languages/esql/commands/fork

<img width="520" height="681" alt="image" src="https://github.com/user-attachments/assets/116e0485-3e8b-4f8b-9b1c-2a7e51dd4ac2" />
<img width="510" height="584" alt="image" src="https://github.com/user-attachments/assets/82f53c07-3607-4486-9e1c-3724e3ee9b35" />
<img width="501" height="583" alt="image" src="https://github.com/user-attachments/assets/82b01260-0c2d-4c97-b3a1-b688b52e166a" />

Closes: https://github.com/elastic/docs-content/issues/1826

More PRs are coming to include other missing commands

## Release notes

Adds in-product documentation for the ES|QL FORK comand.

