### PR TITLE
[Streams] Adjust warning icon and date picker size

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
@@ -50,6 +50,15 @@ import {
 } from './translations';
 import { DiscoverBadgeButton } from '../stream_badges';
 
+const datePickerStyle = css`
+  .euiFormControlLayout {
+    height: 40px;
+  }
+  .euiButton {
+    height: 40px;
+  }
+`;
+
 export function StreamsTreeTable({
   loading,
   streams = [],
@@ -246,6 +255,7 @@ export function StreamsTreeTable({
                       data-test-subj={`${isCollapsed ? 'expand' : 'collapse'}Button-${
                         item.stream.name
                       }`}
+                      // eslint-disable-next-line @kbn/i18n/i18n_translate_should_start_with_the_right_id
                       aria-label={i18n.translate(
                         isCollapsed
                           ? 'xpack.streams.streamsTreeTable.collapsedNodeAriaLabel'
@@ -293,14 +303,15 @@ export function StreamsTreeTable({
           field: 'documentsCount',
           name: (
             <EuiFlexGroup alignItems="center" gutterSize="s">
+              {DOCUMENTS_COLUMN_HEADER}
               {!canReadFailureStore && (
                 <EuiIconTip
                   content={FAILURE_STORE_PERMISSIONS_ERROR}
                   type="warning"
                   color="warning"
+                  size="s"
                 />
               )}
-              {DOCUMENTS_COLUMN_HEADER}
             </EuiFlexGroup>
           ),
           width: '180px',
@@ -321,14 +332,15 @@ export function StreamsTreeTable({
           field: 'dataQuality',
           name: (
             <EuiFlexGroup alignItems="center" gutterSize="s">
+              {DATA_QUALITY_COLUMN_HEADER}
               {!canReadFailureStore && (
                 <EuiIconTip
                   content={FAILURE_STORE_PERMISSIONS_ERROR}
                   type="warning"
                   color="warning"
+                  size="s"
                 />
               )}
-              {DATA_QUALITY_COLUMN_HEADER}
             </EuiFlexGroup>
           ),
           width: '150px',
@@ -396,7 +408,11 @@ export function StreamsTreeTable({
           incremental: true,
           'aria-label': STREAMS_TABLE_SEARCH_ARIA_LABEL,
         },
-        toolsRight: <StreamsAppSearchBar showDatePicker />,
+        toolsRight: (
+          <div className={datePickerStyle}>
+            <StreamsAppSearchBar showDatePicker />
+          </div>
+        ),
       }}
       tableCaption={STREAMS_TABLE_CAPTION_ARIA_LABEL}
     />

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
@@ -255,7 +255,6 @@ export function StreamsTreeTable({
                       data-test-subj={`${isCollapsed ? 'expand' : 'collapse'}Button-${
                         item.stream.name
                       }`}
-                      // eslint-disable-next-line @kbn/i18n/i18n_translate_should_start_with_the_right_id
                       aria-label={i18n.translate(
                         isCollapsed
                           ? 'xpack.streams.streamsTreeTable.collapsedNodeAriaLabel'


### PR DESCRIPTION
Fixes: https://github.com/elastic/streams-program/issues/524
Fixes: https://github.com/elastic/streams-program/issues/532

## Summary
* Adjust indication icon size and position for failing to fetch failure store
* Unify search bar and Superdate heights to 40px
<img width="1189" height="538" alt="Screenshot 2025-09-30 at 09 27 00" src="https://github.com/user-attachments/assets/679bd154-16be-41f6-8002-a29a9a592d04" />
