### PR TITLE
[Scout] Add AI prompt to generate a Scout boilerplate test from existing FTR test

### DIFF
--- a/src/platform/packages/private/kbn-scout-info/llms/README.md
+++ b/src/platform/packages/private/kbn-scout-info/llms/README.md
@@ -19,7 +19,7 @@ A “boilerplate” Scout test file refers to a test file containing test case(s
 
 ### How to Use
 
-**Sample prompt** (using Claude's `@path/to/import` syntax):
+**Sample prompt** (replace the FTR file path):
 
 ```
 Generate an empty Scout skeleton from this file:
@@ -30,5 +30,8 @@ Instructions:
 @src/platform/packages/private/kbn-scout-info/llms/generate-scout-skeleton-from-ftr-test.md contains instructions on how to convert a test
 @src/platform/packages/private/kbn-scout-info/llms/what-is-scout.md contains a high-level description of the Scout framework
 ```
+
+> [!NOTE]
+> This prompt uses Claude's `@path/to/import` [syntax](https://docs.claude.com/en/docs/claude-code/memory).
 
 **Sample output**: available [here](https://gist.github.com/csr/71e635d856154df64f7d1ccb7e8333df).

--- a/src/platform/packages/private/kbn-scout-info/llms/README.md
+++ b/src/platform/packages/private/kbn-scout-info/llms/README.md
@@ -19,7 +19,7 @@ A “boilerplate” Scout test file refers to a test file containing test case(s
 
 ### How to Use
 
-**Sample prompt** (replace the FTR file path):
+**Sample prompt** (replace the FTR test file path as needed):
 
 ```
 Generate an empty Scout skeleton from this file:

--- a/src/platform/packages/private/kbn-scout-info/llms/README.md
+++ b/src/platform/packages/private/kbn-scout-info/llms/README.md
@@ -1,0 +1,32 @@
+# FTR to Scout Test AI Migration Utilities
+
+These AI prompts help automate the conversion of existing FTR tests to Scout format, reducing manual effort and ensuring consistency during migration.
+
+## What's included
+
+- `ftr-to-scout-skeleton-guide.md` - A prompt you can use to convert an FTR test to a Scout skeleton test
+- `what-is-scout.md` - Overview of Scout framework, its features, fixtures, and how to write API and UI tests
+
+### Requirements
+
+These prompts have been tested with **Claude Sonnet 4.5** and the [**Claude VS Code extension**](https://docs.claude.com/en/docs/claude-code/vs-code), but should work with your LLM of choice. Adjust the prompt syntax as needed for your preferred AI assistant (e.g., GitHub Copilot, ChatGPT, or other code assistants).
+
+## Generate a Scout boilerplate file from an existing FTR test
+
+A “boilerplate” Scout test file refers to a test file containing test case(s) and test suite(s) with no implementation code. These blocks will include `// TODO` comments to guide the developer or the AI in writing the actual test body.
+
+### How to Use
+
+**Sample prompt** (using Claude's `@path/to/import` syntax):
+
+```
+Generate an empty Scout skeleton from this file:
+
+@src/platform/test/functional/apps/discover/group4/_document_comparison.ts
+
+Instructions:
+@src/platform/packages/private/kbn-scout-info/llms/generate-scout-skeleton-from-ftr-test.md contains instructions on how to convert a test
+@src/platform/packages/private/kbn-scout-info/llms/what-is-scout.md contains a high-level description of the Scout framework
+```
+
+**Sample output**: available [here](https://gist.github.com/csr/71e635d856154df64f7d1ccb7e8333df).

--- a/src/platform/packages/private/kbn-scout-info/llms/README.md
+++ b/src/platform/packages/private/kbn-scout-info/llms/README.md
@@ -1,15 +1,17 @@
 # FTR to Scout Test AI Migration Utilities
 
-These AI prompts help automate the conversion of existing FTR tests to Scout format, reducing manual effort and ensuring consistency during migration.
+These AI prompts help automate the conversion of existing FTR tests to the [Scout](https://github.com/elastic/kibana/tree/main/src/platform/packages/shared/kbn-scout) framework, reducing manual effort and ensuring consistency and correctness during migration.
 
 ## What's included
 
 - `ftr-to-scout-skeleton-guide.md` - A prompt you can use to convert an FTR test to a Scout skeleton test
-- `what-is-scout.md` - Overview of Scout framework, its features, fixtures, and how to write API and UI tests
+- `what-is-scout.md` - Overview of the Scout framework, its features, fixtures, and how to write API and UI tests
 
 ### Requirements
 
 These prompts have been tested with **Claude Sonnet 4.5** and the [**Claude VS Code extension**](https://docs.claude.com/en/docs/claude-code/vs-code), but should work with your LLM of choice. Adjust the prompt syntax as needed for your preferred AI assistant (e.g., GitHub Copilot, ChatGPT, or other code assistants).
+
+# Prompts
 
 ## Generate a Scout boilerplate file from an existing FTR test
 

--- a/src/platform/packages/private/kbn-scout-info/llms/generate-scout-skeleton-from-ftr-test.md
+++ b/src/platform/packages/private/kbn-scout-info/llms/generate-scout-skeleton-from-ftr-test.md
@@ -16,9 +16,9 @@ Migrate existing FTR tests to Scout by creating empty test skeletons. Generate t
 
 Import from one of these Scout packages:
 
-- @kbn/scout: Platform tests (generally tests in "x-pack/platform/test/functional")
-- @kbn/scout-security: Security solution tests (generally tests in "x-pack/solutions/security/test/functional)
-- @kbn/scout-oblt: Observability solution tests (generally tests in "x-pack/solutions/observability/test/functional")
+- `@kbn/scout`: Platform tests (generally tests in `x-pack/platform/test/functional`)
+- `@kbn/scout-security`: Security solution tests (generally tests in `x-pack/solutions/security/test/functional`)
+- `@kbn/scout-oblt`: Observability solution tests (generally tests in `x-pack/solutions/observability/test/functional`)
 
 For API tests, import `apiTest` instead of `test`. If the path is ambiguous, infer from test content.
 

--- a/src/platform/packages/private/kbn-scout-info/llms/generate-scout-skeleton-from-ftr-test.md
+++ b/src/platform/packages/private/kbn-scout-info/llms/generate-scout-skeleton-from-ftr-test.md
@@ -1,0 +1,264 @@
+# Generate Scout skeleton with empty test cases from existing FTR test
+
+Migrate existing FTR tests to Scout by creating empty test skeletons. Generate the complete test structure with TODO comments indicating what needs to be implemented, but without actual test logic.
+
+# Core Requirements
+
+**IMPORTANT**: Do not modify the codebase. Instead, output the migrated code as explained in the Output Format section below.
+
+- Convert ALL test suites and test cases - do not skip any
+- Preserve the Elasticsearch license header
+- Keep any constants defined outside test cases and hooks in their original location
+- Remove all non-Scout imports
+- No syntax errors permitted
+
+### Import Selection
+
+Import from one of these Scout packages:
+
+- @kbn/scout: Platform tests (generally tests in "x-pack/platform/test/functional")
+- @kbn/scout-security: Security solution tests (generally tests in "x-pack/solutions/security/test/functional)
+- @kbn/scout-oblt: Observability solution tests (generally tests in "x-pack/solutions/observability/test/functional")
+
+For API tests, import `apiTest` instead of `test`. If the path is ambiguous, infer from test content.
+
+## Migration rules
+
+- Preserve all `describe` nesting and hierarchy
+- Convert `describe()` to `test.describe()` or `apiTest.describe()`
+- Convert `it` to `test()`or `apiTest()`
+- Preserve `.skip()`, `.only()` modifiers as-is
+- Keep all test suite tags
+- Preserve test titles exactly as written - do not modify or rephrase
+
+### Hooks
+
+- `before()` to `test.beforeAll()` or `apiTest.beforeAll()`
+- `after()` to `test.afterAll()` or `apiTest.afterAll()`
+- `beforeEach()` to `test.beforeEach()` or `apiTest.beforeEach()`
+- `afterEach()` to `test.afterEach()` or `apiTest.afterEach()`
+
+### Fixtures
+
+Deconstruct fixtures based on test type and clear need.
+
+- API tests are likely going to need `kbnClient` and `apiClient` (a complete list will be provided separately).
+- Functional tests will likely need `page`, `pageObjects`, `browserAuth`, and `kbnClient` (a complete list will be provided separately).
+
+**When in doubt, include the fixture** - it's better to include a fixture that might be needed than to omit one that is necessary. Only exclude fixtures that are clearly not used.
+
+### TODO comments
+
+Add a single TODO comment block at the start of each test/hook body with numbered implementation steps. Be specific about what the original test did. When converting an API test, include, if possible, the complete endpoint under test.
+
+## Examples
+
+A test is considered an API test if it:
+
+- Makes HTTP requests to Kibana/ES APIs directly
+- Does not use browser automation (no `page` fixture)
+- Typically located in `**/api_integration/**` directories
+
+A test is a UI test if it:
+
+- Uses browser automation (`page`, `pageObjects`)
+- Tests user interactions and visual elements
+- Typically located in `**/functional/**` directories
+
+### API Test Migration
+
+```ts
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect, apiTest } from '@kbn/scout-oblt';
+
+apiTest.describe('AddProjectMonitors', () => {
+  apiTest.describe.configure({ tag: 'skipCloud' });
+
+  apiTest.beforeAll(async ({ kbnClient, apiClient }) => {
+    // TODO: Implement test setup
+    // 1. Clean standard saved objects list
+    // 2. Enable Synthetics via PUT request to SYNTHETICS_ENABLEMENT endpoint
+    // 3. Install Synthetics package
+    // 4. Create private location
+    // 5. Create global test parameters (testGlobalParam, testGlobalParam2)
+  });
+
+  apiTest.beforeEach(async ({ apiClient }) => {
+    // TODO: Implement test setup
+    // 1. Generate unique IDs for project monitors
+    // 2. Set up projectMonitors with browser monitor fixtures
+    // 3. Set up httpProjectMonitors with http monitor fixtures
+  });
+
+  apiTest(
+    'project monitors - saves space as data stream namespace',
+    async ({ apiClient, kbnClient }) => {
+      // TODO: Implement test
+      // 1. Create test project with unique ID
+      // 2. Create test space with unique ID and name
+      // 3. Create synthetics_admin role with uptime:all permissions for all spaces
+      // 4. Create test user with synthetics_admin role
+      // 5. PUT request to update project monitors in test space
+      // 6. GET request to verify monitor was created
+      // 7. Verify monitors array length equals 1
+      // 8. Verify monitor namespace equals formatted space ID
+      // 9. Cleanup: delete monitor, user, and role
+    }
+  );
+
+  apiTest(
+    'project monitors - browser - handles custom namespace',
+    async ({ apiClient, kbnClient }) => {
+      // TODO: Implement test
+      // 1. Create test project and space with unique IDs
+      // 2. Define custom namespace as 'custom.namespace'
+      // 3. Create synthetics_admin role with uptime:all permissions
+      // 4. Create test user with role
+      // 5. PUT request to update monitor with custom namespace
+      // 6. GET request to verify monitor creation
+      // 7. Verify monitor namespace equals custom namespace
+      // 8. Cleanup: delete monitor, user, role
+    }
+  );
+
+  apiTest(
+    'project monitors - lightweight - handles custom namespace',
+    async ({ apiClient, kbnClient }) => {
+      // TODO: Implement test
+      // 1. Create test project and space with unique IDs
+      // 2. Define custom namespace as 'custom.namespace'
+      // 3. Create synthetics_admin role with uptime:all permissions
+      // 4. Create test user with role
+      // 5. PUT request to update HTTP monitor with custom namespace
+      // 6. GET request to verify monitor creation
+      // 7. Verify monitor namespace equals custom namespace
+      // 8. Cleanup: delete monitor, user, role
+    }
+  );
+
+  apiTest(
+    'project monitors - cannot update project monitors when user does not have access to all spaces using * in spaces',
+    async ({ apiClient, kbnClient }) => {
+      // TODO: Implement test
+      // 1. Create test project with unique ID
+      // 2. Create two test spaces (SPACE_ID_1, SPACE_ID_2)
+      // 3. Create role with access only to SPACE_ID_1
+      // 4. Create test user with limited role
+      // 5. Attempt to create monitor with spaces: ['*']
+      // 6. Verify request returns 403 status
+      // 7. Verify error message about insufficient permissions
+      // 8. Cleanup: delete monitor, user, role, spaces
+    }
+  );
+
+  apiTest(
+    'project monitors - user with access to all spaces can specify * in spaces and monitor is created in all spaces',
+    async ({ apiClient, kbnClient }) => {
+      // TODO: Implement test
+      // 1. Create test project with unique ID
+      // 2. Create two test spaces (SPACE_ID_1, SPACE_ID_2)
+      // 3. Create role with access to all spaces (spaces: ['*'])
+      // 4. Create test user with admin role
+      // 5. Create HTTP monitor with spaces: ['*']
+      // 6. PUT request to create monitor in SPACE_ID_1 context
+      // 7. Verify response shows monitor was created
+      // 8. Use savedObjects client to verify monitor exists in all spaces
+      // 9. Verify monitor namespaces equals '*'
+      // 10. Cleanup: delete user, role, spaces
+    }
+  );
+});
+```
+
+### UI Test Migration
+
+```ts
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect, test } from '@kbn/scout';
+
+test.describe('filter by map extent', () => {
+  test.beforeAll(async ({ kbnClient, browserAuth, pageObjects }) => {
+    // TODO: Implement test setup
+    // 1. Set user roles: ['test_logstash_reader', 'global_maps_all', 'global_dashboard_all']
+    // 2. Navigate to dashboard app
+    // 3. Go to 'filter by map extent dashboard' in edit mode
+    // 4. Wait for loading to finish
+    // 5. Wait for dashboard to render completely
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    // TODO: Implement cleanup
+    // 1. Restore user defaults
+  });
+
+  test('should not filter dashboard by map extent before "filter by map extent" is enabled', async ({
+    page,
+    pageObjects,
+  }) => {
+    // TODO: Implement test
+    // 1. Assert legacy metric shows 'Count of records' with value '6'
+  });
+
+  test('should filter dashboard by map extent when "filter by map extent" is enabled', async ({
+    page,
+    pageObjects,
+  }) => {
+    // TODO: Implement test
+    // 1. Click panel action 'FILTER_BY_MAP_EXTENT' on 'document example' panel
+    // 2. Set EUI switch 'filterByMapExtentSwitch24ade730-afe4-42b6-919a-c4e0a98c94f2' to 'check'
+    // 3. Press ESCAPE key to close panel
+    // 4. Wait for loading to finish
+    // 5. Assert legacy metric shows 'Count of records' with value '1'
+  });
+
+  test('should filter dashboard by new map extent when map is moved', async ({
+    page,
+    pageObjects,
+  }) => {
+    // TODO: Implement test
+    // 1. Set map view to coordinates (32.95539, -93.93054) with zoom level 5
+    // 2. Wait for loading to finish
+    // 3. Assert legacy metric shows 'Count of records' with value '2'
+  });
+
+  test('should remove map extent filter dashboard when "filter by map extent" is disabled', async ({
+    page,
+    pageObjects,
+  }) => {
+    // TODO: Implement test
+    // 1. Click panel action 'FILTER_BY_MAP_EXTENT' on 'document example' panel
+    // 2. Set EUI switch 'filterByMapExtentSwitch24ade730-afe4-42b6-919a-c4e0a98c94f2' to 'uncheck'
+    // 3. Press ESCAPE key to close panel
+    // 4. Wait for loading to finish
+    // 5. Assert legacy metric shows 'Count of records' with value '6'
+  });
+});
+```
+
+## Output Format
+
+IMPORTANT. Don't make changes to the codebase. Simply present the code to the user. In most cases you won't need to search around in the codebase.
+
+Structure your response like this:
+
+1. Summary (one sentence describing the migration. Example: "Migrated 5 test cases from FTR to Scout")
+2. Code: complete Scout test file with license header
+3. Notes: brief explanation of decisions made. Keep explanations concise - focus on non-obvious decisions only:
+
+- Which Scout package was chosen and why
+- Any notable structural changes
+- Any ambiguities or assumptions made
+
+4. Missing information: if you don't know how to handle a specific scenario, or if you think the prompt lacks details, mention it in this section so we can improve the prompt. This will help tremendously, so you're encouraged to provide a brief explanation of the improvements to the migration tool.

--- a/src/platform/packages/private/kbn-scout-info/llms/what-is-scout.md
+++ b/src/platform/packages/private/kbn-scout-info/llms/what-is-scout.md
@@ -44,7 +44,7 @@ Scout makes it easy to run tests your way – sequentially, in parallel, and mor
 
 ## Fixtures
 
-Fixtures offer essential context to your tests. The `@kbn/scout` package includes a collection of fixtures specifically designed for Scout tests. These fixtures provide reusable, scoped resources to ensure that tests have consistent and isolated access to criticial services such as logging, configuration, and Kibana and Elasticsearch clients.
+Fixtures offer essential context to your tests. The `@kbn/scout` package includes a collection of fixtures specifically designed for Scout tests. These fixtures provide reusable, scoped resources to ensure that tests have consistent and isolated access to critical services such as logging, configuration, and Kibana and Elasticsearch clients.
 
 ### Usage
 

--- a/src/platform/packages/private/kbn-scout-info/llms/what-is-scout.md
+++ b/src/platform/packages/private/kbn-scout-info/llms/what-is-scout.md
@@ -44,7 +44,7 @@ Scout makes it easy to run tests your way – sequentially, in parallel, and mor
 
 ## Fixtures
 
-Fixtures offer essential context to your tests. The `@kbn/scout` package includes a collection of fixtures specifically designed for Scout tests. These fixtures provide reusable, scoped resources to ensure that tests have consistent and isolated access to critical services such as logging, configuration, and Kibana and Elasticsearch clients.
+Fixtures offer essential context to your tests. The `@kbn/scout` package includes a collection of fixtures specifically designed for Scout tests. These fixtures provide reusable, scoped resources to ensure that tests have consistent and isolated access to criticial services such as logging, configuration, and Kibana and Elasticsearch clients.
 
 ### Usage
 
@@ -143,13 +143,10 @@ apiTest.describe(
 );
 ```
 
-**[1]** Import from `@kbn/scout-oblt` or from `@kbn/scout-security` if your plugin belongs to a specific solution.
-
-**[2]** We request an API key for the `admin` role using the `requestAuth` fixture.
-
-**[3]** We send a POST request to our plugin endpoint using the `apiClient` fixture.
-
-**[4]** We finally check that the response status code and body are as expected.
+- **[1]** Import from `@kbn/scout-oblt` or from `@kbn/scout-security` if your plugin belongs to a specific solution.
+- **[2]** We request an API key for the `admin` role using the `requestAuth` fixture.
+- **[3]** We send a POST request to our plugin endpoint using the `apiClient` fixture.
+- **[4]** We finally check that the response status code and body are as expected.
 
 In the example above, note the following:
 
@@ -207,8 +204,9 @@ test.describe('Painless Lab', { tag: tags.ESS_ONLY }, () => {
 });
 ```
 
-- **[1]**: Import from `@kbn/scout-oblt` or from `@kbn/scout-security` if your plugin belongs to a specific solution.
-- **[2]**: The `browserAuth` and `pageObjects` fixtures are used to log into and interact with Kibana.
+**[1]**: Import from `@kbn/scout-oblt` or from `@kbn/scout-security` if your plugin belongs to a specific solution.
+
+**[2]**: The `browserAuth` and `pageObjects` fixtures are used to log into and interact with Kibana.
 
 In the example above, note the following:
 

--- a/src/platform/packages/private/kbn-scout-info/llms/what-is-scout.md
+++ b/src/platform/packages/private/kbn-scout-info/llms/what-is-scout.md
@@ -1,0 +1,224 @@
+# What is Scout?
+
+Scout is the modern test orchestration framework designed to elevate the **developer experience**, improve **test maintainability**, and deliver **faster**, more **reliable** test execution.
+
+> 📌 As of now, Scout supports **UI** and **API** testing with [**Playwright**](https://playwright.dev).
+
+## Main features
+
+Scout comes packed with great features:
+
+| Feature                            |                                                                                                                                                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ⚡ Faster test execution           | Scout allows you to run tests in parallel against the same cluster.                                                                                                                                   |
+| 🧩 Tests live alongside the plugin | Scout tests live close to the plugin **source code**, making them easier to write, run, and maintain.                                                                                                 |
+| 🌐 Deployment-agnostic by design   | Write tests **once** and run them across different environments (e.g., stateful or serverless).                                                                                                       |
+| 🧱 Fixture-based architecture      | Use fixtures in your tests to perform authentication, data ingestion, parallelization, performance. Fixtures also provide access to the Kibana APIs and the Elasticsearch client.                     |
+| 🛠️ Enhanced developer experience   | Playwright comes with a [UI Mode](https://playwright.dev/docs/test-ui-mode) that lets you walk through each step of the test, see logs, errors, network requests, inspect the DOM snapshot, and more. |
+| 📊 Test result reporting           | The Scout Reporter captures test run metrics and uploads them to the AppEx QA team's cluster, helping teams better track, analyze, and optimize their tests.                                          |
+
+## Core principles
+
+### Modular and extensible by design
+
+The **core** Scout testing functionality resides in the [`@kbn/scout` package](https://github.com/elastic/kibana/tree/main/src/platform/packages/shared/kbn-scout), which includes common fixtures, page objects, and shared utilities. We expect these resources to be useful in most tests.
+
+Some solutions have created their **solution-specific** Scout packages (e.g., [`@kbn/scout-oblt`](https://github.com/elastic/kibana/tree/main/x-pack/solutions/observability/packages/kbn-scout-oblt) and [`@kbn/scout-security`](https://github.com/elastic/kibana/tree/main/x-pack/solutions/security/packages/kbn-scout-security)) to introduce solution-specific fixtures, helpers, and page objects that plugins can import.
+
+It is also possible for a **plugin** to define its own fixtures, page objects, and utilities – if those resources are expected to be used just by the plugin itself.
+
+### Encourages collaboration and reusability
+
+Scout encourages teams to reuse the resources created by the AppEx QA or any other team. This helps reduce code duplication, and simplifies support and adoption. If existing functionality is missing, teams can contribute it to one of the Scout packages.
+
+### Follows best practices
+
+Scout makes it easy to run tests your way – sequentially, in parallel, and more – while guiding you toward best practices. For example, Scout:
+
+- Runs every test in a clean [browser context](https://playwright.dev/docs/browser-contexts), which improves reproducibility and prevents cascading test failures.
+- Validates the Playwright configuration files to ensure consistent behavior across test suites.
+- Limits certain fixtures to provide only the functionality that a test would need.
+  - For example, the ES archiver only allows tests to load archive data; unloading is disabled as we take care of that for you at the end of the test run.
+- Extends some of the existing Playwright fixtures with additional helper methods (e.g, `page.waitForLoadingIndicatorHidden()`).
+- Initializes page objects lazily, so that they are initialized only when your test uses them.
+
+## Fixtures
+
+Fixtures offer essential context to your tests. The `@kbn/scout` package includes a collection of fixtures specifically designed for Scout tests. These fixtures provide reusable, scoped resources to ensure that tests have consistent and isolated access to critical services such as logging, configuration, and Kibana and Elasticsearch clients.
+
+### Usage
+
+Fixtures are similar to **FTR services**. They help tests with authentication, parallelization, and provide access to the Elasticsearch client, ES archiver, Kibana APIs, and more.
+
+```ts
+test.describe('My test suite', { tag: tags.DEPLOYMENT_AGNOSTIC }, () => {
+  test.beforeAll(async ({ kbnClient }) => {
+    // [1]
+    await kbnClient.importExport.load(testData.KBN_ARCHIVES.ECOMMERCE);
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    // [2]
+    await browserAuth.loginAsViewer();
+  });
+
+  // ...
+});
+```
+
+**[1]** `kbnClient` is a fixture from `@kbn/scout` that provides access to the Kibana client.
+
+**[2]** `browserAuth` is also a fixture from `@kbn/scout`.
+
+### Fixture scope
+
+Fixtures can be scoped either to the **test** or the **worker**. The scope decides when to initialize a new fixture instance: once per worker or for every test function.
+
+It is important to choose the correct scope to ensure optimal test execution speed: if a new instance is not needed for every test, the fixture should be scoped to the **worker**. Otherwise, it should be scoped to the **test**.
+
+Worker-scoped fixtures live as long as the worker lives. If a test fails, Playwright [shuts down](https://playwright.dev/docs/test-parallel#worker-processes) the workers to guarantee pristine environment for the following tests.
+
+### Core Scout fixtures
+
+Here are the fixtures provided by `@kbn/scout` (as well as solution-specific Scout packages):
+
+| Scout worker-scoped fixtures |                                                                                            |
+| ---------------------------- | ------------------------------------------------------------------------------------------ |
+| `apiClient`                  | A [supertest](https://github.com/forwardemail/supertest) wrapper for making HTTP requests. |
+| `apiServices`                | An extendable group of API helpers that interact with servers.                             |
+| `config`                     | Access to the test servers configuration.                                                  |
+| `esArchiver`                 | Utility for loading Elasticsearch data archives.                                           |
+| `esClient`                   | An Elasticsearch client instance for interacting with the cluster.                         |
+| `kbnClient`                  | A Kibana client for making HTTP requests to the Kibana server.                             |
+| `requestAuth`                | Utility for retrieving an API key for a specified role using SAML authentication.          |
+| `log`                        | A logger instance for use within fixtures and tests.                                       |
+| `samlAuth`                   | Utility for generating and handling SAML authentication flows in Kibana.                   |
+
+| Scout **test**-scoped fixtures |                                                                                                                            |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `browserAuth`                  | Enables Kibana login by setting authentication cookies directly in the browser context.                                    |
+| `pageObjects`                  | Provides access to the registered page objects.                                                                            |
+| `page`                         | [Built-in Playwright fixture](https://playwright.dev/docs/api/class-page) that Scout extends with some additional methods. |
+
+> **⚠️ Limited fixture availability**
+> Some fixtures are only available in **UI** tests (e.g., browser-related fixtures), whereas others are only available in **API** tests (e.g., `ApiWorkerFixtures` like `apiClient` and `requestAuth`).
+
+## Write Scout API tests
+
+In this guide we take a look at a real-world Scout API test. We assume you have set up your plugin to work with Scout.
+
+### A real-world example
+
+Let's take a look at [this](https://github.com/elastic/kibana/blob/0cc78184957fcd12110dabae50353392ea937508/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_disabled.spec.ts#L12-L33) API test of the [painless_lab](https://github.com/elastic/kibana/tree/main/x-pack/platform/plugins/private/painless_lab/test/scout) plugin:
+
+```ts
+import type { RoleApiCredentials } from '@kbn/scout'; // [1]
+import { apiTest, expect } from '@kbn/scout'; // [1]
+import { COMMON_HEADERS, TEST_INPUT } from '../fixtures/constants';
+
+apiTest.describe(
+  '[search serverless] POST api/painless_lab/execute',
+  { tag: ['@svlSearch'] },
+  () => {
+    let adminApiCredentials: RoleApiCredentials;
+
+    apiTest.beforeAll(async ({ requestAuth }) => {
+      adminApiCredentials = await requestAuth.getApiKey('admin'); // [2]
+    });
+
+    apiTest('should return 404', async ({ apiClient }) => {
+      const response = await apiClient.post('api/painless_lab/execute', {
+        // [3]
+        headers: {
+          ...COMMON_HEADERS,
+          ...adminApiCredentials.apiKeyHeader,
+        },
+        responseType: 'json',
+        body: TEST_INPUT.script,
+      });
+      expect(response.statusCode).toBe(404); // [4]
+      expect(response.body.message).toBe('Not Found');
+    });
+  }
+);
+```
+
+**[1]** Import from `@kbn/scout-oblt` or from `@kbn/scout-security` if your plugin belongs to a specific solution.
+
+**[2]** We request an API key for the `admin` role using the `requestAuth` fixture.
+
+**[3]** We send a POST request to our plugin endpoint using the `apiClient` fixture.
+
+**[4]** We finally check that the response status code and body are as expected.
+
+In the example above, note the following:
+
+- In the `beforeAll` block we use the `requestAuth` fixture to request an API key for the `admin` role (that we later pass to `apiClient`).
+- In the `should return 404` test case we use the `apiClient` fixture to send an HTTP request to our plugin endpoint.
+- We finally check that the response status code and body are as expected.
+
+> **⚠️ Fixture availability**
+> Some fixtures (e.g., browser-specific) are disabled as API tests should test server-side functionality only.
+
+### Save the test file
+
+API tests must have a file name that ends with `.spec.ts` (example: `execute_api_disabled.spec.ts`), and should be saved under the `<plugin-root>/test/scout/api/tests` directory.
+
+> **API tests and parallelism**
+> 📌 We're not expecting API tests to benefit from parallel runs as they usually run extremely quickly (in the order of _milliseconds_). Reach out to our team if you have a specific use case in mind that can benefit from parallel execution.
+
+## Write Scout UI tests
+
+This guide reviews a real-world UI test using Scout. We assume you have set up your plugin to work with Scout.
+
+### A real-world example
+
+Let's take a look at [this](https://github.com/elastic/kibana/blob/5d49f1bb0de978e1896254378161c3da23a7d8e6/x-pack/platform/plugins/private/painless_lab/test/scout/ui/tests/painless_lab.spec.ts#L41-L63) UI test from the `painless_lab` plugin:
+
+```ts
+import { expect, tags } from '@kbn/scout'; // [1]
+import { test } from '../fixtures';
+
+// ...
+
+test.describe('Painless Lab', { tag: tags.ESS_ONLY }, () => {
+  // [2]
+  test.beforeEach(async ({ browserAuth, pageObjects }) => {
+    await browserAuth.loginAsAdmin();
+    await pageObjects.painlessLab.goto();
+    await pageObjects.painlessLab.waitForEditorToLoad();
+  });
+
+  test('validate painless lab editor and request', async ({ pageObjects }) => {
+    await pageObjects.painlessLab.setCodeEditorValue(TEST_SCRIPT);
+    await pageObjects.painlessLab.editorOutputPane.waitFor({ state: 'visible' });
+    await expect(pageObjects.painlessLab.editorOutputPane).toContainText(TEST_SCRIPT_RESULT);
+
+    await pageObjects.painlessLab.viewRequestButton.click();
+    await expect(pageObjects.painlessLab.requestFlyoutHeader).toBeVisible();
+
+    expect(await pageObjects.painlessLab.getFlyoutRequestBody()).toBe(TEST_SCRIPT_REQUEST);
+
+    await pageObjects.painlessLab.flyoutResponseTab.click();
+    expect(await pageObjects.painlessLab.getFlyoutResponseBody()).toBe(
+      UPDATED_TEST_SCRIPT_RESPONSE
+    );
+  });
+});
+```
+
+- **[1]**: Import from `@kbn/scout-oblt` or from `@kbn/scout-security` if your plugin belongs to a specific solution.
+- **[2]**: The `browserAuth` and `pageObjects` fixtures are used to log into and interact with Kibana.
+
+In the example above, note the following:
+
+- We import `test` instead of `spaceTest` (used in parallel test runs).
+- We use the `browserAuth` fixture to log into Kibana as an admin.
+- We navigate to the Painless Lab page and wait for the editor to load with page objects (available via the `pageObjects` fixture).
+
+### Save the test file
+
+UI tests must have a file name that ends with `.spec.ts` (example: `painless_lab.spec.ts`), and should be saved under:
+
+- `<plugin-root>/test/scout/ui/tests` (for sequential tests) or
+- `<plugin-root>/test/scout/ui/parallel_tests` (for parallel tests).

--- a/src/platform/packages/shared/kbn-scout/README.md
+++ b/src/platform/packages/shared/kbn-scout/README.md
@@ -572,3 +572,7 @@ On merge commits, Scout tests run in a non-blocking mode.
 | 1         | Missing configuration (e.g. SCOUT_CONFIG_GROUP_KEY and SCOUT_CONFIG_GROUP_TYPE environment variables not set) |
 | 2         | No tests in Playwright config                                                                                 |
 | 10        | Tests failed                                                                                                  |
+
+### AI prompts to help you migrate from FTR
+
+The `@kbn/scout-info` package contains [AI prompts](https://github.com/elastic/kibana/tree/main/src/platform/packages/private/kbn-scout-info/llms) to help you migrate FTR test files.


### PR DESCRIPTION
This PR adds creates a new `llms` folder in the `@kbn/scout-info` package to add a prompt developers (and LLMs) can use to generate a Scout skeleton test (a test file complete with test suites and test cases, but with no actual implementation). 

We provide the first prompt, `generate-scout-skeleton-from-ftr-test.md`, developers can use to convert an existing FTR test into a Scout skeleton. Find more instructions under `llms/README.md`.