### PR TITLE
[ES|QL] Return one empty array when user drops all columns

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/run_query.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/run_query.ts
@@ -181,8 +181,22 @@ export async function getESQLResults({
       }
     )
   );
+
+  const rawResponse = result.rawResponse as unknown as ESQLSearchResponse;
+
+  // Normalize response.values: if all arrays are empty, convert to single empty array
+  const normalizedValues =
+    rawResponse.values && rawResponse.values.every((row) => Array.isArray(row) && row.length === 0)
+      ? []
+      : rawResponse.values;
+
+  const response = {
+    ...rawResponse,
+    values: normalizedValues,
+  };
+
   return {
-    response: result.rawResponse as unknown as ESQLSearchResponse,
+    response,
     params: result.requestParams as unknown as ESQLSearchParams,
   };
 }

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.ts
@@ -351,6 +351,13 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
               }
             : undefined;
 
+          // Normalize body.values: if all arrays are empty, convert to single empty array
+          const normalizedValues = body.values.every(
+            (row) => Array.isArray(row) && row.length === 0
+          )
+            ? []
+            : body.values;
+
           const allColumns =
             // eslint-disable-next-line @typescript-eslint/naming-convention
             (body.all_columns ?? body.columns)?.map(({ name, type, original_types }) => {
@@ -398,7 +405,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
           }
           const columnNames = updatedWithVariablesColumns?.map(({ name }) => name);
 
-          const rows = body.values.map((row) => zipObject(columnNames, row));
+          const rows = normalizedValues.map((row) => zipObject(columnNames, row));
 
           return {
             type: 'datatable',
@@ -406,7 +413,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
               type: ESQL_TABLE_TYPE,
               query,
               statistics: {
-                totalCount: body.values.length,
+                totalCount: normalizedValues.length,
               },
             },
             columns: updatedWithVariablesColumns,


### PR DESCRIPTION
## Summary

With https://github.com/elastic/dev/issues/3284 ES made one change. When the user drops all columns

e.g.

```
FROM logs-aws_s3 | KEEP @timestamp | DROP @timestamp
```

Now instead of getting


```
{
   "columns": [ ],
   "values": [ ]       // all the rows are dropped
}
```

we get
```
{
   "columns": [ ],
   "values": [
       [ ],
       [ ],
       [ ],        // preserve the rows
       [ ],
       [ ]
    ]
}
```
This is making Discover (and lens table results) to display n empty rows which I think is problematic. This makes sense for ES but for us it causes a regression. This PR makes certain that we keep the old behavior (which is show the empty state)

