### PR TITLE
[Contextual Security] replace node label and detail labels tooltips with popovers

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/constants.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/constants.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
+
 /**
  * Whether or not to instruct the graph component to only render nodes and edges that would be visible in the viewport.
  */
@@ -24,6 +26,21 @@ export const STACK_NODE_VERTICAL_PADDING = 20;
  * The horizontal padding between nodes when being stacked, in pixels.
  */
 export const STACK_NODE_HORIZONTAL_PADDING = 20;
+
+/**
+ * graph package scope id - to be used by flyout hook
+ */
+export const GRAPH_SCOPE_ID = 'graph';
+
+export const i18nNamespaceKey = 'securitySolutionPackages.csp.graph.flyout.networkPreviewPanel';
+
+export const NETWORK_PREVIEW_BANNER = {
+  title: i18n.translate(`${i18nNamespaceKey}.bannerTitle`, {
+    defaultMessage: 'Preview network details',
+  }),
+  backgroundColor: 'warning',
+  textColor: 'warning',
+};
 
 export {
   NODE_WIDTH,

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/graph_investigation.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/graph_investigation.tsx
@@ -48,7 +48,9 @@ const useGraphPopovers = ({
 }) => {
   const [currentIps, setCurrentIps] = useState<string[]>([]);
   const [currentCountryCodes, setCurrentCountryCodes] = useState<string[]>([]);
-  const [currentEventAnalysis, setCurrentEventAnalysis] = useState<DocumentAnalysisOutput | null>(null);
+  const [currentEventAnalysis, setCurrentEventAnalysis] = useState<DocumentAnalysisOutput | null>(
+    null
+  );
   const [currentEventText, setCurrentEventText] = useState<string>('');
   const nodeExpandPopover = useEntityNodeExpandPopover(
     setSearchFilters,
@@ -95,11 +97,12 @@ const useGraphPopovers = ({
   );
 
   const createEventClickHandler = useCallback(
-    (analysis: DocumentAnalysisOutput, text: string) => (e: React.MouseEvent<HTMLButtonElement>) => {
-      setCurrentEventAnalysis(analysis);
-      setCurrentEventText(text);
-      openPopoverCallback(eventPopover.onEventClick, e);
-    },
+    (analysis: DocumentAnalysisOutput, text: string) =>
+      (e: React.MouseEvent<HTMLButtonElement>) => {
+        setCurrentEventAnalysis(analysis);
+        setCurrentEventText(text);
+        openPopoverCallback(eventPopover.onEventClick, e);
+      },
     [setCurrentEventAnalysis, setCurrentEventText, openPopoverCallback, eventPopover.onEventClick]
   );
 
@@ -357,7 +360,10 @@ export const GraphInvestigation = memo<GraphInvestigationProps>(
             const nodeCountryCodes = node.countryCodes || [];
             const numEvents = node.uniqueEventsCount ?? 0;
             const numAlerts = node.uniqueAlertsCount ?? 0;
-            const analysis = analyzeDocuments({ uniqueEventsCount: numEvents, uniqueAlertsCount: numAlerts });
+            const analysis = analyzeDocuments({
+              uniqueEventsCount: numEvents,
+              uniqueAlertsCount: numAlerts,
+            });
             const text = node.label ? node.label : node.id;
             const docEventIds: string[] =
               'documentsData' in node && Array.isArray(node.documentsData)

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/graph_investigation.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/graph_investigation.tsx
@@ -33,6 +33,7 @@ import { useEntityNodeExpandPopover } from './use_entity_node_expand_popover';
 import { useLabelNodeExpandPopover } from './use_label_node_expand_popover';
 import type { NodeViewModel } from '../types';
 import { isLabelNode, showErrorToast } from '../utils';
+import { GRAPH_SCOPE_ID } from '../constants';
 
 const useGraphPopovers = ({
   dataViewId,
@@ -61,7 +62,7 @@ const useGraphPopovers = ({
     searchFilters,
     nodeDetailsClickHandler
   );
-  const ipPopover = useIpPopover(currentIps);
+  const ipPopover = useIpPopover(currentIps, GRAPH_SCOPE_ID);
   const countryFlagsPopover = useCountryFlagsPopover(currentCountryCodes);
   const eventPopover = useEventDetailsPopover(currentEventAnalysis, currentEventText);
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_event_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_event_details_popover.tsx
@@ -11,7 +11,7 @@ import { css } from '@emotion/react';
 import type { PopoverActions, PopoverState } from '../graph/use_graph_popover';
 import { useGraphPopover } from '../graph/use_graph_popover';
 import { GraphPopover } from '../graph/graph_popover';
-import { LabelNodePopoverContent } from '../node/label_node/label_node_tooltip';
+import { LabelNodePopoverContent } from '../node/label_node/label_node_popover';
 import type { DocumentAnalysisOutput } from '../node/label_node/analyze_documents';
 import { GRAPH_EVENTS_POPOVER_ID } from '../test_ids';
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_event_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_event_details_popover.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useMemo, useCallback } from 'react';
+import { EuiHorizontalRule, EuiTextTruncate, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import type { PopoverActions, PopoverState } from '../graph/use_graph_popover';
+import { useGraphPopover } from '../graph/use_graph_popover';
+import { GraphPopover } from '../graph/graph_popover';
+import { LabelNodePopoverContent } from '../node/label_node/label_node_tooltip';
+import type { DocumentAnalysisOutput } from '../node/label_node/analyze_documents';
+import { GRAPH_EVENTS_POPOVER_ID } from '../test_ids';
+
+export interface UseEventDetailsPopoverReturn {
+  /**
+   * The ID of the popover.
+   */
+  id: string;
+
+  /**
+   * Handler to open the popover when the button is clicked.
+   */
+  onEventClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+
+  /**
+   * The component that renders the popover.
+   */
+  PopoverComponent: React.FC;
+
+  /**
+   * The popover actions and state.
+   */
+  actions: PopoverActions;
+
+  /**
+   * The popover state.
+   */
+  state: PopoverState;
+}
+
+export const useEventDetailsPopover = (
+  analysis: DocumentAnalysisOutput | null,
+  text: string
+): UseEventDetailsPopoverReturn => {
+  const { id, state, actions } = useGraphPopover('events-popover');
+  const { euiTheme } = useEuiTheme();
+
+  // eslint-disable-next-line react/display-name
+  const PopoverComponent = memo(() => (
+    <GraphPopover
+      anchorPosition="upCenter"
+      panelPaddingSize="m"
+      isOpen={state.isOpen}
+      anchorElement={state.anchorElement}
+      closePopover={actions.closePopover}
+      data-test-subj={GRAPH_EVENTS_POPOVER_ID}
+    >
+      {text && (
+        <>
+          <EuiTextTruncate
+            css={css`
+              font-weight: ${euiTheme.font.weight.bold};
+            `}
+            truncation="end"
+            text={text}
+          />
+          <EuiHorizontalRule
+            margin="m"
+            size="full"
+            css={css`
+              width: calc(100% + ${euiTheme.size.xl});
+              margin-left: -${euiTheme.size.base};
+            `}
+          />
+        </>
+      )}
+      {analysis && <LabelNodePopoverContent analysis={analysis} />}
+    </GraphPopover>
+  ));
+
+  const onEventClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => actions.openPopover(e.currentTarget),
+    [actions]
+  );
+
+  return useMemo(
+    () => ({
+      id,
+      onEventClick,
+      PopoverComponent,
+      actions,
+      state,
+    }),
+    [PopoverComponent, actions, id, state, onEventClick]
+  );
+};

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { renderHook, render, screen } from '@testing-library/react';
+import { TestProviders } from '../mock/test_providers';
+import { useNodeDetailsPopover } from './use_node_details_popover';
+import type { GenericPopoverItem } from './use_node_details_popover';
+
+const mockOpenPopover = jest.fn();
+const mockClosePopover = jest.fn();
+
+const mockUseGraphPopover = jest.fn(() => ({
+  id: 'test-popover-id',
+  state: {
+    isOpen: false,
+    anchorElement: null,
+  },
+  actions: {
+    openPopover: mockOpenPopover,
+    closePopover: mockClosePopover,
+  },
+}));
+
+jest.mock('../graph/use_graph_popover', () => ({
+  useGraphPopover: () => mockUseGraphPopover(),
+}));
+
+const createTestItems = (count: number): GenericPopoverItem[] => {
+  return Array.from({ length: count }, (_, index) => ({
+    key: `item-${index}`,
+    label: `Test Item ${index + 1}`,
+  }));
+};
+
+const defaultProps = {
+  popoverId: 'test-popover',
+  contentTestSubj: 'test-content',
+  itemTestSubj: 'test-item',
+  popoverTestSubj: 'test-popover',
+};
+
+const mockOpenPopoverState = () => {
+  (mockUseGraphPopover as jest.Mock).mockReturnValue({
+    id: 'test-popover-id',
+    state: {
+      isOpen: true,
+      anchorElement: document.createElement('button'),
+    },
+    actions: {
+      openPopover: mockOpenPopover,
+      closePopover: mockClosePopover,
+    },
+  });
+};
+
+const renderPopoverWithItems = (itemCount: number) => {
+  mockOpenPopoverState();
+
+  const items = createTestItems(itemCount);
+  const { result } = renderHook(() => useNodeDetailsPopover({ ...defaultProps, items }), {
+    wrapper: TestProviders,
+  });
+
+  const PopoverComponent = result.current.PopoverComponent;
+  render(<PopoverComponent />, { wrapper: TestProviders });
+
+  return { items, result };
+};
+
+const expectPopoverContentToRender = (items: GenericPopoverItem[], expectedCount: number) => {
+  items.forEach((item) => {
+    expect(screen.getByText(item.label as string)).toBeInTheDocument();
+  });
+
+  expect(screen.getAllByTestId(defaultProps.itemTestSubj)).toHaveLength(expectedCount);
+};
+
+describe('useNodeDetailsPopover', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseGraphPopover.mockReturnValue({
+      id: 'test-popover-id',
+      state: {
+        isOpen: false,
+        anchorElement: null,
+      },
+      actions: {
+        openPopover: mockOpenPopover,
+        closePopover: mockClosePopover,
+      },
+    });
+  });
+
+  it('should call openPopover when onClick is triggered', () => {
+    const items = createTestItems(5);
+    const { result } = renderHook(() => useNodeDetailsPopover({ ...defaultProps, items }), {
+      wrapper: TestProviders,
+    });
+
+    const mockButton = document.createElement('button');
+    const mockEvent = {
+      currentTarget: mockButton,
+    } as React.MouseEvent<HTMLButtonElement>;
+
+    result.current.onClick(mockEvent);
+
+    expect(mockOpenPopover).toHaveBeenCalledWith(mockButton);
+  });
+
+  it('should render popover content with 5 items (less than 10)', () => {
+    const { items } = renderPopoverWithItems(5);
+    expectPopoverContentToRender(items, 5);
+  });
+
+  it('should render popover content with exactly 10 items', () => {
+    const { items } = renderPopoverWithItems(10);
+    expectPopoverContentToRender(items, 10);
+  });
+
+  it('should render popover content with 20 items (more than 10)', () => {
+    const { items } = renderPopoverWithItems(20);
+    expectPopoverContentToRender(items, 20);
+  });
+});

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
@@ -95,10 +95,10 @@ export const useNodeDetailsPopover = ({
   // Calculate dynamic height based on number of items
   const panelStyle = useMemo(() => {
     const shouldScroll = items.length > MAX_VISIBLE_ITEMS;
-    const maxHeight = shouldScroll 
-      ? `${(MAX_VISIBLE_ITEMS * parseInt(euiTheme.size.l, 10)) + parseInt(euiTheme.size.xl, 10)}px`
+    const maxHeight = shouldScroll
+      ? `${MAX_VISIBLE_ITEMS * parseInt(euiTheme.size.l, 10) + parseInt(euiTheme.size.xl, 10)}px`
       : 'auto';
-    
+
     return {
       maxHeight,
       overflowY: shouldScroll ? ('auto' as const) : ('visible' as const),

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useMemo, useCallback } from 'react';
+import React, { memo, useMemo, useCallback, ReactNode } from 'react';
 import { EuiListGroup } from '@elastic/eui';
 import type { PopoverActions, PopoverState } from '../graph/use_graph_popover';
 import { useGraphPopover } from '../graph/use_graph_popover';
@@ -40,7 +40,7 @@ export interface UseNodeDetailsPopoverReturn {
 }
 
 export interface GenericPopoverItem {
-  label: string;
+  label: string | ReactNode;
   key: string;
 }
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
@@ -112,7 +112,7 @@ export const useNodeDetailsPopover = ({
   // eslint-disable-next-line react/display-name
   const PopoverComponent = memo(() => (
     <GraphPopover
-      panelPaddingSize="s"
+      panelPaddingSize="m"
       anchorPosition="rightCenter"
       isOpen={state.isOpen}
       anchorElement={state.anchorElement}

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
@@ -127,7 +127,7 @@ export const useNodeDetailsPopover = ({
     [items, contentTestSubj, itemTestSubj]
   );
 
- // eslint-disable-next-line react/display-name
+  // eslint-disable-next-line react/display-name
   const PopoverComponent = memo(() => (
     <GraphPopover
       panelPaddingSize="m"

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
@@ -69,11 +69,6 @@ export interface UseGenericPopoverProps {
    * Popover test subject ID
    */
   popoverTestSubj: string;
-
-  /**
-   * Limit for visible items before showing popover
-   */
-  visibleLimit: number;
 }
 
 export const useNodeDetailsPopover = ({
@@ -82,7 +77,6 @@ export const useNodeDetailsPopover = ({
   contentTestSubj,
   itemTestSubj,
   popoverTestSubj,
-  visibleLimit,
 }: UseGenericPopoverProps): UseNodeDetailsPopoverReturn => {
   const { id, state, actions } = useGraphPopover(popoverId);
 
@@ -120,7 +114,7 @@ export const useNodeDetailsPopover = ({
       panelStyle={{ maxHeight: '336px', overflowY: 'auto' }}
       data-test-subj={popoverTestSubj}
     >
-      {items.length > visibleLimit ? popoverContent : null}
+      {popoverContent}
     </GraphPopover>
   ));
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import React, { memo, useMemo, useCallback, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React, { memo, useMemo, useCallback } from 'react';
 import { EuiListGroup } from '@elastic/eui';
 import type { PopoverActions, PopoverState } from '../graph/use_graph_popover';
 import { useGraphPopover } from '../graph/use_graph_popover';

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useMemo, useCallback } from 'react';
+import { EuiListGroup } from '@elastic/eui';
+import type { PopoverActions, PopoverState } from '../graph/use_graph_popover';
+import { useGraphPopover } from '../graph/use_graph_popover';
+import { GraphPopover } from '../graph/graph_popover';
+import { ExpandPopoverListItem } from '../styles';
+
+export interface UseNodeDetailsPopoverReturn {
+  /**
+   * The ID of the popover.
+   */
+  id: string;
+
+  /**
+   * Handler to open the popover when the button is clicked.
+   */
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+
+  /**
+   * The component that renders the popover.
+   */
+  PopoverComponent: React.FC;
+
+  /**
+   * The popover actions and state.
+   */
+  actions: PopoverActions;
+
+  /**
+   * The popover state.
+   */
+  state: PopoverState;
+}
+
+export interface GenericPopoverItem {
+  label: string;
+  key: string;
+}
+
+export interface UseGenericPopoverProps {
+  /**
+   * Unique ID for the popover instance
+   */
+  popoverId: string;
+
+  /**
+   * Array of items to display in the popover
+   */
+  items: GenericPopoverItem[];
+
+  /**
+   * Content test subject ID for the popover content
+   */
+  contentTestSubj: string;
+
+  /**
+   * Item test subject ID for individual items
+   */
+  itemTestSubj: string;
+
+  /**
+   * Popover test subject ID
+   */
+  popoverTestSubj: string;
+
+  /**
+   * Limit for visible items before showing popover
+   */
+  visibleLimit: number;
+}
+
+export const useNodeDetailsPopover = ({
+  popoverId,
+  items,
+  contentTestSubj,
+  itemTestSubj,
+  popoverTestSubj,
+  visibleLimit,
+}: UseGenericPopoverProps): UseNodeDetailsPopoverReturn => {
+  const { id, state, actions } = useGraphPopover(popoverId);
+
+  const popoverContent = useMemo(
+    () => (
+      <EuiListGroup
+        gutterSize="none"
+        bordered={false}
+        size="m"
+        flush={true}
+        color="primary"
+        data-test-subj={contentTestSubj}
+      >
+        {items.map((item) => (
+          <ExpandPopoverListItem
+            key={item.key}
+            label={item.label}
+            data-test-subj={itemTestSubj}
+            showToolTip={false}
+          />
+        ))}
+      </EuiListGroup>
+    ),
+    [items, contentTestSubj, itemTestSubj]
+  );
+
+  // eslint-disable-next-line react/display-name
+  const PopoverComponent = memo(() => (
+    <GraphPopover
+      panelPaddingSize="s"
+      anchorPosition="rightCenter"
+      isOpen={state.isOpen}
+      anchorElement={state.anchorElement}
+      closePopover={actions.closePopover}
+      panelStyle={{ maxHeight: '336px', overflowY: 'auto' }}
+      data-test-subj={popoverTestSubj}
+    >
+      {items.length > visibleLimit ? popoverContent : null}
+    </GraphPopover>
+  ));
+
+  const onClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => actions.openPopover(e.currentTarget),
+    [actions]
+  );
+
+  return useMemo(
+    () => ({
+      id,
+      onClick,
+      PopoverComponent,
+      actions,
+      state,
+    }),
+    [PopoverComponent, actions, id, state, onClick]
+  );
+};

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
@@ -127,22 +127,20 @@ export const useNodeDetailsPopover = ({
     [items, contentTestSubj, itemTestSubj]
   );
 
-  const PopoverComponent = useMemo(() => {
-    // eslint-disable-next-line react/display-name
-    return memo(() => (
-      <GraphPopover
-        panelPaddingSize="m"
-        anchorPosition="rightCenter"
-        isOpen={state.isOpen}
-        anchorElement={state.anchorElement}
-        closePopover={actions.closePopover}
-        panelStyle={panelStyle}
-        data-test-subj={popoverTestSubj}
-      >
-        {popoverContent}
-      </GraphPopover>
-    ));
-  }, [panelStyle, popoverContent]);
+ // eslint-disable-next-line react/display-name
+  const PopoverComponent = memo(() => (
+    <GraphPopover
+      panelPaddingSize="m"
+      anchorPosition="rightCenter"
+      isOpen={state.isOpen}
+      anchorElement={state.anchorElement}
+      closePopover={actions.closePopover}
+      panelStyle={panelStyle}
+      data-test-subj={popoverTestSubj}
+    >
+      {popoverContent}
+    </GraphPopover>
+  ));
 
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => actions.openPopover(e.currentTarget),

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/use_node_details_popover.tsx
@@ -87,7 +87,6 @@ export const useNodeDetailsPopover = ({
         bordered={false}
         size="m"
         flush={true}
-        color="primary"
         data-test-subj={contentTestSubj}
       >
         {items.map((item) => (

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.stories.tsx
@@ -8,7 +8,11 @@
 import React from 'react';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { ThemeProvider } from '@emotion/react';
-import { CountryFlags as CountryFlagsComponent, type CountryFlagsProps } from './country_flags';
+import {
+  CountryFlags as CountryFlagsComponent,
+  useCountryFlagsPopover,
+  type CountryFlagsProps,
+} from './country_flags';
 import { GlobalStylesStorybookDecorator } from '../../../../.storybook/decorators';
 
 import '@xyflow/react/dist/style.css';
@@ -41,12 +45,57 @@ const meta: Meta<CountryFlagsProps> = {
 
 export default meta;
 
-const Template: StoryFn<CountryFlagsProps> = (props: CountryFlagsProps) => (
+const CountryFlagsWithPopoverComponent: React.FC<CountryFlagsProps> = (props) => {
+  const countryFlagsPopover = useCountryFlagsPopover(props.countryCodes);
+
+  return (
+    <>
+      <CountryFlagsComponent {...props} onCountryClick={countryFlagsPopover.onCountryClick} />
+      <countryFlagsPopover.PopoverComponent />
+    </>
+  );
+};
+
+const SimpleTemplate: StoryFn<CountryFlagsProps> = (props: CountryFlagsProps) => (
   <ThemeProvider theme={{ darkMode: false }}>
     <CountryFlagsComponent {...props} />
   </ThemeProvider>
 );
 
+const PopoverTemplate: StoryFn<CountryFlagsProps> = (props: CountryFlagsProps) => (
+  <ThemeProvider theme={{ darkMode: false }}>
+    <CountryFlagsWithPopoverComponent {...props} />
+  </ThemeProvider>
+);
+
 export const CountryFlags: StoryObj<CountryFlagsProps> = {
-  render: Template,
+  render: SimpleTemplate,
+};
+
+export const CountryFlagsWithPopover: StoryObj<CountryFlagsProps> = {
+  render: PopoverTemplate,
+  args: {
+    countryCodes: [
+      'US',
+      'INVALID_CODE',
+      '',
+      null as unknown as string,
+      'RU',
+      'ES',
+      'US',
+      'US',
+      'IL',
+      'IT',
+      'DE',
+      'FR',
+      'GR',
+      'BR',
+      'AR',
+      'PT',
+      'NO',
+      'CA',
+      'AU',
+      'JP',
+    ],
+  },
 };

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.test.tsx
@@ -56,7 +56,7 @@ describe('CountryFlags', () => {
     expect(mockOnCountryClick).toHaveBeenCalledTimes(1);
   });
 
-  test('renders badge with none clickable counter when over the visible limit of country flags without onCountryClick callback', async () => {
+  test('renders badge with non clickable counter when over the visible limit of country flags without onCountryClick callback', async () => {
     const testCountryCodes = ['US', 'FR', 'DE', 'JP'];
     render(<CountryFlags countryCodes={testCountryCodes} />);
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.test.tsx
@@ -6,103 +6,71 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { i18n } from '@kbn/i18n';
 import {
   GRAPH_FLAGS_BADGE_ID,
+  GRAPH_FLAGS_PLUS_COUNT_BUTTON_ID,
   GRAPH_FLAGS_PLUS_COUNT_ID,
-  GRAPH_FLAGS_TOOLTIP_CONTENT_ID,
-  GRAPH_FLAGS_TOOLTIP_COUNTRY_ID,
+  GRAPH_FLAGS_POPOVER_CONTENT_ID,
 } from '../../test_ids';
-import { CountryFlags, MAX_COUNTRY_FLAGS_IN_TOOLTIP } from './country_flags';
+import { CountryFlags, useCountryFlagsPopover } from './country_flags';
 
 describe('CountryFlags', () => {
+  const mockOnCountryClick = jest.fn();
+
+  beforeEach(() => {
+    mockOnCountryClick.mockClear();
+  });
+
   test('render null when input array is empty', () => {
     const { container } = render(<CountryFlags countryCodes={[]} />);
     expect(container.firstChild).toBeNull();
   });
 
-  test('renders badge with only country flags when below the limit', async () => {
+  test('renders badge with country flags without counter when below the limit', async () => {
     render(<CountryFlags countryCodes={['US']} />);
     expect(screen.queryByTestId(GRAPH_FLAGS_BADGE_ID)?.textContent).toStrictEqual('🇺🇸');
-    expect(screen.queryByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).not.toBeInTheDocument();
-
-    await userEvent.hover(screen.getByTestId(GRAPH_FLAGS_BADGE_ID));
-
-    await waitFor(() => {
-      expect(screen.queryByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId(GRAPH_FLAGS_POPOVER_CONTENT_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(GRAPH_FLAGS_PLUS_COUNT_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(GRAPH_FLAGS_PLUS_COUNT_BUTTON_ID)).not.toBeInTheDocument();
   });
 
-  test('renders badge with only country flags when reaching the limit', async () => {
+  test('renders badge with country flags without counter when reaching the limit', async () => {
     render(<CountryFlags countryCodes={['US', 'FR']} />);
     expect(screen.queryByTestId(GRAPH_FLAGS_BADGE_ID)?.textContent).toStrictEqual('🇺🇸🇫🇷');
-    expect(screen.queryByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).not.toBeInTheDocument();
-
-    await userEvent.hover(screen.getByTestId(GRAPH_FLAGS_BADGE_ID));
-
-    await waitFor(() => {
-      expect(screen.queryByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).not.toBeInTheDocument();
-      expect(screen.queryByTestId(GRAPH_FLAGS_PLUS_COUNT_ID)).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId(GRAPH_FLAGS_POPOVER_CONTENT_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(GRAPH_FLAGS_PLUS_COUNT_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(GRAPH_FLAGS_PLUS_COUNT_BUTTON_ID)).not.toBeInTheDocument();
   });
 
-  test('renders badge with counter, tooltip and two first country flags when over the visible limit and all are repeated the same amount', async () => {
-    render(<CountryFlags countryCodes={['US', 'FR', 'DE', 'JP']} />);
+  test('renders badge with clickable counter when over the visible limit of country flags with onCountryClick callback', async () => {
+    render(
+      <CountryFlags countryCodes={['US', 'FR', 'DE', 'JP']} onCountryClick={mockOnCountryClick} />
+    );
     expect(screen.queryByTestId(GRAPH_FLAGS_BADGE_ID)?.textContent).toStrictEqual('🇺🇸🇫🇷+2');
-    expect(screen.queryByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(GRAPH_FLAGS_PLUS_COUNT_BUTTON_ID)).toBeInTheDocument();
 
-    await userEvent.hover(screen.getByTestId(GRAPH_FLAGS_BADGE_ID));
+    await userEvent.click(screen.getByTestId(GRAPH_FLAGS_PLUS_COUNT_BUTTON_ID));
 
-    await waitFor(() => {
-      expect(screen.queryByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).toBeInTheDocument();
-    });
-
-    const tooltipContent = screen.getByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID);
-    expect(Array.from(tooltipContent.children).map((li) => li.textContent)).toStrictEqual([
-      '🇺🇸 United States of America',
-      '🇫🇷 France',
-      '🇩🇪 Germany',
-      '🇯🇵 Japan',
-    ]);
+    expect(mockOnCountryClick).toHaveBeenCalledTimes(1);
   });
 
-  test('renders tooltip with max number of countries and copy to open details in flyout', async () => {
-    const countryCodes = ['US', 'FR', 'DE', 'JP', 'IL', 'GB', 'CA', 'BR', 'GR', 'IT', 'RU'];
-    render(<CountryFlags countryCodes={countryCodes} />);
+  test('renders badge with none clickable counter when over the visible limit of country flags without onCountryClick callback', async () => {
+    const testCountryCodes = ['US', 'FR', 'DE', 'JP'];
+    render(<CountryFlags countryCodes={testCountryCodes} />);
 
-    await userEvent.hover(screen.getByTestId(GRAPH_FLAGS_BADGE_ID));
+    expect(screen.queryByTestId(GRAPH_FLAGS_PLUS_COUNT_ID)).toBeInTheDocument();
+    expect(screen.queryByTestId(GRAPH_FLAGS_PLUS_COUNT_BUTTON_ID)).not.toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(screen.queryByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).toBeInTheDocument();
-    });
-
-    const tooltipCountries = screen.getAllByTestId(GRAPH_FLAGS_TOOLTIP_COUNTRY_ID);
-
-    expect(countryCodes).toHaveLength(MAX_COUNTRY_FLAGS_IN_TOOLTIP + 1);
-    expect(tooltipCountries).toHaveLength(MAX_COUNTRY_FLAGS_IN_TOOLTIP);
-
-    const tooltipContent = screen.getByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID);
-    expect(Array.from(tooltipContent.children).map((li) => li.textContent)).toStrictEqual([
-      '🇺🇸 United States of America',
-      '🇫🇷 France',
-      '🇩🇪 Germany',
-      '🇯🇵 Japan',
-      '🇮🇱 Israel',
-      '🇬🇧 United Kingdom',
-      '🇨🇦 Canada',
-      '🇧🇷 Brazil',
-      '🇬🇷 Greece',
-      '🇮🇹 Italy',
-    ]); // Russia is omitted for being over the limit
+    expect(mockOnCountryClick).toHaveBeenCalledTimes(0);
   });
 
   test('renders aria-label in focusable button', () => {
-    render(<CountryFlags countryCodes={['us', 'fr', 'es']} />);
+    render(<CountryFlags countryCodes={['us', 'fr', 'es']} onCountryClick={mockOnCountryClick} />);
 
-    const tooltipButton = screen.getByRole('button');
-    expect(tooltipButton).toHaveAccessibleName('Show geolocation details');
+    const counterButton = screen.getByTestId(GRAPH_FLAGS_PLUS_COUNT_BUTTON_ID);
+    expect(counterButton).toHaveAccessibleName('Country flags popover');
   });
 
   describe('ignores invalid country codes', () => {
@@ -142,72 +110,50 @@ describe('CountryFlags', () => {
         />
       );
       expect(screen.queryByTestId(GRAPH_FLAGS_BADGE_ID)?.textContent).toStrictEqual('🇺🇸');
-      expect(screen.queryByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).not.toBeInTheDocument();
 
       await userEvent.hover(screen.getByTestId(GRAPH_FLAGS_BADGE_ID));
 
       await waitFor(() => {
-        expect(screen.queryByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).not.toBeInTheDocument();
         expect(screen.queryByTestId(GRAPH_FLAGS_PLUS_COUNT_ID)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(GRAPH_FLAGS_PLUS_COUNT_BUTTON_ID)).not.toBeInTheDocument();
       });
     });
+  });
+});
 
-    test('ignores in tooltip', async () => {
-      const countryCodes = ['US', 'INVALID', 'FR', 'JP', 'UK']; // United Kingdom's country code is 'GB', not 'UK'
-      render(<CountryFlags countryCodes={countryCodes} />);
+describe('useCountryFlagsPopover', () => {
+  test('filters invalid country codes and transforms valid ones correctly', () => {
+    const countryCodes = ['US', 'INVALID', 'FR', '', 'DE', null as unknown as string];
+    const { result } = renderHook(() => useCountryFlagsPopover(countryCodes));
 
-      await userEvent.hover(screen.getByTestId(GRAPH_FLAGS_BADGE_ID));
-
-      await waitFor(() => {
-        expect(screen.queryByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).toBeInTheDocument();
-      });
-
-      const tooltipContent = screen.getByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID);
-      expect(Array.from(tooltipContent.children).map((li) => li.textContent)).toStrictEqual([
-        '🇺🇸 United States of America',
-        '🇫🇷 France',
-        '🇯🇵 Japan',
-      ]);
-    });
+    // Should have filtered out invalid codes and transformed valid ones
+    expect(result.current.id).toBe('country-flags-popover');
+    expect(result.current.onCountryClick).toBeInstanceOf(Function);
+    expect(result.current.PopoverComponent).toBeDefined();
+    expect(result.current.actions).toBeDefined();
+    expect(result.current.state).toBeDefined();
   });
 
-  test('handles uppercase, lowercase, or mixed-case input', async () => {
-    render(<CountryFlags countryCodes={['us', 'FR', 'eS']} />);
-    expect(screen.queryByTestId(GRAPH_FLAGS_BADGE_ID)?.textContent).toStrictEqual('🇺🇸🇫🇷+1');
-    expect(screen.queryByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).not.toBeInTheDocument();
+  test('handles empty array', () => {
+    const { result } = renderHook(() => useCountryFlagsPopover([]));
 
-    await userEvent.hover(screen.getByTestId(GRAPH_FLAGS_BADGE_ID));
-
-    await waitFor(() => {
-      expect(screen.getByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).toBeInTheDocument();
-    });
-
-    const tooltipContent = screen.getByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID);
-    expect(Array.from(tooltipContent.children).map((li) => li.textContent)).toStrictEqual([
-      '🇺🇸 United States of America',
-      '🇫🇷 France',
-      '🇪🇸 Spain',
-    ]);
+    expect(result.current.id).toBe('country-flags-popover');
+    expect(result.current.onCountryClick).toBeInstanceOf(Function);
   });
 
-  test('localizes country names based on current locale', async () => {
-    const localeSpy = jest.spyOn(i18n, 'getLocale').mockReturnValue('fr');
+  test('returns correct interface structure', () => {
+    const countryCodes = ['US', 'FR'];
+    const { result } = renderHook(() => useCountryFlagsPopover(countryCodes));
 
-    render(<CountryFlags countryCodes={['us', 'fr', 'es']} />);
+    // Check that it has all required properties from UseCountryFlagsPopoverReturn
+    expect(result.current).toHaveProperty('id');
+    expect(result.current).toHaveProperty('onCountryClick');
+    expect(result.current).toHaveProperty('PopoverComponent');
+    expect(result.current).toHaveProperty('actions');
+    expect(result.current).toHaveProperty('state');
+    expect(result.current).toHaveProperty('onClick');
 
-    await userEvent.hover(screen.getByTestId(GRAPH_FLAGS_BADGE_ID));
-
-    await waitFor(() => {
-      expect(screen.getByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID)).toBeInTheDocument();
-    });
-
-    const tooltipContent = screen.getByTestId(GRAPH_FLAGS_TOOLTIP_CONTENT_ID);
-    expect(Array.from(tooltipContent.children).map((li) => li.textContent)).toStrictEqual([
-      "🇺🇸 États-Unis d'Amérique",
-      '🇫🇷 France',
-      '🇪🇸 Espagne',
-    ]);
-
-    localeSpy.mockRestore();
+    // Verify onCountryClick is the same as onClick (the hook alias)
+    expect(result.current.onCountryClick).toBe(result.current.onClick);
   });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.tsx
@@ -93,9 +93,9 @@ export const CountryFlags = memo(({ countryCodes, onCountryClick }: CountryFlags
           size="xs"
           color="text"
           data-test-subj={GRAPH_FLAGS_PLUS_COUNT_BUTTON_ID}
-        onClick={onCountryClick}
+          onClick={onCountryClick}
           aria-label={popoverAriaLabel}
-          flush='both'
+          flush="both"
           css={css`
             font-weight: medium;
           `}

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo } from 'react';
-import { EuiFlexItem, EuiText, EuiLink, useEuiFontSize, EuiButtonEmpty } from '@elastic/eui';
+import { EuiFlexItem, EuiText, useEuiFontSize, EuiButtonEmpty } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import {
@@ -25,7 +25,6 @@ import {
 import { RoundedBadge } from '../styles';
 import { getCountryFlag, getCountryName } from './country_codes';
 
-export const MAX_COUNTRY_FLAGS_IN_POPOVER = 10;
 const VISIBLE_FLAGS_LIMIT = 2;
 
 const popoverAriaLabel = i18n.translate(
@@ -53,7 +52,6 @@ export const useCountryFlagsPopover = (countryCodes: string[]): UseCountryFlagsP
     contentTestSubj: GRAPH_FLAGS_POPOVER_CONTENT_ID,
     itemTestSubj: GRAPH_FLAGS_POPOVER_COUNTRY_ID,
     popoverTestSubj: GRAPH_FLAGS_POPOVER_ID,
-    visibleLimit: VISIBLE_FLAGS_LIMIT,
   });
 
   return {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo } from 'react';
-import { EuiFlexItem, EuiText, EuiLink, useEuiFontSize } from '@elastic/eui';
+import { EuiFlexItem, EuiText, EuiLink, useEuiFontSize, EuiButtonEmpty } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import {
@@ -91,23 +91,20 @@ export const CountryFlags = memo(({ countryCodes, onCountryClick }: CountryFlags
   const counter =
     validCodes.length > VISIBLE_FLAGS_LIMIT ? (
       onCountryClick ? (
-        <EuiLink
-          color="subdued"
+        <EuiButtonEmpty
+          size="xs"
+          color="text"
           data-test-subj={GRAPH_FLAGS_PLUS_COUNT_BUTTON_ID}
-          onClick={onCountryClick}
+        onClick={onCountryClick}
           aria-label={popoverAriaLabel}
+          flush='both'
+          css={css`
+            font-weight: medium;
+          `}
         >
-          <EuiText
-            aria-label={popoverAriaLabel}
-            css={css`
-              font-weight: medium;
-            `}
-            size="xs"
-          >
-            {'+'}
-            {validCodes.length - VISIBLE_FLAGS_LIMIT}
-          </EuiText>
-        </EuiLink>
+          {'+'}
+          {validCodes.length - VISIBLE_FLAGS_LIMIT}
+        </EuiButtonEmpty>
       ) : (
         <EuiText
           size="xs"

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.tsx
@@ -27,6 +27,13 @@ import { getCountryFlag, getCountryName } from './country_codes';
 
 const VISIBLE_FLAGS_LIMIT = 2;
 
+/**
+ * Filters out invalid country codes that don't have corresponding flags
+ */
+const getValidCountryCodes = (countryCodes: string[]): string[] => {
+  return countryCodes.filter((code) => getCountryFlag(code) !== null);
+};
+
 const popoverAriaLabel = i18n.translate(
   'securitySolutionPackages.csp.graph.countryFlags.popoverAriaLabel',
   {
@@ -39,7 +46,7 @@ export type UseCountryFlagsPopoverReturn = UseNodeDetailsPopoverReturn & {
 };
 
 export const useCountryFlagsPopover = (countryCodes: string[]): UseCountryFlagsPopoverReturn => {
-  const validCodes = countryCodes.filter((code) => getCountryFlag(code) !== null);
+  const validCodes = getValidCountryCodes(countryCodes);
 
   const items = validCodes.map((countryCode, index) => ({
     key: `${index}-${countryCode}`,
@@ -70,7 +77,7 @@ export interface CountryFlagsProps {
 }
 
 export const CountryFlags = memo(({ countryCodes, onCountryClick }: CountryFlagsProps) => {
-  const validCodes = countryCodes.filter((code) => getCountryFlag(code) !== null);
+  const validCodes = getValidCountryCodes(countryCodes);
   const xsFontSize = useEuiFontSize('xs');
 
   if (validCodes.length === 0) {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/diamond_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/diamond_node.tsx
@@ -51,6 +51,7 @@ export const DiamondNode = memo<NodeProps>((props: NodeProps) => {
     interactive,
     expandButtonClick,
     nodeClick,
+    ipClickHandler,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -136,6 +137,7 @@ export const DiamondNode = memo<NodeProps>((props: NodeProps) => {
         label={label ? label : id}
         ips={ips}
         countryCodes={countryCodes}
+        onIpClick={ipClickHandler}
       />
     </NodeContainer>
   );

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/diamond_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/diamond_node.tsx
@@ -52,6 +52,7 @@ export const DiamondNode = memo<NodeProps>((props: NodeProps) => {
     expandButtonClick,
     nodeClick,
     ipClickHandler,
+    countryClickHandler,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -138,6 +139,7 @@ export const DiamondNode = memo<NodeProps>((props: NodeProps) => {
         ips={ips}
         countryCodes={countryCodes}
         onIpClick={ipClickHandler}
+        onCountryClick={countryClickHandler}
       />
     </NodeContainer>
   );

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ellipse_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ellipse_node.tsx
@@ -52,6 +52,7 @@ export const EllipseNode = memo<NodeProps>((props: NodeProps) => {
     expandButtonClick,
     nodeClick,
     ipClickHandler,
+    countryClickHandler,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -138,6 +139,7 @@ export const EllipseNode = memo<NodeProps>((props: NodeProps) => {
         ips={ips}
         countryCodes={countryCodes}
         onIpClick={ipClickHandler}
+        onCountryClick={countryClickHandler}
       />
     </NodeContainer>
   );

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ellipse_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ellipse_node.tsx
@@ -51,6 +51,7 @@ export const EllipseNode = memo<NodeProps>((props: NodeProps) => {
     interactive,
     expandButtonClick,
     nodeClick,
+    ipClickHandler,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -136,6 +137,7 @@ export const EllipseNode = memo<NodeProps>((props: NodeProps) => {
         label={label ? label : id}
         ips={ips}
         countryCodes={countryCodes}
+        onIpClick={ipClickHandler}
       />
     </NodeContainer>
   );

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/hexagon_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/hexagon_node.tsx
@@ -52,6 +52,7 @@ export const HexagonNode = memo<NodeProps>((props: NodeProps) => {
     expandButtonClick,
     nodeClick,
     ipClickHandler,
+    countryClickHandler,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -142,6 +143,7 @@ export const HexagonNode = memo<NodeProps>((props: NodeProps) => {
         ips={ips}
         countryCodes={countryCodes}
         onIpClick={ipClickHandler}
+        onCountryClick={countryClickHandler}
       />
     </NodeContainer>
   );

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/hexagon_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/hexagon_node.tsx
@@ -51,6 +51,7 @@ export const HexagonNode = memo<NodeProps>((props: NodeProps) => {
     interactive,
     expandButtonClick,
     nodeClick,
+    ipClickHandler,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -140,6 +141,7 @@ export const HexagonNode = memo<NodeProps>((props: NodeProps) => {
         label={label ? label : id}
         ips={ips}
         countryCodes={countryCodes}
+        onIpClick={ipClickHandler}
       />
     </NodeContainer>
   );

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.stories.tsx
@@ -8,13 +8,43 @@
 import React from 'react';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { ThemeProvider } from '@emotion/react';
-import { Ips as IpsComponent, type IpsProps } from './ips';
+import { Ips as IpsComponent, useIpPopover, type IpsProps } from './ips';
 import { GlobalStylesStorybookDecorator } from '../../../../.storybook/decorators';
 
 import '@xyflow/react/dist/style.css';
 
 const meta: Meta<IpsProps> = {
   title: 'Components/Graph Components/Additional Components',
+  decorators: [GlobalStylesStorybookDecorator],
+};
+
+export default meta;
+
+const IpsWithPopoverComponent: React.FC<IpsProps> = (props) => {
+  const ipPopover = useIpPopover(props.ips);
+
+  return (
+    <>
+      <IpsComponent {...props} onIpClick={ipPopover.onIpClick} />
+      <ipPopover.PopoverComponent />
+    </>
+  );
+};
+
+const SimpleTemplate: StoryFn<IpsProps> = (props: IpsProps) => (
+  <ThemeProvider theme={{ darkMode: false }}>
+    <IpsComponent {...props} />
+  </ThemeProvider>
+);
+
+const PopoverTemplate: StoryFn<IpsProps> = (props: IpsProps) => (
+  <ThemeProvider theme={{ darkMode: false }}>
+    <IpsWithPopoverComponent {...props} />
+  </ThemeProvider>
+);
+
+export const Ips: StoryObj<IpsProps> = {
+  render: SimpleTemplate,
   args: {
     ips: [
       '10.200.0.202',
@@ -25,17 +55,19 @@ const meta: Meta<IpsProps> = {
       '10.200.0.202',
     ],
   },
-  decorators: [GlobalStylesStorybookDecorator],
 };
 
-export default meta;
-
-const Template: StoryFn<IpsProps> = (props: IpsProps) => (
-  <ThemeProvider theme={{ darkMode: false }}>
-    <IpsComponent {...props} />
-  </ThemeProvider>
-);
-
-export const Ips: StoryObj<IpsProps> = {
-  render: Template,
+export const IpsWithPopover: StoryObj<IpsProps> = {
+  render: PopoverTemplate,
+  args: {
+    ips: [
+      '10.200.0.202',
+      '192.14.29.80',
+      '74.25.14.20',
+      '172.16.0.1',
+      '203.0.113.1',
+      '198.51.100.1',
+      '192.0.2.1',
+    ],
+  },
 };

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.test.tsx
@@ -8,7 +8,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { GRAPH_IPS_TEXT_ID, GRAPH_IPS_PLUS_COUNT_ID } from '../../test_ids';
+import {
+  GRAPH_IPS_TEXT_ID,
+  GRAPH_IPS_PLUS_COUNT_ID,
+  GRAPH_IPS_PLUS_COUNT_BUTTON_ID,
+} from '../../test_ids';
 import { Ips } from './ips';
 
 describe('Ips', () => {
@@ -29,6 +33,7 @@ describe('Ips', () => {
 
     expect(screen.getByTestId(GRAPH_IPS_TEXT_ID)).toHaveTextContent(`${'IP: '}${testIp}`);
     expect(screen.queryByTestId(GRAPH_IPS_PLUS_COUNT_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(GRAPH_IPS_PLUS_COUNT_BUTTON_ID)).not.toBeInTheDocument();
   });
 
   test('renders multiple IPs with a counter', () => {
@@ -37,6 +42,7 @@ describe('Ips', () => {
 
     expect(screen.getByTestId(GRAPH_IPS_TEXT_ID)).toHaveTextContent(`${'IP: '}${testIps[0]}`);
     expect(screen.getByTestId(GRAPH_IPS_PLUS_COUNT_ID)).toHaveTextContent('+2');
+    expect(screen.queryByTestId(GRAPH_IPS_PLUS_COUNT_BUTTON_ID)).not.toBeInTheDocument();
   });
 
   test('renders aria-label in focusable button', () => {
@@ -52,7 +58,7 @@ describe('Ips', () => {
       const testIps = ['192.168.1.1', '10.0.0.1', '172.16.0.1'];
       render(<Ips ips={testIps} onIpClick={mockOnIpClick} />);
 
-      const counterButton = screen.getByTestId(GRAPH_IPS_PLUS_COUNT_ID);
+      const counterButton = screen.getByTestId(GRAPH_IPS_PLUS_COUNT_BUTTON_ID);
       await userEvent.click(counterButton);
 
       expect(mockOnIpClick).toHaveBeenCalledTimes(1);
@@ -62,18 +68,15 @@ describe('Ips', () => {
       const testIps = ['192.168.1.1'];
       render(<Ips ips={testIps} onIpClick={mockOnIpClick} />);
 
-      expect(screen.queryByTestId(GRAPH_IPS_PLUS_COUNT_ID)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(GRAPH_IPS_PLUS_COUNT_BUTTON_ID)).not.toBeInTheDocument();
     });
 
     test('does not call onIpClick when onIpClick is not provided', async () => {
       const testIps = ['192.168.1.1', '10.0.0.1', '172.16.0.1'];
       render(<Ips ips={testIps} />);
 
-      const counterButton = screen.getByTestId(GRAPH_IPS_PLUS_COUNT_ID);
-      await userEvent.click(counterButton);
-
-      // Should not throw any errors
-      expect(mockOnIpClick).not.toHaveBeenCalled();
+      const counterButton = screen.queryByTestId(GRAPH_IPS_PLUS_COUNT_BUTTON_ID);
+      expect(counterButton).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
@@ -25,9 +25,12 @@ import { createPreviewItems } from '../utils';
 
 export const VISIBLE_IPS_LIMIT = 1;
 
-const popoverTipAriaLabel = i18n.translate('securitySolutionPackages.csp.graph.ips.popoverAriaLabel', {
-  defaultMessage: 'Show IP address details',
-});
+const popoverTipAriaLabel = i18n.translate(
+  'securitySolutionPackages.csp.graph.ips.popoverAriaLabel',
+  {
+    defaultMessage: 'Show IP address details',
+  }
+);
 
 export type UseIpPopoverReturn = UseNodeDetailsPopoverReturn & {
   onIpClick: (e: React.MouseEvent<HTMLButtonElement>) => void;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
@@ -24,7 +24,6 @@ import {
 import { createPreviewItems } from '../utils';
 
 export const VISIBLE_IPS_LIMIT = 1;
-export const MAX_IPS_IN_POPOVER = 10;
 
 const toolTipAriaLabel = i18n.translate('securitySolutionPackages.csp.graph.ips.toolTipAriaLabel', {
   defaultMessage: 'Show IP address details',

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiText, EuiLink, useEuiFontSize } from '@elastic/eui';
+import { EuiFlexGroup, EuiText, EuiButtonEmpty, useEuiFontSize } from '@elastic/eui';
 import { css } from '@emotion/css';
 import { i18n } from '@kbn/i18n';
 import {
@@ -87,19 +87,19 @@ export const Ips = ({ ips, onIpClick }: IpsProps) => {
   const counter =
     ips.length > VISIBLE_IPS_LIMIT ? (
       onIpClick ? (
-        <EuiLink
-          color="subdued"
+        <EuiButtonEmpty
+          size="xs"
+          color="text"
           data-test-subj={GRAPH_IPS_PLUS_COUNT_BUTTON_ID}
           onClick={onIpClick}
           aria-label={toolTipAriaLabel}
+          flush='both'
+          css={css`
+            font-weight: medium;
+          `}
         >
-          <EuiText
-            css={css`
-              font-weight: medium;
-            `}
-            size="xs"
-          >{`+${ips.length - VISIBLE_IPS_LIMIT}`}</EuiText>
-        </EuiLink>
+          {`+${ips.length - VISIBLE_IPS_LIMIT}`}
+        </EuiButtonEmpty>
       ) : (
         <EuiText
           size="xs"

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
@@ -25,7 +25,7 @@ import { createPreviewItems } from '../utils';
 
 export const VISIBLE_IPS_LIMIT = 1;
 
-const toolTipAriaLabel = i18n.translate('securitySolutionPackages.csp.graph.ips.toolTipAriaLabel', {
+const popoverTipAriaLabel = i18n.translate('securitySolutionPackages.csp.graph.ips.popoverAriaLabel', {
   defaultMessage: 'Show IP address details',
 });
 
@@ -93,7 +93,7 @@ export const Ips = ({ ips, onIpClick }: IpsProps) => {
           color="text"
           data-test-subj={GRAPH_IPS_PLUS_COUNT_BUTTON_ID}
           onClick={onIpClick}
-          aria-label={toolTipAriaLabel}
+          aria-label={popoverTipAriaLabel}
           flush="both"
           css={css`
             font-weight: medium;
@@ -105,7 +105,7 @@ export const Ips = ({ ips, onIpClick }: IpsProps) => {
         <EuiText
           size="xs"
           color="subdued"
-          aria-label={toolTipAriaLabel}
+          aria-label={popoverTipAriaLabel}
           data-test-subj={GRAPH_IPS_PLUS_COUNT_ID}
           css={css`
             font-weight: medium;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
@@ -21,6 +21,7 @@ import {
   GRAPH_IPS_POPOVER_ID,
   GRAPH_IPS_PLUS_COUNT_BUTTON_ID,
 } from '../../test_ids';
+import { createPreviewItems } from '../utils';
 
 export const VISIBLE_IPS_LIMIT = 1;
 export const MAX_IPS_IN_POPOVER = 10;
@@ -33,11 +34,13 @@ export type UseIpPopoverReturn = UseNodeDetailsPopoverReturn & {
   onIpClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
-export const useIpPopover = (ips: string[]): UseIpPopoverReturn => {
-  const items = ips.map((ip, index) => ({
-    key: `${index}-${ip}`,
-    label: ip,
-  }));
+export const useIpPopover = (ips: string[], scopeId?: string): UseIpPopoverReturn => {
+  const items = scopeId 
+    ? createPreviewItems('network-preview', ips, scopeId)
+    : ips.map((ip, index) => ({
+        key: `${index}-${ip}`,
+        label: ip,
+      }));
 
   const { id, onClick, PopoverComponent, actions, state } = useNodeDetailsPopover({
     popoverId: 'ips-popover',

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
@@ -35,7 +35,7 @@ export type UseIpPopoverReturn = UseNodeDetailsPopoverReturn & {
 };
 
 export const useIpPopover = (ips: string[], scopeId?: string): UseIpPopoverReturn => {
-  const items = scopeId 
+  const items = scopeId
     ? createPreviewItems('network-preview', ips, scopeId)
     : ips.map((ip, index) => ({
         key: `${index}-${ip}`,
@@ -95,7 +95,7 @@ export const Ips = ({ ips, onIpClick }: IpsProps) => {
           data-test-subj={GRAPH_IPS_PLUS_COUNT_BUTTON_ID}
           onClick={onIpClick}
           aria-label={toolTipAriaLabel}
-          flush='both'
+          flush="both"
           css={css`
             font-weight: medium;
           `}

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.tsx
@@ -45,7 +45,6 @@ export const useIpPopover = (ips: string[]): UseIpPopoverReturn => {
     contentTestSubj: GRAPH_IPS_POPOVER_CONTENT_ID,
     itemTestSubj: GRAPH_IPS_POPOVER_IP_ID,
     popoverTestSubj: GRAPH_IPS_POPOVER_ID,
-    visibleLimit: VISIBLE_IPS_LIMIT,
   });
 
   return {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.test.tsx
@@ -18,6 +18,8 @@ import {
   TEST_SUBJ_EXPAND_BTN,
   TEST_SUBJ_HANDLE,
   TEST_SUBJ_HOVER_OUTLINE,
+  TEST_SUBJ_LABEL_TEXT,
+  TEST_SUBJ_TOOLTIP,
 } from './label_node';
 
 jest.mock('./label_node_badges', () => {
@@ -158,6 +160,67 @@ describe('LabelNode', () => {
 
     expect(screen.queryByTestId(GRAPH_IPS_TEXT_ID)).toBeInTheDocument();
     expect(screen.queryByTestId(GRAPH_FLAGS_BADGE_ID)).toBeInTheDocument();
+  });
+
+  describe('Tooltip', () => {
+    test('shows tooltip when text is truncated', async () => {
+      const props = {
+        ...baseProps,
+        data: {
+          ...baseProps.data,
+          label: 'This label is too long so it will be truncated for sure oh yeah',
+        },
+      };
+
+      render(
+        <ReactFlow>
+          <LabelNode {...props} />
+        </ReactFlow>
+      );
+
+      await userEvent.hover(screen.getByTestId(TEST_SUBJ_LABEL_TEXT));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(TEST_SUBJ_TOOLTIP)).toBeInTheDocument();
+      });
+    });
+
+    test('tooltip shows full text content', async () => {
+      const longText = 'This is a very long label that exceeds twenty-seven characters';
+      const props = {
+        ...baseProps,
+        data: {
+          ...baseProps.data,
+          label: longText,
+        },
+      };
+      render(
+        <ReactFlow>
+          <LabelNode {...props} />
+        </ReactFlow>
+      );
+
+      await userEvent.hover(screen.getByTestId(TEST_SUBJ_LABEL_TEXT));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(TEST_SUBJ_TOOLTIP)).toBeInTheDocument();
+        expect(screen.queryByTestId(TEST_SUBJ_TOOLTIP)).toHaveTextContent(longText);
+      });
+    });
+
+    test('does not show tooltip otherwise', async () => {
+      render(
+        <ReactFlow>
+          <LabelNode {...baseProps} />
+        </ReactFlow>
+      );
+
+      await userEvent.hover(screen.getByTestId(TEST_SUBJ_LABEL_TEXT));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(TEST_SUBJ_TOOLTIP)).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('Shape colors', () => {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.test.tsx
@@ -18,7 +18,6 @@ import {
   TEST_SUBJ_EXPAND_BTN,
   TEST_SUBJ_HANDLE,
   TEST_SUBJ_HOVER_OUTLINE,
-  TEST_SUBJ_TOOLTIP,
 } from './label_node';
 
 jest.mock('./label_node_badges', () => {
@@ -187,88 +186,6 @@ describe('LabelNode', () => {
         backgroundColor: mockEuiTheme.colors.backgroundBasePrimary,
         borderColor: mockEuiTheme.colors.borderStrongPrimary,
         textColor: mockEuiTheme.colors.textPrimary,
-      });
-    });
-  });
-
-  describe('Tooltip', () => {
-    test('shows tooltip when text is truncated', async () => {
-      const props = {
-        ...baseProps,
-        data: {
-          ...baseProps.data,
-          label: 'This label is too long so it will be truncated for sure oh yeah',
-        },
-      };
-
-      render(
-        <ReactFlow>
-          <LabelNode {...props} />
-        </ReactFlow>
-      );
-
-      await userEvent.hover(screen.getByTestId(GRAPH_LABEL_NODE_ID));
-
-      await waitFor(() => {
-        expect(screen.queryByTestId(TEST_SUBJ_TOOLTIP)).toBeInTheDocument();
-      });
-    });
-
-    test('shows tooltip when number of events is over limit', async () => {
-      const props = {
-        ...baseProps,
-        data: {
-          ...baseProps.data,
-          uniqueEventsCount: 3,
-        },
-      };
-
-      render(
-        <ReactFlow>
-          <LabelNode {...props} />
-        </ReactFlow>
-      );
-
-      await userEvent.hover(screen.getByTestId(GRAPH_LABEL_NODE_ID));
-
-      await waitFor(() => {
-        expect(screen.queryByTestId(TEST_SUBJ_TOOLTIP)).toBeInTheDocument();
-      });
-    });
-
-    test('shows tooltip when number of alerts is over limit', async () => {
-      const props = {
-        ...baseProps,
-        data: {
-          ...baseProps.data,
-          uniqueAlertsCount: 3,
-        },
-      };
-
-      render(
-        <ReactFlow>
-          <LabelNode {...props} />
-        </ReactFlow>
-      );
-
-      await userEvent.hover(screen.getByTestId(GRAPH_LABEL_NODE_ID));
-
-      await waitFor(() => {
-        expect(screen.queryByTestId(TEST_SUBJ_TOOLTIP)).toBeInTheDocument();
-      });
-    });
-
-    test('does not show tooltip otherwise', async () => {
-      render(
-        <ReactFlow>
-          <LabelNode {...baseProps} />
-        </ReactFlow>
-      );
-
-      await userEvent.hover(screen.getByTestId(GRAPH_LABEL_NODE_ID));
-
-      await waitFor(() => {
-        expect(screen.queryByTestId(TEST_SUBJ_TOOLTIP)).not.toBeInTheDocument();
       });
     });
   });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
@@ -57,6 +57,7 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
     countryCodes,
     nodeClick,
     expandButtonClick,
+    ipClickHandler,
   } = props.data as LabelNodeViewModel;
 
   const { euiTheme } = useEuiTheme();
@@ -166,7 +167,7 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
           />
         </LabelNodeContainer>
       </EuiToolTip>
-      <LabelNodeDetails ips={ips} countryCodes={countryCodes} />
+      <LabelNodeDetails ips={ips} countryCodes={countryCodes} onIpClick={ipClickHandler} />
     </>
   );
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
@@ -100,9 +100,7 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
             >
               <EuiTextTruncate truncation="end" text={text} />
             </EuiText>
-            <div css={css``}>
               <LabelNodeBadges analysis={analysis} onEventClick={eventClickHandler} />
-            </div>
           </div>
         </LabelShape>
         {showStackedShape(numEvents + numAlerts) && (

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
@@ -8,7 +8,14 @@
 import React, { memo, useMemo } from 'react';
 import { Handle, Position } from '@xyflow/react';
 import { css } from '@emotion/react';
-import { EuiText, EuiTextTruncate, transparentize, useEuiShadow, useEuiTheme } from '@elastic/eui';
+import {
+  EuiText,
+  EuiTextTruncate,
+  EuiToolTip,
+  transparentize,
+  useEuiShadow,
+  useEuiTheme,
+} from '@elastic/eui';
 import {
   LabelNodeContainer,
   LabelShape,
@@ -33,6 +40,10 @@ export const TEST_SUBJ_STACKED_SHAPE = 'label-node-stacked-shape';
 export const TEST_SUBJ_HANDLE = 'label-node-handle';
 export const TEST_SUBJ_EXPAND_BTN = 'label-node-expand-btn';
 export const TEST_SUBJ_HOVER_OUTLINE = 'label-node-hover-outline';
+export const TEST_SUBJ_TOOLTIP = 'label-node-tooltip';
+export const TEST_SUBJ_LABEL_TEXT = 'label-node-text';
+
+const MAX_LABEL_LENGTH = 27;
 
 export const LabelNode = memo<NodeProps>((props: NodeProps) => {
   const {
@@ -98,7 +109,21 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
                 font-size: ${euiTheme.font.scale.xs * 10.5}px;
               `}
             >
-              <EuiTextTruncate truncation="end" text={text} />
+              {text.length > MAX_LABEL_LENGTH ? (
+                <EuiToolTip content={text} display="block" data-test-subj={TEST_SUBJ_TOOLTIP}>
+                  <EuiTextTruncate
+                    data-test-subj={TEST_SUBJ_LABEL_TEXT}
+                    truncation="middle"
+                    text={text}
+                  />
+                </EuiToolTip>
+              ) : (
+                <EuiTextTruncate
+                  data-test-subj={TEST_SUBJ_LABEL_TEXT}
+                  truncation="middle"
+                  text={text}
+                />
+              )}
             </EuiText>
             <LabelNodeBadges analysis={analysis} onEventClick={eventClickHandler} />
           </div>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
@@ -58,6 +58,7 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
     nodeClick,
     expandButtonClick,
     ipClickHandler,
+    countryClickHandler,
   } = props.data as LabelNodeViewModel;
 
   const { euiTheme } = useEuiTheme();
@@ -167,7 +168,12 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
           />
         </LabelNodeContainer>
       </EuiToolTip>
-      <LabelNodeDetails ips={ips} countryCodes={countryCodes} onIpClick={ipClickHandler} />
+      <LabelNodeDetails
+        ips={ips}
+        countryCodes={countryCodes}
+        onIpClick={ipClickHandler}
+        onCountryClick={countryClickHandler}
+      />
     </>
   );
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
@@ -11,7 +11,6 @@ import { css } from '@emotion/react';
 import {
   EuiText,
   EuiTextTruncate,
-  EuiToolTip,
   transparentize,
   useEuiShadow,
   useEuiTheme,
@@ -29,21 +28,19 @@ import {
 } from '../styles';
 import type { LabelNodeViewModel, NodeProps } from '../../types';
 import { NodeExpandButton } from '../node_expand_button';
-import { GRAPH_LABEL_NODE_ID } from '../../test_ids';
+import {
+  GRAPH_LABEL_NODE_ID,
+} from '../../test_ids';
 import { analyzeDocuments } from './analyze_documents';
-import { LabelNodeBadges, LIMIT as BADGES_LIMIT } from './label_node_badges';
-import { LabelNodeTooltipContent } from './label_node_tooltip';
+import { LabelNodeBadges } from './label_node_badges';
 import { LabelNodeDetails } from './label_node_details';
 import { showStackedShape } from '../../utils';
 
 export const TEST_SUBJ_SHAPE = 'label-node-shape';
 export const TEST_SUBJ_STACKED_SHAPE = 'label-node-stacked-shape';
-export const TEST_SUBJ_TOOLTIP = 'label-node-tooltip';
 export const TEST_SUBJ_HANDLE = 'label-node-handle';
 export const TEST_SUBJ_EXPAND_BTN = 'label-node-expand-btn';
 export const TEST_SUBJ_HOVER_OUTLINE = 'label-node-hover-outline';
-
-const MAX_LABEL_LENGTH = 27;
 
 export const LabelNode = memo<NodeProps>((props: NodeProps) => {
   const {
@@ -59,6 +56,7 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
     expandButtonClick,
     ipClickHandler,
     countryClickHandler,
+    eventClickHandler,
   } = props.data as LabelNodeViewModel;
 
   const { euiTheme } = useEuiTheme();
@@ -75,99 +73,95 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
   const numAlerts = uniqueAlertsCount ?? 0;
 
   const analysis = analyzeDocuments({ uniqueEventsCount: numEvents, uniqueAlertsCount: numAlerts });
-  const shouldShowTooltip =
-    text.length >= MAX_LABEL_LENGTH || numEvents > BADGES_LIMIT || numAlerts > BADGES_LIMIT;
 
   return (
     <>
-      <EuiToolTip
-        display="block"
-        title={shouldShowTooltip ? text : null}
-        content={shouldShowTooltip ? <LabelNodeTooltipContent analysis={analysis} /> : null}
-        position="top"
-        data-test-subj={TEST_SUBJ_TOOLTIP}
-      >
-        <LabelNodeContainer data-test-subj={GRAPH_LABEL_NODE_ID}>
-          {interactive && (
-            <LabelShapeOnHover data-test-subj={TEST_SUBJ_HOVER_OUTLINE} color={color} />
-          )}
-          <LabelShape
-            data-test-subj={TEST_SUBJ_SHAPE}
-            backgroundColor={backgroundColor}
-            borderColor={borderColor}
-            textAlign="center"
-            shadow={shadow}
+      <LabelNodeContainer data-test-subj={GRAPH_LABEL_NODE_ID}>
+        {interactive && (
+          <LabelShapeOnHover data-test-subj={TEST_SUBJ_HOVER_OUTLINE} color={color} />
+        )}
+        <LabelShape
+          data-test-subj={TEST_SUBJ_SHAPE}
+          backgroundColor={backgroundColor}
+          borderColor={borderColor}
+          textAlign="center"
+          shadow={shadow}
+        >
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+              justify-content: space-between;
+              width: 100%;
+              gap: ${euiTheme.size.xs};
+            `}
           >
-            <div
+            <EuiText
+              color={textColor}
               css={css`
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
-                width: 100%;
-                gap: ${euiTheme.size.xs};
+                flex: 1;
+                min-width: 0;
+                text-overflow: ellipsis;
+                font-weight: ${euiTheme.font.weight.semiBold};
+                font-size: ${euiTheme.font.scale.xs * 10.5}px;
               `}
             >
-              <EuiText
-                color={textColor}
-                css={css`
-                  flex: 1;
-                  min-width: 0;
-                  text-overflow: ellipsis;
-                  font-weight: ${euiTheme.font.weight.semiBold};
-                  font-size: ${euiTheme.font.scale.xs * 10.5}px;
-                `}
-              >
-                <EuiTextTruncate truncation="end" text={text} />
-              </EuiText>
-              <LabelNodeBadges analysis={analysis} />
+              <EuiTextTruncate truncation="end" text={text} />
+            </EuiText>
+            <div
+              css={css`
+              `}
+            >
+              <LabelNodeBadges analysis={analysis} onEventClick={eventClickHandler} />
             </div>
-          </LabelShape>
-          {showStackedShape(numEvents + numAlerts) && (
-            <LabelStackedShape
-              data-test-subj={TEST_SUBJ_STACKED_SHAPE}
-              borderColor={transparentize(borderColor, 0.5)}
+          </div>
+        </LabelShape>
+        {showStackedShape(numEvents + numAlerts) && (
+          <LabelStackedShape
+            data-test-subj={TEST_SUBJ_STACKED_SHAPE}
+            borderColor={transparentize(borderColor, 0.5)}
+          />
+        )}
+        {interactive && (
+          <>
+            <NodeButton
+              css={css`
+                margin-top: -${ACTUAL_LABEL_HEIGHT}px;
+                pointer-events: none;
+              `}
+              height={ACTUAL_LABEL_HEIGHT}
+              width={NODE_LABEL_WIDTH}
+              onClick={(e) => nodeClick?.(e, props)}
             />
-          )}
-          {interactive && (
-            <>
-              <NodeButton
-                css={css`
-                  margin-top: -${ACTUAL_LABEL_HEIGHT}px;
-                `}
-                height={ACTUAL_LABEL_HEIGHT}
-                width={NODE_LABEL_WIDTH}
-                onClick={(e) => nodeClick?.(e, props)}
-              />
-              <NodeExpandButton
-                data-test-subj={TEST_SUBJ_EXPAND_BTN}
-                color={'primary'}
-                onClick={(e, unToggleCallback) => expandButtonClick?.(e, props, unToggleCallback)}
-                x={`${NODE_LABEL_WIDTH - 3}px`}
-                y={`${
-                  -ACTUAL_LABEL_HEIGHT +
-                  (ACTUAL_LABEL_HEIGHT - NodeExpandButton.ExpandButtonSize) / 2
-                }px`}
-              />
-            </>
-          )}
-          <Handle
-            data-test-subj={TEST_SUBJ_HANDLE}
-            type="target"
-            isConnectable={false}
-            position={Position.Left}
-            id="in"
-            style={HandleStyleOverride}
-          />
-          <Handle
-            data-test-subj={TEST_SUBJ_HANDLE}
-            type="source"
-            isConnectable={false}
-            position={Position.Right}
-            id="out"
-            style={HandleStyleOverride}
-          />
-        </LabelNodeContainer>
-      </EuiToolTip>
+            <NodeExpandButton
+              data-test-subj={TEST_SUBJ_EXPAND_BTN}
+              color={'primary'}
+              onClick={(e, unToggleCallback) => expandButtonClick?.(e, props, unToggleCallback)}
+              x={`${NODE_LABEL_WIDTH - 3}px`}
+              y={`${
+                -ACTUAL_LABEL_HEIGHT +
+                (ACTUAL_LABEL_HEIGHT - NodeExpandButton.ExpandButtonSize) / 2
+              }px`}
+            />
+          </>
+        )}
+        <Handle
+          data-test-subj={TEST_SUBJ_HANDLE}
+          type="target"
+          isConnectable={false}
+          position={Position.Left}
+          id="in"
+          style={HandleStyleOverride}
+        />
+        <Handle
+          data-test-subj={TEST_SUBJ_HANDLE}
+          type="source"
+          isConnectable={false}
+          position={Position.Right}
+          id="out"
+          style={HandleStyleOverride}
+        />
+      </LabelNodeContainer>
       <LabelNodeDetails
         ips={ips}
         countryCodes={countryCodes}

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
@@ -100,7 +100,7 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
             >
               <EuiTextTruncate truncation="end" text={text} />
             </EuiText>
-              <LabelNodeBadges analysis={analysis} onEventClick={eventClickHandler} />
+            <LabelNodeBadges analysis={analysis} onEventClick={eventClickHandler} />
           </div>
         </LabelShape>
         {showStackedShape(numEvents + numAlerts) && (

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
@@ -8,13 +8,7 @@
 import React, { memo, useMemo } from 'react';
 import { Handle, Position } from '@xyflow/react';
 import { css } from '@emotion/react';
-import {
-  EuiText,
-  EuiTextTruncate,
-  transparentize,
-  useEuiShadow,
-  useEuiTheme,
-} from '@elastic/eui';
+import { EuiText, EuiTextTruncate, transparentize, useEuiShadow, useEuiTheme } from '@elastic/eui';
 import {
   LabelNodeContainer,
   LabelShape,
@@ -28,9 +22,7 @@ import {
 } from '../styles';
 import type { LabelNodeViewModel, NodeProps } from '../../types';
 import { NodeExpandButton } from '../node_expand_button';
-import {
-  GRAPH_LABEL_NODE_ID,
-} from '../../test_ids';
+import { GRAPH_LABEL_NODE_ID } from '../../test_ids';
 import { analyzeDocuments } from './analyze_documents';
 import { LabelNodeBadges } from './label_node_badges';
 import { LabelNodeDetails } from './label_node_details';
@@ -108,10 +100,7 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
             >
               <EuiTextTruncate truncation="end" text={text} />
             </EuiText>
-            <div
-              css={css`
-              `}
-            >
+            <div css={css``}>
               <LabelNodeBadges analysis={analysis} onEventClick={eventClickHandler} />
             </div>
           </div>
@@ -139,8 +128,7 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
               onClick={(e, unToggleCallback) => expandButtonClick?.(e, props, unToggleCallback)}
               x={`${NODE_LABEL_WIDTH - 3}px`}
               y={`${
-                -ACTUAL_LABEL_HEIGHT +
-                (ACTUAL_LABEL_HEIGHT - NodeExpandButton.ExpandButtonSize) / 2
+                -ACTUAL_LABEL_HEIGHT + (ACTUAL_LABEL_HEIGHT - NodeExpandButton.ExpandButtonSize) / 2
               }px`}
             />
           </>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
@@ -10,6 +10,8 @@ import { ThemeProvider, css } from '@emotion/react';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { LabelNodeViewModel } from '../..';
 import { Graph } from '../..';
+import { useEventDetailsPopover } from '../../graph_investigation/use_event_details_popover';
+import { analyzeDocuments } from './analyze_documents';
 import { GlobalStylesStorybookDecorator } from '../../../../.storybook/decorators';
 
 export default {
@@ -28,9 +30,17 @@ const useCases = {
   'Multiple events and alerts': { uniqueEventsCount: 2, uniqueAlertsCount: 2 },
   'Hundreds of events and alerts': { uniqueEventsCount: 120, uniqueAlertsCount: 120 },
   'Millions of events and alerts': { uniqueEventsCount: 1_200_000, uniqueAlertsCount: 1_200_000 },
+  'With clickable events popover': { uniqueEventsCount: 5, uniqueAlertsCount: 3 },
 };
 
 const Template = () => {
+  // Create analysis for the popover use case
+  const popoverAnalysis = analyzeDocuments({ uniqueEventsCount: 5, uniqueAlertsCount: 3 });
+  const eventDetailsPopover = useEventDetailsPopover(
+    popoverAnalysis,
+    'With clickable events popover'
+  );
+
   const nodes: LabelNodeViewModel[] = useMemo(
     () =>
       Object.entries(useCases).map(([useCaseName, { uniqueEventsCount, uniqueAlertsCount }]) => ({
@@ -41,8 +51,13 @@ const Template = () => {
         shape: 'label',
         uniqueEventsCount,
         uniqueAlertsCount,
+        // Add event click handler only for the last use case
+        eventClickHandler:
+          useCaseName === 'With clickable events popover'
+            ? eventDetailsPopover.onEventClick
+            : undefined,
       })),
-    []
+    [eventDetailsPopover.onEventClick]
   );
 
   return (
@@ -56,6 +71,7 @@ const Template = () => {
         edges={[]}
         interactive={true}
       />
+      <eventDetailsPopover.PopoverComponent />
     </ThemeProvider>
   );
 };

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
@@ -36,32 +36,44 @@ const useCases = {
 };
 
 const Template = () => {
-  // Create analysis for the popover use case
-  const popoverAnalysis = analyzeDocuments({ uniqueEventsCount: 5, uniqueAlertsCount: 3 });
-  const eventDetailsPopover = useEventDetailsPopover(
-    popoverAnalysis,
+  // Create popover hooks for each clickable use case
+  const eventsOnlyPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 5, uniqueAlertsCount: 0 }),
+    'With clickable events popover - only events'
+  );
+  const alertsOnlyPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 0, uniqueAlertsCount: 3 }),
+    'With clickable events popover - only alerts'
+  );
+  const mixedPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 5, uniqueAlertsCount: 3 }),
     'With clickable events popover'
   );
 
   const nodes: LabelNodeViewModel[] = useMemo(
     () =>
-      Object.entries(useCases).map(([useCaseName, { uniqueEventsCount, uniqueAlertsCount }]) => ({
-        id: useCaseName,
-        label: useCaseName,
-        color: uniqueAlertsCount >= 1 && uniqueEventsCount === 0 ? 'danger' : 'primary',
-        interactive: true,
-        shape: 'label',
-        uniqueEventsCount,
-        uniqueAlertsCount,
-        // Add event click handler only for the last use case
-        eventClickHandler:
-          useCaseName === 'With clickable events popover' ||
-          useCaseName === 'With clickable events popover - only events' ||
-          useCaseName === 'With clickable events popover - only alerts'
-            ? eventDetailsPopover.onEventClick
-            : undefined,
-      })),
-    [eventDetailsPopover.onEventClick]
+      Object.entries(useCases).map(([useCaseName, { uniqueEventsCount, uniqueAlertsCount }]) => {
+        let eventClickHandler;
+        if (useCaseName === 'With clickable events popover - only events') {
+          eventClickHandler = eventsOnlyPopover.onEventClick;
+        } else if (useCaseName === 'With clickable events popover - only alerts') {
+          eventClickHandler = alertsOnlyPopover.onEventClick;
+        } else if (useCaseName === 'With clickable events popover') {
+          eventClickHandler = mixedPopover.onEventClick;
+        }
+
+        return {
+          id: useCaseName,
+          label: useCaseName,
+          color: uniqueAlertsCount >= 1 && uniqueEventsCount === 0 ? 'danger' : 'primary',
+          interactive: true,
+          shape: 'label',
+          uniqueEventsCount,
+          uniqueAlertsCount,
+          eventClickHandler,
+        };
+      }),
+    [eventsOnlyPopover.onEventClick, alertsOnlyPopover.onEventClick, mixedPopover.onEventClick]
   );
 
   return (
@@ -75,7 +87,9 @@ const Template = () => {
         edges={[]}
         interactive={true}
       />
-      <eventDetailsPopover.PopoverComponent />
+      <eventsOnlyPopover.PopoverComponent />
+      <alertsOnlyPopover.PopoverComponent />
+      <mixedPopover.PopoverComponent />
     </ThemeProvider>
   );
 };

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
@@ -30,37 +30,74 @@ const useCases = {
   'Multiple events and alerts': { uniqueEventsCount: 2, uniqueAlertsCount: 2 },
   'Hundreds of events and alerts': { uniqueEventsCount: 120, uniqueAlertsCount: 120 },
   'Millions of events and alerts': { uniqueEventsCount: 1_200_000, uniqueAlertsCount: 1_200_000 },
-  'With clickable events popover - only events': { uniqueEventsCount: 5, uniqueAlertsCount: 0 },
-  'With clickable events popover - only alerts': { uniqueEventsCount: 0, uniqueAlertsCount: 3 },
-  'With clickable events popover': { uniqueEventsCount: 5, uniqueAlertsCount: 3 },
 };
 
 const Template = () => {
-  // Create popover hooks for each clickable use case
-  const eventsOnlyPopover = useEventDetailsPopover(
-    analyzeDocuments({ uniqueEventsCount: 5, uniqueAlertsCount: 0 }),
-    'With clickable events popover - only events'
+  // Create individual popovers for each use case at the top level (following Rules of Hooks)
+  const singleEventPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 1, uniqueAlertsCount: 0 }),
+    'Single event'
   );
-  const alertsOnlyPopover = useEventDetailsPopover(
-    analyzeDocuments({ uniqueEventsCount: 0, uniqueAlertsCount: 3 }),
-    'With clickable events popover - only alerts'
+  const singleAlertPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 0, uniqueAlertsCount: 1 }),
+    'Single alert'
   );
-  const mixedPopover = useEventDetailsPopover(
-    analyzeDocuments({ uniqueEventsCount: 5, uniqueAlertsCount: 3 }),
-    'With clickable events popover'
+  const multipleEventsPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 2, uniqueAlertsCount: 0 }),
+    'Multiple events'
   );
+  const multipleAlertsPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 0, uniqueAlertsCount: 2 }),
+    'Multiple alerts'
+  );
+  const hundredsOfEventsPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 120, uniqueAlertsCount: 0 }),
+    'Hundreds of events'
+  );
+  const hundredsOfAlertsPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 0, uniqueAlertsCount: 120 }),
+    'Hundreds of alerts'
+  );
+  const multipleEventsAndAlertsPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 2, uniqueAlertsCount: 2 }),
+    'Multiple events and alerts'
+  );
+  const hundredsOfEventsAndAlertsPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 120, uniqueAlertsCount: 120 }),
+    'Hundreds of events and alerts'
+  );
+  const millionsOfEventsAndAlertsPopover = useEventDetailsPopover(
+    analyzeDocuments({ uniqueEventsCount: 1_200_000, uniqueAlertsCount: 1_200_000 }),
+    'Millions of events and alerts'
+  );
+
+  // Create popovers mapping
+  const popovers = useMemo(() => ({
+    'Single event': singleEventPopover,
+    'Single alert': singleAlertPopover,
+    'Multiple events': multipleEventsPopover,
+    'Multiple alerts': multipleAlertsPopover,
+    'Hundreds of events': hundredsOfEventsPopover,
+    'Hundreds of alerts': hundredsOfAlertsPopover,
+    'Multiple events and alerts': multipleEventsAndAlertsPopover,
+    'Hundreds of events and alerts': hundredsOfEventsAndAlertsPopover,
+    'Millions of events and alerts': millionsOfEventsAndAlertsPopover,
+  }), [
+    singleEventPopover,
+    singleAlertPopover,
+    multipleEventsPopover,
+    multipleAlertsPopover,
+    hundredsOfEventsPopover,
+    hundredsOfAlertsPopover,
+    multipleEventsAndAlertsPopover,
+    hundredsOfEventsAndAlertsPopover,
+    millionsOfEventsAndAlertsPopover,
+  ]);
 
   const nodes: LabelNodeViewModel[] = useMemo(
     () =>
       Object.entries(useCases).map(([useCaseName, { uniqueEventsCount, uniqueAlertsCount }]) => {
-        let eventClickHandler;
-        if (useCaseName === 'With clickable events popover - only events') {
-          eventClickHandler = eventsOnlyPopover.onEventClick;
-        } else if (useCaseName === 'With clickable events popover - only alerts') {
-          eventClickHandler = alertsOnlyPopover.onEventClick;
-        } else if (useCaseName === 'With clickable events popover') {
-          eventClickHandler = mixedPopover.onEventClick;
-        }
+        const eventClickHandler = popovers[useCaseName as keyof typeof popovers]?.onEventClick;
 
         return {
           id: useCaseName,
@@ -73,7 +110,7 @@ const Template = () => {
           eventClickHandler,
         };
       }),
-    [eventsOnlyPopover.onEventClick, alertsOnlyPopover.onEventClick, mixedPopover.onEventClick]
+    [popovers]
   );
 
   return (
@@ -87,9 +124,9 @@ const Template = () => {
         edges={[]}
         interactive={true}
       />
-      <eventsOnlyPopover.PopoverComponent />
-      <alertsOnlyPopover.PopoverComponent />
-      <mixedPopover.PopoverComponent />
+      {Object.values(popovers).map((popover, index) => (
+        <popover.PopoverComponent key={index} />
+      ))}
     </ThemeProvider>
   );
 };

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
@@ -72,27 +72,30 @@ const Template = () => {
   );
 
   // Create popovers mapping
-  const popovers = useMemo(() => ({
-    'Single event': singleEventPopover,
-    'Single alert': singleAlertPopover,
-    'Multiple events': multipleEventsPopover,
-    'Multiple alerts': multipleAlertsPopover,
-    'Hundreds of events': hundredsOfEventsPopover,
-    'Hundreds of alerts': hundredsOfAlertsPopover,
-    'Multiple events and alerts': multipleEventsAndAlertsPopover,
-    'Hundreds of events and alerts': hundredsOfEventsAndAlertsPopover,
-    'Millions of events and alerts': millionsOfEventsAndAlertsPopover,
-  }), [
-    singleEventPopover,
-    singleAlertPopover,
-    multipleEventsPopover,
-    multipleAlertsPopover,
-    hundredsOfEventsPopover,
-    hundredsOfAlertsPopover,
-    multipleEventsAndAlertsPopover,
-    hundredsOfEventsAndAlertsPopover,
-    millionsOfEventsAndAlertsPopover,
-  ]);
+  const popovers = useMemo(
+    () => ({
+      'Single event': singleEventPopover,
+      'Single alert': singleAlertPopover,
+      'Multiple events': multipleEventsPopover,
+      'Multiple alerts': multipleAlertsPopover,
+      'Hundreds of events': hundredsOfEventsPopover,
+      'Hundreds of alerts': hundredsOfAlertsPopover,
+      'Multiple events and alerts': multipleEventsAndAlertsPopover,
+      'Hundreds of events and alerts': hundredsOfEventsAndAlertsPopover,
+      'Millions of events and alerts': millionsOfEventsAndAlertsPopover,
+    }),
+    [
+      singleEventPopover,
+      singleAlertPopover,
+      multipleEventsPopover,
+      multipleAlertsPopover,
+      hundredsOfEventsPopover,
+      hundredsOfAlertsPopover,
+      multipleEventsAndAlertsPopover,
+      hundredsOfEventsAndAlertsPopover,
+      millionsOfEventsAndAlertsPopover,
+    ]
+  );
 
   const nodes: LabelNodeViewModel[] = useMemo(
     () =>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
@@ -30,6 +30,8 @@ const useCases = {
   'Multiple events and alerts': { uniqueEventsCount: 2, uniqueAlertsCount: 2 },
   'Hundreds of events and alerts': { uniqueEventsCount: 120, uniqueAlertsCount: 120 },
   'Millions of events and alerts': { uniqueEventsCount: 1_200_000, uniqueAlertsCount: 1_200_000 },
+  'With clickable events popover - only events': { uniqueEventsCount: 5, uniqueAlertsCount: 0 },
+  'With clickable events popover - only alerts': { uniqueEventsCount: 0, uniqueAlertsCount: 3 },
   'With clickable events popover': { uniqueEventsCount: 5, uniqueAlertsCount: 3 },
 };
 
@@ -53,7 +55,9 @@ const Template = () => {
         uniqueAlertsCount,
         // Add event click handler only for the last use case
         eventClickHandler:
-          useCaseName === 'With clickable events popover'
+          useCaseName === 'With clickable events popover' ||
+          useCaseName === 'With clickable events popover - only events' ||
+          useCaseName === 'With clickable events popover - only alerts'
             ? eventDetailsPopover.onEventClick
             : undefined,
       })),

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.test.tsx
@@ -7,11 +7,13 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   LabelNodeBadges,
   TEST_SUBJ_ALERT_ICON,
   TEST_SUBJ_ALERT_COUNT,
   TEST_SUBJ_EVENT_COUNT,
+  TEST_SUBJ_EVENT_COUNT_BUTTON,
 } from './label_node_badges';
 import { analyzeDocuments } from './analyze_documents';
 
@@ -101,5 +103,45 @@ describe('LabelNodeBadges', () => {
     expect(screen.getByTestId(TEST_SUBJ_EVENT_COUNT)).toHaveTextContent('+99');
     expect(screen.queryByTestId(TEST_SUBJ_ALERT_ICON)).toBeInTheDocument();
     expect(screen.getByTestId(TEST_SUBJ_ALERT_COUNT)).toHaveTextContent('+99');
+  });
+
+  describe('Popover', () => {
+    const mockOnEventClick = jest.fn();
+
+    beforeEach(() => {
+      mockOnEventClick.mockClear();
+    });
+
+    test('calls onEventClick when event badge button is clicked', async () => {
+      const analysis = analyzeDocuments({ uniqueEventsCount: 3, uniqueAlertsCount: 0 });
+
+      render(<LabelNodeBadges analysis={analysis} onEventClick={mockOnEventClick} />);
+
+      const eventBadgeButton = screen.getByTestId(TEST_SUBJ_EVENT_COUNT_BUTTON);
+      await userEvent.click(eventBadgeButton);
+
+      expect(mockOnEventClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not render clickable event badge when onEventClick is not provided', () => {
+      const analysis = analyzeDocuments({ uniqueEventsCount: 3, uniqueAlertsCount: 0 });
+
+      render(<LabelNodeBadges analysis={analysis} />);
+
+      const eventBadgeButton = screen.queryByTestId(TEST_SUBJ_EVENT_COUNT_BUTTON);
+      const eventBadge = screen.queryByTestId(TEST_SUBJ_EVENT_COUNT);
+
+      expect(eventBadgeButton).not.toBeInTheDocument();
+      expect(eventBadge).toBeInTheDocument();
+    });
+
+    test('does not render event badge when single event', () => {
+      const analysis = analyzeDocuments({ uniqueEventsCount: 1, uniqueAlertsCount: 0 });
+
+      render(<LabelNodeBadges analysis={analysis} onEventClick={mockOnEventClick} />);
+
+      const eventBadgeButton = screen.queryByTestId(TEST_SUBJ_EVENT_COUNT_BUTTON);
+      expect(eventBadgeButton).not.toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.test.tsx
@@ -12,6 +12,7 @@ import {
   LabelNodeBadges,
   TEST_SUBJ_ALERT_ICON,
   TEST_SUBJ_ALERT_COUNT,
+  TEST_SUBJ_ALERT_COUNT_BUTTON,
   TEST_SUBJ_EVENT_COUNT,
   TEST_SUBJ_EVENT_COUNT_BUTTON,
 } from './label_node_badges';
@@ -142,6 +143,40 @@ describe('LabelNodeBadges', () => {
 
       const eventBadgeButton = screen.queryByTestId(TEST_SUBJ_EVENT_COUNT_BUTTON);
       expect(eventBadgeButton).not.toBeInTheDocument();
+    });
+
+    test('calls onEventClick when alert count badge button is clicked', async () => {
+      const analysis = analyzeDocuments({ uniqueEventsCount: 0, uniqueAlertsCount: 3 });
+
+      render(<LabelNodeBadges analysis={analysis} onEventClick={mockOnEventClick} />);
+
+      const alertBadgeButton = screen.getByTestId(TEST_SUBJ_ALERT_COUNT_BUTTON);
+      await userEvent.click(alertBadgeButton);
+
+      expect(mockOnEventClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not render clickable alert count badge when onEventClick is not provided', () => {
+      const analysis = analyzeDocuments({ uniqueEventsCount: 0, uniqueAlertsCount: 3 });
+
+      render(<LabelNodeBadges analysis={analysis} />);
+
+      const alertBadgeButton = screen.queryByTestId(TEST_SUBJ_ALERT_COUNT_BUTTON);
+      const alertBadge = screen.queryByTestId(TEST_SUBJ_ALERT_COUNT);
+
+      expect(alertBadgeButton).not.toBeInTheDocument();
+      expect(alertBadge).toBeInTheDocument();
+    });
+
+    test('calls onEventClick when alert count badge button is clicked in mixed scenario', async () => {
+      const analysis = analyzeDocuments({ uniqueEventsCount: 2, uniqueAlertsCount: 2 });
+
+      render(<LabelNodeBadges analysis={analysis} onEventClick={mockOnEventClick} />);
+
+      const alertBadgeButton = screen.getByTestId(TEST_SUBJ_ALERT_COUNT_BUTTON);
+      await userEvent.click(alertBadgeButton);
+
+      expect(mockOnEventClick).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_details.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_details.tsx
@@ -15,9 +15,10 @@ import { CountryFlags } from '../country_flags/country_flags';
 export interface LabelNodeDetailsProps {
   ips?: string[];
   countryCodes?: string[];
+  onIpClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export const LabelNodeDetails = ({ ips, countryCodes }: LabelNodeDetailsProps) => {
+export const LabelNodeDetails = ({ ips, countryCodes, onIpClick }: LabelNodeDetailsProps) => {
   const { euiTheme } = useEuiTheme();
   const shouldRenderIps = ips && ips.length > 0;
   const shouldRenderCountryFlags = countryCodes && countryCodes.length > 0;
@@ -31,7 +32,7 @@ export const LabelNodeDetails = ({ ips, countryCodes }: LabelNodeDetailsProps) =
         margin-top: ${euiTheme.size.xs};
       `}
     >
-      {shouldRenderIps && <Ips ips={ips} />}
+      {shouldRenderIps && <Ips ips={ips} onIpClick={onIpClick} />}
       {shouldRenderCountryFlags && <CountryFlags countryCodes={countryCodes} />}
     </div>
   ) : null;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_details.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_details.tsx
@@ -16,9 +16,15 @@ export interface LabelNodeDetailsProps {
   ips?: string[];
   countryCodes?: string[];
   onIpClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onCountryClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export const LabelNodeDetails = ({ ips, countryCodes, onIpClick }: LabelNodeDetailsProps) => {
+export const LabelNodeDetails = ({
+  ips,
+  countryCodes,
+  onIpClick,
+  onCountryClick,
+}: LabelNodeDetailsProps) => {
   const { euiTheme } = useEuiTheme();
   const shouldRenderIps = ips && ips.length > 0;
   const shouldRenderCountryFlags = countryCodes && countryCodes.length > 0;
@@ -33,7 +39,9 @@ export const LabelNodeDetails = ({ ips, countryCodes, onIpClick }: LabelNodeDeta
       `}
     >
       {shouldRenderIps && <Ips ips={ips} onIpClick={onIpClick} />}
-      {shouldRenderCountryFlags && <CountryFlags countryCodes={countryCodes} />}
+      {shouldRenderCountryFlags && (
+        <CountryFlags countryCodes={countryCodes} onCountryClick={onCountryClick} />
+      )}
     </div>
   ) : null;
 };

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_popover.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_popover.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { LabelNodePopoverContent } from './label_node_tooltip';
+import { LabelNodePopoverContent } from './label_node_popover';
 import { analyzeDocuments } from './analyze_documents';
 
 const TEST_SUBJ_ALERT_SECTION = 'label-node-tooltip-alert-section';

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_popover.tsx
@@ -10,6 +10,7 @@ import { EuiText, EuiIcon, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { getAbbreviatedNumber } from '@kbn/cloud-security-posture-common';
+import { useKibanaIsDarkMode } from '@kbn/react-kibana-context-theme';
 import { RoundedBadge } from '../styles';
 import type { DocumentAnalysisOutput } from './analyze_documents';
 
@@ -27,7 +28,7 @@ const defaultEventsText = i18n.translate(
   }
 );
 
-interface LabelNodeTooltipProps {
+interface LabelNodePopoverProps {
   analysis: DocumentAnalysisOutput;
 }
 
@@ -56,6 +57,8 @@ const Section: React.FC<{ testSubj: string; badge: React.ReactNode; label: strin
   label,
 }) => {
   const { euiTheme } = useEuiTheme();
+  const isDarkMode = useKibanaIsDarkMode();
+
   return (
     <div
       data-test-subj={testSubj}
@@ -68,6 +71,7 @@ const Section: React.FC<{ testSubj: string; badge: React.ReactNode; label: strin
       {badge}
       <EuiText
         size="s"
+        color={isDarkMode ? 'ghost' : 'text'}
         css={css`
           font-weight: ${euiTheme.font.weight.medium};
         `}
@@ -96,7 +100,7 @@ const EventBadge: React.FC<{ count: number }> = ({ count }) => (
   </RoundedBadge>
 );
 
-export const LabelNodePopoverContent = ({ analysis }: LabelNodeTooltipProps) => {
+export const LabelNodePopoverContent = ({ analysis }: LabelNodePopoverProps) => {
   const { euiTheme } = useEuiTheme();
   return (
     <div

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_tooltip.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_tooltip.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { LabelNodeTooltipContent } from './label_node_tooltip';
+import { LabelNodePopoverContent } from './label_node_tooltip';
 import { analyzeDocuments } from './analyze_documents';
 
 const TEST_SUBJ_ALERT_SECTION = 'label-node-tooltip-alert-section';
@@ -17,11 +17,11 @@ const TEST_SUBJ_ALERT_COUNT = 'label-node-tooltip-alert-count';
 const TEST_SUBJ_EVENT_SECTION = 'label-node-tooltip-event-section';
 const TEST_SUBJ_EVENT_COUNT = 'label-node-tooltip-event-count';
 
-describe('LabelNodeTooltipContent', () => {
+describe('LabelNodePopoverContent', () => {
   test('renders nothing with no events or alerts', () => {
     const analysis = analyzeDocuments({ uniqueEventsCount: 0, uniqueAlertsCount: 0 });
 
-    const { container } = render(<LabelNodeTooltipContent analysis={analysis} />);
+    const { container } = render(<LabelNodePopoverContent analysis={analysis} />);
 
     // Verify that the container is mostly empty (only has the outer div)
     expect(container.firstChild).toBeEmptyDOMElement();
@@ -30,7 +30,7 @@ describe('LabelNodeTooltipContent', () => {
   test('renders with a single event', () => {
     const analysis = analyzeDocuments({ uniqueEventsCount: 1, uniqueAlertsCount: 0 });
 
-    render(<LabelNodeTooltipContent analysis={analysis} />);
+    render(<LabelNodePopoverContent analysis={analysis} />);
 
     expect(screen.getByTestId(TEST_SUBJ_EVENT_SECTION)).toBeInTheDocument();
     expect(screen.queryByTestId(TEST_SUBJ_ALERT_SECTION)).not.toBeInTheDocument();
@@ -41,7 +41,7 @@ describe('LabelNodeTooltipContent', () => {
   test('renders with a single alert', () => {
     const analysis = analyzeDocuments({ uniqueEventsCount: 0, uniqueAlertsCount: 1 });
 
-    render(<LabelNodeTooltipContent analysis={analysis} />);
+    render(<LabelNodePopoverContent analysis={analysis} />);
 
     expect(screen.getByTestId(TEST_SUBJ_ALERT_SECTION)).toBeInTheDocument();
     expect(screen.queryByTestId(TEST_SUBJ_EVENT_SECTION)).not.toBeInTheDocument();
@@ -55,7 +55,7 @@ describe('LabelNodeTooltipContent', () => {
     const uniqueEventsCount = 120;
     const analysis = analyzeDocuments({ uniqueEventsCount, uniqueAlertsCount: 0 });
 
-    render(<LabelNodeTooltipContent analysis={analysis} />);
+    render(<LabelNodePopoverContent analysis={analysis} />);
 
     expect(screen.getByTestId(TEST_SUBJ_EVENT_SECTION)).toBeInTheDocument();
     expect(screen.queryByTestId(TEST_SUBJ_ALERT_SECTION)).not.toBeInTheDocument();
@@ -70,7 +70,7 @@ describe('LabelNodeTooltipContent', () => {
     const uniqueAlertsCount = 120;
     const analysis = analyzeDocuments({ uniqueEventsCount: 0, uniqueAlertsCount });
 
-    render(<LabelNodeTooltipContent analysis={analysis} />);
+    render(<LabelNodePopoverContent analysis={analysis} />);
 
     expect(screen.getByTestId(TEST_SUBJ_ALERT_SECTION)).toBeInTheDocument();
     expect(screen.queryByTestId(TEST_SUBJ_EVENT_SECTION)).not.toBeInTheDocument();
@@ -87,7 +87,7 @@ describe('LabelNodeTooltipContent', () => {
     const uniqueAlertsCount = 120;
     const analysis = analyzeDocuments({ uniqueEventsCount, uniqueAlertsCount });
 
-    render(<LabelNodeTooltipContent analysis={analysis} />);
+    render(<LabelNodePopoverContent analysis={analysis} />);
 
     expect(screen.getByTestId(TEST_SUBJ_EVENT_SECTION)).toBeInTheDocument();
     expect(screen.getByTestId(TEST_SUBJ_ALERT_SECTION)).toBeInTheDocument();
@@ -109,7 +109,7 @@ describe('LabelNodeTooltipContent', () => {
     const uniqueAlertsCount = 1_200_000;
     const analysis = analyzeDocuments({ uniqueEventsCount, uniqueAlertsCount });
 
-    render(<LabelNodeTooltipContent analysis={analysis} />);
+    render(<LabelNodePopoverContent analysis={analysis} />);
 
     expect(screen.getByTestId(TEST_SUBJ_EVENT_SECTION)).toBeInTheDocument();
     expect(screen.getByTestId(TEST_SUBJ_ALERT_SECTION)).toBeInTheDocument();

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_tooltip.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_tooltip.tsx
@@ -68,7 +68,6 @@ const Section: React.FC<{ testSubj: string; badge: React.ReactNode; label: strin
       {badge}
       <EuiText
         size="s"
-        color="ghost"
         css={css`
           font-weight: ${euiTheme.font.weight.medium};
         `}
@@ -97,7 +96,7 @@ const EventBadge: React.FC<{ count: number }> = ({ count }) => (
   </RoundedBadge>
 );
 
-export const LabelNodeTooltipContent = ({ analysis }: LabelNodeTooltipProps) => {
+export const LabelNodePopoverContent = ({ analysis }: LabelNodeTooltipProps) => {
   const { euiTheme } = useEuiTheme();
   return (
     <div
@@ -105,7 +104,6 @@ export const LabelNodeTooltipContent = ({ analysis }: LabelNodeTooltipProps) => 
         display: flex;
         flex-direction: column;
         gap: ${euiTheme.size.s};
-        margin-top: ${euiTheme.size.s};
       `}
     >
       {analysis.uniqueAlertsCount > 0 && (

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/node_details.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/node_details.tsx
@@ -21,6 +21,7 @@ interface NodeDetailsProps {
   ips?: string[];
   countryCodes?: string[];
   onIpClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onCountryClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const NodeDetails = ({
@@ -30,6 +31,7 @@ export const NodeDetails = ({
   ips,
   countryCodes,
   onIpClick,
+  onCountryClick,
 }: NodeDetailsProps) => {
   const { euiTheme } = useEuiTheme();
 
@@ -59,7 +61,9 @@ export const NodeDetails = ({
         <EuiFlexItem grow={false} css={{ alignItems: 'center', gap: euiTheme.size.xxs }}>
           {shouldRenderLabel ? <Label text={label} /> : null}
           {shouldRenderIps ? <Ips ips={ips} onIpClick={onIpClick} /> : null}
-          {shouldRenderFlags ? <CountryFlags countryCodes={countryCodes} /> : null}
+          {shouldRenderFlags ? (
+            <CountryFlags countryCodes={countryCodes} onCountryClick={onCountryClick} />
+          ) : null}
         </EuiFlexItem>
       ) : null}
     </EuiFlexGroup>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/node_details.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/node_details.tsx
@@ -20,9 +20,17 @@ interface NodeDetailsProps {
   label?: string;
   ips?: string[];
   countryCodes?: string[];
+  onIpClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export const NodeDetails = ({ count, tag, label, ips, countryCodes }: NodeDetailsProps) => {
+export const NodeDetails = ({
+  count,
+  tag,
+  label,
+  ips,
+  countryCodes,
+  onIpClick,
+}: NodeDetailsProps) => {
   const { euiTheme } = useEuiTheme();
 
   const shouldRenderTag = !!tag || (count && count > 1);
@@ -50,7 +58,7 @@ export const NodeDetails = ({ count, tag, label, ips, countryCodes }: NodeDetail
       {shouldRenderBottom ? (
         <EuiFlexItem grow={false} css={{ alignItems: 'center', gap: euiTheme.size.xxs }}>
           {shouldRenderLabel ? <Label text={label} /> : null}
-          {shouldRenderIps ? <Ips ips={ips} /> : null}
+          {shouldRenderIps ? <Ips ips={ips} onIpClick={onIpClick} /> : null}
           {shouldRenderFlags ? <CountryFlags countryCodes={countryCodes} /> : null}
         </EuiFlexItem>
       ) : null}

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/pentagon_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/pentagon_node.tsx
@@ -52,6 +52,7 @@ export const PentagonNode = memo<NodeProps>((props: NodeProps) => {
     expandButtonClick,
     nodeClick,
     ipClickHandler,
+    countryClickHandler,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -142,6 +143,7 @@ export const PentagonNode = memo<NodeProps>((props: NodeProps) => {
         ips={ips}
         countryCodes={countryCodes}
         onIpClick={ipClickHandler}
+        onCountryClick={countryClickHandler}
       />
     </NodeContainer>
   );

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/pentagon_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/pentagon_node.tsx
@@ -51,6 +51,7 @@ export const PentagonNode = memo<NodeProps>((props: NodeProps) => {
     interactive,
     expandButtonClick,
     nodeClick,
+    ipClickHandler,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -140,6 +141,7 @@ export const PentagonNode = memo<NodeProps>((props: NodeProps) => {
         label={label ? label : id}
         ips={ips}
         countryCodes={countryCodes}
+        onIpClick={ipClickHandler}
       />
     </NodeContainer>
   );

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/rectangle_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/rectangle_node.tsx
@@ -51,6 +51,7 @@ export const RectangleNode = memo<NodeProps>((props: NodeProps) => {
     interactive,
     expandButtonClick,
     nodeClick,
+    ipClickHandler,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -136,6 +137,7 @@ export const RectangleNode = memo<NodeProps>((props: NodeProps) => {
         label={label ? label : id}
         ips={ips}
         countryCodes={countryCodes}
+        onIpClick={ipClickHandler}
       />
     </NodeContainer>
   );

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/rectangle_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/rectangle_node.tsx
@@ -52,6 +52,7 @@ export const RectangleNode = memo<NodeProps>((props: NodeProps) => {
     expandButtonClick,
     nodeClick,
     ipClickHandler,
+    countryClickHandler,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -138,6 +139,7 @@ export const RectangleNode = memo<NodeProps>((props: NodeProps) => {
         ips={ips}
         countryCodes={countryCodes}
         onIpClick={ipClickHandler}
+        onCountryClick={countryClickHandler}
       />
     </NodeContainer>
   );

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/utils/index.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/utils/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { createPreviewItems } from './preview-link';

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/utils/preview-link.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/utils/preview-link.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiLink } from '@elastic/eui';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import type { GenericPopoverItem } from '../../graph_investigation/use_node_details_popover';
+import { NETWORK_PREVIEW_BANNER } from '../../constants';
+import { GRAPH_POPOVER_PREVIEW_PANEL } from '../../test_ids';
+
+// Local constant matching security solution definition
+const IP_FIELD_TYPE = 'ip';
+
+interface PreviewLinkProps {
+  id: string;
+  field: string;
+  value: string;
+  scopeId: string;
+  'data-test-subj'?: string;
+  children?: React.ReactNode;
+}
+
+export enum FlowTargetSourceDest {
+  destination = 'destination',
+  source = 'source',
+}
+
+/*
+ * Placeholder PreviewLink component that mimics the security solution PreviewLink
+ * TODO: check if possible to move <PreviewLink> component to a common package and all related dependencies
+ * would require refactoring in multiple places across security solution plugin - should be done separately
+ */
+const PreviewLink: React.FC<PreviewLinkProps> = ({
+  id,
+  field,
+  value,
+  scopeId,
+  'data-test-subj': dataTestSubj,
+  children,
+}) => {
+  const { openPreviewPanel } = useExpandableFlyoutApi();
+
+  const handleClick = (event: React.MouseEvent) => {
+    openPreviewPanel({
+      id,
+      params: {
+        ip: value,
+        scopeId,
+        flowTarget: field.includes(FlowTargetSourceDest.destination)
+          ? FlowTargetSourceDest.destination
+          : FlowTargetSourceDest.source,
+        banner: NETWORK_PREVIEW_BANNER,
+        isPreviewMode: true,
+      },
+    });
+  };
+
+  return (
+    <EuiLink onClick={handleClick} data-test-subj={dataTestSubj}>
+      {children || value}
+    </EuiLink>
+  );
+};
+
+/**
+ * Converts array of primitives to PreviewLink components for use in popovers
+ */
+export const createPreviewItems = (
+  id: string,
+  values: string[],
+  scopeId: string
+): GenericPopoverItem[] =>
+  values.map((value, index) => ({
+    key: `${index}-${value}`,
+    label: (
+      <PreviewLink
+        id={id}
+        field={IP_FIELD_TYPE}
+        value={value}
+        scopeId={scopeId}
+        data-test-subj={GRAPH_POPOVER_PREVIEW_PANEL}
+      />
+    ),
+  }));

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
@@ -65,6 +65,9 @@ export const GRAPH_ENTITY_NODE_DETAILS_ID =
 
 export const GRAPH_IPS_TEXT_ID = `${GRAPH_INVESTIGATION_TEST_ID}IpsText` as const;
 export const GRAPH_IPS_PLUS_COUNT_ID = `${GRAPH_INVESTIGATION_TEST_ID}IpsPlusCount` as const;
+export const GRAPH_IPS_PLUS_COUNT_BUTTON_ID =
+  `${GRAPH_INVESTIGATION_TEST_ID}IpsPlusCountButton` as const;
+
 export const GRAPH_IPS_POPOVER_CONTENT_ID =
   `${GRAPH_INVESTIGATION_TEST_ID}IpsPopoverContent` as const;
 export const GRAPH_IPS_POPOVER_IP_ID = `${GRAPH_INVESTIGATION_TEST_ID}IpsPopoverId` as const;
@@ -75,10 +78,17 @@ export const GRAPH_FLAGS_VISIBLE_FLAG_ID =
   `${GRAPH_INVESTIGATION_TEST_ID}CountryFlagsVisibleFlag` as const;
 export const GRAPH_FLAGS_PLUS_COUNT_ID =
   `${GRAPH_INVESTIGATION_TEST_ID}CountryFlagsPlusCount` as const;
+export const GRAPH_FLAGS_PLUS_COUNT_BUTTON_ID =
+  `${GRAPH_INVESTIGATION_TEST_ID}CountryFlagsPlusCountButton` as const;
 export const GRAPH_FLAGS_TOOLTIP_CONTENT_ID =
   `${GRAPH_INVESTIGATION_TEST_ID}CountryFlagsTooltipContent` as const;
 export const GRAPH_FLAGS_TOOLTIP_COUNTRY_ID =
   `${GRAPH_INVESTIGATION_TEST_ID}CountryFlagsTooltipCountry` as const;
+export const GRAPH_FLAGS_POPOVER_CONTENT_ID =
+  `${GRAPH_INVESTIGATION_TEST_ID}CountryFlagsPopoverContent` as const;
+export const GRAPH_FLAGS_POPOVER_COUNTRY_ID =
+  `${GRAPH_INVESTIGATION_TEST_ID}CountryFlagsPopoverCountry` as const;
+export const GRAPH_FLAGS_POPOVER_ID = `${GRAPH_INVESTIGATION_TEST_ID}CountryFlagsPopover` as const;
 
 export const GRAPH_TAG_WRAPPER_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagWrapper` as const;
 export const GRAPH_TAG_COUNT_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagCount` as const;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
@@ -95,3 +95,5 @@ export const GRAPH_EVENTS_POPOVER_ID = `${GRAPH_INVESTIGATION_TEST_ID}EventsPopo
 export const GRAPH_TAG_WRAPPER_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagWrapper` as const;
 export const GRAPH_TAG_COUNT_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagCount` as const;
 export const GRAPH_TAG_TEXT_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagText` as const;
+
+export const GRAPH_POPOVER_PREVIEW_PANEL = `${GRAPH_INVESTIGATION_TEST_ID}PopoverPreviewPanel` as const;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
@@ -65,9 +65,10 @@ export const GRAPH_ENTITY_NODE_DETAILS_ID =
 
 export const GRAPH_IPS_TEXT_ID = `${GRAPH_INVESTIGATION_TEST_ID}IpsText` as const;
 export const GRAPH_IPS_PLUS_COUNT_ID = `${GRAPH_INVESTIGATION_TEST_ID}IpsPlusCount` as const;
-export const GRAPH_IPS_TOOLTIP_CONTENT_ID =
-  `${GRAPH_INVESTIGATION_TEST_ID}IpsTooltipContent` as const;
-export const GRAPH_IPS_TOOLTIP_IP_ID = `${GRAPH_INVESTIGATION_TEST_ID}IpsTooltipIp` as const;
+export const GRAPH_IPS_POPOVER_CONTENT_ID =
+  `${GRAPH_INVESTIGATION_TEST_ID}IpsPopoverContent` as const;
+export const GRAPH_IPS_POPOVER_IP_ID = `${GRAPH_INVESTIGATION_TEST_ID}IpsPopoverId` as const;
+export const GRAPH_IPS_POPOVER_ID = `${GRAPH_INVESTIGATION_TEST_ID}IpsPopover` as const;
 
 export const GRAPH_FLAGS_BADGE_ID = `${GRAPH_INVESTIGATION_TEST_ID}CountryFlagsBadge` as const;
 export const GRAPH_FLAGS_VISIBLE_FLAG_ID =

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
@@ -96,4 +96,5 @@ export const GRAPH_TAG_WRAPPER_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagWrapper` a
 export const GRAPH_TAG_COUNT_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagCount` as const;
 export const GRAPH_TAG_TEXT_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagText` as const;
 
-export const GRAPH_POPOVER_PREVIEW_PANEL = `${GRAPH_INVESTIGATION_TEST_ID}PopoverPreviewPanel` as const;
+export const GRAPH_POPOVER_PREVIEW_PANEL =
+  `${GRAPH_INVESTIGATION_TEST_ID}PopoverPreviewPanel` as const;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
@@ -90,6 +90,8 @@ export const GRAPH_FLAGS_POPOVER_COUNTRY_ID =
   `${GRAPH_INVESTIGATION_TEST_ID}CountryFlagsPopoverCountry` as const;
 export const GRAPH_FLAGS_POPOVER_ID = `${GRAPH_INVESTIGATION_TEST_ID}CountryFlagsPopover` as const;
 
+export const GRAPH_EVENTS_POPOVER_ID = `${GRAPH_INVESTIGATION_TEST_ID}EventsPopover` as const;
+
 export const GRAPH_TAG_WRAPPER_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagWrapper` as const;
 export const GRAPH_TAG_COUNT_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagCount` as const;
 export const GRAPH_TAG_TEXT_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagText` as const;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/types.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/types.ts
@@ -36,6 +36,8 @@ export type ExpandButtonClickCallback = (
 
 export type IpClickCallback = (e: React.MouseEvent<HTMLButtonElement>) => void;
 
+export type CountryClickCallback = (e: React.MouseEvent<HTMLButtonElement>) => void;
+
 export interface EntityNodeViewModel
   extends Record<string, unknown>,
     EntityNodeDataModel,
@@ -43,6 +45,7 @@ export interface EntityNodeViewModel
   expandButtonClick?: ExpandButtonClickCallback;
   nodeClick?: NodeClickCallback;
   ipClickHandler?: IpClickCallback;
+  countryClickHandler?: CountryClickCallback;
 }
 
 export interface GroupNodeViewModel
@@ -59,6 +62,7 @@ export interface LabelNodeViewModel
   expandButtonClick?: ExpandButtonClickCallback;
   nodeClick?: NodeClickCallback;
   ipClickHandler?: IpClickCallback;
+  countryClickHandler?: CountryClickCallback;
 }
 
 export type NodeViewModel = EntityNodeViewModel | GroupNodeViewModel | LabelNodeViewModel;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/types.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/types.ts
@@ -34,12 +34,15 @@ export type ExpandButtonClickCallback = (
   unToggleCallback: () => void
 ) => void;
 
+export type IpClickCallback = (e: React.MouseEvent<HTMLButtonElement>) => void;
+
 export interface EntityNodeViewModel
   extends Record<string, unknown>,
     EntityNodeDataModel,
     BaseNodeDataViewModel {
   expandButtonClick?: ExpandButtonClickCallback;
   nodeClick?: NodeClickCallback;
+  ipClickHandler?: IpClickCallback;
 }
 
 export interface GroupNodeViewModel
@@ -55,6 +58,7 @@ export interface LabelNodeViewModel
     BaseNodeDataViewModel {
   expandButtonClick?: ExpandButtonClickCallback;
   nodeClick?: NodeClickCallback;
+  ipClickHandler?: IpClickCallback;
 }
 
 export type NodeViewModel = EntityNodeViewModel | GroupNodeViewModel | LabelNodeViewModel;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/types.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/types.ts
@@ -34,9 +34,11 @@ export type ExpandButtonClickCallback = (
   unToggleCallback: () => void
 ) => void;
 
-export type IpClickCallback = (e: React.MouseEvent<HTMLButtonElement>) => void;
+export type IpClickCallback = (e: React.MouseEvent<HTMLElement>) => void;
 
-export type CountryClickCallback = (e: React.MouseEvent<HTMLButtonElement>) => void;
+export type CountryClickCallback = (e: React.MouseEvent<HTMLElement>) => void;
+
+export type EventClickCallback = (e: React.MouseEvent<HTMLButtonElement>) => void;
 
 export interface EntityNodeViewModel
   extends Record<string, unknown>,
@@ -63,6 +65,7 @@ export interface LabelNodeViewModel
   nodeClick?: NodeClickCallback;
   ipClickHandler?: IpClickCallback;
   countryClickHandler?: CountryClickCallback;
+  eventClickHandler?: EventClickCallback;
 }
 
 export type NodeViewModel = EntityNodeViewModel | GroupNodeViewModel | LabelNodeViewModel;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/tsconfig.json
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/tsconfig.json
@@ -21,6 +21,7 @@
     "@kbn/core-application-browser-mocks",
     "@kbn/core",
     "@kbn/discover-utils",
-    "@kbn/cloud-security-posture"
+    "@kbn/cloud-security-posture",
+    "@kbn/react-kibana-context-theme"
   ]
 }

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/tsconfig.json
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/tsconfig.json
@@ -22,6 +22,7 @@
     "@kbn/core",
     "@kbn/discover-utils",
     "@kbn/cloud-security-posture",
-    "@kbn/react-kibana-context-theme"
+    "@kbn/react-kibana-context-theme",
+    "@kbn/expandable-flyout"
   ]
 }

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_graph.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_graph.test.ts
@@ -264,9 +264,8 @@ describe('fetchGraph', () => {
     expect(query).toContain(`EVAL targetDocData = TO_STRING(null)`);
     expect(query).toContain(`EVAL targetHostIp = TO_STRING(null)`);
 
-    // Fallback eval clauses for non-enriched contextual data
-    expect(query).toContain(`EVAL sourceIps = TO_STRING(null)`);
-    expect(query).toContain(`EVAL sourceCountryCodes = TO_STRING(null)`);
+    expect(query).toContain('EVAL sourceIps = source.ip');
+    expect(query).toContain('EVAL sourceCountryCodes = source.geo.country_iso_code');
 
     expect(query).toContain(`actorsDocData = VALUES(actorDocData)`);
     expect(query).toContain(`targetsDocData = VALUES(targetDocData)`);

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_graph.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_graph.ts
@@ -211,9 +211,7 @@ ${
       ),
     "}",
   "}")
-// Map host and source values to enriched contextual data
-| EVAL sourceIps = source.ip
-| EVAL sourceCountryCodes = source.geo.country_iso_code`
+`
     : `
 // Fallback to null string with non-enriched actor
 | EVAL actorEntityType = TO_STRING(null)
@@ -226,12 +224,11 @@ ${
 | EVAL targetEntitySubType = TO_STRING(null)
 | EVAL targetHostIp = TO_STRING(null)
 | EVAL targetDocData = TO_STRING(null)
-
-// Fallback to null string with non-enriched host and source data
-| EVAL sourceIps = TO_STRING(null)
-| EVAL sourceCountryCodes = TO_STRING(null)
 `
 }
+// Map host and source values to enriched contextual data
+| EVAL sourceIps = source.ip
+| EVAL sourceCountryCodes = source.geo.country_iso_code
 // Origin event and alerts allow us to identify the start position of graph traversal
 | EVAL isOrigin = ${
     originEventIds.length > 0

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/constants/test_subject_ids.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/constants/test_subject_ids.ts
@@ -35,4 +35,10 @@ export const testSubjectIds = {
     'cloudSecurityGraphGraphInvestigationInvestigateInTimeline',
   ALERT_TABLE_ROW_CSS_SELECTOR: '[data-test-subj="alertsTableIsLoaded"] .euiDataGridRow',
   GRAPH_CONTROL_FIT_TO_VIEW_TEST_ID: 'cloudSecurityGraphGraphInvestigationFitView',
+  GRAPH_IPS_TEXT_ID: 'cloudSecurityGraphGraphInvestigationIpsText',
+  GRAPH_IPS_PLUS_COUNT_BUTTON_ID: 'cloudSecurityGraphGraphInvestigationIpsPlusCountButton',
+  GRAPH_IPS_POPOVER_ID: 'cloudSecurityGraphGraphInvestigationIpsPopover',
+  GRAPH_IPS_POPOVER_CONTENT_ID: 'cloudSecurityGraphGraphInvestigationIpsPopoverContent',
+  GRAPH_IPS_POPOVER_IP_ID: 'cloudSecurityGraphGraphInvestigationIpsPopoverId',
+  PREVIEW_SECTION_BANNER_PANEL: 'previewSectionBannerPanel',
 };

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/logs_gcp_audit/data.json
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/logs_gcp_audit/data.json
@@ -221,12 +221,12 @@
       },
       "related": {
         "entity": [
-          "10.0.0.1",
+          "10.0.0.2",
           "projects/your-project-id/roles/customRole",
           "admin2@example.com"
         ],
         "ip": [
-          "10.0.0.1"
+          "10.0.0.2"
         ],
         "user": [
           "admin2@example.com"
@@ -236,7 +236,7 @@
         "name": "iam.googleapis.com"
       },
       "source": {
-        "ip": "10.0.0.1"
+        "ip": "10.0.0.2"
       },
       "tags": [
         "_geoip_database_unavailable_GeoLite2-City.mmdb",
@@ -351,12 +351,12 @@
       },
       "related": {
         "entity": [
-          "10.0.0.1",
+          "10.0.0.3",
           "projects/your-project-id/roles/customRole",
           "admin3@example.com"
         ],
         "ip": [
-          "10.0.0.1"
+          "10.0.0.3"
         ],
         "user": [
           "admin3@example.com"
@@ -366,7 +366,7 @@
         "name": "iam.googleapis.com"
       },
       "source": {
-        "ip": "10.0.0.1"
+        "ip": "10.0.0.3"
       },
       "tags": [
         "_geoip_database_unavailable_GeoLite2-City.mmdb",

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/expanded_flyout_graph.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/expanded_flyout_graph.ts
@@ -28,6 +28,11 @@ const {
   GRAPH_ACTIONS_TOGGLE_SEARCH_ID,
   GRAPH_ACTIONS_INVESTIGATE_IN_TIMELINE_ID,
   GRAPH_CONTROL_FIT_TO_VIEW_TEST_ID,
+  GRAPH_IPS_PLUS_COUNT_BUTTON_ID,
+  GRAPH_IPS_POPOVER_ID,
+  GRAPH_IPS_POPOVER_CONTENT_ID,
+  GRAPH_IPS_POPOVER_IP_ID,
+  PREVIEW_SECTION_BANNER_PANEL,
 } = testSubjectIds;
 
 type Filter = Parameters<FilterBarService['addFilter']>[0];
@@ -185,5 +190,36 @@ export class ExpandedFlyoutGraph extends GenericFtrService<SecurityTelemetryFtrP
   async clickOnFitGraphIntoViewControl(): Promise<void> {
     await this.testSubjects.click(GRAPH_CONTROL_FIT_TO_VIEW_TEST_ID);
     await this.pageObjects.header.waitUntilLoadingHasFinished();
+  }
+
+  async clickOnIpsPlusButton(): Promise<void> {
+    const ipsPlusButton = await this.testSubjects.find(GRAPH_IPS_PLUS_COUNT_BUTTON_ID);
+    await ipsPlusButton.click();
+  }
+
+  async assertIpsPopoverIsOpen(): Promise<void> {
+    await this.testSubjects.existOrFail(GRAPH_IPS_POPOVER_ID);
+    await this.testSubjects.existOrFail(GRAPH_IPS_POPOVER_CONTENT_ID);
+  }
+
+  async clickOnFirstIpInPopover(): Promise<void> {
+    await this.testSubjects.existOrFail(GRAPH_IPS_POPOVER_CONTENT_ID);
+    const popoverContent = await this.testSubjects.find(GRAPH_IPS_POPOVER_CONTENT_ID);
+    const firstIpElement = await popoverContent.findByTestSubject(GRAPH_IPS_POPOVER_IP_ID);
+    await firstIpElement.click();
+  }
+
+  async assertPreviewPopoverIsOpen(): Promise<void> {
+    await this.testSubjects.existOrFail(PREVIEW_SECTION_BANNER_PANEL);
+  }
+
+  async assertIpsPopoverContainsIps(expectedIps: string[]): Promise<void> {
+    await this.testSubjects.existOrFail(GRAPH_IPS_POPOVER_CONTENT_ID);
+    const popoverContent = await this.testSubjects.find(GRAPH_IPS_POPOVER_CONTENT_ID);
+
+    for (const expectedIp of expectedIps) {
+      const ipText = await popoverContent.getVisibleText();
+      expect(ipText).to.contain(expectedIp);
+    }
   }
 }

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/pages/events_flyout.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/pages/events_flyout.ts
@@ -193,6 +193,38 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
       await networkEventsPage.flyout.assertPreviewPanelIsOpen('event');
     });
 
+    it('expanded flyout - test IP popover functionality', async () => {
+      await networkEventsPage.navigateToNetworkEventsPage(
+        `${networkEventsPage.getAbsoluteTimerangeFilter(
+          '2024-09-01T00:00:00.000Z',
+          '2024-09-02T00:00:00.000Z'
+        )}&${networkEventsPage.getFlyoutFilter('1')}`
+      );
+      await networkEventsPage.waitForListToHaveEvents();
+
+      await networkEventsPage.flyout.expandVisualizations();
+      await networkEventsPage.flyout.assertGraphPreviewVisible();
+      await networkEventsPage.flyout.assertGraphNodesNumber(3);
+
+      await expandedFlyoutGraph.expandGraph();
+      await expandedFlyoutGraph.waitGraphIsLoaded();
+      await expandedFlyoutGraph.assertGraphNodesNumber(3);
+
+      await expandedFlyoutGraph.addFilter({
+        field: 'event.action',
+        operation: 'is',
+        value: 'google.iam.admin.v1.CreateRole',
+      });
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      await expandedFlyoutGraph.clickOnFitGraphIntoViewControl();
+
+      await expandedFlyoutGraph.clickOnIpsPlusButton();
+      await expandedFlyoutGraph.assertIpsPopoverIsOpen();
+      await expandedFlyoutGraph.assertIpsPopoverContainsIps(['10.0.0.1', '10.0.0.3']);
+      await expandedFlyoutGraph.clickOnFirstIpInPopover();
+      await expandedFlyoutGraph.assertPreviewPopoverIsOpen();
+    });
+
     it('show related alerts', async () => {
       // Setting the timerange to fit the data and open the flyout for a specific alert
       await networkEventsPage.navigateToNetworkEventsPage(


### PR DESCRIPTION
This PR closes the following tickets:
[Migrate tooltips to popovers in label nodes](https://github.com/elastic/kibana/issues/233881)
[Show IP flyout preview when clicking on any IP within entity/label IPs popover](https://github.com/elastic/kibana/issues/237678)


## Summary
This pull request enhances the graph investigation feature by introducing new popover components for displaying additional node details such as IPs, country flags, and event/alert analysis. These changes improve the user experience by allowing users to interactively view more granular information about graph nodes. The implementation includes new hooks, handlers, and integration with existing node types.

**Popover Feature Additions**

* Added new popover hooks and components: `useIpPopover`, `useCountryFlagsPopover` which both use `useNodeDetailsPopover` hook, and `useEventDetailsPopover`, enabling interactive popover displays for IP addresses, country flags, and event details in the graph investigation UI.
* Integrated popover handlers (`createIpClickHandler`, `createCountryClickHandler`, `createEventClickHandler`) into node rendering logic, allowing entity and label nodes to trigger corresponding popovers on click.

**Graph Investigation Component Enhancements**

* Updated the `GraphInvestigation` component to manage popover state for IPs, country codes, and event analysis, and to render the new popover components alongside existing ones.
* extended popover open/close logic to ensure only one popover is open at a time, now including the new popover types in the check.

**Storybook Improvements**

* Enhanced the `CountryFlags` Storybook stories to showcase the new popover functionality, including a new story (`CountryFlagsWithPopover`) that demonstrates interactive country flag popover.
* Enhanced the `Ips` Storybook stories to showcase the new popover functionality, including a new story (`IpsWithPopover`) that demonstrates interactive ip popover.
* Enhanced the `LabelNode -> badges` storybook

**Generic Popover Utility**

* Introduced a generic popover utility (`useNodeDetailsPopover`) to simplify the creation and management of popover components for displaying lists of node details.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### How to test

1. Run Elasticsearch with `yarn es snapshot --license trial -E reindex.remote.whitelist=keep-long-live-env-ess.es.us-west2.gcp.elastic-cloud.com:443`
2. Run Kibana locally with `yarn start --no-base-path`
3. Install Cloud Asset Discovery (skip agent installation)
4. Re-index Asset Inventory data with this query
    ```
    POST _reindex?wait_for_completion=true
    {
      "conflicts": "proceed", 
      "source": {
        "remote": {
          "host": "${ES_REMOTE_HOST}", # <-- Set var in Config tab to https://keep-long-live-env-ess.es.us-west2.gcp.elastic-cloud.com:443
          "username": "${ES_REMOTE_USER}", # <-- Set var in Config tab to your user in https://keep-long-live-env-ess.kb.us-west2.gcp.elastic-cloud.com/app/management/security/users i.e. alberto
          "password": "${ES_REMOTE_PASS}" # <-- Set var in Config tab to your password in the same cloud env
        },
        "index": "logs-cloud_asset_inventory*",
        "query": {
          "bool": {
            "must": [
              {
                "range": {
                  "@timestamp": {
                    "gte": "now-1d"
                  }
                }
              }
            ]
          }
        }
      },
      "dest": {
        "op_type": "create",
        "index": "logs-cloud_asset_inventory.asset_inventory-default"
      }
    }
    ```
5. Reindex AWS Cloudtrail logs with this query
    ```
    POST _reindex?wait_for_completion=false
    {
      "conflicts": "proceed", 
      "source": {
        "remote": {
          "host": "${ES_REMOTE_HOST}",
          "username": "${ES_REMOTE_USER}",
          "password": "${ES_REMOTE_PASS}"
        },
        "index": "logs-aws.cloudtrail-*",
        "query": {
           "bool": {
             "must": [],
             "filter": [
               {
                 "range": {
                   "@timestamp": {
                     "gte": "now-3h",
                     "lte": "now"
                   }
                 }
               }
             ]
           }
         }
      },
      "dest": {
        "op_type": "create",
        "index": "logs-aws.cloudtrail-reindexed"
      }
    }
    ```
6. Create a new Data View that matches this index pattern `logs-aws.cloudtrail-*`. Give it the exact same name
7. Open the data-view you created and copy the id from the url
<img width="1700" height="906" alt="image" src="https://github.com/user-attachments/assets/c3fbf289-9a86-491d-97bb-2b52daf80e13" />

8. Download and decompress this exported rule: [rules_export (2).ndjson.zip](https://github.com/user-attachments/files/22530457/rules_export.2.ndjson.zip). Replace the value of "data_view_id" with the id you copied in the previous step
<img width="659" height="430" alt="image" src="https://github.com/user-attachments/assets/9632b750-0499-49a0-aa9a-9af5fac93839" />

9. Go to Rules page and click on "Import rule"
10. Go to Alerts page. Set the date range from several days ago until now. You'll see a bunch of alerts.
11. Open one alert flyout and check you can expand the Graph Visualization tab.
12. Click on all options to show related events, related entities, show actions on this entity, etc.... try to show as many nodes as possible and check they're grouped.
<img width="1459" height="930" alt="image" src="https://github.com/user-attachments/assets/6667dea8-40a8-4da5-af4e-86f5b7ac9599" />

### Screenshots

country flags:

<img width="1654" height="931" alt="image" src="https://github.com/user-attachments/assets/b76e2fe5-3c1f-4c59-abc5-f250f13631ee" />

ips popover + network preview popover:

<img width="1648" height="933" alt="image" src="https://github.com/user-attachments/assets/3d538312-de09-4dce-a8e6-15e4ce313767" />

only events popover:

<img width="1454" height="933" alt="image" src="https://github.com/user-attachments/assets/0753f6e1-0d99-4872-b82f-7e9b595c3530" />

events and alerts storybook:

<img width="1445" height="935" alt="image" src="https://github.com/user-attachments/assets/3007bfc6-8d0e-4402-8dd7-b105340d565d" />

events and alerts popover: 

<img width="1472" height="934" alt="image" src="https://github.com/user-attachments/assets/d8470e3c-7571-4f30-b5de-75c5dd7d6a52" />


