### PR TITLE
[8.18] [dashboard] fixs controls cause double fetch (#237169)

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -285,7 +285,7 @@ export function getDashboardApi({
               resolve();
             });
         });
-      }
+      },
     } as DashboardInternalApi,
     cleanup: () => {
       dataLoadingManager.cleanup();

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -12,7 +12,7 @@ import { ControlGroupApi, ControlGroupSerializedState } from '@kbn/controls-plug
 import { EmbeddablePackageState } from '@kbn/embeddable-plugin/public';
 import { StateComparators } from '@kbn/presentation-publishing';
 import { omit } from 'lodash';
-import { BehaviorSubject, debounceTime, merge } from 'rxjs';
+import { BehaviorSubject, debounceTime, merge, first, skipWhile, switchMap } from 'rxjs';
 import { v4 } from 'uuid';
 import {
   getReferencesForControls,
@@ -271,6 +271,21 @@ export function getDashboardApi({
       },
       setControlGroupApi: (controlGroupApi: ControlGroupApi) =>
         controlGroupApi$.next(controlGroupApi),
+      untilControlsInitialized: async () => {
+        return new Promise((resolve) => {
+          controlGroupApi$
+            .pipe(
+              skipWhile((controlGroupApi) => !controlGroupApi),
+              switchMap(async (controlGroupApi) => {
+                await controlGroupApi?.untilInitialized();
+              }),
+              first()
+            )
+            .subscribe(() => {
+              resolve();
+            });
+        });
+      }
     } as DashboardInternalApi,
     cleanup: () => {
       dataLoadingManager.cleanup();

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/types.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/types.ts
@@ -189,4 +189,5 @@ export interface DashboardInternalApi {
   getSerializedStateForControlGroup: () => SerializedPanelState<ControlGroupSerializedState>;
   registerChildApi: (api: DefaultEmbeddableApi) => void;
   setControlGroupApi: (controlGroupApi: ControlGroupApi) => void;
+  untilControlsInitialized: () => Promise<void>;
 }

--- a/src/platform/plugins/shared/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
@@ -79,23 +79,18 @@ export const DashboardViewport = ({
     };
   }, [controlGroupApi]);
 
-  // Bug in main where panels are loaded before control filters are ready
-  // Want to migrate to react embeddable controls with same behavior
-  // TODO - do not load panels until control filters are ready
-  /*
-  const [dashboardInitialized, setDashboardInitialized] = useState(false);
+  const [controlsReady, setControlsReady] = useState(false);
   useEffect(() => {
     let ignore = false;
-    dashboard.untilContainerInitialized().then(() => {
+    dashboardInternalApi.untilControlsInitialized().then(() => {
       if (!ignore) {
-        setDashboardInitialized(true);
+        setControlsReady(true);
       }
     });
     return () => {
       ignore = true;
     };
-  }, [dashboard]);
-  */
+  }, [dashboardInternalApi]);
 
   return (
     <div
@@ -140,7 +135,9 @@ export const DashboardViewport = ({
         data-description={description}
         data-shared-items-count={panelCount}
       >
-        <DashboardGrid dashboardContainerRef={dashboardContainerRef} />
+        {viewMode === 'print' || controlsReady ? (
+          <DashboardGrid dashboardContainerRef={dashboardContainerRef} />
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[dashboard] fixs controls cause double fetch (#237169)](https://github.com/elastic/kibana/pull/237169)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2025-10-02T16:42:05Z","message":"[dashboard] fixs controls cause double fetch (#237169)\n\nFixes https://github.com/elastic/kibana/issues/237147\n\nPR updates dashboard to wait until controls are ready before rendering\npanels. This prevents a double fetch when panels would fetch data while\ncontrols where building filters and then fetch data again once controls\nfilters are available.\n\nThis PR introduces a small performance degradation to dashboards with\ncontrols. Panels will not start rendering until controls have finished\ninitializing. This is a better performance trade-off then the current\nbehavior of issuing a new round of requests once controls are ready.\n\n### Testing\n* install sample web logs\n* create new dashboard \n* add options list control on field `machine.os.keyword`\n* Select `ios` in control\n* add metric vis with count\n* save dashboard\n* open dashboard filter network requests to `ese`. Ensure metric chart\nonly makes a single request\n<img width=\"2048\" height=\"698\" alt=\"Screenshot 2025-10-01 at 12 39\n45 PM\"\nsrc=\"https://github.com/user-attachments/assets/b24e039c-2585-4eec-af9b-e459fccf90d7\"\n/>\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7f7bd4fd3b5d731ba9f2e073f4a2a82efad0cd4c","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","backport:version","v9.2.0","v9.3.0","v8.19.9","v9.1.6","v8.18.9"],"title":"[dashboard] fixs controls cause double fetch","number":237169,"url":"https://github.com/elastic/kibana/pull/237169","mergeCommit":{"message":"[dashboard] fixs controls cause double fetch (#237169)\n\nFixes https://github.com/elastic/kibana/issues/237147\n\nPR updates dashboard to wait until controls are ready before rendering\npanels. This prevents a double fetch when panels would fetch data while\ncontrols where building filters and then fetch data again once controls\nfilters are available.\n\nThis PR introduces a small performance degradation to dashboards with\ncontrols. Panels will not start rendering until controls have finished\ninitializing. This is a better performance trade-off then the current\nbehavior of issuing a new round of requests once controls are ready.\n\n### Testing\n* install sample web logs\n* create new dashboard \n* add options list control on field `machine.os.keyword`\n* Select `ios` in control\n* add metric vis with count\n* save dashboard\n* open dashboard filter network requests to `ese`. Ensure metric chart\nonly makes a single request\n<img width=\"2048\" height=\"698\" alt=\"Screenshot 2025-10-01 at 12 39\n45 PM\"\nsrc=\"https://github.com/user-attachments/assets/b24e039c-2585-4eec-af9b-e459fccf90d7\"\n/>\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7f7bd4fd3b5d731ba9f2e073f4a2a82efad0cd4c"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1","8.18"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/237356","number":237356,"state":"OPEN"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237169","number":237169,"mergeCommit":{"message":"[dashboard] fixs controls cause double fetch (#237169)\n\nFixes https://github.com/elastic/kibana/issues/237147\n\nPR updates dashboard to wait until controls are ready before rendering\npanels. This prevents a double fetch when panels would fetch data while\ncontrols where building filters and then fetch data again once controls\nfilters are available.\n\nThis PR introduces a small performance degradation to dashboards with\ncontrols. Panels will not start rendering until controls have finished\ninitializing. This is a better performance trade-off then the current\nbehavior of issuing a new round of requests once controls are ready.\n\n### Testing\n* install sample web logs\n* create new dashboard \n* add options list control on field `machine.os.keyword`\n* Select `ios` in control\n* add metric vis with count\n* save dashboard\n* open dashboard filter network requests to `ese`. Ensure metric chart\nonly makes a single request\n<img width=\"2048\" height=\"698\" alt=\"Screenshot 2025-10-01 at 12 39\n45 PM\"\nsrc=\"https://github.com/user-attachments/assets/b24e039c-2585-4eec-af9b-e459fccf90d7\"\n/>\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7f7bd4fd3b5d731ba9f2e073f4a2a82efad0cd4c"}},{"branch":"8.19","label":"v8.19.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->