### PR TITLE
[Search] Stateful homepage promo update

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateful_promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateful_promo.tsx
@@ -14,20 +14,21 @@ export const StatefulHeaderPromo = () => {
   return (
     <HeaderPromo
       title={i18n.translate('xpack.searchHomepage.header.statefulPromo.title', {
-        defaultMessage: 'Build your first search solution',
+        defaultMessage: 'GPUs go brrr! GPU-accelerated inference for ELSER',
       })}
       description={i18n.translate('xpack.searchHomepage.header.statefulPromo.description', {
         defaultMessage:
-          'Learn the fundamentals of creating a complete search experience with this hands-on tutorial.',
+          'We are thrilled to launch ELSER on ElS -- get state-of-the-art semantic search relevance without having to manage your own machine learning nodes.',
       })}
       cta={
         <HeaderCTALink
           data-test-subj="searchHomepageSearchHomepageHeaderCTA"
-          data-telemetry-id="8-search-tutorial"
-          href="https://www.elastic.co/search-labs/tutorials/search-tutorial/welcome"
+          // "search-promo-homepage-" is prepended to the telemetry id in HeaderCTALink
+          data-telemetry-id="10-elser-on-eis"
+          href="https://www.elastic.co/docs/explore-analyze/elastic-inference/eis#elser-on-eis"
         >
           {i18n.translate('xpack.searchHomepage.statefulPromo.content', {
-            defaultMessage: 'Start the tutorial',
+            defaultMessage: 'View docs',
           })}
         </HeaderCTALink>
       }


### PR DESCRIPTION
## Summary

Update the home page promo real estate for the 9.2 stack release.

### Screenshot

<img width="1235" height="672" alt="Screenshot 2025-10-06 at 09 09 35" src="https://github.com/user-attachments/assets/d3c64f79-7419-46db-aefd-9ec1f92b8ec2" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->