### PR TITLE
[8.18] [ML] Anomaly Explorer: Fixes display of alerts from anomaly detection alerting rule (#236289)

### DIFF
--- a/x-pack/platform/plugins/shared/ml/common/constants/alerts.ts
+++ b/x-pack/platform/plugins/shared/ml/common/constants/alerts.ts
@@ -23,7 +23,12 @@ export const ML_ALERT_TYPES = {
 } as const;
 
 export const ML_RULE_TYPE_IDS = Object.values(ML_ALERT_TYPES);
-export const ML_VALID_CONSUMERS = [AlertConsumers.ML, AlertConsumers.ALERTS];
+
+export const ML_VALID_CONSUMERS = [
+  AlertConsumers.ML,
+  AlertConsumers.ALERTS,
+  AlertConsumers.STACK_ALERTS,
+];
 
 export type MlAlertType = (typeof ML_ALERT_TYPES)[keyof typeof ML_ALERT_TYPES];
 

--- a/x-pack/platform/plugins/shared/ml/common/types/capabilities.ts
+++ b/x-pack/platform/plugins/shared/ml/common/types/capabilities.ts
@@ -6,7 +6,7 @@
  */
 
 import type { KibanaRequest } from '@kbn/core/server';
-import { AlertConsumers, DEPRECATED_ALERTING_CONSUMERS } from '@kbn/rule-data-utils';
+import { AlertConsumers } from '@kbn/rule-data-utils';
 import { ALERTING_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { PLUGIN_ID } from '../constants/app';
 import {

--- a/x-pack/platform/plugins/shared/ml/common/types/capabilities.ts
+++ b/x-pack/platform/plugins/shared/ml/common/types/capabilities.ts
@@ -6,6 +6,7 @@
  */
 
 import type { KibanaRequest } from '@kbn/core/server';
+import { AlertConsumers, DEPRECATED_ALERTING_CONSUMERS } from '@kbn/rule-data-utils';
 import { ALERTING_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { PLUGIN_ID } from '../constants/app';
 import {
@@ -112,7 +113,7 @@ export function getDefaultCapabilities(): MlCapabilities {
 
 const alertingFeatures = Object.values(ML_ALERT_TYPES).map((ruleTypeId) => ({
   ruleTypeId,
-  consumers: [PLUGIN_ID, ALERTING_FEATURE_ID],
+  consumers: [PLUGIN_ID, ALERTING_FEATURE_ID, AlertConsumers.STACK_ALERTS],
 }));
 
 export function getPluginPrivileges() {

--- a/x-pack/platform/plugins/shared/ml/common/types/capabilities.ts
+++ b/x-pack/platform/plugins/shared/ml/common/types/capabilities.ts
@@ -111,7 +111,7 @@ export function getDefaultCapabilities(): MlCapabilities {
   };
 }
 
-const alertingFeatures = Object.values(ML_ALERT_TYPES).map((ruleTypeId) => ({
+export const alertingFeatures = Object.values(ML_ALERT_TYPES).map((ruleTypeId) => ({
   ruleTypeId,
   consumers: [PLUGIN_ID, ALERTING_FEATURE_ID, AlertConsumers.STACK_ALERTS],
 }));

--- a/x-pack/platform/plugins/shared/ml/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/ml/server/plugin.ts
@@ -26,7 +26,6 @@ import type { SpacesPluginSetup } from '@kbn/spaces-plugin/server';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/server';
 import type { HomeServerPluginSetup } from '@kbn/home-plugin/server';
 import type { CasesServerSetup } from '@kbn/cases-plugin/server';
-import { ALERTING_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import type { PluginsSetup, PluginsStart, RouteInitialization } from './types';
 import type { MlCapabilities } from '../common/types/capabilities';
 import { notificationsRoutes } from './routes/notifications';
@@ -57,7 +56,7 @@ import { systemRoutes } from './routes/system';
 import { MlLicense } from '../common/license';
 import type { SharedServices } from './shared_services';
 import { createSharedServices } from './shared_services';
-import { getPluginPrivileges } from '../common/types/capabilities';
+import { alertingFeatures, getPluginPrivileges } from '../common/types/capabilities';
 import { setupCapabilitiesSwitcher } from './lib/capabilities';
 import { registerKibanaSettings } from './lib/register_settings';
 import { trainedModelsRoutes } from './routes/trained_models';
@@ -69,7 +68,6 @@ import {
 } from './saved_objects';
 import { RouteGuard } from './lib/route_guard';
 import { registerMlAlerts } from './lib/alerts/register_ml_alerts';
-import { ML_ALERT_TYPES } from '../common/constants/alerts';
 import { alertingRoutes } from './routes/alerting';
 import { registerCollector } from './usage';
 import { SavedObjectsSyncService } from './saved_objects/sync_task';
@@ -141,10 +139,7 @@ export class MlServerPlugin
       management: {
         insightsAndAlerting: ['jobsListLink', 'triggersActions'],
       },
-      alerting: Object.values(ML_ALERT_TYPES).map((ruleTypeId) => ({
-        ruleTypeId,
-        consumers: [PLUGIN_ID, ALERTING_FEATURE_ID],
-      })),
+      alerting: alertingFeatures,
       privileges: {
         all: admin,
         read: user,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ML] Anomaly Explorer: Fixes display of alerts from anomaly detection alerting rule (#236289)](https://github.com/elastic/kibana/pull/236289)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Robert Jaszczurek","email":"92210485+rbrtj@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-09-26T11:43:40Z","message":"[ML] Anomaly Explorer: Fixes display of alerts from anomaly detection alerting rule (#236289)\n\nResolves https://github.com/elastic/kibana/issues/235504\nCurrently, when an ML-only user creates ML rules from both creation\nflows, the consumer is set to `alerts`.\nCreating a rule from the \"Anomaly Detection Jobs\" page in Stack\nmanagement sets the consumer to `stackAlerts` for a user with access to\nboth feature privileges, instead of setting the consumer to `alerts`.\nWith this PR, ML-only user will be able to access all ML rules, no\nmatter if the consumer is `alerts` or `stackAlerts`.\n\n<img width=\"896\" height=\"611\" alt=\"Screenshot 2025-09-25 at 13 42 19\"\nsrc=\"https://github.com/user-attachments/assets/14ec0af4-03fb-41e2-b3cf-de36106ed68c\"\n/>","sha":"7d682e38784717604aac8714ff9b7fd94dc3cac6","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","Team:ML","backport:version","v9.2.0","v8.18.8","v8.19.5","v9.0.8","v9.1.5"],"title":"[ML] Anomaly Explorer: Fixes display of alerts from anomaly detection alerting rule","number":236289,"url":"https://github.com/elastic/kibana/pull/236289","mergeCommit":{"message":"[ML] Anomaly Explorer: Fixes display of alerts from anomaly detection alerting rule (#236289)\n\nResolves https://github.com/elastic/kibana/issues/235504\nCurrently, when an ML-only user creates ML rules from both creation\nflows, the consumer is set to `alerts`.\nCreating a rule from the \"Anomaly Detection Jobs\" page in Stack\nmanagement sets the consumer to `stackAlerts` for a user with access to\nboth feature privileges, instead of setting the consumer to `alerts`.\nWith this PR, ML-only user will be able to access all ML rules, no\nmatter if the consumer is `alerts` or `stackAlerts`.\n\n<img width=\"896\" height=\"611\" alt=\"Screenshot 2025-09-25 at 13 42 19\"\nsrc=\"https://github.com/user-attachments/assets/14ec0af4-03fb-41e2-b3cf-de36106ed68c\"\n/>","sha":"7d682e38784717604aac8714ff9b7fd94dc3cac6"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236289","number":236289,"mergeCommit":{"message":"[ML] Anomaly Explorer: Fixes display of alerts from anomaly detection alerting rule (#236289)\n\nResolves https://github.com/elastic/kibana/issues/235504\nCurrently, when an ML-only user creates ML rules from both creation\nflows, the consumer is set to `alerts`.\nCreating a rule from the \"Anomaly Detection Jobs\" page in Stack\nmanagement sets the consumer to `stackAlerts` for a user with access to\nboth feature privileges, instead of setting the consumer to `alerts`.\nWith this PR, ML-only user will be able to access all ML rules, no\nmatter if the consumer is `alerts` or `stackAlerts`.\n\n<img width=\"896\" height=\"611\" alt=\"Screenshot 2025-09-25 at 13 42 19\"\nsrc=\"https://github.com/user-attachments/assets/14ec0af4-03fb-41e2-b3cf-de36106ed68c\"\n/>","sha":"7d682e38784717604aac8714ff9b7fd94dc3cac6"}},{"branch":"8.18","label":"v8.18.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/236577","number":236577,"state":"OPEN"},{"branch":"9.0","label":"v9.0.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/236578","number":236578,"state":"OPEN"}]}] BACKPORT-->