### PR TITLE
Add chunk rescorer to Kibana Autocomplete

### DIFF
--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
@@ -9,7 +9,7 @@
 
 import type { SpecDefinitionsService } from '../../../services';
 
-import { BOOLEAN } from './shared';
+import { BOOLEAN, ChunkingSettings } from './shared';
 
 export const mappings = (specService: SpecDefinitionsService) => {
   specService.addEndpointDescription('put_mapping', {
@@ -117,14 +117,7 @@ export const mappings = (specService: SpecDefinitionsService) => {
               DenseVectorIndexOptions,
             ],
           },
-          chunking_settings: {
-            strategy: {
-              __one_of: ['sentence', 'word', 'none'],
-            },
-            max_chunk_size: 250,
-            sentence_overlap: 1,
-            overlap: 1,
-          },
+          chunking_settings: ChunkingSettings,
           analyzer: 'standard',
           search_analyzer: 'standard',
           include_in_all: {

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/retriever.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/retriever.ts
@@ -8,6 +8,7 @@
  */
 
 import type { SpecDefinitionsService } from '../../../services';
+import { ChunkingSettings } from './shared';
 
 export const retriever = (specService: SpecDefinitionsService) => {
   specService.addGlobalAutocompleteRules('retriever', {
@@ -149,6 +150,7 @@ export const retriever = (specService: SpecDefinitionsService) => {
         inference_id: '',
         inference_text: '',
         field: '',
+        chunk_rescorer: {}
       },
       retriever: {
         __scope_link: '.',
@@ -160,6 +162,10 @@ export const retriever = (specService: SpecDefinitionsService) => {
       min_score: 0,
       filter: {
         __scope_link: 'GLOBAL.query',
+      },
+      chunk_rescorer: {
+        size: 1,
+        chunking_settings: ChunkingSettings
       },
     },
   });

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/retriever.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/retriever.ts
@@ -150,7 +150,7 @@ export const retriever = (specService: SpecDefinitionsService) => {
         inference_id: '',
         inference_text: '',
         field: '',
-        chunk_rescorer: {}
+        chunk_rescorer: {},
       },
       retriever: {
         __scope_link: '.',
@@ -165,7 +165,7 @@ export const retriever = (specService: SpecDefinitionsService) => {
       },
       chunk_rescorer: {
         size: 1,
-        chunking_settings: ChunkingSettings
+        chunking_settings: ChunkingSettings,
       },
     },
   });

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/shared.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/shared.ts
@@ -10,3 +10,12 @@
 export const BOOLEAN = Object.freeze({
   __one_of: [true, false],
 });
+
+export const ChunkingSettings = {
+  strategy: {
+    __one_of: ['sentence', 'word', 'none', 'recursive'],
+  },
+  max_chunk_size: 250,
+  sentence_overlap: 1,
+  overlap: 1,
+}

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/shared.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/shared.ts
@@ -18,4 +18,4 @@ export const ChunkingSettings = {
   max_chunk_size: 250,
   sentence_overlap: 1,
   overlap: 1,
-}
+};


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/133576 introduced the concept of a `chunk_rescorer` in the `text_similarity_reranker` retriever. This PR adds the chunk rescorer to Dev Tools AutoComplete. 

https://github.com/user-attachments/assets/9688a4ce-2cd5-40ad-ba8e-e8e69abed26e

