### PR TITLE
[SideNav] `Indices, data streams and roll ups` -> `Indices and data streams`

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
@@ -445,9 +445,9 @@ function createNavTree({ streamsAvailable }: { streamsAvailable?: boolean }) {
                 ],
               },
               {
-                id: 'indicesDataStreamsAndRollups',
-                title: i18n.translate('xpack.observability.obltNav.indicesDataStreamsAndRollups', {
-                  defaultMessage: 'Indices, data streams and roll ups',
+                id: 'indicesAndDataStreams',
+                title: i18n.translate('xpack.observability.obltNav.indicesAndDataStreams', {
+                  defaultMessage: 'Indices and data streams',
                   description:
                     'Heading in a nav tree dedicated to UIs for leveraging various Elasticsearch features for data management',
                 }),

--- a/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
@@ -331,7 +331,7 @@ export const getNavigationTreeDefinition = ({
                       title: i18n.translate(
                         'xpack.enterpriseSearch.searchNav.ingest.indices.title',
                         {
-                          defaultMessage: 'Indices, data streams and roll ups',
+                          defaultMessage: 'Indices and data streams',
                         }
                       ),
                     },

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -274,7 +274,7 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                   { link: 'management:data_usage', breadcrumbStatus: 'hidden' },
                 ],
                 title: i18n.translate('xpack.serverlessSearch.nav.ingest.indices.title', {
-                  defaultMessage: 'Indices, data streams and roll ups',
+                  defaultMessage: 'Indices and data streams',
                 }),
               },
               {

--- a/x-pack/solutions/security/packages/navigation/src/i18n_strings.ts
+++ b/x-pack/solutions/security/packages/navigation/src/i18n_strings.ts
@@ -260,11 +260,11 @@ export const i18nStrings = {
         }
       ),
     },
-    indicesDsAndRollups: {
+    indicesAndDataStreams: {
       title: i18n.translate(
-        'securitySolutionPackages.navLinks.ingestAndManageData.indicesDsAndRollups',
+        'securitySolutionPackages.navLinks.ingestAndManageData.indicesAndDataStreams',
         {
-          defaultMessage: 'Indices, Data Streams, and roll ups',
+          defaultMessage: 'Indices and data streams',
         }
       ),
     },

--- a/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/v2_footer_items.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/v2_footer_items.ts
@@ -33,7 +33,7 @@ export const v2FooterItems: NodeDefinition<AppDeepLinkId, string, string>[] = [
         ],
       },
       {
-        title: i18nStrings.ingestAndManageData.indicesDsAndRollups.title,
+        title: i18nStrings.ingestAndManageData.indicesAndDataStreams.title,
         children: [
           { link: 'streams' },
           { link: 'management:index_management' },

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/v2_ease_footer_items.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/v2_ease_footer_items.ts
@@ -32,7 +32,7 @@ export const v2EaseFooterItems: NodeDefinition<AppDeepLinkId, string, string>[] 
         ],
       },
       {
-        title: i18nStrings.ingestAndManageData.indicesDsAndRollups.title,
+        title: i18nStrings.ingestAndManageData.indicesAndDataStreams.title,
         children: [
           { link: 'management:index_management' },
           { link: 'management:transform' },

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/v2_footer_items.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/v2_footer_items.ts
@@ -49,7 +49,7 @@ export const createV2footerItemsTree = (): NodeDefinition => ({
           ],
         },
         {
-          title: i18nStrings.ingestAndManageData.indicesDsAndRollups.title,
+          title: i18nStrings.ingestAndManageData.indicesAndDataStreams.title,
           breadcrumbStatus: 'hidden',
           children: [
             { link: 'streams' },


### PR DESCRIPTION
## Summary

Shorten to allow to reduce width of the panel 

https://elastic.slack.com/archives/C0941BFS56D/p1759323537399639?thread_ts=1759310985.124459&cid=C0941BFS56D





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->