### PR TITLE
[Renovate] Remove duplicated monaco-yaml group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4153,25 +4153,6 @@
       "enabled": true
     },
     {
-      "groupName": "Cloud Defend",
-      "matchDepNames": [
-        "monaco-yaml"
-      ],
-      "reviewers": [
-        "team:sec-cloudnative-integrations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team: Cloud Native Integrations",
-        "release_note:skip",
-        "backport:skip"
-      ],
-      "minimumReleaseAge": "14 days",
-      "enabled": true
-    },
-    {
       "groupName": "JSON Web Token",
       "matchDepNames": [
         "jsonwebtoken",


### PR DESCRIPTION
## Summary

`monaco-yaml` is already covered by an existing dependency group. This PR removes the extra (& invalid) declaration.

Resolves https://github.com/elastic/kibana/issues/236779

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->