### PR TITLE
[ES|QL] Add `esql.suggestions_with_custom_command_shown` telemetry event

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -495,6 +495,8 @@ const ESQLEditorInternal = function ESQLEditor({
     () => ({
       onDecorationHoverShown: (hoverMessage: string) =>
         telemetryService.trackLookupJoinHoverActionShown(hoverMessage),
+      onSuggestionsWithCustomCommandShown: (commandIds: string[]) =>
+        telemetryService.trackSuggestionsWithCustomCommandShown(commandIds),
     }),
     [telemetryService]
   );
@@ -790,8 +792,8 @@ const ESQLEditorInternal = function ESQLEditor({
   );
 
   const suggestionProvider = useMemo(
-    () => ESQLLang.getSuggestionProvider?.(esqlCallbacks),
-    [esqlCallbacks]
+    () => ESQLLang.getSuggestionProvider?.({ ...esqlCallbacks, telemetry: telemetryCallbacks }),
+    [esqlCallbacks, telemetryCallbacks]
   );
 
   const hoverProvider = useMemo(

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/events_registration.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/events_registration.ts
@@ -14,6 +14,8 @@ import { once } from 'lodash';
  * Event types.
  */
 export const ESQL_LOOKUP_JOIN_ACTION_SHOWN = 'esql.lookup_action_shown';
+export const ESQL_SUGGESTIONS_WITH_CUSTOM_COMMAND_SHOWN =
+  'esql.suggestions_with_custom_command_shown';
 
 /**
  * Registers the esql editor analytics events.
@@ -42,6 +44,24 @@ export const registerESQLEditorAnalyticsEvents = once((analytics: AnalyticsServi
         _meta: {
           description:
             'The higher privilege the user has for this index. Possible values are: create|edit|read',
+        },
+      },
+    },
+  });
+
+  analytics.registerEventType({
+    eventType: ESQL_SUGGESTIONS_WITH_CUSTOM_COMMAND_SHOWN,
+    schema: {
+      command_names: {
+        type: 'array',
+        items: {
+          type: 'keyword',
+          _meta: {
+            description: 'The command id attached to the suggestion item',
+          },
+        },
+        _meta: {
+          description: 'List of commands ids suggested',
         },
       },
     },

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/events_registration.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/events_registration.ts
@@ -52,7 +52,7 @@ export const registerESQLEditorAnalyticsEvents = once((analytics: AnalyticsServi
   analytics.registerEventType({
     eventType: ESQL_SUGGESTIONS_WITH_CUSTOM_COMMAND_SHOWN,
     schema: {
-      command_names: {
+      command_ids: {
         type: 'array',
         items: {
           type: 'keyword',

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.ts
@@ -70,7 +70,7 @@ export class ESQLEditorTelemetryService {
 
   public trackSuggestionsWithCustomCommandShown(commandIds: string[]) {
     this._reportEvent(ESQL_SUGGESTIONS_WITH_CUSTOM_COMMAND_SHOWN, {
-      command_names: commandIds,
+      command_ids: commandIds,
     });
   }
 

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.ts
@@ -7,7 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import type { AnalyticsServiceStart } from '@kbn/core/server';
-import { ESQL_LOOKUP_JOIN_ACTION_SHOWN } from './events_registration';
+import {
+  ESQL_LOOKUP_JOIN_ACTION_SHOWN,
+  ESQL_SUGGESTIONS_WITH_CUSTOM_COMMAND_SHOWN,
+} from './events_registration';
 import type { IndexEditorCommandArgs } from '../custom_commands/use_lookup_index_editor';
 import { COMMAND_ID as LOOKUP_INDEX_EDITOR_COMMAND } from '../custom_commands/use_lookup_index_editor';
 
@@ -63,6 +66,12 @@ export class ESQLEditorTelemetryService {
         highest_privilege: commandData.highestPrivilege,
       });
     }
+  }
+
+  public trackSuggestionsWithCustomCommandShown(commandIds: string[]) {
+    this._reportEvent(ESQL_SUGGESTIONS_WITH_CUSTOM_COMMAND_SHOWN, {
+      command_names: commandIds,
+    });
   }
 
   private _determineTriggerAction(commandData: IndexEditorCommandArgs): string {

--- a/src/platform/packages/shared/kbn-esql-types/src/esql_telemetry_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/esql_telemetry_types.ts
@@ -8,5 +8,6 @@
  */
 
 export interface ESQLTelemetryCallbacks {
-  onDecorationHoverShown: (hoverMessage: string) => void;
+  onDecorationHoverShown?: (hoverMessage: string) => void;
+  onSuggestionsWithCustomCommandShown?: (commandNames: string[]) => void;
 }

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.test.ts
@@ -8,14 +8,15 @@
  */
 
 import type { PartialFieldsMetadataClient } from '@kbn/esql-validation-autocomplete/src/shared/types';
-import { getHoverItem } from '@kbn/esql-validation-autocomplete';
+import { getHoverItem, suggest } from '@kbn/esql-validation-autocomplete';
 import { monaco } from '../../monaco_imports';
 import { ESQLLang, type ESQLDependencies } from './language';
 
-// Mock the getHoverItem function
+// Mock the getHoverItem and suggest functions
 jest.mock('@kbn/esql-validation-autocomplete', () => ({
   ...jest.requireActual('@kbn/esql-validation-autocomplete'),
   getHoverItem: jest.fn(),
+  suggest: jest.fn(),
 }));
 
 describe('ESQLLang', () => {
@@ -135,6 +136,80 @@ describe('ESQLLang', () => {
         expect(mockFind).toBeCalledTimes(1);
         expect(notECSFieldResolvedItem).toEqual(notECSFieldItem);
       });
+
+      it('should call onSuggestionsWithCustomCommandShown when suggestions contain custom commands', async () => {
+        const mockOnSuggestionsWithCustomCommandShown = jest.fn();
+
+        const mockDeps: ESQLDependencies = {
+          telemetry: {
+            onSuggestionsWithCustomCommandShown: mockOnSuggestionsWithCustomCommandShown,
+          },
+        };
+
+        // Mock the suggest function to return suggestions with custom commands
+        const mockSuggest = suggest as jest.MockedFunction<typeof suggest>;
+        mockSuggest.mockResolvedValue([
+          {
+            label: 'EVAL',
+            text: 'EVAL',
+            kind: 'Keyword',
+            detail: 'EVAL command',
+            command: {
+              title: 'Trigger suggest',
+              id: 'editor.action.triggerSuggest',
+            },
+          },
+          {
+            label: 'Custom Command 1',
+            text: 'custom1',
+            kind: 'Method',
+            detail: 'Custom command 1',
+            command: {
+              title: 'Custom Action 1',
+              id: 'custom.command.1',
+            },
+          },
+          {
+            label: 'Custom Command 2',
+            text: 'custom2',
+            kind: 'Method',
+            detail: 'Custom command 2',
+            command: {
+              title: 'Custom Action 2',
+              id: 'custom.command.2',
+            },
+          },
+          {
+            label: 'No Command',
+            text: 'nocommand',
+            kind: 'Variable',
+            detail: 'No command item',
+          },
+        ]);
+
+        const suggestionProvider = ESQLLang.getSuggestionProvider(mockDeps);
+
+        const mockModel = {
+          getValue: jest.fn().mockReturnValue('FROM index | EVAL'),
+        } as unknown as monaco.editor.ITextModel;
+
+        const mockPosition = new monaco.Position(1, 18);
+        const mockContext = {} as monaco.languages.CompletionContext;
+        const mockToken = {} as monaco.CancellationToken;
+
+        await suggestionProvider.provideCompletionItems(
+          mockModel,
+          mockPosition,
+          mockContext,
+          mockToken
+        );
+
+        // Should be called with the custom command IDs (excluding 'editor.action.triggerSuggest')
+        expect(mockOnSuggestionsWithCustomCommandShown).toHaveBeenCalledWith([
+          'custom.command.1',
+          'custom.command.2',
+        ]);
+      });
     });
   });
 
@@ -166,6 +241,7 @@ describe('ESQLLang', () => {
           getFieldsMetadata: Promise.resolve({} as any),
           telemetry: {
             onDecorationHoverShown: jest.fn(),
+            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 
@@ -187,6 +263,7 @@ describe('ESQLLang', () => {
         const mockDeps: ESQLDependencies = {
           telemetry: {
             onDecorationHoverShown: mockOnDecorationHoverShown,
+            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 
@@ -221,6 +298,7 @@ describe('ESQLLang', () => {
         const mockDeps: ESQLDependencies = {
           telemetry: {
             onDecorationHoverShown: mockOnDecorationHoverShown,
+            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 
@@ -260,6 +338,7 @@ describe('ESQLLang', () => {
         const mockDeps: ESQLDependencies = {
           telemetry: {
             onDecorationHoverShown: mockOnDecorationHoverShown,
+            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 
@@ -306,6 +385,7 @@ describe('ESQLLang', () => {
         const mockDeps: ESQLDependencies = {
           telemetry: {
             onDecorationHoverShown: mockOnDecorationHoverShown,
+            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 
@@ -332,6 +412,7 @@ describe('ESQLLang', () => {
         const mockDeps: ESQLDependencies = {
           telemetry: {
             onDecorationHoverShown: mockOnDecorationHoverShown,
+            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.test.ts
@@ -241,7 +241,6 @@ describe('ESQLLang', () => {
           getFieldsMetadata: Promise.resolve({} as any),
           telemetry: {
             onDecorationHoverShown: jest.fn(),
-            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 
@@ -263,7 +262,6 @@ describe('ESQLLang', () => {
         const mockDeps: ESQLDependencies = {
           telemetry: {
             onDecorationHoverShown: mockOnDecorationHoverShown,
-            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 
@@ -298,7 +296,6 @@ describe('ESQLLang', () => {
         const mockDeps: ESQLDependencies = {
           telemetry: {
             onDecorationHoverShown: mockOnDecorationHoverShown,
-            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 
@@ -338,7 +335,6 @@ describe('ESQLLang', () => {
         const mockDeps: ESQLDependencies = {
           telemetry: {
             onDecorationHoverShown: mockOnDecorationHoverShown,
-            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 
@@ -385,7 +381,6 @@ describe('ESQLLang', () => {
         const mockDeps: ESQLDependencies = {
           telemetry: {
             onDecorationHoverShown: mockOnDecorationHoverShown,
-            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 
@@ -412,7 +407,6 @@ describe('ESQLLang', () => {
         const mockDeps: ESQLDependencies = {
           telemetry: {
             onDecorationHoverShown: mockOnDecorationHoverShown,
-            onSuggestionsWithCustomCommandShown: jest.fn(),
           },
         };
 

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.ts
@@ -22,7 +22,11 @@ import type { CustomLangModuleType } from '../../types';
 import { ESQL_LANG_ID } from './lib/constants';
 import { wrapAsMonacoMessages } from './lib/converters/positions';
 import { wrapAsMonacoSuggestions } from './lib/converters/suggestions';
-import { getDecorationHoveredMessages, monacoPositionToOffset } from './lib/shared/utils';
+import {
+  getDecorationHoveredMessages,
+  filterSuggestionsWithCustomCommands,
+  monacoPositionToOffset,
+} from './lib/shared/utils';
 import { buildEsqlTheme } from './lib/theme';
 
 const removeKeywordSuffix = (name: string) => {
@@ -107,7 +111,7 @@ export const ESQLLang: CustomLangModuleType<ESQLDependencies, MonacoMessage> = {
       },
     };
   },
-  getSuggestionProvider: (callbacks?: ESQLCallbacks): monaco.languages.CompletionItemProvider => {
+  getSuggestionProvider: (deps?: ESQLDependencies): monaco.languages.CompletionItemProvider => {
     return {
       triggerCharacters: ESQL_AUTOCOMPLETE_TRIGGER_CHARS,
       async provideCompletionItems(
@@ -116,12 +120,18 @@ export const ESQLLang: CustomLangModuleType<ESQLDependencies, MonacoMessage> = {
       ): Promise<monaco.languages.CompletionList> {
         const fullText = model.getValue();
         const offset = monacoPositionToOffset(fullText, position);
-        const suggestions = await suggest(fullText, offset, callbacks);
+        const suggestions = await suggest(fullText, offset, deps);
+
+        const suggestionsWithCustomCommands = filterSuggestionsWithCustomCommands(suggestions);
+        if (suggestionsWithCustomCommands.length) {
+          deps?.telemetry?.onSuggestionsWithCustomCommandShown?.(suggestionsWithCustomCommands);
+        }
+
         return wrapAsMonacoSuggestions(suggestions, fullText);
       },
       async resolveCompletionItem(item, token): Promise<monaco.languages.CompletionItem> {
-        if (!callbacks?.getFieldsMetadata) return item;
-        const fieldsMetadataClient = await callbacks?.getFieldsMetadata;
+        if (!deps?.getFieldsMetadata) return item;
+        const fieldsMetadataClient = await deps?.getFieldsMetadata;
 
         const fullEcsMetadataList = await fieldsMetadataClient?.find({
           attributes: ['type'],

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/shared/utils.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/shared/utils.ts
@@ -8,6 +8,7 @@
  */
 
 import { isArray } from 'lodash';
+import type { ISuggestionItem } from '@kbn/esql-ast/src/commands_registry/types';
 import { monaco } from '../../../../monaco_imports';
 
 // From Monaco position to linear offset
@@ -114,4 +115,18 @@ export const getDecorationHoveredMessages = (
     console.error('Error extracting decoration hover messages:', error);
     return [];
   }
+};
+
+/**
+ * Extracts the suggestions with custom commands from a list of suggestions.
+ * Suggestions with editor.action.triggerSuggest are excluded.
+ * @param suggestions
+ * @returns
+ */
+export const filterSuggestionsWithCustomCommands = (suggestions: ISuggestionItem[]): string[] => {
+  return suggestions
+    .filter(
+      (suggestion) => suggestion.command && suggestion.command.id !== 'editor.action.triggerSuggest'
+    )
+    .map((suggestion) => suggestion.command!.id); // we know command is defined because of the filter
 };


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/235376
## Summary
In order to track when the lookup join "Create lookup index" suggestion is shown, a new event `esql.suggestions_with_custom_command_shown` is introduced.

Instead of only tracking particularly the lookup join suggestion this event tracks whenever a suggestion with a custom command is shown, for instance this event also works for `controls` suggestions.

If multiple suggestions with commands are shown, a single event is sent with an array of command ids.

`esql.suggestions_with_custom_command_shown`

```ts
{
      command_ids: {
        type: 'array',
        items: {
          type: 'keyword',
          _meta: {
            description: 'The command id attached to the suggestion item',
          },
        },
        _meta: {
          description: 'List of commands ids suggested',
        },
      },
    }
```

<img width="634" height="279" alt="image" src="https://github.com/user-attachments/assets/0b7a93cd-9de7-40ff-95b8-3434bcad60fd" />

<img width="635" height="259" alt="image" src="https://github.com/user-attachments/assets/869b671a-d9af-43c9-8677-b02e9b472266" />


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



