### PR TITLE
[Fleet] remove incorrect `fleet.ssl` config

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -1704,11 +1704,9 @@ describe('generateFleetConfig', () => {
 
   it('should work without proxy', () => {
     const res = generateFleetConfig(
-      agentPolicy,
       {
         host_urls: ['https://test.fr'],
       } as any,
-      [],
       []
     );
 
@@ -1723,7 +1721,6 @@ describe('generateFleetConfig', () => {
 
   it('should work with proxy', () => {
     const res = generateFleetConfig(
-      agentPolicy,
       {
         host_urls: ['https://test.fr'],
         proxy_id: 'proxy-1',
@@ -1733,8 +1730,7 @@ describe('generateFleetConfig', () => {
           id: 'proxy-1',
           url: 'https://proxy.fr',
         } as any,
-      ],
-      []
+      ]
     );
 
     expect(res).toMatchInlineSnapshot(`
@@ -1749,7 +1745,6 @@ describe('generateFleetConfig', () => {
 
   it('should work with proxy with headers and certificate authorities', () => {
     const res = generateFleetConfig(
-      agentPolicy,
       {
         host_urls: ['https://test.fr'],
         proxy_id: 'proxy-1',
@@ -1761,8 +1756,7 @@ describe('generateFleetConfig', () => {
           certificate_authorities: ['/tmp/ssl/ca.crt'],
           proxy_headers: { Authorization: 'xxx' },
         } as any,
-      ],
-      []
+      ]
     );
 
     expect(res).toMatchInlineSnapshot(`
@@ -1789,7 +1783,6 @@ describe('generateFleetConfig', () => {
 
   it('should work with proxy with headers and certificate authorities and certificate and key', () => {
     const res = generateFleetConfig(
-      agentPolicy,
       {
         host_urls: ['https://test.fr'],
         proxy_id: 'proxy-1',
@@ -1803,8 +1796,7 @@ describe('generateFleetConfig', () => {
           certificate: 'my-cert',
           certificate_key: 'my-key',
         } as any,
-      ],
-      []
+      ]
     );
 
     expect(res).toMatchInlineSnapshot(`
@@ -1829,263 +1821,6 @@ describe('generateFleetConfig', () => {
       },
     }
   `);
-  });
-
-  it('should generate ssl config when a default ES output has ssl options', () => {
-    const outputs = [
-      {
-        id: 'output-1',
-        name: 'Output 1',
-        type: 'elasticsearch',
-        is_default_monitoring: true,
-        is_default: true,
-        hosts: ['http://test.fr:9200'],
-        ssl: {
-          certificate_authorities: ['/tmp/ssl/ca.crt'],
-          certificate: 'my-cert',
-          key: 'my-key',
-        },
-      },
-      {
-        id: 'output-2',
-        name: 'Output 2',
-        type: 'remote_elasticsearch',
-        is_default_monitoring: false,
-        hosts: ['http://test.fr:9200'],
-        is_default: false,
-      },
-    ] as any;
-
-    const res = generateFleetConfig(
-      agentPolicy,
-      {
-        host_urls: ['https://test.fr'],
-      } as any,
-      [], // no proxies
-      outputs
-    );
-
-    expect(res).toEqual({
-      hosts: ['https://test.fr'],
-      ssl: {
-        certificate: 'my-cert',
-        certificate_authorities: ['/tmp/ssl/ca.crt'],
-        key: 'my-key',
-      },
-    });
-  });
-
-  it('should generate ssl config when a default remote_elasticsearch output has ssl options', () => {
-    const outputs = [
-      {
-        id: 'output-1',
-        name: 'Output 1',
-        type: 'remote_elasticsearch',
-        is_default_monitoring: true,
-        is_default: true,
-        hosts: ['http://test.fr:9200'],
-        ssl: {
-          certificate_authorities: ['/tmp/ssl/ca.crt'],
-          certificate: 'my-cert',
-          key: 'my-key',
-        },
-        secrets: {
-          service_token: { id: 'my-service-token' },
-        },
-      },
-      {
-        id: 'output-2',
-        name: 'Output 2',
-        type: 'remote_elasticsearch',
-        is_default_monitoring: false,
-        hosts: ['http://test.fr:9200'],
-        is_default: false,
-      },
-    ] as any;
-
-    const res = generateFleetConfig(
-      agentPolicy,
-      {
-        host_urls: ['https://test.fr'],
-      } as any,
-      [], // no proxies
-      outputs
-    );
-
-    expect(res).toEqual({
-      hosts: ['https://test.fr'],
-      ssl: {
-        certificate: 'my-cert',
-        certificate_authorities: ['/tmp/ssl/ca.crt'],
-        key: 'my-key',
-      },
-      secrets: {
-        service_token: { id: 'my-service-token' },
-      },
-    });
-  });
-
-  it('should generate ssl config when a ES custom output has ssl options', () => {
-    const outputs = [
-      {
-        id: 'output-1',
-        name: 'Output 1',
-        type: 'elasticsearch',
-        is_default: true,
-        hosts: ['http://test.fr:9200'],
-      },
-      {
-        id: 'output-2',
-        name: 'Output 2',
-        type: 'elasticsearch',
-        is_default_monitoring: false,
-        hosts: ['http://test.fr:9200'],
-        is_default: false,
-        ssl: {
-          certificate_authorities: ['/tmp/ssl/ca.crt'],
-          certificate: 'my-cert',
-        },
-        secrets: {
-          ssl: {
-            key: { id: 'my-key' },
-          },
-        },
-      },
-    ] as any;
-
-    const agentPolicyWithCustomOutput = { ...agentPolicy, data_output_id: 'output-2' };
-    const res = generateFleetConfig(
-      agentPolicyWithCustomOutput,
-      {
-        host_urls: ['https://test.fr'],
-      } as any,
-      [], // no proxies
-      outputs
-    );
-
-    expect(res).toEqual({
-      hosts: ['https://test.fr'],
-      secrets: {
-        ssl: {
-          key: { id: 'my-key' },
-        },
-      },
-      ssl: {
-        certificate: 'my-cert',
-        certificate_authorities: ['/tmp/ssl/ca.crt'],
-      },
-    });
-  });
-
-  it('should generate ssl config when a remote_elasticsearch custom output has ssl options', () => {
-    const outputs = [
-      {
-        id: 'output-1',
-        name: 'Output 1',
-        type: 'elasticsearch',
-        is_default: true,
-        hosts: ['http://test.fr:9200'],
-      },
-      {
-        id: 'output-2',
-        name: 'Output 2',
-        type: 'remote_elasticsearch',
-        is_default_monitoring: false,
-        hosts: ['http://test.fr:9200'],
-        is_default: false,
-        ssl: {
-          certificate_authorities: ['/tmp/ssl/ca.crt'],
-          certificate: 'my-cert',
-        },
-        secrets: {
-          ssl: {
-            key: { id: 'my-key' },
-          },
-        },
-      },
-    ] as any;
-
-    const agentPolicyWithCustomOutput = { ...agentPolicy, data_output_id: 'output-2' };
-    const res = generateFleetConfig(
-      agentPolicyWithCustomOutput,
-      {
-        host_urls: ['https://test.fr'],
-      } as any,
-      [], // no proxies
-      outputs
-    );
-
-    expect(res).toEqual({
-      hosts: ['https://test.fr'],
-      secrets: {
-        ssl: {
-          key: {
-            id: 'my-key',
-          },
-        },
-      },
-      ssl: {
-        certificate: 'my-cert',
-        certificate_authorities: ['/tmp/ssl/ca.crt'],
-      },
-    });
-  });
-
-  it('should use secrets key if both keys are present', () => {
-    const outputs = [
-      {
-        id: 'output-1',
-        name: 'Output 1',
-        type: 'elasticsearch',
-        is_default: true,
-        hosts: ['http://test.fr:9200'],
-      },
-      {
-        id: 'output-2',
-        name: 'Output 2',
-        type: 'remote_elasticsearch',
-        is_default_monitoring: false,
-        hosts: ['http://test.fr:9200'],
-        is_default: false,
-        ssl: {
-          certificate_authorities: ['/tmp/ssl/ca.crt'],
-          certificate: 'my-cert',
-          key: { id: 'my-key' },
-        },
-        secrets: {
-          ssl: {
-            key: { id: 'my-secret-key' },
-          },
-          service_token: { id: 'my-service-token' },
-        },
-      },
-    ] as any;
-
-    const agentPolicyWithCustomOutput = { ...agentPolicy, data_output_id: 'output-2' };
-    const res = generateFleetConfig(
-      agentPolicyWithCustomOutput,
-      {
-        host_urls: ['https://test.fr'],
-      } as any,
-      [],
-      outputs
-    );
-
-    expect(res).toEqual({
-      hosts: ['https://test.fr'],
-      secrets: {
-        ssl: {
-          key: {
-            id: 'my-secret-key',
-          },
-        },
-        service_token: { id: 'my-service-token' },
-      },
-      ssl: {
-        certificate: 'my-cert',
-        certificate_authorities: ['/tmp/ssl/ca.crt'],
-      },
-    });
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -1689,19 +1689,6 @@ ssl.test: 123
 });
 
 describe('generateFleetConfig', () => {
-  const agentPolicy = {
-    id: 'agent-policy',
-    status: 'active',
-    package_policies: [],
-    is_managed: false,
-    namespace: 'default',
-    revision: 1,
-    name: 'Policy',
-    updated_at: '2020-01-01',
-    updated_by: 'qwerty',
-    is_protected: false,
-  } as any;
-
   it('should work without proxy', () => {
     const res = generateFleetConfig(
       {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/233780

Remove the `fleet.ssl` config generated from the ES output incorrectly in the full agent policy.

The `fleet.ssl` settings should be generated from the new UI settings that will be added here: https://github.com/elastic/kibana/issues/233753

To verify:
- create an ES output with SSL config
- use the output in an Agent policy
- View policy yaml
- Verify that the SSL config is under `outputs[output_id].ssl`, not `fleet.ssl`

<img width="599" height="650" alt="image" src="https://github.com/user-attachments/assets/fa66047e-203b-41f5-a94b-ed90e841e7e1" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->