### PR TITLE
[9.1] Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit (#237025)

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index.ts
@@ -19,10 +19,5 @@ export default function alertingCircuitBreakerTests({
      * This tests the expected behavior for a rule type that hits the alert limit in a single execution.
      */
     loadTestFile(require.resolve('./alert_limit_services'));
-    /**
-     * This tests the expected behavior for the active and recovered alerts generated over
-     * a sequence of rule executions that hit the alert limit.
-     */
-    loadTestFile(require.resolve('./index_threshold_max_alerts'));
   });
 }

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/index.ts
@@ -12,5 +12,12 @@ export default function alertingTests({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./long_running'));
     loadTestFile(require.resolve('./cancellable'));
     loadTestFile(require.resolve('./auto_recover'));
+    loadTestFile(require.resolve('./async_search'));
+
+    /**
+     * This tests the expected behavior for the active and recovered alerts generated over
+     * a sequence of rule executions that hit the alert limit.
+     */
+    loadTestFile(require.resolve('./index_threshold_max_alerts'));
   });
 }

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/index.ts
@@ -12,7 +12,6 @@ export default function alertingTests({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./long_running'));
     loadTestFile(require.resolve('./cancellable'));
     loadTestFile(require.resolve('./auto_recover'));
-    loadTestFile(require.resolve('./async_search'));
 
     /**
      * This tests the expected behavior for the active and recovered alerts generated over

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/index_threshold_max_alerts.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/index_threshold_max_alerts.ts
@@ -8,10 +8,10 @@
 import expect from '@kbn/expect';
 
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
-import { Spaces } from '../../../../../scenarios';
-import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
-import { getUrlPrefix, ObjectRemover, getEventLog } from '../../../../../../common/lib';
-import { createEsDocumentsWithGroups } from '../../../create_test_data';
+import { Spaces } from '../../../../scenarios';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import { getUrlPrefix, ObjectRemover, getEventLog } from '../../../../../common/lib';
+import { createEsDocumentsWithGroups } from '../../create_test_data';
 
 const RULE_INTERVAL_SECONDS = 6;
 const RULE_INTERVALS_TO_WRITE = 1;
@@ -23,17 +23,17 @@ export default function maxAlertsRuleTests({ getService }: FtrProviderContext) {
   const es = getService('es');
   const esTestIndexTool = new ESTestIndexTool(es, retry);
 
-  // Failing: See https://github.com/elastic/kibana/issues/193876
-  describe.skip('index threshold rule that hits max alerts circuit breaker', () => {
+  describe('index threshold rule that hits max alerts circuit breaker', () => {
     const objectRemover = new ObjectRemover(supertest);
 
     beforeEach(async () => {
       await esTestIndexTool.destroy();
-
       await esTestIndexTool.setup();
+      await deleteDocs();
     });
 
     afterEach(async () => {
+      await deleteDocs();
       await objectRemover.removeAll();
       await esTestIndexTool.destroy();
     });
@@ -71,7 +71,11 @@ export default function maxAlertsRuleTests({ getService }: FtrProviderContext) {
       // this should trigger the circuit breaker and while we'd expect groups 0 and 1
       // to recover under normal conditions, they should stay active because the
       // circuit breaker hit
+      await deleteDocs();
       await createEsDocumentsInGroups(22, getEndDate(), 2);
+
+      // trigger the rule to run
+      await runSoon(ruleId);
 
       // get the events we're expecting
       const events = await retry.try(async () => {
@@ -143,7 +147,14 @@ export default function maxAlertsRuleTests({ getService }: FtrProviderContext) {
       // it looks like alerts were reported in reverse order (group-23, 22, 21, down to 9)
       // so all the 15 new alerts will recover, leading to 17 recovered alerts
       // so our active alerts will be groups 2, 3, 4, 5 and 6 with groups 5 and 6 as new alerts
+      await deleteDocs();
       await createEsDocumentsInGroups(5, getEndDate(), 2);
+
+      // get the first execution to have recovered alerts
+      for (let i = 0; i < 5; i++) {
+        const done = await getRecoveredEvents(ruleId, 3 + i);
+        if (done) break;
+      }
 
       const recoveredEvents = await retry.try(async () => {
         return await getEventLog({
@@ -221,7 +232,7 @@ export default function maxAlertsRuleTests({ getService }: FtrProviderContext) {
           consumer: 'alerts',
           enabled: true,
           rule_type_id: '.index-threshold',
-          schedule: { interval: `${RULE_INTERVAL_SECONDS}s` },
+          schedule: { interval: '1d' },
           actions: [],
           notify_when: 'onActiveAlert',
           params: {
@@ -232,8 +243,8 @@ export default function maxAlertsRuleTests({ getService }: FtrProviderContext) {
             groupBy: params.groupBy,
             termField: params.termField,
             termSize: params.termSize,
-            timeWindowSize: params.timeWindowSize ?? RULE_INTERVAL_SECONDS * 5,
-            timeWindowUnit: 's',
+            timeWindowSize: 1,
+            timeWindowUnit: 'h',
             thresholdComparator: params.thresholdComparator,
             threshold: params.threshold,
           },
@@ -262,6 +273,48 @@ export default function maxAlertsRuleTests({ getService }: FtrProviderContext) {
         indexName: ES_TEST_INDEX_NAME,
         groupOffset,
       });
+    }
+
+    async function runSoon(ruleId: string) {
+      await retry.try(async () => {
+        // Sometimes the rule may already be running, which returns a 200. Try until it isn't
+        const runSoonResponse = await supertest
+          .post(`${getUrlPrefix(Spaces.space1.id)}/internal/alerting/rule/${ruleId}/_run_soon`)
+          .set('kbn-xsrf', 'foo');
+        expect(runSoonResponse.status).to.eql(204);
+      });
+    }
+
+    async function deleteDocs() {
+      await es.deleteByQuery({
+        index: ES_TEST_INDEX_NAME,
+        query: { match_all: {} },
+        conflicts: 'proceed',
+      });
+    }
+
+    async function getRecoveredEvents(ruleId: string, numExecutions: number) {
+      await runSoon(ruleId);
+
+      const events = await retry.try(async () => {
+        return await getEventLog({
+          getService,
+          spaceId: Spaces.space1.id,
+          type: 'alert',
+          id: ruleId,
+          provider: 'alerting',
+          actions: new Map([['execute', { gte: numExecutions }]]),
+        });
+      });
+
+      // check num recovered events in latest execution
+      if (
+        events[events.length - 1]?.kibana?.alert?.rule?.execution?.metrics?.alert_counts
+          ?.recovered === 17
+      ) {
+        return true;
+      }
+      return false;
     }
 
     function getEndDate() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit (#237025)](https://github.com/elastic/kibana/pull/237025)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-10-02T15:59:01Z","message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit (#237025)\n\nResolves https://github.com/elastic/kibana/issues/193876\n\n## Summary\n\nThis test was flaky due to timing issues and got flakier after switching\nto a default poll interval of `500ms` from `3s`. Previously, it was\nwriting documents to a test index with specific timestamps and relying\non a fast rule interval to return the correct number of documents during\neach execution of the rule. This PR changes\n\n- the rule interval to be `1d` and uses the run soon API to control when\nthe rule runs\n- increases the rule lookback time\n- clears the test data between each rule run so that we can guarantee\nthe correct number of documents during each execution.","sha":"99c66647ebdf7256546e86d6a59f9153aba82f38","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","backport:all-open","v9.3.0"],"title":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit","number":237025,"url":"https://github.com/elastic/kibana/pull/237025","mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit (#237025)\n\nResolves https://github.com/elastic/kibana/issues/193876\n\n## Summary\n\nThis test was flaky due to timing issues and got flakier after switching\nto a default poll interval of `500ms` from `3s`. Previously, it was\nwriting documents to a test index with specific timestamps and relying\non a fast rule interval to return the correct number of documents during\neach execution of the rule. This PR changes\n\n- the rule interval to be `1d` and uses the run soon API to control when\nthe rule runs\n- increases the rule lookback time\n- clears the test data between each rule run so that we can guarantee\nthe correct number of documents during each execution.","sha":"99c66647ebdf7256546e86d6a59f9153aba82f38"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237025","number":237025,"mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit (#237025)\n\nResolves https://github.com/elastic/kibana/issues/193876\n\n## Summary\n\nThis test was flaky due to timing issues and got flakier after switching\nto a default poll interval of `500ms` from `3s`. Previously, it was\nwriting documents to a test index with specific timestamps and relying\non a fast rule interval to return the correct number of documents during\neach execution of the rule. This PR changes\n\n- the rule interval to be `1d` and uses the run soon API to control when\nthe rule runs\n- increases the rule lookback time\n- clears the test data between each rule run so that we can guarantee\nthe correct number of documents during each execution.","sha":"99c66647ebdf7256546e86d6a59f9153aba82f38"}},{"url":"https://github.com/elastic/kibana/pull/237349","number":237349,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->