### PR TITLE
[8.18][Fleet] Re-enable inputs_with_standalone_docker_agent test (#237137)

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
+++ b/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
@@ -25,8 +25,7 @@ export default function (providerContext: FtrProviderContext) {
   const config = getService('config');
   const log = getService('log');
 
-  // Failing: See https://github.com/elastic/kibana/issues/193625
-  describe.skip('inputs_with_standalone_docker_agent', () => {
+  describe('inputs_with_standalone_docker_agent', () => {
     skipIfNoDockerRegistry(providerContext);
     let apiKey: string;
     let agent: AgentProcess;


### PR DESCRIPTION
Backport https://github.com/elastic/kibana/pull/237137 to 8.18