### PR TITLE
[Security Solution] skip failing Threat Hunting Investigations Cypress test

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/alert_table_controls.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/alert_table_controls.cy.ts
@@ -42,7 +42,7 @@ import { DATAGRID_HEADER } from '../../../screens/timeline';
  *
  * */
 
-describe(`Alert Table Controls`, { tags: ['@ess', '@serverless'] }, () => {
+describe.skip(`Alert Table Controls`, { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     deleteAlertsAndRules();
     login();


### PR DESCRIPTION
## Summary

Skipping this test as it started failing on `8.19` and is blocking other teams from merging backports.