### PR TITLE
233750 msi commands

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.test.ts
@@ -116,13 +116,14 @@ describe('getInstallCommandForPlatform', () => {
     it('should return the correct command if the the policyId is not set for windows MSI', () => {
       const res = getInstallCommandForPlatform({
         platform: 'windows_msi',
+        kibanaVersion: '9.0.0',
         esOutputHost: 'http://elasticsearch:9200',
         serviceToken: 'service-token-1',
       });
       expect(res).toMatchInlineSnapshot(`
         "$ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--windows-x86_64.msi -OutFile elastic-agent--windows-x86_64.msi
-        .\\\\elastic-agent.msi --% INSTALLARGS=\\"\`
+        Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.msi -OutFile elastic-agent-9.0.0-windows-x86_64.msi
+        .\\\\elastic-agent-9.0.0-windows-x86_64.msi --% INSTALLARGS=\\"\`
           --fleet-server-es=http://elasticsearch:9200 \`
           --fleet-server-service-token=service-token-1 \`
           --fleet-server-port=8220 \`
@@ -341,12 +342,13 @@ describe('getInstallCommandForPlatform', () => {
         esOutputHost: 'http://elasticsearch:9200',
         serviceToken: 'service-token-1',
         policyId: 'policy-1',
+        kibanaVersion: '9.0.0',
       });
 
       expect(res).toMatchInlineSnapshot(`
         "$ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--windows-x86_64.msi -OutFile elastic-agent--windows-x86_64.msi
-        .\\\\elastic-agent.msi --% INSTALLARGS=\\"\`
+        Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.msi -OutFile elastic-agent-9.0.0-windows-x86_64.msi
+        .\\\\elastic-agent-9.0.0-windows-x86_64.msi --% INSTALLARGS=\\"\`
           --fleet-server-es=http://elasticsearch:9200 \`
           --fleet-server-service-token=service-token-1 \`
           --fleet-server-policy=policy-1 \`
@@ -613,12 +615,13 @@ describe('getInstallCommandForPlatform', () => {
         policyId: 'policy-1',
         fleetServerHost,
         isProductionDeployment: true,
+        kibanaVersion: '9.0.0',
       });
 
       expect(res).toMatchInlineSnapshot(`
         "$ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--windows-x86_64.msi -OutFile elastic-agent--windows-x86_64.msi
-        .\\\\elastic-agent.msi --% INSTALLARGS=\\"--url=http://fleetserver:8220 \`
+        Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.msi -OutFile elastic-agent-9.0.0-windows-x86_64.msi
+        .\\\\elastic-agent-9.0.0-windows-x86_64.msi --% INSTALLARGS=\\"--url=http://fleetserver:8220 \`
           --fleet-server-es=http://elasticsearch:9200 \`
           --fleet-server-service-token=service-token-1 \`
           --fleet-server-policy=policy-1 \`
@@ -1047,12 +1050,13 @@ describe('getInstallCommandForPlatform', () => {
           url: 'http://download-src-proxy:2222',
           is_preconfigured: false,
         },
+        kibanaVersion: '9.0.0',
       });
 
       expect(res).toMatchInlineSnapshot(`
         "$ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -Uri https://download-src/8.12.0-test/beats/elastic-agent/elastic-agent--windows-x86_64.msi -OutFile elastic-agent--windows-x86_64.msi -Proxy \\"http://download-src-proxy:2222\\"
-        .\\\\elastic-agent.msi --% INSTALLARGS=\\"\`
+        Invoke-WebRequest -Uri https://download-src/8.12.0-test/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.msi -OutFile elastic-agent-9.0.0-windows-x86_64.msi -Proxy \\"http://download-src-proxy:2222\\"
+        .\\\\elastic-agent-9.0.0-windows-x86_64.msi --% INSTALLARGS=\\"\`
           --fleet-server-es=http://elasticsearch:9200 \`
           --fleet-server-service-token=service-token-1 \`
           --fleet-server-policy=policy-1 \`
@@ -1474,12 +1478,13 @@ describe('getInstallCommandForPlatform', () => {
           },
           is_preconfigured: false,
         },
+        kibanaVersion: '9.0.0',
       });
 
       expect(res).toMatchInlineSnapshot(`
         "$ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -Uri https://download-src/8.12.0-test/beats/elastic-agent/elastic-agent--windows-x86_64.msi -OutFile elastic-agent--windows-x86_64.msi -Proxy \\"http://download-src-proxy:2222\\" -Headers @{\\"Accept-Language\\"=\\"en-US,en;q=0.5\\"; \\"second-header\\"=\\"second-value\\"}
-        .\\\\elastic-agent.msi --% INSTALLARGS=\\"\`
+        Invoke-WebRequest -Uri https://download-src/8.12.0-test/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.msi -OutFile elastic-agent-9.0.0-windows-x86_64.msi -Proxy \\"http://download-src-proxy:2222\\" -Headers @{\\"Accept-Language\\"=\\"en-US,en;q=0.5\\"; \\"second-header\\"=\\"second-value\\"}
+        .\\\\elastic-agent-9.0.0-windows-x86_64.msi --% INSTALLARGS=\\"\`
           --fleet-server-es=http://elasticsearch:9200 \`
           --fleet-server-service-token=service-token-1 \`
           --fleet-server-policy=policy-1 \`

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.ts
@@ -112,8 +112,8 @@ function getArtifact(
 export function getInstallCommandForPlatform({
   platform,
   esOutputHost,
-  esOutputProxy,
   serviceToken,
+  esOutputProxy,
   policyId,
   fleetServerHost,
   isProductionDeployment,
@@ -124,8 +124,8 @@ export function getInstallCommandForPlatform({
 }: {
   platform: PLATFORM_TYPE;
   esOutputHost: string;
-  esOutputProxy?: FleetProxy | undefined;
   serviceToken: string;
+  esOutputProxy?: FleetProxy | undefined;
   policyId?: string;
   fleetServerHost?: FleetServerHost | null;
   isProductionDeployment?: boolean;
@@ -204,7 +204,7 @@ export function getInstallCommandForPlatform({
     mac_aarch64: `${artifact.downloadCommand}\nsudo ./elastic-agent install ${commandArgumentsStr}`,
     mac_x86_64: `${artifact.downloadCommand}\nsudo ./elastic-agent install ${commandArgumentsStr}`,
     windows: `${artifact.downloadCommand}\n.\\elastic-agent.exe install ${commandArgumentsStr}`,
-    windows_msi: `${artifact.downloadCommand}\n.\\elastic-agent.msi --% INSTALLARGS="${commandArgumentsStr}"`,
+    windows_msi: `${artifact.downloadCommand}\n.\\elastic-agent-${kibanaVersion}-windows-x86_64.msi --% INSTALLARGS="${commandArgumentsStr}"`,
     deb_aarch64: `${artifact.downloadCommand}\nsudo systemctl enable elastic-agent\nsudo systemctl start elastic-agent\nsudo elastic-agent enroll ${commandArgumentsStr}`,
     deb_x86_64: `${artifact.downloadCommand}\nsudo systemctl enable elastic-agent\nsudo systemctl start elastic-agent\nsudo elastic-agent enroll ${commandArgumentsStr}`,
     rpm_aarch64: `${artifact.downloadCommand}\nsudo systemctl enable elastic-agent\nsudo systemctl start elastic-agent\nsudo elastic-agent enroll ${commandArgumentsStr}`,

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.test.tsx
@@ -95,6 +95,24 @@ describe('ManualInstructions', () => {
       ]);
     });
 
+    it('should return instructions for windows', async () => {
+      expect(result.windows.split('\n')).toEqual([
+        "$ProgressPreference = 'SilentlyContinue'",
+        'Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.zip -OutFile elastic-agent-9.0.0-windows-x86_64.zip ',
+        'Expand-Archive .\\elastic-agent-9.0.0-windows-x86_64.zip -DestinationPath .',
+        'cd elastic-agent-9.0.0-windows-x86_64',
+        '.\\elastic-agent.exe install --url=https://testhost --enrollment-token=APIKEY',
+      ]);
+    });
+
+    it('should return instructions for windows msi', async () => {
+      expect(result.windows_msi.split('\n')).toEqual([
+        "$ProgressPreference = 'SilentlyContinue'",
+        'Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.msi -OutFile elastic-agent-9.0.0-windows-x86_64.msi ',
+        '.\\elastic-agent-9.0.0-windows-x86_64.msi --% INSTALLARGS="--url=https://testhost --enrollment-token=APIKEY"',
+      ]);
+    });
+
     it('should return instructions for kubernetes', async () => {
       expect(result.kubernetes.split('\n')).toEqual([
         'kubectl apply -f elastic-agent-managed-kubernetes.yml',
@@ -187,6 +205,24 @@ describe('ManualInstructions', () => {
         'tar xzvf elastic-agent-9.0.0-darwin-x86_64.tar.gz',
         'cd elastic-agent-9.0.0-darwin-x86_64',
         'sudo ./elastic-agent install --url=https://testhost --enrollment-token=APIKEY --install-servers',
+      ]);
+    });
+
+    it('should return instructions for windows', async () => {
+      expect(result.windows.split('\n')).toEqual([
+        "$ProgressPreference = 'SilentlyContinue'",
+        'Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.zip -OutFile elastic-agent-9.0.0-windows-x86_64.zip ',
+        'Expand-Archive .\\elastic-agent-9.0.0-windows-x86_64.zip -DestinationPath .',
+        'cd elastic-agent-9.0.0-windows-x86_64',
+        '.\\elastic-agent.exe install --url=https://testhost --enrollment-token=APIKEY --install-servers',
+      ]);
+    });
+
+    it('should return instructions for windows msi', async () => {
+      expect(result.windows_msi.split('\n')).toEqual([
+        "$ProgressPreference = 'SilentlyContinue'",
+        'Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.msi -OutFile elastic-agent-9.0.0-windows-x86_64.msi ',
+        '.\\elastic-agent-9.0.0-windows-x86_64.msi --% INSTALLARGS="--url=https://testhost --enrollment-token=APIKEY --install-servers"',
       ]);
     });
 
@@ -297,6 +333,24 @@ describe('ManualInstructions', () => {
       ]);
     });
 
+    it('should return instructions for windows', async () => {
+      expect(result.windows.split('\n')).toEqual([
+        "$ProgressPreference = 'SilentlyContinue'",
+        'Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.zip -OutFile elastic-agent-9.0.0-windows-x86_64.zip ',
+        'Expand-Archive .\\elastic-agent-9.0.0-windows-x86_64.zip -DestinationPath .',
+        'cd elastic-agent-9.0.0-windows-x86_64',
+        '.\\elastic-agent.exe install --url=https://testhost --enrollment-token=APIKEY --proxy-url=http://test-proxy --proxy-header "test1=header"',
+      ]);
+    });
+
+    it('should return instructions for windows msi', async () => {
+      expect(result.windows_msi.split('\n')).toEqual([
+        "$ProgressPreference = 'SilentlyContinue'",
+        'Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.msi -OutFile elastic-agent-9.0.0-windows-x86_64.msi ',
+        '.\\elastic-agent-9.0.0-windows-x86_64.msi --% INSTALLARGS="--url=https://testhost --enrollment-token=APIKEY --proxy-url=http://test-proxy --proxy-header "test1=header""',
+      ]);
+    });
+
     it('should return instructions for kubernetes', async () => {
       expect(result.kubernetes.split('\n')).toEqual([
         'kubectl apply -f elastic-agent-managed-kubernetes.yml',
@@ -404,6 +458,24 @@ describe('ManualInstructions', () => {
         'tar xzvf elastic-agent-9.0.0-darwin-x86_64.tar.gz',
         'cd elastic-agent-9.0.0-darwin-x86_64',
         'sudo ./elastic-agent install --url=https://testhost --enrollment-token=APIKEY',
+      ]);
+    });
+
+    it('should return instructions for windows', async () => {
+      expect(result.windows.split('\n')).toEqual([
+        "$ProgressPreference = 'SilentlyContinue'",
+        'Invoke-WebRequest -Uri http://localregistry.co/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.zip -OutFile elastic-agent-9.0.0-windows-x86_64.zip -Proxy "http://ds-proxy"',
+        'Expand-Archive .\\elastic-agent-9.0.0-windows-x86_64.zip -DestinationPath .',
+        'cd elastic-agent-9.0.0-windows-x86_64',
+        '.\\elastic-agent.exe install --url=https://testhost --enrollment-token=APIKEY',
+      ]);
+    });
+
+    it('should return instructions for windows msi', async () => {
+      expect(result.windows_msi.split('\n')).toEqual([
+        "$ProgressPreference = 'SilentlyContinue'",
+        'Invoke-WebRequest -Uri http://localregistry.co/beats/elastic-agent/elastic-agent-9.0.0-windows-x86_64.msi -OutFile elastic-agent-9.0.0-windows-x86_64.msi -Proxy "http://ds-proxy"',
+        '.\\elastic-agent-9.0.0-windows-x86_64.msi --% INSTALLARGS="--url=https://testhost --enrollment-token=APIKEY"',
       ]);
     });
 

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.tsx
@@ -141,7 +141,9 @@ cd elastic-agent-${agentVersion}-windows-x86_64
 
   const windowsMSICommand = `$ProgressPreference = 'SilentlyContinue'
 Invoke-WebRequest -Uri ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-windows-x86_64.msi -OutFile elastic-agent-${agentVersion}-windows-x86_64.msi ${windowsDownloadSourceProxyArgs}
-.\\elastic-agent.msi --% INSTALLARGS="${getEnrollArgsByPlatForm('windows_msi')}"`;
+.\\elastic-agent-${agentVersion}-windows-x86_64.msi --% INSTALLARGS="${getEnrollArgsByPlatForm(
+    'windows_msi'
+  )}"`;
 
   const linuxDebAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-arm64.deb ${curlDownloadSourceProxyArgs}
 sudo ${debOrRpmWithInstallServers}dpkg -i elastic-agent-${agentVersion}-arm64.deb

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/standalone/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/standalone/index.tsx
@@ -62,7 +62,7 @@ cd elastic-agent-${agentVersion}-windows-x86_64
 
   const windowsMSICommand = `$ProgressPreference = 'SilentlyContinue'
 Invoke-WebRequest -Uri ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-windows-x86_64.msi -OutFile elastic-agent-${agentVersion}-windows-x86_64.msi ${windowsDownloadSourceProxyArgs}
-.\\elastic-agent.msi install`;
+.\\elastic-agent-${agentVersion}-windows-x86_64.msi install`;
 
   const k8sCommand = 'kubectl apply -f elastic-agent-standalone-kubernetes.yml';
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/233750

## Summary

Fix msi commands by including version number in agent executable

Fleet server enrollment instructions:
<img width="775" height="604" alt="Screenshot 2025-09-30 at 17 14 23" src="https://github.com/user-attachments/assets/504c785b-0599-4cf1-8117-a26d3d8fb83d" />

Agent enrollment instructions:
<img width="764" height="475" alt="Screenshot 2025-09-30 at 17 32 40" src="https://github.com/user-attachments/assets/e2d18f30-0ad9-48e5-a7db-e2a0831a7fda" />


### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["9.1","9.3"]} ONMERGE-->