### PR TITLE
[Security solution][Alerts] Fix raw event visualisation

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.test.tsx
@@ -7,8 +7,16 @@
 
 import { waitFor, render } from '@testing-library/react';
 import React from 'react';
+import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 import { TestProviders } from '../../../common/mock';
 import { TopValuesPopover } from './top_values_popover';
+import { StatefulTopN } from '../../../common/components/top_n';
+
+jest.mock('../../../common/components/top_n', () => ({
+  StatefulTopN: jest.fn(() => <div data-test-subj="topN-container" />),
+}));
+
+const StatefulTopNMocked = StatefulTopN as jest.MockedFunction<typeof StatefulTopN>;
 
 jest.mock('../../../common/components/visualization_actions/lens_embeddable');
 jest.mock('react-router-dom', () => {
@@ -46,6 +54,10 @@ jest.mock('../../../common/lib/kibana', () => {
   };
 });
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('TopNAction', () => {
   it('renders', async () => {
     mockUseObservable.mockReturnValue(data);
@@ -80,6 +92,30 @@ describe('TopNAction', () => {
 
     await waitFor(() => {
       expect(queryByTestId('topN-container')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('activeTimelineEventsTypeOverride', () => {
+    it('passes "alert" when fieldName is ALERT_WORKFLOW_STATUS', async () => {
+      mockUseObservable.mockReturnValue({ ...data, fieldName: ALERT_WORKFLOW_STATUS });
+
+      render(<TopValuesPopover />, { wrapper: TestProviders });
+
+      await waitFor(() => {
+        expect(StatefulTopNMocked.mock.calls[0][0].activeTimelineEventsTypeOverride).toBe('alert');
+      });
+    });
+
+    it('passes undefined when fieldName is not ALERT_WORKFLOW_STATUS', async () => {
+      mockUseObservable.mockReturnValue(data);
+
+      render(<TopValuesPopover />, { wrapper: TestProviders });
+
+      await waitFor(() => {
+        expect(
+          StatefulTopNMocked.mock.calls[0][0].activeTimelineEventsTypeOverride
+        ).toBeUndefined();
+      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.tsx
@@ -53,6 +53,9 @@ export const TopValuesPopover = React.memo(() => {
         toggleTopN={onClose}
         dataView={dataView}
         browserFields={browserFields}
+        activeTimelineEventsTypeOverride={
+          data.fieldName === 'kibana.alert.workflow_status' ? 'alert' : undefined
+        }
       />
     </EuiWrappingPopover>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback } from 'react';
 import { EuiWrappingPopover } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 import { useLocation } from 'react-router-dom';
 import useObservable from 'react-use/lib/useObservable';
 import { StatefulTopN } from '../../../common/components/top_n';
@@ -54,7 +55,7 @@ export const TopValuesPopover = React.memo(() => {
         dataView={dataView}
         browserFields={browserFields}
         activeTimelineEventsTypeOverride={
-          data.fieldName === 'kibana.alert.workflow_status' ? 'alert' : undefined
+          data.fieldName === ALERT_WORKFLOW_STATUS ? 'alert' : undefined
         }
       />
     </EuiWrappingPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/index.test.tsx
@@ -14,7 +14,7 @@ import { mockBrowserFields } from '../../containers/source/mock';
 import { createMockStore, mockDataViewSpec, mockGlobalState, TestProviders } from '../../mock';
 import type { State } from '../../store';
 import { TopN } from './top_n';
-import { detectionAlertsTables } from './helpers';
+import { detectionAlertsTables, getOptions } from './helpers';
 import { StatefulTopN } from '.';
 import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 
@@ -353,6 +353,20 @@ describe('StatefulTopN', () => {
       test(`provides 'applyGlobalQueriesAndFilters' = true`, () => {
         expect(TopNMocked.mock.calls[0][0].applyGlobalQueriesAndFilters).toEqual(true);
       });
+    });
+  });
+
+  describe('rendering with activeTimelineEventsTypeOverride', () => {
+    beforeEach(() => {
+      render(
+        <TestProviders store={store}>
+          <StatefulTopN {...testProps} activeTimelineEventsTypeOverride="alert" />
+        </TestProviders>
+      );
+    });
+
+    test('passes options from getOptions("alert") when activeTimelineEventsTypeOverride is "alert"', () => {
+      expect(TopNMocked.mock.calls[0][0].options).toEqual(getOptions('alert'));
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/index.tsx
@@ -25,6 +25,7 @@ import type { TimelineModel } from '../../../timelines/store/model';
 
 import { getOptions, isDetectionsAlertsTable } from './helpers';
 import { TopN } from './top_n';
+import type { TimelineEventsType } from '../../../../common/types/timeline';
 import { TimelineId, TimelineTabs } from '../../../../common/types/timeline';
 import type { AlertsStackByField } from '../../../detections/components/alerts_kpis/common/types';
 
@@ -83,6 +84,7 @@ export interface OwnProps {
   onFilterAdded?: () => void;
   paddingSize?: 's' | 'm' | 'l' | 'none';
   globalFilters?: Filter[];
+  activeTimelineEventsTypeOverride?: TimelineEventsType;
 }
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
@@ -105,11 +107,21 @@ const StatefulTopNComponent: React.FC<Props> = ({
   paddingSize,
   scopeId,
   toggleTopN,
+  activeTimelineEventsTypeOverride,
 }) => {
   const { uiSettings } = useKibana().services;
   const { from, deleteQuery, to } = useGlobalTime();
 
-  const options = getOptions(isActiveTimeline(scopeId ?? '') ? activeTimelineEventType : undefined);
+  const isTimelineActive = isActiveTimeline(scopeId ?? '');
+
+  const timelineEventsType = useMemo(() => {
+    if (activeTimelineEventsTypeOverride) {
+      return activeTimelineEventsTypeOverride;
+    }
+    return isTimelineActive ? activeTimelineEventType : undefined;
+  }, [activeTimelineEventType, activeTimelineEventsTypeOverride, isTimelineActive]);
+
+  const options = getOptions(timelineEventsType);
   const applyGlobalQueriesAndFilters = !isActiveTimeline(scopeId ?? '');
 
   const combinedQueries = useMemo(


### PR DESCRIPTION
## Summary

Fixes #227017 

## 🛑 The problem

When checking out the "top N" panel in the alerts flyout, the user is able to switch between "Detection Alerts" and "Raw events" for the `kibana.alert.workflow_status` field.
However, that field is present only in alerts documents, not in raw events. Therefore, users should be able to only see "Detection alerts" in the top N panel.

## 💡 Solution

After a bit of investigation and consideration I noticed that we know for what field we are showing the panel. The easiest fix for this is to just check if the field is `kibana.alert.workflow_status` override the default behaviour, which only takes into account the timeline's event type.

## 💭 Considerations

- First of all, this solution could be improve by checking if the field has the `kibana.alert.` prefix. 
  - That way we know if we are addressing an alert's field rather than checking for every possible combination
- This is a short term solution. It doesn't scale. We would need to refactor this component to make it properly re-usable, but that would be too much work for the time being.