### PR TITLE
[Automatic Migrations] Extract columns with LLM with aggregation as the first column

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/graph.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/graph.ts
@@ -17,6 +17,7 @@ import { translateDashboardPanelState } from './state';
 import type { TranslatePanelGraphParams, TranslateDashboardPanelState } from './types';
 import { migrateDashboardConfigSchema } from '../../state';
 import { getSelectIndexPatternNode } from './nodes/select_index_pattern';
+import { getExtractColumnsFromEsqlQueryNode } from './nodes/extract_columns';
 
 export function getTranslatePanelGraph(params: TranslatePanelGraphParams) {
   const translateQueryNode = getTranslateQueryNode(params);
@@ -24,6 +25,7 @@ export function getTranslatePanelGraph(params: TranslatePanelGraphParams) {
   const validationNode = getValidationNode(params);
   const fixQueryErrorsNode = getFixQueryErrorsNode(params);
   const ecsMappingNode = getEcsMappingNode(params);
+  const extractColumnsFromEsqlNode = getExtractColumnsFromEsqlQueryNode(params);
   const selectIndexPatternNode = getSelectIndexPatternNode(params);
   const translationResultNode = getTranslationResultNode(params);
 
@@ -37,6 +39,7 @@ export function getTranslatePanelGraph(params: TranslatePanelGraphParams) {
     .addNode('validation', validationNode)
     .addNode('fixQueryErrors', fixQueryErrorsNode)
     .addNode('ecsMapping', ecsMappingNode)
+    .addNode('extractColumnsFromEsql', extractColumnsFromEsqlNode)
     .addNode('selectIndexPattern', selectIndexPatternNode)
     .addNode('translationResult', translationResultNode)
 
@@ -49,8 +52,9 @@ export function getTranslatePanelGraph(params: TranslatePanelGraphParams) {
     .addConditionalEdges('validation', validationRouter, [
       'fixQueryErrors',
       'ecsMapping',
-      'selectIndexPattern',
+      'extractColumnsFromEsql',
     ])
+    .addEdge('extractColumnsFromEsql', 'selectIndexPattern')
     .addEdge('selectIndexPattern', 'translationResult')
     .addEdge('translationResult', END);
 
@@ -73,5 +77,5 @@ const validationRouter = (state: TranslateDashboardPanelState) => {
   if (!state.includes_ecs_mapping) {
     return 'ecsMapping';
   }
-  return 'selectIndexPattern';
+  return 'extractColumnsFromEsql';
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/nodes/extract_columns/extract_columns.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/nodes/extract_columns/extract_columns.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { EsqlKnowledgeBase } from '../../../../../../../common/task/util/esql_knowledge_base';
+import type { ChatModel } from '../../../../../../../common/task/util/actions_client_chat';
+import { EXTRACT_COLUMNS_ESQL_QUERY_TEMPLATE } from './prompts';
+import type { EsqlColumn, GraphNode } from '../../types';
+
+interface GetExtractColumnsFromEsqlQueryNodeParams {
+  model: ChatModel;
+  esqlKnowledgeBase: EsqlKnowledgeBase;
+  logger: Logger;
+}
+
+interface GetExtractColumnsFromEsqlQueryResponse {
+  columns: EsqlColumn[];
+}
+
+export const getExtractColumnsFromEsqlQueryNode = ({
+  model,
+  esqlKnowledgeBase,
+  logger,
+}: GetExtractColumnsFromEsqlQueryNodeParams): GraphNode => {
+  return async (state) => {
+    const query = state.esql_query;
+    if (!query) {
+      return { esql_query_columns: undefined };
+    }
+
+    const prompt = await EXTRACT_COLUMNS_ESQL_QUERY_TEMPLATE.format({
+      esql_query: query,
+    });
+    const response = await esqlKnowledgeBase.translate(prompt);
+    const columns: EsqlColumn[] = [];
+
+    try {
+      const outputJsonStr = response.match(/```json\n([\s\S]*?)\n```/)?.[1];
+      if (!outputJsonStr) {
+        throw new Error('No ESQL Columns JSON found in the response');
+      }
+      const outputJson = JSON.parse(outputJsonStr) as GetExtractColumnsFromEsqlQueryResponse;
+
+      columns.push(...outputJson.columns);
+    } catch (e) {
+      const message = `Failed to parse JSON when extracting columns from ES|QL query. Trying again: ${e}`;
+      logger.error(message);
+    }
+
+    return { esql_query_columns: columns };
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/nodes/extract_columns/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/nodes/extract_columns/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './extract_columns';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/nodes/extract_columns/prompts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/nodes/extract_columns/prompts.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ChatPromptTemplate } from '@langchain/core/prompts';
+
+export const EXTRACT_COLUMNS_ESQL_QUERY_TEMPLATE =
+  ChatPromptTemplate.fromTemplate(`You are a helpful ES|QL (Elasticsearch Query Language) expert agent.
+ Your task to find the column names in the given ES|QL Query. You need to follow below guidelines
+
+- You will be provided with a ES|QL query below.
+- Try to find the columns that will be returned by the query and their types.
+- You must respond only with a valid json object inside a \`\`\`json code block in schema {{"columns":[{{"name":"name", "type":"type"}}]}}.
+- When returning the columns array, make sure the aggregation (count, sum, min, max, avg) is the first item in the array.
+
+<context>
+
+<esql_query>
+{esql_query}
+</esql_query>
+
+</context>
+`);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/nodes/translation_result/translation_result.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/nodes/translation_result/translation_result.ts
@@ -57,7 +57,12 @@ export const getTranslationResultNode = (params: GetTranslationResultNodeParams)
       };
     }
 
-    const panelJSON = processPanel(panel, query, state.parsed_panel);
+    const panelJSON = processPanel(
+      panel,
+      query,
+      state.esql_query_columns ?? [],
+      state.parsed_panel
+    );
 
     return {
       elastic_panel: panelJSON,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/state.ts
@@ -10,7 +10,7 @@ import type { MigrationComments } from '../../../../../../../../common/siem_migr
 import type { ParsedPanel } from '../../../../../../../../common/siem_migrations/parsers/types';
 import { MigrationTranslationResult } from '../../../../../../../../common/siem_migrations/constants';
 import type { MigrationResources } from '../../../../../common/task/retrievers/resource_retriever';
-import type { ValidationErrors } from './types';
+import type { EsqlColumn, ValidationErrors } from './types';
 
 export const translateDashboardPanelState = Annotation.Root({
   parsed_panel: Annotation<ParsedPanel>(),
@@ -25,6 +25,7 @@ export const translateDashboardPanelState = Annotation.Root({
   }),
   inline_query: Annotation<string | undefined>(),
   esql_query: Annotation<string | undefined>(),
+  esql_query_columns: Annotation<EsqlColumn[] | undefined>(),
   validation_errors: Annotation<ValidationErrors>({
     reducer: (current, value) => value ?? current,
     default: () => ({ retries_left: 3 }), // Max self-healing ES|QL validation retries

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/sub_graphs/translate_panel/types.ts
@@ -36,3 +36,8 @@ export interface ValidationErrors {
   retries_left: number;
   esql_errors?: string;
 }
+
+export interface EsqlColumn {
+  name: string;
+  type: string;
+}


### PR DESCRIPTION
- Resolves https://github.com/elastic/security-team/issues/13946

## Problem Statement


Today, we extract columns from an `esql` query using esql parsing utilities which result in columns without any particular order. After that we assign the column with `index === 0` as a metric column even though, we do not know what kind of column will it be. 

There are multiple problems with its approach: 
1. The result is not always accurate.
2. In panels that are of metric type, the only column should be numeric. It cannot be ensured using current method.


## Solution

This PR adds a new step called `extractColumnsFromEsql`. [Here](https://smith.langchain.com/o/a9ce6102-b198-4b3d-9190-95bedc24ca4f/projects/p/66aedda3-8cfd-4eee-950d-7ba2f93a317e?timeModel=%7B%22duration%22%3A%227d%22%7D&searchModel=%7B%22filter%22%3A%22and%28eq%28name%2C+%5C%22extractColumnsFromEsql%5C%22%29%2C+eq%28status%2C+%5C%22success%5C%22%29%29%22%7D) some sample traces of the step where results are much better and predictable.

This method uses `naturalLanguageToEsql` tool to get the correct list of columns.

<img width="809" height="1195" alt="image" src="https://github.com/user-attachments/assets/b9ca359d-ec5a-4b9a-a266-b790b769e34d" />

