### PR TITLE
add usage collection to intercept plugin

### DIFF
--- a/src/platform/test/plugin_functional/test_suites/usage_collection/usage_counters.ts
+++ b/src/platform/test/plugin_functional/test_suites/usage_collection/usage_counters.ts
@@ -14,12 +14,10 @@ import type { PluginFunctionalProviderContext } from '../../services';
 
 export default function ({ getService, getPageObjects }: PluginFunctionalProviderContext) {
   const supertest = getService('supertest');
+  const retry = getService('retry');
 
   async function getSavedObjectCounters() {
-    // wait until ES indexes the counter SavedObject;
-    await new Promise((res) => setTimeout(res, 10 * 1000));
-
-    return await supertest
+    return supertest
       .get('/api/saved_objects/_find?type=usage-counter')
       .set('kbn-xsrf', 'true')
       .expect(200)
@@ -49,17 +47,25 @@ export default function ({ getService, getPageObjects }: PluginFunctionalProvide
     });
 
     it('stores usage counters sent during start and setup', async () => {
-      const { duringSetup, duringStart, routeAccessed } = await getSavedObjectCounters();
+      await retry.try(async () => {
+        const { duringSetup, duringStart, routeAccessed } = await getSavedObjectCounters();
 
-      expect(duringSetup).to.be(11);
-      expect(duringStart).to.be(1);
-      expect(routeAccessed).to.be(undefined);
+        expect(duringSetup).to.be(11);
+        expect(duringStart).to.be(1);
+        expect(routeAccessed).to.be(undefined);
+      });
     });
 
     it('stores usage counters triggered by runtime activities', async () => {
       await supertest.get('/api/usage_collection_test_plugin').set('kbn-xsrf', 'true').expect(200);
 
-      const { routeAccessed } = await getSavedObjectCounters();
+      let routeAccessed: number | undefined;
+
+      await retry.waitFor('routeAccessed counter is initialized', async () => {
+        ({ routeAccessed } = await getSavedObjectCounters());
+        return Boolean(routeAccessed);
+      });
+
       expect(routeAccessed).to.be(1);
     });
   });

--- a/x-pack/platform/plugins/private/intercepts/common/constants.ts
+++ b/x-pack/platform/plugins/private/intercepts/common/constants.ts
@@ -5,7 +5,21 @@
  * 2.0.
  */
 
+/**
+ * API route for intercept
+ */
+
 export const TRIGGER_INFO_API_ROUTE = '/internal/api/intercepts/trigger_info' as const;
 
 export const TRIGGER_USER_INTERACTION_METADATA_API_ROUTE =
   '/internal/api/intercepts/user_interaction/{triggerId}' as const;
+
+/**
+ * Telemetry
+ */
+
+export const API_USAGE_COUNTER_TYPE = 'interceptApi' as const;
+
+export const API_USAGE_ERROR_TYPE = 'interceptApiError' as const;
+
+export const USAGE_COLLECTION_DOMAIN_ID = 'intercepts' as const;

--- a/x-pack/platform/plugins/private/intercepts/kibana.jsonc
+++ b/x-pack/platform/plugins/private/intercepts/kibana.jsonc
@@ -10,6 +10,7 @@
     "browser": true,
     "server": true,
     "requiredPlugins": ["cloud"],
+    "optionalPlugins": ["usageCollection"],
     "requiredBundles": [],
     "configPath": ["xpack", "intercepts"]
   }

--- a/x-pack/platform/plugins/private/intercepts/public/prompter/prompter.ts
+++ b/x-pack/platform/plugins/private/intercepts/public/prompter/prompter.ts
@@ -105,6 +105,7 @@ export class InterceptPrompter {
               if (isHidden) return Rx.EMPTY;
 
               return Rx.timer(
+                // create a timer that will not exceed the max timer interval
                 Math.min(nextRunId * response.triggerIntervalInMs - diff, this.MAX_TIMER_INTERVAL),
                 Math.min(response.triggerIntervalInMs, this.MAX_TIMER_INTERVAL)
               ).pipe(

--- a/x-pack/platform/plugins/private/intercepts/server/plugin.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/plugin.ts
@@ -12,10 +12,17 @@ import {
   type PluginInitializerContext,
   type Logger,
 } from '@kbn/core/server';
+import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { InterceptsTriggerOrchestrator } from './orchestrator';
 import type { ServerConfigSchema } from '../common/config';
 
-export class InterceptsServerPlugin implements Plugin<object, object, object, never> {
+interface InterceptsServerSetupDeps {
+  usageCollection?: UsageCollectionSetup;
+}
+
+export class InterceptsServerPlugin
+  implements Plugin<object, object, InterceptsServerSetupDeps, never>
+{
   private readonly logger: Logger;
   private readonly config: ServerConfigSchema;
   private readonly interceptsOrchestrator?: InterceptsTriggerOrchestrator;
@@ -29,9 +36,11 @@ export class InterceptsServerPlugin implements Plugin<object, object, object, ne
     }
   }
 
-  public setup(core: CoreSetup) {
-    this.interceptsOrchestrator?.setup(core, this.logger, {
+  public setup(core: CoreSetup, { usageCollection }: InterceptsServerSetupDeps) {
+    this.interceptsOrchestrator?.setup(core, {
+      logger: this.logger,
       kibanaVersion: this.initContext.env.packageInfo.version,
+      usageCollection,
     });
 
     return {};

--- a/x-pack/platform/plugins/private/intercepts/server/services/intercept_trigger.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/services/intercept_trigger.ts
@@ -8,10 +8,14 @@
 import { type CoreSetup, type CoreStart, type Logger } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { ISavedObjectsRepository } from '@kbn/core-saved-objects-api-server';
+import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { interceptTriggerRecordSavedObject, type InterceptTriggerRecord } from '../saved_objects';
+import { getCounters } from '../usage_collection/intercepts_usage_collection';
 
 interface InterceptTriggerServiceSetupDeps {
+  logger: Logger;
   kibanaVersion: string;
+  usageCollector?: ReturnType<UsageCollectionSetup['createUsageCounter']>;
 }
 
 export interface InterceptRegistrationCallbackArgs {
@@ -20,14 +24,19 @@ export interface InterceptRegistrationCallbackArgs {
 
 export class InterceptTriggerService {
   private logger?: Logger;
+  private counter?: ReturnType<typeof getCounters>;
   private savedObjectsClient?: ISavedObjectsRepository;
   private kibanaVersion?: string;
 
   private savedObjectRef = interceptTriggerRecordSavedObject;
 
-  setup(core: CoreSetup, logger: Logger, { kibanaVersion }: InterceptTriggerServiceSetupDeps) {
+  setup(
+    core: CoreSetup,
+    { kibanaVersion, usageCollector, logger }: InterceptTriggerServiceSetupDeps
+  ) {
     this.logger = logger;
     this.kibanaVersion = kibanaVersion;
+    this.counter = getCounters(usageCollector);
 
     core.savedObjects.registerType(this.savedObjectRef);
 
@@ -60,6 +69,7 @@ export class InterceptTriggerService {
         return null;
       } else {
         this.logger?.error(`Error fetching registered task: ${err.message}`);
+        this.counter?.errorCounter(`productInterceptTriggerRecordFetch:${triggerId}`);
         return null;
       }
     }
@@ -86,6 +96,8 @@ export class InterceptTriggerService {
     }
 
     if (!existingTriggerDefinition) {
+      const contextName = `productInterceptTriggerCreation:${triggerId}` as const;
+
       await this.savedObjectsClient
         ?.create<InterceptTriggerRecord>(
           this.savedObjectRef.name,
@@ -97,9 +109,13 @@ export class InterceptTriggerService {
           },
           { id: triggerId }
         )
+        .then((result) => {
+          this.counter?.usageCounter(contextName);
+          return result;
+        })
         .catch((err) => {
-          // TODO: handle error properly
           this.logger?.error(err.message);
+          this.counter?.errorCounter(contextName);
         });
       return;
     } else if (
@@ -107,13 +123,19 @@ export class InterceptTriggerService {
       existingTriggerDefinition &&
       existingTriggerDefinition.triggerAfter !== triggerAfter
     ) {
+      const contextName = `productInterceptTriggerUpdate:${triggerId}` as const;
+
       await this.savedObjectsClient
         ?.update<InterceptTriggerRecord>(this.savedObjectRef.name, triggerId, {
           triggerAfter,
         })
+        .then((result) => {
+          this.counter?.usageCounter(contextName);
+          return result;
+        })
         .catch((err) => {
-          // TODO: handle error properly
           this.logger?.error(err.message);
+          this.counter?.errorCounter(contextName);
         });
       return;
     }

--- a/x-pack/platform/plugins/private/intercepts/server/usage_collection/intercepts_usage_collection.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/usage_collection/intercepts_usage_collection.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
+
+import { API_USAGE_COUNTER_TYPE, API_USAGE_ERROR_TYPE } from '../../common/constants';
+
+/**
+ * Helper function to help with understanding the usage of the intercept across clients
+ */
+export function getCounters(usageCollector?: UsageCounter) {
+  return {
+    usageCounter(counterName: string) {
+      usageCollector?.incrementCounter({
+        counterName,
+        counterType: API_USAGE_COUNTER_TYPE,
+      });
+    },
+
+    errorCounter(counterName: string) {
+      usageCollector?.incrementCounter({
+        counterName,
+        counterType: API_USAGE_ERROR_TYPE,
+      });
+    },
+  };
+}
+
+interface FormatPathInfoForCounterArgs {
+  method: string;
+  path: string;
+  pathSuffix?: string;
+  statusCode?: number;
+}
+
+export function formatPathInfoForCounter({
+  method,
+  path,
+  pathSuffix,
+  statusCode,
+}: FormatPathInfoForCounterArgs) {
+  const pathRequestInfo = [path];
+
+  pathRequestInfo.push(pathSuffix ?? '');
+  pathRequestInfo.push(statusCode ? String(statusCode) : '');
+
+  return `${method} ${pathRequestInfo.join(':')}`;
+}

--- a/x-pack/platform/plugins/private/intercepts/tsconfig.json
+++ b/x-pack/platform/plugins/private/intercepts/tsconfig.json
@@ -19,13 +19,15 @@
     "@kbn/config-schema",
     "@kbn/i18n",
     "@kbn/task-manager-plugin",
+    "@kbn/usage-collection-plugin",
     "@kbn/core-http-browser-mocks",
     "@kbn/core-notifications-browser-mocks",
     "@kbn/core-analytics-browser-mocks",
     "@kbn/core-rendering-browser-mocks",
     "@kbn/core-rendering-browser",
     "@kbn/core-notifications-browser",
-    "@kbn/core-http-browser"
+    "@kbn/core-http-browser",
+    "@kbn/logging-mocks"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
@@ -89,6 +89,6 @@ export class ProductInterceptPublicPlugin implements Plugin {
       this.interceptSubscription,
       this.trialInterceptSubscription,
       this.upgradeInterceptSubscription,
-    ]?.forEach((subscription) => subscription?.unsubscribe());
+    ].forEach((subscription) => subscription?.unsubscribe());
   }
 }

--- a/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
@@ -69,7 +69,7 @@ export class ProductInterceptServerPlugin
       );
 
       // Register trial intercept only if the trial end date is set and not passed
-      if (this.trialEndDate && Date.now() <= this.trialEndDate.getTime()) {
+      if (Date.now() <= (this.trialEndDate?.getTime() ?? 0)) {
         void intercepts.registerTriggerDefinition?.(
           `${TRIAL_TRIGGER_DEF_ID}:${this.buildVersion}`,
           () => {


### PR DESCRIPTION
## Summary

This PR adds in support for getting usage metrics on the server, so we can tell to what degree we are having successful installs for intercept trigger configurations.

<!-- ### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->