### PR TITLE
[Security Solution] minor UI adjustments to the Intelligence page table

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/actions_row_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/actions_row_cell.tsx
@@ -7,6 +7,7 @@
 
 import type { FC } from 'react';
 import React from 'react';
+import { css } from '@emotion/react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useIndicatorsTableContext } from '../../hooks/use_table_context';
 import { MoreActions } from './more_actions';
@@ -18,24 +19,35 @@ import { INVESTIGATE_IN_TIMELINE_TEST_ID } from './test_ids';
 export const ActionsRowCell: FC<{ indicator: Indicator }> = ({ indicator }) => {
   const indicatorTableContext = useIndicatorsTableContext();
 
-  const { setExpanded, expanded } = indicatorTableContext;
+  const { setExpanded } = indicatorTableContext;
 
   return (
     <EuiFlexGroup justifyContent="center" gutterSize="none">
-      <EuiFlexItem grow={false}>
-        <OpenIndicatorFlyoutButton
-          indicator={indicator}
-          onOpen={setExpanded}
-          isOpen={Boolean(expanded && expanded._id === indicator._id)}
-        />
+      <EuiFlexItem
+        grow={false}
+        css={css`
+          width: 28px;
+        `}
+      >
+        <OpenIndicatorFlyoutButton indicator={indicator} onOpen={setExpanded} />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem
+        grow={false}
+        css={css`
+          width: 28px;
+        `}
+      >
         <InvestigateInTimelineButtonIcon
           data={indicator}
           data-test-subj={INVESTIGATE_IN_TIMELINE_TEST_ID}
         />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem
+        grow={false}
+        css={css`
+          width: 28px;
+        `}
+      >
         <MoreActions indicator={indicator} />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/actions_row_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/actions_row_cell.tsx
@@ -17,9 +17,7 @@ import { OpenIndicatorFlyoutButton } from './open_flyout_button';
 import { INVESTIGATE_IN_TIMELINE_TEST_ID } from './test_ids';
 
 export const ActionsRowCell: FC<{ indicator: Indicator }> = ({ indicator }) => {
-  const indicatorTableContext = useIndicatorsTableContext();
-
-  const { setExpanded } = indicatorTableContext;
+  const { setExpanded } = useIndicatorsTableContext();
 
   return (
     <EuiFlexGroup justifyContent="center" gutterSize="none">

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/more_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/more_actions.tsx
@@ -70,12 +70,11 @@ export const MoreActions: FC<TakeActionProps> = ({ indicator }) => {
     <EuiToolTip content={MORE_ACTIONS_BUTTON_LABEL} disableScreenReaderOutput>
       <EuiButtonIcon
         aria-label={MORE_ACTIONS_BUTTON_LABEL}
-        iconType="boxesHorizontal"
-        iconSize="s"
-        size="xs"
-        onClick={() => setPopover((prevIsPopoverOpen) => !prevIsPopoverOpen)}
-        css={{ height: '100%' }}
+        color="text"
         data-test-subj={MORE_ACTIONS_TEST_ID}
+        iconType="boxesHorizontal"
+        onClick={() => setPopover((prevIsPopoverOpen) => !prevIsPopoverOpen)}
+        size="s"
       />
     </EuiToolTip>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/open_flyout_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/open_flyout_button.test.tsx
@@ -15,25 +15,13 @@ import { BUTTON_TEST_ID } from './test_ids';
 const mockIndicator = generateMockIndicator();
 
 describe('<IndicatorsFlyout />', () => {
-  it('should render expand button if flyout is closed', () => {
+  it('should render expand button', () => {
     const { getByTestId } = render(
       <TestProvidersComponent>
-        <OpenIndicatorFlyoutButton indicator={mockIndicator} isOpen={false} onOpen={jest.fn()} />
+        <OpenIndicatorFlyoutButton indicator={mockIndicator} onOpen={jest.fn()} />
       </TestProvidersComponent>
     );
 
     expect(getByTestId(BUTTON_TEST_ID).innerHTML).toContain('expand');
-  });
-
-  it(`should render minimize button if flyout is open`, () => {
-    const { getByTestId } = render(
-      <TestProvidersComponent>
-        <OpenIndicatorFlyoutButton indicator={mockIndicator} isOpen={true} onOpen={jest.fn()} />
-      </TestProvidersComponent>
-    );
-
-    const button = getByTestId(BUTTON_TEST_ID);
-    button.click();
-    expect(button.innerHTML).toContain('minimize');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/open_flyout_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/open_flyout_button.tsx
@@ -21,10 +21,6 @@ export interface OpenIndicatorFlyoutButtonProps {
    * Method called by the onClick event to open/close the flyout.
    */
   onOpen: (indicator: Indicator) => void;
-  /**
-   * Boolean used to change the color and type of icon depending on the state of the flyout.
-   */
-  isOpen: boolean;
 }
 
 /**
@@ -33,18 +29,16 @@ export interface OpenIndicatorFlyoutButtonProps {
 export const OpenIndicatorFlyoutButton: FC<OpenIndicatorFlyoutButtonProps> = ({
   indicator,
   onOpen,
-  isOpen,
 }) => {
   return (
     <EuiToolTip content={VIEW_DETAILS_BUTTON_LABEL} disableScreenReaderOutput>
       <EuiButtonIcon
-        data-test-subj={BUTTON_TEST_ID}
-        color={isOpen ? 'text' : 'primary'}
-        iconType={isOpen ? 'minimize' : 'expand'}
-        isSelected={isOpen}
-        iconSize="s"
         aria-label={VIEW_DETAILS_BUTTON_LABEL}
+        color="text"
+        data-test-subj={BUTTON_TEST_ID}
+        iconType="expand"
         onClick={() => onOpen(indicator)}
+        size="s"
       />
     </EuiToolTip>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/open_flyout_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/open_flyout_button.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FC } from 'react';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import type { Indicator } from '../../../../../../common/threat_intelligence/types/indicator';
 import { BUTTON_TEST_ID } from './test_ids';
@@ -30,6 +30,8 @@ export const OpenIndicatorFlyoutButton: FC<OpenIndicatorFlyoutButtonProps> = ({
   indicator,
   onOpen,
 }) => {
+  const open = useCallback(() => onOpen(indicator), [indicator, onOpen]);
+
   return (
     <EuiToolTip content={VIEW_DETAILS_BUTTON_LABEL} disableScreenReaderOutput>
       <EuiButtonIcon
@@ -37,7 +39,7 @@ export const OpenIndicatorFlyoutButton: FC<OpenIndicatorFlyoutButtonProps> = ({
         color="text"
         data-test-subj={BUTTON_TEST_ID}
         iconType="expand"
-        onClick={() => onOpen(indicator)}
+        onClick={open}
         size="s"
       />
     </EuiToolTip>

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/table.tsx
@@ -19,10 +19,7 @@ import {
 } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
-import type {
-  EuiDataGridColumn,
-  EuiDataGridRowHeightsOptions,
-} from '@elastic/eui/src/components/datagrid/data_grid_types';
+import type { EuiDataGridColumn } from '@elastic/eui/src/components/datagrid/data_grid_types';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { CellActions } from './cell_actions';
 import { cellPopoverRendererFactory } from './cell_popover_renderer';
@@ -42,7 +39,7 @@ import type { Pagination } from '../../services/fetch_indicators';
 import { TABLE_TEST_ID, TABLE_UPDATE_PROGRESS_TEST_ID } from './test_ids';
 import { extractTimelineCapabilities } from '../../../../../common/utils/timeline_capabilities';
 
-const actionsColumnIconWidth = 28;
+const actionsColumnIconWidth = 32;
 
 export interface IndicatorsTableProps {
   indicators: Indicator[];
@@ -60,7 +57,7 @@ export interface IndicatorsTableProps {
 }
 
 const gridStyle = {
-  border: 'horizontal',
+  border: 'none',
   header: 'underline',
   cellPadding: 'm',
   fontSize: 's',
@@ -176,10 +173,6 @@ export const IndicatorsTable: FC<IndicatorsTableProps> = ({
       );
     }
 
-    const rowHeightsOptions: EuiDataGridRowHeightsOptions = {
-      lineHeight: '30px',
-    };
-
     if (!indicatorCount) {
       return <EmptyState />;
     }
@@ -213,7 +206,6 @@ export const IndicatorsTable: FC<IndicatorsTableProps> = ({
           sorting={sorting}
           columnVisibility={columnVisibility}
           columns={mappedColumns}
-          rowHeightsOptions={rowHeightsOptions}
         />
       </>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/timeline/components/investigate_in_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/timeline/components/investigate_in_timeline.tsx
@@ -99,12 +99,11 @@ export const InvestigateInTimelineButtonIcon: VFC<InvestigateInTimelineProps> = 
     <EuiToolTip content={BUTTON_ICON_LABEL} disableScreenReaderOutput>
       <EuiButtonIcon
         aria-label={BUTTON_ICON_LABEL}
-        iconType="timeline"
-        iconSize="s"
-        size="xs"
-        color="primary"
-        onClick={investigateInTimelineFn}
+        color="text"
         data-test-subj={dataTestSub}
+        iconType="timeline"
+        onClick={investigateInTimelineFn}
+        size="s"
       />
     </EuiToolTip>
   );


### PR DESCRIPTION
## Summary

This PR makes some very small UI adjustments to the Intelligence page table:
- the icons are now rendered in black and are slightly bigger, to match the rendering of the Alerts page (and most of the other page where we have a table)
- the rows are now a bit thinner in height and don't show a border, again to match the rendering of the Alerts page (and most of the other page where we have a table)

| Before  | After |
| ------------- | ------------- |
| <img width="1326" height="953" alt="Screenshot 2025-10-01 at 7 00 15 PM" src="https://github.com/user-attachments/assets/74da4daf-38b5-4cf5-b103-28f9195b83c7" /> | <img width="1328" height="950" alt="Screenshot 2025-10-01 at 6 56 55 PM" src="https://github.com/user-attachments/assets/63678baa-b5c3-45c2-95c3-e20559677fab" /> |

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->