### PR TITLE
Allow xpack.spaces.defaultSolution to be configured via docker

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -420,6 +420,7 @@ kibana_vars=(
     xpack.securitySolution.packagerTaskInterval
     xpack.securitySolution.prebuiltRulesPackageVersion
     xpack.spaces.maxSpaces
+    xpack.spaces.defaultSolution
     xpack.task_manager.capacity
     xpack.task_manager.claim_strategy
     xpack.task_manager.auto_calculate_default_ech_capacity


### PR DESCRIPTION
## Summary

Adds `xpack.spaces.defaultSolution` to the allow-list of settings that are configurable via environment variables for docker-based deployments.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.1","9.3"]} ONMERGE-->