### PR TITLE
[ES|QL] Fix undefined values when user does not have write privilege in the index editor

### DIFF
--- a/src/platform/packages/private/kbn-index-editor/src/components/grid_custom_renderers/cell_value_renderer.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/grid_custom_renderers/cell_value_renderer.tsx
@@ -53,12 +53,16 @@ export const getCellValueRenderer =
           >
             {
               // Only check for undefined, other falsy values might be user inputs
-              cellValue === undefined && canEditIndex ? (
+              cellValue === undefined ? (
                 <EuiText size="xs" color="subdued">
-                  <FormattedMessage
-                    id="indexEditor.flyout.grid.cell.default"
-                    defaultMessage="Add value…"
-                  />
+                  {canEditIndex ? (
+                    <FormattedMessage
+                      id="indexEditor.flyout.grid.cell.default"
+                      defaultMessage="Add value…"
+                    />
+                  ) : (
+                    ''
+                  )}
                 </EuiText>
               ) : (
                 `${cellValue}`

--- a/src/platform/packages/private/kbn-index-editor/src/components/grid_custom_renderers/cell_value_renderer.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/grid_custom_renderers/cell_value_renderer.tsx
@@ -54,18 +54,18 @@ export const getCellValueRenderer =
             {
               // Only check for undefined, other falsy values might be user inputs
               cellValue === undefined ? (
-                <EuiText size="xs" color="subdued">
-                  {canEditIndex ? (
+                canEditIndex ? (
+                  <EuiText size="xs" color="subdued">
                     <FormattedMessage
                       id="indexEditor.flyout.grid.cell.default"
                       defaultMessage="Add value…"
                     />
-                  ) : (
-                    ''
-                  )}
-                </EuiText>
+                  </EuiText>
+                ) : null
               ) : (
-                `${cellValue}`
+                <EuiText size="xs" title={cellValue}>
+                  {cellValue}
+                </EuiText>
               )
             }
           </div>


### PR DESCRIPTION
## Summary
When a user with only read privileges enters the index editor, it sees empty values as `undefined`.


## Before
<img width="637" height="284" alt="image" src="https://github.com/user-attachments/assets/e8faff38-4469-4cae-80e2-1cae9912b6bd" />

## After
<img width="631" height="278" alt="image" src="https://github.com/user-attachments/assets/113a93a6-8f5b-4ee4-91d2-635fb56495be" />
