### PR TITLE
[Background search] Integrate backgroundTask icon

### DIFF
--- a/src/platform/packages/private/kbn-split-button/src/split_button.tsx
+++ b/src/platform/packages/private/kbn-split-button/src/split_button.tsx
@@ -8,7 +8,7 @@
  */
 
 import { EuiButton, EuiButtonIcon, useEuiTheme } from '@elastic/eui';
-import type { UseEuiTheme } from '@elastic/eui';
+import type { IconType, UseEuiTheme } from '@elastic/eui';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import React from 'react';
 
@@ -19,7 +19,7 @@ type SplitButtonProps = React.ComponentProps<typeof EuiButton> & {
 
   isSecondaryButtonLoading?: boolean;
   isSecondaryButtonDisabled?: boolean;
-  secondaryButtonIcon: string;
+  secondaryButtonIcon: IconType;
   secondaryButtonAriaLabel?: string;
   secondaryButtonTitle?: string;
   onSecondaryButtonClick?: React.MouseEventHandler<HTMLButtonElement>;

--- a/src/platform/packages/shared/kbn-background-search/index.ts
+++ b/src/platform/packages/shared/kbn-background-search/index.ts
@@ -8,3 +8,4 @@
  */
 
 export { BackgroundSearchRestoredCallout } from './src/components';
+export { EuiIconBackgroundTask } from './src/components';

--- a/src/platform/packages/shared/kbn-background-search/src/components/eui_icon_background_task.tsx
+++ b/src/platform/packages/shared/kbn-background-search/src/components/eui_icon_background_task.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as React from 'react';
+import type { SVGProps } from 'react';
+
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+
+// https://raw.githubusercontent.com/elastic/eui/refs/heads/main/packages/eui/src/components/icon/assets/background_task.tsx
+
+// TODO: Remove when the backgroundTask icon is available in EUI
+const EuiIconBackgroundTask = ({
+  title,
+  titleId,
+  ...props
+}: SVGProps<SVGSVGElement> & SVGRProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={16}
+    height={16}
+    viewBox="0 0 16 16"
+    aria-labelledby={titleId}
+    {...props}
+  >
+    {title ? <title id={titleId}>{title}</title> : null}
+    <path d="M11.157 9.013a1.004 1.004 0 0 1 .373.14l4 2.5a1 1 0 0 1 0 1.695l-4 2.5A1 1 0 0 1 10 15v-5l.009-.135a1 1 0 0 1 .407-.677l.1-.063a1 1 0 0 1 .641-.112ZM11 15l4-2.5-1.122-.702-.849-.53L11 10v5ZM6.45 13.794a5.99 5.99 0 0 0 1.55.205v1a6.993 6.993 0 0 1-1.81-.24l.26-.965Zm-2.692-1.552c.373.373.792.692 1.243.952l-.5.866a6.99 6.99 0 0 1-1.45-1.11l.707-.708ZM2.205 9.55a6.06 6.06 0 0 0 .6 1.449l-.433.249-.433.25a7.07 7.07 0 0 1-.7-1.688l.483-.13.483-.13ZM8.001.999a7 7 0 0 1 7 7c0 .683-.1 1.342-.284 1.966l-.887-.555a5.97 5.97 0 0 0 .171-1.411 6 6 0 0 0-6-6v-1ZM2.805 4.997A6.013 6.013 0 0 0 2 7.998L1.001 8a7.022 7.022 0 0 1 .937-3.502l.867.5ZM6.45 2.201a6.036 6.036 0 0 0-2.692 1.554L3.405 3.4l-.353-.353a7.036 7.036 0 0 1 3.137-1.812l.26.966Z" />
+  </svg>
+);
+
+export { EuiIconBackgroundTask };

--- a/src/platform/packages/shared/kbn-background-search/src/components/index.ts
+++ b/src/platform/packages/shared/kbn-background-search/src/components/index.ts
@@ -8,3 +8,4 @@
  */
 
 export { BackgroundSearchRestoredCallout } from './background_search_restored_callout';
+export { EuiIconBackgroundTask } from './eui_icon_background_task';

--- a/src/platform/packages/shared/kbn-discover-utils/src/components/app_menu/types.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/components/app_menu/types.ts
@@ -8,7 +8,7 @@
  */
 
 import type React from 'react';
-import type { EuiIconType } from '@elastic/eui/src/components/icon/icon';
+import type { IconType } from '@elastic/eui';
 
 export interface AppMenuControlOnClickParams {
   anchorElement: HTMLElement;
@@ -33,11 +33,11 @@ export type AppMenuControlProps = TopNavMenuData & {
 };
 
 export type AppMenuControlWithIconProps = AppMenuControlProps & {
-  iconType: EuiIconType;
+  iconType: IconType;
 };
 
 interface ControlWithOptionalIcon {
-  iconType?: EuiIconType;
+  iconType?: IconType;
 }
 
 export enum AppMenuActionId {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -15,6 +15,7 @@ import type { TopNavMenuData } from '@kbn/navigation-plugin/public';
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
 
 import useObservable from 'react-use/lib/useObservable';
+import { EuiIconBackgroundTask } from '@kbn/background-search';
 import { UI_SETTINGS } from '../../../common/constants';
 import { useDashboardApi } from '../../dashboard_api/use_dashboard_api';
 import { confirmDiscardUnsavedChanges } from '../../dashboard_listing/confirm_overlays';
@@ -194,7 +195,8 @@ export const useDashboardMenuItems = ({
       backgroundSearch: {
         ...topNavStrings.backgroundSearch,
         id: 'backgroundSearch',
-        iconType: 'clock',
+        // TODO: Replace when the backgroundTask icon is available in EUI
+        iconType: EuiIconBackgroundTask,
         iconOnly: true,
         testId: 'backgroundSearchButton',
         run: () =>

--- a/src/platform/plugins/shared/dashboard/tsconfig.json
+++ b/src/platform/plugins/shared/dashboard/tsconfig.json
@@ -90,7 +90,8 @@
     "@kbn/data-service-server",
     "@kbn/controls-schemas",
     "@kbn/controls-constants",
-    "@kbn/presentation-util"
+    "@kbn/presentation-util",
+    "@kbn/background-search"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_background_search_flyout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_background_search_flyout.tsx
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { EuiIconBackgroundTask } from '@kbn/background-search';
 import { AppMenuActionId, AppMenuActionType, type AppMenuItemPrimary } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
 
@@ -22,7 +23,8 @@ export const getBackgroundSearchFlyout = ({
       label: i18n.translate('discover.localMenu.localMenu.openBackgroundSearchFlyoutTitle', {
         defaultMessage: 'Background searches',
       }),
-      iconType: 'clock',
+      // TODO: Replace when the backgroundTask icon is available in EUI
+      iconType: EuiIconBackgroundTask,
       testId: 'openBackgroundSearchFlyoutButton',
       onClick,
     },

--- a/src/platform/plugins/shared/discover/tsconfig.json
+++ b/src/platform/plugins/shared/discover/tsconfig.json
@@ -119,6 +119,7 @@
     "@kbn/timerange",
     "@kbn/metrics-experience-plugin",
     "@kbn/unified-metrics-grid",
+    "@kbn/background-search",
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/navigation/public/top_nav_menu/top_nav_menu_data.tsx
+++ b/src/platform/plugins/shared/navigation/public/top_nav_menu/top_nav_menu_data.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { EuiButtonProps, EuiBetaBadgeProps } from '@elastic/eui';
+import type { EuiButtonProps, EuiBetaBadgeProps, IconType } from '@elastic/eui';
 import type { InjectedIntl } from '@kbn/i18n-react';
 
 export type TopNavMenuAction = (anchorElement: HTMLElement) => void;
@@ -27,7 +27,7 @@ export interface TopNavMenuData {
   fill?: boolean;
   color?: string;
   isLoading?: boolean;
-  iconType?: string;
+  iconType?: IconType;
   iconSide?: EuiButtonProps['iconSide'];
   iconOnly?: boolean;
   target?: string;

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -46,6 +46,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import { UI_SETTINGS } from '@kbn/data-plugin/common';
 import { SplitButton } from '@kbn/split-button';
+import { EuiIconBackgroundTask } from '@kbn/background-search';
 import type { IUnifiedSearchPluginServices, UnifiedSearchDraft } from '../types';
 import { QueryStringInput } from './query_string_input';
 import { NoDataPopover } from './no_data_popover';
@@ -630,7 +631,8 @@ export const QueryBarTopRow = React.memo(
             onClick={onClickCancelButton}
             onSecondaryButtonClick={onClickSendToBackground}
             secondaryButtonAriaLabel={strings.getSendToBackgroundLabel()}
-            secondaryButtonIcon="clock"
+            // TODO: Replace when the backgroundTask icon is available in EUI
+            secondaryButtonIcon={EuiIconBackgroundTask}
             secondaryButtonTitle={strings.getSendToBackgroundLabel()}
             size="s"
           >
@@ -693,7 +695,8 @@ export const QueryBarTopRow = React.memo(
           onClick={onClickSubmitButton}
           onSecondaryButtonClick={onClickSendToBackground}
           secondaryButtonAriaLabel={strings.getSendToBackgroundLabel()}
-          secondaryButtonIcon="clock"
+          // TODO: Replace when the backgroundTask icon is available in EUI
+          secondaryButtonIcon={EuiIconBackgroundTask}
           secondaryButtonTitle={strings.getSendToBackgroundLabel()}
           size="s"
         >


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/236538

EUI can't deliver a new version with the icon for now so we are adding it to kibana directly and using this version of the icon. Once the icon is delivered from EUI we should update all the usages with it, they should be pretty easy to find since they are all labelled with TODO.

| Scenario | Before | After |
|----------|--------|------|
| Discover | <img width="2560" height="1197" alt="image" src="https://github.com/user-attachments/assets/b765842f-8b4c-407a-967b-572899322039" /> | <img width="2560" height="1199" alt="image" src="https://github.com/user-attachments/assets/52500d29-d083-4d7f-a71f-633f9407b7b6" /> |
| Dashboards (View) | <img width="2560" height="1200" alt="image" src="https://github.com/user-attachments/assets/f0e62c68-5550-49d2-a4e0-83384cf6a55e" /> | <img width="2560" height="1201" alt="image" src="https://github.com/user-attachments/assets/25e92612-6d92-418c-ac28-60931beb3afb" /> |
| Dashboards (Edit) | <img width="2558" height="1198" alt="image" src="https://github.com/user-attachments/assets/58a6840b-ac92-405b-adbd-854395adef56" /> | <img width="2557" height="1202" alt="image" src="https://github.com/user-attachments/assets/0c97bc03-8e8f-41ac-b70e-1a101012ec0b" /> |


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


