### PR TITLE
[9.2] [Upgrade Assistant] Fix privileges for reindexing indices (#237055)

### DIFF
--- a/x-pack/platform/plugins/private/reindex_service/server/src/lib/reindex_service.test.ts
+++ b/x-pack/platform/plugins/private/reindex_service/server/src/lib/reindex_service.test.ts
@@ -110,10 +110,6 @@ describe('reindexService', () => {
             allow_restricted_indices: true,
             privileges: ['all'],
           },
-          {
-            names: ['.tasks'],
-            privileges: ['read'],
-          },
         ],
       });
     });

--- a/x-pack/platform/plugins/private/reindex_service/server/src/lib/reindex_service.ts
+++ b/x-pack/platform/plugins/private/reindex_service/server/src/lib/reindex_service.ts
@@ -543,10 +543,6 @@ export const reindexServiceFactory = (
             allow_restricted_indices: true,
             privileges: ['all'],
           },
-          {
-            names: ['.tasks'],
-            privileges: ['read'],
-          },
         ],
       });
 

--- a/x-pack/platform/plugins/private/reindex_service/server/src/lib/reindex_service_wrapper.ts
+++ b/x-pack/platform/plugins/private/reindex_service/server/src/lib/reindex_service_wrapper.ts
@@ -34,7 +34,6 @@ import type {
 import type { ReindexSavedObject } from './types';
 
 export interface ReindexServiceScopedClientArgs {
-  savedObjects: SavedObjectsClientContract;
   dataClient: IScopedClusterClient;
   request: KibanaRequest;
 }
@@ -74,6 +73,7 @@ export class ReindexServiceWrapper {
     logger: Logger;
     licensing: LicensingPluginStart;
     security: SecurityPluginStart;
+    soClient: SavedObjectsClientContract;
     version: Version;
   };
 
@@ -91,6 +91,7 @@ export class ReindexServiceWrapper {
       logger,
       licensing,
       security,
+      soClient,
       version,
     };
 
@@ -116,10 +117,13 @@ export class ReindexServiceWrapper {
   public getScopedClient({
     dataClient,
     request,
-    savedObjects,
   }: ReindexServiceScopedClientArgs): ReindexServiceScopedClient {
     const callAsCurrentUser = dataClient.asCurrentUser;
-    const reindexActions = reindexActionsFactory(savedObjects, callAsCurrentUser, this.deps.logger);
+    const reindexActions = reindexActionsFactory(
+      this.deps.soClient,
+      callAsCurrentUser,
+      this.deps.logger
+    );
     const reindexService = reindexServiceFactory(
       callAsCurrentUser,
       reindexActions,

--- a/x-pack/platform/plugins/private/reindex_service/server/src/routes/batch_reindex_indices.ts
+++ b/x-pack/platform/plugins/private/reindex_service/server/src/routes/batch_reindex_indices.ts
@@ -8,7 +8,6 @@
 import { schema } from '@kbn/config-schema';
 import { errors } from '@elastic/elasticsearch';
 import { handleEsError } from '@kbn/es-ui-shared-plugin/server';
-import { REINDEX_OP_TYPE } from '@kbn/upgrade-assistant-pkg-server';
 import { REINDEX_SERVICE_BASE_PATH } from '../../../common';
 import type { RouteDependencies } from '../../types';
 import { mapAnyErrorToKibanaHttpResponse } from './map_any_error_to_kibana_http_response';
@@ -33,13 +32,10 @@ export function registerBatchReindexIndicesRoutes({
     async ({ core }, request, response) => {
       const {
         elasticsearch: { client: esClient },
-        savedObjects,
       } = await core;
-      const { getClient } = savedObjects;
 
       try {
         const reindexService = (await getReindexService()).getScopedClient({
-          savedObjects: getClient({ includedHiddenTypes: [REINDEX_OP_TYPE] }),
           dataClient: esClient,
           request,
         });
@@ -74,13 +70,11 @@ export function registerBatchReindexIndicesRoutes({
     },
     async ({ core }, request, response) => {
       const {
-        savedObjects: { getClient },
         elasticsearch: { client: esClient },
       } = await core;
       const { indices } = request.body;
 
       const reindexService = (await getReindexService()).getScopedClient({
-        savedObjects: getClient({ includedHiddenTypes: [REINDEX_OP_TYPE] }),
         dataClient: esClient,
         request,
       });

--- a/x-pack/platform/plugins/private/reindex_service/server/src/routes/reindex_indices.ts
+++ b/x-pack/platform/plugins/private/reindex_service/server/src/routes/reindex_indices.ts
@@ -8,7 +8,6 @@
 import { schema } from '@kbn/config-schema';
 import { errors } from '@elastic/elasticsearch';
 import { handleEsError } from '@kbn/es-ui-shared-plugin/server';
-import { REINDEX_OP_TYPE } from '@kbn/upgrade-assistant-pkg-server';
 import { REINDEX_SERVICE_BASE_PATH } from '../../../common';
 import type { RouteDependencies } from '../../types';
 import { mapAnyErrorToKibanaHttpResponse } from './map_any_error_to_kibana_http_response';
@@ -53,7 +52,6 @@ export function registerReindexIndicesRoutes({ router, getReindexService }: Rout
     },
     async ({ core }, request, response) => {
       const {
-        savedObjects: { getClient },
         elasticsearch: { client: esClient },
       } = await core;
 
@@ -63,7 +61,6 @@ export function registerReindexIndicesRoutes({ router, getReindexService }: Rout
 
       try {
         const reindexService = (await getReindexService()).getScopedClient({
-          savedObjects: getClient({ includedHiddenTypes: [REINDEX_OP_TYPE] }),
           dataClient: esClient,
           request,
         });
@@ -103,15 +100,12 @@ export function registerReindexIndicesRoutes({ router, getReindexService }: Rout
     },
     async ({ core }, request, response) => {
       const {
-        savedObjects,
         elasticsearch: { client: esClient },
       } = await core;
-      const { getClient } = savedObjects;
       const { indexName } = request.params;
 
       try {
         const reindexService = (await getReindexService()).getScopedClient({
-          savedObjects: getClient({ includedHiddenTypes: [REINDEX_OP_TYPE] }),
           dataClient: esClient,
           request,
         });
@@ -147,15 +141,12 @@ export function registerReindexIndicesRoutes({ router, getReindexService }: Rout
     },
     async ({ core }, request, response) => {
       const {
-        savedObjects,
         elasticsearch: { client: esClient },
       } = await core;
       const { indexName } = request.params;
-      const { getClient } = savedObjects;
 
       try {
         const reindexService = (await getReindexService()).getScopedClient({
-          savedObjects: getClient({ includedHiddenTypes: [REINDEX_OP_TYPE] }),
           dataClient: esClient,
           request,
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Upgrade Assistant] Fix privileges for reindexing indices (#237055)](https://github.com/elastic/kibana/pull/237055)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Matthew Kime","email":"matt@mattki.me"},"sourceCommit":{"committedDate":"2025-10-02T13:43:31Z","message":"[Upgrade Assistant] Fix privileges for reindexing indices (#237055)\n\n## Summary\n\nPreviously Upgrade Assistant was checking for `.tasks` index access when\nchecking privs in order to reindex an index. Only the `superuser` role\nprovides access. Further, access is not needed as its been replaced by\nthe tasks api which is available via `cluster: ['manage']`\n\nAdditionally, the saved objects client usage required the `superuser`\nrole since the reindex saved object was hidden and we didn't have a way\nof providing kibana feature privileges for the saved object. The\nsolution is to rely on our our preexisting privilege checks (cluster:\nmanage and 'all' access for the particular indices being reindexed) and\nuse the internal saved object client.\n\nPart of https://github.com/elastic/kibana/issues/237054\n\nTo test -\n\nCreate a role with the following (index names could be more limited and\nit should work)\n```\n{\n  \"cluster\": [ \"manage\" ],\n  \"index\" : [\n    {\n      \"names\": [ \"*\" ],\n      \"privileges\": [ \"all\" ]\n    }\n  ]\n}\n```\nassign it to a user. Now try running upgrade assistant and reindexing\nwith that user. It should work.\n\nSimplified testing of upgrade assistant - \nTo test, follow directions here -\nhttps://github.com/elastic/kibana/pull/228705\nMocked response -\nhttps://github.com/elastic/kibana/pull/230021/commits/5aab34cdcee2df76d702a058348388a7d10fb73c#diff-f7eb2d7fe666aad1bedcd73d356612d2f74f81c76ba2e8e26b2983b9fb92a661R50\n\n---\n\nRelease note\n\nFixes privilege requirements when reindexing indices via Upgrade\nAssistant. Previously, the \"superuser\" role was required. Now \"cluster:\nmanage\" and \"all\" privileges for the relevant indices are sufficient.","sha":"0250b590f20ac6dcdc5df64ee0a8fd758553957c","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Kibana Management","Feature:Upgrade Assistant","backport:version","v9.2.0","v8.18.8","v8.19.5","v9.0.8","v9.1.5"],"title":"[Upgrade Assistant] Fix privileges for reindexing indices","number":237055,"url":"https://github.com/elastic/kibana/pull/237055","mergeCommit":{"message":"[Upgrade Assistant] Fix privileges for reindexing indices (#237055)\n\n## Summary\n\nPreviously Upgrade Assistant was checking for `.tasks` index access when\nchecking privs in order to reindex an index. Only the `superuser` role\nprovides access. Further, access is not needed as its been replaced by\nthe tasks api which is available via `cluster: ['manage']`\n\nAdditionally, the saved objects client usage required the `superuser`\nrole since the reindex saved object was hidden and we didn't have a way\nof providing kibana feature privileges for the saved object. The\nsolution is to rely on our our preexisting privilege checks (cluster:\nmanage and 'all' access for the particular indices being reindexed) and\nuse the internal saved object client.\n\nPart of https://github.com/elastic/kibana/issues/237054\n\nTo test -\n\nCreate a role with the following (index names could be more limited and\nit should work)\n```\n{\n  \"cluster\": [ \"manage\" ],\n  \"index\" : [\n    {\n      \"names\": [ \"*\" ],\n      \"privileges\": [ \"all\" ]\n    }\n  ]\n}\n```\nassign it to a user. Now try running upgrade assistant and reindexing\nwith that user. It should work.\n\nSimplified testing of upgrade assistant - \nTo test, follow directions here -\nhttps://github.com/elastic/kibana/pull/228705\nMocked response -\nhttps://github.com/elastic/kibana/pull/230021/commits/5aab34cdcee2df76d702a058348388a7d10fb73c#diff-f7eb2d7fe666aad1bedcd73d356612d2f74f81c76ba2e8e26b2983b9fb92a661R50\n\n---\n\nRelease note\n\nFixes privilege requirements when reindexing indices via Upgrade\nAssistant. Previously, the \"superuser\" role was required. Now \"cluster:\nmanage\" and \"all\" privileges for the relevant indices are sufficient.","sha":"0250b590f20ac6dcdc5df64ee0a8fd758553957c"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.19","9.0","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237055","number":237055,"mergeCommit":{"message":"[Upgrade Assistant] Fix privileges for reindexing indices (#237055)\n\n## Summary\n\nPreviously Upgrade Assistant was checking for `.tasks` index access when\nchecking privs in order to reindex an index. Only the `superuser` role\nprovides access. Further, access is not needed as its been replaced by\nthe tasks api which is available via `cluster: ['manage']`\n\nAdditionally, the saved objects client usage required the `superuser`\nrole since the reindex saved object was hidden and we didn't have a way\nof providing kibana feature privileges for the saved object. The\nsolution is to rely on our our preexisting privilege checks (cluster:\nmanage and 'all' access for the particular indices being reindexed) and\nuse the internal saved object client.\n\nPart of https://github.com/elastic/kibana/issues/237054\n\nTo test -\n\nCreate a role with the following (index names could be more limited and\nit should work)\n```\n{\n  \"cluster\": [ \"manage\" ],\n  \"index\" : [\n    {\n      \"names\": [ \"*\" ],\n      \"privileges\": [ \"all\" ]\n    }\n  ]\n}\n```\nassign it to a user. Now try running upgrade assistant and reindexing\nwith that user. It should work.\n\nSimplified testing of upgrade assistant - \nTo test, follow directions here -\nhttps://github.com/elastic/kibana/pull/228705\nMocked response -\nhttps://github.com/elastic/kibana/pull/230021/commits/5aab34cdcee2df76d702a058348388a7d10fb73c#diff-f7eb2d7fe666aad1bedcd73d356612d2f74f81c76ba2e8e26b2983b9fb92a661R50\n\n---\n\nRelease note\n\nFixes privilege requirements when reindexing indices via Upgrade\nAssistant. Previously, the \"superuser\" role was required. Now \"cluster:\nmanage\" and \"all\" privileges for the relevant indices are sufficient.","sha":"0250b590f20ac6dcdc5df64ee0a8fd758553957c"}},{"branch":"8.18","label":"v8.18.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->