### PR TITLE
[One Workflow] Fix refetch on window focus

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/model/use_workflow_detail.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/model/use_workflow_detail.ts
@@ -18,6 +18,7 @@ export function useWorkflowDetail(id: string | null) {
     networkMode: 'always',
     enabled: !!id,
     queryKey: ['workflows', id],
+    refetchOnWindowFocus: false,
     queryFn: () => {
       return http!.get<WorkflowDetailDto>(`/api/workflows/${id}`).then((res) => {
         return {


### PR DESCRIPTION
## Summary

fixes: https://github.com/elastic/security-team/issues/14136

The react-query hook was configured to refetch when the window was focused, overriding the changes made until that point. Added the `refetchOnWindowFocus: false` setting




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->