### PR TITLE
[9.1] [dashboard] fixs controls cause double fetch (#237169)

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/control_group_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/control_group_manager.ts
@@ -9,7 +9,7 @@
 
 import type { Reference } from '@kbn/content-management-utils';
 import { ControlGroupApi, ControlGroupSerializedState } from '@kbn/controls-plugin/public';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, first, skipWhile, switchMap } from 'rxjs';
 
 export const CONTROL_GROUP_EMBEDDABLE_ID = 'CONTROL_GROUP_EMBEDDABLE_ID';
 
@@ -18,6 +18,22 @@ export function initializeControlGroupManager(
   getReferences: (id: string) => Reference[]
 ) {
   const controlGroupApi$ = new BehaviorSubject<ControlGroupApi | undefined>(undefined);
+
+  async function untilControlsInitialized(): Promise<void> {
+    return new Promise((resolve) => {
+      controlGroupApi$
+        .pipe(
+          skipWhile((controlGroupApi) => !controlGroupApi),
+          switchMap(async (controlGroupApi) => {
+            await controlGroupApi?.untilInitialized();
+          }),
+          first()
+        )
+        .subscribe(() => {
+          resolve();
+        });
+    });
+  }
 
   return {
     api: {
@@ -52,6 +68,7 @@ export function initializeControlGroupManager(
       },
       setControlGroupApi: (controlGroupApi: ControlGroupApi) =>
         controlGroupApi$.next(controlGroupApi),
+      untilControlsInitialized,
     },
   };
 }

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -232,6 +232,7 @@ export function getDashboardApi({
     ...layoutManager.internalApi,
     ...unifiedSearchManager.internalApi,
     setControlGroupApi: controlGroupManager.internalApi.setControlGroupApi,
+    untilControlsInitialized: controlGroupManager.internalApi.untilControlsInitialized,
   };
 
   const searchSessionManager = initializeSearchSessionManager(

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/types.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/types.ts
@@ -159,4 +159,5 @@ export interface DashboardInternalApi {
   setControlGroupApi: (controlGroupApi: ControlGroupApi) => void;
   serializeLayout: () => Pick<DashboardState, 'panels' | 'references'>;
   isSectionCollapsed: (sectionId?: string) => boolean;
+  untilControlsInitialized: () => Promise<void>;
 }

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/dashboard_viewport.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/dashboard_viewport.test.tsx
@@ -16,8 +16,16 @@ import { DashboardContext } from '../../dashboard_api/use_dashboard_api';
 import { DashboardInternalContext } from '../../dashboard_api/use_dashboard_internal_api';
 import { buildMockDashboardApi, getMockPanels } from '../../mocks';
 import { DashboardViewport } from './dashboard_viewport';
+import { BehaviorSubject, first, skipWhile } from 'rxjs';
+import type { DashboardInternalApi } from '../../dashboard_api/types';
 
-const createAndMountDashboardViewport = async () => {
+jest.mock('../grid', () => {
+  return {
+    DashboardGrid: () => <div data-test-subj="mockDashboardGrid" />,
+  };
+});
+
+const renderDashboardViewport = async (internalApiOverrides?: Partial<DashboardInternalApi>) => {
   const panels = getMockPanels();
   const { api, internalApi } = buildMockDashboardApi({
     overrides: {
@@ -27,7 +35,12 @@ const createAndMountDashboardViewport = async () => {
   const component = render(
     <EuiThemeProvider>
       <DashboardContext.Provider value={api}>
-        <DashboardInternalContext.Provider value={internalApi}>
+        <DashboardInternalContext.Provider
+          value={{
+            ...internalApi,
+            ...internalApiOverrides,
+          }}
+        >
           <DashboardViewport />
         </DashboardInternalContext.Provider>
       </DashboardContext.Provider>
@@ -36,19 +49,51 @@ const createAndMountDashboardViewport = async () => {
 
   // wait for first render
   await waitFor(() => {
-    expect(component.queryAllByTestId('dashboardPanel').length).toBe(Object.keys(panels).length);
+    component.getByTestId('dshDashboardViewport');
   });
 
   return { dashboardApi: api, internalApi, component };
 };
 
 describe('DashboardViewport', () => {
-  test('renders', async () => {
-    await createAndMountDashboardViewport();
+  test('should render DashboardGrid when dashboard has panels', async () => {
+    const { component } = await renderDashboardViewport();
+    await waitFor(() => {
+      component.getByTestId('mockDashboardGrid');
+    });
+  });
+
+  test('should not render DashboardGrid until controls are ready', async () => {
+    const controlsReadyMock$ = new BehaviorSubject(false);
+    const { component } = await renderDashboardViewport({
+      untilControlsInitialized: () => {
+        return new Promise((resolve) => {
+          controlsReadyMock$
+            .pipe(
+              skipWhile((controlsReady) => !controlsReady),
+              first()
+            )
+            .subscribe(() => {
+              resolve();
+            });
+        });
+      },
+    });
+
+    await waitFor(() => {
+      expect(component.queryByTestId('mockDashboardGrid')).toBeNull();
+    });
+
+    // simulate controls ready
+    controlsReadyMock$.next(true);
+
+    await waitFor(() => {
+      component.getByTestId('mockDashboardGrid');
+    });
   });
 
   test('renders print mode styles', async () => {
-    const { component, dashboardApi } = await createAndMountDashboardViewport();
+    const { component, dashboardApi } = await renderDashboardViewport();
     dashboardApi.setViewMode('print');
 
     await waitFor(() => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/dashboard_viewport.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/dashboard_viewport.tsx
@@ -85,23 +85,18 @@ export const DashboardViewport = ({
     };
   }, [controlGroupApi]);
 
-  // Bug in main where panels are loaded before control filters are ready
-  // Want to migrate to react embeddable controls with same behavior
-  // TODO - do not load panels until control filters are ready
-  /*
-  const [dashboardInitialized, setDashboardInitialized] = useState(false);
+  const [controlsReady, setControlsReady] = useState(false);
   useEffect(() => {
     let ignore = false;
-    dashboard.untilContainerInitialized().then(() => {
+    dashboardInternalApi.untilControlsInitialized().then(() => {
       if (!ignore) {
-        setDashboardInitialized(true);
+        setControlsReady(true);
       }
     });
     return () => {
       ignore = true;
     };
-  }, [dashboard]);
-  */
+  }, [dashboardInternalApi]);
 
   const styles = useMemoCss(dashboardViewportStyles);
 
@@ -147,9 +142,9 @@ export const DashboardViewport = ({
       >
         {panelCount === 0 && sectionCount === 0 ? (
           <DashboardEmptyScreen />
-        ) : (
+        ) : viewMode === 'print' || controlsReady ? (
           <DashboardGrid dashboardContainerRef={dashboardContainerRef} />
-        )}
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[dashboard] fixs controls cause double fetch (#237169)](https://github.com/elastic/kibana/pull/237169)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2025-10-02T16:42:05Z","message":"[dashboard] fixs controls cause double fetch (#237169)\n\nFixes https://github.com/elastic/kibana/issues/237147\n\nPR updates dashboard to wait until controls are ready before rendering\npanels. This prevents a double fetch when panels would fetch data while\ncontrols where building filters and then fetch data again once controls\nfilters are available.\n\nThis PR introduces a small performance degradation to dashboards with\ncontrols. Panels will not start rendering until controls have finished\ninitializing. This is a better performance trade-off then the current\nbehavior of issuing a new round of requests once controls are ready.\n\n### Testing\n* install sample web logs\n* create new dashboard \n* add options list control on field `machine.os.keyword`\n* Select `ios` in control\n* add metric vis with count\n* save dashboard\n* open dashboard filter network requests to `ese`. Ensure metric chart\nonly makes a single request\n<img width=\"2048\" height=\"698\" alt=\"Screenshot 2025-10-01 at 12 39\n45 PM\"\nsrc=\"https://github.com/user-attachments/assets/b24e039c-2585-4eec-af9b-e459fccf90d7\"\n/>\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7f7bd4fd3b5d731ba9f2e073f4a2a82efad0cd4c","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","backport:version","v9.2.0","v9.3.0","v8.19.9","v9.1.6","v8.18.9"],"title":"[dashboard] fixs controls cause double fetch","number":237169,"url":"https://github.com/elastic/kibana/pull/237169","mergeCommit":{"message":"[dashboard] fixs controls cause double fetch (#237169)\n\nFixes https://github.com/elastic/kibana/issues/237147\n\nPR updates dashboard to wait until controls are ready before rendering\npanels. This prevents a double fetch when panels would fetch data while\ncontrols where building filters and then fetch data again once controls\nfilters are available.\n\nThis PR introduces a small performance degradation to dashboards with\ncontrols. Panels will not start rendering until controls have finished\ninitializing. This is a better performance trade-off then the current\nbehavior of issuing a new round of requests once controls are ready.\n\n### Testing\n* install sample web logs\n* create new dashboard \n* add options list control on field `machine.os.keyword`\n* Select `ios` in control\n* add metric vis with count\n* save dashboard\n* open dashboard filter network requests to `ese`. Ensure metric chart\nonly makes a single request\n<img width=\"2048\" height=\"698\" alt=\"Screenshot 2025-10-01 at 12 39\n45 PM\"\nsrc=\"https://github.com/user-attachments/assets/b24e039c-2585-4eec-af9b-e459fccf90d7\"\n/>\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7f7bd4fd3b5d731ba9f2e073f4a2a82efad0cd4c"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1","8.18"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/237356","number":237356,"state":"OPEN"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237169","number":237169,"mergeCommit":{"message":"[dashboard] fixs controls cause double fetch (#237169)\n\nFixes https://github.com/elastic/kibana/issues/237147\n\nPR updates dashboard to wait until controls are ready before rendering\npanels. This prevents a double fetch when panels would fetch data while\ncontrols where building filters and then fetch data again once controls\nfilters are available.\n\nThis PR introduces a small performance degradation to dashboards with\ncontrols. Panels will not start rendering until controls have finished\ninitializing. This is a better performance trade-off then the current\nbehavior of issuing a new round of requests once controls are ready.\n\n### Testing\n* install sample web logs\n* create new dashboard \n* add options list control on field `machine.os.keyword`\n* Select `ios` in control\n* add metric vis with count\n* save dashboard\n* open dashboard filter network requests to `ese`. Ensure metric chart\nonly makes a single request\n<img width=\"2048\" height=\"698\" alt=\"Screenshot 2025-10-01 at 12 39\n45 PM\"\nsrc=\"https://github.com/user-attachments/assets/b24e039c-2585-4eec-af9b-e459fccf90d7\"\n/>\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7f7bd4fd3b5d731ba9f2e073f4a2a82efad0cd4c"}},{"branch":"8.19","label":"v8.19.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->