### PR TITLE
[ci] fix flaky-test-runner reporter for scout/synthetics

### DIFF
--- a/.buildkite/pipelines/flaky_tests/constants.ts
+++ b/.buildkite/pipelines/flaky_tests/constants.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export enum TestSuiteType {
+  FTR = 'ftr-suite',
+  SCOUT = 'scout-suite',
+  CYPRESS = 'cypress-suite',
+  SYNTHETICS = 'synthetics-suite',
+}
+
+export const TEST_SUITE_TYPES = Object.values(TestSuiteType);

--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -8,6 +8,7 @@
  */
 
 import { groups } from './groups.json';
+import { TestSuiteType } from './constants';
 import type { BuildkiteStep } from '#pipeline-utils';
 import { expandAgentQueue, collectEnvFromLabels } from '#pipeline-utils';
 
@@ -171,7 +172,7 @@ for (const testSuite of testSuites) {
       env: {
         FTR_CONFIG: testSuite.ftrConfig,
       },
-      key: `ftr-suite-${suiteIndex++}`,
+      key: `${TestSuiteType.FTR}-${suiteIndex++}`,
       label: `${testSuite.ftrConfig}`,
       parallelism: testSuite.count,
       concurrency,
@@ -198,7 +199,7 @@ for (const testSuite of testSuites) {
         SCOUT_CONFIG: testSuite.scoutConfig,
         SCOUT_CONFIG_GROUP_TYPE: scoutConfigGroupType!,
       },
-      key: `scout-suite-${suiteIndex++}`,
+      key: `${TestSuiteType.SCOUT}-${suiteIndex++}`,
       label: `${testSuite.scoutConfig}`,
       parallelism: testSuite.count,
       concurrency,
@@ -229,7 +230,7 @@ for (const testSuite of testSuites) {
         command: `.buildkite/scripts/steps/functional/${suiteName}.sh`,
         label: group.name,
         agents: expandAgentQueue(agentQueue),
-        key: `cypress-suite-${suiteIndex++}`,
+        key: `${TestSuiteType.CYPRESS}-${suiteIndex++}`,
         depends_on: 'build',
         timeout_in_minutes: 150,
         parallelism: testSuite.count,
@@ -262,7 +263,7 @@ for (const testSuite of testSuites) {
         command: `.buildkite/scripts/steps/functional/${suiteName}.sh`,
         label: synthGroup.name,
         agents: expandAgentQueue('n2-4-spot'),
-        key: `synthetics-suite-${suiteIndex++}`,
+        key: `${TestSuiteType.SYNTHETICS}-${suiteIndex++}`,
         depends_on: 'build',
         timeout_in_minutes: 30,
         parallelism: testSuite.count,

--- a/.buildkite/pipelines/flaky_tests/post_stats_on_pr.ts
+++ b/.buildkite/pipelines/flaky_tests/post_stats_on_pr.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { TEST_SUITE_TYPES } from './constants';
 import { BuildkiteClient, getGithubClient } from '#pipeline-utils';
 
 interface TestSuiteResult {
@@ -28,7 +29,7 @@ async function main() {
   // Calculate success metrics
   const jobs = buildkiteBuild.jobs;
   const testSuiteRuns = jobs.filter((step) => {
-    return step.step_key?.includes('ftr-suite') || step.step_key?.includes('cypress-suite');
+    return TEST_SUITE_TYPES.some((testType) => step.step_key?.includes(testType));
   });
   const testSuiteGroups = groupBy('name', testSuiteRuns);
 


### PR DESCRIPTION
## Summary

We saw `🎉 All tests passed!` reported for Scout tests, even when they failed. This PR adjusts `post_stats_on_pr.ts` to properly handle Scout tests (Synthetics as well?)

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->