### PR TITLE
[dashboards] fix panels in sections from URL state are not transformed

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/extract_panels_state.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/extract_panels_state.test.ts
@@ -101,6 +101,47 @@ describe('extractPanelsState', () => {
         },
       ]);
     });
+
+    test('should migrate panels in sections', () => {
+      const { panels } = extractPanelsState({
+        panels: [
+          {
+            title: 'Section 1',
+            gridData: {},
+            panels: [
+              {
+                embeddableConfig: {
+                  timeRange: {
+                    from: 'now-7d/d',
+                    to: 'now',
+                  },
+                },
+                gridData: {},
+                type: 'map',
+              },
+            ]
+          }
+        ],
+      });
+      expect(panels).toEqual([
+        {
+          title: 'Section 1',
+          grid: {},
+          panels: [
+            {
+              config: {
+                timeRange: {
+                  from: 'now-7d/d',
+                  to: 'now',
+                },
+              },
+              grid: {},
+              type: 'map',
+            }
+          ],
+        }
+      ]);
+    });
   });
 
   describe('< 8.19 panels state', () => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/extract_panels_state.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/extract_panels_state.test.ts
@@ -101,7 +101,9 @@ describe('extractPanelsState', () => {
         },
       ]);
     });
+  });
 
+  describe('8.19', () => {
     test('should migrate panels in sections', () => {
       const { panels } = extractPanelsState({
         panels: [

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/extract_panels_state.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/extract_panels_state.test.ts
@@ -119,8 +119,8 @@ describe('extractPanelsState', () => {
                 gridData: {},
                 type: 'map',
               },
-            ]
-          }
+            ],
+          },
         ],
       });
       expect(panels).toEqual([
@@ -137,9 +137,9 @@ describe('extractPanelsState', () => {
               },
               grid: {},
               type: 'map',
-            }
+            },
           ],
-        }
+        },
       ]);
     });
   });

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/extract_panels_state.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/extract_panels_state.ts
@@ -42,7 +42,6 @@ export function extractPanelsState(state: { [key: string]: unknown }): {
   savedObjectReferences?: DashboardState['references'];
 } {
   const panels = Array.isArray(state.panels) ? state.panels : [];
-
   if (panels.length === 0) {
     return {};
   }
@@ -55,6 +54,12 @@ export function extractPanelsState(state: { [key: string]: unknown }): {
   const savedObjectReferences: Reference[] = [];
   const standardizedPanels: DashboardState['panels'] = panels.map((legacyPanel) => {
     const panel = typeof legacyPanel === 'object' ? { ...legacyPanel } : {};
+
+    if (panel.panels) {
+      const { panels: sectionPanels, savedObjectReferences: sectionPanelReferences } = extractPanelsState({ panels: panel.panels });
+      savedObjectReferences.push(...(sectionPanelReferences ?? []));
+      panel.panels = sectionPanels;
+    }
 
     // < 8.17 panels state stored panelConfig as embeddableConfig
     if (panel?.embeddableConfig) {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/extract_panels_state.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/extract_panels_state.ts
@@ -42,6 +42,7 @@ export function extractPanelsState(state: { [key: string]: unknown }): {
   savedObjectReferences?: DashboardState['references'];
 } {
   const panels = Array.isArray(state.panels) ? state.panels : [];
+
   if (panels.length === 0) {
     return {};
   }
@@ -56,7 +57,8 @@ export function extractPanelsState(state: { [key: string]: unknown }): {
     const panel = typeof legacyPanel === 'object' ? { ...legacyPanel } : {};
 
     if (panel.panels) {
-      const { panels: sectionPanels, savedObjectReferences: sectionPanelReferences } = extractPanelsState({ panels: panel.panels });
+      const { panels: sectionPanels, savedObjectReferences: sectionPanelReferences } =
+        extractPanelsState({ panels: panel.panels });
       savedObjectReferences.push(...(sectionPanelReferences ?? []));
       panel.panels = sectionPanels;
     }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/237375

PR closes the issue by adding logic to extract BWC state from panels in sections

Steps
* in 9.1 cloud instance - create a dashboard
* add a section
* add a panel to the section
* Before saving dashboard, click share icon and click copy link
* Go to saved object page and export goto link
* Start kibana instance locally
* import goto link exported from cloud instance.
* Open goto link. Dashboard should open as expected with panel in section

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->