### PR TITLE
[Streams] Update tab order in stream management

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/classic.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/classic.tsx
@@ -128,6 +128,15 @@ export function ClassicStreamDetailManagement({
     tabs.processing = processing;
   }
 
+  tabs.schema = {
+    content: (
+      <StreamDetailSchemaEditor definition={definition} refreshDefinition={refreshDefinition} />
+    ),
+    label: i18n.translate('xpack.streams.streamDetailView.schemaEditorTab', {
+      defaultMessage: 'Schema',
+    }),
+  };
+
   tabs.dataQuality = {
     content: <StreamDetailDataQuality definition={definition} />,
     label: (
@@ -144,6 +153,10 @@ export function ClassicStreamDetailManagement({
       </EuiToolTip>
     ),
   };
+
+  if (otherTabs.significantEvents) {
+    tabs.significantEvents = otherTabs.significantEvents;
+  }
 
   if (definition.privileges.manage) {
     tabs.advanced = {
@@ -176,19 +189,8 @@ export function ClassicStreamDetailManagement({
         </EuiToolTip>
       ),
     };
-    tabs.schema = {
-      content: (
-        <StreamDetailSchemaEditor definition={definition} refreshDefinition={refreshDefinition} />
-      ),
-      label: i18n.translate('xpack.streams.streamDetailView.schemaEditorTab', {
-        defaultMessage: 'Schema',
-      }),
-    };
   }
 
-  if (otherTabs.significantEvents) {
-    tabs.significantEvents = otherTabs.significantEvents;
-  }
   if (isValidManagementSubTab(tab)) {
     return <Wrapper tabs={tabs} streamId={key} tab={tab} />;
   }


### PR DESCRIPTION
Updates tab order for classic streams

### Before
<img width="743" height="160" alt="image" src="https://github.com/user-attachments/assets/ab091b85-505e-40b5-85fb-33ec9f9b7d7b" />

### After

<img width="763" height="169" alt="image" src="https://github.com/user-attachments/assets/bf4d4ad8-4bf9-4365-9798-8e60fd71ab4e" />


Closes https://github.com/elastic/streams-program/issues/546