### PR TITLE
[ES|QL] fix: keyword fields displayed as text in index editor

### DIFF
--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -426,7 +426,7 @@ export class IndexUpdateService {
                 },
                 aggregatable: field.aggregatable,
                 searchable: field.searchable,
-                esTypes: field.esTypes,
+                esType: field.esTypes?.at(0),
               },
             } as DatatableColumn;
           })

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -12,7 +12,7 @@ import type { HttpStart, NotificationsStart } from '@kbn/core/public';
 import { type DataPublicPluginStart, KBN_FIELD_TYPES } from '@kbn/data-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import type { DatatableColumn } from '@kbn/expressions-plugin/common';
+import type { DatatableColumn, DatatableColumnType } from '@kbn/expressions-plugin/common';
 import { groupBy, times, zipObject } from 'lodash';
 import {
   BehaviorSubject,
@@ -405,32 +405,24 @@ export class IndexUpdateService {
           });
         });
 
-      return (
-        dataView.fields
-          .concat(unsavedFields)
-          // Exclude metadata fields. TODO check if this is the right way to do it
-          // @ts-ignore
-          .filter((field) => field.spec.metadata_field !== true && !field.spec.subType)
-          .map((field) => {
-            return {
-              name: field.name,
-              id: field.name,
-              isNull: field.isNull,
-              meta: {
-                type: field.type,
-                params: {
-                  id: field.name,
-                  sourceParams: {
-                    fieldName: field.name,
-                  },
-                },
-                aggregatable: field.aggregatable,
-                searchable: field.searchable,
-                esType: field.esTypes?.at(0),
+      return dataView.fields
+        .concat(unsavedFields)
+        .filter((field) => field.spec.metadata_field !== true && !field.spec.subType)
+        .map((field) => {
+          const datatableColumn: DatatableColumn = {
+            name: field.name,
+            id: field.name,
+            isNull: field.isNull,
+            meta: {
+              type: field.type as DatatableColumnType,
+              params: {
+                id: field.name,
               },
-            } as DatatableColumn;
-          })
-      );
+              esType: field.esTypes?.at(0),
+            },
+          };
+          return datatableColumn;
+        });
     }),
     shareReplay({ bufferSize: 1, refCount: true })
   );

--- a/src/platform/test/functional/apps/discover/esql/_index_editor.ts
+++ b/src/platform/test/functional/apps/discover/esql/_index_editor.ts
@@ -94,12 +94,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const gridData = await dataGrid.getDataGridTableData();
         expect(gridData.columns).to.eql([
           'Select column',
-          'Stringcustomer_first_name',
-          'Stringcustomer_full_name',
-          'Stringcustomer_gender',
+          'Keywordcustomer_first_name',
+          'Keywordcustomer_full_name',
+          'Keywordcustomer_gender',
           'Numbercustomer_id',
-          'Stringcustomer_last_name',
-          'Stringemail',
+          'Keywordcustomer_last_name',
+          'Keywordemail',
         ]);
         expect(gridData.rows[0]).to.eql([
           '', // toggles column


### PR DESCRIPTION
## Summary
Keyword fields were displayed with the text icon in the index editor table.

### Before
<img width="1282" height="470" alt="image" src="https://github.com/user-attachments/assets/91a880be-bf58-460d-a0d6-84a54f0a51a1" />

### After
<img width="1288" height="474" alt="image" src="https://github.com/user-attachments/assets/dfbdc69e-9b90-4444-b9ed-d6419cbfeec7" />



