### PR TITLE
[ES|QL] Fix map walking, when key value is wrapped in array

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/__tests__/fixtures.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/__tests__/fixtures.ts
@@ -29,6 +29,13 @@ FROM index, metrics:index, "another_index", """index""", metrics-metrics-metrics
   | LIMIT 10
   | STATS bytes = (SUM(destination.bytes, true))::INTEGER
   | SORT asdf
+  | WHERE MATCH( aws.s3.bucket.name, ?variable, {
+      "minimum_should_match": ?min_should_match,
+      "fuzziness": 2,
+      "key": "value",
+      "nil": NULL,
+      "another_param": ?param
+    })
   | SORT @timestamp DESC, @timestamp ASC
   | SORT kb, date ASC NULLS FIRST, ip DESC NULLS LAST
   | DROP date, ip, \`AVG(FALSE, null, { "this": "is", "map": 123 })\`

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/cst_to_ast_converter.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/cst_to_ast_converter.ts
@@ -2402,10 +2402,12 @@ export class CstToAstConverter {
   // -------------------------------------------------------- expression: "map"
 
   private fromMapExpression(ctx: cst.MapExpressionContext): ast.ESQLMap {
+    const location = getPosition(ctx.start, ctx.stop);
     const map = Builder.expression.map(
       {},
       {
-        location: getPosition(ctx.start, ctx.stop),
+        text: this.parser.src.slice(location.min, location.max + 1),
+        location,
         incomplete: Boolean(ctx.exception),
       }
     );
@@ -2458,8 +2460,10 @@ export class CstToAstConverter {
       }
 
       if (value) {
+        const location = getPosition(ctx.start, ctx.stop);
         const entry = Builder.expression.entry(key, value, {
-          location: getPosition(ctx.start, ctx.stop),
+          text: this.parser.src.slice(location.min, location.max + 1),
+          location,
           incomplete: Boolean(ctx.exception) || key.incomplete || value.incomplete,
         });
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/walker/__tests__/walker_statics.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/walker/__tests__/walker_statics.test.ts
@@ -181,6 +181,28 @@ describe('Walker static methods', () => {
         },
       ]);
     });
+
+    test('can collect params from function trailing map argument', () => {
+      const query =
+        'FROM a | WHERE MATCH( aws.s3.bucket.name, ?variable, {"minimum_should_match": ?min_should_match})';
+      const { ast } = parse(query);
+      const params = Walker.params(ast);
+
+      expect(params).toMatchObject([
+        {
+          type: 'literal',
+          literalType: 'param',
+          paramType: 'named',
+          value: 'variable',
+        },
+        {
+          type: 'literal',
+          literalType: 'param',
+          paramType: 'named',
+          value: 'min_should_match',
+        },
+      ]);
+    });
   });
 
   describe('Walker.find()', () => {
@@ -318,6 +340,34 @@ describe('Walker static methods', () => {
       expect(res).toMatchObject({
         type: 'column',
         name: 'a.b.c',
+      });
+    });
+
+    test('can map and inside map', () => {
+      const query = 'ROW F(1, {"b": ?var, "a": 123})';
+      const { root } = parse(query);
+      const map = Walker.match(root, {
+        type: 'map',
+      });
+      const number = Walker.match(root, {
+        type: 'literal',
+        value: 123,
+      });
+      const param = Walker.match(root, {
+        type: 'literal',
+        literalType: 'param',
+      });
+
+      expect(map).toMatchObject({
+        type: 'map',
+      });
+      expect(number).toMatchObject({
+        type: 'literal',
+        value: 123,
+      });
+      expect(param).toMatchObject({
+        type: 'literal',
+        literalType: 'param',
       });
     });
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/walker/__tests__/walker_statics.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/walker/__tests__/walker_statics.test.ts
@@ -343,7 +343,7 @@ describe('Walker static methods', () => {
       });
     });
 
-    test('can map and inside map', () => {
+    test('can find map and inside map', () => {
       const query = 'ROW F(1, {"b": ?var, "a": 123})';
       const { root } = parse(query);
       const map = Walker.match(root, {

--- a/src/platform/packages/shared/kbn-esql-ast/src/walker/walker.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/walker/walker.ts
@@ -8,6 +8,7 @@
  */
 
 import type * as types from '../types';
+import { resolveItem } from '../visitor/utils';
 import type { NodeMatchTemplate } from './helpers';
 import { replaceProperties, templateToPredicate } from './helpers';
 
@@ -665,11 +666,11 @@ export class Walker {
     (options.visitMapEntry ?? options.visitAny)?.(node, parent, this);
 
     if (options.order === 'backward') {
-      this.walkSingleAstItem(node.value, node);
-      this.walkSingleAstItem(node.key, node);
+      this.walkSingleAstItem(resolveItem(node.value), node);
+      this.walkSingleAstItem(resolveItem(node.key), node);
     } else {
-      this.walkSingleAstItem(node.key, node);
-      this.walkSingleAstItem(node.value, node);
+      this.walkSingleAstItem(resolveItem(node.key), node);
+      this.walkSingleAstItem(resolveItem(node.value), node);
     }
   }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/237061

Fixes the bug, where param in the AST was wrapped in an array, and hence was not traversed by the `Walker`:

```ts
[
  {
    type: 'literal',
    paramKind: '?',
    literalType: 'param',
    // ...
  }
]
```

As the `Walker` logic in that place expected a single AST node object, this PR fixes it by unwrapping the arrays in map entries.

Also `map` and `map-entry` had missing `text` field, I added that field in this PR to pass the updated tests. But it is not relevant for the fix.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
