### PR TITLE
[Fleet] Use @lifecycle ilm policy for otel input

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/default_settings.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/default_settings.test.ts
@@ -34,4 +34,21 @@ describe('buildDefaultSettings', () => {
       }
     `);
   });
+
+  it('should use @lifecycle ILM policy for OTEL input type', () => {
+    const settings = buildDefaultSettings({
+      type: 'logs',
+      isOtelInputType: true,
+    });
+
+    expect(settings).toMatchInlineSnapshot(`
+      Object {
+        "index": Object {
+          "lifecycle": Object {
+            "name": "logs@lifecycle",
+          },
+        },
+      }
+    `);
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/default_settings.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/default_settings.ts
@@ -10,11 +10,14 @@ import { appContextService } from '../../../app_context';
 export function buildDefaultSettings({
   ilmPolicy,
   type,
+  isOtelInputType,
 }: {
   type: string;
   ilmPolicy?: string | undefined;
+  isOtelInputType?: boolean;
 }) {
   const isILMPolicyDisabled = appContextService.getConfig()?.internal?.disableILMPolicies ?? false;
+  const defaultIlmPolicy = isOtelInputType ? `${type}@lifecycle` : type;
 
   return {
     index: {
@@ -23,7 +26,7 @@ export function buildDefaultSettings({
         : {
             // ILM Policy must be added here, for now point to the default global ILM policy name
             lifecycle: {
-              name: ilmPolicy ? ilmPolicy : type,
+              name: ilmPolicy ? ilmPolicy : defaultIlmPolicy,
             },
           }),
     },

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -674,6 +674,7 @@ export function prepareTemplate({
   const defaultSettings = buildDefaultSettings({
     type: dataStream.type,
     ilmPolicy: dataStream.ilm_policy,
+    isOtelInputType,
   });
 
   const componentTemplates = buildComponentTemplates({


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/236383

use `@lifecycle` ilm policies for new otel template, as these datastreams are new we do not have to migrate them.

