### PR TITLE
[9.1] [scout] extend api helpers + add integration tests (#232682)

### DIFF
--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -64,7 +64,7 @@ steps:
   - command: .buildkite/scripts/steps/test/scout_test_run_builder.sh
     label: 'Scout Test Run Builder'
     agents:
-      machineType: n2-standard-2
+      machineType: n2-standard-4
     key: build_scout_tests
     timeout_in_minutes: 10
     env:

--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -62,8 +62,11 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-2
+      machineType: n2-standard-4
+    key: build_scout_tests
     timeout_in_minutes: 10
+    depends_on:
+      - build
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -52,7 +52,8 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-2
+      machineType: n2-standard-4
+    key: build_scout_tests
     timeout_in_minutes: 10
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'

--- a/.buildkite/pipelines/pull_request/scout_tests.yml
+++ b/.buildkite/pipelines/pull_request/scout_tests.yml
@@ -2,9 +2,17 @@ steps:
   - command: .buildkite/scripts/steps/test/scout_test_run_builder.sh
     label: 'Scout Test Run Builder'
     agents:
-      machineType: n2-standard-2
-    key: 'build_scout_tests'
+      machineType: n2-standard-4
+    key: build_scout_tests
     timeout_in_minutes: 10
+    depends_on:
+      - build
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_types
+      - check_oas_snapshot
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:

--- a/.buildkite/scripts/steps/test/scout_test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout_test_run_builder.sh
@@ -2,10 +2,7 @@
 
 set -euo pipefail
 
-source .buildkite/scripts/common/util.sh
-.buildkite/scripts/bootstrap.sh
-.buildkite/scripts/download_build_artifacts.sh
-.buildkite/scripts/setup_es_snapshot_cache.sh
+source .buildkite/scripts/steps/functional/common.sh
 
 echo '--- Verify Playwright CLI is functional'
 node scripts/scout run-playwright-test-check
@@ -15,5 +12,11 @@ node scripts/scout discover-playwright-configs --save
 cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
 buildkite-agent artifact upload "scout_playwright_configs.json"
 
-echo '--- Scout Test Run Builder'
+echo '--- Running Scout Integration Tests'
+node scripts/scout.js run-tests \
+--serverless=security \
+--config src/platform/packages/shared/kbn-scout/integration_tests/playwright.config.ts \
+--kibana-install-dir "$KIBANA_BUILD_LOCATION"
+
+echo '--- Producing Scout Test Execution Steps'
 ts-node "$(dirname "${0}")/scout_test_run_builder.ts"

--- a/src/platform/packages/shared/kbn-scout/integration_tests/fixtures/constants.ts
+++ b/src/platform/packages/shared/kbn-scout/integration_tests/fixtures/constants.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CreateCaseParams } from '../../src/playwright/fixtures/scope/worker/apis/cases';
+
+export const createAlertRuleParams = {
+  aggType: 'count',
+  termSize: 5,
+  thresholdComparator: '>',
+  timeWindowSize: 5,
+  timeWindowUnit: 'm',
+  groupBy: 'all',
+  threshold: [10],
+  index: ['.kibana-event-log-*'],
+  timeField: '@timestamp',
+};
+
+export const createCasePayload: CreateCaseParams = {
+  title: 'test',
+  tags: ['scout'],
+  category: null,
+  severity: 'low',
+  description: 'integration test',
+  connector: {
+    id: 'none',
+    name: 'none',
+    type: '.none',
+    fields: null,
+  },
+  settings: {
+    syncAlerts: true,
+  },
+  owner: '',
+  customFields: [],
+};

--- a/src/platform/packages/shared/kbn-scout/integration_tests/playwright.config.ts
+++ b/src/platform/packages/shared/kbn-scout/integration_tests/playwright.config.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createPlaywrightConfig } from '..';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/src/platform/packages/shared/kbn-scout/integration_tests/tests/api_services/alerting_rules.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/integration_tests/tests/api_services/alerting_rules.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { randomUUID } from 'crypto';
+import { apiTest, expect } from '../../../src/playwright';
+import { createAlertRuleParams } from '../../fixtures/constants';
+
+apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, () => {
+  let ruleId: string;
+  const alertName = `index_threshold_rule_${randomUUID()}`;
+  const ruleTypeId = '.index-threshold';
+  const updatedAlertName = `updated_rule_${randomUUID()}`;
+
+  apiTest.beforeEach(async ({ apiServices }) => {
+    const createdResponse = await apiServices.alerting.rules.create({
+      ruleTypeId,
+      name: alertName,
+      consumer: 'alerts',
+      schedule: { interval: '1m' },
+      enabled: false,
+      actions: [],
+      params: createAlertRuleParams,
+      tags: ['test'],
+    });
+    expect(createdResponse.status).toBe(200);
+    expect(createdResponse.data.enabled).toBe(false);
+    ruleId = createdResponse.data.id;
+  });
+
+  apiTest.afterEach(async ({ apiServices }) => {
+    await apiServices.alerting.rules.delete(ruleId);
+    const fetchedResponse = await apiServices.alerting.rules.get(ruleId, undefined, {
+      ignoreErrors: [404],
+    });
+    expect(fetchedResponse.status).toBe(404);
+    ruleId = '';
+  });
+
+  apiTest(`should fetch alert with 'alerting.rules.get'`, async ({ apiServices }) => {
+    const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
+    expect(fetchedResponse.status).toBe(200);
+    expect(fetchedResponse.data.enabled).toBe(false);
+    expect(fetchedResponse.data.name).toEqual(alertName);
+    expect(fetchedResponse.data.rule_type_id).toEqual(ruleTypeId);
+  });
+
+  apiTest(`should update alert with 'alerting.rules.update'`, async ({ apiServices }) => {
+    const updatedResponse = await apiServices.alerting.rules.update(ruleId, {
+      name: updatedAlertName,
+    });
+    expect(updatedResponse.status).toBe(200);
+    expect(updatedResponse.data.name).toEqual(updatedAlertName);
+  });
+
+  apiTest('should enable/disable rule', async ({ apiServices }) => {
+    await apiTest.step(`with 'alerting.rules.enable'`, async () => {
+      await apiServices.alerting.rules.enable(ruleId);
+      const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
+      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse.data.enabled).toBe(true);
+    });
+
+    await apiTest.step(`with 'alerting.rules.disable'`, async () => {
+      await apiServices.alerting.rules.disable(ruleId);
+      const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
+      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse.data.enabled).toBe(false);
+    });
+  });
+
+  apiTest(`should find rule with 'alerting.rules.find'`, async ({ apiServices }) => {
+    const foundResponse = await apiServices.alerting.rules.find({
+      search: alertName,
+      search_fields: ['name'],
+      per_page: 10,
+      page: 1,
+    });
+    expect(foundResponse.status).toBe(200);
+    const match = foundResponse.data.data.find((obj: any) => obj.name === alertName);
+    expect(match).toBeDefined();
+    expect(match?.id).toBe(ruleId);
+  });
+
+  apiTest(`should mute/unmute rule`, async ({ apiServices }) => {
+    await apiTest.step('alerting.rules.muteAll', async () => {
+      await apiServices.alerting.rules.muteAll(ruleId);
+
+      const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
+      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse.data.mute_all).toBe(true);
+    });
+
+    await apiTest.step('alerting.rules.unmuteAll', async () => {
+      await apiServices.alerting.rules.unmuteAll(ruleId);
+
+      const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
+      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse.data.mute_all).toBe(false);
+    });
+  });
+
+  apiTest(`should mute/unmute alert for rule`, async ({ apiServices }) => {
+    await apiTest.step('alerting.rules.muteAlert', async () => {
+      const mockAlertId = 'test-alert-instance-id';
+      await apiServices.alerting.rules.muteAlert(ruleId, mockAlertId);
+
+      const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
+      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse.data.muted_alert_ids).toContain(mockAlertId);
+    });
+
+    await apiTest.step('alerting.rules.unmuteAlert', async () => {
+      const mockAlertId = 'test-alert-instance-id';
+      await apiServices.alerting.rules.unmuteAlert(ruleId, mockAlertId);
+
+      const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
+      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse.data.muted_alert_ids).not.toContain(mockAlertId);
+    });
+  });
+
+  apiTest(`should snooze/unsnooze rule`, async ({ apiServices }) => {
+    await apiTest.step('alerting.rules.snooze', async () => {
+      const durationMs = 3600000;
+      const snoozeResponse = await apiServices.alerting.rules.snooze(ruleId, durationMs);
+      expect(snoozeResponse.status).toBe(204);
+    });
+
+    await apiTest.step('alerting.rules.unsnooze', async () => {
+      const beforeUnsnooze = await apiServices.alerting.rules.get(ruleId);
+      const scheduleIds =
+        beforeUnsnooze.data.snooze_schedule?.map((schedule: any) => schedule.id) || [];
+
+      const unsnoozeResponse = await apiServices.alerting.rules.unsnooze(ruleId, scheduleIds);
+      expect(unsnoozeResponse.status).toBe(204);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/integration_tests/tests/api_services/cases.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/integration_tests/tests/api_services/cases.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { apiTest, expect } from '../../../src/playwright';
+import { createCasePayload } from '../../fixtures/constants';
+
+apiTest.describe('Cases Helpers', { tag: ['@svlSecurity', '@ess'] }, () => {
+  let caseId: string;
+  let caseOwner = '';
+  apiTest.beforeEach(async ({ apiServices, config }) => {
+    caseOwner =
+      config.serverless && config.projectType === 'security' ? 'securitySolution' : 'cases';
+    const createdResponse = await apiServices.cases.create({
+      ...createCasePayload,
+      owner: caseOwner,
+    });
+    expect(createdResponse.status).toBe(200);
+    expect(createdResponse.data.owner).toBe(caseOwner);
+    expect(createdResponse.data.status).toBe('open');
+    caseId = createdResponse.data.id;
+  });
+
+  apiTest.afterEach(async ({ apiServices }) => {
+    await apiServices.cases.delete([caseId]);
+    const fetchedResponse = await apiServices.cases.get(caseId);
+    expect(fetchedResponse.status).toBe(404);
+    caseId = '';
+  });
+
+  apiTest(`should fetch case with 'cases.get'`, async ({ apiServices }) => {
+    const fetchedResponse = await apiServices.cases.get(caseId);
+    expect(fetchedResponse.status).toBe(200);
+  });
+
+  apiTest(`should update case with 'cases.update'`, async ({ apiServices, log }) => {
+    // First get the case to obtain its current version
+    const currentCase = await apiServices.cases.get(caseId);
+
+    const updatedResponse = await apiServices.cases.update([
+      {
+        id: caseId,
+        version: currentCase.data.version,
+        severity: 'medium',
+      },
+    ]);
+    expect(updatedResponse.status).toBe(200);
+    expect(updatedResponse.data.length).toBe(1);
+    expect(updatedResponse.data[0].severity).toBe('medium');
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/alerting/README.md
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/alerting/README.md
@@ -1,0 +1,223 @@
+# Alerting API Service
+
+This service provides a comprehensive interface to interact with Kibana's Alerting APIs in Scout tests using Playwright.
+
+## Features
+
+- **Space-aware**: All endpoints support Kibana spaces
+- **Built-in retry logic**: Uses kbnClient's internal retry mechanism with exponential backoff
+- **Performance monitoring**: Automatic performance measurement for all operations
+- **Comprehensive coverage**: Includes rules, connectors, waiting helpers, and cleanup utilities
+- **Robust error handling**: Automatic retry on network errors, timeouts, and HTTP error status codes
+
+## Usage Example
+
+```typescript
+import { test } from '@kbn/scout';
+
+test('create and manage alerting rule', async ({ apiServices }) => {
+  const { alerting } = apiServices;
+
+  // Create a connector
+  const connector = await alerting.connectors.create({
+    name: 'test-index-connector',
+    connectorTypeId: '.index',
+    config: {
+      index: 'test-alerts',
+      refresh: true,
+    },
+  });
+
+  // Create a rule
+  const rule = await alerting.rules.create({
+    name: 'test-es-query-rule',
+    ruleTypeId: '.es-query',
+    consumer: 'alerts',
+    params: {
+      size: 100,
+      thresholdComparator: '>',
+      threshold: [0],
+      index: ['test-data'],
+      timeField: '@timestamp',
+      esQuery: '{"query":{"match_all":{}}}',
+      timeWindowSize: 5,
+      timeWindowUnit: 'm',
+    },
+    actions: [
+      {
+        id: connector.id,
+        group: 'query matched',
+        params: {
+          documents: [{ test: 'value' }],
+        },
+      },
+    ],
+    schedule: { interval: '1m' },
+  });
+
+  // Wait for rule to be active
+  await alerting.waiting.waitForRuleStatus(rule.id, 'ok');
+
+  // Run the rule manually
+  await alerting.rules.runSoon(rule.id);
+
+  // Wait for alert to appear in index
+  await alerting.waiting.waitForAlertInIndex('test-alerts', rule.id);
+
+  // Disable the rule
+  await alerting.rules.disable(rule.id);
+
+  // Cleanup
+  await alerting.cleanup.deleteAllRules();
+  await alerting.cleanup.deleteAllConnectors();
+});
+
+// Working with spaces
+import { spaceTest } from '@kbn/scout';
+
+spaceTest('use alerting in custom space', async ({ apiServices, scoutSpace }) => {
+  const { alerting } = apiServices;
+
+  const rule = await alerting.rules.create(
+    {
+      name: 'space-specific-rule',
+      ruleTypeId: '.es-query',
+      consumer: 'alerts',
+      params: {
+        /* ... */
+      },
+    },
+    scoutSpace.id
+  );
+
+  await alerting.rules.enable(rule.id, scoutSpace.id);
+});
+```
+
+## API Reference
+
+### Rules Management
+
+- `create(params, spaceId?)` - Create a new rule
+- `get(ruleId, spaceId?, options?)` - Get rule details with optional error handling
+- `update(ruleId, updates, spaceId?)` - Update a rule
+- `delete(ruleId, spaceId?)` - Delete a rule
+- `find(searchParams?, spaceId?)` - Search for rules
+- `enable(ruleId, spaceId?)` - Enable a rule
+- `disable(ruleId, spaceId?)` - Disable a rule
+- `muteAll(ruleId, spaceId?)` - Mute all alerts for a rule
+- `unmuteAll(ruleId, spaceId?)` - Unmute all alerts for a rule
+- `muteAlert(ruleId, alertId, spaceId?)` - Mute a specific alert
+- `unmuteAlert(ruleId, alertId, spaceId?)` - Unmute a specific alert
+- `snooze(ruleId, duration, spaceId?)` - Snooze a rule
+- `unsnooze(ruleId, scheduleIds?, spaceId?)` - Unsnooze a rule
+- `runSoon(ruleId, spaceId?)` - Trigger immediate rule execution
+- `getRuleTypes(spaceId?)` - Get available rule types
+- `getExecutionLog(ruleId, spaceId?)` - Get rule execution history
+- `getHealth()` - Get alerting framework health
+
+#### RequestOptions
+
+The `get` method supports additional options:
+
+```typescript
+interface RequestOptions {
+  ignoreErrors?: number[]; // HTTP status codes to ignore (e.g., [404])
+}
+
+// Example: Get rule and ignore 404 errors
+const rule = await alerting.rules.get(ruleId, spaceId, { ignoreErrors: [404] });
+```
+
+### Connectors Management
+
+- `create(params, spaceId?)` - Create a new connector
+- `get(connectorId, spaceId?)` - Get connector details
+- `update(connectorId, updates, spaceId?)` - Update a connector
+- `delete(connectorId, spaceId?)` - Delete a connector
+- `getAll(spaceId?)` - Get all connectors
+- `getTypes(spaceId?)` - Get available connector types
+- `execute(connectorId, params, spaceId?)` - Execute a connector
+
+### Waiting Helpers
+
+- `waitForRuleStatus(ruleId, expectedStatus, spaceId?, timeoutMs?)` - Wait for rule to reach specific status
+- `waitForAlertInIndex(indexName, ruleId, timeoutMs?)` - Wait for alert document in Elasticsearch index
+- `waitForExecutionCount(ruleId, count, spaceId?, timeoutMs?)` - Wait for minimum execution count
+- `waitForNextExecution(ruleId, spaceId?, timeoutMs?)` - Wait for next rule execution
+
+### Cleanup Utilities
+
+- `deleteAllRules(spaceId?)` - Delete all rules in space
+- `deleteAllConnectors(spaceId?)` - Delete all connectors in space
+- `deleteRulesByTags(tags, spaceId?)` - Delete rules with specific tags
+
+## Supported Rule Types
+
+Based on the Kibana Alerting API documentation, the service supports all rule types including:
+
+- `.es-query` - Elasticsearch query rules
+- `metrics.alert.inventory.threshold` - Infrastructure inventory threshold
+- `apm.anomaly` - APM anomaly detection
+- `apm.transaction_duration` - APM latency threshold
+- `apm.error_rate` - APM error rate
+- `slo.rules.burnRate` - SLO burn rate
+- Custom rule types defined by plugins
+
+## Error Handling
+
+The service leverages kbnClient's robust built-in retry mechanism with enhanced error reporting:
+
+- **Automatic retries**: All operations retry up to 3 times (configurable via `retries` option)
+- **Exponential backoff**: Delay increases with each retry attempt (`1000ms * attempt`)
+- **Comprehensive error coverage**: Retries on network errors, timeouts, and HTTP error status codes
+- **Enhanced error logging**: Detailed error information including status codes, response bodies, and error causes
+- **Ignorable errors**: Specific HTTP errors like 404 can be ignored using `ignoreErrors` option
+- **Optimized polling**: Waiting operations use fewer retries (1) to avoid excessive delays during frequent polling
+
+### Enhanced Error Information
+
+The service now provides detailed error context when requests fail:
+
+```
+KbnClientRequesterError: [POST - http://localhost:5620/api/alerting/rule]
+request failed (attempt=3/3): ERR_BAD_REQUEST
+-- Status: 400, Cause: ERR_BAD_REQUEST, Response: {
+  "error": "Bad Request",
+  "message": "Invalid rule parameters",
+  "statusCode": 400,
+  "validation": {
+    "source": "payload",
+    "keys": ["params.threshold"]
+  }
+} -- and ran out of retries
+```
+
+### Retry Strategy Examples
+
+```typescript
+// Standard operations use 3 retries
+await alerting.rules.create({
+  /* params */
+});
+
+// Polling operations use 1 retry to avoid delays
+await alerting.waiting.waitForRuleStatus(ruleId, 'ok');
+
+// Delete operations ignore 404 errors
+await alerting.rules.delete(ruleId); // Won't throw on already-deleted rules
+
+// Get operations with custom error handling
+const rule = await alerting.rules.get(ruleId, undefined, { ignoreErrors: [404] });
+if (rule.status === 404) {
+  console.log('Rule not found');
+}
+```
+
+## Performance Monitoring
+
+All operations are automatically wrapped with performance measurement using the Scout logger. Performance metrics are logged with operation names like:
+
+- `alertingApi.rules.create [rule-name]`
+- `alertingApi.waiting.waitForRuleStatus [rule-id/expected-status]`
+- `alertingApi.cleanup.deleteAllRules`

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/alerting/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/alerting/index.ts
@@ -1,0 +1,770 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KbnClient, ScoutLogger } from '../../../../../../common';
+import { measurePerformanceAsync } from '../../../../../../common';
+
+export interface CreateRuleParams {
+  name: string;
+  ruleTypeId: string;
+  params: Record<string, any>;
+  consumer: string;
+  actions?: Array<{
+    id: string;
+    group: string;
+    params: Record<string, any>;
+    frequency?: {
+      summary: boolean;
+      notifyWhen: string;
+      throttle?: string;
+    };
+  }>;
+  tags?: string[];
+  schedule?: { interval: string };
+  enabled?: boolean;
+  notifyWhen?: string;
+  throttle?: string;
+}
+
+export interface CreateConnectorParams {
+  name: string;
+  connectorTypeId: string;
+  config?: Record<string, any>;
+  secrets?: Record<string, any>;
+}
+
+export interface UpdateRuleParams {
+  name?: string;
+  params?: Record<string, any>;
+  actions?: Array<{
+    id: string;
+    group: string;
+    params: Record<string, any>;
+    frequency?: {
+      summary: boolean;
+      notifyWhen: string;
+      throttle?: string;
+    };
+  }>;
+  tags?: string[];
+  schedule?: { interval: string };
+  throttle?: string;
+  notifyWhen?: string;
+}
+
+export interface RequestOptions {
+  ignoreErrors?: number[];
+}
+
+export interface AlertingApiService {
+  rules: {
+    create: (params: CreateRuleParams, spaceId?: string) => Promise<any>;
+    get: (ruleId: string, spaceId?: string, options?: RequestOptions) => Promise<any>;
+    update: (ruleId: string, updates: UpdateRuleParams, spaceId?: string) => Promise<any>;
+    delete: (ruleId: string, spaceId?: string) => Promise<void>;
+    find: (searchParams?: Record<string, any>, spaceId?: string) => Promise<any>;
+    enable: (ruleId: string, spaceId?: string) => Promise<void>;
+    disable: (ruleId: string, spaceId?: string) => Promise<void>;
+    muteAll: (ruleId: string, spaceId?: string) => Promise<void>;
+    unmuteAll: (ruleId: string, spaceId?: string) => Promise<void>;
+    muteAlert: (ruleId: string, alertId: string, spaceId?: string) => Promise<void>;
+    unmuteAlert: (ruleId: string, alertId: string, spaceId?: string) => Promise<void>;
+    snooze: (ruleId: string, duration: number, spaceId?: string) => Promise<any>;
+    unsnooze: (ruleId: string, scheduleIds?: string[], spaceId?: string) => Promise<any>;
+    runSoon: (ruleId: string, spaceId?: string) => Promise<void>;
+    getRuleTypes: (spaceId?: string) => Promise<any>;
+    getExecutionLog: (ruleId: string, spaceId?: string) => Promise<any>;
+    getHealth: () => Promise<any>;
+  };
+  connectors: {
+    create: (params: CreateConnectorParams, spaceId?: string) => Promise<any>;
+    get: (connectorId: string, spaceId?: string) => Promise<any>;
+    update: (
+      connectorId: string,
+      updates: Partial<CreateConnectorParams>,
+      spaceId?: string
+    ) => Promise<any>;
+    delete: (connectorId: string, spaceId?: string) => Promise<void>;
+    getAll: (spaceId?: string) => Promise<any>;
+    getTypes: (spaceId?: string) => Promise<any>;
+    execute: (connectorId: string, params: Record<string, any>, spaceId?: string) => Promise<any>;
+  };
+  waiting: {
+    waitForRuleStatus: (
+      ruleId: string,
+      expectedStatus: string,
+      spaceId?: string,
+      timeoutMs?: number
+    ) => Promise<string>;
+    waitForAlertInIndex: (indexName: string, ruleId: string, timeoutMs?: number) => Promise<any>;
+    waitForExecutionCount: (
+      ruleId: string,
+      count: number,
+      spaceId?: string,
+      timeoutMs?: number
+    ) => Promise<void>;
+    waitForNextExecution: (ruleId: string, spaceId?: string, timeoutMs?: number) => Promise<void>;
+  };
+  cleanup: {
+    deleteAllRules: (spaceId?: string) => Promise<void>;
+    deleteAllConnectors: (spaceId?: string) => Promise<void>;
+    deleteRulesByTags: (tags: string[], spaceId?: string) => Promise<void>;
+  };
+}
+
+export const getAlertingApiHelper = (
+  log: ScoutLogger,
+  kbnClient: KbnClient
+): AlertingApiService => {
+  const buildSpacePath = (spaceId?: string, path: string = '') => {
+    return spaceId && spaceId !== 'default' ? `/s/${spaceId}${path}` : path;
+  };
+
+  const waitForCondition = async <T>(
+    checkFn: () => Promise<T>,
+    conditionFn: (result: T) => boolean,
+    timeoutMs: number = 30000,
+    intervalMs: number = 1000,
+    conditionName: string = 'condition'
+  ): Promise<T> => {
+    const startTime = Date.now();
+    let lastResult: T;
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        lastResult = await checkFn();
+        if (conditionFn(lastResult)) {
+          return lastResult;
+        }
+      } catch (error) {
+        log.debug(`Condition check failed: ${error}`);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+
+    throw new Error(
+      `Timeout waiting for ${conditionName} after ${timeoutMs}ms. Last result: ${JSON.stringify(
+        lastResult!
+      )}`
+    );
+  };
+
+  return {
+    rules: {
+      create: async (params: CreateRuleParams, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.create [${params.name}]`,
+          async () => {
+            return await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/api/alerting/rule`,
+              retries: 3,
+              body: {
+                name: params.name,
+                rule_type_id: params.ruleTypeId,
+                params: params.params,
+                consumer: params.consumer,
+                actions: params.actions || [],
+                tags: params.tags || [],
+                schedule: params.schedule || { interval: '1m' },
+                enabled: params.enabled ?? true,
+                ...(params.notifyWhen && { notify_when: params.notifyWhen }),
+                ...(params.throttle && { throttle: params.throttle }),
+              },
+            });
+          }
+        );
+      },
+
+      get: async (ruleId: string, spaceId?: string, options?: RequestOptions) => {
+        return await measurePerformanceAsync(log, `alertingApi.rules.get [${ruleId}]`, async () => {
+          return await kbnClient.request({
+            method: 'GET',
+            path: `${buildSpacePath(spaceId)}/api/alerting/rule/${ruleId}`,
+            retries: 3,
+            ignoreErrors: options?.ignoreErrors,
+          });
+        });
+      },
+
+      update: async (ruleId: string, updates: UpdateRuleParams, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.update [${ruleId}]`,
+          async () => {
+            // First get the current rule to merge with updates
+            const currentRule = await kbnClient.request({
+              method: 'GET',
+              path: `${buildSpacePath(spaceId)}/api/alerting/rule/${ruleId}`,
+              retries: 3,
+            });
+
+            const currentRuleData = currentRule.data as any;
+
+            const response = await kbnClient.request({
+              method: 'PUT',
+              path: `${buildSpacePath(spaceId)}/api/alerting/rule/${ruleId}`,
+              retries: 3,
+              body: {
+                name: updates.name || currentRuleData.name,
+                params: updates.params || currentRuleData.params,
+                actions:
+                  updates.actions ||
+                  currentRuleData.actions.map((action: any) => ({
+                    group: action.group,
+                    params: action.params,
+                    id: action.id,
+                    frequency: action.frequency,
+                  })),
+                tags: updates.tags || currentRuleData.tags,
+                schedule: updates.schedule || currentRuleData.schedule,
+                throttle: updates.throttle || currentRuleData.throttle,
+                notify_when: updates.notifyWhen || currentRuleData.notify_when,
+              },
+            });
+            return response;
+          }
+        );
+      },
+
+      delete: async (ruleId: string, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.delete [${ruleId}]`,
+          async () => {
+            await kbnClient.request({
+              method: 'DELETE',
+              path: `${buildSpacePath(spaceId)}/api/alerting/rule/${ruleId}`,
+              retries: 0,
+              ignoreErrors: [204, 404],
+            });
+          }
+        );
+      },
+
+      find: async (searchParams?: Record<string, any>, spaceId?: string) => {
+        return await measurePerformanceAsync(log, 'alertingApi.rules.find', async () => {
+          return await kbnClient.request({
+            method: 'GET',
+            path: `${buildSpacePath(spaceId)}/api/alerting/rules/_find`,
+            retries: 3,
+            query: searchParams,
+          });
+        });
+      },
+
+      enable: async (ruleId: string, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.enable [${ruleId}]`,
+          async () => {
+            await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/api/alerting/rule/${ruleId}/_enable`,
+              retries: 3,
+            });
+          }
+        );
+      },
+
+      disable: async (ruleId: string, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.disable [${ruleId}]`,
+          async () => {
+            await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/api/alerting/rule/${ruleId}/_disable`,
+              retries: 3,
+            });
+          }
+        );
+      },
+
+      muteAll: async (ruleId: string, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.muteAll [${ruleId}]`,
+          async () => {
+            await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/api/alerting/rule/${ruleId}/_mute_all`,
+              retries: 3,
+            });
+          }
+        );
+      },
+
+      unmuteAll: async (ruleId: string, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.unmuteAll [${ruleId}]`,
+          async () => {
+            await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/api/alerting/rule/${ruleId}/_unmute_all`,
+              retries: 3,
+            });
+          }
+        );
+      },
+
+      muteAlert: async (ruleId: string, alertId: string, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.muteAlert [${ruleId}/${alertId}]`,
+          async () => {
+            await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/api/alerting/rule/${ruleId}/alert/${alertId}/_mute`,
+              retries: 3,
+            });
+          }
+        );
+      },
+
+      unmuteAlert: async (ruleId: string, alertId: string, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.unmuteAlert [${ruleId}/${alertId}]`,
+          async () => {
+            await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(
+                spaceId
+              )}/api/alerting/rule/${ruleId}/alert/${alertId}/_unmute`,
+              retries: 3,
+            });
+          }
+        );
+      },
+
+      snooze: async (ruleId: string, duration: number, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.snooze [${ruleId}]`,
+          async () => {
+            return await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/internal/alerting/rule/${ruleId}/_snooze`,
+              retries: 3,
+              body: {
+                snooze_schedule: {
+                  duration,
+                  rRule: {
+                    count: 1,
+                    dtstart: new Date().toISOString(),
+                    tzid: 'UTC',
+                  },
+                },
+              },
+            });
+          }
+        );
+      },
+
+      unsnooze: async (ruleId: string, scheduleIds?: string[], spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.unsnooze [${ruleId}]`,
+          async () => {
+            return await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/internal/alerting/rule/${ruleId}/_unsnooze`,
+              retries: 3,
+              body: scheduleIds ? { schedule_ids: scheduleIds } : {},
+            });
+          }
+        );
+      },
+
+      runSoon: async (ruleId: string, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.runSoon [${ruleId}]`,
+          async () => {
+            await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/internal/alerting/rule/${ruleId}/_run_soon`,
+              retries: 3,
+            });
+          }
+        );
+      },
+
+      getRuleTypes: async (spaceId?: string) => {
+        return await measurePerformanceAsync(log, 'alertingApi.rules.getRuleTypes', async () => {
+          const response = await kbnClient.request({
+            method: 'GET',
+            path: `${buildSpacePath(spaceId)}/api/alerting/rule_types`,
+            retries: 3,
+          });
+          return response.data;
+        });
+      },
+
+      getExecutionLog: async (ruleId: string, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.rules.getExecutionLog [${ruleId}]`,
+          async () => {
+            const response = await kbnClient.request({
+              method: 'GET',
+              path: `${buildSpacePath(spaceId)}/internal/alerting/rule/${ruleId}/_execution_log`,
+              retries: 3,
+            });
+            return response.data;
+          }
+        );
+      },
+
+      getHealth: async () => {
+        return await measurePerformanceAsync(log, 'alertingApi.rules.getHealth', async () => {
+          const response = await kbnClient.request({
+            method: 'GET',
+            path: '/api/alerting/_health',
+            retries: 3,
+          });
+          return response.data;
+        });
+      },
+    },
+
+    connectors: {
+      create: async (params: CreateConnectorParams, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.connectors.create [${params.name}]`,
+          async () => {
+            const response = await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/api/actions/connector`,
+              retries: 3,
+              body: {
+                name: params.name,
+                connector_type_id: params.connectorTypeId,
+                config: params.config || {},
+                secrets: params.secrets || {},
+              },
+            });
+            return response.data;
+          }
+        );
+      },
+
+      get: async (connectorId: string, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.connectors.get [${connectorId}]`,
+          async () => {
+            const response = await kbnClient.request({
+              method: 'GET',
+              path: `${buildSpacePath(spaceId)}/api/actions/connector/${connectorId}`,
+              retries: 3,
+            });
+            return response.data;
+          }
+        );
+      },
+
+      update: async (
+        connectorId: string,
+        updates: Partial<CreateConnectorParams>,
+        spaceId?: string
+      ) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.connectors.update [${connectorId}]`,
+          async () => {
+            const response = await kbnClient.request({
+              method: 'PUT',
+              path: `${buildSpacePath(spaceId)}/api/actions/connector/${connectorId}`,
+              retries: 3,
+              body: {
+                name: updates.name,
+                config: updates.config || {},
+                secrets: updates.secrets || {},
+              },
+            });
+            return response.data;
+          }
+        );
+      },
+
+      delete: async (connectorId: string, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.connectors.delete [${connectorId}]`,
+          async () => {
+            await kbnClient.request({
+              method: 'DELETE',
+              path: `${buildSpacePath(spaceId)}/api/actions/connector/${connectorId}`,
+              retries: 3,
+              ignoreErrors: [404],
+            });
+          }
+        );
+      },
+
+      getAll: async (spaceId?: string) => {
+        return await measurePerformanceAsync(log, 'alertingApi.connectors.getAll', async () => {
+          const response = await kbnClient.request({
+            method: 'GET',
+            path: `${buildSpacePath(spaceId)}/api/actions/connectors`,
+            retries: 3,
+          });
+          return response.data;
+        });
+      },
+
+      getTypes: async (spaceId?: string) => {
+        return await measurePerformanceAsync(log, 'alertingApi.connectors.getTypes', async () => {
+          const response = await kbnClient.request({
+            method: 'GET',
+            path: `${buildSpacePath(spaceId)}/api/actions/connector_types`,
+            retries: 3,
+          });
+          return response.data;
+        });
+      },
+
+      execute: async (connectorId: string, params: Record<string, any>, spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.connectors.execute [${connectorId}]`,
+          async () => {
+            const response = await kbnClient.request({
+              method: 'POST',
+              path: `${buildSpacePath(spaceId)}/api/actions/connector/${connectorId}/_execute`,
+              retries: 3,
+              body: { params },
+            });
+            return response.data;
+          }
+        );
+      },
+    },
+
+    waiting: {
+      waitForRuleStatus: async (
+        ruleId: string,
+        expectedStatus: string,
+        spaceId?: string,
+        timeoutMs: number = 30000
+      ) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.waiting.waitForRuleStatus [${ruleId}/${expectedStatus}]`,
+          async () => {
+            return await waitForCondition(
+              async () => {
+                const rule = await kbnClient.request({
+                  method: 'GET',
+                  path: `${buildSpacePath(spaceId)}/api/alerting/rule/${ruleId}`,
+                  retries: 1, // Lower retries for frequent polling operations
+                });
+                const ruleData = rule.data as any;
+                return ruleData.execution_status?.status;
+              },
+              (status) => status === expectedStatus,
+              timeoutMs,
+              1000,
+              `rule ${ruleId} to have status ${expectedStatus}`
+            );
+          }
+        );
+      },
+
+      waitForAlertInIndex: async (indexName: string, ruleId: string, timeoutMs: number = 30000) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.waiting.waitForAlertInIndex [${indexName}/${ruleId}]`,
+          async () => {
+            return await waitForCondition(
+              async () => {
+                const response = await kbnClient.request({
+                  method: 'POST',
+                  path: '/_search',
+                  retries: 1, // Lower retries for frequent polling operations
+                  body: {
+                    index: indexName,
+                    query: {
+                      term: {
+                        'kibana.alert.rule.uuid': ruleId,
+                      },
+                    },
+                  },
+                });
+                return response.data;
+              },
+              (result) => {
+                const resultData = result as any;
+                return resultData.hits?.hits?.length > 0;
+              },
+              timeoutMs,
+              1000,
+              `alert for rule ${ruleId} to appear in index ${indexName}`
+            );
+          }
+        );
+      },
+
+      waitForExecutionCount: async (
+        ruleId: string,
+        count: number,
+        spaceId?: string,
+        timeoutMs: number = 30000
+      ) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.waiting.waitForExecutionCount [${ruleId}/${count}]`,
+          async () => {
+            await waitForCondition(
+              async () => {
+                const executionLog = await kbnClient.request({
+                  method: 'GET',
+                  path: `${buildSpacePath(
+                    spaceId
+                  )}/internal/alerting/rule/${ruleId}/_execution_log`,
+                  retries: 1, // Lower retries for frequent polling operations
+                });
+                const logData = executionLog.data as any;
+                return logData.total;
+              },
+              (total) => total >= count,
+              timeoutMs,
+              1000,
+              `rule ${ruleId} to have at least ${count} executions`
+            );
+          }
+        );
+      },
+
+      waitForNextExecution: async (ruleId: string, spaceId?: string, timeoutMs: number = 30000) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.waiting.waitForNextExecution [${ruleId}]`,
+          async () => {
+            // Get current execution count
+            const initialLog = await kbnClient.request({
+              method: 'GET',
+              path: `${buildSpacePath(spaceId)}/internal/alerting/rule/${ruleId}/_execution_log`,
+              retries: 3,
+            });
+            const initialLogData = initialLog.data as any;
+            const initialCount = initialLogData.total;
+
+            await waitForCondition(
+              async () => {
+                const executionLog = await kbnClient.request({
+                  method: 'GET',
+                  path: `${buildSpacePath(
+                    spaceId
+                  )}/internal/alerting/rule/${ruleId}/_execution_log`,
+                  retries: 1, // Lower retries for frequent polling operations
+                });
+                const logData = executionLog.data as any;
+                return logData.total;
+              },
+              (total) => total > initialCount,
+              timeoutMs,
+              1000,
+              `rule ${ruleId} to execute at least once more`
+            );
+          }
+        );
+      },
+    },
+
+    cleanup: {
+      deleteAllRules: async (spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          'alertingApi.cleanup.deleteAllRules',
+          async () => {
+            const rules = await kbnClient.request({
+              method: 'GET',
+              path: `${buildSpacePath(spaceId)}/api/alerting/rules/_find`,
+              retries: 3,
+              query: { per_page: 10000 },
+            });
+
+            const rulesData = rules.data as any;
+            await Promise.all(
+              rulesData.data.map(async (rule: any) => {
+                await kbnClient.request({
+                  method: 'DELETE',
+                  path: `${buildSpacePath(spaceId)}/api/alerting/rule/${rule.id}`,
+                  retries: 3,
+                  ignoreErrors: [404],
+                });
+              })
+            );
+          }
+        );
+      },
+
+      deleteAllConnectors: async (spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          'alertingApi.cleanup.deleteAllConnectors',
+          async () => {
+            const connectors = await kbnClient.request({
+              method: 'GET',
+              path: `${buildSpacePath(spaceId)}/api/actions/connectors`,
+              retries: 3,
+            });
+
+            const connectorsData = connectors.data as any;
+            await Promise.all(
+              connectorsData.map(async (connector: any) => {
+                await kbnClient.request({
+                  method: 'DELETE',
+                  path: `${buildSpacePath(spaceId)}/api/actions/connector/${connector.id}`,
+                  retries: 3,
+                  ignoreErrors: [404],
+                });
+              })
+            );
+          }
+        );
+      },
+
+      deleteRulesByTags: async (tags: string[], spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `alertingApi.cleanup.deleteRulesByTags [${tags.join(',')}]`,
+          async () => {
+            const filter = tags.map((tag) => `alert.attributes.tags:"${tag}"`).join(' OR ');
+            const rules = await kbnClient.request({
+              method: 'GET',
+              path: `${buildSpacePath(spaceId)}/api/alerting/rules/_find`,
+              retries: 3,
+              query: { filter, per_page: 10000 },
+            });
+
+            const rulesData = rules.data as any;
+            await Promise.all(
+              rulesData.data.map(async (rule: any) => {
+                await kbnClient.request({
+                  method: 'DELETE',
+                  path: `${buildSpacePath(spaceId)}/api/alerting/rule/${rule.id}`,
+                  retries: 3,
+                  ignoreErrors: [404],
+                });
+              })
+            );
+          }
+        );
+      },
+    },
+  };
+};

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/cases/README.md
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/cases/README.md
@@ -1,0 +1,339 @@
+# Cases API Service
+
+This service provides a basic interface to interact with Kibana's Cases APIs in Scout tests using Playwright. Cases are used to open and track issues, with support for assignees, tags, severity levels, and external connector integrations.
+
+## Features
+
+- **Space-aware**: All endpoints support Kibana spaces
+- **Built-in retry logic**: Uses kbnClient's internal retry mechanism with exponential backoff
+- **Performance monitoring**: Automatic performance measurement for all operations
+- **Basic coverage**: Includes case management, connectors, and cleanup utilities
+- **Robust error handling**: Automatic retry on network errors, timeouts, and HTTP error status codes
+
+## Usage Example
+
+```typescript
+import { test } from '@kbn/scout';
+
+test('create and manage case workflow', async ({ apiServices }) => {
+  const { cases } = apiServices;
+
+  // Create a new case
+  const newCase = await cases.create({
+    title: 'Security incident investigation',
+    description: 'Investigating suspicious activity on user account',
+    tags: ['security', 'investigation'],
+    severity: 'high',
+    assignees: [{ uid: 'user123' }],
+    category: 'security',
+    customFields: [],
+    settings: {
+      syncAlerts: true,
+    },
+  });
+
+  // Get case details
+  const caseDetails = await cases.get(newCase.data.id);
+
+  // Update case status and severity (note: version is required)
+  await cases.update([
+    {
+      id: newCase.data.id,
+      version: newCase.data.version,
+      status: 'in-progress',
+      severity: 'critical',
+    },
+  ]);
+
+  // Search for cases
+  const searchResults = await cases.find({
+    tags: 'security',
+    status: 'in-progress',
+    perPage: 10,
+  });
+
+  // Get available connectors
+  const connectors = await cases.connectors.get();
+
+  // Cleanup
+  await cases.cleanup.deleteAllCases();
+});
+
+// Working with spaces
+import { spaceTest } from '@kbn/scout';
+
+spaceTest('use cases in custom space', async ({ apiServices, scoutSpace }) => {
+  const { cases } = apiServices;
+
+  const newCase = await cases.create(
+    {
+      title: 'Space-specific case',
+      description: 'Case in security team space',
+      tags: ['team-specific'],
+      category: null,
+      customFields: [],
+    },
+    spaceId
+  );
+
+  const caseDetails = await cases.get(newCase.data.id, scoutSpace.id);
+});
+
+// Working with connectors
+test('get available connectors', async ({ apiServices }) => {
+  const { cases } = apiServices;
+
+  // Get available case connectors
+  const connectors = await cases.connectors.get();
+
+  // Create case with connector if available
+  if (connectors.length > 0) {
+    const newCase = await cases.create({
+      title: 'Case with external integration',
+      description: 'This case can be configured with external connectors',
+      category: 'integration',
+      customFields: [],
+      connector: {
+        id: connectors[0].id,
+        name: connectors[0].name,
+        type: connectors[0].connectorTypeId,
+        fields: null,
+      },
+    });
+  }
+});
+```
+
+## API Reference
+
+### Case Management
+
+- `create(params, spaceId?)` - Create a new case
+- `get(caseId, spaceId?)` - Get case details
+- `update(updates, spaceId?)` - Update one or more cases (requires id and version)
+- `delete(caseIds, spaceId?)` - Delete multiple cases by ID array
+- `find(searchParams?, spaceId?)` - Search for cases
+
+### Connectors
+
+- `connectors.get(spaceId?)` - Get available case connectors
+
+### Cleanup Utilities
+
+- `cleanup.deleteAllCases(spaceId?)` - Delete all cases in space
+- `cleanup.deleteCasesByTags(tags, spaceId?)` - Delete cases with specific tags
+
+## Example Workflows
+
+### Basic Case Management Workflow
+
+```typescript
+test('basic case management workflow', async ({ apiServices }) => {
+  const { cases } = apiServices;
+
+  // 1. Create case
+  const incident = await cases.create({
+    title: 'Security Breach - User Account Compromise',
+    description: 'Multiple failed login attempts detected',
+    severity: 'high',
+    tags: ['security', 'breach', 'urgent'],
+    assignees: [{ uid: 'security-analyst-1' }],
+    category: 'security',
+    customFields: [],
+  });
+
+  // 2. Update case status
+  await cases.update([
+    {
+      id: incident.data.id,
+      version: incident.data.version,
+      severity: 'critical',
+      status: 'in-progress',
+      assignees: [{ uid: 'security-analyst-1' }, { uid: 'security-lead' }],
+    },
+  ]);
+
+  // 3. Get updated case to get new version
+  const updatedCase = await cases.get(incident.data.id);
+
+  // 4. Close case
+  await cases.update([
+    {
+      id: incident.data.id,
+      version: updatedCase.data.version,
+      status: 'closed',
+    },
+  ]);
+});
+```
+
+### Bulk Case Management
+
+```typescript
+test('bulk case operations', async ({ apiServices }) => {
+  const { cases } = apiServices;
+
+  // Create multiple cases
+  const case1 = await cases.create({
+    title: 'Case 1',
+    description: 'Description 1',
+    tags: ['batch-1', 'test'],
+    category: null,
+    customFields: [],
+  });
+
+  const case2 = await cases.create({
+    title: 'Case 2',
+    description: 'Description 2',
+    tags: ['batch-1', 'test'],
+    category: null,
+    customFields: [],
+  });
+
+  // Bulk update multiple cases
+  await cases.update([
+    {
+      id: case1.data.id,
+      version: case1.data.version,
+      status: 'in-progress',
+      assignees: [{ uid: 'analyst-1' }],
+    },
+    {
+      id: case2.data.id,
+      version: case2.data.version,
+      status: 'in-progress',
+      assignees: [{ uid: 'analyst-2' }],
+    },
+  ]);
+
+  // Search for batch cases
+  const batchCases = await cases.find({
+    tags: 'batch-1',
+    status: 'in-progress',
+  });
+
+  // Cleanup by tags
+  await cases.cleanup.deleteCasesByTags(['batch-1']);
+});
+```
+
+## Error Handling
+
+The service leverages kbnClient's robust built-in retry mechanism with enhanced error reporting:
+
+- **Automatic retries**: All operations retry up to 3 times (configurable via `retries` option)
+- **Exponential backoff**: Delay increases with each retry attempt (`1000ms * attempt`)
+- **Comprehensive error coverage**: Retries on network errors, timeouts, and HTTP error status codes
+- **Enhanced error logging**: Detailed error information including status codes, response bodies, and error causes
+- **Ignorable errors**: Delete operations ignore 404 errors for idempotent behavior
+- **Version validation**: Update operations validate that required `id` and `version` fields are provided
+
+### Enhanced Error Information
+
+The service provides detailed error context when requests fail:
+
+```
+KbnClientRequesterError: [POST - http://localhost:5620/api/cases]
+request failed (attempt=3/3): ERR_BAD_REQUEST
+-- Status: 400, Cause: ERR_BAD_REQUEST, Response: {
+  "error": "Bad Request",
+  "message": "Invalid value \"undefined\" supplied to \"cases,version\"",
+  "statusCode": 400,
+  "validation": {
+    "source": "payload",
+    "keys": ["version"]
+  }
+} -- and ran out of retries
+```
+
+### Common Error Scenarios
+
+```typescript
+// Version mismatch error (optimistic concurrency control)
+try {
+  await cases.update([
+    {
+      id: caseId,
+      version: 'old-version',
+      status: 'closed',
+    },
+  ]);
+} catch (error) {
+  // Handle version conflict - need to get latest version
+  const currentCase = await cases.get(caseId);
+  await cases.update([
+    {
+      id: caseId,
+      version: currentCase.data.version,
+      status: 'closed',
+    },
+  ]);
+}
+
+// Missing required fields
+try {
+  await cases.create({
+    title: 'Test case',
+    // Missing required fields: description, category, customFields
+  });
+} catch (error) {
+  // Error will show which fields are missing in validation details
+}
+```
+
+## Integration with Other Services
+
+The Cases API service works seamlessly with other Scout API services:
+
+```typescript
+test('cases and alerting integration', async ({ apiServices }) => {
+  const { cases, alerting } = apiServices;
+
+  // Create alerting rule
+  const rule = await alerting.rules.create({
+    name: 'Test Rule',
+    ruleTypeId: '.es-query',
+    consumer: 'alerts',
+    params: {
+      size: 100,
+      thresholdComparator: '>',
+      threshold: [0],
+      index: ['test-data'],
+      timeField: '@timestamp',
+      esQuery: '{"query":{"match_all":{}}}',
+      timeWindowSize: 5,
+      timeWindowUnit: 'm',
+    },
+    schedule: { interval: '1m' },
+  });
+
+  // Create case for investigation
+  const caseData = await cases.create({
+    title: `Rule Investigation - ${rule.data.name}`,
+    description: 'Investigating alerts from test rule',
+    tags: ['alerting', 'investigation'],
+    category: 'investigation',
+    customFields: [],
+  });
+
+  // Wait for alerts to be generated
+  await alerting.waiting.waitForAlertInIndex('.alerts-observability', rule.data.id);
+
+  // Case can be updated with investigation findings
+  await cases.update([
+    {
+      id: caseData.data.id,
+      version: caseData.data.version,
+      status: 'in-progress',
+    },
+  ]);
+});
+```
+
+## Performance Monitoring
+
+All operations are automatically wrapped with performance measurement using the Scout logger. Performance metrics are logged with operation names like:
+
+- `casesApi.cases.create [case-title]`
+- `casesApi.comments.add [case-id]`
+- `casesApi.cleanup.deleteAllCases`

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/cases/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/cases/index.ts
@@ -1,0 +1,263 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KbnClient, ScoutLogger } from '../../../../../../common';
+import { measurePerformanceAsync } from '../../../../../../common';
+
+export interface CreateCaseParams {
+  title: string;
+  description: string;
+  tags?: string[];
+  severity?: 'low' | 'medium' | 'high' | 'critical';
+  assignees?: Array<{ uid: string }>;
+  connector?: {
+    id: string;
+    name: string;
+    type: string;
+    fields: Record<string, any> | null;
+  };
+  settings?: {
+    syncAlerts: boolean;
+  };
+  owner?: string;
+  category: string | null;
+  customFields: string[];
+}
+
+export interface UpdateCaseParams {
+  id: string;
+  version: string;
+  title?: string;
+  description?: string;
+  status?: 'open' | 'in-progress' | 'closed';
+  tags?: string[];
+  severity?: 'low' | 'medium' | 'high' | 'critical';
+  assignees?: Array<{ uid: string }>;
+  connector?: {
+    id: string;
+    name: string;
+    type: string;
+    fields: Record<string, any>;
+  };
+  settings?: {
+    syncAlerts: boolean;
+  };
+  category?: string;
+}
+
+export interface CasesApiService {
+  create: (params: CreateCaseParams, spaceId?: string) => Promise<any>;
+  get: (caseId: string, spaceId?: string) => Promise<any>;
+  update: (updates: UpdateCaseParams[], spaceId?: string) => Promise<any>;
+  delete: (caseIds: string[], spaceId?: string) => Promise<void>;
+  find: (searchParams?: Record<string, any>, spaceId?: string) => Promise<any>;
+  connectors: {
+    get: (spaceId?: string) => Promise<any>;
+  };
+  cleanup: {
+    deleteAllCases: (spaceId?: string) => Promise<void>;
+    deleteCasesByTags: (tags: string[], spaceId?: string) => Promise<void>;
+  };
+}
+
+export const getCasesApiHelper = (log: ScoutLogger, kbnClient: KbnClient): CasesApiService => {
+  const buildSpacePath = (spaceId?: string, path: string = '') => {
+    return spaceId && spaceId !== 'default' ? `/s/${spaceId}${path}` : path;
+  };
+
+  return {
+    create: async (params: CreateCaseParams, spaceId?: string) => {
+      return await measurePerformanceAsync(
+        log,
+        `casesApi.cases.create [${params.title}]`,
+        async () => {
+          return await kbnClient.request({
+            method: 'POST',
+            path: `${buildSpacePath(spaceId)}/api/cases`,
+            retries: 3,
+            body: {
+              title: params.title,
+              description: params.description,
+              tags: params.tags || [],
+              severity: params.severity || 'low',
+              assignees: params.assignees || [],
+              connector: params.connector || {
+                id: 'none',
+                name: 'none',
+                type: '.none',
+                fields: null,
+              },
+              settings: params.settings || {
+                syncAlerts: true,
+              },
+              owner: params.owner || 'cases',
+              ...(params.category && { category: params.category }),
+            },
+          });
+        }
+      );
+    },
+
+    get: async (caseId: string, spaceId?: string) => {
+      return await measurePerformanceAsync(log, `casesApi.cases.get [${caseId}]`, async () => {
+        return await kbnClient.request({
+          method: 'GET',
+          path: `${buildSpacePath(spaceId)}/api/cases/${caseId}`,
+          retries: 3,
+          ignoreErrors: [404],
+        });
+      });
+    },
+
+    update: async (updates: UpdateCaseParams[], spaceId?: string) => {
+      return await measurePerformanceAsync(
+        log,
+        `casesApi.cases.update [${updates.length} cases]`,
+        async () => {
+          return await kbnClient.request({
+            method: 'PATCH',
+            path: `${buildSpacePath(spaceId)}/api/cases`,
+            retries: 3,
+            body: {
+              cases: updates.map((update) => {
+                // Validate required fields
+                if (!update.id) {
+                  throw new Error('Case ID is required for update');
+                }
+                if (!update.version) {
+                  throw new Error('Case version is required for update');
+                }
+
+                const caseUpdate: any = {
+                  id: update.id,
+                  version: update.version,
+                };
+
+                // Only include fields that are explicitly provided
+                if (update.title !== undefined) caseUpdate.title = update.title;
+                if (update.description !== undefined) caseUpdate.description = update.description;
+                if (update.status !== undefined) caseUpdate.status = update.status;
+                if (update.tags !== undefined) caseUpdate.tags = update.tags;
+                if (update.severity !== undefined) caseUpdate.severity = update.severity;
+                if (update.assignees !== undefined) caseUpdate.assignees = update.assignees;
+                if (update.connector !== undefined) caseUpdate.connector = update.connector;
+                if (update.settings !== undefined) caseUpdate.settings = update.settings;
+                if (update.category !== undefined) caseUpdate.category = update.category;
+
+                return caseUpdate;
+              }),
+            },
+          });
+        }
+      );
+    },
+
+    delete: async (caseIds: string[], spaceId?: string) => {
+      return await measurePerformanceAsync(
+        log,
+        `casesApi.cases.delete [${caseIds.length} cases]`,
+        async () => {
+          await kbnClient.request({
+            method: 'DELETE',
+            path: `${buildSpacePath(spaceId)}/api/cases`,
+            retries: 0,
+            query: {
+              ids: JSON.stringify(caseIds),
+            },
+            ignoreErrors: [204, 404],
+          });
+        }
+      );
+    },
+
+    find: async (searchParams?: Record<string, any>, spaceId?: string) => {
+      return await measurePerformanceAsync(log, 'casesApi.cases.find', async () => {
+        const response = await kbnClient.request({
+          method: 'GET',
+          path: `${buildSpacePath(spaceId)}/api/cases/_find`,
+          retries: 3,
+          query: searchParams,
+        });
+        return response.data;
+      });
+    },
+
+    connectors: {
+      get: async (spaceId?: string) => {
+        return await measurePerformanceAsync(log, 'casesApi.connectors.get', async () => {
+          const response = await kbnClient.request({
+            method: 'GET',
+            path: `${buildSpacePath(spaceId)}/api/cases/configure/connectors/_find`,
+            retries: 3,
+          });
+          return response.data;
+        });
+      },
+    },
+
+    cleanup: {
+      deleteAllCases: async (spaceId?: string) => {
+        return await measurePerformanceAsync(log, 'casesApi.cleanup.deleteAllCases', async () => {
+          const cases = await kbnClient.request({
+            method: 'GET',
+            path: `${buildSpacePath(spaceId)}/api/cases/_find`,
+            retries: 3,
+            query: { perPage: 10000 },
+          });
+
+          const casesData = cases.data as any;
+          if (casesData.cases && casesData.cases.length > 0) {
+            const caseIds = casesData.cases.map((caseItem: any) => caseItem.id);
+            await kbnClient.request({
+              method: 'DELETE',
+              path: `${buildSpacePath(spaceId)}/api/cases`,
+              retries: 3,
+              query: {
+                ids: JSON.stringify(caseIds),
+              },
+              ignoreErrors: [404],
+            });
+          }
+        });
+      },
+
+      deleteCasesByTags: async (tags: string[], spaceId?: string) => {
+        return await measurePerformanceAsync(
+          log,
+          `casesApi.cleanup.deleteCasesByTags [${tags.join(',')}]`,
+          async () => {
+            const cases = await kbnClient.request({
+              method: 'GET',
+              path: `${buildSpacePath(spaceId)}/api/cases/_find`,
+              retries: 3,
+              query: {
+                tags: tags.join(','),
+                perPage: 10000,
+              },
+            });
+
+            const casesData = cases.data as any;
+            if (casesData.cases && casesData.cases.length > 0) {
+              const caseIds = casesData.cases.map((caseItem: any) => caseItem.id);
+              await kbnClient.request({
+                method: 'DELETE',
+                path: `${buildSpacePath(spaceId)}/api/cases`,
+                retries: 3,
+                query: {
+                  ids: JSON.stringify(caseIds),
+                },
+                ignoreErrors: [404],
+              });
+            }
+          }
+        );
+      },
+    },
+  };
+};

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/index.ts
@@ -8,11 +8,20 @@
  */
 
 import { coreWorkerFixtures } from '../core_fixtures';
-import { CoreApiService, getCoreApiHelper } from './core';
-import { FleetApiService, getFleetApiHelper } from './fleet';
-import { StreamsApiService, getStreamsApiService } from './streams';
+import type { AlertingApiService } from './alerting';
+import { getAlertingApiHelper } from './alerting';
+import type { CasesApiService } from './cases';
+import { getCasesApiHelper } from './cases';
+import type { CoreApiService } from './core';
+import { getCoreApiHelper } from './core';
+import type { FleetApiService } from './fleet';
+import { getFleetApiHelper } from './fleet';
+import type { StreamsApiService } from './streams';
+import { getStreamsApiService } from './streams';
 
 export interface ApiServicesFixture {
+  alerting: AlertingApiService;
+  cases: CasesApiService;
   fleet: FleetApiService;
   streams: StreamsApiService;
   core: CoreApiService;
@@ -20,7 +29,7 @@ export interface ApiServicesFixture {
 }
 
 /**
- * This fixture provides a helper to interact with the Kibana APIs like Fleet, Spaces, Alerting, etc.
+ * This fixture provides a helper to interact with the Kibana APIs like Alerting, Cases, Fleet, Streams, Spaces, etc.
  */
 export const apiServicesFixture = coreWorkerFixtures.extend<
   {},
@@ -29,6 +38,8 @@ export const apiServicesFixture = coreWorkerFixtures.extend<
   apiServices: [
     async ({ kbnClient, log }, use) => {
       const services = {
+        alerting: getAlertingApiHelper(log, kbnClient),
+        cases: getCasesApiHelper(log, kbnClient),
         fleet: getFleetApiHelper(log, kbnClient),
         streams: getStreamsApiService({ kbnClient, log }),
         core: getCoreApiHelper(log, kbnClient),

--- a/src/platform/packages/shared/kbn-scout/src/playwright/test/api/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/test/api/index.ts
@@ -12,6 +12,7 @@ import {
   coreWorkerFixtures,
   esArchiverFixture,
   apiClientFixture,
+  apiServicesFixture,
   defaultRolesFixture,
   requestAuthFixture,
 } from '../../fixtures/scope/worker';
@@ -21,6 +22,7 @@ import type {
   RequestAuthFixture,
   ApiClientFixture,
   DefaultRolesFixture,
+  ApiServicesFixture,
 } from '../../fixtures/scope/worker';
 
 /**
@@ -28,6 +30,7 @@ import type {
  */
 export interface ApiWorkerFixtures extends CoreWorkerFixtures {
   apiClient: ApiClientFixture;
+  apiServices: ApiServicesFixture;
   defaultRolesFixture: DefaultRolesFixture;
   requestAuth: RequestAuthFixture;
   esArchiver: EsArchiverFixture;
@@ -69,6 +72,7 @@ export const apiTest = mergeTests(
   noBrowserFixtures,
   coreWorkerFixtures,
   apiClientFixture,
+  apiServicesFixture,
   defaultRolesFixture,
   requestAuthFixture,
   esArchiverFixture

--- a/src/platform/packages/shared/kbn-test/src/kbn_client/kbn_client_requester.ts
+++ b/src/platform/packages/shared/kbn-test/src/kbn_client/kbn_client_requester.ts
@@ -134,13 +134,22 @@ export class KbnClientRequester {
         this.log.debug(`Requesting url (redacted): [${redacted}]`);
         return await Axios.request(buildRequest(url, this.httpsAgent, options));
       } catch (error) {
+        const statusCode = isAxiosResponseError(error) ? error.response.status : 'N/A';
+        const errorCause = error.code || error.message || 'Unknown error';
+        const responseBody = isAxiosResponseError(error)
+          ? JSON.stringify(error.response.data, null, 2)
+          : 'No response body';
+        const errorDetails = `Status: ${statusCode}, Cause: ${errorCause}, Response: ${responseBody}`;
+
+        this.log.debug(`Request failed - ${errorDetails}, Attempt: ${attempt}/${maxAttempts}`);
+
         if (isIgnorableError(error, options.ignoreErrors)) return error.response;
         if (attempt < maxAttempts) {
           await delay(1000 * attempt);
           continue;
         }
         throw new KbnClientRequesterError(
-          `${msgOrThrow(attempt, error)} -- and ran out of retries`,
+          `${msgOrThrow(attempt, error)} -- ${errorDetails} -- and ran out of retries`,
           error
         );
       }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[scout] extend api helpers + add integration tests (#232682)](https://github.com/elastic/kibana/pull/232682)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-09-15T16:03:31Z","message":"[scout] extend api helpers + add integration tests (#232682)\n\n## Summary\n\nThis PR extends `apiServices` with helpers for `Cases` and `Alerting`.\nIt should be used in both api and ui scout tests to setup/teardown\nenvironment for tests.\n\nTo keep track on helpers stability, I added integration tests that will\ncall helpers against running Kibana instance on CI as part of Scout\nbootstrap.","sha":"d064b7d4e21eafaf4448aa671cb94f752c84e974","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","test:scout","v9.2.0"],"title":"[scout] extend api helpers + add integration tests","number":232682,"url":"https://github.com/elastic/kibana/pull/232682","mergeCommit":{"message":"[scout] extend api helpers + add integration tests (#232682)\n\n## Summary\n\nThis PR extends `apiServices` with helpers for `Cases` and `Alerting`.\nIt should be used in both api and ui scout tests to setup/teardown\nenvironment for tests.\n\nTo keep track on helpers stability, I added integration tests that will\ncall helpers against running Kibana instance on CI as part of Scout\nbootstrap.","sha":"d064b7d4e21eafaf4448aa671cb94f752c84e974"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232682","number":232682,"mergeCommit":{"message":"[scout] extend api helpers + add integration tests (#232682)\n\n## Summary\n\nThis PR extends `apiServices` with helpers for `Cases` and `Alerting`.\nIt should be used in both api and ui scout tests to setup/teardown\nenvironment for tests.\n\nTo keep track on helpers stability, I added integration tests that will\ncall helpers against running Kibana instance on CI as part of Scout\nbootstrap.","sha":"d064b7d4e21eafaf4448aa671cb94f752c84e974"}}]}] BACKPORT-->