### PR TITLE
[Data quality] Allow undefined failure store retention period

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_failure_store_modal.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_failure_store_modal.ts
@@ -41,7 +41,7 @@ export function useFailureStoreModal() {
   };
 
   const renderModal = (): React.ReactElement | null => {
-    if (canUserManageFailureStore && isFailureStoreModalOpen && defaultRetentionPeriod) {
+    if (canUserManageFailureStore && isFailureStoreModalOpen) {
       return React.createElement(FailureStoreModal, {
         onCloseModal: closeModal,
         onSaveModal: handleSaveModal,

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/get_data_stream_details.test.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/get_data_stream_details.test.ts
@@ -1,0 +1,364 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { badRequest } from '@hapi/boom';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { datasetQualityPrivileges } from '../../../services';
+import { createDatasetQualityESClient } from '../../../utils';
+import { getFailedDocsPaginated } from '../failed_docs/get_failed_docs';
+import { getDataStreams } from '../get_data_streams';
+import { getDataStreamsMeteringStats } from '../get_data_streams_metering_stats';
+import { getDataStreamDetails } from '.';
+
+jest.mock('../../../services');
+jest.mock('../../../utils');
+jest.mock('../failed_docs/get_failed_docs');
+jest.mock('../get_data_streams');
+jest.mock('../get_data_streams_metering_stats');
+
+const mockDatasetQualityPrivileges = datasetQualityPrivileges as jest.Mocked<
+  typeof datasetQualityPrivileges
+>;
+const mockCreateDatasetQualityESClient = createDatasetQualityESClient as jest.MockedFunction<
+  typeof createDatasetQualityESClient
+>;
+const mockGetFailedDocsPaginated = getFailedDocsPaginated as jest.MockedFunction<
+  typeof getFailedDocsPaginated
+>;
+const mockGetDataStreams = getDataStreams as jest.MockedFunction<typeof getDataStreams>;
+const mockGetDataStreamsMeteringStats = getDataStreamsMeteringStats as jest.MockedFunction<
+  typeof getDataStreamsMeteringStats
+>;
+
+const detailsObject = {
+  docsCount: 1000,
+  degradedDocsCount: 50,
+  services: { 'service.name': ['service1', 'service2'] },
+  hosts: { 'host.name': ['host1', 'host2'] },
+  failedDocsCount: 10,
+  sizeBytes: 5000,
+  hasFailureStore: true,
+  lastActivity: 1234567890,
+  userPrivileges: {
+    canMonitor: true,
+    canReadFailureStore: true,
+    canManageFailureStore: true,
+  },
+  customRetentionPeriod: '7d',
+  defaultRetentionPeriod: '30d',
+};
+
+describe('getDataStreamDetails', () => {
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createScopedClusterClient>;
+  let mockESClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+  let mockDatasetQualityESClient: {
+    search: jest.MockedFunction<any>;
+  };
+
+  beforeEach(() => {
+    esClient = elasticsearchServiceMock.createScopedClusterClient();
+    mockESClient = elasticsearchServiceMock.createElasticsearchClient();
+    mockDatasetQualityESClient = {
+      search: jest.fn(),
+    };
+    esClient.asCurrentUser = mockESClient;
+
+    mockCreateDatasetQualityESClient.mockReturnValue(mockDatasetQualityESClient as any);
+    mockDatasetQualityPrivileges.getHasIndexPrivileges.mockResolvedValue({
+      'logs-test-default': {
+        monitor: true,
+        read_failure_store: true,
+        manage_failure_store: true,
+      },
+    });
+    mockGetDataStreams.mockResolvedValue({
+      dataStreams: [
+        {
+          name: 'logs-test-default',
+          hasFailureStore: true,
+          lastActivity: 1234567890,
+          customRetentionPeriod: '7d',
+          defaultRetentionPeriod: '30d',
+        },
+      ],
+      datasetUserPrivileges: { datasetsPrivilages: {} },
+    } as any);
+    mockGetFailedDocsPaginated.mockResolvedValue([{ count: 10 }] as any);
+    mockGetDataStreamsMeteringStats.mockResolvedValue({
+      'logs-test-default': {
+        totalDocs: 1000,
+        sizeBytes: 5000,
+      },
+    } as any);
+
+    mockDatasetQualityESClient.search.mockResolvedValue({
+      aggregations: {
+        total_count: { value: 1000 },
+        degraded_count: { doc_count: 50 },
+        'service.name': {
+          buckets: [{ key: 'service1' }, { key: 'service2' }],
+        },
+        'host.name': {
+          buckets: [{ key: 'host1' }, { key: 'host2' }],
+        },
+      },
+    });
+
+    mockESClient.indices.stats.mockResolvedValue({
+      _all: {
+        total: {
+          docs: { count: 1000 },
+          store: { size_in_bytes: 5000 },
+        },
+      },
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('parameter validation', () => {
+    it('throws badRequest error when dataStream is empty', async () => {
+      await expect(
+        getDataStreamDetails({
+          esClient,
+          dataStream: '',
+          start: 1234567890,
+          end: 1234567890,
+          isServerless: false,
+        })
+      ).rejects.toThrow(badRequest('Data Stream name cannot be empty. Received value ""'));
+    });
+
+    it('throws badRequest error when dataStream is undefined', async () => {
+      await expect(
+        getDataStreamDetails({
+          esClient,
+          dataStream: undefined as any,
+          start: 1234567890,
+          end: 1234567890,
+          isServerless: false,
+        })
+      ).rejects.toThrow(badRequest('Data Stream name cannot be empty. Received value "undefined"'));
+    });
+
+    describe('successful execution', () => {
+      it('returns complete data stream details with all privileges', async () => {
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-test-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: false,
+        });
+
+        expect(result).toEqual(detailsObject);
+
+        expect(mockDatasetQualityPrivileges.getHasIndexPrivileges).toHaveBeenCalledWith(
+          esClient.asCurrentUser,
+          ['logs-test-default'],
+          ['monitor', 'read_failure_store', 'manage_failure_store']
+        );
+      });
+
+      it('throws when user lacks privileges', async () => {
+        mockDatasetQualityPrivileges.getHasIndexPrivileges.mockResolvedValue({
+          'logs-test-default': {
+            monitor: false,
+            read_failure_store: true,
+            manage_failure_store: false,
+          },
+        });
+
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-test-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: false,
+        });
+
+        expect(mockGetDataStreams).not.toHaveBeenCalled();
+        expect(result.sizeBytes).toBe(0);
+        expect(result.userPrivileges?.canMonitor).toBe(false);
+      });
+
+      it('uses metering stats for serverless', async () => {
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-test-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: true,
+        });
+
+        expect(mockGetDataStreamsMeteringStats).toHaveBeenCalledWith({
+          esClient: esClient.asSecondaryAuthUser,
+          dataStreams: ['logs-test-default'],
+        });
+        expect(result).toMatchObject(detailsObject);
+      });
+
+      it('uses indices stats for non-serverless', async () => {
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-test-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: false,
+        });
+
+        expect(mockESClient.indices.stats).toHaveBeenCalledWith({
+          index: 'logs-test-default',
+          forbid_closed_indices: false,
+        });
+        expect(result).toMatchObject(detailsObject);
+      });
+
+      it('calculates average document size correctly when docs count is zero', async () => {
+        mockDatasetQualityESClient.search.mockResolvedValue({
+          aggregations: {
+            total_count: { value: 0 },
+            degraded_count: { doc_count: 0 },
+          },
+        });
+
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-test-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: false,
+        });
+
+        expect(result.docsCount).toBe(0);
+        expect(result.sizeBytes).toBe(0);
+      });
+    });
+
+    describe('error handling', () => {
+      it('returns empty object when data stream does not exist (404 error)', async () => {
+        mockDatasetQualityPrivileges.getHasIndexPrivileges.mockResolvedValue({
+          'logs-nonexistent-default': {
+            monitor: true,
+            read_failure_store: true,
+            manage_failure_store: true,
+          },
+        });
+
+        const error = new Error('Not Found');
+        (error as any).statusCode = 404;
+        mockDatasetQualityESClient.search.mockRejectedValue(error);
+
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-nonexistent-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: false,
+        });
+
+        expect(result).toEqual({});
+      });
+
+      it('returns empty object when index is closed', async () => {
+        mockDatasetQualityPrivileges.getHasIndexPrivileges.mockResolvedValue({
+          'logs-closed-default': {
+            monitor: true,
+            read_failure_store: true,
+            manage_failure_store: true,
+          },
+        });
+
+        const error = new Error('Index closed');
+        (error as any).body = { error: { type: 'index_closed_exception' } };
+        mockDatasetQualityESClient.search.mockRejectedValue(error);
+
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-closed-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: false,
+        });
+
+        expect(result).toEqual({});
+      });
+
+      it('throws error for other types of errors', async () => {
+        mockDatasetQualityPrivileges.getHasIndexPrivileges.mockResolvedValue({
+          'logs-test-default': {
+            monitor: true,
+            read_failure_store: true,
+            manage_failure_store: true,
+          },
+        });
+
+        const error = new Error('Internal Server Error');
+        (error as any).statusCode = 500;
+        mockDatasetQualityESClient.search.mockRejectedValue(error);
+
+        await expect(
+          getDataStreamDetails({
+            esClient,
+            dataStream: 'logs-test-default',
+            start: 1234567890,
+            end: 1234567900,
+            isServerless: false,
+          })
+        ).rejects.toThrow('Internal Server Error');
+      });
+    });
+
+    describe('size calculation', () => {
+      it('calculates average doc size in bytes for serverless', async () => {
+        mockGetDataStreamsMeteringStats.mockResolvedValue({
+          'logs-test-default': {
+            totalDocs: 20,
+            sizeBytes: 30,
+          },
+        } as any);
+
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-test-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: true,
+        });
+
+        // avgDocSizeInBytes = 30 / 20 = 1.5
+        // sizeBytes = Math.ceil(1.5 * 1000) = 1500
+        expect(result.sizeBytes).toBe(1500);
+      });
+
+      it('calculates average doc size in bytes for non-serverless', async () => {
+        mockESClient.indices.stats.mockResolvedValue({
+          _all: {
+            total: {
+              docs: { count: 20 },
+              store: { size_in_bytes: 30 },
+            },
+          },
+        } as any);
+
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-test-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: false,
+        });
+
+        // avgDocSizeInBytes = 30 / 20 = 1.5
+        // sizeBytes = Math.ceil(1.5 * 1000) = 1500
+        expect(result.sizeBytes).toBe(1500);
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/index.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/index.ts
@@ -98,6 +98,7 @@ export async function getDataStreamDetails({
         canManageFailureStore: dataStreamPrivileges[MANAGE_FAILURE_STORE_PRIVILEGE],
       },
       customRetentionPeriod: esDataStream?.customRetentionPeriod,
+      defaultRetentionPeriod: esDataStream?.defaultRetentionPeriod,
     };
   } catch (e) {
     // Respond with empty object if data stream does not exist

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_streams_default_retention_period/get_data_streams_default_retention_period.test.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_streams_default_retention_period/get_data_streams_default_retention_period.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { getDataStreamDefaultRetentionPeriod } from '.';
+
+describe('getDataStreamDefaultRetentionPeriod', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns persistent retention setting when available', async () => {
+    const esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+    esClientMock.cluster.getSettings.mockResolvedValue({
+      persistent: {
+        data_streams: {
+          lifecycle: {
+            retention: {
+              failures_default: '7d',
+            },
+          },
+        },
+      },
+      transient: {},
+      defaults: {},
+    });
+
+    const result = await getDataStreamDefaultRetentionPeriod({
+      esClient: esClientMock,
+    });
+
+    expect(esClientMock.cluster.getSettings).toHaveBeenCalledWith({
+      include_defaults: true,
+    });
+    expect(result).toBe('7d');
+  });
+
+  it('returns defaults retention setting when persistent is not available', async () => {
+    const esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+    esClientMock.cluster.getSettings.mockResolvedValue({
+      persistent: {},
+      transient: {},
+      defaults: {
+        data_streams: {
+          lifecycle: {
+            retention: {
+              failures_default: '30d',
+            },
+          },
+        },
+      },
+    });
+
+    const result = await getDataStreamDefaultRetentionPeriod({
+      esClient: esClientMock,
+    });
+
+    expect(esClientMock.cluster.getSettings).toHaveBeenCalledWith({
+      include_defaults: true,
+    });
+    expect(result).toBe('30d');
+  });
+
+  it('returns undefined when neither persistent nor defaults have retention settings', async () => {
+    const esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+    esClientMock.cluster.getSettings.mockResolvedValue({
+      persistent: {},
+      transient: {},
+      defaults: {},
+    });
+
+    const result = await getDataStreamDefaultRetentionPeriod({
+      esClient: esClientMock,
+    });
+
+    expect(esClientMock.cluster.getSettings).toHaveBeenCalledWith({
+      include_defaults: true,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when user lacks permissions (403 error)', async () => {
+    const esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+    const error = new Error('Forbidden');
+    (error as any).meta = { statusCode: 403 };
+    esClientMock.cluster.getSettings.mockRejectedValue(error);
+
+    const result = await getDataStreamDefaultRetentionPeriod({
+      esClient: esClientMock,
+    });
+
+    expect(esClientMock.cluster.getSettings).toHaveBeenCalledWith({
+      include_defaults: true,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('throws error for non-403 errors', async () => {
+    const esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+    const error = new Error('Internal Server Error');
+    (error as any).meta = { statusCode: 500 };
+    esClientMock.cluster.getSettings.mockRejectedValue(error);
+
+    await expect(
+      getDataStreamDefaultRetentionPeriod({
+        esClient: esClientMock,
+      })
+    ).rejects.toThrow('Internal Server Error');
+
+    expect(esClientMock.cluster.getSettings).toHaveBeenCalledWith({
+      include_defaults: true,
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_streams_default_retention_period/index.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_streams_default_retention_period/index.ts
@@ -7,18 +7,25 @@
 
 import type { ElasticsearchClient } from '@kbn/core/server';
 
-// In case this retention is not present in cluster.
-// This is extracted from the docs that indicate that a thirty day (30d) retention is applied to failure store data:
-// https://www.elastic.co/docs/manage-data/data-store/data-streams/failure-store#manage-failure-store-lifecycle
-const DEFAULT_RETENTION_PERIOD = '30d';
-
 export async function getDataStreamDefaultRetentionPeriod({
   esClient,
 }: {
   esClient: ElasticsearchClient;
 }) {
-  const { persistent, defaults } = await esClient.cluster.getSettings({ include_defaults: true });
-  const persistentDSRetention = persistent?.data_streams?.lifecycle?.retention?.failures_default;
-  const defaultsDSRetention = defaults?.data_streams?.lifecycle?.retention?.failures_default;
-  return persistentDSRetention ?? defaultsDSRetention ?? DEFAULT_RETENTION_PERIOD;
+  let defaultRetention: string | undefined;
+  try {
+    const { persistent, defaults } = await esClient.cluster.getSettings({
+      include_defaults: true,
+    });
+    const persistentDSRetention = persistent?.data_streams?.lifecycle?.retention?.failures_default;
+    const defaultsDSRetention = defaults?.data_streams?.lifecycle?.retention?.failures_default;
+    defaultRetention = persistentDSRetention ?? defaultsDSRetention;
+  } catch (e) {
+    if (e.meta?.statusCode === 403) {
+      // if user doesn't have permissions to read cluster settings, we just return undefined
+    } else {
+      throw e;
+    }
+  }
+  return defaultRetention;
 }

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/routes.test.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/routes.test.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { loggerMock } from '@kbn/logging-mocks';
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { getDataStreamDetails } from './get_data_stream_details';
+import { getDataStreamDefaultRetentionPeriod } from './get_data_streams_default_retention_period';
+import { dataStreamsRouteRepository } from './routes';
+import type { DatasetQualityRouteHandlerResources } from '../types';
+
+const handler =
+  dataStreamsRouteRepository['GET /internal/dataset_quality/data_streams/{dataStream}/details']
+    .handler;
+
+jest.mock('./get_data_stream_details');
+jest.mock('./get_data_streams_default_retention_period');
+
+const mockGetDataStreamDetails = getDataStreamDetails as jest.MockedFunction<
+  typeof getDataStreamDetails
+>;
+const mockGetDataStreamDefaultRetentionPeriod =
+  getDataStreamDefaultRetentionPeriod as jest.MockedFunction<
+    typeof getDataStreamDefaultRetentionPeriod
+  >;
+
+describe('dataStreamDetailsRoute', () => {
+  let mockResources: DatasetQualityRouteHandlerResources & {
+    params: {
+      path: { dataStream: string };
+      query: { start: number; end: number };
+    };
+  };
+  let mockLogger: ReturnType<typeof loggerMock.create>;
+  let mockRequest: ReturnType<typeof httpServerMock.createKibanaRequest>;
+  let mockEsClient: ReturnType<typeof elasticsearchServiceMock.createScopedClusterClient>;
+
+  beforeEach(() => {
+    mockLogger = loggerMock.create();
+    mockRequest = httpServerMock.createKibanaRequest();
+    mockEsClient = elasticsearchServiceMock.createScopedClusterClient();
+
+    mockResources = {
+      context: {
+        core: Promise.resolve({
+          elasticsearch: {
+            client: mockEsClient,
+          },
+          savedObjects: {
+            client: jest.fn(),
+          },
+          uiSettings: {
+            client: jest.fn(),
+          },
+        }),
+      } as any,
+      logger: mockLogger,
+      request: mockRequest,
+      plugins: {
+        fleet: {
+          setup: {} as any,
+          start: jest.fn().mockResolvedValue({
+            packageService: {
+              asScoped: jest.fn().mockReturnValue({}),
+            },
+          }),
+        },
+      } as any,
+      getEsCapabilities: jest.fn(),
+      params: {
+        path: {
+          dataStream: 'logs-test-default',
+        },
+        query: {
+          start: 1234567890,
+          end: 1234567900,
+        },
+      },
+    } as any;
+
+    mockGetDataStreamDetails.mockResolvedValue({
+      docsCount: 1000,
+      degradedDocsCount: 50,
+      services: { 'service.name': ['service1', 'service2'] },
+      hosts: { 'host.name': ['host1', 'host2'] },
+      failedDocsCount: 10,
+      sizeBytes: 5000000,
+      hasFailureStore: true,
+      lastActivity: 1234567890,
+      userPrivileges: {
+        canMonitor: true,
+        canReadFailureStore: true,
+        canManageFailureStore: true,
+      },
+      customRetentionPeriod: '7d',
+    });
+
+    mockGetDataStreamDefaultRetentionPeriod.mockResolvedValue('30d');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('non-serverless', () => {
+    beforeEach(() => {
+      (mockResources.getEsCapabilities as jest.Mock).mockResolvedValue({
+        serverless: false,
+      });
+    });
+
+    it('does not fetch default retention period when already present in details', async () => {
+      mockGetDataStreamDetails.mockResolvedValue({
+        docsCount: 1000,
+        degradedDocsCount: 50,
+        services: {},
+        hosts: {},
+        sizeBytes: 5000000,
+        userPrivileges: {
+          canMonitor: true,
+          canReadFailureStore: true,
+          canManageFailureStore: true,
+        },
+        defaultRetentionPeriod: '14d',
+      });
+
+      const result = await handler(mockResources);
+
+      expect(mockGetDataStreamDefaultRetentionPeriod).not.toHaveBeenCalled();
+      expect(result.defaultRetentionPeriod).toBe('14d');
+    });
+
+    it('fetch default retention period if not present in details', async () => {
+      mockGetDataStreamDetails.mockResolvedValue({
+        docsCount: 1000,
+        degradedDocsCount: 50,
+        services: {},
+        hosts: {},
+        sizeBytes: 5000000,
+        userPrivileges: {
+          canMonitor: true,
+          canReadFailureStore: true,
+          canManageFailureStore: true,
+        },
+      });
+
+      const result = await handler(mockResources);
+
+      expect(mockGetDataStreamDetails).toHaveBeenCalledWith({
+        esClient: mockEsClient,
+        dataStream: 'logs-test-default',
+        start: 1234567890,
+        end: 1234567900,
+        isServerless: false,
+      });
+
+      expect(mockGetDataStreamDefaultRetentionPeriod).toHaveBeenCalledWith({
+        esClient: mockEsClient.asCurrentUser,
+      });
+      expect(result.defaultRetentionPeriod).toBe('30d');
+    });
+
+    it('returns undefined default retention period if not available', async () => {
+      mockGetDataStreamDetails.mockResolvedValue({
+        docsCount: 1000,
+        degradedDocsCount: 50,
+        services: {},
+        hosts: {},
+        sizeBytes: 5000000,
+        userPrivileges: {
+          canMonitor: true,
+          canReadFailureStore: true,
+          canManageFailureStore: true,
+        },
+      });
+      mockGetDataStreamDefaultRetentionPeriod.mockResolvedValue(undefined);
+
+      const result = await handler(mockResources);
+
+      expect(result.defaultRetentionPeriod).toBe(undefined);
+    });
+
+    it('returns empty object when getDataStreamDetails returns empty object', async () => {
+      mockGetDataStreamDetails.mockResolvedValue({});
+
+      const result = await handler(mockResources);
+
+      expect(mockGetDataStreamDefaultRetentionPeriod).not.toHaveBeenCalled();
+      expect(result).toEqual({});
+    });
+
+    it('returns empty object when getDataStreamDetails returns null', async () => {
+      mockGetDataStreamDetails.mockResolvedValue(null as any);
+
+      const result = await handler(mockResources);
+
+      expect(mockGetDataStreamDefaultRetentionPeriod).not.toHaveBeenCalled();
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('serverless', () => {
+    beforeEach(() => {
+      (mockResources.getEsCapabilities as jest.Mock).mockResolvedValue({
+        serverless: true,
+      });
+    });
+
+    it('returns retention period when present in details', async () => {
+      mockGetDataStreamDetails.mockResolvedValue({
+        docsCount: 1000,
+        degradedDocsCount: 50,
+        services: {},
+        hosts: {},
+        sizeBytes: 5000000,
+        userPrivileges: {
+          canMonitor: true,
+          canReadFailureStore: true,
+          canManageFailureStore: true,
+        },
+        defaultRetentionPeriod: '14d',
+      });
+
+      const result = await handler(mockResources);
+
+      expect(mockGetDataStreamDefaultRetentionPeriod).not.toHaveBeenCalled();
+
+      expect(result.defaultRetentionPeriod).toBe('14d');
+    });
+
+    it('returns undefined default retention period if not available in details', async () => {
+      mockGetDataStreamDetails.mockResolvedValue({
+        docsCount: 1000,
+        degradedDocsCount: 50,
+        services: {},
+        hosts: {},
+        sizeBytes: 5000000,
+        userPrivileges: {
+          canMonitor: true,
+          canReadFailureStore: true,
+          canManageFailureStore: true,
+        },
+      });
+      const result = await handler(mockResources);
+
+      expect(mockGetDataStreamDefaultRetentionPeriod).not.toHaveBeenCalled();
+
+      expect(result.defaultRetentionPeriod).toBeUndefined();
+    });
+
+    it('returns empty object when getDataStreamDetails returns empty in serverless', async () => {
+      mockGetDataStreamDetails.mockResolvedValue({});
+
+      const result = await handler(mockResources);
+
+      expect(mockGetDataStreamDefaultRetentionPeriod).not.toHaveBeenCalled();
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/routes.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/routes.ts
@@ -490,12 +490,15 @@ const dataStreamDetailsRoute = createDatasetQualityServerRoute({
     if (!dataStreamDetails || Object.keys(dataStreamDetails).length === 0) {
       return {} as DataStreamDetails;
     }
+    const details = { ...dataStreamDetails };
 
-    const defaultRetentionPeriod = await getDataStreamDefaultRetentionPeriod({
-      esClient: esClient.asSecondaryAuthUser,
-    });
+    if (!isServerless && details.defaultRetentionPeriod === undefined) {
+      details.defaultRetentionPeriod = await getDataStreamDefaultRetentionPeriod({
+        esClient: esClient.asCurrentUser,
+      });
+    }
 
-    return { ...dataStreamDetails, defaultRetentionPeriod };
+    return details;
   },
 });
 

--- a/x-pack/platform/plugins/shared/dataset_quality/tsconfig.json
+++ b/x-pack/platform/plugins/shared/dataset_quality/tsconfig.json
@@ -70,7 +70,9 @@
     "@kbn/unified-search-plugin",
     "@kbn/usage-collection-plugin",
     "@kbn/xstate-utils",
-    "@kbn/failure-store-modal"
+    "@kbn/failure-store-modal",
+    "@kbn/logging-mocks",
+    "@kbn/core-http-server-mocks"
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
## Summary

For consistency with the work done in the Retention tab, this PR modifies how the "default period" value is fetched [related [comment](https://github.com/elastic/kibana/pull/234303#discussion_r2363798206)].
* If the default value is already available in the data stream info because it has the `default_failures_retention` assigned, return the `effective_retention`.
* Otherwise, fetch the info from the cluster if the user has the needed permissions. This API is not available in serverless so in that case it would return undefined. 
* The modal now accepts `defaultRetentionPeriod` to be undefined so it would display an informative banner instead of the retention period in disabled mode.

<img width="1226" height="726" alt="Screenshot 2025-09-29 at 15 22 26" src="https://github.com/user-attachments/assets/27565c25-6e7e-4294-a2d0-3da095fff7ec" />