### PR TITLE
[9.1] [Reporting] roll over the reporting data stream when the template has changed (#234119)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1002,6 +1002,8 @@ x-pack/platform/test/plugin_api_integration/plugins/feature_usage_test @elastic/
 x-pack/platform/test/plugin_api_integration/plugins/sample_task_plugin @elastic/response-ops
 x-pack/platform/test/plugin_api_perf/plugins/task_manager_performance @elastic/response-ops
 x-pack/platform/test/plugin_functional/plugins/global_search_test @elastic/kibana-core
+x-pack/platform/test/reporting_api_integration/plugins/reporting_fixture @elastic/response-ops
+x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes @elastic/response-ops
 x-pack/platform/test/saved_object_api_integration/common/plugins/saved_object_test_plugin @elastic/kibana-security
 x-pack/platform/test/security_api_integration/packages/helpers @elastic/kibana-security
 x-pack/platform/test/security_api_integration/plugins/audit_log @elastic/kibana-security

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1002,8 +1002,6 @@ x-pack/platform/test/plugin_api_integration/plugins/feature_usage_test @elastic/
 x-pack/platform/test/plugin_api_integration/plugins/sample_task_plugin @elastic/response-ops
 x-pack/platform/test/plugin_api_perf/plugins/task_manager_performance @elastic/response-ops
 x-pack/platform/test/plugin_functional/plugins/global_search_test @elastic/kibana-core
-x-pack/platform/test/reporting_api_integration/plugins/reporting_fixture @elastic/response-ops
-x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes @elastic/response-ops
 x-pack/platform/test/saved_object_api_integration/common/plugins/saved_object_test_plugin @elastic/kibana-security
 x-pack/platform/test/security_api_integration/packages/helpers @elastic/kibana-security
 x-pack/platform/test/security_api_integration/plugins/audit_log @elastic/kibana-security
@@ -1322,6 +1320,8 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/functional/page_objects/reporting_page.ts @elastic/response-ops
 /x-pack/platform/test/upgrade/apps/reporting @elastic/response-ops
 /x-pack/platform/test/serverless/fixtures/kbn_archives/reporting @elastic/response-ops
+/x-pack/platform/test/reporting_api_integration/plugins/reporting_fixture @elastic/response-ops
+/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes @elastic/response-ops
 
 ### Global Experience Tagging
 /x-pack/platform/test/saved_object_tagging/ @elastic/appex-sharedux

--- a/package.json
+++ b/package.json
@@ -794,6 +794,7 @@
     "@kbn/reporting-plugin": "link:x-pack/platform/plugins/private/reporting",
     "@kbn/reporting-public": "link:src/platform/packages/private/kbn-reporting/public",
     "@kbn/reporting-server": "link:src/platform/packages/private/kbn-reporting/server",
+    "@kbn/reporting-test-routes": "link:x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes",
     "@kbn/resizable-layout": "link:src/platform/packages/shared/kbn-resizable-layout",
     "@kbn/resizable-layout-examples-plugin": "link:examples/resizable_layout_examples",
     "@kbn/resolver-test-plugin": "link:x-pack/solutions/security/test/plugin_functional/plugins/resolver_test",

--- a/src/platform/packages/private/kbn-reporting/server/constants.ts
+++ b/src/platform/packages/private/kbn-reporting/server/constants.ts
@@ -23,6 +23,11 @@ export const REPORTING_LEGACY_INDICES = '.reporting-*';
 export const REPORTING_DATA_STREAM_WILDCARD_WITH_LEGACY = '.reporting-*,.kibana-reporting*';
 // Name of component template which Kibana overrides for lifecycle settings
 export const REPORTING_DATA_STREAM_COMPONENT_TEMPLATE = 'kibana-reporting@custom';
+// Name of index template
+export const REPORTING_DATA_STREAM_INDEX_TEMPLATE = '.kibana-reporting';
+// Name of mapping meta field which contains the version of the index template
+// see: https://github.com/elastic/elasticsearch/pull/133846
+export const REPORTING_INDEX_TEMPLATE_MAPPING_META_FIELD = 'template_version';
 
 /*
  * Telemetry

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1562,6 +1562,8 @@
       "@kbn/reporting-public/*": ["src/platform/packages/private/kbn-reporting/public/*"],
       "@kbn/reporting-server": ["src/platform/packages/private/kbn-reporting/server"],
       "@kbn/reporting-server/*": ["src/platform/packages/private/kbn-reporting/server/*"],
+      "@kbn/reporting-test-routes": ["x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes"],
+      "@kbn/reporting-test-routes/*": ["x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/*"],
       "@kbn/resizable-layout": ["src/platform/packages/shared/kbn-resizable-layout"],
       "@kbn/resizable-layout/*": ["src/platform/packages/shared/kbn-resizable-layout/*"],
       "@kbn/resizable-layout-examples-plugin": ["examples/resizable_layout_examples"],

--- a/x-pack/platform/plugins/private/reporting/server/lib/store/rollover.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/lib/store/rollover.test.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  REPORTING_DATA_STREAM_ALIAS,
+  REPORTING_DATA_STREAM_INDEX_TEMPLATE,
+  REPORTING_INDEX_TEMPLATE_MAPPING_META_FIELD,
+} from '@kbn/reporting-server';
+import type {
+  IndicesGetIndexTemplateIndexTemplateItem,
+  IndicesGetMappingResponse,
+} from '@elastic/elasticsearch/lib/api/types';
+
+import { rollDataStreamIfRequired } from './rollover';
+
+describe('rollDataStreamIfRequired', () => {
+  const mockLogger = loggingSystemMock.createLogger();
+  let mockEsClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+
+  beforeEach(async () => {
+    mockEsClient = elasticsearchServiceMock.createElasticsearchClient();
+  });
+
+  const msgPrefix = `Data stream ${REPORTING_DATA_STREAM_ALIAS}`;
+  const skipMessage = 'does not need to be rolled over';
+  const rollMessage = 'rolling over the data stream';
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+  });
+
+  it('does nothing if there is no data stream', async () => {
+    mockEsClient.indices.exists.mockResponse(false);
+    await rollDataStreamIfRequired(mockLogger, mockEsClient);
+
+    expect(mockEsClient.indices.exists).toHaveBeenCalledWith({
+      index: REPORTING_DATA_STREAM_ALIAS,
+      expand_wildcards: 'all',
+    });
+    expect(mockLogger.debug).toHaveBeenCalledWith(`${msgPrefix} does not exist so ${skipMessage}`);
+    expect(mockEsClient.indices.getIndexTemplate).not.toHaveBeenCalled();
+    expect(mockEsClient.indices.getMapping).not.toHaveBeenCalled();
+    expect(mockEsClient.indices.rollover).not.toHaveBeenCalled();
+  });
+
+  it('throws an error if no index template is returned', async () => {
+    mockEsClient.indices.exists.mockResponse(true);
+    mockEsClient.indices.getIndexTemplate.mockResponse({ index_templates: [] });
+    const err = `${msgPrefix} index template ${REPORTING_DATA_STREAM_INDEX_TEMPLATE} not found`;
+    await expect(rollDataStreamIfRequired(mockLogger, mockEsClient)).rejects.toThrow(err);
+
+    expect(mockEsClient.indices.getIndexTemplate).toHaveBeenCalledWith({
+      name: REPORTING_DATA_STREAM_INDEX_TEMPLATE,
+    });
+    expect(mockEsClient.indices.getMapping).not.toHaveBeenCalled();
+    expect(mockEsClient.indices.rollover).not.toHaveBeenCalled();
+  });
+
+  it('throws an error if there is no index template with a version', async () => {
+    mockEsClient.indices.exists.mockResponse(true);
+    const templateWithoutVersion = getBasicIndexTemplate();
+    delete templateWithoutVersion.index_template.version;
+    mockEsClient.indices.getIndexTemplate.mockResponse({
+      index_templates: [templateWithoutVersion],
+    });
+
+    const err = `${msgPrefix} index template ${REPORTING_DATA_STREAM_INDEX_TEMPLATE} does not have a version field`;
+    await expect(rollDataStreamIfRequired(mockLogger, mockEsClient)).rejects.toThrow(err);
+
+    expect(mockEsClient.indices.getMapping).not.toHaveBeenCalled();
+    expect(mockEsClient.indices.rollover).not.toHaveBeenCalled();
+  });
+
+  it('does nothing if there are no mappings on the backing indices', async () => {
+    mockEsClient.indices.exists.mockResponse(true);
+    mockEsClient.indices.getIndexTemplate.mockResponse({
+      index_templates: [getBasicIndexTemplate()],
+    });
+    mockEsClient.indices.getMapping.mockResponse({});
+    await rollDataStreamIfRequired(mockLogger, mockEsClient);
+
+    const msg = `${msgPrefix} has no backing indices so ${skipMessage}`;
+    expect(mockLogger.debug).toHaveBeenCalledWith(msg);
+    expect(mockEsClient.indices.rollover).not.toHaveBeenCalled();
+  });
+
+  it('rolls over the data stream if there are no versions in the backing index mappings', async () => {
+    mockEsClient.indices.exists.mockResponse(true);
+    mockEsClient.indices.getIndexTemplate.mockResponse({
+      index_templates: [getBasicIndexTemplate()],
+    });
+    const mappings: IndicesGetMappingResponse = {
+      indexName: {
+        mappings: { _meta: {} },
+      },
+    };
+    mockEsClient.indices.getMapping.mockResponse(mappings);
+    await rollDataStreamIfRequired(mockLogger, mockEsClient);
+
+    const msg = `${msgPrefix} has no mapping versions so ${rollMessage}`;
+    expect(mockLogger.info).toHaveBeenCalledWith(msg);
+    expect(mockEsClient.indices.rollover).toHaveBeenCalled();
+  });
+
+  it('rolls over the data stream if the index template version is newer than the backing index mappings versions', async () => {
+    mockEsClient.indices.exists.mockResponse(true);
+    mockEsClient.indices.getIndexTemplate.mockResponse({
+      index_templates: [getBasicIndexTemplate()],
+    });
+    const mappings: IndicesGetMappingResponse = {
+      indexName: {
+        mappings: { _meta: { [REPORTING_INDEX_TEMPLATE_MAPPING_META_FIELD]: 41 } },
+      },
+    };
+    mockEsClient.indices.getMapping.mockResponse(mappings);
+    await rollDataStreamIfRequired(mockLogger, mockEsClient);
+
+    const msg = `${msgPrefix} has older mappings than the template so ${rollMessage}`;
+    expect(mockLogger.info).toHaveBeenCalledWith(msg);
+    expect(mockEsClient.indices.rollover).toHaveBeenCalled();
+  });
+
+  it('throws an error if the index template version is older than the backing index mappings versions', async () => {
+    mockEsClient.indices.exists.mockResponse(true);
+    mockEsClient.indices.getIndexTemplate.mockResponse({
+      index_templates: [getBasicIndexTemplate()],
+    });
+    const mappings: IndicesGetMappingResponse = {
+      indexName: {
+        mappings: { _meta: { [REPORTING_INDEX_TEMPLATE_MAPPING_META_FIELD]: 43 } },
+      },
+    };
+    mockEsClient.indices.getMapping.mockResponse(mappings);
+    const err = `${msgPrefix} has newer mappings than the template`;
+    await expect(rollDataStreamIfRequired(mockLogger, mockEsClient)).rejects.toThrow(err);
+
+    expect(mockEsClient.indices.rollover).not.toHaveBeenCalled();
+  });
+
+  it('does nothing if the index template version is not newer than the backing index mapping versions', async () => {
+    mockEsClient.indices.exists.mockResponse(true);
+    mockEsClient.indices.getIndexTemplate.mockResponse({
+      index_templates: [getBasicIndexTemplate()],
+    });
+    const mappings: IndicesGetMappingResponse = {
+      indexName: {
+        mappings: { _meta: { [REPORTING_INDEX_TEMPLATE_MAPPING_META_FIELD]: 42 } },
+      },
+    };
+    mockEsClient.indices.getMapping.mockResponse(mappings);
+    await rollDataStreamIfRequired(mockLogger, mockEsClient);
+
+    const msg = `${msgPrefix} has latest mappings applied so ${skipMessage}`;
+    expect(mockLogger.debug).toHaveBeenCalledWith(msg);
+    expect(mockEsClient.indices.rollover).not.toHaveBeenCalled();
+  });
+});
+
+function getBasicIndexTemplate(): IndicesGetIndexTemplateIndexTemplateItem {
+  return {
+    name: REPORTING_DATA_STREAM_INDEX_TEMPLATE,
+    index_template: {
+      index_patterns: ['ignored'],
+      composed_of: ['ignored'],
+      version: 42,
+    },
+  };
+}

--- a/x-pack/platform/plugins/private/reporting/server/lib/store/rollover.ts
+++ b/x-pack/platform/plugins/private/reporting/server/lib/store/rollover.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  REPORTING_DATA_STREAM_ALIAS,
+  REPORTING_DATA_STREAM_INDEX_TEMPLATE,
+  REPORTING_INDEX_TEMPLATE_MAPPING_META_FIELD,
+} from '@kbn/reporting-server';
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+
+export async function rollDataStreamIfRequired(
+  logger: Logger,
+  esClient: ElasticsearchClient
+): Promise<boolean> {
+  const msgPrefix = `Data stream ${REPORTING_DATA_STREAM_ALIAS}`;
+  const skipMessage = 'does not need to be rolled over';
+  const rollMessage = 'rolling over the data stream';
+  // easy way to change debug log level when debugging
+  const debug = (msg: string) => logger.debug(msg);
+
+  const exists = await esClient.indices.exists({
+    index: REPORTING_DATA_STREAM_ALIAS,
+    expand_wildcards: 'all',
+  });
+
+  if (!exists) {
+    debug(`${msgPrefix} does not exist so ${skipMessage}`);
+    return false;
+  }
+
+  const gotTemplate = await esClient.indices.getIndexTemplate({
+    name: REPORTING_DATA_STREAM_INDEX_TEMPLATE,
+  });
+  if (gotTemplate.index_templates.length === 0) {
+    throw new Error(
+      `${msgPrefix} index template ${REPORTING_DATA_STREAM_INDEX_TEMPLATE} not found`
+    );
+  }
+
+  const templateVersions: number[] = [];
+  for (const template of gotTemplate.index_templates) {
+    const templateVersion = template.index_template.version;
+    if (templateVersion) templateVersions.push(templateVersion);
+  }
+
+  if (templateVersions.length === 0) {
+    throw new Error(
+      `${msgPrefix} index template ${REPORTING_DATA_STREAM_INDEX_TEMPLATE} does not have a version field`
+    );
+  }
+
+  // assume the highest version is the one in use
+  const templateVersion = Math.max(...templateVersions);
+  debug(`${msgPrefix} template version: ${templateVersion}`);
+
+  const mappings = await esClient.indices.getMapping({
+    index: REPORTING_DATA_STREAM_ALIAS,
+    allow_no_indices: true,
+    expand_wildcards: 'all',
+  });
+
+  const mappingsArray = Object.values(mappings);
+  if (mappingsArray.length === 0) {
+    debug(`${msgPrefix} has no backing indices so ${skipMessage}`);
+    return false;
+  }
+
+  // get the value of _meta.template_version from each index's mappings
+  const mappingsVersions = mappingsArray
+    .map((m) => m.mappings._meta?.[REPORTING_INDEX_TEMPLATE_MAPPING_META_FIELD])
+    .filter((a: any): a is number => typeof a === 'number');
+
+  const mappingsVersion = mappingsVersions.length === 0 ? undefined : Math.max(...mappingsVersions);
+  debug(`${msgPrefix} mappings version: ${mappingsVersion ?? '<none>'}`);
+
+  if (mappingsVersion === undefined) {
+    // no mapping version found on any indices
+    logger.info(`${msgPrefix} has no mapping versions so ${rollMessage}`);
+  } else if (mappingsVersion < templateVersion) {
+    // all mappings are old
+    logger.info(`${msgPrefix} has older mappings than the template so ${rollMessage}`);
+  } else if (mappingsVersion > templateVersion) {
+    // newer mappings than the template shouldn't happen
+    throw new Error(`${msgPrefix} has newer mappings than the template`);
+  } else {
+    // latest mappings already applied
+    debug(`${msgPrefix} has latest mappings applied so ${skipMessage}`);
+    return false;
+  }
+
+  // Roll over the data stream to pick up the new mappings.
+  // The `lazy` option will cause the rollover to run on the next write.
+  // This limits potential race conditions of multiple Kibana's rolling over at once.
+  await esClient.indices.rollover({
+    alias: REPORTING_DATA_STREAM_ALIAS,
+    lazy: true,
+  });
+
+  logger.info(`${msgPrefix} rolled over to pick up index template version ${templateVersion}`);
+  return true;
+}

--- a/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/kibana.jsonc
+++ b/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/kibana.jsonc
@@ -1,0 +1,16 @@
+{
+  "type": "plugin",
+  "id": "@kbn/reporting-test-routes",
+  "owner": "@elastic/response-ops",
+  "visibility": "private",
+  "plugin": {
+    "id": "reportingTestRoutes",
+    "server": true,
+    "browser": false,
+    "requiredPlugins": [
+      "reporting",
+    ],
+    "optionalPlugins": [
+    ]
+  }
+}

--- a/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/package.json
+++ b/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@kbn/reporting-test-routes",
+  "version": "1.0.0",
+  "kibana": {
+    "version": "kibana",
+    "templateVersion": "1.0.0"
+  },
+  "main": "target/test/reporting_api_integration/plugins/reporting_api_integration",
+  "scripts": {
+    "kbn": "node ../../../../../../scripts/kbn.js",
+    "build": "rm -rf './target' && ../../../../../../node_modules/.bin/tsc"
+  },
+  "license": "Elastic License 2.0"
+}

--- a/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/server/index.ts
+++ b/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/server/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginInitializerContext } from '@kbn/core/server';
+import { TestPlugin } from './plugin';
+
+export const plugin = async (initContext: PluginInitializerContext) => new TestPlugin(initContext);

--- a/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/server/plugin.ts
+++ b/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/server/plugin.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Plugin, CoreSetup, Logger, PluginInitializerContext } from '@kbn/core/server';
+import { defineRoutes } from './routes';
+
+export class TestPlugin implements Plugin<void, void, {}, {}> {
+  private readonly logger: Logger;
+
+  constructor(initializerContext: PluginInitializerContext) {
+    this.logger = initializerContext.logger.get('fixtures', 'plugins', 'alerts');
+  }
+
+  public setup(core: CoreSetup) {
+    defineRoutes(core, this.logger);
+  }
+
+  public start() {}
+  public stop() {}
+}

--- a/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/server/routes.ts
+++ b/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/server/routes.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  CoreSetup,
+  RequestHandlerContext,
+  KibanaRequest,
+  KibanaResponseFactory,
+  IKibanaResponse,
+  Logger,
+} from '@kbn/core/server';
+import { rollDataStreamIfRequired } from '@kbn/reporting-plugin/server/lib/store/rollover';
+
+export const URI_ROLLOVER = '/_test/reporting/rollDataStreamIfRequired';
+
+export function defineRoutes(core: CoreSetup, logger: Logger) {
+  const router = core.http.createRouter();
+  router.post(
+    {
+      path: URI_ROLLOVER,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization as it is used in tests only',
+        },
+      },
+      validate: {},
+    },
+    async (
+      context: RequestHandlerContext,
+      req: KibanaRequest<any, any, any, any>,
+      res: KibanaResponseFactory
+    ): Promise<IKibanaResponse<any>> => {
+      try {
+        const esClient = (await context.core).elasticsearch.client.asInternalUser;
+        const result = await rollDataStreamIfRequired(logger, esClient);
+        return res.ok({
+          body: { result },
+        });
+      } catch (err) {
+        logger.error(`Error in ${URI_ROLLOVER}: ${err.message}`, err);
+        return res.badRequest({ body: err.message });
+      }
+    }
+  );
+}

--- a/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/tsconfig.json
+++ b/x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "isolatedModules": true
+  },
+  "include": [
+    "server/**/**/*",
+  ],
+  "kbn_references": [
+    "@kbn/core",
+    "@kbn/reporting-plugin",
+  ],
+  "exclude": [
+    "target/**/*",
+  ]
+}

--- a/x-pack/platform/test/reporting_api_integration/reporting_without_security.config.ts
+++ b/x-pack/platform/test/reporting_api_integration/reporting_without_security.config.ts
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import { FtrConfigProviderContext } from '@kbn/test';
+import path from 'node:path';
+import { type FtrConfigProviderContext, findTestPluginPaths } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const apiConfig = await readConfigFile(require.resolve('./reporting_and_security.config'));
-
+  const pluginPath = path.resolve(__dirname, 'plugins');
   return {
     ...apiConfig.getAll(),
     junit: { reportName: 'X-Pack Reporting API Integration Tests Without Security Enabled' },
@@ -24,7 +25,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     },
     kbnTestServer: {
       ...apiConfig.get('kbnTestServer'),
-      serverArgs: [...apiConfig.get('kbnTestServer.serverArgs')],
+      serverArgs: [
+        ...apiConfig.get('kbnTestServer.serverArgs'),
+        ...findTestPluginPaths(pluginPath),
+      ],
     },
   };
 }

--- a/x-pack/platform/test/reporting_api_integration/reporting_without_security/index.ts
+++ b/x-pack/platform/test/reporting_api_integration/reporting_without_security/index.ts
@@ -17,5 +17,6 @@ export default function ({ loadTestFile, getService }: FtrProviderContext) {
 
     loadTestFile(require.resolve('./csv/job_apis_csv'));
     loadTestFile(require.resolve('./schedule'));
+    loadTestFile(require.resolve('./roll_datastream'));
   });
 }

--- a/x-pack/platform/test/reporting_api_integration/reporting_without_security/roll_datastream.ts
+++ b/x-pack/platform/test/reporting_api_integration/reporting_without_security/roll_datastream.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type {
+  IndicesPutIndexTemplateRequest,
+  IndicesGetIndexTemplateIndexTemplateItem,
+} from '@elastic/elasticsearch/lib/api/types';
+import { type Client as ElasticsearchClient } from '@elastic/elasticsearch';
+import {
+  REPORTING_DATA_STREAM_ALIAS,
+  REPORTING_DATA_STREAM_INDEX_TEMPLATE,
+  REPORTING_INDEX_TEMPLATE_MAPPING_META_FIELD,
+} from '@kbn/reporting-server';
+import type { Agent as Superagent } from 'superagent';
+import { set } from '@kbn/safer-lodash-set';
+import { cloneDeep } from 'lodash';
+
+import { URI_ROLLOVER } from '@kbn/reporting-test-routes/server/routes';
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const esClient: ElasticsearchClient = getService('es');
+  const supertest: Superagent = getService('supertest');
+  let originalIndexTemplate: IndicesPutIndexTemplateRequest;
+
+  describe('Roll reporting data stream at startup', () => {
+    before(async () => {
+      originalIndexTemplate = await getOriginalIndexTemplate(esClient);
+    });
+    beforeEach(async () => {
+      await updateIndexTemplate(esClient, originalIndexTemplate);
+      await deleteDataStream(esClient);
+    });
+    afterEach(async () => {
+      await updateIndexTemplate(esClient, originalIndexTemplate);
+      await deleteDataStream(esClient);
+    });
+
+    it('should not roll the data stream if not yet created', async () => {
+      const rolled = await rollDataStreamIfRequired(supertest);
+      expect(rolled).to.be(false);
+    });
+
+    it('should not roll the data stream if it matches the template', async () => {
+      await writeToDataStream(esClient);
+
+      const templateVersion = await getMaxTemplateVersion(esClient);
+      const mappingVersion = await getMaxMappingVersion(esClient);
+      expect(mappingVersion).to.be(templateVersion);
+
+      const rolled = await rollDataStreamIfRequired(supertest);
+      expect(rolled).to.be(false);
+    });
+
+    it('should roll the data stream if it does not match the template', async () => {
+      await writeToDataStream(esClient);
+
+      const oldTemplateVersion = await getMaxTemplateVersion(esClient);
+      const oldMappingVersion = await getMaxMappingVersion(esClient);
+
+      // upgrade the template version
+      const updatedTemplate = upgradeTemplateVersion(originalIndexTemplate);
+      await updateIndexTemplate(esClient, updatedTemplate);
+
+      const rolled = await rollDataStreamIfRequired(supertest);
+      expect(rolled).to.be(true);
+
+      // with lazy rollover, mapping version won't be updated yet
+      const newTemplateVersion = await getMaxTemplateVersion(esClient);
+      const newMappingVersion = await getMaxMappingVersion(esClient);
+      expect(newTemplateVersion).to.be(oldTemplateVersion + 1);
+      expect(newMappingVersion).to.be(oldMappingVersion);
+      expect(newMappingVersion).not.to.be(newTemplateVersion);
+
+      // it will get rolled when we write to it
+      await writeToDataStream(esClient);
+      const newerMappingVersion = await getMaxMappingVersion(esClient);
+      expect(newerMappingVersion).to.be(newTemplateVersion);
+    });
+
+    it('should not roll the data stream if it was just rolled', async () => {
+      await writeToDataStream(esClient);
+
+      // upgrade the template version
+      const updatedTemplate = upgradeTemplateVersion(originalIndexTemplate);
+      await updateIndexTemplate(esClient, updatedTemplate);
+
+      const rolled = await rollDataStreamIfRequired(supertest);
+      expect(rolled).to.be(true);
+
+      await writeToDataStream(esClient);
+
+      const rolled2 = await rollDataStreamIfRequired(supertest);
+      expect(rolled2).to.be(false);
+    });
+  });
+}
+
+function upgradeTemplateVersion(originalIndexTemplate: IndicesPutIndexTemplateRequest) {
+  expect(originalIndexTemplate.version).to.be.a('number');
+  const newVersion = originalIndexTemplate.version! + 1;
+
+  const updatedTemplate = cloneDeep(originalIndexTemplate);
+  updatedTemplate.version = newVersion;
+  const meta = { [REPORTING_INDEX_TEMPLATE_MAPPING_META_FIELD]: newVersion };
+  set(updatedTemplate, 'template.mappings._meta', meta);
+  expect(
+    updatedTemplate.template?.mappings?._meta?.[REPORTING_INDEX_TEMPLATE_MAPPING_META_FIELD]
+  ).to.eql(updatedTemplate.version);
+
+  return updatedTemplate;
+}
+
+async function getOriginalIndexTemplate(esClient: ElasticsearchClient) {
+  const gotOriginalIndexTemplate = await getIndexTemplate(esClient);
+  const { name, index_template: indexTemplate } = gotOriginalIndexTemplate;
+  const originalIndexTemplate = {
+    name,
+    create: false,
+    index_patterns: indexTemplate.index_patterns,
+    composed_of: indexTemplate.composed_of,
+    template: indexTemplate.template,
+    data_stream: indexTemplate.data_stream,
+    priority: indexTemplate.priority,
+    version: indexTemplate.version,
+    _meta: indexTemplate._meta,
+    allow_auto_create: indexTemplate.allow_auto_create,
+    deprecated: indexTemplate.deprecated,
+  };
+  return originalIndexTemplate;
+}
+
+async function rollDataStreamIfRequired(supertest: Superagent) {
+  const res = await supertest.post(URI_ROLLOVER).set('kbn-xsrf', 'foo').send({});
+  expect(res.status).to.eql(200);
+  const { result } = res.body;
+  if (typeof result !== 'boolean') {
+    throw new Error(`Unexpected result from ${URI_ROLLOVER}: ${JSON.stringify(res.body)}`);
+  }
+  return result;
+}
+
+async function dataStreamExists(esClient: ElasticsearchClient) {
+  return await esClient.indices.exists({
+    index: REPORTING_DATA_STREAM_ALIAS,
+    expand_wildcards: 'all',
+  });
+}
+
+async function writeToDataStream(esClient: ElasticsearchClient) {
+  const document = { '@timestamp': new Date().toISOString() };
+  const result = await esClient.index({
+    index: REPORTING_DATA_STREAM_ALIAS,
+    document,
+    refresh: true,
+  });
+  expect(result.result).to.be('created');
+  expect(await dataStreamExists(esClient)).to.be(true);
+}
+
+async function deleteDataStream(esClient: ElasticsearchClient) {
+  if (!(await dataStreamExists(esClient))) return;
+
+  const result = await esClient.indices.deleteDataStream({
+    name: REPORTING_DATA_STREAM_ALIAS,
+    expand_wildcards: 'all',
+  });
+
+  // @ts-ignore ; I've seen either result.acknowledged or result.status === 404
+  expect(result.acknowledged || result.status === 404).to.be(true);
+  expect(await dataStreamExists(esClient)).to.be(false);
+}
+
+async function updateIndexTemplate(
+  esClient: ElasticsearchClient,
+  template: IndicesPutIndexTemplateRequest
+) {
+  const result = await esClient.indices.putIndexTemplate(template);
+  expect(result.acknowledged).to.be(true);
+
+  const newTemplateVersion = await getMaxTemplateVersion(esClient);
+  expect(newTemplateVersion).to.be(template.version);
+}
+
+async function getIndexTemplate(
+  esClient: ElasticsearchClient
+): Promise<IndicesGetIndexTemplateIndexTemplateItem> {
+  const res = await esClient.indices.getIndexTemplate({
+    name: REPORTING_DATA_STREAM_INDEX_TEMPLATE,
+  });
+
+  expect(res.index_templates.length).to.be(1);
+  return res.index_templates[0];
+}
+
+async function getMaxMappingVersion(esClient: ElasticsearchClient) {
+  if (!(await dataStreamExists(esClient))) return;
+
+  const mappingsRecord = await esClient.indices.getMapping({
+    index: REPORTING_DATA_STREAM_ALIAS,
+    expand_wildcards: 'all',
+    allow_no_indices: true,
+  });
+  const mappingsArray = Object.values(mappingsRecord);
+
+  // ensure the _meta field is set on the mappings
+  const mappingVersions: number[] = mappingsArray.map(
+    (m) => m.mappings._meta?.[REPORTING_INDEX_TEMPLATE_MAPPING_META_FIELD]
+  );
+  const mappingVersion = Math.max(...mappingVersions);
+  return mappingVersion;
+}
+
+async function getMaxTemplateVersion(esClient: ElasticsearchClient) {
+  const gotTemplate = await esClient.indices.getIndexTemplate({
+    name: REPORTING_DATA_STREAM_INDEX_TEMPLATE,
+  });
+  expect(gotTemplate.index_templates.length).to.be.greaterThan(0);
+
+  const templateVersions: number[] = [];
+  for (const template of gotTemplate.index_templates) {
+    const templateVersion = template.index_template.version;
+    if (templateVersion) templateVersions.push(templateVersion);
+  }
+  expect(templateVersions.length).to.be.greaterThan(0);
+
+  // assume the highest version is the one in use
+  const templateVersion = Math.max(...templateVersions);
+  return templateVersion;
+}

--- a/x-pack/platform/test/tsconfig.json
+++ b/x-pack/platform/test/tsconfig.json
@@ -161,10 +161,6 @@
     "@kbn/management-settings-ids",
     "@kbn/product-intercept-plugin",
     "@kbn/core-chrome-browser",
-    "@kbn/onechat-common",
-    "@kbn/reindex-service-plugin",
-    "@kbn/streamlang",
-    "@kbn/onechat-plugin",
     "@kbn/reporting-test-routes",
   ]
 }

--- a/x-pack/platform/test/tsconfig.json
+++ b/x-pack/platform/test/tsconfig.json
@@ -159,8 +159,12 @@
     "@kbn/serverless-common-settings",
     "@kbn/core-saved-objects-import-export-server-internal",
     "@kbn/management-settings-ids",
-    "@kbn/core-chrome-browser",
     "@kbn/product-intercept-plugin",
     "@kbn/core-chrome-browser",
+    "@kbn/onechat-common",
+    "@kbn/reindex-service-plugin",
+    "@kbn/streamlang",
+    "@kbn/onechat-plugin",
+    "@kbn/reporting-test-routes",
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6981,6 +6981,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/reporting-test-routes@link:x-pack/platform/test/reporting_api_integration/plugins/reporting_test_routes":
+  version "0.0.0"
+  uid ""
+
 "@kbn/resizable-layout-examples-plugin@link:examples/resizable_layout_examples":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Reporting] roll over the reporting data stream when the template has changed (#234119)](https://github.com/elastic/kibana/pull/234119)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2025-09-29T23:06:34Z","message":"[Reporting] roll over the reporting data stream when the template has changed (#234119)\n\nresolves: https://github.com/elastic/kibana/issues/231200\n\nThis PR adds code run at startup to check the version in the reporting\nindex template against the `_meta.template_version` value stamped into\neach backing index's mappings via\nhttps://github.com/elastic/elasticsearch/pull/133846\n\nIf it determines there are existing reporting indices that have not been\ncreated with the current index template version, it will roll over the\nreporting data stream, to ensure future indexing will use the latest\nmappings. This is done with the \"lazy\" option, which will perform the\nroll over on the next write to the datastream. This will prevent\nsituations where multiple Kibanas restarting at the same time would roll\nover multiple times.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c89ba8264f5a43c01d69b42577d79925cb020c04","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","backport missing","backport:all-open","Feature:Reporting:Framework","v9.2.0"],"title":"[Reporting] roll over the reporting data stream when the template has changed","number":234119,"url":"https://github.com/elastic/kibana/pull/234119","mergeCommit":{"message":"[Reporting] roll over the reporting data stream when the template has changed (#234119)\n\nresolves: https://github.com/elastic/kibana/issues/231200\n\nThis PR adds code run at startup to check the version in the reporting\nindex template against the `_meta.template_version` value stamped into\neach backing index's mappings via\nhttps://github.com/elastic/elasticsearch/pull/133846\n\nIf it determines there are existing reporting indices that have not been\ncreated with the current index template version, it will roll over the\nreporting data stream, to ensure future indexing will use the latest\nmappings. This is done with the \"lazy\" option, which will perform the\nroll over on the next write to the datastream. This will prevent\nsituations where multiple Kibanas restarting at the same time would roll\nover multiple times.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c89ba8264f5a43c01d69b42577d79925cb020c04"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/234119","number":234119,"mergeCommit":{"message":"[Reporting] roll over the reporting data stream when the template has changed (#234119)\n\nresolves: https://github.com/elastic/kibana/issues/231200\n\nThis PR adds code run at startup to check the version in the reporting\nindex template against the `_meta.template_version` value stamped into\neach backing index's mappings via\nhttps://github.com/elastic/elasticsearch/pull/133846\n\nIf it determines there are existing reporting indices that have not been\ncreated with the current index template version, it will roll over the\nreporting data stream, to ensure future indexing will use the latest\nmappings. This is done with the \"lazy\" option, which will perform the\nroll over on the next write to the datastream. This will prevent\nsituations where multiple Kibanas restarting at the same time would roll\nover multiple times.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c89ba8264f5a43c01d69b42577d79925cb020c04"}}]}] BACKPORT-->