### PR TITLE
[Contextual Security] Fix for Huge space between last string and show more button in Vulnerability Flyout

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_description_section.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_description_section.tsx
@@ -72,17 +72,18 @@ export const VulnerabilityDescriptionSection: React.FC<ClampedMarkdownProps> = (
   };
 
   return (
-    <div ref={containerRef} style={{ position: 'relative' }}>
+    <div ref={containerRef}>
       <div ref={contentRef} style={isExpanded ? expandedStyle : clampedStyle}>
         <CspFlyoutMarkdown>{content}</CspFlyoutMarkdown>
-        {isExpanded && isOverflowing && (
+      </div>
+      {isExpanded && isOverflowing && (
+        <div style={{ marginTop: euiTheme.size.xs }}>
           <EuiButtonEmpty
             color="primary"
             flush="left"
             onClick={() => setIsExpanded(false)}
+            aria-label="Show less description"
             style={{
-              display: 'inline-block',
-              verticalAlign: 'baseline',
               height: 'auto',
               minHeight: 'auto',
               fontSize: 'inherit',
@@ -93,22 +94,15 @@ export const VulnerabilityDescriptionSection: React.FC<ClampedMarkdownProps> = (
               defaultMessage="Show less"
             />
           </EuiButtonEmpty>
-        )}
-      </div>
+        </div>
+      )}
       {isOverflowing && !isExpanded && (
-        <div
-          style={{
-            position: 'absolute',
-            bottom: '0',
-            right: '0',
-            backgroundColor: euiTheme.colors.emptyShade,
-            paddingLeft: '4px',
-          }}
-        >
+        <div style={{ marginTop: euiTheme.size.xs }}>
           <EuiButtonEmpty
             color="primary"
             onClick={() => setIsExpanded(true)}
             flush="left"
+            aria-label="Show more description"
             style={{
               height: 'auto',
               minHeight: 'auto',
@@ -117,7 +111,7 @@ export const VulnerabilityDescriptionSection: React.FC<ClampedMarkdownProps> = (
           >
             <FormattedMessage
               id="xpack.csp.vulnerabilities.vulnerabilityDescriptionSection.showMore"
-              defaultMessage="...Show more"
+              defaultMessage="Show more"
             />
           </EuiButtonEmpty>
         </div>


### PR DESCRIPTION
## Summary

This PR moves the Show more button to be under instead of inline


https://github.com/user-attachments/assets/5ab598b4-3035-4c1a-b2ee-365fd35b9ca9






