### PR TITLE
[8.19] [Synthetics] Clean up extra synthetics package policies !! (#235200)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -1422,8 +1422,10 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     const logger = appContextService.getLogger();
     logger.debug(`Deleting package policies ${ids}`);
 
-    const packagePolicies = await this.getByIDs(soClient, ids, { ignoreMissing: true });
-    if (!packagePolicies) {
+    const packagePolicies = await this.getByIDs(soClient, ids, {
+      ignoreMissing: true,
+    });
+    if (!packagePolicies || packagePolicies.length === 0) {
       return [];
     }
 

--- a/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
@@ -23,6 +23,7 @@ export enum SYNTHETICS_API_URLS {
   SERVICE_ALLOWED = '/internal/synthetics/service/allowed',
   SYNTHETICS_PROJECT_APIKEY = '/internal/synthetics/service/api_key',
   SYNTHETICS_HAS_INTEGRATION_MONITORS = '/internal/synthetics/fleet/has_integration_monitors',
+  PRIVATE_LOCATIONS_CLEANUP = `/internal/synthetics/private_locations/_cleanup`,
 
   PINGS = '/internal/synthetics/pings',
   MONITOR_STATUS_HEATMAP = '/internal/synthetics/ping_heatmap',
@@ -42,6 +43,7 @@ export enum SYNTHETICS_API_URLS {
   JOURNEY_SCREENSHOT = `/internal/synthetics/journey/screenshot/{checkGroup}/{stepIndex}`,
   DELETE_PACKAGE_POLICY = `/internal/synthetics/monitor/policy/{packagePolicyId}`,
   FILTERS = '/internal/synthetics/monitor/filters',
+  TRIGGER_TASK_RUN = '/internal/synthetics/trigger_task_run/{taskType}',
 
   CERTS = '/internal/synthetics/certs',
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { cleanupPrivateLocationRoute } from './settings/private_locations/cleanup_private_locations';
+import { getSyntheticsTriggerTaskRun } from './tasks/trigger_task_run';
 import { syntheticsInspectStatusRuleRoute } from './rules/inspect_status_rule';
 import { syntheticsInspectTLSRuleRoute } from './rules/inspect_tls_rule';
 import { syntheticsGetLatestTestRunRoute } from './pings/get_latest_test_run';
@@ -104,6 +106,8 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   createOverviewTrendsRoute,
   syntheticsInspectStatusRuleRoute,
   syntheticsInspectTLSRuleRoute,
+  getSyntheticsTriggerTaskRun,
+  cleanupPrivateLocationRoute,
 ];
 
 export const syntheticsAppPublicRestApiRoutes: SyntheticsRestApiRouteFactory[] = [

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/cleanup_private_locations.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/cleanup_private_locations.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PRIVATE_LOCATION_WRITE_API } from '../../../feature';
+import type { SyntheticsRestApiRouteFactory } from '../../types';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { resetSyncPrivateCleanUpState } from '../../../tasks/sync_private_locations_monitors_task';
+
+export const cleanupPrivateLocationRoute: SyntheticsRestApiRouteFactory = () => ({
+  method: 'PUT',
+  path: SYNTHETICS_API_URLS.PRIVATE_LOCATIONS_CLEANUP,
+  validate: {},
+  requiredPrivileges: [PRIVATE_LOCATION_WRITE_API],
+  handler: async (routeContext) => {
+    const { server } = routeContext;
+
+    await resetSyncPrivateCleanUpState({ server });
+
+    return {
+      success: true,
+      message: 'Task to start clean up has been started, it may take a while.',
+    };
+  },
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/tasks/trigger_task_run.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/tasks/trigger_task_run.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { schema } from '@kbn/config-schema';
+import { PRIVATE_LOCATIONS_SYNC_TASK_ID } from '../../tasks/sync_private_locations_monitors_task';
+import { scheduleCleanUpTask } from '../../synthetics_service/private_location/clean_up_task';
+import type { SyntheticsRestApiRouteFactory } from '../types';
+import { SYNTHETICS_API_URLS } from '../../../common/constants';
+
+export const getSyntheticsTriggerTaskRun: SyntheticsRestApiRouteFactory = () => ({
+  method: 'POST',
+  path: SYNTHETICS_API_URLS.TRIGGER_TASK_RUN,
+  validate: {
+    params: schema.object({
+      taskType: schema.oneOf([
+        schema.literal('syncPrivateLocationMonitors'),
+        schema.literal('cleanUpPackagePolicyTask'),
+      ]),
+    }),
+  },
+  writeAccess: true,
+  handler: async ({ server, request }) => {
+    const { taskType } = request.params;
+
+    switch (taskType) {
+      case 'syncPrivateLocationMonitors':
+        await server.pluginsStart.taskManager.runSoon(PRIVATE_LOCATIONS_SYNC_TASK_ID);
+        break;
+      case 'cleanUpPackagePolicyTask':
+        await scheduleCleanUpTask(server);
+
+        break;
+      default:
+        throw new Error(`Unknown task type: ${taskType}`);
+    }
+  },
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/synthetics_monitor_config.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/synthetics_monitor_config.ts
@@ -17,7 +17,7 @@ export const getSyntheticsMonitorConfigSavedObjectType = (): SavedObjectsType =>
     namespaceType: 'multiple',
     mappings: monitorConfigMappings,
     management: {
-      importableAndExportable: true,
+      importableAndExportable: false,
       icon: 'uptimeApp',
       getTitle: (savedObject) =>
         i18n.translate('xpack.synthetics.syntheticsMonitors.multiple.label', {

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/synthetics_monitor_config.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/synthetics_monitor_config.ts
@@ -17,7 +17,7 @@ export const getSyntheticsMonitorConfigSavedObjectType = (): SavedObjectsType =>
     namespaceType: 'multiple',
     mappings: monitorConfigMappings,
     management: {
-      importableAndExportable: false,
+      importableAndExportable: true,
       icon: 'uptimeApp',
       getTitle: (savedObject) =>
         i18n.translate('xpack.synthetics.syntheticsMonitors.multiple.label', {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/clean_up_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/clean_up_task.ts
@@ -114,7 +114,7 @@ export const scheduleCleanUpTask = async ({ logger, pluginsStart }: SyntheticsSe
       scope: ['uptime'],
     });
 
-    logger?.info(
+    logger?.debug(
       `Task ${SYNTHETICS_SERVICE_CLEAN_UP_TASK_ID} scheduled with interval ${taskInstance.schedule?.interval}.`
     );
 
@@ -127,12 +127,14 @@ export const scheduleCleanUpTask = async ({ logger, pluginsStart }: SyntheticsSe
   }
 };
 
-const getFilterForTestNowRun = () => {
+export const getFilterForTestNowRun = (exclude?: boolean) => {
   const pkg = 'ingest-package-policies';
 
   let filter = `${pkg}.package.name:synthetics and ${pkg}.is_managed:true`;
   const lightweight = `${pkg}.name: ${LIGHTWEIGHT_TEST_NOW_RUN}`;
   const browser = `${pkg}.name: ${BROWSER_TEST_NOW_RUN}`;
-  filter = `${filter} and (${lightweight} or ${browser})`;
+  filter = exclude
+    ? `${filter} and not (${lightweight} or ${browser})`
+    : `${filter} and (${lightweight} or ${browser})`;
   return filter;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -63,7 +63,7 @@ export class SyntheticsPrivateLocation {
     return newPolicy;
   }
 
-  getPolicyId(config: HeartbeatConfig, locId: string, spaceId: string) {
+  getPolicyId(config: { origin?: string; id: string }, locId: string, spaceId: string) {
     if (config[ConfigKey.MONITOR_SOURCE_TYPE] === SourceType.PROJECT) {
       return `${config.id}-${locId}`;
     }

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
@@ -14,18 +14,18 @@ import {
 import { SyntheticsServerSetup } from '../types';
 import { SyntheticsMonitorClient } from '../synthetics_service/synthetics_monitor/synthetics_monitor_client';
 import * as getPrivateLocationsModule from '../synthetics_service/get_private_locations';
-import { coreMock } from '@kbn/core/server/mocks';
-import { CoreStart } from '@kbn/core-lifecycle-server';
+import { coreMock, savedObjectsRepositoryMock } from '@kbn/core/server/mocks';
+import type { CoreStart } from '@kbn/core-lifecycle-server';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
 import { loggerMock } from '@kbn/logging-mocks';
 import { TaskStatus } from '@kbn/task-manager-plugin/server';
 import { mockEncryptedSO } from '../synthetics_service/utils/mocks';
+import { createFleetStartContractMock } from '@kbn/fleet-plugin/server/mocks';
 
 const mockTaskManagerStart = taskManagerMock.createStart();
 const mockTaskManager = taskManagerMock.createSetup();
-
 const mockSoClient = {
-  find: jest.fn(),
+  ...savedObjectsRepositoryMock.create(),
   createInternalRepository: jest.fn(),
 };
 
@@ -42,10 +42,13 @@ const mockSyntheticsMonitorClient = {
 };
 const mockLogger = loggerMock.create();
 
+const mockFleet = createFleetStartContractMock();
+
 const mockServerSetup: jest.Mocked<SyntheticsServerSetup> = {
   coreStart: coreMock.createStart() as CoreStart,
   pluginsStart: {
     taskManager: mockTaskManagerStart,
+    fleet: mockFleet,
   } as any,
   encryptedSavedObjects: mockEncryptedSoClient as any,
   logger: mockLogger,
@@ -125,8 +128,6 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const taskInstance = getMockTaskInstance();
       jest.spyOn(task, 'hasAnyDataChanged').mockResolvedValue({
         hasDataChanged: false,
-        totalParams: 1,
-        totalMWs: 1,
       });
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
         {
@@ -146,9 +147,12 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(mockSyntheticsMonitorClient.privateLocationAPI.editMonitors).not.toHaveBeenCalled();
       expect(result.error).toBeUndefined();
       expect(result.state).toEqual({
-        lastStartedAt: taskInstance.startedAt?.toISOString(),
+        hasAlreadyDoneCleanup: false,
+        startedAt: expect.anything(),
+        lastStartedAt: expect.anything(),
         lastTotalParams: 1,
         lastTotalMWs: 1,
+        maxCleanUpRetries: 2,
       });
     });
 
@@ -156,8 +160,6 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const taskInstance = getMockTaskInstance();
       jest.spyOn(task, 'hasAnyDataChanged').mockResolvedValue({
         hasDataChanged: true,
-        totalParams: 2,
-        totalMWs: 1,
       });
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
         {
@@ -170,25 +172,28 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       jest.spyOn(task, 'syncGlobalParams').mockResolvedValue(undefined);
 
       const result = await task.runTask({ taskInstance });
-
-      expect(mockLogger.debug).toHaveBeenNthCalledWith(
-        1,
-        '[syncGlobalParams] Syncing private location monitors, last total params 1 '
-      );
       expect(mockLogger.debug).toHaveBeenNthCalledWith(
         2,
-        '[syncGlobalParams] Syncing private location monitors because data has changed '
+        '[SyncPrivateLocationMonitorsTask] Starting cleanup of duplicated package policies '
       );
+
       expect(mockLogger.debug).toHaveBeenNthCalledWith(
         3,
-        '[syncGlobalParams] Sync of private location monitors succeeded '
+        '[SyncPrivateLocationMonitorsTask] Syncing private location monitors because data has changed '
+      );
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        4,
+        '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded '
       );
       expect(task.syncGlobalParams).toHaveBeenCalled();
       expect(result.error).toBeUndefined();
       expect(result.state).toEqual({
-        lastStartedAt: taskInstance.startedAt?.toISOString(),
-        lastTotalParams: 2,
+        lastTotalParams: 1,
         lastTotalMWs: 1,
+        maxCleanUpRetries: 2,
+        hasAlreadyDoneCleanup: false,
+        lastStartedAt: expect.anything(),
+        startedAt: expect.anything(),
       });
     });
 
@@ -196,8 +201,6 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const taskInstance = getMockTaskInstance();
       jest.spyOn(task, 'hasAnyDataChanged').mockResolvedValue({
         hasDataChanged: true,
-        totalParams: 2,
-        totalMWs: 1,
       });
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([]);
       jest.spyOn(task, 'syncGlobalParams');
@@ -207,7 +210,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(getPrivateLocationsModule.getPrivateLocations).toHaveBeenCalled();
       expect(task.syncGlobalParams).not.toHaveBeenCalled();
       expect(mockLogger.debug).toHaveBeenLastCalledWith(
-        '[syncGlobalParams] Sync of private location monitors succeeded '
+        '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded '
       );
     });
 
@@ -223,9 +226,12 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       );
       expect(result.error).toBe(error);
       expect(result.state).toEqual({
-        lastStartedAt: taskInstance.startedAt?.toISOString(),
+        startedAt: expect.anything(),
+        lastStartedAt: expect.anything(),
         lastTotalParams: 1,
         lastTotalMWs: 1,
+        hasAlreadyDoneCleanup: false,
+        maxCleanUpRetries: 2,
       });
     });
   });
@@ -238,15 +244,16 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       jest
         .spyOn(task, 'hasMWsChanged')
         .mockResolvedValue({ hasMWsChanged: false, totalMWs: 1 } as any);
+      const taskState = { lastTotalParams: 1, lastTotalMWs: 1 };
 
       const res = await task.hasAnyDataChanged({
-        taskInstance: getMockTaskInstance(),
+        taskState: taskState as any,
         soClient: mockSoClient as any,
       });
 
       expect(res.hasDataChanged).toBe(true);
-      expect(res.totalParams).toBe(2);
-      expect(res.totalMWs).toBe(1);
+      expect(taskState.lastTotalParams).toBe(2);
+      expect(taskState.lastTotalMWs).toBe(1);
     });
 
     it('should return true if maintenance windows changed', async () => {
@@ -258,7 +265,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         .mockResolvedValue({ hasMWsChanged: true, totalMWs: 2 } as any);
 
       const res = await task.hasAnyDataChanged({
-        taskInstance: getMockTaskInstance(),
+        taskState: { lastTotalParams: 1, lastTotalMWs: 1 } as any,
         soClient: mockSoClient as any,
       });
 
@@ -273,8 +280,10 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         .spyOn(task, 'hasMWsChanged')
         .mockResolvedValue({ hasMWsChanged: false, totalMWs: 1 } as any);
 
+      const taskState = { lastTotalParams: 1, lastTotalMWs: 1 };
+
       const res = await task.hasAnyDataChanged({
-        taskInstance: getMockTaskInstance(),
+        taskState: taskState as any,
         soClient: mockSoClient as any,
       });
 
@@ -285,8 +294,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
   describe('hasAnyParamChanged', () => {
     it('returns true if updated params are found', async () => {
       mockSoClient.find
-        .mockResolvedValueOnce({ total: 1 }) // updated
-        .mockResolvedValueOnce({ total: 10 }); // total
+        .mockResolvedValueOnce({ total: 1 } as any) // updated
+        .mockResolvedValueOnce({ total: 10 } as any); // total
       const { hasParamsChanges } = await task.hasAnyParamChanged({
         soClient: mockSoClient as any,
         lastStartedAt: '...',
@@ -297,8 +306,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
 
     it('returns true if total number of params changed', async () => {
       mockSoClient.find
-        .mockResolvedValueOnce({ total: 0 }) // updated
-        .mockResolvedValueOnce({ total: 11 }); // total
+        .mockResolvedValueOnce({ total: 0 } as any) // updated
+        .mockResolvedValueOnce({ total: 11 } as any); // total
       const { hasParamsChanges } = await task.hasAnyParamChanged({
         soClient: mockSoClient as any,
         lastStartedAt: '...',
@@ -309,8 +318,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
 
     it('returns false if no changes are detected', async () => {
       mockSoClient.find
-        .mockResolvedValueOnce({ total: 0 }) // updated
-        .mockResolvedValueOnce({ total: 10 }); // total
+        .mockResolvedValueOnce({ total: 0 } as any) // updated
+        .mockResolvedValueOnce({ total: 10 } as any); // total
       const { hasParamsChanges } = await task.hasAnyParamChanged({
         soClient: mockSoClient as any,
         lastStartedAt: '...',
@@ -323,8 +332,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
   describe('hasMWsChanged', () => {
     it('returns true if updated MWs are found', async () => {
       mockSoClient.find
-        .mockResolvedValueOnce({ total: 1 }) // updated
-        .mockResolvedValueOnce({ total: 5 }); // total
+        .mockResolvedValueOnce({ total: 1 } as any) // updated
+        .mockResolvedValueOnce({ total: 5 } as any); // total
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
         lastStartedAt: '...',
@@ -335,8 +344,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
 
     it('returns true if total number of MWs changed', async () => {
       mockSoClient.find
-        .mockResolvedValueOnce({ total: 0 }) // updated
-        .mockResolvedValueOnce({ total: 6 }); // total
+        .mockResolvedValueOnce({ total: 0 } as any) // updated
+        .mockResolvedValueOnce({ total: 6 } as any); // total
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
         lastStartedAt: '...',
@@ -347,8 +356,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
 
     it('returns false if no changes are detected', async () => {
       mockSoClient.find
-        .mockResolvedValueOnce({ total: 0 }) // updated
-        .mockResolvedValueOnce({ total: 5 }); // total
+        .mockResolvedValueOnce({ total: 0 } as any) // updated
+        .mockResolvedValueOnce({ total: 5 } as any); // total
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
         lastStartedAt: '...',
@@ -437,6 +446,122 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const { privateLocations, publicLocations } = task.parseLocations(config as any);
       expect(privateLocations).toHaveLength(0);
       expect(publicLocations).toHaveLength(0);
+    });
+  });
+
+  describe('cleanUpDuplicatedPackagePolicies', () => {
+    let mockFinder: any;
+
+    beforeEach(() => {
+      // // Mock finder
+      let closed = false;
+      mockFinder = {
+        async *find() {
+          if (closed) throw new Error('Finder closed');
+          yield {
+            saved_objects: [
+              {
+                id: 'monitor1',
+                attributes: {
+                  origin: 'ui',
+                  locations: [{ id: 'loc1', isServiceManaged: false }],
+                },
+                namespaces: ['space1'],
+              },
+            ],
+          };
+        },
+        close: jest.fn().mockImplementation(() => {
+          closed = true;
+          return Promise.resolve();
+        }),
+      };
+      mockSoClient.createPointInTimeFinder = jest.fn().mockReturnValue(mockFinder);
+      task = new SyncPrivateLocationMonitorsTask(
+        mockServerSetup as any,
+        mockTaskManager as unknown as TaskManagerSetupContract,
+        mockSyntheticsMonitorClient as unknown as SyntheticsMonitorClient
+      );
+    });
+
+    it('should not delete any policies if all are expected', async () => {
+      mockFleet.packagePolicyService.fetchAllItemIds.mockResolvedValue(
+        (async function* () {
+          yield ['monitor1-loc1-space1'];
+        })()
+      );
+      const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, {} as any);
+      expect(mockFleet.packagePolicyService.delete).not.toHaveBeenCalled();
+      expect(result.performSync).toBe(false);
+    });
+
+    it('should delete unexpected policies and set performSync true', async () => {
+      mockFleet.packagePolicyService.fetchAllItemIds.mockResolvedValue(
+        (async function* () {
+          yield ['monitor1-loc1-space1', 'unexpected-policy'];
+        })()
+      );
+      const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, {} as any);
+      expect(mockFleet.packagePolicyService.delete).toHaveBeenCalledWith(
+        mockSoClient,
+        expect.anything(),
+        ['unexpected-policy'],
+        { force: true, spaceIds: ['*'] }
+      );
+      expect(result.performSync).toBe(true);
+    });
+
+    it('should set performSync true if expected policies are missing', async () => {
+      mockFleet.packagePolicyService.fetchAllItemIds.mockResolvedValue(
+        (async function* () {
+          yield [];
+        })()
+      );
+      const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, {} as any);
+      expect(result.performSync).toBe(true);
+    });
+
+    it('should handle errors gracefully and return performSync', async () => {
+      mockFleet.packagePolicyService.fetchAllItemIds.mockRejectedValue(new Error('fail'));
+      const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, {} as any);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(result).toHaveProperty('performSync');
+    });
+
+    it('should skip cleanup if hasAlreadyDoneCleanup is true', async () => {
+      const state = { hasAlreadyDoneCleanup: true, maxCleanUpRetries: 3 };
+      const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, state as any);
+      expect(result.performSync).toBe(false);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as it has already been done once '
+      );
+    });
+
+    it('should skip cleanup if maxCleanUpRetries is 0 or less', async () => {
+      const state = { hasAlreadyDoneCleanup: false, maxCleanUpRetries: 0 };
+      const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, state as any);
+      expect(result.performSync).toBe(false);
+      expect(state.hasAlreadyDoneCleanup).toBe(true);
+      expect(state.maxCleanUpRetries).toBe(3);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as max retries have been reached '
+      );
+    });
+
+    it('should decrement maxCleanUpRetries and eventually skip after failures', async () => {
+      // Simulate error in fetchAllItemIds
+      mockFleet.packagePolicyService.fetchAllItemIds.mockRejectedValue(new Error('fail'));
+      const state = { hasAlreadyDoneCleanup: false, maxCleanUpRetries: 2 };
+      const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, state as any);
+      expect(state.maxCleanUpRetries).toBe(1);
+      expect(result).toHaveProperty('performSync');
+      // Call again to reach 0
+      await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, state as any);
+      expect(state.hasAlreadyDoneCleanup).toBe(true);
+      expect(state.maxCleanUpRetries).toBe(3);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as max retries have been reached '
+      );
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
@@ -506,7 +506,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         mockSoClient,
         expect.anything(),
         ['unexpected-policy'],
-        { force: true, spaceIds: ['*'] }
+        { force: true }
       );
       expect(result.performSync).toBe(true);
     });

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
@@ -16,10 +16,12 @@ import { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import moment from 'moment';
 import { MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/common';
 import pRetry from 'p-retry';
-import { syntheticsParamType } from '../../common/types/saved_objects';
+import { getFilterForTestNowRun } from '../synthetics_service/private_location/clean_up_task';
+import { syntheticsMonitorSOTypes, syntheticsParamType } from '../../common/types/saved_objects';
 import { normalizeSecrets } from '../synthetics_service/utils';
 import type { PrivateLocationAttributes } from '../runtime_types/private_locations';
-import {
+import type {
+  EncryptedSyntheticsMonitorAttributes,
   HeartbeatConfig,
   MonitorFields,
   SyntheticsMonitorWithSecretsAttributes,
@@ -32,15 +34,18 @@ import {
   formatHeartbeatRequest,
   mixParamsWithGlobalParams,
 } from '../synthetics_service/formatters/public_formatters/format_configs';
+import { SyntheticsPrivateLocation } from '../synthetics_service/private_location/synthetics_private_location';
 
 const TASK_TYPE = 'Synthetics:Sync-Private-Location-Monitors';
-const TASK_ID = `${TASK_TYPE}-single-instance`;
+export const PRIVATE_LOCATIONS_SYNC_TASK_ID = `${TASK_TYPE}-single-instance`;
 const TASK_SCHEDULE = '5m';
 
 interface TaskState extends Record<string, unknown> {
   lastStartedAt: string;
   lastTotalParams: number;
   lastTotalMWs: number;
+  hasAlreadyDoneCleanup: boolean;
+  maxCleanUpRetries: number;
 }
 
 export type CustomTaskInstance = Omit<ConcreteTaskInstance, 'state'> & {
@@ -84,22 +89,38 @@ export class SyncPrivateLocationMonitorsTask {
     const lastStartedAt =
       taskInstance.state.lastStartedAt || moment().subtract(10, 'minute').toISOString();
     const startedAt = taskInstance.startedAt || new Date();
-    let lastTotalParams = taskInstance.state.lastTotalParams || 0;
-    let lastTotalMWs = taskInstance.state.lastTotalMWs || 0;
+
+    const taskState = {
+      lastStartedAt,
+      startedAt: startedAt.toISOString(),
+      lastTotalParams: taskInstance.state.lastTotalParams || 0,
+      lastTotalMWs: taskInstance.state.lastTotalMWs || 0,
+      hasAlreadyDoneCleanup: taskInstance.state.hasAlreadyDoneCleanup || false,
+      maxCleanUpRetries: taskInstance.state.maxCleanUpRetries || 3,
+    };
+
     try {
-      this.debugLog(`Syncing private location monitors, last total params ${lastTotalParams}`);
+      this.debugLog(
+        `Syncing private location monitors, current task state is ${JSON.stringify(taskState)}`
+      );
       const soClient = savedObjects.createInternalRepository([
         MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE,
       ]);
+
+      const { performSync } = await this.cleanUpDuplicatedPackagePolicies(soClient, taskState);
+
       const allPrivateLocations = await getPrivateLocations(soClient, ALL_SPACES_ID);
-      const { totalMWs, totalParams, hasDataChanged } = await this.hasAnyDataChanged({
+      const { hasDataChanged } = await this.hasAnyDataChanged({
         soClient,
-        taskInstance,
+        taskState,
       });
-      lastTotalParams = totalParams;
-      lastTotalMWs = totalMWs;
-      if (hasDataChanged) {
-        this.debugLog(`Syncing private location monitors because data has changed`);
+
+      if (hasDataChanged || performSync) {
+        if (hasDataChanged) {
+          this.debugLog(`Syncing private location monitors because data has changed`);
+        } else {
+          this.debugLog(`Syncing private location monitors because cleanup performed a change`);
+        }
 
         if (allPrivateLocations.length > 0) {
           await this.syncGlobalParams({
@@ -118,19 +139,11 @@ export class SyncPrivateLocationMonitorsTask {
       logger.error(`Sync of private location monitors failed: ${error.message}`);
       return {
         error,
-        state: {
-          lastStartedAt: startedAt.toISOString(),
-          lastTotalParams,
-          lastTotalMWs,
-        },
+        state: taskState,
       };
     }
     return {
-      state: {
-        lastStartedAt: startedAt.toISOString(),
-        lastTotalParams,
-        lastTotalMWs,
-      },
+      state: taskState,
     };
   }
 
@@ -141,7 +154,7 @@ export class SyncPrivateLocationMonitorsTask {
     } = this.serverSetup;
     logger.debug(`Scheduling private location task`);
     await taskManager.ensureScheduled({
-      id: TASK_ID,
+      id: PRIVATE_LOCATIONS_SYNC_TASK_ID,
       state: {},
       schedule: {
         interval: TASK_SCHEDULE,
@@ -153,16 +166,13 @@ export class SyncPrivateLocationMonitorsTask {
   };
 
   hasAnyDataChanged = async ({
-    taskInstance,
+    taskState,
     soClient,
   }: {
-    taskInstance: CustomTaskInstance;
+    taskState: TaskState;
     soClient: SavedObjectsClientContract;
   }) => {
-    const lastStartedAt =
-      taskInstance.state.lastStartedAt || moment().subtract(10, 'minute').toISOString();
-    const lastTotalParams = taskInstance.state.lastTotalParams || 0;
-    const lastTotalMWs = taskInstance.state.lastTotalMWs || 0;
+    const { lastTotalParams, lastTotalMWs, lastStartedAt } = taskState;
 
     const { totalParams, hasParamsChanges } = await this.hasAnyParamChanged({
       soClient,
@@ -174,8 +184,11 @@ export class SyncPrivateLocationMonitorsTask {
       lastStartedAt,
       lastTotalMWs,
     });
+    taskState.lastTotalParams = totalParams;
+    taskState.lastTotalMWs = totalMWs;
+
     const hasDataChanged = hasMWsChanged || hasParamsChanges;
-    return { hasDataChanged, totalParams, totalMWs };
+    return { hasDataChanged };
   };
 
   async syncGlobalParams({
@@ -200,7 +213,6 @@ export class SyncPrivateLocationMonitorsTask {
         config: HeartbeatConfig;
         globalParams: Record<string, string>;
       }> = [];
-
       const monitors = configsBySpaces[spaceId];
       this.debugLog(`Processing spaceId: ${spaceId}, monitors count: ${monitors?.length ?? 0}`);
       if (!monitors) {
@@ -391,8 +403,115 @@ export class SyncPrivateLocationMonitorsTask {
   }
 
   debugLog = (message: string) => {
-    this.serverSetup.logger.debug(`[syncGlobalParams] ${message} `);
+    this.serverSetup.logger.debug(`[SyncPrivateLocationMonitorsTask] ${message} `);
   };
+
+  async cleanUpDuplicatedPackagePolicies(
+    soClient: SavedObjectsClientContract,
+    taskState: TaskState
+  ) {
+    let performSync = false;
+
+    if (taskState.hasAlreadyDoneCleanup) {
+      this.debugLog(
+        'Skipping cleanup of duplicated package policies as it has already been done once'
+      );
+      return { performSync };
+    } else if (taskState.maxCleanUpRetries <= 0) {
+      this.debugLog(
+        'Skipping cleanup of duplicated package policies as max retries have been reached'
+      );
+      taskState.hasAlreadyDoneCleanup = true;
+      taskState.maxCleanUpRetries = 3;
+      return { performSync };
+    }
+    this.debugLog('Starting cleanup of duplicated package policies');
+    const { fleet } = this.serverSetup.pluginsStart;
+    const { logger } = this.serverSetup;
+
+    try {
+      const esClient = this.serverSetup.coreStart?.elasticsearch?.client.asInternalUser;
+
+      const finder = soClient.createPointInTimeFinder<EncryptedSyntheticsMonitorAttributes>({
+        type: syntheticsMonitorSOTypes,
+        fields: ['id', 'name', 'locations', 'origin'],
+        namespaces: ['*'],
+      });
+
+      const privateLocationAPI = new SyntheticsPrivateLocation(this.serverSetup);
+
+      const expectedPackagePolicies = new Set<string>();
+      for await (const result of finder.find()) {
+        result.saved_objects.forEach((monitor) => {
+          monitor.attributes.locations?.forEach((location) => {
+            const spaceId = monitor.namespaces?.[0];
+            if (!location.isServiceManaged && spaceId) {
+              const policyId = privateLocationAPI.getPolicyId(
+                {
+                  origin: monitor.attributes.origin,
+                  id: monitor.id,
+                },
+                location.id,
+                spaceId
+              );
+              expectedPackagePolicies.add(policyId);
+            }
+          });
+        });
+      }
+
+      finder.close().catch(() => {});
+
+      const packagePoliciesKuery = getFilterForTestNowRun(true);
+
+      const policiesIterator = await fleet.packagePolicyService.fetchAllItemIds(soClient, {
+        kuery: packagePoliciesKuery,
+        perPage: 100,
+      });
+      const packagePoliciesToDelete: string[] = [];
+
+      for await (const packagePoliciesIds of policiesIterator) {
+        for (const packagePolicyId of packagePoliciesIds) {
+          if (!expectedPackagePolicies.has(packagePolicyId)) {
+            packagePoliciesToDelete.push(packagePolicyId);
+          }
+          // remove it from the set to mark it as found
+          expectedPackagePolicies.delete(packagePolicyId);
+        }
+      }
+
+      // if we have any to delete or any expected that were not found we need to perform a sync
+      performSync = packagePoliciesToDelete.length > 0 || expectedPackagePolicies.size > 0;
+
+      if (packagePoliciesToDelete.length > 0) {
+        logger.info(
+          ` [PrivateLocationCleanUpTask] Found ${
+            packagePoliciesToDelete.length
+          } duplicate package policies to delete: ${packagePoliciesToDelete.join(', ')}`
+        );
+        await fleet.packagePolicyService.delete(soClient, esClient, packagePoliciesToDelete, {
+          force: true,
+        });
+      }
+      taskState.hasAlreadyDoneCleanup = true;
+      taskState.maxCleanUpRetries = 3;
+      return { performSync };
+    } catch (e) {
+      taskState.maxCleanUpRetries -= 1;
+      if (taskState.maxCleanUpRetries <= 0) {
+        this.debugLog(
+          'Skipping cleanup of duplicated package policies as max retries have been reached'
+        );
+        taskState.hasAlreadyDoneCleanup = true;
+        taskState.maxCleanUpRetries = 3;
+      }
+      logger.error(
+        '[SyncPrivateLocationMonitorsTask] Error cleaning up duplicated package policies',
+        { error: e }
+      );
+      return { performSync };
+    }
+  }
 }
 
 export const runSynPrivateLocationMonitorsTaskSoon = async ({
@@ -410,7 +529,7 @@ export const runSynPrivateLocationMonitorsTaskSoon = async ({
           pluginsStart: { taskManager },
         } = server;
         logger.debug(`Scheduling Synthetics sync private location monitors task soon`);
-        await taskManager.runSoon(TASK_ID);
+        await taskManager.runSoon(PRIVATE_LOCATIONS_SYNC_TASK_ID);
         logger.debug(`Synthetics sync private location task scheduled successfully`);
       },
       {
@@ -423,4 +542,22 @@ export const runSynPrivateLocationMonitorsTaskSoon = async ({
       { error }
     );
   }
+};
+
+export const resetSyncPrivateCleanUpState = async ({
+  server,
+}: {
+  server: SyntheticsServerSetup;
+}) => {
+  const {
+    logger,
+    pluginsStart: { taskManager },
+  } = server;
+  logger.debug(`Resetting Synthetics sync private location monitors cleanup state`);
+  await taskManager.bulkUpdateState([PRIVATE_LOCATIONS_SYNC_TASK_ID], (state) => ({
+    ...state,
+    hasAlreadyDoneCleanup: false,
+  }));
+  await runSynPrivateLocationMonitorsTaskSoon({ server });
+  logger.debug(`Synthetics sync private location monitors cleanup state reset successfully`);
 };

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/clean_up_extra_package_policies.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/clean_up_extra_package_policies.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { RoleCredentials } from '@kbn/ftr-common-functional-services';
+import type { HTTPFields, PrivateLocation } from '@kbn/synthetics-plugin/common/runtime_types';
+import expect from '@kbn/expect';
+import { syntheticsMonitorSavedObjectType } from '@kbn/synthetics-plugin/common/types/saved_objects';
+import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+import { getFixtureJson } from './helpers/get_fixture_json';
+import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
+
+export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  describe('CleanUpExtraPackagePolicies', function () {
+    const kibanaServer = getService('kibanaServer');
+    const samlAuth = getService('samlAuth');
+    const retry = getService('retry');
+
+    let editorUser: RoleCredentials;
+    let privateLocation: PrivateLocation | undefined;
+    let newMonitorId: string;
+    let secondMonitorId: string;
+
+    let _httpMonitorJson: HTTPFields;
+    let httpMonitorJson: HTTPFields;
+    const monitorTestService = new SyntheticsMonitorTestService(getService);
+    const testPrivateLocations = new PrivateLocationTestService(getService);
+
+    before(async () => {
+      await kibanaServer.savedObjects.cleanStandardList();
+      await testPrivateLocations.installSyntheticsPackage();
+      editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
+
+      _httpMonitorJson = getFixtureJson('http_monitor');
+    });
+
+    beforeEach(() => {
+      httpMonitorJson = {
+        ..._httpMonitorJson,
+        locations: privateLocation ? [privateLocation] : [],
+      };
+    });
+
+    it('add test monitors', async () => {
+      privateLocation = await testPrivateLocations.addTestPrivateLocation();
+      const newMonitor = {
+        ...httpMonitorJson,
+        locations: [privateLocation],
+      };
+      const resp = await monitorTestService.createMonitor(newMonitor, editorUser);
+      newMonitorId = resp.id;
+      const items = await testPrivateLocations.getPackagePolicies();
+      expect(items.length).eql(1);
+
+      secondMonitorId = (
+        await monitorTestService.createMonitor(
+          {
+            ...httpMonitorJson,
+            name: 'second-monitor',
+            locations: [privateLocation],
+          },
+          editorUser
+        )
+      ).id;
+      expect((await testPrivateLocations.getPackagePolicies()).length).eql(2);
+    });
+
+    it('it cleans up the extra package policy', async () => {
+      // only delete the saved object to make policy orphaned
+      await kibanaServer.savedObjects.delete({
+        type: syntheticsMonitorSavedObjectType,
+        id: newMonitorId,
+      });
+
+      await monitorTestService.testNowMonitor(secondMonitorId, editorUser);
+
+      expect((await testPrivateLocations.getPackagePolicies()).length).eql(3);
+
+      // trigger cleanup endpoint
+      await monitorTestService.triggerCleanup(editorUser);
+
+      await retry.try(async () => {
+        const items = await testPrivateLocations.getPackagePolicies();
+        // 2 is for the temporary policy, which is created by the test now run
+        expect(items.length).eql(2);
+        const names = items.map((item) => item.name);
+        expect(names.includes('LIGHTWEIGHT_SYNTHETICS_TEST_NOW_RUN')).eql(true);
+        expect(
+          names.filter((name) => name.includes('second-monitor-Test private location')).length
+        ).eql(1);
+      });
+    });
+  });
+}

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
@@ -35,5 +35,6 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./test_now_monitor'));
     loadTestFile(require.resolve('./get_private_location_monitors'));
     loadTestFile(require.resolve('./edit_private_location'));
+    loadTestFile(require.resolve('./clean_up_extra_package_policies'));
   });
 }

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/test_now_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/test_now_monitor.ts
@@ -49,7 +49,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     it('runs test manually', async () => {
-      const resp = await monitorTestService.addMonitor(newMonitor, editorUser);
+      const resp = await monitorTestService.createMonitor(newMonitor, editorUser);
 
       const res = await supertest
         .post(SYNTHETICS_API_URLS.TRIGGER_MONITOR + `/${resp.id}`)

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_monitor.ts
@@ -105,7 +105,7 @@ export class SyntheticsMonitorTestService {
     return apiResponse.body;
   }
 
-  async addMonitor(monitor: any, user: RoleCredentials) {
+  async createMonitor(monitor: any, user: RoleCredentials) {
     const res = await this.supertest
       .post(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS)
       .set(user.apiKeyHeader)
@@ -114,6 +114,30 @@ export class SyntheticsMonitorTestService {
       .expect(200);
 
     return res.body as EncryptedSyntheticsSavedMonitor;
+  }
+
+  async triggerSyntheticsTaskManually(taskType: string, user: RoleCredentials) {
+    await this.supertest
+      .post(SYNTHETICS_API_URLS.TRIGGER_TASK_RUN.replace('{taskType}', taskType))
+      .set(user.apiKeyHeader)
+      .set(this.samlAuth.getInternalRequestHeader())
+      .expect(200);
+  }
+
+  async triggerCleanup(user: RoleCredentials) {
+    await this.supertest
+      .put(SYNTHETICS_API_URLS.PRIVATE_LOCATIONS_CLEANUP)
+      .set(user.apiKeyHeader)
+      .set(this.samlAuth.getInternalRequestHeader())
+      .expect(200);
+  }
+
+  async testNowMonitor(id: string, user: RoleCredentials) {
+    await this.supertest
+      .post(SYNTHETICS_API_URLS.TEST_NOW_MONITOR + `/${id}`)
+      .set(user.apiKeyHeader)
+      .set(this.samlAuth.getInternalRequestHeader())
+      .expect(200);
   }
 
   async inspectMonitor(user: RoleCredentials, monitor: any, hideParams: boolean = true) {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_monitor.ts
@@ -134,7 +134,7 @@ export class SyntheticsMonitorTestService {
 
   async testNowMonitor(id: string, user: RoleCredentials) {
     await this.supertest
-      .post(SYNTHETICS_API_URLS.TEST_NOW_MONITOR + `/${id}`)
+      .post(SYNTHETICS_API_URLS.TRIGGER_MONITOR + `/${id}`)
       .set(user.apiKeyHeader)
       .set(this.samlAuth.getInternalRequestHeader())
       .expect(200);

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
@@ -8,9 +8,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { RetryService } from '@kbn/ftr-common-functional-services';
 import { X_ELASTIC_INTERNAL_ORIGIN_REQUEST } from '@kbn/core-http-common';
 import { privateLocationSavedObjectName } from '@kbn/synthetics-plugin/common/saved_objects/private_locations';
-import { SyntheticsPrivateLocations } from '@kbn/synthetics-plugin/common/runtime_types';
-import { KibanaSupertestProvider } from '@kbn/ftr-common-functional-services';
-import { DeploymentAgnosticFtrProviderContext } from '../ftr_provider_context';
+import type { SyntheticsPrivateLocations } from '@kbn/synthetics-plugin/common/runtime_types';
+import type { KibanaSupertestProvider } from '@kbn/ftr-common-functional-services';
+import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import type { DeploymentAgnosticFtrProviderContext } from '../ftr_provider_context';
 
 export const INSTALLED_VERSION = '1.4.2';
 
@@ -61,6 +62,13 @@ export class PrivateLocationTestService {
         });
       return response;
     });
+  }
+
+  async getPackagePolicies(): Promise<PackagePolicy[]> {
+    const apiResponse = await this.supertestWithAuth.get(
+      '/api/fleet/package_policies?page=1&perPage=2000&kuery=ingest-package-policies.package.name%3A%20synthetics'
+    );
+    return apiResponse.body.items;
   }
 
   async setTestLocations(testFleetPolicyIds: string[], spaceId?: string | string[]) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Clean up extra synthetics package policies !! (#235200)](https://github.com/elastic/kibana/pull/235200)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2025-09-30T19:46:07Z","message":"[Synthetics] Clean up extra synthetics package policies !! (#235200)\n\n## Summary\n\nClean up extra synthetics package policies created via\nhttps://github.com/elastic/kibana/pull/235021 !!\n\n### Clean up\n\nThere are three basic tests for clean up\n\n1. SpaceIds being added in a processor where there should only be one \n2. Multiple package policies exists for same configId and locationId\n3. ConfigId is missing altogether from monitors for a package policy \n\nThe bug meant multiple spaceIds were being added in processor and also\nif multiple package policies exists for a locationId and configId, that\nalso passes the test, so we clean up those policies.\n\n\n### Testing \n\nRevert changes in PR https://github.com/elastic/kibana/pull/235021, it\nwill create extra package policies once you have monitors in multiple\nplaces, switching to this branch should clean up those.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ced929a22bff204846cad448d3603f517cdd240f","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","Team:obs-ux-management","backport:version","author:obs-ux-management","v9.2.0","v8.19.5","v9.1.5"],"title":"[Synthetics] Clean up extra synthetics package policies !!","number":235200,"url":"https://github.com/elastic/kibana/pull/235200","mergeCommit":{"message":"[Synthetics] Clean up extra synthetics package policies !! (#235200)\n\n## Summary\n\nClean up extra synthetics package policies created via\nhttps://github.com/elastic/kibana/pull/235021 !!\n\n### Clean up\n\nThere are three basic tests for clean up\n\n1. SpaceIds being added in a processor where there should only be one \n2. Multiple package policies exists for same configId and locationId\n3. ConfigId is missing altogether from monitors for a package policy \n\nThe bug meant multiple spaceIds were being added in processor and also\nif multiple package policies exists for a locationId and configId, that\nalso passes the test, so we clean up those policies.\n\n\n### Testing \n\nRevert changes in PR https://github.com/elastic/kibana/pull/235021, it\nwill create extra package policies once you have monitors in multiple\nplaces, switching to this branch should clean up those.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ced929a22bff204846cad448d3603f517cdd240f"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/235200","number":235200,"mergeCommit":{"message":"[Synthetics] Clean up extra synthetics package policies !! (#235200)\n\n## Summary\n\nClean up extra synthetics package policies created via\nhttps://github.com/elastic/kibana/pull/235021 !!\n\n### Clean up\n\nThere are three basic tests for clean up\n\n1. SpaceIds being added in a processor where there should only be one \n2. Multiple package policies exists for same configId and locationId\n3. ConfigId is missing altogether from monitors for a package policy \n\nThe bug meant multiple spaceIds were being added in processor and also\nif multiple package policies exists for a locationId and configId, that\nalso passes the test, so we clean up those policies.\n\n\n### Testing \n\nRevert changes in PR https://github.com/elastic/kibana/pull/235021, it\nwill create extra package policies once you have monitors in multiple\nplaces, switching to this branch should clean up those.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ced929a22bff204846cad448d3603f517cdd240f"}},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/237032","number":237032,"state":"OPEN"}]}] BACKPORT-->