### PR TITLE
[Security Solution] Remove `null` in confirmation dialog when bulk editing index patterns for rules.

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/translations.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/translations.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BulkActionEditTypeEnum } from '../../../../../common/api/detection_engine/rule_management';
+import * as i18n from '../../../common/translations';
+import { explainBulkEditSuccess } from './translations';
+import type { BulkActionSummary } from '../../api/api';
+
+describe('explainBulkEditSuccess', () => {
+  const baseSummary: BulkActionSummary = {
+    total: 10,
+    succeeded: 8,
+    skipped: 2,
+    failed: 0,
+  };
+
+  it('includes data view skip detail when skipped count > 0 and editPayload contains add_index_patterns action', () => {
+    const editPayload = [
+      { type: BulkActionEditTypeEnum.add_index_patterns, value: ['add-pattern-*'] },
+    ];
+
+    const result = explainBulkEditSuccess(editPayload, baseSummary);
+
+    expect(result).toContain(i18n.RULES_BULK_EDIT_SUCCESS_DATA_VIEW_RULES_SKIPPED_DETAIL);
+    expect(result).toBe(
+      `${i18n.RULES_BULK_EDIT_SUCCESS_DESCRIPTION(8, 2)} ${
+        i18n.RULES_BULK_EDIT_SUCCESS_DATA_VIEW_RULES_SKIPPED_DETAIL
+      }`
+    );
+  });
+
+  it('includes data view skip detail when skipped count > 0 and editPayload contains set_index_patterns action', () => {
+    const editPayload = [
+      { type: BulkActionEditTypeEnum.set_index_patterns, value: ['set-pattern-*'] },
+    ];
+
+    const result = explainBulkEditSuccess(editPayload, baseSummary);
+
+    expect(result).toContain(i18n.RULES_BULK_EDIT_SUCCESS_DATA_VIEW_RULES_SKIPPED_DETAIL);
+  });
+
+  it('does not include data view skip detail when skipped count is 0 even with index pattern actions', () => {
+    const editPayload = [
+      { type: BulkActionEditTypeEnum.add_index_patterns, value: ['add-pattern-*'] },
+    ];
+    const summaryNoSkipped = { ...baseSummary, skipped: 0, succeeded: 10 };
+
+    const result = explainBulkEditSuccess(editPayload, summaryNoSkipped);
+
+    expect(result).not.toContain(i18n.RULES_BULK_EDIT_SUCCESS_DATA_VIEW_RULES_SKIPPED_DETAIL);
+    expect(result).toBe(i18n.RULES_BULK_EDIT_SUCCESS_DESCRIPTION(10, 0));
+  });
+
+  it('does not include data view skip detail when no index pattern actions are present, even with skipped rules', () => {
+    const editPayload = [{ type: BulkActionEditTypeEnum.add_tags, value: ['tag1'] }];
+
+    const result = explainBulkEditSuccess(editPayload, baseSummary);
+
+    expect(result).not.toContain(i18n.RULES_BULK_EDIT_SUCCESS_DATA_VIEW_RULES_SKIPPED_DETAIL);
+    expect(result).toBe(i18n.RULES_BULK_EDIT_SUCCESS_DESCRIPTION(8, 2));
+  });
+
+  it('handles case where all rules are skipped', () => {
+    const editPayload = [
+      { type: BulkActionEditTypeEnum.delete_index_patterns, value: ['delete-pattern-*'] },
+    ];
+    const allSkippedSummary = { total: 5, succeeded: 0, skipped: 5, failed: 0 };
+
+    const result = explainBulkEditSuccess(editPayload, allSkippedSummary);
+
+    expect(result).toContain(i18n.RULES_BULK_EDIT_SUCCESS_DATA_VIEW_RULES_SKIPPED_DETAIL);
+    expect(result).toBe(
+      `${i18n.RULES_BULK_EDIT_SUCCESS_DESCRIPTION(0, 5)} ${
+        i18n.RULES_BULK_EDIT_SUCCESS_DATA_VIEW_RULES_SKIPPED_DETAIL
+      }`
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/translations.ts
@@ -84,7 +84,7 @@ export function explainBulkEditSuccess(
   summary: BulkActionSummary
 ): string {
   const dataViewSkipDetail =
-    summary.skipped > 0 ? ` ${i18n.RULES_BULK_EDIT_SUCCESS_DATA_VIEW_RULES_SKIPPED_DETAIL}` : null;
+    summary.skipped > 0 ? ` ${i18n.RULES_BULK_EDIT_SUCCESS_DATA_VIEW_RULES_SKIPPED_DETAIL}` : '';
   if (
     editPayload.some(
       (x) =>


### PR DESCRIPTION
**Resolves:  #235794**

## Summary

This PR removes a `null` value appearing on a success confirmation dialog when bulk-editing multiple security rules and setting a new index pattern.

<img width="500" src="https://github.com/user-attachments/assets/06241840-3bc0-4eec-93b0-94755c77cd9d" />

This is done by swapping `null` for empty string and adding unit tests for `explainBulkExitSucess()`.

### Testing

To test this PR please checkout the relevant branch and run kibana locally. 

1. Security App > `Rules` > `Detection Rules (SIEM)`
2. Make sure several rules are created or pre installed.
3. Select 3 rules > `Bulk actions` > `Index patterns` > `Add Index patterns`
4. Add index pattern (ie test123-*) > `Save`

Expected Result:

5. Dialog shows: `Rules Updated: You've successfully updated 3 rules.`

<details>
<summary><h3>Click to see detailed testing steps (screenshots)</h3></summary>

<img width="800" src="https://github.com/user-attachments/assets/b5cdb962-7e01-4cec-8021-0ff3928b2615" />

<img width="800" src="https://github.com/user-attachments/assets/07692af9-7f61-499a-b813-359aeee6def7" />

<img width="800" src="https://github.com/user-attachments/assets/9332be94-41ab-4325-81d6-acf7ee947fb0" />

</details>


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->