### PR TITLE
[Renovate] Marks uuid as a blocked dependency upgrade

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3497,7 +3497,6 @@
         "require-in-the-middle",
         "tape",
         "tough-cookie",
-        "uuid",
         "xml-crypto",
         "@elastic/node-crypto",
         "@types/js-yaml",
@@ -3505,8 +3504,7 @@
         "@types/minimist",
         "@types/node-forge",
         "@types/object-hash",
-        "@types/tough-cookie",
-        "@types/uuid"
+        "@types/tough-cookie"
       ],
       "reviewers": [
         "team:kibana-security"
@@ -3525,7 +3523,9 @@
     {
       "groupName": "platform security modules - ESM required",
       "matchDepNames": [
-        "@kayahr/text-encoding"
+        "@kayahr/text-encoding",
+        "uuid",
+        "@types/uuid"
       ],
       "reviewers": [
         "team:kibana-security"


### PR DESCRIPTION
## Summary

Moves `uuid` to the set of dependencies which cannot be upgraded due to a lack of ESM support (#106868 )

Relates: https://github.com/elastic/kibana/pull/234968#pullrequestreview-3252887018

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->