### PR TITLE
[EDR Workflows] Fix MDE runscript args

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
@@ -531,11 +531,12 @@ export const getEndpointConsoleCommands = ({
   }
 
   if (microsoftDefenderEndpointCancelEnabled) {
+    const isSupported = canCancelForCurrentContext();
     consoleCommands.push({
       name: 'cancel',
       about: getCommandAboutInfo({
         aboutInfo: CONSOLE_COMMANDS.cancel.about,
-        isSupported: canCancelForCurrentContext(),
+        isSupported,
       }),
       RenderComponent: CancelActionResult,
       meta: commandMeta,
@@ -546,25 +547,29 @@ export const getEndpointConsoleCommands = ({
       ),
       mustHaveArgs: true,
       args: {
-        action: {
-          required: true,
-          allowMultiples: false,
-          about: i18n.translate(
-            'xpack.securitySolution.endpointConsoleCommands.cancel.action.about',
-            {
-              defaultMessage: 'The response action to cancel',
+        ...(isSupported
+          ? {
+              action: {
+                required: true,
+                allowMultiples: false,
+                about: i18n.translate(
+                  'xpack.securitySolution.endpointConsoleCommands.cancel.action.about',
+                  {
+                    defaultMessage: 'The response action to cancel',
+                  }
+                ),
+                mustHaveValue: 'truthy',
+                selectorShowTextValue: true,
+                SelectorComponent: PendingActionsSelector,
+              },
             }
-          ),
-          mustHaveValue: 'truthy',
-          selectorShowTextValue: true,
-          SelectorComponent: PendingActionsSelector,
-        },
+          : []),
       },
       helpGroupLabel: HELP_GROUPS.responseActions.label,
       helpGroupPosition: HELP_GROUPS.responseActions.position,
       helpCommandPosition: 10,
-      helpDisabled: !canCancelForCurrentContext(),
-      helpHidden: !canCancelForCurrentContext(),
+      helpDisabled: !isSupported,
+      helpHidden: !isSupported,
       validate: capabilitiesAndPrivilegesValidator(agentType),
     });
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
@@ -563,7 +563,7 @@ export const getEndpointConsoleCommands = ({
                 SelectorComponent: PendingActionsSelector,
               },
             }
-          : []),
+          : {}),
         comment: {
           required: false,
           allowMultiples: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
@@ -564,6 +564,12 @@ export const getEndpointConsoleCommands = ({
               },
             }
           : []),
+        comment: {
+          required: false,
+          allowMultiples: false,
+          mustHaveValue: 'non-empty-string',
+          about: COMMENT_ARG_ABOUT,
+        },
       },
       helpGroupLabel: HELP_GROUPS.responseActions.label,
       helpGroupPosition: HELP_GROUPS.responseActions.position,


### PR DESCRIPTION
 **Properly validate `--action` arg for cancel response action**
 This change makes sure we do not render the pending actions selector when the cancel action is not supported (agent type other than MDE).
 **Add `--comment` as optional parameter.** 
 This fixes a bug where `--comment` was not accepted. 