### PR TITLE
Skip mki_create_agent test suite for MKI

### DIFF
--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/mki_only/agentless/mki_create_agent.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/mki_only/agentless/mki_create_agent.ts
@@ -25,7 +25,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   // This test suite is only running in the Serverless Quality Gates environment
   describe('Agentless API Serverless MKI only', function () {
-    this.tags(['cloud_security_posture_agentless']);
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/236699
+    this.tags(['cloud_security_posture_agentless', 'failsOnMKI']);
     let cisIntegration: typeof pageObjects.cisAddIntegration;
 
     before(async () => {


### PR DESCRIPTION
## Summary

This PR skips the `mki_create_agent` test uite for MKI.
Details about the failure/flakiness in #236699.

