### PR TITLE
[Renovate] Update ownership information for chromedriver

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3569,6 +3569,14 @@
       "matchDepNames": [
         "chromedriver"
       ],
+      "reviewers": [
+        "team:kibana-operations"
+      ],
+      "labels": [
+        "Team:Operations",
+        "release_note:skip",
+        "backport:skip"
+      ],
       "enabled": true
     },
     {


### PR DESCRIPTION
## Summary

Followup from https://github.com/elastic/kibana/pull/220307.
It appears that Chromium PRs are raised without team ownership information. This attempts to correct that by duplicating this config to both of our chromium groups in `renovate.json`.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->