### PR TITLE
[Streams] Reorder ilm retention

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/ilm_summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/ilm_summary.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { capitalize, last } from 'lodash';
+import { capitalize, first } from 'lodash';
 import React, { useMemo } from 'react';
 import type { IlmPolicyDeletePhase, IlmPolicyPhase, Streams } from '@kbn/streams-schema';
 import { i18n } from '@kbn/i18n';
@@ -57,17 +57,17 @@ export function IlmSummary({
   const phasesWithGrow = useMemo(() => {
     if (!value) return undefined;
 
-    const orderedPhases = orderIlmPhases(value.phases);
-    const totalDuration = parseDurationInSeconds(last(orderedPhases)!.min_age);
+    const orderedPhases = orderIlmPhases(value.phases).reverse();
+    const totalDuration = parseDurationInSeconds(first(orderedPhases)!.min_age);
 
     return orderedPhases.map((phase, index, phases) => {
-      const nextPhase = phases[index + 1];
-      if (!nextPhase) {
+      const prevPhase = phases[index - 1];
+      if (!prevPhase) {
         return { ...phase, grow: phase.name === 'delete' ? false : 2 };
       }
 
       const phaseDuration =
-        parseDurationInSeconds(nextPhase!.min_age) - parseDurationInSeconds(phase!.min_age);
+        parseDurationInSeconds(prevPhase!.min_age) - parseDurationInSeconds(phase!.min_age);
       return {
         ...phase,
         grow: Math.max(2, Math.round((phaseDuration / totalDuration) * 10)),
@@ -100,7 +100,7 @@ export function IlmSummary({
                 key={`${phase.name}-timeline`}
                 grow={phase.grow as false | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10}
               >
-                <IlmPhase phase={phase} minAge={phasesWithGrow[index + 1]?.min_age} />
+                <IlmPhase phase={phase} minAge={phasesWithGrow[index - 1]?.min_age} />
               </EuiFlexItem>
             ))}
           </EuiFlexGroup>
@@ -120,15 +120,15 @@ function IlmPhase({
   const borderRadius =
     phase.name === 'delete'
       ? minAge
-        ? '0px'
-        : '0px 4px 4px 0px'
+        ? '4px 4px 4px 4px'
+        : '4px 0px 0px 4px'
       : phase.name === 'hot'
       ? minAge
-        ? '4px 0px 0px 4px'
-        : '4px 4px 4px 4px'
+        ? '0px 4px 4px 0px'
+        : '0px'
       : minAge
       ? '0px'
-      : '0px 4px 4px 0px';
+      : '4px 0px 0px 4px';
   const { ilmPhases } = useIlmPhasesColorAndDescription();
   const { euiTheme } = useEuiTheme();
 
@@ -168,11 +168,11 @@ function IlmPhase({
             </EuiText>
           ) : (
             <>
-              <EuiText size="xs" color={euiTheme.colors.plainDark}>
+              <EuiText size="xs" color={euiTheme.colors.plainDark} textAlign="right">
                 <b>{capitalize(phase.name)}</b>
               </EuiText>
               {'size_in_bytes' in phase && (
-                <EuiText size="xs" color={euiTheme.colors.plainDark}>
+                <EuiText size="xs" color={euiTheme.colors.plainDark} textAlign="right">
                   {formatBytes(phase.size_in_bytes)}
                 </EuiText>
               )}
@@ -188,18 +188,18 @@ function IlmPhase({
           css={{
             paddingBottom: '5px',
             ...(phase.name !== 'delete' && {
-              borderRight: `1px solid ${ilmPhases.delete.color}`,
+              borderLeft: `1px solid ${ilmPhases.delete.color}`,
             }),
           }}
         />
       </EuiFlexGroup>
 
-      <EuiFlexGroup justifyContent="flexEnd">
+      <EuiFlexGroup justifyContent="flexStart">
         {phase.name !== 'delete' ? (
           <EuiPanel
             paddingSize="xs"
             css={{
-              marginRight: minAge ? '-40px' : '-10px',
+              marginLeft: minAge ? '-40px' : '-10px',
               width: minAge ? '80px' : '20px',
             }}
             grow={false}


### PR DESCRIPTION
## Summary
Small fix for the ILM policy data tiers. As per papercut docs:

> Reverse ILM policy data tiers order. There are some conversations about having hot in the same order for both charts, which would leave us with hot on the right of the ILM Policy data tiers to match how it appears on ingestion overtime (most recent, on the right, being hot.) Make sure to align the text to the right.

<img width="993" height="340" alt="Screenshot 2025-09-29 at 17 32 13" src="https://github.com/user-attachments/assets/8245a376-476f-48be-9fda-edbd35b1fec5" />

Changed ILM sreenshot:
<img width="1492" height="383" alt="Screenshot 2025-09-29 at 17 19 18" src="https://github.com/user-attachments/assets/a57741ce-9827-4521-a945-d13c81886641" />
