### PR TITLE
[ES|QL] Wrap the parseErrors in try catch

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -77,6 +77,24 @@ describe('helpers', function () {
         },
       ]);
     });
+
+    it('should return the generic error object for an error with unexpected format', function () {
+      const error = new Error(
+        '[esql] > Unexpected error from Elasticsearch: verification_exception - Found ambiguous reference to [user_id]; matches any of [line 3:15 [user_id], line 4:15 [user_id]]'
+      );
+      const errors = [error];
+      expect(parseErrors(errors, `FROM "kibana_sample_data_ecommerce"`)).toEqual([
+        {
+          endColumn: 10,
+          endLineNumber: 1,
+          message: error.message,
+          severity: 8,
+          startColumn: 1,
+          startLineNumber: 1,
+          code: 'unknownError',
+        },
+      ]);
+    });
   });
 
   describe('parseWarning', function () {

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -140,42 +140,54 @@ export const parseWarning = (warning: string): MonacoMessage[] => {
 
 export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
   return errors.map((error) => {
-    if (
-      // Found while testing random commands (as inlinestats)
-      !error.message.includes('esql_illegal_argument_exception') &&
-      error.message.includes('line')
-    ) {
-      const text = error.message.split('line')[1];
-      const [lineNumber, startPosition, errorMessage] = text.split(':');
-      // initialize the length to 10 in case no error word found
-      let errorLength = 10;
-      const [_, wordWithError] = errorMessage.split('[');
-      if (wordWithError) {
-        errorLength = wordWithError.length - 1;
+    try {
+      if (
+        // Found while testing random commands (as inlinestats)
+        !error.message.includes('esql_illegal_argument_exception') &&
+        error.message.includes('line')
+      ) {
+        const text = error.message.split('line')[1];
+        const [lineNumber, startPosition, errorMessage] = text.split(':');
+        // initialize the length to 10 in case no error word found
+        let errorLength = 10;
+        const [_, wordWithError] = errorMessage.split('[');
+        if (wordWithError) {
+          errorLength = wordWithError.length - 1;
+        }
+        return {
+          message: errorMessage,
+          startColumn: Number(startPosition),
+          startLineNumber: Number(lineNumber),
+          endColumn: Number(startPosition) + errorLength + 1,
+          endLineNumber: Number(lineNumber),
+          severity: monaco.MarkerSeverity.Error,
+          code: 'errorFromES',
+        };
+      } else if (error.message.includes('expression was aborted')) {
+        return {
+          message: i18n.translate('esqlEditor.query.aborted', {
+            defaultMessage: 'Request was aborted',
+          }),
+          startColumn: 1,
+          startLineNumber: 1,
+          endColumn: 10,
+          endLineNumber: 1,
+          severity: monaco.MarkerSeverity.Warning,
+          code: 'abortedRequest',
+        };
+      } else {
+        // unknown error message
+        return {
+          message: error.message,
+          startColumn: 1,
+          startLineNumber: 1,
+          endColumn: 10,
+          endLineNumber: 1,
+          severity: monaco.MarkerSeverity.Error,
+          code: 'unknownError',
+        };
       }
-      return {
-        message: errorMessage,
-        startColumn: Number(startPosition),
-        startLineNumber: Number(lineNumber),
-        endColumn: Number(startPosition) + errorLength + 1,
-        endLineNumber: Number(lineNumber),
-        severity: monaco.MarkerSeverity.Error,
-        code: 'errorFromES',
-      };
-    } else if (error.message.includes('expression was aborted')) {
-      return {
-        message: i18n.translate('esqlEditor.query.aborted', {
-          defaultMessage: 'Request was aborted',
-        }),
-        startColumn: 1,
-        startLineNumber: 1,
-        endColumn: 10,
-        endLineNumber: 1,
-        severity: monaco.MarkerSeverity.Warning,
-        code: 'abortedRequest',
-      };
-    } else {
-      // unknown error message
+    } catch (e) {
       return {
         message: error.message,
         startColumn: 1,


### PR DESCRIPTION
## Summary

Sometimes the format of the errors doesnt come with the anticipated format. For that reason this PR adds a try catch to ensure that we don't break the apps.

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



