### PR TITLE
[9.0] [Upgrade Assistant] Fix privileges for reindexing indices (#237055)

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/reindexing/reindex_service.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/reindexing/reindex_service.test.ts
@@ -109,10 +109,6 @@ describe('reindexService', () => {
               allow_restricted_indices: true,
               privileges: ['all'],
             },
-            {
-              names: ['.tasks'],
-              privileges: ['read'],
-            },
           ],
         },
       });

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/reindexing/reindex_service.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/reindexing/reindex_service.ts
@@ -457,10 +457,6 @@ export const reindexServiceFactory = (
               allow_restricted_indices: true,
               privileges: ['all'],
             },
-            {
-              names: ['.tasks'],
-              privileges: ['read'],
-            },
           ],
         },
       });

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/reindex_indices/batch_reindex_indices.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/reindex_indices/batch_reindex_indices.ts
@@ -34,7 +34,6 @@ export function registerBatchReindexIndicesRoutes(
 ) {
   const BASE_PATH = `${API_BASE_PATH}/reindex`;
 
-
   const soClient = new SavedObjectsClient(
     getSavedObjectsService().createInternalRepository([REINDEX_OP_TYPE])
   );
@@ -57,10 +56,7 @@ export function registerBatchReindexIndicesRoutes(
       } = await core;
       const callAsCurrentUser = esClient.asCurrentUser;
 
-      const reindexActions = reindexActionsFactory(
-        soClient,
-        callAsCurrentUser
-      );
+      const reindexActions = reindexActionsFactory(soClient, callAsCurrentUser);
       try {
         const inProgressOps = await reindexActions.findAllByStatus(ReindexStatus.inProgress);
         const { queue } = sortAndOrderReindexOperations(inProgressOps);

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/reindex_indices/batch_reindex_indices.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/reindex_indices/batch_reindex_indices.ts
@@ -34,11 +34,6 @@ export function registerBatchReindexIndicesRoutes(
 ) {
   const BASE_PATH = `${API_BASE_PATH}/reindex`;
 
-
-  const soClient = new SavedObjectsClient(
-    getSavedObjectsService().createInternalRepository([REINDEX_OP_TYPE])
-  );
-
   // Get the current batch queue
   router.get(
     {
@@ -56,6 +51,10 @@ export function registerBatchReindexIndicesRoutes(
         elasticsearch: { client: esClient },
       } = await core;
       const callAsCurrentUser = esClient.asCurrentUser;
+
+      const soClient = new SavedObjectsClient(
+        getSavedObjectsService().createInternalRepository([REINDEX_OP_TYPE])
+      );
 
       const reindexActions = reindexActionsFactory(
         soClient,
@@ -100,6 +99,11 @@ export function registerBatchReindexIndicesRoutes(
         elasticsearch: { client: esClient },
       } = await core;
       const { indexNames } = request.body;
+
+      const soClient = new SavedObjectsClient(
+        getSavedObjectsService().createInternalRepository([REINDEX_OP_TYPE])
+      );
+
       const results: PostBatchResponse = {
         enqueued: [],
         errors: [],

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/reindex_indices/reindex_indices.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/reindex_indices/reindex_indices.ts
@@ -32,10 +32,6 @@ export function registerReindexIndicesRoutes(
 ) {
   const BASE_PATH = `${API_BASE_PATH}/reindex`;
 
-  const soClient = new SavedObjectsClient(
-    getSavedObjectsService().createInternalRepository([REINDEX_OP_TYPE])
-  );
-
   // Start reindex for an index
   router.post(
     {
@@ -57,6 +53,10 @@ export function registerReindexIndicesRoutes(
         elasticsearch: { client: esClient },
       } = await core;
       const { indexName } = request.params;
+
+      const soClient = new SavedObjectsClient(
+        getSavedObjectsService().createInternalRepository([REINDEX_OP_TYPE])
+      );
 
       try {
         const result = await reindexHandler({
@@ -102,7 +102,12 @@ export function registerReindexIndicesRoutes(
       const { indexName } = request.params;
       const asCurrentUser = esClient.asCurrentUser;
 
-      const reindexActions = reindexActionsFactory( soClient, asCurrentUser);
+
+      const soClient = new SavedObjectsClient(
+        getSavedObjectsService().createInternalRepository([REINDEX_OP_TYPE])
+    );
+
+      const reindexActions = reindexActionsFactory(soClient, asCurrentUser);
       const reindexService = reindexServiceFactory(asCurrentUser, reindexActions, log, licensing);
 
       try {

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/reindex_indices/reindex_indices.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/reindex_indices/reindex_indices.ts
@@ -102,7 +102,7 @@ export function registerReindexIndicesRoutes(
       const { indexName } = request.params;
       const asCurrentUser = esClient.asCurrentUser;
 
-      const reindexActions = reindexActionsFactory( soClient, asCurrentUser);
+      const reindexActions = reindexActionsFactory(soClient, asCurrentUser);
       const reindexService = reindexServiceFactory(asCurrentUser, reindexActions, log, licensing);
 
       try {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Upgrade Assistant] Fix privileges for reindexing indices (#237055)](https://github.com/elastic/kibana/pull/237055)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Matthew Kime","email":"matt@mattki.me"},"sourceCommit":{"committedDate":"2025-10-02T13:43:31Z","message":"[Upgrade Assistant] Fix privileges for reindexing indices (#237055)\n\n## Summary\n\nPreviously Upgrade Assistant was checking for `.tasks` index access when\nchecking privs in order to reindex an index. Only the `superuser` role\nprovides access. Further, access is not needed as its been replaced by\nthe tasks api which is available via `cluster: ['manage']`\n\nAdditionally, the saved objects client usage required the `superuser`\nrole since the reindex saved object was hidden and we didn't have a way\nof providing kibana feature privileges for the saved object. The\nsolution is to rely on our our preexisting privilege checks (cluster:\nmanage and 'all' access for the particular indices being reindexed) and\nuse the internal saved object client.\n\nPart of https://github.com/elastic/kibana/issues/237054\n\nTo test -\n\nCreate a role with the following (index names could be more limited and\nit should work)\n```\n{\n  \"cluster\": [ \"manage\" ],\n  \"index\" : [\n    {\n      \"names\": [ \"*\" ],\n      \"privileges\": [ \"all\" ]\n    }\n  ]\n}\n```\nassign it to a user. Now try running upgrade assistant and reindexing\nwith that user. It should work.\n\nSimplified testing of upgrade assistant - \nTo test, follow directions here -\nhttps://github.com/elastic/kibana/pull/228705\nMocked response -\nhttps://github.com/elastic/kibana/pull/230021/commits/5aab34cdcee2df76d702a058348388a7d10fb73c#diff-f7eb2d7fe666aad1bedcd73d356612d2f74f81c76ba2e8e26b2983b9fb92a661R50\n\n---\n\nRelease note\n\nFixes privilege requirements when reindexing indices via Upgrade\nAssistant. Previously, the \"superuser\" role was required. Now \"cluster:\nmanage\" and \"all\" privileges for the relevant indices are sufficient.","sha":"0250b590f20ac6dcdc5df64ee0a8fd758553957c","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Kibana Management","Feature:Upgrade Assistant","backport:version","v9.2.0","v8.18.8","v8.19.5","v9.0.8","v9.1.5"],"title":"[Upgrade Assistant] Fix privileges for reindexing indices","number":237055,"url":"https://github.com/elastic/kibana/pull/237055","mergeCommit":{"message":"[Upgrade Assistant] Fix privileges for reindexing indices (#237055)\n\n## Summary\n\nPreviously Upgrade Assistant was checking for `.tasks` index access when\nchecking privs in order to reindex an index. Only the `superuser` role\nprovides access. Further, access is not needed as its been replaced by\nthe tasks api which is available via `cluster: ['manage']`\n\nAdditionally, the saved objects client usage required the `superuser`\nrole since the reindex saved object was hidden and we didn't have a way\nof providing kibana feature privileges for the saved object. The\nsolution is to rely on our our preexisting privilege checks (cluster:\nmanage and 'all' access for the particular indices being reindexed) and\nuse the internal saved object client.\n\nPart of https://github.com/elastic/kibana/issues/237054\n\nTo test -\n\nCreate a role with the following (index names could be more limited and\nit should work)\n```\n{\n  \"cluster\": [ \"manage\" ],\n  \"index\" : [\n    {\n      \"names\": [ \"*\" ],\n      \"privileges\": [ \"all\" ]\n    }\n  ]\n}\n```\nassign it to a user. Now try running upgrade assistant and reindexing\nwith that user. It should work.\n\nSimplified testing of upgrade assistant - \nTo test, follow directions here -\nhttps://github.com/elastic/kibana/pull/228705\nMocked response -\nhttps://github.com/elastic/kibana/pull/230021/commits/5aab34cdcee2df76d702a058348388a7d10fb73c#diff-f7eb2d7fe666aad1bedcd73d356612d2f74f81c76ba2e8e26b2983b9fb92a661R50\n\n---\n\nRelease note\n\nFixes privilege requirements when reindexing indices via Upgrade\nAssistant. Previously, the \"superuser\" role was required. Now \"cluster:\nmanage\" and \"all\" privileges for the relevant indices are sufficient.","sha":"0250b590f20ac6dcdc5df64ee0a8fd758553957c"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.19","9.0","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237055","number":237055,"mergeCommit":{"message":"[Upgrade Assistant] Fix privileges for reindexing indices (#237055)\n\n## Summary\n\nPreviously Upgrade Assistant was checking for `.tasks` index access when\nchecking privs in order to reindex an index. Only the `superuser` role\nprovides access. Further, access is not needed as its been replaced by\nthe tasks api which is available via `cluster: ['manage']`\n\nAdditionally, the saved objects client usage required the `superuser`\nrole since the reindex saved object was hidden and we didn't have a way\nof providing kibana feature privileges for the saved object. The\nsolution is to rely on our our preexisting privilege checks (cluster:\nmanage and 'all' access for the particular indices being reindexed) and\nuse the internal saved object client.\n\nPart of https://github.com/elastic/kibana/issues/237054\n\nTo test -\n\nCreate a role with the following (index names could be more limited and\nit should work)\n```\n{\n  \"cluster\": [ \"manage\" ],\n  \"index\" : [\n    {\n      \"names\": [ \"*\" ],\n      \"privileges\": [ \"all\" ]\n    }\n  ]\n}\n```\nassign it to a user. Now try running upgrade assistant and reindexing\nwith that user. It should work.\n\nSimplified testing of upgrade assistant - \nTo test, follow directions here -\nhttps://github.com/elastic/kibana/pull/228705\nMocked response -\nhttps://github.com/elastic/kibana/pull/230021/commits/5aab34cdcee2df76d702a058348388a7d10fb73c#diff-f7eb2d7fe666aad1bedcd73d356612d2f74f81c76ba2e8e26b2983b9fb92a661R50\n\n---\n\nRelease note\n\nFixes privilege requirements when reindexing indices via Upgrade\nAssistant. Previously, the \"superuser\" role was required. Now \"cluster:\nmanage\" and \"all\" privileges for the relevant indices are sufficient.","sha":"0250b590f20ac6dcdc5df64ee0a8fd758553957c"}},{"branch":"8.18","label":"v8.18.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->