### PR TITLE
[9.0] [Ranovate] Remove duplicated monaco-yaml group (#236774)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4016,25 +4016,6 @@
       "enabled": true
     },
     {
-      "groupName": "Cloud Defend",
-      "matchDepNames": [
-        "monaco-yaml"
-      ],
-      "reviewers": [
-        "team:sec-cloudnative-integrations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team: Cloud Native Integrations",
-        "release_note:skip",
-        "backport:skip"
-      ],
-      "minimumReleaseAge": "7 days",
-      "enabled": true
-    },
-    {
       "groupName": "JSON Web Token",
       "matchDepNames": [
         "jsonwebtoken",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Ranovate] Remove duplicated monaco-yaml group (#236774)](https://github.com/elastic/kibana/pull/236774)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2025-09-29T14:45:14Z","message":"[Ranovate] Remove duplicated monaco-yaml group (#236774)\n\n## Summary\n\n`monaco-yaml` is already covered by an existing dependency group. This\nPR removes the extra (& invalid) declaration.","sha":"dd905d5aebe3a18c7b7c8f8d827904cfc77c3592","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:all-open","v9.2.0"],"title":"[Renovate] Remove duplicated monaco-yaml group","number":236774,"url":"https://github.com/elastic/kibana/pull/236774","mergeCommit":{"message":"[Ranovate] Remove duplicated monaco-yaml group (#236774)\n\n## Summary\n\n`monaco-yaml` is already covered by an existing dependency group. This\nPR removes the extra (& invalid) declaration.","sha":"dd905d5aebe3a18c7b7c8f8d827904cfc77c3592"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236774","number":236774,"mergeCommit":{"message":"[Ranovate] Remove duplicated monaco-yaml group (#236774)\n\n## Summary\n\n`monaco-yaml` is already covered by an existing dependency group. This\nPR removes the extra (& invalid) declaration.","sha":"dd905d5aebe3a18c7b7c8f8d827904cfc77c3592"}}]}] BACKPORT-->