### PR TITLE
[8.19] Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit (#237025)

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index.ts
@@ -19,10 +19,5 @@ export default function alertingCircuitBreakerTests({
      * This tests the expected behavior for a rule type that hits the alert limit in a single execution.
      */
     loadTestFile(require.resolve('./alert_limit_services'));
-    /**
-     * This tests the expected behavior for the active and recovered alerts generated over
-     * a sequence of rule executions that hit the alert limit.
-     */
-    loadTestFile(require.resolve('./index_threshold_max_alerts'));
   });
 }

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/index.ts
@@ -12,5 +12,11 @@ export default function alertingTests({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./long_running'));
     loadTestFile(require.resolve('./cancellable'));
     loadTestFile(require.resolve('./auto_recover'));
+
+    /**
+     * This tests the expected behavior for the active and recovered alerts generated over
+     * a sequence of rule executions that hit the alert limit.
+     */
+    loadTestFile(require.resolve('./index_threshold_max_alerts'));
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit (#237025)](https://github.com/elastic/kibana/pull/237025)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-10-02T15:59:01Z","message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit (#237025)\n\nResolves https://github.com/elastic/kibana/issues/193876\n\n## Summary\n\nThis test was flaky due to timing issues and got flakier after switching\nto a default poll interval of `500ms` from `3s`. Previously, it was\nwriting documents to a test index with specific timestamps and relying\non a fast rule interval to return the correct number of documents during\neach execution of the rule. This PR changes\n\n- the rule interval to be `1d` and uses the run soon API to control when\nthe rule runs\n- increases the rule lookback time\n- clears the test data between each rule run so that we can guarantee\nthe correct number of documents during each execution.","sha":"99c66647ebdf7256546e86d6a59f9153aba82f38","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","backport:all-open","v9.3.0"],"title":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit","number":237025,"url":"https://github.com/elastic/kibana/pull/237025","mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit (#237025)\n\nResolves https://github.com/elastic/kibana/issues/193876\n\n## Summary\n\nThis test was flaky due to timing issues and got flakier after switching\nto a default poll interval of `500ms` from `3s`. Previously, it was\nwriting documents to a test index with specific timestamps and relying\non a fast rule interval to return the correct number of documents during\neach execution of the rule. This PR changes\n\n- the rule interval to be `1d` and uses the run soon API to control when\nthe rule runs\n- increases the rule lookback time\n- clears the test data between each rule run so that we can guarantee\nthe correct number of documents during each execution.","sha":"99c66647ebdf7256546e86d6a59f9153aba82f38"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237025","number":237025,"mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts·ts - Alerting builtin alertTypes circuit_breakers index threshold rule that hits max alerts circuit breaker persist existing alerts to next execution if circuit breaker is hit (#237025)\n\nResolves https://github.com/elastic/kibana/issues/193876\n\n## Summary\n\nThis test was flaky due to timing issues and got flakier after switching\nto a default poll interval of `500ms` from `3s`. Previously, it was\nwriting documents to a test index with specific timestamps and relying\non a fast rule interval to return the correct number of documents during\neach execution of the rule. This PR changes\n\n- the rule interval to be `1d` and uses the run soon API to control when\nthe rule runs\n- increases the rule lookback time\n- clears the test data between each rule run so that we can guarantee\nthe correct number of documents during each execution.","sha":"99c66647ebdf7256546e86d6a59f9153aba82f38"}},{"url":"https://github.com/elastic/kibana/pull/237349","number":237349,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->