### PR TITLE
[Streams] Fix flaky Scout test

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/error_handling.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/error_handling.spec.ts
@@ -9,8 +9,7 @@ import { expect } from '@kbn/scout';
 import { test } from '../../../fixtures';
 import { generateLogsData } from '../../../fixtures/generators';
 
-// Failing: See https://github.com/elastic/kibana/issues/236525
-test.describe.skip(
+test.describe(
   'Stream data processing - error handling and recovery',
   { tag: ['@ess', '@svlOblt'] },
   () => {
@@ -48,7 +47,6 @@ test.describe.skip(
       });
 
       await pageObjects.streams.saveStepsListChanges();
-      await pageObjects.streams.confirmChangesInReviewModal();
 
       // Should show error and stay in creating state
       await pageObjects.streams.expectToastVisible();
@@ -75,7 +73,6 @@ test.describe.skip(
       await pageObjects.streams.fillGrokPatternInput('%{WORD:attributes.method}');
       await pageObjects.streams.clickSaveProcessor();
       await pageObjects.streams.saveStepsListChanges();
-      await pageObjects.streams.confirmChangesInReviewModal();
       await pageObjects.streams.closeToasts();
 
       // Edit the processor


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/236525

## What happened?

This was purely a case of unfortunate merge timing. 

This PR slightly changed the review modal behaviour: https://github.com/elastic/kibana/pull/235810/files

This PR https://github.com/elastic/kibana/issues/235508 was based off the old behaviour where the review modal would show with "unmanaged" changes.

But, there weren't any explicit merge conflicts, just test divergence. And the latter PR merged whilst still being deemed fresh enough, but minus the changes of the former.



