### PR TITLE
[Search][FTR] update basic nav test with Data management label

### DIFF
--- a/x-pack/solutions/search/test/functional_search/tests/solution_navigation.basic.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/solution_navigation.basic.ts
@@ -20,8 +20,7 @@ export default function searchSolutionNavigation({
   const testSubjects = getService('testSubjects');
   const esArchiver = getService('esArchiver');
 
-  // Failing: See https://github.com/elastic/kibana/issues/236973
-  describe.skip('Elasticsearch Solution Navigation', () => {
+  describe('Elasticsearch Solution Navigation', () => {
     let cleanUp: () => Promise<unknown>;
     let spaceCreated: { id: string } = { id: '' };
 
@@ -44,7 +43,7 @@ export default function searchSolutionNavigation({
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Developer Tools' });
       // await solutionNavigation.sidenav.expectLinkExists({ text: 'Agents' }); enable when available
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Machine Learning' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Ingest and manage data' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Data management' });
     });
 
     it('has expected navigation', async () => {
@@ -112,7 +111,7 @@ export default function searchSolutionNavigation({
           // 'searchPlayground',
           'machine_learning',
           'dev_tools',
-          'ingest_and_data',
+          'data_management',
           'stack_management',
         ],
         { checkOrder: false }


### PR DESCRIPTION
## Summary

Fix new basic license solution nav test to account for the updated Data management label

Closes [#236973](https://github.com/elastic/kibana/issues/236973)

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
