### PR TITLE
kbn-typed-react-router-config: Remove observability-specificness

### DIFF
--- a/src/platform/packages/shared/kbn-typed-react-router-config/tsconfig.json
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/tsconfig.json
@@ -16,10 +16,7 @@
     "@kbn/io-ts-utils",
     "@kbn/shared-ux-router",
     "@kbn/core",
-    "@kbn/i18n",
     "@kbn/kibana-react-plugin",
-    "@kbn/core-chrome-browser",
-    "@kbn/serverless"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
There was some existing logic in the internal `useBreadcrumbs` function of the kbn-typed-react-router-config package which was only used by streams. This logic would add a link to the observability overview app for the classic nav.

Since streams is not an observability app, this isn't required. I first thought about making this behavior configurable, but since no other consumer depends on it, I just removed it for now. We can bring it back when necessary, but it should happen in a solution-agnostic way since this package is not necessarily only used for observability.