### PR TITLE
[9.1] [Data Views] Fix detail page header not being full width (#236441)

### DIFF
--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -12,7 +12,6 @@ import { withRouter, RouteComponentProps, useLocation } from 'react-router-dom';
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiHorizontalRule,
   EuiSpacer,
   EuiBadge,
   EuiCallOut,
@@ -189,20 +188,20 @@ export const EditIndexPattern = withRouter(
     return (
       <div data-test-subj="editIndexPattern" role="region" aria-label={headingAriaLabel}>
         {dataView && (
-          <IndexHeader
-            indexPattern={dataView}
-            setDefault={() => dataViewMgmtService.setDefaultDataView()}
-            editIndexPatternClick={editPattern}
-            deleteIndexPatternClick={() =>
-              removeHandler(
-                [dataView as RemoveDataViewProps],
-                deleteModalMsg([dataView as RemoveDataViewProps], Boolean(dataView.namespaces))
-              )
-            }
-            defaultIndex={defaultIndex}
-            canSave={userEditPermission}
-          >
-            <EuiHorizontalRule margin="none" />
+          <>
+            <IndexHeader
+              indexPattern={dataView}
+              setDefault={() => dataViewMgmtService.setDefaultDataView()}
+              editIndexPatternClick={editPattern}
+              deleteIndexPatternClick={() =>
+                removeHandler(
+                  [dataView as RemoveDataViewProps],
+                  deleteModalMsg([dataView as RemoveDataViewProps], Boolean(dataView.namespaces))
+                )
+              }
+              defaultIndex={defaultIndex}
+              canSave={userEditPermission}
+            />
             <EuiSpacer size="l" />
             <EuiFlexGroup wrap gutterSize="l" alignItems="center">
               {Boolean(indexPattern.title) && (
@@ -274,7 +273,7 @@ export const EditIndexPattern = withRouter(
                 </EuiCallOut>
               </>
             )}
-          </IndexHeader>
+          </>
         )}
         <EuiSpacer size="xl" />
         {dataView && (

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/index_header/index_header.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/index_header/index_header.tsx
@@ -59,6 +59,7 @@ export const IndexHeader: FC<PropsWithChildren<IndexHeaderProps>> = ({
   return (
     <EuiPageHeader
       pageTitle={<span data-test-subj="indexPatternTitle">{indexPattern.getName()}</span>}
+      bottomBorder
       rightSideItems={[
         canSave && (
           <EuiButton


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Data Views] Fix detail page header not being full width (#236441)](https://github.com/elastic/kibana/pull/236441)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Damian Polewski","email":"125268832+damian-polewski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-09-29T11:08:56Z","message":"[Data Views] Fix detail page header not being full width (#236441)\n\n## Summary\n\nCloses #233305\n\nThis PR fixes an issue where Data Views Detail page header was not\nshowing at full width of page template.","sha":"887d2090a09501e57074e08e23d4d85186a91bb2","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Data Views","Team:Kibana Management","release_note:skip","backport:all-open","v9.2.0"],"title":"[Data Views] Fix detail page header not being full width","number":236441,"url":"https://github.com/elastic/kibana/pull/236441","mergeCommit":{"message":"[Data Views] Fix detail page header not being full width (#236441)\n\n## Summary\n\nCloses #233305\n\nThis PR fixes an issue where Data Views Detail page header was not\nshowing at full width of page template.","sha":"887d2090a09501e57074e08e23d4d85186a91bb2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236441","number":236441,"mergeCommit":{"message":"[Data Views] Fix detail page header not being full width (#236441)\n\n## Summary\n\nCloses #233305\n\nThis PR fixes an issue where Data Views Detail page header was not\nshowing at full width of page template.","sha":"887d2090a09501e57074e08e23d4d85186a91bb2"}}]}] BACKPORT-->