### PR TITLE
[8.19] [Synthetics] Fix overview page vizs for large number of monitors !! (#199512)

### DIFF
--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/lens_attributes.ts
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/lens_attributes.ts
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { capitalize } from 'lodash';
-import { type ExistsFilter, type Query, isExistsFilter } from '@kbn/es-query';
+import { type ExistsFilter, type Query, type Filter, isExistsFilter } from '@kbn/es-query';
 import {
   AvgIndexPatternColumn,
   CardinalityIndexPatternColumn,
@@ -40,6 +40,7 @@ import type { DataView } from '@kbn/data-views-plugin/common';
 import { PersistableFilter } from '@kbn/lens-plugin/common';
 import { DataViewSpec } from '@kbn/data-views-plugin/common';
 import { LegendSize } from '@kbn/visualizations-plugin/common/constants';
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { urlFiltersToKueryString } from '../utils/stringify_kueries';
 import {
   FILTER_RECORDS,
@@ -167,17 +168,20 @@ export class LensAttributes {
   globalFilter?: { query: string; language: string };
   reportType: string;
   lensFormulaHelper?: FormulaPublicApi;
+  dslFilters?: QueryDslQueryContainer[];
 
   constructor(
     layerConfigs: LayerConfig[],
     reportType: string,
-    lensFormulaHelper?: FormulaPublicApi
+    lensFormulaHelper?: FormulaPublicApi,
+    dslFilters?: QueryDslQueryContainer[]
   ) {
     this.layers = {};
     this.seriesReferenceLines = {};
     this.reportType = reportType;
     this.lensFormulaHelper = lensFormulaHelper;
     this.isMultiSeries = layerConfigs.length > 1;
+    this.dslFilters = dslFilters;
 
     layerConfigs.forEach(({ seriesConfig, operationType }) => {
       if (operationType && reportType !== ReportTypes.SINGLE_METRIC) {
@@ -1258,6 +1262,31 @@ export class LensAttributes {
     return { internalReferences, adHocDataViews };
   }
 
+  getFilters(): Filter[] {
+    const { internalReferences } = this.getReferences();
+
+    const dslFilters = this.dslFilters;
+    if (!dslFilters) {
+      return [];
+    }
+    return dslFilters.map((filter) => {
+      return {
+        meta: {
+          index: internalReferences?.[0].id,
+          type: 'query_string',
+          disabled: false,
+          negate: false,
+          alias: null,
+          key: 'query',
+        },
+        $state: {
+          store: 'appState',
+        },
+        query: filter,
+      } as Filter;
+    });
+  }
+
   getJSON(
     visualizationType: 'lnsXY' | 'lnsLegacyMetric' | 'lnsHeatmap' = 'lnsXY',
     lastRefresh?: number
@@ -1281,7 +1310,7 @@ export class LensAttributes {
         },
         visualization: this.visualization,
         query: query || { query: '', language: 'kuery' },
-        filters: [],
+        filters: this.getFilters(),
       },
     };
   }

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/lens_attributes/single_metric_attributes.ts
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/lens_attributes/single_metric_attributes.ts
@@ -10,6 +10,7 @@ import { FormulaPublicApi, MetricState, OperationType } from '@kbn/lens-plugin/p
 import type { DataView } from '@kbn/data-views-plugin/common';
 
 import { Query } from '@kbn/es-query';
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { getColorPalette } from '../synthetics/single_metric_config';
 import { FORMULA_COLUMN, RECORDS_FIELD } from '../constants';
 import { ColumnFilter, MetricOption } from '../../types';
@@ -28,9 +29,10 @@ export class SingleMetricLensAttributes extends LensAttributes {
   constructor(
     layerConfigs: LayerConfig[],
     reportType: string,
-    lensFormulaHelper: FormulaPublicApi
+    lensFormulaHelper: FormulaPublicApi,
+    dslFilters?: QueryDslQueryContainer[]
   ) {
-    super(layerConfigs, reportType, lensFormulaHelper);
+    super(layerConfigs, reportType, lensFormulaHelper, dslFilters);
     this.layers = {};
     this.reportType = reportType;
 
@@ -145,7 +147,7 @@ export class SingleMetricLensAttributes extends LensAttributes {
             ? {
                 id: 'percent',
                 params: {
-                  decimals: 1,
+                  decimals: 3,
                 },
               }
             : undefined,

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
@@ -106,7 +106,7 @@ export function getSyntheticsKPIConfig({ dataView }: ConfigProps): SeriesConfig 
         label: 'Monitor Errors',
         id: 'monitor_errors',
         columnType: OPERATION_COLUMN,
-        field: 'monitor.check_group',
+        field: 'state.id',
         columnFilters: [
           {
             language: 'kuery',

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/single_metric_config.ts
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/single_metric_config.ts
@@ -16,8 +16,7 @@ import { ConfigProps, SeriesConfig } from '../../types';
 import { FieldLabels, FORMULA_COLUMN, RECORDS_FIELD } from '../constants';
 import { buildExistsFilter } from '../utils';
 
-export const FINAL_SUMMARY_KQL =
-  'summary: * and (summary.final_attempt: true or not summary.final_attempt: *)';
+export const FINAL_SUMMARY_KQL = 'summary.final_attempt: true';
 export function getSyntheticsSingleMetricConfig({ dataView }: ConfigProps): SeriesConfig {
   return {
     defaultSeriesType: 'line',

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/test_data/test_formula_metric_attribute.ts
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/test_data/test_formula_metric_attribute.ts
@@ -50,7 +50,7 @@ export const sampleMetricFormulaAttribute = {
                   format: {
                     id: 'percent',
                     params: {
-                      decimals: 1,
+                      decimals: 3,
                     },
                   },
                   formula: "1- (count(kql='summary.down > 0') / count())",

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.tsx
@@ -13,6 +13,7 @@ import { FormulaPublicApi, LensPublicStart, XYState } from '@kbn/lens-plugin/pub
 import { observabilityFeatureId } from '@kbn/observability-shared-plugin/public';
 import styled from 'styled-components';
 import { AnalyticsServiceSetup } from '@kbn/core-analytics-browser';
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { useEBTTelemetry } from '../hooks/use_ebt_telemetry';
 import { AllSeries } from '../../../..';
 import { AppDataType, ReportViewType } from '../types';
@@ -51,6 +52,7 @@ export interface ExploratoryEmbeddableProps {
   lineHeight?: number;
   dataTestSubj?: string;
   searchSessionId?: string;
+  dslFilters?: QueryDslQueryContainer[];
 }
 
 export interface ExploratoryEmbeddableComponentProps extends ExploratoryEmbeddableProps {

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/use_embeddable_attributes.ts
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/use_embeddable_attributes.ts
@@ -21,6 +21,7 @@ export const useEmbeddableAttributes = ({
   reportType,
   reportConfigMap = {},
   lensFormulaHelper,
+  dslFilters,
 }: ExploratoryEmbeddableComponentProps) => {
   const spaceId = useKibanaSpace();
   const theme = useTheme();
@@ -40,7 +41,8 @@ export const useEmbeddableAttributes = ({
         const lensAttributes = new SingleMetricLensAttributes(
           layerConfigs,
           reportType,
-          lensFormulaHelper!
+          lensFormulaHelper!,
+          dslFilters
         );
         return lensAttributes?.getJSON('lnsLegacyMetric');
       } else if (reportType === ReportTypes.HEATMAP) {
@@ -51,7 +53,12 @@ export const useEmbeddableAttributes = ({
         );
         return lensAttributes?.getJSON('lnsHeatmap');
       } else {
-        const lensAttributes = new LensAttributes(layerConfigs, reportType, lensFormulaHelper);
+        const lensAttributes = new LensAttributes(
+          layerConfigs,
+          reportType,
+          lensFormulaHelper,
+          dslFilters
+        );
         return lensAttributes?.getJSON();
       }
     } catch (error) {
@@ -60,6 +67,7 @@ export const useEmbeddableAttributes = ({
   }, [
     attributes,
     dataViewState,
+    dslFilters,
     lensFormulaHelper,
     reportConfigMap,
     reportType,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_filters.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_filters.test.ts
@@ -100,20 +100,17 @@ describe('useMonitorFilters', () => {
   it('should handle a combination of parameters', () => {
     spaceSpy.mockReturnValue({ space: { id: 'space3' } } as any);
     paramSpy.mockReturnValue({
-      schedules: 'daily',
       projects: ['projectA'],
       tags: ['tagB'],
       locations: ['locationC'],
       monitorTypes: 'http',
     } as any);
-    selSPy.mockReturnValue({ status: { allIds: ['id3', 'id4'] } });
 
     const { result } = renderHook(() => useMonitorFilters({ forAlerts: false }), {
       wrapper: WrappedHelper,
     });
 
     expect(result.current).toEqual([
-      { field: 'monitor.id', values: ['id3', 'id4'] },
       { field: 'monitor.project.id', values: ['projectA'] },
       { field: 'monitor.type', values: ['http'] },
       { field: 'tags', values: ['tagB'] },

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_filters.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_filters.test.ts
@@ -100,17 +100,20 @@ describe('useMonitorFilters', () => {
   it('should handle a combination of parameters', () => {
     spaceSpy.mockReturnValue({ space: { id: 'space3' } } as any);
     paramSpy.mockReturnValue({
+      schedules: 'daily',
       projects: ['projectA'],
       tags: ['tagB'],
       locations: ['locationC'],
       monitorTypes: 'http',
     } as any);
+    selSPy.mockReturnValue({ status: { allIds: ['id3', 'id4'] } });
 
     const { result } = renderHook(() => useMonitorFilters({ forAlerts: false }), {
       wrapper: WrappedHelper,
     });
 
     expect(result.current).toEqual([
+      { field: 'monitor.id', values: ['id3', 'id4'] },
       { field: 'monitor.project.id', values: ['projectA'] },
       { field: 'monitor.type', values: ['http'] },
       { field: 'tags', values: ['tagB'] },

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_filters.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_filters.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { UrlFilter } from '@kbn/exploratory-view-plugin/public';
+import type { UrlFilter } from '@kbn/exploratory-view-plugin/public';
 import { useSelector } from 'react-redux';
 import { isEmpty, uniqueId } from 'lodash';
 import { useGetUrlParams } from '../../../hooks/use_url_params';

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_errors/monitor_async_error.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_errors/monitor_async_error.tsx
@@ -36,7 +36,7 @@ export const MonitorAsyncError = () => {
             defaultMessage="There was a problem running your monitors for one or more locations:"
           />
         </p>
-        <ul>
+        <ul style={{ maxHeight: 100, overflow: 'auto' }}>
           {Object.values(syncErrors ?? {}).map((e) => {
             return (
               <li key={e.locationId}>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_stats.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_stats.tsx
@@ -73,9 +73,9 @@ export const MonitorStats = ({
           <EuiFlexItem
             css={{ display: 'flex', flexDirection: 'row', gap: euiTheme.size.l, height: '200px' }}
           >
-            <MonitorTestRunsCount monitorIds={overviewStatus?.allIds ?? []} />
+            <MonitorTestRunsCount />
             <EuiFlexItem grow={true}>
-              <MonitorTestRunsSparkline monitorIds={overviewStatus?.allIds ?? []} />
+              <MonitorTestRunsSparkline />
             </EuiFlexItem>
           </EuiFlexItem>
         </EuiPanel>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs.tsx
@@ -11,31 +11,36 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useTheme } from '@kbn/observability-shared-plugin/public';
 import { ReportTypes } from '@kbn/exploratory-view-plugin/public';
 
+import { useMonitorFilters } from '../../hooks/use_monitor_filters';
 import { useRefreshedRange } from '../../../../hooks';
 import { ClientPluginsStart } from '../../../../../../plugin';
 import * as labels from '../labels';
+import { useMonitorQueryFilters } from '../../hooks/use_monitor_query_filters';
 
-export const MonitorTestRunsCount = ({ monitorIds }: { monitorIds: string[] }) => {
+export const MonitorTestRunsCount = () => {
   const {
     exploratoryView: { ExploratoryViewEmbeddable },
   } = useKibana<ClientPluginsStart>().services;
   const theme = useTheme();
 
   const { from, to } = useRefreshedRange(30, 'days');
+  const filters = useMonitorFilters({});
+  const queryFilter = useMonitorQueryFilters();
 
   return (
     <ExploratoryViewEmbeddable
+      dslFilters={queryFilter}
       align="left"
       reportType={ReportTypes.SINGLE_METRIC}
       attributes={[
         {
+          filters,
           time: { from, to },
           reportDefinitions: {
-            'monitor.id': monitorIds.length > 0 ? monitorIds : ['false-monitor-id'], // Show no data when monitorIds is empty
+            'monitor.type': ['http', 'tcp', 'browser', 'icmp'],
           },
           dataType: 'synthetics',
           selectedMetricField: 'monitor_total_runs',
-          filters: [],
           name: labels.TEST_RUNS_LABEL,
           color: theme.eui.euiColorVis1,
         },

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs_sparkline.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs_sparkline.tsx
@@ -10,11 +10,13 @@ import React, { useMemo } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useTheme } from '@kbn/observability-shared-plugin/public';
 
+import { useMonitorQueryFilters } from '../../hooks/use_monitor_query_filters';
+import { useMonitorFilters } from '../../hooks/use_monitor_filters';
 import { useRefreshedRange } from '../../../../hooks';
 import { ClientPluginsStart } from '../../../../../../plugin';
 import * as labels from '../labels';
 
-export const MonitorTestRunsSparkline = ({ monitorIds }: { monitorIds: string[] }) => {
+export const MonitorTestRunsSparkline = () => {
   const {
     exploratoryView: { ExploratoryViewEmbeddable },
   } = useKibana<ClientPluginsStart>().services;
@@ -22,6 +24,8 @@ export const MonitorTestRunsSparkline = ({ monitorIds }: { monitorIds: string[] 
   const theme = useTheme();
 
   const { from, to } = useRefreshedRange(30, 'days');
+  const filters = useMonitorFilters({});
+  const queryFilter = useMonitorQueryFilters();
 
   const attributes = useMemo(() => {
     return [
@@ -29,18 +33,18 @@ export const MonitorTestRunsSparkline = ({ monitorIds }: { monitorIds: string[] 
         seriesType: 'area' as const,
         time: { from, to },
         reportDefinitions: {
-          'monitor.id': monitorIds.length > 0 ? monitorIds : ['false-monitor-id'], // Show no data when monitorIds is empty
+          'monitor.type': ['http', 'tcp', 'browser', 'icmp'],
         },
         dataType: 'synthetics' as const,
         selectedMetricField: 'total_test_runs',
-        filters: [],
+        filters,
         name: labels.TEST_RUNS_LABEL,
         color: theme.eui.euiColorVis1,
         operationType: 'count',
       },
     ];
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [from, JSON.stringify({ ids: [...monitorIds].sort() }), theme.eui.euiColorVis1, to]);
+  }, [from, theme.eui.euiColorVis1, to]);
 
   return (
     <ExploratoryViewEmbeddable
@@ -51,6 +55,7 @@ export const MonitorTestRunsSparkline = ({ monitorIds }: { monitorIds: string[] 
       hideTicks={true}
       attributes={attributes}
       customHeight={'68px'}
+      dslFilters={queryFilter}
     />
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_errors/overview_errors.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_errors/overview_errors.tsx
@@ -5,33 +5,15 @@
  * 2.0.
  */
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiSkeletonText,
-  EuiPanel,
-  EuiSpacer,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { i18n } from '@kbn/i18n';
-import { useMonitorQueryIds } from '../overview_alerts';
-import { selectOverviewStatus } from '../../../../../state/overview_status';
 import { OverviewErrorsSparklines } from './overview_errors_sparklines';
-import { useRefreshedRange, useGetUrlParams } from '../../../../../hooks';
+import { useRefreshedRange } from '../../../../../hooks';
 import { OverviewErrorsCount } from './overview_errors_count';
 
 export function OverviewErrors() {
-  const { status } = useSelector(selectOverviewStatus);
-
-  const loading = !status?.allIds || status?.allIds.length === 0;
-
   const { from, to } = useRefreshedRange(6, 'hours');
-
-  const { locations } = useGetUrlParams();
-
-  const monitorIds = useMonitorQueryIds();
 
   return (
     <EuiPanel hasShadow={false} hasBorder>
@@ -39,28 +21,14 @@ export function OverviewErrors() {
         <h3>{headingText}</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
-      {loading ? (
-        <EuiSkeletonText lines={3} />
-      ) : (
-        <EuiFlexGroup gutterSize="xl">
-          <EuiFlexItem grow={false}>
-            <OverviewErrorsCount
-              from={from}
-              to={to}
-              monitorIds={monitorIds}
-              locations={locations}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={true}>
-            <OverviewErrorsSparklines
-              from={from}
-              to={to}
-              monitorIds={monitorIds}
-              locations={locations}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      )}
+      <EuiFlexGroup gutterSize="xl">
+        <EuiFlexItem grow={false}>
+          <OverviewErrorsCount from={from} to={to} />
+        </EuiFlexItem>
+        <EuiFlexItem grow={true}>
+          <OverviewErrorsSparklines from={from} to={to} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </EuiPanel>
   );
 }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_errors/overview_errors_count.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_errors/overview_errors_count.tsx
@@ -8,26 +8,22 @@
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import React, { useMemo } from 'react';
 import { ReportTypes } from '@kbn/exploratory-view-plugin/public';
+import { useMonitorFilters } from '../../../hooks/use_monitor_filters';
 import { ERRORS_LABEL } from '../../../../monitor_details/monitor_summary/monitor_errors_count';
 import { ClientPluginsStart } from '../../../../../../../plugin';
+import { useMonitorQueryFilters } from '../../../hooks/use_monitor_query_filters';
 
 interface MonitorErrorsCountProps {
   from: string;
   to: string;
-  locationLabel?: string;
-  monitorIds: string[];
-  locations?: string[];
 }
 
-export const OverviewErrorsCount = ({
-  monitorIds,
-  from,
-  to,
-  locations,
-}: MonitorErrorsCountProps) => {
+export const OverviewErrorsCount = ({ from, to }: MonitorErrorsCountProps) => {
   const {
     exploratoryView: { ExploratoryViewEmbeddable },
   } = useKibana<ClientPluginsStart>().services;
+
+  const filters = useMonitorFilters({});
 
   const time = useMemo(() => ({ from, to }), [from, to]);
 
@@ -36,17 +32,18 @@ export const OverviewErrorsCount = ({
       id="overviewErrorsCount"
       align="left"
       customHeight="70px"
+      dslFilters={useMonitorQueryFilters()}
       reportType={ReportTypes.SINGLE_METRIC}
       attributes={[
         {
           time,
           reportDefinitions: {
-            'monitor.id': monitorIds.length > 0 ? monitorIds : ['false-monitor-id'],
-            ...(locations?.length ? { 'observer.geo.name': locations } : {}),
+            'monitor.type': ['http', 'tcp', 'browser', 'icmp'],
           },
           dataType: 'synthetics',
           selectedMetricField: 'monitor_errors',
           name: ERRORS_LABEL,
+          filters,
         },
       ]}
     />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_errors/overview_errors_sparklines.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_errors/overview_errors_sparklines.tsx
@@ -8,20 +8,21 @@
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import React, { useMemo } from 'react';
 import { useEuiTheme } from '@elastic/eui';
-import { ClientPluginsStart } from '../../../../../../../plugin';
 import { ERRORS_LABEL } from '../../../../monitor_details/monitor_summary/monitor_errors_count';
+import { ClientPluginsStart } from '../../../../../../../plugin';
+import { useMonitorFilters } from '../../../hooks/use_monitor_filters';
+import { useMonitorQueryFilters } from '../../../hooks/use_monitor_query_filters';
 
 interface Props {
   from: string;
   to: string;
-  monitorIds: string[];
-  locations?: string[];
 }
-export const OverviewErrorsSparklines = ({ from, to, monitorIds, locations }: Props) => {
+export const OverviewErrorsSparklines = ({ from, to }: Props) => {
   const {
     exploratoryView: { ExploratoryViewEmbeddable },
   } = useKibana<ClientPluginsStart>().services;
 
+  const filters = useMonitorFilters({});
   const { euiTheme } = useEuiTheme();
 
   const time = useMemo(() => ({ from, to }), [from, to]);
@@ -34,19 +35,20 @@ export const OverviewErrorsSparklines = ({ from, to, monitorIds, locations }: Pr
       axisTitlesVisibility={{ x: false, yRight: false, yLeft: false }}
       legendIsVisible={false}
       hideTicks={true}
+      dslFilters={useMonitorQueryFilters()}
       attributes={[
         {
           time,
           seriesType: 'area',
           reportDefinitions: {
-            'monitor.id': monitorIds.length > 0 ? monitorIds : ['false-monitor-id'],
-            ...(locations?.length ? { 'observer.geo.name': locations } : {}),
+            'monitor.type': ['http', 'tcp', 'browser', 'icmp'],
           },
           dataType: 'synthetics',
           selectedMetricField: 'monitor_errors',
           name: ERRORS_LABEL,
           color: euiTheme.colors.danger,
           operationType: 'unique_count',
+          filters,
         },
       ]}
     />

--- a/x-pack/solutions/observability/plugins/synthetics/public/hooks/use_kibana_space.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/hooks/use_kibana_space.tsx
@@ -8,7 +8,7 @@ import type { Space } from '@kbn/spaces-plugin/common';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useFetcher } from '@kbn/observability-shared-plugin/public';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
-import { ClientPluginsStart } from '../plugin';
+import type { ClientPluginsStart } from '../plugin';
 
 export const useKibanaSpace = () => {
   const { services } = useKibana<ClientPluginsStart>();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Fix overview page vizs for large number of monitors !! (#199512)](https://github.com/elastic/kibana/pull/199512)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2024-11-21T07:27:41Z","message":"[Synthetics] Fix overview page vizs for large number of monitors !! (#199512)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/187264 !!\r\n\r\nApply filters directly instead of passing each monitor id !!\r\n\r\n### Testing\r\n\r\nNo special testing is needed, other than make sure, alerts/errors vizs\r\ncontinue to work as expected !!\r\n\r\n<img width=\"1726\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/9c1889a5-4822-442b-97af-c2a4084c4503\">\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"944e6fa0376702342bb37c3c9893e1574689b211","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","ci:project-deploy-observability","Team:obs-ux-management","backport:version","v8.17.0","v8.18.0","v8.16.2","v9.2.0","v8.18.7","v8.19.5"],"title":"[Synthetics] Fix overview page vizs for large number of monitors !!","number":199512,"url":"https://github.com/elastic/kibana/pull/199512","mergeCommit":{"message":"[Synthetics] Fix overview page vizs for large number of monitors !! (#199512)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/187264 !!\r\n\r\nApply filters directly instead of passing each monitor id !!\r\n\r\n### Testing\r\n\r\nNo special testing is needed, other than make sure, alerts/errors vizs\r\ncontinue to work as expected !!\r\n\r\n<img width=\"1726\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/9c1889a5-4822-442b-97af-c2a4084c4503\">\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"944e6fa0376702342bb37c3c9893e1574689b211"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/199512","number":199512,"mergeCommit":{"message":"[Synthetics] Fix overview page vizs for large number of monitors !! (#199512)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/187264 !!\r\n\r\nApply filters directly instead of passing each monitor id !!\r\n\r\n### Testing\r\n\r\nNo special testing is needed, other than make sure, alerts/errors vizs\r\ncontinue to work as expected !!\r\n\r\n<img width=\"1726\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/9c1889a5-4822-442b-97af-c2a4084c4503\">\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"944e6fa0376702342bb37c3c9893e1574689b211"}},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201081","number":201081,"state":"MERGED","mergeCommit":{"sha":"6fb8dc6837ef7bb58a17ea07e940d70e3f64eaf4","message":"[8.17] [Synthetics] Fix overview page vizs for large number of monitors !! (#199512) (#201081)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.17`:\n- [[Synthetics] Fix overview page vizs for large number of monitors !!\n(#199512)](https://github.com/elastic/kibana/pull/199512)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>\nCo-authored-by: Brad White <Ikuni17@users.noreply.github.com>"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.16","label":"v8.16.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201080","number":201080,"state":"MERGED","mergeCommit":{"sha":"d0a3d5deed8ca01ebb3cb810a8000680c989f2cf","message":"[8.16] [Synthetics] Fix overview page vizs for large number of monitors !! (#199512) (#201080)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.16`:\n- [[Synthetics] Fix overview page vizs for large number of monitors !!\n(#199512)](https://github.com/elastic/kibana/pull/199512)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>"}},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/234067","number":234067,"state":"MERGED","mergeCommit":{"sha":"da6fd6c61abd3afd48065dec2b763901341a4b70","message":"[8.18] [Synthetics] Fix overview page vizs for large number of monitors !! (#199512) (#234067)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Synthetics] Fix overview page vizs for large number of monitors !!\n(#199512)](https://github.com/elastic/kibana/pull/199512)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->