### PR TITLE
[Data quality] Fix overflowing text in issue flyout

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/expandable_truncated_text.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/expandable_truncated_text.tsx
@@ -39,7 +39,11 @@ export const ExpandableTruncatedText = ({
     >
       <EuiCode
         language={codeLanguage}
-        style={{ fontWeight: 'normal', color: euiTheme.colors.textParagraph, overflowWrap: 'break-word' }}
+        style={{
+          fontWeight: 'normal',
+          color: euiTheme.colors.textParagraph,
+          overflowWrap: 'break-word',
+        }}
       >
         {displayText}
       </EuiCode>

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/expandable_truncated_text.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/expandable_truncated_text.tsx
@@ -39,7 +39,7 @@ export const ExpandableTruncatedText = ({
     >
       <EuiCode
         language={codeLanguage}
-        style={{ fontWeight: 'normal', color: euiTheme.colors.textParagraph }}
+        style={{ fontWeight: 'normal', color: euiTheme.colors.textParagraph, overflowWrap: 'break-word' }}
       >
         {displayText}
       </EuiCode>


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/236227

## Summary

This PR fixes overflowing text in the quality issue flyout, which happened when the text contains a very long word, as words are not wrapped by default.

Before:
<img width="3438" height="1898" alt="image" src="https://github.com/user-attachments/assets/cc38b9e3-020c-4b40-9bc2-b6d8a4218850" />

Now:
<img width="1163" height="579" alt="Screenshot 2025-09-25 at 18 10 48" src="https://github.com/user-attachments/assets/97539ec0-6736-40b3-a911-fc530c3d5b3e" />
