### PR TITLE
[9.1] [CI] Fallback to GITHUB_PR_NUMBER, when BUILDKITE_PULL_REQUEST is false (#237034)

### DIFF
--- a/.buildkite/scripts/steps/cloud/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/cloud/build_and_deploy.sh
@@ -22,7 +22,14 @@ ELASTICSEARCH_SHA=$(curl -s $ELASTICSEARCH_MANIFEST_URL | jq -r '.sha')
 ELASTICSEARCH_CLOUD_IMAGE="docker.elastic.co/kibana-ci/elasticsearch-cloud-ess:$VERSION-$ELASTICSEARCH_SHA"
 
 KIBANA_CLOUD_IMAGE="docker.elastic.co/kibana-ci/kibana-cloud:$VERSION-$GIT_COMMIT"
-CLOUD_DEPLOYMENT_NAME="kibana-pr-$BUILDKITE_PULL_REQUEST"
+
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
+  PR_NUMBER="$GITHUB_PR_NUMBER"
+else
+  PR_NUMBER="$BUILDKITE_PULL_REQUEST"
+fi
+
+CLOUD_DEPLOYMENT_NAME="kibana-pr-$PR_NUMBER"
 
 set +e
 DISTRIBUTION_EXISTS=$(docker manifest inspect $KIBANA_CLOUD_IMAGE &> /dev/null; echo $?)

--- a/.buildkite/scripts/steps/serverless/deploy.sh
+++ b/.buildkite/scripts/steps/serverless/deploy.sh
@@ -5,7 +5,13 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
-KIBANA_IMAGE="docker.elastic.co/kibana-ci/kibana-serverless:pr-$BUILDKITE_PULL_REQUEST-${BUILDKITE_COMMIT:0:12}"
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
+  PR_NUMBER="$GITHUB_PR_NUMBER"
+else
+  PR_NUMBER="$BUILDKITE_PULL_REQUEST"
+fi
+
+KIBANA_IMAGE="docker.elastic.co/kibana-ci/kibana-serverless:pr-$PR_NUMBER-${BUILDKITE_COMMIT:0:12}"
 
 deploy() {
   PROJECT_TYPE=$1
@@ -22,7 +28,7 @@ deploy() {
     ;;
   esac
 
-  PROJECT_NAME="kibana-pr-$BUILDKITE_PULL_REQUEST-$PROJECT_TYPE"
+  PROJECT_NAME="kibana-pr-$PR_NUMBER-$PROJECT_TYPE"
   VAULT_KEY_NAME="$PROJECT_NAME"
   is_pr_with_label "ci:project-persist-deployment" && PROJECT_NAME="keep_$PROJECT_NAME"
   PROJECT_CREATE_CONFIGURATION='{
@@ -144,16 +150,16 @@ $KIBANA_IMAGE
 
 ### Kibana pull request
 
-$BUILDKITE_PULL_REQUEST
+$PR_NUMBER
 
 ### Further details
 
-Caused by the GitHub label 'ci:project-deploy-observability' in https://github.com/elastic/kibana/pull/$BUILDKITE_PULL_REQUEST
+Caused by the GitHub label 'ci:project-deploy-observability' in https://github.com/elastic/kibana/pull/$PR_NUMBER
 EOF
 
   GH_TOKEN="$GITHUB_TOKEN" \
   gh issue create \
-    --title "[Deploy Serverless Kibana] for user $GITHUB_PR_TRIGGER_USER with PR kibana@pr-$BUILDKITE_PULL_REQUEST" \
+    --title "[Deploy Serverless Kibana] for user $GITHUB_PR_TRIGGER_USER with PR kibana@pr-$PR_NUMBER" \
     --body-file "${GITHUB_ISSUE}" \
     --label 'deploy-custom-kibana-serverless' \
     --repo 'elastic/observability-test-environments'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[CI] Fallback to GITHUB_PR_NUMBER, when BUILDKITE_PULL_REQUEST is false (#237034)](https://github.com/elastic/kibana/pull/237034)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-01T16:22:05Z","message":"[CI] Fallback to GITHUB_PR_NUMBER, when BUILDKITE_PULL_REQUEST is false (#237034)\n\n## Summary\n\nBK has a bug where `BUILDKITE_PULL_REQUEST` is `false` when there should\nbe a PR number. Example\n[here](https://buildkite.com/elastic/kibana-pull-request/builds/345435).\nWe then deploy to `kibana-pr-false`. This has been happening for about\ntwo months from what I can tell and would have multiple PRs deploying to\nthe same URL and overwriting each other.","sha":"0870546e115330616410847bf3766588c4e68a50","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","ci:cloud-deploy","ci:project-deploy-elasticsearch","v9.2.0"],"title":"[CI] Fallback to GITHUB_PR_NUMBER, when BUILDKITE_PULL_REQUEST is false","number":237034,"url":"https://github.com/elastic/kibana/pull/237034","mergeCommit":{"message":"[CI] Fallback to GITHUB_PR_NUMBER, when BUILDKITE_PULL_REQUEST is false (#237034)\n\n## Summary\n\nBK has a bug where `BUILDKITE_PULL_REQUEST` is `false` when there should\nbe a PR number. Example\n[here](https://buildkite.com/elastic/kibana-pull-request/builds/345435).\nWe then deploy to `kibana-pr-false`. This has been happening for about\ntwo months from what I can tell and would have multiple PRs deploying to\nthe same URL and overwriting each other.","sha":"0870546e115330616410847bf3766588c4e68a50"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237034","number":237034,"mergeCommit":{"message":"[CI] Fallback to GITHUB_PR_NUMBER, when BUILDKITE_PULL_REQUEST is false (#237034)\n\n## Summary\n\nBK has a bug where `BUILDKITE_PULL_REQUEST` is `false` when there should\nbe a PR number. Example\n[here](https://buildkite.com/elastic/kibana-pull-request/builds/345435).\nWe then deploy to `kibana-pr-false`. This has been happening for about\ntwo months from what I can tell and would have multiple PRs deploying to\nthe same URL and overwriting each other.","sha":"0870546e115330616410847bf3766588c4e68a50"}}]}] BACKPORT-->