### PR TITLE
[Observability AI Assistant] Fix missing space ID in conversation links (#231667)

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.test.ts
@@ -131,7 +131,7 @@ describe('Observability AI Assistant client', () => {
 
   let llmSimulator: LlmSimulator;
 
-  function createClient() {
+  function createClient(namespace: string = 'default') {
     jest.resetAllMocks();
 
     // uncomment this line for debugging
@@ -1658,9 +1658,9 @@ describe('Observability AI Assistant client', () => {
     });
 
     const runWithNamespace = async (namespace: string) => {
+      // client = createClient(namespace);
       client = createClient();
       (client as any).dependencies.namespace = namespace;
-
       (
         await client.complete({
           functionClient: functionClientMock,
@@ -1689,12 +1689,13 @@ describe('Observability AI Assistant client', () => {
     });
 
     it('generates a link with space segment for non-default space', async () => {
+      const space = 'myspace';
       await runWithNamespace('myspace');
 
       expect(functionClientMock.registerInstruction).toHaveBeenCalled();
       expect(functionClientMock.registerInstruction).toHaveBeenCalledWith(
         expect.stringContaining(
-          'http://localhost:5601/s/myspace/app/observabilityAIAssistant/conversations/'
+          `http://localhost:5601/s/${space}/app/observabilityAIAssistant/conversations/`
         )
       );
     });

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.test.ts
@@ -1646,4 +1646,57 @@ describe('Observability AI Assistant client', () => {
       });
     });
   });
+
+  describe('space-aware links', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      (functionClientMock as any).registerInstruction = jest.fn();
+      inferenceClientMock.chatComplete.mockImplementation(
+        () => new Observable((sub) => sub.complete())
+      );
+    });
+
+    const runWithNamespace = async (namespace: string) => {
+      client = createClient();
+      (client as any).dependencies.namespace = namespace;
+
+      (
+        await client.complete({
+          functionClient: functionClientMock,
+          connectorId: 'foo',
+          messages: [],
+          signal: new AbortController().signal,
+          persist: true,
+          kibanaPublicUrl: 'http://localhost:5601',
+          title: 'Generated title',
+        })
+      ).subscribe({});
+
+      await nextTick();
+    };
+
+    it('generates a link without space segment for default space', async () => {
+      await runWithNamespace('default');
+
+      expect(functionClientMock.registerInstruction).toHaveBeenCalled();
+      expect(functionClientMock.registerInstruction).toHaveBeenCalledWith(
+        expect.stringContaining('http://localhost:5601/app/observabilityAIAssistant/conversations/')
+      );
+      expect(functionClientMock.registerInstruction).not.toHaveBeenCalledWith(
+        expect.stringContaining('/s/')
+      );
+    });
+
+    it('generates a link with space segment for non-default space', async () => {
+      await runWithNamespace('myspace');
+
+      expect(functionClientMock.registerInstruction).toHaveBeenCalled();
+      expect(functionClientMock.registerInstruction).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'http://localhost:5601/s/myspace/app/observabilityAIAssistant/conversations/'
+        )
+      );
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -12,6 +12,7 @@ import type { Logger } from '@kbn/logging';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import { last, merge, omit } from 'lodash';
 import type { Observable } from 'rxjs';
+import { addSpaceIdToPath } from '@kbn/spaces-utils';
 import {
   catchError,
   defer,
@@ -207,10 +208,9 @@ export class ObservabilityAIAssistantClient {
 
       if (persist && !isConversationUpdate && kibanaPublicUrl) {
         const { namespace } = this.dependencies;
-        const spacePrefix =
-          namespace && namespace !== 'default' ? `/s/${encodeURIComponent(namespace)}` : '';
+        const spaceAwarePath = addSpaceIdToPath('/', namespace, '/app/observabilityAIAssistant');
 
-        const conversationUrl = `${kibanaPublicUrl}${spacePrefix}/app/observabilityAIAssistant/conversations/${conversationId}`;
+        const conversationUrl = `${kibanaPublicUrl}${spaceAwarePath}/conversations/${conversationId}`;
 
         functionClient.registerInstruction(
           `This conversation will be persisted in Kibana and available at this url: ${conversationUrl}.`

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -206,8 +206,14 @@ export class ObservabilityAIAssistantClient {
       const conversationId = persist ? predefinedConversationId || v4() : '';
 
       if (persist && !isConversationUpdate && kibanaPublicUrl) {
+        const { namespace } = this.dependencies;
+        const spacePrefix =
+          namespace && namespace !== 'default' ? `/s/${encodeURIComponent(namespace)}` : '';
+
+        const conversationUrl = `${kibanaPublicUrl}${spacePrefix}/app/observabilityAIAssistant/conversations/${conversationId}`;
+
         functionClient.registerInstruction(
-          `This conversation will be persisted in Kibana and available at this url: ${kibanaPublicUrl}/app/observabilityAIAssistant/conversations/${conversationId}.`
+          `This conversation will be persisted in Kibana and available at this url: ${conversationUrl}.`
         );
       }
 

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/tsconfig.json
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/tsconfig.json
@@ -60,7 +60,8 @@
     "@kbn/licensing-types",
     "@kbn/llm-tasks-plugin",
     "@kbn/product-doc-base-plugin",
-    "@kbn/inference-endpoint-plugin"
+    "@kbn/inference-endpoint-plugin",
+    "@kbn/spaces-utils"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/231667

## Summary

This MR fixes a bug where the Observability AI Assistant generated conversation links without including the space. As a result, links to conversations were broken in non-default spaces.

## Test scenarios 

### Presetup

1. Run es & kibana locally:  `yarn es snapshot --license trial` `yarn start --run-examples`
2. Run local MailHog:

`docker run -d --name mailhog -p 1025:1025 -p 8025:8025 mailhog/mailhog`
  Web UI: `http://localhost:8025/`
  SMTP port: `1025`

3. Create a new space in Kibana.
4. Create a new Email connector
<img width="942" height="605" alt="Screenshot 2025-10-01 at 18 37 46" src="https://github.com/user-attachments/assets/6e4661d5-3182-40f3-9da9-8af477281e80" />

5. Optional: If you dont have any data locally, you can monitor MailHog logs:
5.1. Create `elastic-agent.yml`:

```
outputs:
  default:
    type: elasticsearch
    hosts: ["http://host.docker.internal:9200"]
    username: "elastic"
    password: "changeme"
inputs:
  - type: filestream
    use_output: default
    streams:
      - paths: ["/var/lib/docker/containers/*/*-json.log"]
    parsers:
      - container: {}
```


5.2. Run elastic agent:

```
docker run -d --name ea \
  -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
  -v /var/run/docker.sock:/var/run/docker.sock:ro \
  -v $PWD/elastic-agent.yml:/usr/share/elastic-agent/elastic-agent.yml:ro \
  docker.elastic.co/beats/elastic-agent:8.14.3
```

5.3. Verify logs appear in Kibana.

6. Create an alert that will fire. Could be something like this 
<img width="1225" height="614" alt="Screenshot 2025-10-02 at 13 11 14" src="https://github.com/user-attachments/assets/f74dd1d9-43a5-437c-8598-f7cc9e1fdd04" />


7. Add an AI Assistant action with a prompt like:
`send an email to me@example.com with an action plan`
<img width="1247" height="560" alt="Screenshot 2025-10-02 at 13 11 25" src="https://github.com/user-attachments/assets/875877f9-b5e4-4db0-8231-f25405a4d7fb" />


8. Save and wait the alert to trigger.

9. Observe that the Observability AI Assistant created a chat for the alert and generated conversation link contains space 

10. Open MailHog http://localhost:8025/# and check that you received an email with alert's info and it contains links to with space info 






<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->