### PR TITLE
[9.1] Normalize resulting paths to unix paths after glob usage (#236044)

### DIFF
--- a/src/core/packages/i18n/server-internal/src/get_translation_paths.ts
+++ b/src/core/packages/i18n/server-internal/src/get_translation_paths.ts
@@ -9,6 +9,7 @@
 
 import { resolve, dirname } from 'path';
 import { readFile, glob } from 'fs/promises';
+import normalizePath from 'normalize-path';
 
 interface I18NRCFileStructure {
   translations?: string[];
@@ -21,7 +22,7 @@ export async function getTranslationPaths({ cwd, nested }: { cwd: string; nested
   const translationPaths: string[] = [];
 
   for await (const entry of glob(globPattern, { cwd })) {
-    const entryFullPath = resolve(cwd, entry);
+    const entryFullPath = resolve(cwd, normalizePath(entry));
     const pluginBasePath = dirname(entryFullPath);
     try {
       const content = await readFile(entryFullPath, 'utf8');

--- a/src/platform/plugins/private/vis_types/timelion/server/lib/load_functions.js
+++ b/src/platform/plugins/private/vis_types/timelion/server/lib/load_functions.js
@@ -9,18 +9,20 @@
 
 import _ from 'lodash';
 import { globSync } from 'fs';
+import normalizePath from 'normalize-path';
 import processFunctionDefinition from './process_function_definition';
 
 export default function (directory) {
   function getTuple(directory, name) {
-    return [name, require('../' + directory + '/' + name)]; // eslint-disable-line import/no-dynamic-require
+    return [name, require(`../${directory}/${name}`)]; // eslint-disable-line import/no-dynamic-require
   }
 
   // Get a list of all files and use the filename as the object key
   const files = _.map(
-    globSync('../' + directory + '/*.js', { cwd: __dirname }).filter(
-      (filename) => !filename.includes('.test')
-    ),
+    globSync(`../${directory}/*.js`, { cwd: __dirname })
+      .filter((filename) => !filename.includes('.test'))
+      .map((p) => normalizePath(p)),
+
     function (file) {
       const name = file.substring(file.lastIndexOf('/') + 1, file.lastIndexOf('.'));
       return getTuple(directory, name);
@@ -29,12 +31,12 @@ export default function (directory) {
 
   // Get a list of all directories with an index.js, use the directory name as the key in the object
   const directories = _.chain(
-    globSync('../' + directory + '/*/index.js', {
+    globSync(`../${directory}/*/index.js`, {
       cwd: __dirname,
     })
   )
     .map(function (file) {
-      const parts = file.split('/');
+      const parts = normalizePath(file).split('/');
       const name = parts[parts.length - 2];
       return getTuple(directory, name);
     })

--- a/src/platform/plugins/shared/console/server/services/spec_definitions_service.ts
+++ b/src/platform/plugins/shared/console/server/services/spec_definitions_service.ts
@@ -106,13 +106,13 @@ export class SpecDefinitionsService {
     // we need to normalize paths otherwise they don't work on windows, see https://github.com/elastic/kibana/issues/151032
     const generatedFiles = globSync(
       normalizePath(join(AUTOCOMPLETE_DEFINITIONS_FOLDER, GENERATED_SUBFOLDER, '*.json'))
-    );
+    ).map((p) => normalizePath(p));
     const overrideFiles = globSync(
       normalizePath(join(AUTOCOMPLETE_DEFINITIONS_FOLDER, OVERRIDES_SUBFOLDER, '*.json'))
-    );
+    ).map((p) => normalizePath(p));
     const manualFiles = globSync(
       normalizePath(join(AUTOCOMPLETE_DEFINITIONS_FOLDER, MANUAL_SUBFOLDER, '*.json'))
-    );
+    ).map((p) => normalizePath(p));
 
     // definitions files contain only 1 definition per endpoint name { "endpointName": { endpointDescription }}
     // all endpoints need to be merged into 1 object with endpoint names as keys and endpoint definitions as values

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/content_loaders/security_labs_loader.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/content_loaders/security_labs_loader.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { glob } from 'fs/promises';
+import { globSync } from 'fs';
+import normalizePath from 'normalize-path';
 import type { Logger } from '@kbn/core/server';
 import { DirectoryLoader } from 'langchain/document_loaders/fs/directory';
 import { resolve } from 'path';
@@ -73,12 +74,9 @@ export const loadSecurityLabs = async (
 
 export const getSecurityLabsDocsCount = async ({ logger }: { logger: Logger }): Promise<number> => {
   try {
-    // @ts-expect-error incorrect type for Array.fromAsync
-    const files = await Array.fromAsync(
-      glob(ENCODED_FILE_MICROMATCH_PATTERN, {
-        cwd: resolve(__dirname, '../../../knowledge_base/security_labs'),
-      })
-    );
+    const files = globSync(ENCODED_FILE_MICROMATCH_PATTERN, {
+      cwd: resolve(__dirname, '../../../knowledge_base/security_labs'),
+    }).map((p) => normalizePath(p));
 
     return files.length;
   } catch (e) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Normalize resulting paths to unix paths after glob usage (#236044)](https://github.com/elastic/kibana/pull/236044)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2025-09-29T08:42:25Z","message":"Normalize resulting paths to unix paths after glob usage (#236044)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/236004\n\nAfter https://github.com/elastic/kibana/pull/233481 the resulting glob\npaths are yielded as windows paths, but probably processed as unix paths\n(since `globby` always returned paths with unix separators).\n\nThis PR applies a normalization on resulting paths.","sha":"1cac4d2b739423bbfb2c8d93cc60a02a456707f4","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.2.0","v8.19.5","v9.1.5"],"title":"Normalize resulting paths to unix paths after glob usage","number":236044,"url":"https://github.com/elastic/kibana/pull/236044","mergeCommit":{"message":"Normalize resulting paths to unix paths after glob usage (#236044)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/236004\n\nAfter https://github.com/elastic/kibana/pull/233481 the resulting glob\npaths are yielded as windows paths, but probably processed as unix paths\n(since `globby` always returned paths with unix separators).\n\nThis PR applies a normalization on resulting paths.","sha":"1cac4d2b739423bbfb2c8d93cc60a02a456707f4"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236044","number":236044,"mergeCommit":{"message":"Normalize resulting paths to unix paths after glob usage (#236044)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/236004\n\nAfter https://github.com/elastic/kibana/pull/233481 the resulting glob\npaths are yielded as windows paths, but probably processed as unix paths\n(since `globby` always returned paths with unix separators).\n\nThis PR applies a normalization on resulting paths.","sha":"1cac4d2b739423bbfb2c8d93cc60a02a456707f4"}},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->