### PR TITLE
[8.19] [APM] Debouncing table search bar for less request spam (#236588)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
@@ -305,6 +305,7 @@ function UnoptimizedManagedTable<T extends object>(props: {
           searchQuery={searchQuery}
           onChangeSearchQuery={onChangeSearchQuery}
           techPreview={tableSearchBar.techPreview}
+          isLoading={isLoading}
         />
       ) : null}
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/table_search_bar/table_search_bar.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/table_search_bar/table_search_bar.tsx
@@ -4,14 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { debounce } from 'lodash';
 import { EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import { TechnicalPreviewBadge } from '../technical_preview_badge';
 
 interface Props {
   placeholder: string;
   searchQuery: string;
+  isLoading?: boolean;
   onChangeSearchQuery: (value: string) => void;
   techPreview?: boolean;
 }
@@ -20,8 +22,14 @@ export function TableSearchBar({
   placeholder,
   searchQuery,
   onChangeSearchQuery,
+  isLoading,
   techPreview = false,
 }: Props) {
+  const debouncedSearchQuery = useMemo(
+    () => debounce(onChangeSearchQuery, 500),
+    [onChangeSearchQuery]
+  );
+
   return (
     <EuiFlexGroup gutterSize="s">
       {techPreview ? (
@@ -39,9 +47,10 @@ export function TableSearchBar({
           data-test-subj="tableSearchInput"
           placeholder={placeholder}
           fullWidth={true}
-          value={searchQuery}
+          defaultValue={searchQuery}
+          isLoading={isLoading}
           onChange={(e) => {
-            onChangeSearchQuery(e.target.value);
+            debouncedSearchQuery(e.target.value);
           }}
         />
       </EuiFlexItem>
@@ -58,10 +67,11 @@ export function getItemsFilteredBySearchQuery<T, P extends keyof T>({
   fieldsToSearch: P[];
   searchQuery: string;
 }) {
+  const query = searchQuery.toLowerCase();
   return items.filter((item) => {
     return fieldsToSearch.some((field) => {
       const fieldValue = item[field] as unknown as string | undefined;
-      return fieldValue?.toLowerCase().includes(searchQuery.toLowerCase());
+      return fieldValue?.toLowerCase().includes(query);
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM] Debouncing table search bar for less request spam (#236588)](https://github.com/elastic/kibana/pull/236588)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2025-09-29T17:34:07Z","message":"[APM] Debouncing table search bar for less request spam (#236588)\n\n## Summary\n\nQuick fix to reduce the firing/aborting of many requests as a search is\ntyped to filter the services table. 500ms default applied to prevent too\nmany requests being done as a user types out a name.\n\n\nhttps://github.com/user-attachments/assets/ca940c41-d5a4-450f-b05d-8d5265cf58ee\n\nCloses #212923\n\n## How to test\n\n- Go to Applications -> Service Inventory\n- On the table search bar, type in a name to filter by, and ensure the\ntable only updates after a pause of half a second.\n- CAVEAT: Clearing the search bar does reset the table, but the updated\nview takes longer because the table update for the full data is quite\nslow.","sha":"6867f0f71c8cecf421f69e04a5c6f84d759044ca","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.2.0","v8.19.5","v9.1.5"],"title":"[APM] Debouncing table search bar for less request spam","number":236588,"url":"https://github.com/elastic/kibana/pull/236588","mergeCommit":{"message":"[APM] Debouncing table search bar for less request spam (#236588)\n\n## Summary\n\nQuick fix to reduce the firing/aborting of many requests as a search is\ntyped to filter the services table. 500ms default applied to prevent too\nmany requests being done as a user types out a name.\n\n\nhttps://github.com/user-attachments/assets/ca940c41-d5a4-450f-b05d-8d5265cf58ee\n\nCloses #212923\n\n## How to test\n\n- Go to Applications -> Service Inventory\n- On the table search bar, type in a name to filter by, and ensure the\ntable only updates after a pause of half a second.\n- CAVEAT: Clearing the search bar does reset the table, but the updated\nview takes longer because the table update for the full data is quite\nslow.","sha":"6867f0f71c8cecf421f69e04a5c6f84d759044ca"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236588","number":236588,"mergeCommit":{"message":"[APM] Debouncing table search bar for less request spam (#236588)\n\n## Summary\n\nQuick fix to reduce the firing/aborting of many requests as a search is\ntyped to filter the services table. 500ms default applied to prevent too\nmany requests being done as a user types out a name.\n\n\nhttps://github.com/user-attachments/assets/ca940c41-d5a4-450f-b05d-8d5265cf58ee\n\nCloses #212923\n\n## How to test\n\n- Go to Applications -> Service Inventory\n- On the table search bar, type in a name to filter by, and ensure the\ntable only updates after a pause of half a second.\n- CAVEAT: Clearing the search bar does reset the table, but the updated\nview takes longer because the table update for the full data is quite\nslow.","sha":"6867f0f71c8cecf421f69e04a5c6f84d759044ca"}},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/236828","number":236828,"state":"MERGED","mergeCommit":{"sha":"12bc662f7c74d6aa4f38bf9ac9db254edbe87e2a","message":"[9.1] [APM] Debouncing table search bar for less request spam (#236588) (#236828)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[APM] Debouncing table search bar for less request spam\n(#236588)](https://github.com/elastic/kibana/pull/236588)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Gonçalo Rica Pais da Silva <goncalo.rica@elastic.co>"}}]}] BACKPORT-->