### PR TITLE
[UII] Let integrations subcategory buttons wrap for smaller viewports

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
@@ -235,7 +235,7 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
           </EuiFlexItem>
         )}
 
-        {availableSubCategories?.length ? <EuiSpacer /> : null}
+        {availableSubCategories?.length ? <EuiSpacer size="m" /> : null}
 
         <EuiFlexItem grow={false}>
           <EuiFlexGroup
@@ -244,7 +244,8 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
             direction="row"
             gutterSize="s"
             style={{
-              maxWidth: 943,
+              maxWidth: '100%',
+              flexWrap: 'wrap',
             }}
           >
             {visibleSubCategories?.map((subCategory) => {
@@ -257,6 +258,7 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
                     fill={isSelected}
                     aria-label={subCategory?.title}
                     onClick={() => onSubCategoryClick(subCategory.id)}
+                    size="s"
                   >
                     <FormattedMessage
                       id="xpack.fleet.epmList.subcategoriesButton"
@@ -280,7 +282,7 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
                       onClick={onButtonClick}
                       iconType="boxesHorizontal"
                       aria-label="Show more subcategories"
-                      size="m"
+                      size="s"
                     />
                   }
                   isOpen={isPopoverOpen}


### PR DESCRIPTION
## Summary

While testing something else, I noticed an issue where the integration subcategories would not wrap on smaller viewports, causing the rest of the page to not resize properly (main categories on left starts to disappear, card grid doesn't resize, and subcategories row is cut off):

<img width="1064" height="944" alt="image" src="https://github.com/user-attachments/assets/d9640162-0844-4de7-8245-970b33545552" />


This PR adjusts the styles here so that subcategories are allowed to wrap, and also make the buttons small size:

<img width="999" height="928" alt="image" src="https://github.com/user-attachments/assets/6ea893cf-444d-4581-b1cc-0d9eed992f93" />

### Checklist
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->