### PR TITLE
[9.0] [Scout] Improve Cases API helper with type annotations and tests (#235237)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/cases/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/cases/index.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type {
+  ApiResponse,
+  ApiStatusResponse,
+  Attachment,
+  Case,
+  CaseUpdateRequest,
+  CaseCreateRequest,
+  CasesFindRequest,
+  CasesFindResponse,
+  AttachmentRequest,
+} from './types';
+
+import type { KbnClient, ScoutLogger } from '../../../../../../common';
+import { measurePerformanceAsync } from '../../../../../../common';
+
+export interface CasesApiService {
+  create: (params: CaseCreateRequest, spaceId?: string) => Promise<ApiResponse<Case>>;
+  get: (caseId: string, spaceId?: string) => Promise<ApiResponse<Case>>;
+  update: (params: CaseUpdateRequest[], spaceId?: string) => Promise<ApiResponse<Case[]>>;
+  delete: (caseIds: string[], spaceId?: string) => Promise<ApiStatusResponse>;
+  find: (params?: CasesFindRequest, spaceId?: string) => Promise<ApiResponse<Case[]>>;
+  connectors: {
+    get: (spaceId?: string) => Promise<ApiResponse<any>>;
+  };
+  comments: {
+    create: (
+      caseId: string,
+      params: AttachmentRequest,
+      spaceId?: string
+    ) => Promise<ApiResponse<Case>>;
+    get: (caseId: string, commentId: string, spaceId?: string) => Promise<ApiResponse<Attachment>>;
+  };
+  cleanup: {
+    deleteAllCases: (spaceId?: string) => Promise<ApiStatusResponse>;
+    deleteCasesByTags: (tags: string[], spaceId?: string) => Promise<ApiStatusResponse>;
+  };
+}
+
+export const getCasesApiHelper = (log: ScoutLogger, kbnClient: KbnClient): CasesApiService => {
+  const buildSpacePath = (spaceId?: string, path: string = '') => {
+    return spaceId && spaceId !== 'default' ? `/s/${spaceId}${path}` : path;
+  };
+
+  /**
+   * Helper to find case IDs matching the query parameters
+   * @param spaceId - Optional space ID
+   * @param query - Search parameters
+   * @returns Array of case IDs
+   * @note Limited to first page (100 cases max)
+   */
+  const findCaseIds = async (spaceId?: string, query?: Record<string, any>): Promise<string[]> => {
+    const response = await kbnClient.request({
+      method: 'GET',
+      path: `${buildSpacePath(spaceId)}/api/cases/_find`,
+      retries: 3,
+      query: { ...query, page: 1, perPage: 100 },
+    });
+    const casesData = response.data as CasesFindResponse;
+    const caseIds: string[] = casesData.cases.map((caseItem) => caseItem.id);
+    return caseIds;
+  };
+
+  return {
+    create: async (params, spaceId) => {
+      return await measurePerformanceAsync(
+        log,
+        `casesApi.cases.create [${params.title}]`,
+        async () => {
+          const response = await kbnClient.request({
+            method: 'POST',
+            path: `${buildSpacePath(spaceId)}/api/cases`,
+            retries: 3,
+            body: { ...params },
+          });
+          return { data: response.data as Case, status: response.status };
+        }
+      );
+    },
+    get: async (caseId, spaceId) => {
+      return await measurePerformanceAsync(log, `casesApi.cases.get [${caseId}]`, async () => {
+        const response = await kbnClient.request({
+          method: 'GET',
+          path: `${buildSpacePath(spaceId)}/api/cases/${caseId}`,
+          retries: 3,
+          ignoreErrors: [404],
+        });
+        return { data: response.data as Case, status: response.status };
+      });
+    },
+    update: async (params, spaceId) => {
+      return await measurePerformanceAsync(
+        log,
+        `casesApi.cases.update [${params.length} cases]`,
+        async () => {
+          const response = await kbnClient.request({
+            method: 'PATCH',
+            path: `${buildSpacePath(spaceId)}/api/cases`,
+            retries: 3,
+            body: {
+              cases: params.map((update) => {
+                // Validate required fields
+                if (!update.id) {
+                  throw new Error('Case ID is required for update');
+                }
+                if (!update.version) {
+                  throw new Error('Case version is required for update');
+                }
+
+                const caseUpdate: any = {
+                  id: update.id,
+                  version: update.version,
+                };
+
+                // Only include fields that are explicitly provided
+                if (update.title !== undefined) caseUpdate.title = update.title;
+                if (update.description !== undefined) caseUpdate.description = update.description;
+                if (update.status !== undefined) caseUpdate.status = update.status;
+                if (update.tags !== undefined) caseUpdate.tags = update.tags;
+                if (update.severity !== undefined) caseUpdate.severity = update.severity;
+                if (update.assignees !== undefined) caseUpdate.assignees = update.assignees;
+                if (update.connector !== undefined) caseUpdate.connector = update.connector;
+                if (update.settings !== undefined) caseUpdate.settings = update.settings;
+                if (update.category !== undefined) caseUpdate.category = update.category;
+
+                return caseUpdate;
+              }),
+            },
+          });
+          return { data: response.data as Case[], status: response.status };
+        }
+      );
+    },
+    delete: async (caseIds, spaceId) => {
+      return await measurePerformanceAsync(
+        log,
+        `casesApi.cases.delete [${caseIds.length} cases]`,
+        async () => {
+          if (caseIds.length === 0) return { status: 200 };
+          const response = await kbnClient.request({
+            method: 'DELETE',
+            path: `${buildSpacePath(spaceId)}/api/cases`,
+            retries: 0,
+            query: { ids: JSON.stringify(caseIds) },
+            ignoreErrors: [204, 404],
+          });
+          return { status: response.status };
+        }
+      );
+    },
+    find: async (params, spaceId) => {
+      return await measurePerformanceAsync(log, 'casesApi.cases.find', async () => {
+        // Note: By default, the Cases API will return the first page with default page size.
+        // If not explicitly set in the params, this will only fetch the first page (up to 100 cases).
+        const response = await kbnClient.request({
+          method: 'GET',
+          path: `${buildSpacePath(spaceId)}/api/cases/_find`,
+          retries: 3,
+          query: params,
+        });
+        const data = response.data as CasesFindResponse;
+
+        return { data: data.cases, status: response.status };
+      });
+    },
+    connectors: {
+      get: async (spaceId) => {
+        return await measurePerformanceAsync(log, 'casesApi.connectors.get', async () => {
+          const response = await kbnClient.request({
+            method: 'GET',
+            path: `${buildSpacePath(spaceId)}/api/cases/configure/connectors/_find`,
+            retries: 3,
+          });
+          return { data: response.data, status: response.status };
+        });
+      },
+    },
+    comments: {
+      create: async (caseId, params, spaceId) => {
+        return await measurePerformanceAsync(
+          log,
+          `casesApi.comments.create [${caseId}]`,
+          async () => {
+            const response = await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/api/cases/${caseId}/comments`,
+              retries: 3,
+              body: params,
+            });
+            return { data: response.data as Case, status: response.status };
+          }
+        );
+      },
+      get: async (caseId, commentId, spaceId) => {
+        return await measurePerformanceAsync(
+          log,
+          `casesApi.comments.get [${caseId}, ${commentId}]`,
+          async () => {
+            const response = await kbnClient.request({
+              method: 'GET',
+              path: `${buildSpacePath(spaceId)}/api/cases/${caseId}/comments/${commentId}`,
+              retries: 3,
+              ignoreErrors: [404],
+            });
+            return { data: response.data as Attachment, status: response.status };
+          }
+        );
+      },
+    },
+    cleanup: {
+      deleteAllCases: async (spaceId) => {
+        return await measurePerformanceAsync(log, 'casesApi.cleanup.deleteAllCases', async () => {
+          const caseIds = await findCaseIds(spaceId);
+          if (caseIds.length === 0) return { status: 200 };
+          const response = await kbnClient.request({
+            method: 'DELETE',
+            path: `${buildSpacePath(spaceId)}/api/cases`,
+            retries: 3,
+            query: { ids: JSON.stringify(caseIds) },
+            ignoreErrors: [404],
+          });
+          return { status: response.status };
+        });
+      },
+      deleteCasesByTags: async (tags, spaceId) => {
+        return await measurePerformanceAsync(
+          log,
+          `casesApi.cleanup.deleteCasesByTags [${tags.join(',')}]`,
+          async () => {
+            const caseIds = await findCaseIds(spaceId, { tags: tags.join(',') });
+            if (caseIds.length === 0) return { status: 200 };
+            const response = await kbnClient.request({
+              method: 'DELETE',
+              path: `${buildSpacePath(spaceId)}/api/cases`,
+              retries: 3,
+              query: { ids: JSON.stringify(caseIds) },
+              ignoreErrors: [404],
+            });
+            return { status: response.status };
+          }
+        );
+      },
+    },
+  };
+};

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/cases/types.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/cases/types.ts
@@ -1,0 +1,323 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export interface ApiResponse<T> {
+  data: T;
+  status: number;
+}
+
+export interface ApiStatusResponse {
+  status: number;
+}
+
+export type CaseSeverity = 'low' | 'medium' | 'high' | 'critical';
+
+export type CaseStatus = 'open' | 'closed' | 'in-progress';
+
+export interface CaseConnector {
+  id: string;
+  name: string;
+  type: string;
+  fields: null | Record<string, any>;
+}
+
+export interface CaseSettings {
+  syncAlerts: boolean;
+}
+
+export interface CaseUserProfile {
+  uid: string;
+  username?: string;
+  fullName?: string | null;
+  email?: string | null;
+}
+
+export interface CaseCreateRequest {
+  description: string;
+  tags: string[];
+  title: string;
+  connector: CaseConnector;
+  settings: CaseSettings;
+  owner: string;
+  assignees?: CaseUserProfile[];
+  severity?: CaseSeverity;
+  category?: string | null;
+  customFields?: Array<{
+    key: string;
+    type: string;
+    value: any | null;
+  }>;
+}
+
+export interface CaseUpdateRequest {
+  id: string;
+  version: string;
+  description?: string;
+  tags?: string[];
+  title?: string;
+  connector?: CaseConnector;
+  severity?: CaseSeverity;
+  assignees?: CaseUserProfile[];
+  category?: string | null;
+  customFields?: Array<{
+    key: string;
+    type: string;
+    value: any | null;
+  }>;
+  settings?: CaseSettings;
+  status?: CaseStatus;
+  owner?: string;
+}
+
+export interface CasesFindRequest {
+  [key: string]: any;
+}
+
+export interface CasesFindResponse {
+  cases: Case[];
+  page: number;
+  per_page: number;
+  total: number;
+  count_open_cases: number;
+  count_in_progress_cases: number;
+  count_closed_cases: number;
+}
+
+export interface CasesFindRequest {
+  // Filter parameters
+  tags?: string | string[];
+  status?: CaseStatus | CaseStatus[];
+  severity?: CaseSeverity | CaseSeverity[];
+  assignees?: string | string[];
+  reporters?: string | string[];
+  owner?: string | string[];
+  category?: string | string[];
+
+  // Search parameters
+  defaultSearchOperator?: 'AND' | 'OR';
+  search?: string;
+  searchFields?: Array<'description' | 'title'> | 'description' | 'title';
+
+  // Sort parameters
+  sortField?: 'title' | 'category' | 'createdAt' | 'updatedAt' | 'closedAt' | 'status' | 'severity';
+  sortOrder?: 'desc' | 'asc';
+
+  // Date filters
+  from?: string;
+  to?: string;
+
+  // Pagination parameters (defaults: page=1, perPage=20, max perPage=100)
+  page?: number;
+  perPage?: number;
+}
+
+export type AttachmentType =
+  | 'user'
+  | 'alert'
+  | 'actions'
+  | 'externalReference'
+  | 'persistableState'
+  | 'event';
+
+export type AttachmentRequest =
+  | UserCommentAttachmentRequest
+  | AlertAttachmentRequest
+  | ActionsAttachmentRequest
+  | ExternalReferenceAttachmentRequest
+  | PersistableStateAttachmentRequest
+  | EventAttachmentRequest;
+
+export interface UserCommentAttachmentRequest {
+  comment: string;
+  type: 'user';
+  owner: string;
+}
+
+export interface AlertAttachmentRequest {
+  type: 'alert';
+  alertId: string | string[];
+  index: string | string[];
+  rule?: {
+    id: string | null;
+    name: string | null;
+  };
+  owner: string;
+}
+
+export interface ActionsAttachmentRequest {
+  type: 'actions';
+  comment: string;
+  actions: {
+    targets: Array<{
+      hostname: string;
+      endpointId: string;
+    }>;
+    type: string;
+  };
+  owner: string;
+}
+
+export interface ExternalReferenceAttachmentRequest {
+  type: 'externalReference';
+  externalReferenceId: string;
+  externalReferenceStorage?: {
+    type: 'savedObject' | 'elasticSearchDoc';
+    soType?: string;
+  };
+  externalReferenceAttachmentTypeId?: string;
+  externalReferenceMetadata?: Record<string, any> | null;
+  owner: string;
+}
+
+export interface PersistableStateAttachmentRequest {
+  type: 'persistableState';
+  persistableStateAttachmentTypeId: string;
+  persistableStateAttachmentState: Record<string, any>;
+  owner: string;
+}
+
+export interface EventAttachmentRequest {
+  type: 'event';
+  event: {
+    id: string;
+    relatedItems: Array<{
+      id: string;
+      type: string;
+      title?: string;
+      index?: string;
+    }>;
+  };
+  owner: string;
+}
+
+export interface Attachment {
+  // Common properties for all attachment types
+  id: string;
+  version: string;
+
+  // Common metadata fields
+  created_at: string;
+  created_by: {
+    username: string;
+    fullName: string | null;
+    email: string | null;
+  };
+  owner: string;
+  pushed_at: string | null;
+  pushed_by: {
+    username: string;
+    fullName: string | null;
+    email: string | null;
+  } | null;
+  updated_at: string | null;
+  updated_by: {
+    username: string;
+    fullName: string | null;
+    email: string | null;
+  } | null;
+
+  // Type-specific properties (one of these sets will be present)
+  type: AttachmentType;
+
+  // User comment attachment
+  comment?: string;
+
+  // Alert attachment
+  alertId?: string | string[];
+  index?: string | string[];
+  rule?: {
+    id: string | null;
+    name: string | null;
+  };
+
+  // Actions attachment
+  actions?: {
+    targets: Array<{
+      hostname: string;
+      endpointId: string;
+    }>;
+    type: string;
+  };
+
+  // External reference attachment
+  externalReferenceId?: string;
+  externalReferenceStorage?: {
+    type: 'savedObject' | 'elasticSearchDoc';
+    soType?: string; // Present for savedObject type
+  };
+  externalReferenceAttachmentTypeId?: string;
+  externalReferenceMetadata?: Record<string, any> | null;
+
+  // Persistable state attachment
+  persistableStateAttachmentTypeId?: string;
+  persistableStateAttachmentState?: Record<string, any>;
+}
+
+export interface Case {
+  id: string;
+  version: string;
+  title: string;
+  description: string;
+  tags: string[];
+  status: CaseStatus;
+  owner: string;
+  connector: {
+    id: string;
+    name: string;
+    type: string;
+    fields: null | Record<string, any>;
+  };
+  severity: CaseSeverity;
+  assignees: Array<{
+    uid: string;
+    username?: string;
+    fullName?: string | null;
+    email?: string | null;
+  }>;
+  category: string | null;
+  customFields: Array<{
+    key: string;
+    type: string;
+    value: any | null;
+  }>;
+  settings: {
+    syncAlerts: boolean;
+  };
+  observables: any[];
+  duration: number | null;
+  closed_at: string | null;
+  closed_by: {
+    username: string;
+    fullName: string | null;
+    email: string | null;
+  } | null;
+  created_at: string;
+  created_by: {
+    username: string;
+    fullName: string | null;
+    email: string | null;
+  };
+  external_service: any | null;
+  updated_at: string | null;
+  updated_by: {
+    username: string;
+    fullName: string | null;
+    email: string | null;
+  } | null;
+
+  incremental_id?: number | null;
+  in_progress_at?: string | null;
+  time_to_acknowledge?: number | null;
+  time_to_investigate?: number | null;
+  time_to_resolve?: number | null;
+
+  totalComment: number;
+  totalAlerts: number;
+  comments?: Array<any>;
+}

--- a/src/platform/packages/shared/kbn-scout/test/scout/fixtures/constants.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/fixtures/constants.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CaseCreateRequest } from '../../../src/playwright/fixtures/scope/worker/apis/cases/types';
+
+export const createAlertRuleParams = {
+  aggType: 'count',
+  termSize: 5,
+  thresholdComparator: '>',
+  timeWindowSize: 5,
+  timeWindowUnit: 'm',
+  groupBy: 'all',
+  threshold: [10],
+  index: ['.kibana-event-log-*'],
+  timeField: '@timestamp',
+};
+
+export const createCasePayload: CaseCreateRequest = {
+  title: 'test',
+  tags: ['scout'],
+  category: null,
+  severity: 'low',
+  description: 'integration test',
+  connector: {
+    id: 'none',
+    name: 'none',
+    type: '.none',
+    fields: null,
+  },
+  settings: {
+    syncAlerts: true,
+  },
+  owner: '',
+  customFields: [],
+};

--- a/src/platform/packages/shared/kbn-scout/test/scout/tests/api_services/cases.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/tests/api_services/cases.spec.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { apiTest, expect } from '../../../../src/playwright';
+import { createCasePayload } from '../../fixtures/constants';
+
+apiTest.describe('Cases Helpers', { tag: ['@svlSecurity', '@ess'] }, () => {
+  let caseId: string;
+  let caseOwner: 'cases' | 'observability' | 'securitySolution';
+
+  apiTest.beforeEach(async ({ apiServices, config }) => {
+    caseOwner =
+      config.serverless && config.projectType === 'security' ? 'securitySolution' : 'cases';
+    const { data, status } = await apiServices.cases.create({
+      ...createCasePayload,
+      owner: caseOwner,
+      category: 'test',
+    });
+    expect(status).toBe(200);
+    expect(data.owner).toBe(caseOwner);
+    expect(data.status).toBe('open');
+    caseId = data.id;
+  });
+
+  apiTest.afterEach(async ({ apiServices }) => {
+    await apiServices.cases.cleanup.deleteAllCases();
+    const fetchedResponse = await apiServices.cases.get(caseId);
+    expect(fetchedResponse.status).toBe(404);
+    caseId = '';
+  });
+
+  apiTest(`should fetch case with 'cases.get'`, async ({ apiServices }) => {
+    const fetchedResponse = await apiServices.cases.get(caseId);
+    expect(fetchedResponse.status).toBe(200);
+  });
+
+  apiTest(`should update case with a new severity with 'cases.update'`, async ({ apiServices }) => {
+    // First get the case to obtain its current version
+    const currentCase = await apiServices.cases.get(caseId);
+
+    const { data: cases, status } = await apiServices.cases.update([
+      {
+        id: caseId,
+        version: currentCase.data.version,
+        severity: 'medium',
+      },
+    ]);
+    expect(status).toBe(200);
+    expect(cases.length).toBe(1);
+    expect(cases[0].severity).toBe('medium');
+  });
+
+  apiTest('should add a new connector to a case', async ({ apiServices }) => {
+    const currentCase = await apiServices.cases.get(caseId);
+    const { status } = await apiServices.cases.update([
+      {
+        id: caseId,
+        version: currentCase.data.version,
+        connector: {
+          id: 'jira',
+          name: 'Jira',
+          type: '.jira',
+          fields: { issueType: 'Task', priority: null, parent: null },
+        },
+      },
+    ]);
+
+    expect(status).toBe(200);
+  });
+
+  apiTest('should delete multiple cases', async ({ apiServices }) => {
+    const createdResponse1 = await apiServices.cases.create({
+      ...createCasePayload,
+      owner: caseOwner,
+    });
+    const createdResponse2 = await apiServices.cases.create({
+      ...createCasePayload,
+      owner: caseOwner,
+    });
+    expect(createdResponse1.status).toBe(200);
+    expect(createdResponse2.status).toBe(200);
+
+    await apiServices.cases.cleanup.deleteAllCases();
+
+    const fetchedResponse1 = await apiServices.cases.get(createdResponse1.data.id);
+    const fetchedResponse2 = await apiServices.cases.get(createdResponse2.data.id);
+    expect(fetchedResponse1.status).toBe(404);
+    expect(fetchedResponse2.status).toBe(404);
+  });
+
+  apiTest('should delete cases by tags', async ({ apiServices }) => {
+    const createdResponse1 = await apiServices.cases.create({
+      ...createCasePayload,
+      owner: caseOwner,
+      tags: ['tag1'],
+    });
+    const createdResponse2 = await apiServices.cases.create({
+      ...createCasePayload,
+      owner: caseOwner,
+      tags: ['tag2'],
+    });
+    expect(createdResponse1.status).toBe(200);
+    expect(createdResponse2.status).toBe(200);
+
+    // delete all cases with tag "tag1"
+    await apiServices.cases.cleanup.deleteCasesByTags(['tag1']);
+
+    const fetchedResponse1 = await apiServices.cases.get(createdResponse1.data.id);
+    const fetchedResponse2 = await apiServices.cases.get(createdResponse2.data.id);
+
+    // this case should have been deleted because it was assigned "tag1"
+    expect(fetchedResponse1.status).toBe(404);
+
+    // this case shouldn't have been deleted because it was assigned "tag2"
+    expect(fetchedResponse2.status).toBe(200);
+  });
+
+  apiTest('should post and find a comment', async ({ apiServices }) => {
+    const { data: updatedCase, status } = await apiServices.cases.comments.create(caseId, {
+      type: 'user',
+      comment: 'This is a test comment',
+      owner: caseOwner,
+    });
+
+    expect(status).toBe(200);
+    expect(updatedCase.totalComment).toBe(1);
+    expect(updatedCase.comments).toHaveLength(1);
+
+    // find comment by ID
+    const commentId = updatedCase.comments?.[0]?.id;
+    if (!commentId) throw new Error('Comment not found');
+
+    const { data: fetchedComment, status: fetchCommentStatus } =
+      await apiServices.cases.comments.get(caseId, commentId);
+
+    expect(fetchCommentStatus).toBe(200);
+    expect(fetchedComment.comment).toBe('This is a test comment');
+  });
+
+  apiTest('should post an alert', async ({ apiServices }) => {
+    const createdAlert = await apiServices.cases.comments.create(caseId, {
+      type: 'alert',
+      owner: caseOwner,
+      alertId: 'test-alert-id',
+      index: 'test-index',
+      rule: { id: 'test-rule-id', name: 'test-rule-name' },
+    });
+
+    expect(createdAlert.status).toBe(200);
+    expect(createdAlert.data.totalAlerts).toBe(1);
+  });
+
+  apiTest('should search for a case by category', async ({ apiServices }) => {
+    const { data: cases, status } = await apiServices.cases.find({ category: 'test' });
+    expect(status).toBe(200);
+    expect(cases.length).toBe(1);
+  });
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Scout] Improve Cases API helper with type annotations and tests (#235237)](https://github.com/elastic/kibana/pull/235237)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cesare de Cal","email":"cesare.decal@elastic.co"},"sourceCommit":{"committedDate":"2025-09-24T16:10:26Z","message":"[Scout] Improve Cases API helper with type annotations and tests (#235237)\n\nThis PR enhances the Scout [Cases\nAPI](https://www.elastic.co/docs/api/doc/kibana/v9/group/endpoint-cases)\nhelper by adding type annotations from the Case plugin and increasing\nthe test coverage (posting comments, alerts, etc.). The helper also now\ncorrectly handles paginated API responses.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8a24f3915333f66e8338f400af7e3f315c5ad62e","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","test:scout","v9.2.0"],"title":"[Scout] Improve Cases API helper with type annotations and tests","number":235237,"url":"https://github.com/elastic/kibana/pull/235237","mergeCommit":{"message":"[Scout] Improve Cases API helper with type annotations and tests (#235237)\n\nThis PR enhances the Scout [Cases\nAPI](https://www.elastic.co/docs/api/doc/kibana/v9/group/endpoint-cases)\nhelper by adding type annotations from the Case plugin and increasing\nthe test coverage (posting comments, alerts, etc.). The helper also now\ncorrectly handles paginated API responses.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8a24f3915333f66e8338f400af7e3f315c5ad62e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/235237","number":235237,"mergeCommit":{"message":"[Scout] Improve Cases API helper with type annotations and tests (#235237)\n\nThis PR enhances the Scout [Cases\nAPI](https://www.elastic.co/docs/api/doc/kibana/v9/group/endpoint-cases)\nhelper by adding type annotations from the Case plugin and increasing\nthe test coverage (posting comments, alerts, etc.). The helper also now\ncorrectly handles paginated API responses.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8a24f3915333f66e8338f400af7e3f315c5ad62e"}}]}] BACKPORT-->