### PR TITLE
[Lens] Add telemetry to track obsolete Lens runtime migrations

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/runtime_state/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/runtime_state/index.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './converters/raw_color_mappings';
+export { trackRuntimeMigration } from './telemetry';

--- a/x-pack/platform/plugins/shared/lens/public/runtime_state/telemetry.ts
+++ b/x-pack/platform/plugins/shared/lens/public/runtime_state/telemetry.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { trackUiCounterEvents } from '../lens_ui_telemetry';
+
+const events = {
+  rawColorMappings: 'raw_color_mappings',
+  legendStats: 'legend_stats',
+  metric: 'metric_refactor',
+};
+
+type ChartTypes = 'xy' | 'tagcloud' | 'partition' | 'metric' | 'datatable';
+
+/**
+ * Track runtime migration events
+ *
+ * @param event
+ * @param chartType - optional event qualifier
+ */
+export function trackRuntimeMigration(event: 'metric'): void;
+export function trackRuntimeMigration(
+  event: 'legendStats',
+  chartType?: Extract<ChartTypes, 'xy' | 'partition'>
+): void;
+export function trackRuntimeMigration(
+  event: 'rawColorMappings',
+  chartType?: Extract<ChartTypes, 'xy' | 'tagcloud' | 'partition' | 'datatable'>
+): void;
+export function trackRuntimeMigration(event: keyof typeof events, chartType?: ChartTypes): void {
+  trackUiCounterEvents(`runtime_migrations_${events[event]}${chartType ? `_${chartType}` : ''}`);
+}

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/runtime_state/converters/raw_color_mappings.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/runtime_state/converters/raw_color_mappings.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ColumnState } from '../../../../../common/expressions';
+import { trackRuntimeMigration } from '../../../../runtime_state';
 import type { DeprecatedColorMappingConfig } from '../../../../runtime_state/converters/raw_color_mappings';
 import {
   convertToRawColorMappings,
@@ -42,6 +43,8 @@ export const convertToRawColorMappingsFn = (
     });
 
     if (!hasDeprecatedColorMappings) return state as DatatableVisualizationState;
+
+    trackRuntimeMigration('rawColorMappings', 'datatable');
 
     const convertedColumns = state.columns.map((column) => {
       if (column.colorMapping?.assignments || column.colorMapping?.specialAssignments) {

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/metric/runtime_state/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/metric/runtime_state/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { trackRuntimeMigration } from '../../../runtime_state';
 import type { MetricVisualizationState } from '../types';
 
 export const convertToRunTimeState = (
@@ -13,8 +14,10 @@ export const convertToRunTimeState = (
   // Remove legacy state properties if they exist
   const { secondaryPrefix, valuesTextAlign, ...restState } = state;
   let newState = { ...restState };
+  let wasMigrated = false;
 
   if (valuesTextAlign) {
+    wasMigrated = true;
     newState = {
       ...newState,
       primaryAlign: state.primaryAlign ?? valuesTextAlign,
@@ -23,10 +26,15 @@ export const convertToRunTimeState = (
   }
 
   if (secondaryPrefix && !newState.secondaryLabel) {
+    wasMigrated = true;
     newState = {
       ...newState,
       secondaryLabel: secondaryPrefix,
     };
+  }
+
+  if (wasMigrated) {
+    trackRuntimeMigration('metric');
   }
 
   return newState;

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/partition/runtime_state/converters/legend_stats.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/partition/runtime_state/converters/legend_stats.tsx
@@ -8,6 +8,7 @@
 import { LegendValue } from '@elastic/charts';
 
 import type { PieLayerState, PieVisualizationState } from '../../../../../common/types';
+import { trackRuntimeMigration } from '../../../../runtime_state';
 
 /** @deprecated */
 type DeprecatedLegendValueLayer = PieLayerState & {
@@ -28,6 +29,8 @@ export function convertToLegendStats(
 ) {
   state.layers.forEach((l) => {
     if ('showValuesInLegend' in l) {
+      trackRuntimeMigration('legendStats', 'partition');
+
       l.legendStats = [
         ...new Set([
           ...(l.showValuesInLegend ? [LegendValue.Value] : []),

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/partition/runtime_state/converters/raw_color_mappings.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/partition/runtime_state/converters/raw_color_mappings.ts
@@ -6,6 +6,7 @@
  */
 
 import type { PieLayerState, PieVisualizationState } from '../../../../../common/types';
+import { trackRuntimeMigration } from '../../../../runtime_state';
 import type { DeprecatedColorMappingConfig } from '../../../../runtime_state/converters/raw_color_mappings';
 import {
   convertToRawColorMappings,
@@ -42,6 +43,8 @@ export const convertToRawColorMappingsFn = (
     });
 
     if (!hasDeprecatedColorMappings) return state as PieVisualizationState;
+
+    trackRuntimeMigration('rawColorMappings', 'partition');
 
     const convertedLayers = state.layers.map((layer) => {
       if (

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/tagcloud/runtime_state/converters/raw_color_mappings.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/tagcloud/runtime_state/converters/raw_color_mappings.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { trackRuntimeMigration } from '../../../../runtime_state';
 import type { DeprecatedColorMappingConfig } from '../../../../runtime_state/converters/raw_color_mappings';
 import {
   convertToRawColorMappings,
@@ -34,6 +35,8 @@ export const convertToRawColorMappingsFn = (
       : false;
 
     if (!hasDeprecatedColorMapping) return state as TagcloudState;
+
+    trackRuntimeMigration('rawColorMappings', 'tagcloud');
 
     const columnMeta = state.tagAccessor ? getColumnMeta?.(state.layerId, state.tagAccessor) : null;
 

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/runtime_state/converters/legend_stats.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/runtime_state/converters/legend_stats.ts
@@ -8,6 +8,7 @@
 import { LegendValue } from '@elastic/charts';
 
 import type { XYState } from '../../types';
+import { trackRuntimeMigration } from '../../../../runtime_state';
 
 /**
  * Old color mapping state meant for type safety during runtime migrations of old configurations
@@ -20,6 +21,8 @@ interface DeprecatedLegendValueXYState extends XYState {
 
 export function convertToLegendStats(state: DeprecatedLegendValueXYState | XYState): XYState {
   if ('valuesInLegend' in state) {
+    trackRuntimeMigration('legendStats', 'xy');
+
     const valuesInLegend = state.valuesInLegend;
     delete state.valuesInLegend;
 

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/runtime_state/converters/raw_color_mappings.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/runtime_state/converters/raw_color_mappings.ts
@@ -11,6 +11,7 @@ import {
   getColumnMetaFn,
   isDeprecatedColorMapping,
 } from '../../../../runtime_state/converters/raw_color_mappings';
+import { trackRuntimeMigration } from '../../../../runtime_state';
 import type { GeneralDatasourceStates } from '../../../../state_management';
 import type { XYDataLayerConfig, XYLayerConfig, XYState } from '../../types';
 
@@ -39,6 +40,8 @@ export const convertToRawColorMappingsFn = (
     });
 
     if (!hasDeprecatedColorMappings) return state as XYState;
+
+    trackRuntimeMigration('rawColorMappings', 'xy');
 
     const convertedLayers = state.layers.map<XYLayerConfig>((layer) => {
       if (


### PR DESCRIPTION
## Summary

Follow up to #235286 & #229534.

In #229534 we add Content Management item transforms in Lens to transform Lens SO into a known trusted state. This means all transforms are applied and the shape of the content is perfectly aligned to the TS definitions coming from the server.

The only exception to this is by-value dashboard panels. These still require the lens runtime migrations in order to function properly as this state can still contain legacy properties. This will be fixed once #235277 is merged which handles transforming the Lens dashboard panel state to the correct state.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.