### PR TITLE
[ES|QL] Fixes the error povover problem when the content is too long

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
@@ -72,7 +72,7 @@ function ErrorsWarningsContent({
   const { euiTheme } = useEuiTheme();
   const { color } = getConstsByType(type, items.length);
   return (
-    <div style={{ width: 500, padding: euiTheme.size.s }}>
+    <div style={{ width: 500, padding: euiTheme.size.s, maxHeight: 300, overflow: 'auto' }}>
       <EuiDescriptionList data-test-subj="ESQLEditor-errors-warnings-content">
         {items.map((item, index) => {
           return (


### PR DESCRIPTION
## Summary

With the changes we did in the validation the error can get too long now. This PR is ensuring that there will be scrollbars when the height becomes too long 

<img width="467" height="284" alt="image" src="https://github.com/user-attachments/assets/615b48c3-80e8-4058-aa16-3906c2faf475" />




