### PR TITLE
[Search] Fix eslint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1853,6 +1853,19 @@ module.exports = {
     },
 
     /**
+     * Search overrides
+     */
+
+    {
+      files: ['x-pack/solutions/search/**/*.{ts,tsx}'],
+      excludedFiles: ['x-pack/solutions/search/**/*.test.tsx'],
+      rules: {
+        '@kbn/i18n/strings_should_be_translated_with_i18n': 'warn',
+        '@kbn/i18n/strings_should_be_translated_with_formatted_message': 'warn',
+      },
+    },
+
+    /**
      * Enterprise Search overrides
      * NOTE: We also have a single rule at the bottom of the file that
      * overrides Prettier's default of not linting unnecessary backticks
@@ -1902,8 +1915,6 @@ module.exports = {
           'error',
           { vars: 'all', args: 'after-used', ignoreRestSiblings: true, varsIgnorePattern: '^_' },
         ],
-        '@kbn/i18n/strings_should_be_translated_with_i18n': 'warn',
-        '@kbn/i18n/strings_should_be_translated_with_formatted_message': 'warn',
         '@kbn/telemetry/event_generating_elements_should_be_instrumented': 'warn',
       },
     },

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_explorer/analytics_collection_explorer_callout.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_explorer/analytics_collection_explorer_callout.tsx
@@ -24,6 +24,7 @@ export const AnalyticsCollectionExplorerCallout: React.FC = () => {
 
   return discoverLink ? (
     <EuiCallOut
+      announceOnMount
       title={i18n.translate(
         'xpack.enterpriseSearch.analytics.collectionsView.explorer.callout.title',
         { defaultMessage: 'Need a deeper analysis?' }

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate/api_key_modal/generate_analytics_api_key_modal.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate/api_key_modal/generate_analytics_api_key_modal.tsx
@@ -130,6 +130,7 @@ export const GenerateAnalyticsApiKeyModal: React.FC<GenerateAnalyticsApiKeyModal
                   ) : (
                     <EuiFlexItem>
                       <EuiCallOut
+                        announceOnMount
                         title={
                           <FormattedMessage
                             id="xpack.enterpriseSearch.content.analytics.api.generateAnalyticsApiKeyModal.callOutMessage"

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_no_events_callout/analytics_collection_no_events_callout.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_no_events_callout/analytics_collection_no_events_callout.tsx
@@ -39,6 +39,7 @@ export const AnalyticsCollectionNoEventsCallout: React.FC<
 
   return hasEvents || isLoading ? null : (
     <EuiCallOut
+      announceOnMount
       color="primary"
       iconType="download"
       title={i18n.translate(

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/layout/page_template.test.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/layout/page_template.test.tsx
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @kbn/i18n/strings_should_be_translated_with_i18n, @kbn/i18n/strings_should_be_translated_with_formatted_message */
-
 import '../../../__mocks__/shallow_useeffect.mock';
 import { setMockValues } from '../../../__mocks__/kea_logic';
 

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/add_indices_flyout.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/add_indices_flyout.tsx
@@ -78,6 +78,7 @@ export const AddIndicesFlyout: React.FC<AddIndicesFlyoutProps> = ({ onClose }) =
           <>
             <EuiSpacer />
             <EuiCallOut
+              announceOnMount
               color="danger"
               title={i18n.translate(
                 'xpack.enterpriseSearch.searchApplications.searchApplication.indices.addIndicesFlyout.updateError.title',

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/connect/generate_api_key_modal/generate_search_application_api_key_modal.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/connect/generate_api_key_modal/generate_search_application_api_key_modal.tsx
@@ -129,6 +129,7 @@ export const GenerateSearchApplicationApiKeyModal: React.FC<
                   ) : (
                     <EuiFlexItem>
                       <EuiCallOut
+                        announceOnMount
                         title={
                           <FormattedMessage
                             id="xpack.enterpriseSearch.searchApplication.searchApplication.api.generateApiKeyModal.callOutMessage"

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_indices.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_indices.tsx
@@ -198,6 +198,7 @@ export const SearchApplicationIndices: React.FC = () => {
       {(hasAllUnreachableIndices || hasUnknownIndices) && (
         <>
           <EuiCallOut
+            announceOnMount
             color="warning"
             iconType="warning"
             title={

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_schema.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_schema.tsx
@@ -117,6 +117,7 @@ const SchemaFieldDetails: React.FC<{ schemaField: SchemaField }> = ({ schemaFiel
       <EuiFlexGroup direction="column" gutterSize="l">
         {notInAllIndices && (
           <EuiCallOut
+            announceOnMount
             iconType="info"
             title={
               <FormattedMessage
@@ -352,6 +353,7 @@ export const SearchApplicationSchema: React.FC = () => {
       <EuiFlexGroup direction="column" gutterSize="l">
         {hasSchemaConflicts && (
           <EuiCallOut
+            announceOnMount
             title={i18n.translate(
               'xpack.enterpriseSearch.searchApplications.searchApplication.schema.conflictsCallOut.title',
               { defaultMessage: 'Potential field mapping issues found' }
@@ -455,6 +457,7 @@ export const SearchApplicationSchema: React.FC = () => {
         />
         {totalConflictsHiddenByTypeFilters > 0 && (
           <EuiCallOut
+            announceOnMount
             title={
               <FormattedMessage
                 id="xpack.enterpriseSearch.searchApplications.searchApplication.schema.filters.conflict.callout.title"

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_applications/create_search_application_flyout.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_applications/create_search_application_flyout.tsx
@@ -121,6 +121,7 @@ export const CreateSearchApplication = ({ onClose }: CreateSearchApplicationFlyo
           <>
             <EuiSpacer />
             <EuiCallOut
+              announceOnMount
               color="danger"
               title={i18n.translate(
                 'xpack.enterpriseSearch.searchApplications.createSearchApplication.header.createError.title',

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/generated_config_fields.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/generated_config_fields.tsx
@@ -291,6 +291,7 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
           <>
             <EuiSpacer size="m" />
             <EuiCallOut
+              announceOnMount
               color="success"
               size="s"
               title={i18n.translate(

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
@@ -419,7 +419,12 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({
                       })
                     )}
                   >
-                    Elastic Connectors
+                    {i18n.translate(
+                      'xpack.enterpriseSearch.connectorStats.elasticConnectorsButton',
+                      {
+                        defaultMessage: 'Elastic Connectors',
+                      }
+                    )}
                   </EuiButtonEmpty>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/overview.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/overview.tsx
@@ -51,6 +51,7 @@ export const ConnectorDetailOverview: React.FC = () => {
           EXAMPLE_CONNECTOR_SERVICE_TYPES.includes(connector.service_type) && (
             <>
               <EuiCallOut
+                announceOnMount
                 iconType="info"
                 color="warning"
                 title={i18n.translate(
@@ -76,6 +77,7 @@ export const ConnectorDetailOverview: React.FC = () => {
         <>
           {isModalVisible && <ConvertConnectorModal />}
           <EuiCallOut
+            announceOnMount
             iconType="warning"
             color="warning"
             title={i18n.translate(
@@ -128,6 +130,7 @@ export const ConnectorDetailOverview: React.FC = () => {
       {error && (
         <>
           <EuiCallOut
+            announceOnMount
             iconType="warning"
             color="danger"
             title={i18n.translate(
@@ -146,6 +149,7 @@ export const ConnectorDetailOverview: React.FC = () => {
       {!!connector && !connector.index_name && (
         <>
           <EuiCallOut
+            announceOnMount
             iconType="info"
             color="warning"
             title={i18n.translate(
@@ -188,6 +192,7 @@ export const ConnectorDetailOverview: React.FC = () => {
       {!!connector?.index_name && !indexData && (
         <>
           <EuiCallOut
+            announceOnMount
             iconType="info"
             title={i18n.translate(
               'xpack.enterpriseSearch.content.connectors.overview.connectorIndexDoesntExistCallOut.title',

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/configuration_step.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/configuration_step.tsx
@@ -70,6 +70,7 @@ export const ConfigurationStep: React.FC<ConfigurationStepProps> = ({ title, set
       <EuiFlexGroup gutterSize="m" direction="column">
         {isWaitingOnAgentlessDeployment && (
           <EuiCallOut
+            announceOnMount
             color="warning"
             title={
               <EuiFlexGroup alignItems="center">

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
@@ -86,6 +86,7 @@ export const NativeConnectorConfigurationConfig: React.FC<
         <>
           <EuiSpacer size="l" />
           <EuiCallOut
+            announceOnMount
             title={i18n.translate(
               'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedRulesCallout',
               { defaultMessage: 'Configuration warning' }

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/advanced_sync_rules.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/advanced_sync_rules.tsx
@@ -70,6 +70,7 @@ export const AdvancedSyncRules: React.FC = () => {
 
       {(!isAdvancedSnippetEmpty || !isLocalSnippetEmpty) && (
         <EuiCallOut
+          announceOnMount
           title={i18n.translate(
             'xpack.enterpriseSearch.content.index.connector.syncRules.advancedTabCallout.title',
             { defaultMessage: 'Configuration warning' }

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
@@ -205,6 +205,7 @@ export const ConnectorSyncRules: React.FC = () => {
                 </EuiCodeBlock>
                 <EuiFlexItem>
                   <EuiCallOut
+                    announceOnMount
                     title={i18n.translate(
                       'xpack.enterpriseSearch.content.index.connector.syncRules.advancedRulesCalloutTitle',
                       { defaultMessage: 'Configuration' }

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/edit_sync_rules_flyout.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/edit_sync_rules_flyout.tsx
@@ -127,6 +127,7 @@ export const EditSyncRulesFlyout: React.FC<EditFilteringFlyoutProps> = ({
             {errors.map((error, index) => (
               <EuiFlexItem id={`${index}`} grow={false}>
                 <EuiCallOut
+                  announceOnMount
                   color="danger"
                   title={i18n.translate(
                     'xpack.enterpriseSearch.content.index.connector.syncRules.flyout.errorTitle',

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -94,6 +94,7 @@ export const SearchIndexDocuments: React.FC = () => {
         <>
           {isAccessControlIndexNotFound && (
             <EuiCallOut
+              announceOnMount
               size="m"
               title={i18n.translate(
                 'xpack.enterpriseSearch.content.searchIndex.documents.noIndex.title',

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
@@ -72,6 +72,7 @@ export const SearchIndexIndexMappings: React.FC = () => {
             <EuiFlexItem grow>
               {isAccessControlIndexNotFound ? (
                 <EuiCallOut
+                  announceOnMount
                   size="m"
                   title={i18n.translate(
                     'xpack.enterpriseSearch.content.searchIndex.mappings.noIndex.title',
@@ -99,6 +100,7 @@ export const SearchIndexIndexMappings: React.FC = () => {
                     />
                   ) : (
                     <EuiCallOut
+                      announceOnMount
                       color="danger"
                       iconType="warn"
                       title={i18n.translate(

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/ingest_pipeline_flyout.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/ingest_pipeline_flyout.tsx
@@ -92,6 +92,7 @@ export const IngestPipelineFlyout: React.FC<IngestPipelineFlyoutProps> = ({
           <EuiFlexItem>
             {extractionDisabled ? (
               <EuiCallOut
+                announceOnMount
                 title={i18n.translate(
                   'xpack.enterpriseSearch.content.index.pipelines.settings.extractBinaryDisabledWarningTitle',
                   {

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/add_inference_pipeline_flyout.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/add_inference_pipeline_flyout.tsx
@@ -121,6 +121,7 @@ export const AddInferencePipelineContent = ({ onClose }: AddInferencePipelineFly
         {createErrors.length > 0 && (
           <>
             <EuiCallOut
+              announceOnMount
               title={i18n.translate(
                 'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.createErrors',
                 { defaultMessage: 'Error creating pipeline' }

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -119,6 +119,7 @@ export const ConfigurePipeline: React.FC = () => {
               <>
                 <EuiSpacer />
                 <EuiCallOut
+                  announceOnMount
                   title={i18n.translate(
                     'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.modelStateChangeError.title',
                     { defaultMessage: 'Error changing model state' }

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
@@ -135,6 +135,7 @@ export const SearchIndexPipelines: React.FC = () => {
       {showMissingPipelineCallout && (
         <>
           <EuiCallOut
+            announceOnMount
             color="danger"
             iconType="error"
             title={i18n.translate(

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
@@ -100,6 +100,7 @@ export const EnterpriseSearchPageTemplateWrapper: React.FC<PageTemplateProps> = 
       {readOnlyMode && (
         <>
           <EuiCallOut
+            announceOnMount
             color="warning"
             iconType="lock"
             title={i18n.translate('xpack.enterpriseSearch.readOnlyMode.warning', {

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
@@ -67,6 +67,7 @@ export const BodyRow = <Item extends object>({
           {errors.map((errorMessage, errorMessageIndex) => (
             <EuiFlexItem key={errorMessageIndex}>
               <EuiCallOut
+                announceOnMount
                 role="alert"
                 aria-live="polite"
                 iconType="warning"

--- a/x-pack/solutions/search/plugins/search_playground/public/components/edit_context/context_fields_select.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/edit_context/context_fields_select.tsx
@@ -63,6 +63,7 @@ export const ContextFieldsSelect = ({
   if (selectOptions.length === 0) {
     return (
       <EuiCallOut
+        announceOnMount
         title={i18n.translate('xpack.searchPlayground.editContext.noSourceFieldWarning', {
           defaultMessage: 'No source fields found',
         })}

--- a/x-pack/solutions/search/plugins/search_playground/public/components/message_list/token_estimate_tooltip.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/message_list/token_estimate_tooltip.tsx
@@ -165,6 +165,7 @@ export const TokenEstimateTooltip: React.FC<TokenEstimateTooltipProps> = ({
                     {clipped ? (
                       <EuiPanel paddingSize="s" hasShadow={false} color="warning">
                         <EuiCallOut
+                          announceOnMount
                           data-test-subj="clipped-tokens-callout"
                           title={
                             <FormattedMessage

--- a/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
@@ -44,6 +44,7 @@ const IndicesErrorCallout = ({ emptyIndices, isFieldsLoading }: IndicesErrorCall
   if (emptyIndices.length > 0) {
     return (
       <EuiCallOut
+        announceOnMount
         color="danger"
         data-test-subj="NoIndicesFieldsMessage"
         title={

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/create_index_button.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/create_index_button.tsx
@@ -49,6 +49,7 @@ export const CreateIndexButton: React.FC = () => {
     </EuiButton>
   ) : (
     <EuiCallOut
+      announceOnMount
       title={i18n.translate('xpack.searchPlayground.createIndexCallout', {
         defaultMessage: 'You need to create an index first',
       })}

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/document_selector/draggable_list.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/document_selector/draggable_list.tsx
@@ -45,6 +45,7 @@ export const DraggableList: React.FC<DraggableListProps> = ({
         <>
           {actionFields.length === 0 && actionIdsFields?.length === 0 && (
             <EuiCallOut
+              announceOnMount
               title="At least one document is required"
               color="warning"
               size="s"

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/query_rule_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/query_rule_flyout.tsx
@@ -203,6 +203,7 @@ export const QueryRuleFlyout: React.FC<QueryRuleFlyoutProps> = ({
               {isIdRule && (
                 <>
                   <EuiCallOut
+                    announceOnMount
                     title="Document action using 'ids' are unsupported"
                     color="warning"
                     size="s"
@@ -235,6 +236,7 @@ export const QueryRuleFlyout: React.FC<QueryRuleFlyoutProps> = ({
               </EuiFlexItem>
               {pinType === 'pinned' && documentCount !== 0 && (
                 <EuiCallOut
+                  announceOnMount
                   iconType="transitionTopIn"
                   size="s"
                   title={
@@ -295,6 +297,7 @@ export const QueryRuleFlyout: React.FC<QueryRuleFlyoutProps> = ({
               {shouldShowCriteriaCallout && (
                 <>
                   <EuiCallOut
+                    announceOnMount
                     iconType="info"
                     size="s"
                     onDismiss={() => {
@@ -335,6 +338,7 @@ export const QueryRuleFlyout: React.FC<QueryRuleFlyoutProps> = ({
                   ) : (
                     <>
                       <EuiCallOut
+                        announceOnMount
                         iconType="info"
                         size="s"
                         color="warning"

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_rule_flyout/synonym_rule_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_rule_flyout/synonym_rule_flyout.tsx
@@ -115,6 +115,7 @@ export const SynonymRuleFlyout: React.FC<SynonymRuleFlyoutProps> = ({
         banner={
           backendError && (
             <EuiCallOut
+              announceOnMount
               data-test-subj="searchSynonymsSynonymsRuleFlyoutErrorBanner"
               color="danger"
               title={i18n.translate(

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_link.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_link.tsx
@@ -98,6 +98,7 @@ export const ConnectorLinkElasticsearch: React.FC<ConnectorLinkElasticsearchProp
         ) : (
           <EuiFlexItem>
             <EuiCallOut
+              announceOnMount
               title={i18n.translate('xpack.serverlessSearch.connectors.pleaseSelectServiceType', {
                 defaultMessage: 'Please select a connector type.',
               })}
@@ -111,6 +112,7 @@ export const ConnectorLinkElasticsearch: React.FC<ConnectorLinkElasticsearchProp
         (status === ConnectorStatus.CREATED || status === ConnectorStatus.NEEDS_CONFIGURATION) ? (
           <EuiFlexItem>
             <EuiCallOut
+              announceOnMount
               title={i18n.translate('xpack.serverlessSearch.connectors.waitingForConnection', {
                 defaultMessage: 'Waiting for connection',
               })}


### PR DESCRIPTION
## Summary

This PR fixes the following eslint errors across search-kibana:

- @elastic/eui/callout-announce-on-mount
- @kbn/i18n/strings_should_be_translated_with_i18n
- @typescript-eslint/member-ordering

It also moves the following rules from the Enterprise Search override to a shared Search override, and excludes test files using `excludedFiles`.

- @kbn/i18n/strings_should_be_translated_with_formatted_message
- @kbn/i18n/strings_should_be_translated_with_i18n


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)`~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~