### PR TITLE
Unskipping session cleanup test

### DIFF
--- a/x-pack/platform/test/security_api_integration/tests/session_lifespan/cleanup.ts
+++ b/x-pack/platform/test/security_api_integration/tests/session_lifespan/cleanup.ts
@@ -85,8 +85,7 @@ export default function ({ getService }: FtrProviderContext) {
     await esSupertest.put('/_cluster/settings').send(addLogging).expect(200);
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/233551
-  describe.skip('Session Lifespan cleanup', () => {
+  describe('Session Lifespan cleanup', () => {
     beforeEach(async () => {
       await es.cluster.health({ index: '.kibana_security_session*', wait_for_status: 'green' });
       await addESDebugLoggingSettings();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/233551

These tests have been successful upon retry. They should be unskipped.

See test failure/success here: https://github.com/elastic/kibana/issues/233551



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->