### PR TITLE
[8.19] Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry·ts - alerting api integration security and spaces enabled - Group 2 Alerting and Actions Telemetry test telemetry should retrieve telemetry data in the expected format (#236623)

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry.ts
@@ -163,6 +163,31 @@ export default function createAlertingAndActionsTelemetryTests({ getService }: F
             apiUrl,
           },
         });
+
+        // AAD rule
+        const ruleWithAadId = await createRule({
+          space: space.id,
+          ruleOverwrites: {
+            rule_type_id: 'test.always-firing-alert-as-data',
+            schedule: { interval: '1h' },
+            notify_when: 'onActiveAlert',
+            throttle: null,
+            params: {
+              index: 'kibana-alerting-test-data',
+              reference: 'test',
+            },
+            actions: [
+              {
+                id: noopConnectorId,
+                group: 'default',
+                params: {},
+              },
+            ],
+          },
+        });
+
+        rulesWithAAD.push(ruleWithAadId);
+
         await createRule({
           space: space.id,
           ruleOverwrites: {
@@ -290,30 +315,6 @@ export default function createAlertingAndActionsTelemetryTests({ getService }: F
             dsl: '{"bool":{"must":[],"filter":[{"bool":{"should":[{"exists":{"field":"kibana.alert.job_errors_results.job_id"}}],"minimum_should_match":1}}],"should":[],"must_not":[]}}',
           },
         });
-
-        // AAD rule
-        const ruleWithAadId = await createRule({
-          space: space.id,
-          ruleOverwrites: {
-            rule_type_id: 'test.always-firing-alert-as-data',
-            schedule: { interval: '1h' },
-            notify_when: 'onActiveAlert',
-            throttle: null,
-            params: {
-              index: '.kibana-alerting-test-data',
-              reference: 'test',
-            },
-            actions: [
-              {
-                id: noopConnectorId,
-                group: 'default',
-                params: {},
-              },
-            ],
-          },
-        });
-
-        rulesWithAAD.push(ruleWithAadId);
 
         // ES query rule
         esQueryRuleId[space.id] = await createRule({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry·ts - alerting api integration security and spaces enabled - Group 2 Alerting and Actions Telemetry test telemetry should retrieve telemetry data in the expected format (#236623)](https://github.com/elastic/kibana/pull/236623)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-09-30T12:24:14Z","message":"Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry·ts - alerting api integration security and spaces enabled - Group 2 Alerting and Actions Telemetry test telemetry should retrieve telemetry data in the expected format (#236623)\n\nResolves https://github.com/elastic/kibana/issues/224236\n\n## Summary\n\nThis test was very occasionally failing due to a race condition. The\nalerting telemetry gets the number of executions per rule type from the\nevent log index and gets the number of alert docs written from the\nalerts as data indices. There is a check that the number of alert docs\nequals twice the number of executions (because the rule is set up to\ngenerate 2 alerts per execution). We expect 3 executions and 6 alert\ndocs. Very occasionally, we see 3 executions and 4 alert docs. I believe\nthis is due to a race condition when the telemetry task runs after rule\nexecution is done but before alert docs are ready to be queried. This\nmoves the AAD rule to be one of the first rules created (and so one of\nthe first rules run) instead of one of the last rules created. This will\nallow the alert docs to be fully written before the telemetry task runs.\n\n### Flaky test runs:\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9399\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9400\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9401\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"63140a1c104a1e971fbb8196034c0512d54dbe8f","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","backport:version","v9.2.0","v8.19.5","v9.1.5"],"title":"Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry·ts - alerting api integration security and spaces enabled - Group 2 Alerting and Actions Telemetry test telemetry should retrieve telemetry data in the expected format","number":236623,"url":"https://github.com/elastic/kibana/pull/236623","mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry·ts - alerting api integration security and spaces enabled - Group 2 Alerting and Actions Telemetry test telemetry should retrieve telemetry data in the expected format (#236623)\n\nResolves https://github.com/elastic/kibana/issues/224236\n\n## Summary\n\nThis test was very occasionally failing due to a race condition. The\nalerting telemetry gets the number of executions per rule type from the\nevent log index and gets the number of alert docs written from the\nalerts as data indices. There is a check that the number of alert docs\nequals twice the number of executions (because the rule is set up to\ngenerate 2 alerts per execution). We expect 3 executions and 6 alert\ndocs. Very occasionally, we see 3 executions and 4 alert docs. I believe\nthis is due to a race condition when the telemetry task runs after rule\nexecution is done but before alert docs are ready to be queried. This\nmoves the AAD rule to be one of the first rules created (and so one of\nthe first rules run) instead of one of the last rules created. This will\nallow the alert docs to be fully written before the telemetry task runs.\n\n### Flaky test runs:\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9399\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9400\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9401\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"63140a1c104a1e971fbb8196034c0512d54dbe8f"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236623","number":236623,"mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry·ts - alerting api integration security and spaces enabled - Group 2 Alerting and Actions Telemetry test telemetry should retrieve telemetry data in the expected format (#236623)\n\nResolves https://github.com/elastic/kibana/issues/224236\n\n## Summary\n\nThis test was very occasionally failing due to a race condition. The\nalerting telemetry gets the number of executions per rule type from the\nevent log index and gets the number of alert docs written from the\nalerts as data indices. There is a check that the number of alert docs\nequals twice the number of executions (because the rule is set up to\ngenerate 2 alerts per execution). We expect 3 executions and 6 alert\ndocs. Very occasionally, we see 3 executions and 4 alert docs. I believe\nthis is due to a race condition when the telemetry task runs after rule\nexecution is done but before alert docs are ready to be queried. This\nmoves the AAD rule to be one of the first rules created (and so one of\nthe first rules run) instead of one of the last rules created. This will\nallow the alert docs to be fully written before the telemetry task runs.\n\n### Flaky test runs:\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9399\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9400\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9401\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"63140a1c104a1e971fbb8196034c0512d54dbe8f"}},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/236961","number":236961,"state":"MERGED","mergeCommit":{"sha":"d3fe9f9b1600e21ce1ed85a2ece67918b3de8013","message":"[9.1] Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry·ts - alerting api integration security and spaces enabled - Group 2 Alerting and Actions Telemetry test telemetry should retrieve telemetry data in the expected format (#236623) (#236961)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [Fixes Failing test: X-Pack Alerting API Integration\nTests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry·ts\n- alerting api integration security and spaces enabled - Group 2\nAlerting and Actions Telemetry test telemetry should retrieve telemetry\ndata in the expected format\n(#236623)](https://github.com/elastic/kibana/pull/236623)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ying Mao <ying.mao@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}}]}] BACKPORT-->