### PR TITLE
fix: [Platform:Dashboards:DashboardEditMode] Successful switch to view mode is not announced

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/ui/header/header_page_announcer.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header_page_announcer.tsx
@@ -37,7 +37,17 @@ export const HeaderPageAnnouncer: FC<{
 
     const breadcrumbText = [...breadcrumbs]
       .reverse()
-      .map((breadcrumb) => (typeof breadcrumb.text === 'string' ? breadcrumb.text : null))
+      .map((breadcrumb) => {
+        if (typeof breadcrumb['aria-label'] === 'string') {
+          return breadcrumb['aria-label'];
+        }
+
+        if (typeof breadcrumb.text === 'string') {
+          return breadcrumb.text;
+        }
+
+        return null;
+      })
       .filter(Boolean) as string[];
 
     breadcrumbText.push(branding);

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -158,6 +158,7 @@ export function InternalDashboardTopNav({
           ) : (
             dashboardTitle
           ),
+        'aria-label': dashboardTitle,
       },
     ];
 


### PR DESCRIPTION
Closes: #214931

## Summary

This PR addresses the issue where successful switching from **Edit Mode** to **View Mode** in the Dashboard was not properly announced for accessibility. This fix ensures that screen readers and other assistive technologies can notify users when the mode change occurs, improving the accessibility of the `Dashboard`.

### What was fixed
- Added an accessibility announcement for successful mode switches.
- Since `EuiBreadcrumbs` already supports the aria-label prop, we just needed to pass it from the `Dashboard` and slightly update `HeaderPageAnnouncer`.






<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->