### PR TITLE
[8.18] [CI] New info versions json / Remove some backport label usage (#234308)

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -9,20 +9,15 @@ jobs:
     name: 'Label and Backport'
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.merged == true
-      && (
-        (
-          github.event.action == 'labeled' && (
-            github.event.label.name == 'backport:prev-minor'
-            || github.event.label.name == 'backport:prev-major'
-            || github.event.label.name == 'backport:current-major'
-            || github.event.label.name == 'backport:all-open'
-            || github.event.label.name == 'backport:version'
-            || github.event.label.name == 'auto-backport'
-          )
-        )
-        || (github.event.action == 'closed')
-      )
+      github.event.pull_request.merged == true &&
+        (github.event.action == 'closed' ||
+          (github.event.action == 'labeled' &&
+            (github.event.label.name == 'backport:all-open' ||
+              github.event.label.name == 'backport:version')) ||
+          (github.event.action == 'unlabeled' &&
+            github.event.label.name == 'backport:skip' &&
+            (contains(github.event.pull_request.labels.*.name, 'backport:all-open') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:version'))))
     steps:
       - name: Checkout Actions
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/dev_docs/contributing/how_we_use_github.mdx
+++ b/dev_docs/contributing/how_we_use_github.mdx
@@ -209,9 +209,6 @@ The following labels are related to backporting PRs:
 
 - `backport:version`: Automatically backport this PR (to the branches related to
    version labels) after it's merged. Requires adding desired target versions labels.
-- `backport:prev-minor`: Automatically backport to one lower minor version.
-- `backport:prev-major`: Automatically backport to all minor version of one lower major version.
-- `backport:current-major`: Automatically backport to all minor version of the current major version.
 - `backport:all-open`: Automatically backport to all generally available versions. This functionally is equivalent to backport:prev-major at the time of writing.
 - `backport:skip`: This PR does not require backporting.
 - `backport`: This PR was backported (added by CI).

--- a/renovate.json
+++ b/renovate.json
@@ -96,8 +96,7 @@
       ],
       "labels": [
         "Team:Operations",
-        "release_note:skip",
-        "backport:current-major"
+        "release_note:skip"
       ],
       "enabled": true,
       "matchManagers": [
@@ -1184,8 +1183,7 @@
       ],
       "labels": [
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "enabled": true
     },
@@ -1221,7 +1219,6 @@
       ],
       "labels": [
         "release_note:skip",
-        "backport:prev-minor",
         "Team:Operations",
         "Team:Core"
       ],
@@ -1242,7 +1239,6 @@
       ],
       "labels": [
         "release_note:skip",
-        "backport:prev-minor",
         "Team:Operations",
         "Team:QA"
       ],
@@ -1309,9 +1305,7 @@
       "labels": [
         "release_note:skip",
         "Team:Security",
-        "Team:Core",
-        "backport:prev-minor",
-        "backport:prev-major"
+        "Team:Core"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -1333,9 +1327,7 @@
       "labels": [
         "release_note:skip",
         "Team:Security",
-        "Team:Core",
-        "backport:prev-minor",
-        "backport:prev-major"
+        "Team:Core"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -1356,9 +1348,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor",
-        "backport:prev-major"
+        "Team:Core"
       ],
       "enabled": true
     },
@@ -1393,8 +1383,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor"
+        "Team:Core"
       ],
       "enabled": true
     },
@@ -1430,8 +1419,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor"
+        "Team:Core"
       ],
       "enabled": true
     },
@@ -1449,8 +1437,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor"
+        "Team:Core"
       ],
       "enabled": true
     },
@@ -1469,8 +1456,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor"
+        "Team:Core"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -1501,8 +1487,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "Team:Core",
-        "backport:prev-minor"
+        "Team:Core"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -2178,8 +2163,7 @@
       "labels": [
         "Feature:Vega",
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -2199,8 +2183,7 @@
       "labels": [
         "Feature:Vega",
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -2226,8 +2209,7 @@
       "labels": [
         "Feature:Vega",
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "dependencyDashboardApproval": true,
       "minimumReleaseAge": "7 days",
@@ -2264,8 +2246,7 @@
       "labels": [
         "Feature:Vega",
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -4333,7 +4314,6 @@
         "Team:Monitoring",
         "Team:Core",
         "Team:Security",
-        "backport:prev-minor",
         "release_note:skip"
       ],
       "minimumReleaseAge": "7 days",
@@ -4495,8 +4475,7 @@
       ],
       "labels": [
         "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
+        "release_note:skip"
       ],
       "enabled": true
     },
@@ -4630,7 +4609,6 @@
       ],
       "labels": [
         "Team:Operations",
-        "backport:prev-minor",
         "release_note:skip"
       ],
       "minimumReleaseAge": "7 days",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[CI] New info versions json / Remove some backport label usage (#234308)](https://github.com/elastic/kibana/pull/234308)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2025-09-26T11:00:15Z","message":"[CI] New info versions json / Remove some backport label usage (#234308)\n\n## Summary\nMerge with https://github.com/elastic/kibana-github-actions/pull/60\nPart of: https://github.com/elastic/kibana-operations/issues/300\n\nThis PR updates the `versions.json` to a new format, that no longer\nmanages major/minor identity, but introduces a label: `branchType:\n'development' | 'release' | 'unmaintained'`.\n\nAlso removes the obsolete label usage for `backport:prev-minor`,\n`backport:prev-major`, `backport:current-major`","sha":"fb391fa59da0c0bdc9c4997b69c21111c86025da","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","ci:cloud-deploy","v9.2.0"],"title":"[CI] New info versions json / Remove some backport label usage","number":234308,"url":"https://github.com/elastic/kibana/pull/234308","mergeCommit":{"message":"[CI] New info versions json / Remove some backport label usage (#234308)\n\n## Summary\nMerge with https://github.com/elastic/kibana-github-actions/pull/60\nPart of: https://github.com/elastic/kibana-operations/issues/300\n\nThis PR updates the `versions.json` to a new format, that no longer\nmanages major/minor identity, but introduces a label: `branchType:\n'development' | 'release' | 'unmaintained'`.\n\nAlso removes the obsolete label usage for `backport:prev-minor`,\n`backport:prev-major`, `backport:current-major`","sha":"fb391fa59da0c0bdc9c4997b69c21111c86025da"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/234308","number":234308,"mergeCommit":{"message":"[CI] New info versions json / Remove some backport label usage (#234308)\n\n## Summary\nMerge with https://github.com/elastic/kibana-github-actions/pull/60\nPart of: https://github.com/elastic/kibana-operations/issues/300\n\nThis PR updates the `versions.json` to a new format, that no longer\nmanages major/minor identity, but introduces a label: `branchType:\n'development' | 'release' | 'unmaintained'`.\n\nAlso removes the obsolete label usage for `backport:prev-minor`,\n`backport:prev-major`, `backport:current-major`","sha":"fb391fa59da0c0bdc9c4997b69c21111c86025da"}}]}] BACKPORT-->