### PR TITLE
[9.1] [CI] New info versions json / Remove some backport label usage (#234308)

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -13,20 +13,12 @@ jobs:
       github.event.pull_request.merged == true &&
         (github.event.action == 'closed' ||
           (github.event.action == 'labeled' &&
-            (github.event.label.name == 'backport:prev-minor' ||
-              github.event.label.name == 'backport:prev-major' ||
-              github.event.label.name == 'backport:current-major' ||
-              github.event.label.name == 'backport:all-open' ||
-              github.event.label.name == 'backport:version' ||
-              github.event.label.name == 'auto-backport')) ||
+            (github.event.label.name == 'backport:all-open' ||
+              github.event.label.name == 'backport:version')) ||
           (github.event.action == 'unlabeled' &&
             github.event.label.name == 'backport:skip' &&
-            (contains(github.event.pull_request.labels.*.name, 'backport:prev-minor') ||
-              contains(github.event.pull_request.labels.*.name, 'backport:prev-major') ||
-              contains(github.event.pull_request.labels.*.name, 'backport:current-major') ||
-              contains(github.event.pull_request.labels.*.name, 'backport:all-open') ||
-              contains(github.event.pull_request.labels.*.name, 'backport:version') ||
-              contains(github.event.pull_request.labels.*.name, 'auto-backport'))))
+            (contains(github.event.pull_request.labels.*.name, 'backport:all-open') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:version'))))
     steps:
       - name: Checkout Actions
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/dev_docs/contributing/how_we_use_github.mdx
+++ b/dev_docs/contributing/how_we_use_github.mdx
@@ -209,9 +209,6 @@ The following labels are related to backporting PRs:
 
 - `backport:version`: Automatically backport this PR (to the branches related to
    version labels) after it's merged. Requires adding desired target versions labels.
-- `backport:prev-minor`: Automatically backport to one lower minor version.
-- `backport:prev-major`: Automatically backport to all minor version of one lower major version.
-- `backport:current-major`: Automatically backport to all minor version of the current major version.
 - `backport:all-open`: Automatically backport to all generally available versions. This functionally is equivalent to backport:prev-major at the time of writing.
 - `backport:skip`: This PR does not require backporting.
 - `backport`: This PR was backported (added by CI).

--- a/renovate.json
+++ b/renovate.json
@@ -90,8 +90,7 @@
       ],
       "labels": [
         "Team:Operations",
-        "release_note:skip",
-        "backport:current-major"
+        "release_note:skip"
       ],
       "enabled": true,
       "matchManagers": [
@@ -1156,8 +1155,7 @@
       ],
       "labels": [
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "enabled": true
     },
@@ -1193,7 +1191,6 @@
       ],
       "labels": [
         "release_note:skip",
-        "backport:prev-minor",
         "Team:Operations",
         "Team:Core"
       ],
@@ -1214,7 +1211,6 @@
       ],
       "labels": [
         "release_note:skip",
-        "backport:prev-minor",
         "Team:Operations",
         "Team:QA"
       ],
@@ -1280,9 +1276,7 @@
       "labels": [
         "release_note:skip",
         "Team:Security",
-        "Team:Core",
-        "backport:prev-minor",
-        "backport:prev-major"
+        "Team:Core"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -1303,9 +1297,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor",
-        "backport:prev-major"
+        "Team:Core"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -1327,9 +1319,7 @@
       "labels": [
         "release_note:skip",
         "Team:Security",
-        "Team:Core",
-        "backport:prev-minor",
-        "backport:prev-major"
+        "Team:Core"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -1350,9 +1340,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor",
-        "backport:prev-major"
+        "Team:Core"
       ],
       "enabled": true
     },
@@ -1387,8 +1375,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor"
+        "Team:Core"
       ],
       "enabled": true
     },
@@ -1424,8 +1411,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor"
+        "Team:Core"
       ],
       "enabled": true
     },
@@ -1443,8 +1429,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor"
+        "Team:Core"
       ],
       "enabled": true
     },
@@ -1463,8 +1448,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor"
+        "Team:Core"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -1492,8 +1476,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor"
+        "Team:Core"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -2148,8 +2131,7 @@
       "labels": [
         "Feature:Vega",
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -2169,8 +2151,7 @@
       "labels": [
         "Feature:Vega",
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -2196,8 +2177,7 @@
       "labels": [
         "Feature:Vega",
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "dependencyDashboardApproval": true,
       "minimumReleaseAge": "7 days",
@@ -2232,8 +2212,7 @@
       "labels": [
         "Feature:Vega",
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -4323,7 +4302,6 @@
         "Team:Monitoring",
         "Team:Core",
         "Team:Security",
-        "backport:prev-minor",
         "release_note:skip"
       ],
       "minimumReleaseAge": "7 days",
@@ -4485,8 +4463,7 @@
       ],
       "labels": [
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "enabled": true
     },
@@ -4601,7 +4578,6 @@
       ],
       "labels": [
         "Team:Operations",
-        "backport:prev-minor",
         "release_note:skip"
       ],
       "minimumReleaseAge": "7 days",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[CI] New info versions json / Remove some backport label usage (#234308)](https://github.com/elastic/kibana/pull/234308)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2025-09-26T11:00:15Z","message":"[CI] New info versions json / Remove some backport label usage (#234308)\n\n## Summary\nMerge with https://github.com/elastic/kibana-github-actions/pull/60\nPart of: https://github.com/elastic/kibana-operations/issues/300\n\nThis PR updates the `versions.json` to a new format, that no longer\nmanages major/minor identity, but introduces a label: `branchType:\n'development' | 'release' | 'unmaintained'`.\n\nAlso removes the obsolete label usage for `backport:prev-minor`,\n`backport:prev-major`, `backport:current-major`","sha":"fb391fa59da0c0bdc9c4997b69c21111c86025da","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","ci:cloud-deploy","v9.2.0"],"title":"[CI] New info versions json / Remove some backport label usage","number":234308,"url":"https://github.com/elastic/kibana/pull/234308","mergeCommit":{"message":"[CI] New info versions json / Remove some backport label usage (#234308)\n\n## Summary\nMerge with https://github.com/elastic/kibana-github-actions/pull/60\nPart of: https://github.com/elastic/kibana-operations/issues/300\n\nThis PR updates the `versions.json` to a new format, that no longer\nmanages major/minor identity, but introduces a label: `branchType:\n'development' | 'release' | 'unmaintained'`.\n\nAlso removes the obsolete label usage for `backport:prev-minor`,\n`backport:prev-major`, `backport:current-major`","sha":"fb391fa59da0c0bdc9c4997b69c21111c86025da"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/234308","number":234308,"mergeCommit":{"message":"[CI] New info versions json / Remove some backport label usage (#234308)\n\n## Summary\nMerge with https://github.com/elastic/kibana-github-actions/pull/60\nPart of: https://github.com/elastic/kibana-operations/issues/300\n\nThis PR updates the `versions.json` to a new format, that no longer\nmanages major/minor identity, but introduces a label: `branchType:\n'development' | 'release' | 'unmaintained'`.\n\nAlso removes the obsolete label usage for `backport:prev-minor`,\n`backport:prev-major`, `backport:current-major`","sha":"fb391fa59da0c0bdc9c4997b69c21111c86025da"}}]}] BACKPORT-->