### PR TITLE
[ML] Inference endpoints list: Make clearer from a user intent point of view

### DIFF
--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/endpoint_model_info.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/endpoint_model_info.tsx
@@ -18,8 +18,8 @@ export interface EndpointModelInfoProps {
 }
 
 const descriptions: Record<string, string> = {
-  [ServiceProviderKeys.elastic]: i18n.ELASTIC_DESCRIPTION,
-  [ServiceProviderKeys.elasticsearch]: i18n.ELASTICSEARCH_DESCRIPTION,
+  [ServiceProviderKeys.elastic]: i18n.TOKEN_BASED_BILLING_DESCRIPTION,
+  [ServiceProviderKeys.elasticsearch]: i18n.RESOURCE_BASED_BILLING_DESCRIPTION,
 };
 
 export const EndpointModelInfo: React.FC<EndpointModelInfoProps> = ({ endpointInfo }) => {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/endpoint_model_info.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/endpoint_model_info.tsx
@@ -17,6 +17,11 @@ export interface EndpointModelInfoProps {
   endpointInfo: InferenceInferenceEndpointInfo;
 }
 
+const descriptions: Record<string, string> = {
+  [ServiceProviderKeys.elastic]: i18n.ELASTIC_DESCRIPTION,
+  [ServiceProviderKeys.elasticsearch]: i18n.ELASTICSEARCH_DESCRIPTION,
+};
+
 export const EndpointModelInfo: React.FC<EndpointModelInfoProps> = ({ endpointInfo }) => {
   const serviceSettings = endpointInfo.service_settings;
   const modelId =
@@ -27,6 +32,9 @@ export const EndpointModelInfo: React.FC<EndpointModelInfoProps> = ({ endpointIn
       : undefined;
 
   const isEligibleForMITBadge = modelId && ELASTIC_MODEL_DEFINITIONS[modelId]?.license === 'MIT';
+  const description = endpointInfo?.inference_id.startsWith('.')
+    ? descriptions[endpointInfo?.service]
+    : undefined;
 
   return (
     <EuiFlexGroup gutterSize="xs" direction="column">
@@ -35,7 +43,7 @@ export const EndpointModelInfo: React.FC<EndpointModelInfoProps> = ({ endpointIn
           <EuiFlexGroup gutterSize="xs" direction="row">
             <EuiFlexItem grow={0}>
               <EuiText size="s" color="subdued">
-                {modelId}
+                {description ?? modelId}
               </EuiText>
             </EuiFlexItem>
             {isEligibleForMITBadge ? (

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/endpoint_model_info.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/endpoint_model_info.tsx
@@ -33,7 +33,7 @@ export const EndpointModelInfo: React.FC<EndpointModelInfoProps> = ({ endpointIn
 
   const isEligibleForMITBadge = modelId && ELASTIC_MODEL_DEFINITIONS[modelId]?.license === 'MIT';
   const description = endpointInfo?.inference_id.startsWith('.')
-    ? descriptions[endpointInfo?.service]
+    ? descriptions[endpointInfo?.service ?? '']
     : undefined;
 
   return (

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/service_provider.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/service_provider.test.tsx
@@ -213,6 +213,18 @@ describe('ServiceProvider component', () => {
       task_type: 'sparse_embedding',
     };
 
+    it('renders the component with modelId', () => {
+      renderComponent(ServiceProviderKeys.elasticsearch, {
+        ...mockEndpoint,
+        inference_id: 'model-123',
+      });
+
+      expect(screen.getByText('Elasticsearch')).toBeInTheDocument();
+      const icon = screen.getByTestId('table-column-service-provider-elasticsearch');
+      expect(icon).toBeInTheDocument();
+      expect(screen.getByText('settings-model-123')).toBeInTheDocument();
+    });
+
     it('renders the component with description', () => {
       renderComponent(ServiceProviderKeys.elasticsearch, mockEndpoint);
 

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/service_provider.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/service_provider.test.tsx
@@ -201,9 +201,9 @@ describe('ServiceProvider component', () => {
     });
   });
 
-  describe('with elasticsearch service', () => {
+  describe('with elasticsearch service preconfigured endpoint', () => {
     const mockEndpoint: InferenceInferenceEndpointInfo = {
-      inference_id: 'model-123',
+      inference_id: '.model-123',
       service: 'elasticsearch',
       service_settings: {
         num_allocations: 5,
@@ -213,13 +213,14 @@ describe('ServiceProvider component', () => {
       task_type: 'sparse_embedding',
     };
 
-    it('renders the component with endpoint model_id', () => {
+    it('renders the component with description', () => {
       renderComponent(ServiceProviderKeys.elasticsearch, mockEndpoint);
 
       expect(screen.getByText('Elasticsearch')).toBeInTheDocument();
       const icon = screen.getByTestId('table-column-service-provider-elasticsearch');
       expect(icon).toBeInTheDocument();
-      expect(screen.getByText('settings-model-123')).toBeInTheDocument();
+      expect(screen.queryByText('settings-model-123')).toBeNull();
+      expect(screen.getByText('Runs on ML Nodes (resource-based billing)')).toBeInTheDocument();
     });
 
     it('renders the MIT license badge if the model is eligible', () => {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/translations.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/translations.ts
@@ -17,7 +17,7 @@ export const MIT_LICENSE = i18n.translate(
 export const ELASTIC_DESCRIPTION = i18n.translate(
   'xpack.searchInferenceEndpoints.elastic.description',
   {
-    defaultMessage: 'Runs on GPUs (billed per token)',
+    defaultMessage: 'Runs on GPUs (token-based billing)',
   }
 );
 

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/translations.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/translations.ts
@@ -14,14 +14,14 @@ export const MIT_LICENSE = i18n.translate(
   }
 );
 
-export const ELASTIC_DESCRIPTION = i18n.translate(
+export const TOKEN_BASED_BILLING_DESCRIPTION = i18n.translate(
   'xpack.searchInferenceEndpoints.elastic.description',
   {
     defaultMessage: 'Runs on GPUs (token-based billing)',
   }
 );
 
-export const ELASTICSEARCH_DESCRIPTION = i18n.translate(
+export const RESOURCE_BASED_BILLING_DESCRIPTION = i18n.translate(
   'xpack.searchInferenceEndpoints.elasticsearch.description',
   {
     defaultMessage: 'Runs on ML Nodes (resource-based billing)',

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/translations.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/translations.ts
@@ -13,3 +13,17 @@ export const MIT_LICENSE = i18n.translate(
     defaultMessage: 'License: MIT',
   }
 );
+
+export const ELASTIC_DESCRIPTION = i18n.translate(
+  'xpack.searchInferenceEndpoints.elastic.description',
+  {
+    defaultMessage: 'Runs on GPUs (billed per token)',
+  }
+);
+
+export const ELASTICSEARCH_DESCRIPTION = i18n.translate(
+  'xpack.searchInferenceEndpoints.elasticsearch.description',
+  {
+    defaultMessage: 'Runs on ML Nodes (resource-based billing)',
+  }
+);

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
@@ -122,6 +122,9 @@ const inferenceEndpoints = [
   },
 ] as InferenceAPIConfigResponse[];
 
+const elasticDescription = 'Runs on GPUs (token-based billing)';
+const elasticsearchDescription = 'Runs on ML Nodes (resource-based billing)';
+
 jest.mock('../../hooks/use_delete_endpoint', () => ({
   useDeleteEndpoint: () => ({
     mutate: jest.fn().mockImplementation(() => Promise.resolve()), // Mock implementation of the mutate function
@@ -152,36 +155,36 @@ describe('When the tabular page is loaded', () => {
 
     const rows = screen.getAllByRole('row');
     expect(rows[1]).toHaveTextContent('Elastic');
-    expect(rows[1]).toHaveTextContent('Runs on GPUs (billed per token)');
+    expect(rows[1]).toHaveTextContent(elasticDescription);
     expect(rows[1]).not.toHaveTextContent('elser_model_2');
 
     expect(rows[2]).toHaveTextContent('Elasticsearch');
-    expect(rows[2]).toHaveTextContent('Runs on ML Nodes (resource-based billing)');
+    expect(rows[2]).toHaveTextContent(elasticsearchDescription);
     expect(rows[2]).not.toHaveTextContent('.elser_model_2');
 
     expect(rows[3]).toHaveTextContent('Elasticsearch');
-    expect(rows[3]).toHaveTextContent('Runs on ML Nodes (resource-based billing)');
+    expect(rows[3]).toHaveTextContent(elasticsearchDescription);
 
     expect(rows[4]).toHaveTextContent('Elastic');
-    expect(rows[1]).toHaveTextContent('Runs on GPUs (billed per token)');
+    expect(rows[1]).toHaveTextContent(elasticDescription);
 
     expect(rows[5]).toHaveTextContent('Elastic');
-    expect(rows[1]).toHaveTextContent('Runs on GPUs (billed per token)');
+    expect(rows[1]).toHaveTextContent(elasticDescription);
 
     expect(rows[6]).toHaveTextContent('Elastic');
-    expect(rows[1]).toHaveTextContent('Runs on GPUs (billed per token)');
+    expect(rows[1]).toHaveTextContent(elasticDescription);
 
     expect(rows[7]).toHaveTextContent('Elastic');
-    expect(rows[1]).toHaveTextContent('Runs on GPUs (billed per token)');
+    expect(rows[1]).toHaveTextContent(elasticDescription);
 
     expect(rows[8]).toHaveTextContent('Elasticsearch');
-    expect(rows[2]).toHaveTextContent('Runs on ML Nodes (resource-based billing)');
+    expect(rows[2]).toHaveTextContent(elasticsearchDescription);
 
     expect(rows[9]).toHaveTextContent('Elasticsearch');
-    expect(rows[2]).toHaveTextContent('Runs on ML Nodes (resource-based billing)');
+    expect(rows[2]).toHaveTextContent(elasticsearchDescription);
 
     expect(rows[10]).toHaveTextContent('Elasticsearch');
-    expect(rows[2]).toHaveTextContent('Runs on ML Nodes (resource-based billing)');
+    expect(rows[2]).toHaveTextContent(elasticsearchDescription);
 
     expect(rows[11]).toHaveTextContent('OpenAI');
     expect(rows[11]).toHaveTextContent('.own_model');

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
@@ -146,39 +146,42 @@ describe('When the tabular page is loaded', () => {
     expect(rows[11]).toHaveTextContent('third-party-model');
   });
 
-  it('should display all service and model ids in the table', () => {
+  // Caveat: preconfigured endpoints display a description instead of model id
+  it('should display all service and model ids or descriptions in the table', () => {
     render(<TabularPage inferenceEndpoints={inferenceEndpoints} />);
 
     const rows = screen.getAllByRole('row');
     expect(rows[1]).toHaveTextContent('Elastic');
-    expect(rows[1]).toHaveTextContent('.elser-2-elastic');
+    expect(rows[1]).toHaveTextContent('Runs on GPUs (billed per token)');
+    expect(rows[1]).not.toHaveTextContent('elser_model_2');
 
     expect(rows[2]).toHaveTextContent('Elasticsearch');
-    expect(rows[2]).toHaveTextContent('.elser_model_2');
+    expect(rows[2]).toHaveTextContent('Runs on ML Nodes (resource-based billing)');
+    expect(rows[2]).not.toHaveTextContent('.elser_model_2');
 
     expect(rows[3]).toHaveTextContent('Elasticsearch');
-    expect(rows[3]).toHaveTextContent('.multilingual-e5-small');
+    expect(rows[3]).toHaveTextContent('Runs on ML Nodes (resource-based billing)');
 
     expect(rows[4]).toHaveTextContent('Elastic');
-    expect(rows[4]).toHaveTextContent('multilingual-embed-v1');
+    expect(rows[1]).toHaveTextContent('Runs on GPUs (billed per token)');
 
     expect(rows[5]).toHaveTextContent('Elastic');
-    expect(rows[5]).toHaveTextContent('rerank-v1');
+    expect(rows[1]).toHaveTextContent('Runs on GPUs (billed per token)');
 
     expect(rows[6]).toHaveTextContent('Elastic');
-    expect(rows[6]).toHaveTextContent('rainbow-sprinkles');
+    expect(rows[1]).toHaveTextContent('Runs on GPUs (billed per token)');
 
     expect(rows[7]).toHaveTextContent('Elastic');
-    expect(rows[7]).toHaveTextContent('elser_model_2');
+    expect(rows[1]).toHaveTextContent('Runs on GPUs (billed per token)');
 
     expect(rows[8]).toHaveTextContent('Elasticsearch');
-    expect(rows[8]).toHaveTextContent('.rerank-v1');
+    expect(rows[2]).toHaveTextContent('Runs on ML Nodes (resource-based billing)');
 
     expect(rows[9]).toHaveTextContent('Elasticsearch');
-    expect(rows[9]).toHaveTextContent('.own_model');
+    expect(rows[2]).toHaveTextContent('Runs on ML Nodes (resource-based billing)');
 
     expect(rows[10]).toHaveTextContent('Elasticsearch');
-    expect(rows[10]).toHaveTextContent('.elser_model_2');
+    expect(rows[2]).toHaveTextContent('Runs on ML Nodes (resource-based billing)');
 
     expect(rows[11]).toHaveTextContent('OpenAI');
     expect(rows[11]).toHaveTextContent('.own_model');


### PR DESCRIPTION
## Summary

This PR:
- Removes the model name from preconfigured endpoints
- In its place, adds a descriptive label (see below)

<img width="1681" height="982" alt="image" src="https://github.com/user-attachments/assets/2dc5d703-7aeb-4144-9b46-a857590e5efc" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



