### PR TITLE
Skip serverless Discover URL state tests for MKI runs

### DIFF
--- a/x-pack/platform/test/serverless/functional/test_suites/discover/group5/_url_state.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/group5/_url_state.ts
@@ -30,7 +30,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     defaultIndex: 'logstash-*',
   };
 
-  describe('discover URL state', () => {
+  describe('discover URL state', function () {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/237086
+    this.tags(['failsOnMKI']);
+
     before(async function () {
       log.debug('load kibana index with default index pattern');
       await kibanaServer.importExport.load(


### PR DESCRIPTION
## Summary

This PR skips the serverless Discover URL state tests for MKI runs.
Details on the failure in #237086