### PR TITLE
[Lens][Config Builder] Fix type and logic for reference lines

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
@@ -50,7 +50,7 @@ function buildVisualizationState(config: LensXYConfig): XYState {
     },
     hideEndzones: true,
     preferredSeriesType: 'line',
-    valueLabels: 'hide',
+    valueLabels: config.valueLabels ?? 'hide',
     emphasizeFitting: config?.emphasizeFitting ?? true,
     fittingFunction: config?.fittingFunction ?? 'Linear',
     yLeftExtent: {
@@ -122,8 +122,10 @@ function buildVisualizationState(config: LensXYConfig): XYState {
               forAccessor: `${ACCESSOR}${i}_${index}`,
               axisMode: 'left',
               color: yAxis.seriesColor,
+              ...(yAxis.fill ? { fill: yAxis.fill } : {}),
+              ...(yAxis.lineThickness ? { lineWidth: yAxis.lineThickness } : {}),
             })),
-          } as XYReferenceLineLayerConfig;
+          } satisfies XYReferenceLineLayerConfig;
         case 'series':
           return {
             layerId: `layer_${i}`,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/top_values.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/top_values.ts
@@ -8,7 +8,11 @@
  */
 
 import type { TermsIndexPatternColumn } from '@kbn/lens-plugin/public';
-import type { TopValuesColumnParams } from '../../attribute_builder/utils';
+
+type TopValuesColumnParams = Pick<
+  TermsIndexPatternColumn['params'],
+  'size' | 'orderDirection' | 'orderBy' | 'secondaryFields' | 'accuracyMode' | 'orderAgg'
+>;
 
 const DEFAULT_BREAKDOWN_SIZE = 10;
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
@@ -7,7 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { FormulaPublicApi, TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import type {
+  FormulaPublicApi,
+  TermsIndexPatternColumn,
+  TypedLensByValueInput,
+} from '@kbn/lens-plugin/public';
 import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import type { Datatable } from '@kbn/expressions-plugin/common';
 import type { DataViewsCommon } from './config_builder';
@@ -142,6 +146,7 @@ export interface LensBreakdownTopValuesConfig {
   type: 'topValues';
   field: string;
   size?: number;
+  orderBy?: Pick<TermsIndexPatternColumn['params'], 'orderDirection' | 'orderBy' | 'orderAgg'>;
 }
 
 export type LensBreakdownConfig =
@@ -242,10 +247,14 @@ export type LensHeatmapConfig = Identity<LensBaseConfig & LensBaseLayer & LensHe
 
 export interface LensReferenceLineLayerBase {
   type: 'reference';
-  lineThickness?: number;
-  color?: string;
-  fill?: 'none' | 'above' | 'below';
-  value?: string;
+  yAxis: Array<
+    LensBaseLayer & {
+      lineThickness?: number;
+      color?: string;
+      fill?: 'none' | 'above' | 'below';
+      value?: string;
+    }
+  >;
 }
 
 export type LensReferenceLineLayer = LensReferenceLineLayerBase & LensBaseXYLayer;
@@ -292,6 +301,7 @@ export interface LensXYConfigBase {
   emphasizeFitting?: boolean;
   fittingFunction?: 'None' | 'Zero' | 'Linear' | 'Carry' | 'Lookahead' | 'Average' | 'Nearest';
   yBounds?: LensYBoundsConfig;
+  valueLabels?: 'hide' | 'show';
 }
 export interface BuildDependencies {
   dataViewsAPI: DataViewsCommon;


### PR DESCRIPTION
## Summary

Preparation for #236627

This PR fixes the logic for reference lines in the config builder as a preparation step for the `attributes_builder` removal, and extends a little the existing types for XY to make the alerting transition to the config builder format easier.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
