### PR TITLE
[9.1] [Docs] Convert asciidoc lifecycle markers into new syntax (#236292)

### DIFF
--- a/docs/extend/ui-settings-service.md
+++ b/docs/extend/ui-settings-service.md
@@ -32,8 +32,11 @@ Configuration through the Advanced Settings UI is restricted to users authorised
 
 
 ## Configuration with UI settings overrides [uisettings-overrides]
+```{applies_to}
+stack: preview
+```
 
-[preview] When a setting is configured as an override in kibana.yml, it will override any other value stored in the config saved object. If an override is misconfigured, it will fail config validation and prevent Kibana from starting up. The override applies to Kibana as a whole for all spaces and users and the option will be disabled in the Advanced Settings page. We refer to these as "global" overrides.
+When a setting is configured as an override in kibana.yml, it will override any other value stored in the config saved object. If an override is misconfigured, it will fail config validation and prevent Kibana from starting up. The override applies to Kibana as a whole for all spaces and users and the option will be disabled in the Advanced Settings page. We refer to these as "global" overrides.
 
 Use the top-level `uiSettings` key for this, for example:
 

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -161,15 +161,11 @@ $$$shortdots-enable$$$`shortDots:enable`
 $$$sort-options$$$`sort:options`
 :   Options for the Elasticsearch [sort](elasticsearch://reference/elasticsearch/rest-apis/sort-search-results.md) parameter.
 
-$$$state-storeinsessionstorage$$$`state:storeInSessionStorage`
-:   [preview] Kibana tracks UI state in the URL, which can lead to problems when there is a lot of state information, and the URL gets very long. Enabling this setting stores part of the URL in your browser session to keep the URL short.
+$$$state-storeinsessionstorage$$$`state:storeInSessionStorage` {applies_to}`stack: preview`
+:   Kibana tracks UI state in the URL, which can lead to problems when there is a lot of state information, and the URL gets very long. Enabling this setting stores part of the URL in your browser session to keep the URL short.
 
-$$$theme-darkmode$$$`theme:darkMode`
-:   :::{admonition} Deprecated in 9.0.0
-    This setting was deprecated in 9.0.0.
-    :::
-
-    The UI theme that the {{kib}} UI should use. Set to `enabled` or `disabled` to enable or disable the dark theme. Set to `system` to have the {{kib}} UI theme follow the system theme. You must refresh the page to apply the setting.
+$$$theme-darkmode$$$`theme:darkMode` {applies_to}`stack: deprecated 9.0`
+:   The UI theme that the {{kib}} UI should use. Set to `enabled` or `disabled` to enable or disable the dark theme. Set to `system` to have the {{kib}} UI theme follow the system theme. You must refresh the page to apply the setting.
 
 $$$theme-version$$$`theme:version`
 :   Kibana only ships with the v8 theme now, so this setting can no longer be edited.
@@ -271,8 +267,8 @@ $$$discover-sample-size$$$`discover:sampleSize`
 $$$discover-searchonpageload$$$`discover:searchOnPageLoad`
 :   Controls whether a search is executed when **Discover** first loads. This setting does not have an effect when loading a saved Discover session.
 
-$$$discover:showFieldStatistics$$$`discover:showFieldStatistics`
-:   [beta] Enables the Field statistics view. Examine details such as the minimum and maximum values of a numeric field or a map of a geo field.
+$$$discover:showFieldStatistics$$$`discover:showFieldStatistics` {applies_to}`stack: beta`
+:   Enables the Field statistics view. Examine details such as the minimum and maximum values of a numeric field or a map of a geo field.
 
 $$$discover:showMultiFields$$$`discover:showMultiFields`
 :   Controls the display of multi-fields in the expanded document view.
@@ -358,8 +354,11 @@ $$$observability-apm-enable-profiling$$$`observability:apmEnableProfilingIntegra
 $$$observability-profiling-show-error-frames$$$`observability:profilingShowErrorFrames`
 :   Show error frames in the Universal Profiling views to indicate stack unwinding failures.
 
-$$$observability-apm-enable-table-search-bar$$$`observability:apmEnableTableSearchBar`
-:   [beta] Enables faster searching in APM tables by adding a handy search bar with live filtering. Available for the following tables: Services, Transactions, and Errors.
+$$$observability-apm-enable-table-search-bar$$$`observability:apmEnableTableSearchBar` {applies_to}`stack: preview`
+:   Enables faster searching in APM tables by adding a handy search bar with live filtering. Available for the following tables: Services, Transactions, and Errors.
+
+$$$observability-apm-enable-service-inventory-table-search-bar$$$`observability:apmEnableServiceInventoryTableSearchBar` {applies_to}`stack: preview`
+:   Enables faster searching in the APM Service inventory table by adding a handy search bar with live filtering.
 
 $$$observability-enable-aws-lambda-metrics$$$`observability:enableAwsLambdaMetrics` {applies_to}`stack: preview 9.0, removed 9.1`
 :   Display Amazon Lambda metrics in the service metrics tab.

--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -383,8 +383,8 @@ $$$csp-strict$$$ `csp.strict`
 `csp.warnLegacyBrowsers`
 :   Shows a warning message after loading Kibana to any browser that does not enforce even rudimentary CSP rules, though Kibana is still accessible. This configuration is effectively ignored when [`csp.strict`](#csp-strict) is enabled. **Default: `true`**
 
-`csp.disableUnsafeEval`
-:   [preview] Set this to `true` to remove the [`unsafe-eval`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_eval_expressions) source expression from the `script-src` directive. **Default: `false`**
+`csp.disableUnsafeEval` {applies_to}`stack: preview`
+:   Set this to `true` to remove the [`unsafe-eval`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_eval_expressions) source expression from the `script-src` directive. **Default: `false`**
 
     By enabling `csp.disableUnsafeEval`, Kibana will use a custom version of the Handlebars template library which doesn’t support [inline partials](https://handlebarsjs.com/guide/partials.md#inline-partials). Handlebars is used in various locations in the Kibana frontend where custom templates can be supplied by the user when for instance setting up a visualisation. If you experience any issues rendering Handlebars templates after turning on `csp.disableUnsafeEval`, or if you rely on inline partials, please revert this setting to `false` and [open an issue](https://github.com/elastic/kibana/issues/new/choose) in the Kibana GitHub repository.
 

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -318,8 +318,8 @@ $$$server-compression$$$ `server.compression.enabled`
 `server.cors.allowCredentials`
 :   Set to `true` to allow browser code to access response body whenever request performed with user credentials. **Default:** `false`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
 
-`server.cors.allowOrigin`
-:   experimental::[] List of origins permitted to access resources. You must specify explicit hostnames and not use `server.cors.allowOrigin: ["*"]` when `server.cors.allowCredentials: true`. **Default:** ["*"]
+`server.cors.allowOrigin` {applies_to}`stack: preview`
+:   List of origins permitted to access resources. You must specify explicit hostnames and not use `server.cors.allowOrigin: ["*"]` when `server.cors.allowCredentials: true`. **Default:** ["*"]
 
 `server.compression.referrerWhitelist`
 :   Specifies an array of trusted hostnames, such as the {{kib}} host, or a reverse proxy sitting in front of it. This determines whether HTTP compression may be used for responses, based on the request `Referer` header. This setting may not be used when [`server.compression.enabled`](#server-compression) is set to `false`. **Default: `none`**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Docs] Convert asciidoc lifecycle markers into new syntax (#236292)](https://github.com/elastic/kibana/pull/236292)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"florent-leborgne","email":"florent.leborgne@elastic.co"},"sourceCommit":{"committedDate":"2025-09-26T07:53:52Z","message":"[Docs] Convert asciidoc lifecycle markers into new syntax (#236292)\n\nPreview/Beta/Deprecated information is handled using a specific syntax\nin markdown docs. This PR removes some outdated (asciidoc) markers and\ninstead adds the expected syntax where appropriate.\n\nRel: https://github.com/elastic/docs-content/issues/2951","sha":"86e0a47b58420a2c2da3dc38e98fbbed46740a2d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","backport:version","v9.2.0","v9.0.8","v9.1.5"],"title":"[Docs] Convert asciidoc lifecycle markers into new syntax","number":236292,"url":"https://github.com/elastic/kibana/pull/236292","mergeCommit":{"message":"[Docs] Convert asciidoc lifecycle markers into new syntax (#236292)\n\nPreview/Beta/Deprecated information is handled using a specific syntax\nin markdown docs. This PR removes some outdated (asciidoc) markers and\ninstead adds the expected syntax where appropriate.\n\nRel: https://github.com/elastic/docs-content/issues/2951","sha":"86e0a47b58420a2c2da3dc38e98fbbed46740a2d"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236292","number":236292,"mergeCommit":{"message":"[Docs] Convert asciidoc lifecycle markers into new syntax (#236292)\n\nPreview/Beta/Deprecated information is handled using a specific syntax\nin markdown docs. This PR removes some outdated (asciidoc) markers and\ninstead adds the expected syntax where appropriate.\n\nRel: https://github.com/elastic/docs-content/issues/2951","sha":"86e0a47b58420a2c2da3dc38e98fbbed46740a2d"}},{"branch":"9.0","label":"v9.0.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->