### PR TITLE
[Hosts][Processes] Check for hits length before accessing in getEcsProcessList

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/server/lib/host_details/process_list.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/host_details/process_list.ts
@@ -154,6 +154,7 @@ const getEcsProcessList = async (
   });
 
   const summary: { [p: string]: number } = response.aggregations?.summaryEvent.summary.hits.hits
+    ?.length
     ? (response.aggregations?.summaryEvent.summary.hits.hits[0]._source as EcsMetaSource).system
         .process.summary
     : {};


### PR DESCRIPTION
## Summary

Adding back a sanity check that was removed during a [PR](https://github.com/elastic/kibana/pull/231283) which refactored and split some of the logic between ECS and OTel for querying host processes.

|Before|After|
|-|-|
|<img width="1208" height="966" alt="Screenshot 2025-09-30 at 16 04 26" src="https://github.com/user-attachments/assets/e3aa9765-d952-453f-9036-539207361c7d" />|<img width="1206" height="967" alt="Screenshot 2025-09-30 at 16 03 56" src="https://github.com/user-attachments/assets/075fae67-da6b-4595-b905-055e4c3bc104" />|



