### PR TITLE
Observability Onboarding: Fix footer padding

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/pages/template.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/pages/template.tsx
@@ -33,7 +33,6 @@ export const PageTemplate: React.FC<React.PropsWithChildren<TemplateProps>> = ({
       </EuiPageTemplate.Section>
       <EuiSpacer size="xl" />
       <EuiPageTemplate.Section
-        contentProps={{ css: { paddingBlock: 0 } }}
         css={css`
           padding-inline: 0px;
           border-top: ${euiTheme.border.thin};


### PR DESCRIPTION
Before:

<img width="1121" height="208" alt="Screenshot 2025-10-02 at 11 38 46" src="https://github.com/user-attachments/assets/640c6f89-91c9-4004-b7f8-dcc511d98bb3" />

After:

<img width="1146" height="273" alt="Screenshot 2025-10-02 at 11 38 28" src="https://github.com/user-attachments/assets/72221c1d-1d33-4add-9217-7f76d50b4704" />

The resource-links component is shared, I suspect that broke at some point due to a refactoring of the shared component.