### PR TITLE
[ci] Fix test failure report

### DIFF
--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file.ts
@@ -46,14 +46,14 @@ async function getJourneySnapshotHtml(log: ToolingLog, journeyMeta: JourneyMeta)
     '<section>',
     '<h5>Steps</h5>',
     ...screenshots.get().flatMap(({ title, path, fullscreenPath }) => {
-      const base64 = Fs.readFileSync(path, 'base64');
-      const fullscreenBase64 = Fs.readFileSync(fullscreenPath, 'base64');
+      const relPath = Path.relative(REPO_ROOT, path);
+      const relFullscreenPath = Path.relative(REPO_ROOT, fullscreenPath);
 
       return [
         `<p><strong>${escape(title)}</strong></p>`,
         `<div class="screenshotContainer">
-          <img class="screenshot img-fluid img-thumbnail" src="data:image/png;base64,${base64}" />
-          <img class="screenshot img-fluid img-thumbnail fs" src="data:image/png;base64,${fullscreenBase64}" />
+          <img class="screenshot img-fluid img-thumbnail" src="${escape(relPath)}" />
+          <img class="screenshot img-fluid img-thumbnail fs" src="${escape(relFullscreenPath)}" />
           <button type="button" class="toggleFs on" title="Expand screenshot to full page">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrows-expand" viewBox="0 0 16 16">
               <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8zM7.646.146a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 1.707V5.5a.5.5 0 0 1-1 0V1.707L6.354 2.854a.5.5 0 1 1-.708-.708l2-2zM8 10a.5.5 0 0 1 .5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 0 1 .708-.708L7.5 14.293V10.5A.5.5 0 0 1 8 10z"/>
@@ -102,10 +102,10 @@ function getFtrScreenshotHtml(log: ToolingLog, failureName: string) {
   return getAllScreenshots(log)
     .filter((s) => s.name.startsWith(FtrScreenshotFilename.create(failureName, { ext: false })))
     .map((s) => {
-      const base64 = Fs.readFileSync(s.path).toString('base64');
+      const relPath = Path.relative(REPO_ROOT, s.path);
       return `
         <div class="screenshotContainer">
-          <img class="screenshot img-fluid img-thumbnail" src="data:image/png;base64,${base64}" />
+          <img class="screenshot img-fluid img-thumbnail" src="${escape(relPath)}" />
         </div>
       `;
     })

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file_html_template.html
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file_html_template.html
@@ -3,12 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
-      crossorigin="anonymous"
-    />
     <style type="text/css">
       pre {
         font-size: 0.75em !important;

--- a/x-pack/platform/test/functional/apps/visualize/reporting.ts
+++ b/x-pack/platform/test/functional/apps/visualize/reporting.ts
@@ -78,7 +78,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visualize.clickAreaChart();
         await visualize.clickNewSearch('ecommerce');
         await reporting.selectExportItem('PDF');
-        expect(await reporting.isGenerateReportButtonDisabled()).to.be(null);
+        expect(await reporting.isGenerateReportButtonDisabled()).to.be(true);
       });
 
       it('becomes available when saved', async () => {


### PR DESCRIPTION
Likely related to https://buildkite.com/resources/changelog/304-native-support-for-html-artifacts/.

There's a more restrictive content security policy in place now for html artifacts.  Instead of inlining test failure screenshots this references the uploaded artifacts.