### PR TITLE
[Metrics][Discover] Fix title truncation

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/chart_title.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/chart_title.tsx
@@ -6,7 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { useEuiTheme, EuiHighlight, euiTextTruncate } from '@elastic/eui';
+import { useEuiTheme, EuiHighlight, EuiTextTruncate } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { getHighlightColors } from '@kbn/data-grid-in-table-search/src/get_highlight_colors';
 import React, { useMemo } from 'react';
@@ -37,20 +37,9 @@ export const ChartTitle = ({
         line-height: ${euiTheme.size.l};
         padding: 0px ${euiTheme.size.s};
 
-        display: flex;
-        flex-wrap: nowrap;
-
         pointer-events: none;
-
-        > * {
-          min-width: 0;
-          flex: 1 !important;
-          max-width: fit-content !important;
-        }
       `,
       chartTitleCss: css`
-        ${euiTextTruncate()};
-
         font-weight: ${euiTheme.font.weight.bold};
       `,
     };
@@ -81,7 +70,7 @@ export const ChartTitle = ({
             {title}
           </EuiHighlight>
         ) : (
-          title
+          <EuiTextTruncate text={title} />
         )}
       </span>
     </div>

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/chart_title.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/chart_title.tsx
@@ -37,7 +37,16 @@ export const ChartTitle = ({
         line-height: ${euiTheme.size.l};
         padding: 0px ${euiTheme.size.s};
 
+        display: flex;
+        flex-wrap: nowrap;
+
         pointer-events: none;
+
+        > * {
+          min-width: 0;
+          flex: 1 !important;
+          max-width: fit-content !important;
+        }
       `,
       chartTitleCss: css`
         ${euiTextTruncate()};

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
@@ -33,7 +33,7 @@ export type ChartProps = Pick<ChartSectionProps, 'searchSessionId' | 'requestPar
     filters?: Array<{ field: string; value: string }>;
     discoverFetch$: Observable<UnifiedHistogramInputMessage>;
     metric: MetricField;
-    onViewDetails: (esqlQuery: string) => void;
+    onViewDetails: (esqlQuery: string, metric: MetricField) => void;
   };
 
 const LensWrapperMemo = React.memo(LensWrapper);
@@ -89,8 +89,8 @@ export const Chart = ({
   });
 
   const handleViewDetails = useCallback(() => {
-    onViewDetails(esqlQuery);
-  }, [onViewDetails, esqlQuery]);
+    onViewDetails(esqlQuery, metric);
+  }, [onViewDetails, esqlQuery, metric]);
 
   return (
     <div

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.tsx
@@ -59,7 +59,7 @@ export const MetricsGrid = ({
 
   const [expandedMetric, setExpandedMetric] = useState<
     | {
-        rowIndex: number;
+        metric: MetricField;
         esqlQuery: string;
       }
     | undefined
@@ -88,13 +88,10 @@ export const MetricsGrid = ({
     gridRef,
   });
 
-  const handleViewDetails = useCallback(
-    (index: number) => (esqlQuery: string) => {
-      setExpandedMetric({ rowIndex: index, esqlQuery });
-      dismissAllFlyoutsExceptFor(DiscoverFlyouts.metricInsights);
-    },
-    []
-  );
+  const handleViewDetails = useCallback((esqlQuery: string, metric: MetricField) => {
+    setExpandedMetric({ metric, esqlQuery });
+    dismissAllFlyoutsExceptFor(DiscoverFlyouts.metricInsights);
+  }, []);
 
   const handleCloseFlyout = useCallback(() => {
     setExpandedMetric(undefined);
@@ -167,7 +164,7 @@ export const MetricsGrid = ({
                     filters={filters}
                     onBrushEnd={onBrushEnd}
                     onFilter={onFilter}
-                    onViewDetails={handleViewDetails(index)}
+                    onViewDetails={handleViewDetails}
                   />
                 </div>
               </EuiFlexItem>
@@ -175,9 +172,9 @@ export const MetricsGrid = ({
           })}
         </EuiFlexGrid>
       </div>
-      {expandedMetric && expandedMetric.rowIndex < rows.length && (
+      {expandedMetric && (
         <MetricInsightsFlyout
-          metric={rows[expandedMetric.rowIndex].metric}
+          metric={expandedMetric.metric}
           esqlQuery={expandedMetric.esqlQuery}
           isOpen
           onClose={handleCloseFlyout}


### PR DESCRIPTION
fixes [231465](https://github.com/elastic/kibana/issues/231465)

## Summary

This PR https://github.com/elastic/kibana/pull/236438 introduced a bug in the chart's title truncation. This PR solves that

<img width="219" height="240" alt="image" src="https://github.com/user-attachments/assets/776b35e4-fa91-4df0-8cba-f59b1f4620f8" />




## How to test
- Clone https://github.com/simianhacker/simian-forge/tree/main
- Run ` ./forge --dataset hosts --count 25 --interval 30s`
  - For beats metrics, the system integration package MUST be installed (after installing it, make sure to delete all existing metrics data streams)
- Set the following config to `kibana.dev.yml`
```yml
feature_flags.overrides:
  metricsExperienceEnabled: true
 ```
- Navigate to Discover and Switch to ESQL mode
- Reduce the screen size and confirm that the title text truncates

