### PR TITLE
Anchor tabbed modal using only CSS

### DIFF
--- a/src/platform/packages/shared/shared-ux/modal/tabbed/src/tabbed_modal.tsx
+++ b/src/platform/packages/shared/shared-ux/modal/tabbed/src/tabbed_modal.tsx
@@ -8,16 +8,14 @@
  */
 
 import React, {
-  useRef,
   useMemo,
-  useState,
-  useLayoutEffect,
   useCallback,
   Fragment,
   type ComponentProps,
   type FC,
   type ReactElement,
 } from 'react';
+import { Global } from '@emotion/react';
 import {
   EuiButton,
   EuiModal,
@@ -77,38 +75,9 @@ const TabbedModalInner: FC<ITabbedModalInner> = ({
 }) => {
   const { tabs, state, dispatch } =
     useModalContext<Array<IModalTabDeclaration<Record<string, any>>>>();
-  const { selectedTabId, defaultSelectedTabId } = state.meta;
+  const { selectedTabId } = state.meta;
   const tabbedModalHTMLId = useGeneratedHtmlId({ prefix: 'tabbedModal' });
-  const tabbedModalHeadingHTMLId = useGeneratedHtmlId({ prefix: 'tabbedModal' });
-  const defaultTabCoordinates = useRef(new Map<string, Pick<DOMRect, 'top'>>());
-  const [translateYValue, setTranslateYValue] = useState(0);
-
-  const onTabContentRender = useCallback(() => {
-    const tabbedModal = document.querySelector(`[id="${tabbedModalHTMLId}"]`) as HTMLDivElement;
-
-    if (!defaultTabCoordinates.current.get(defaultSelectedTabId)) {
-      // on initial render the modal animates into it's final position
-      // hence the need to wait till said animation has completed
-      tabbedModal.onanimationend = () => {
-        const { top } = tabbedModal.getBoundingClientRect();
-        defaultTabCoordinates.current.set(defaultSelectedTabId, { top });
-      };
-    } else {
-      let translateYOverride = 0;
-
-      if (defaultSelectedTabId !== selectedTabId) {
-        const defaultTabData = defaultTabCoordinates.current.get(defaultSelectedTabId);
-
-        const rect = tabbedModal.getBoundingClientRect();
-
-        translateYOverride = translateYValue + (defaultTabData?.top! - rect.top);
-      }
-
-      if (translateYOverride !== translateYValue) {
-        setTranslateYValue(translateYOverride);
-      }
-    }
-  }, [tabbedModalHTMLId, defaultSelectedTabId, selectedTabId, translateYValue]);
+  const tabbedModalHeadingHTMLId = useGeneratedHtmlId({ prefix: 'tabbedModalHeading' });
 
   const selectedTabState = useMemo(
     () => (selectedTabId ? state[selectedTabId] : {}),
@@ -152,12 +121,6 @@ const TabbedModalInner: FC<ITabbedModalInner> = ({
     );
   }, [onSelectedTabChanged, selectedTabId, tabs]);
 
-  const modalPositionOverrideStyles: React.CSSProperties = {
-    transform: `translateY(${translateYValue}px)`,
-    transformOrigin: 'top',
-    willChange: 'transform',
-  };
-
   return (
     <EuiModal
       id={tabbedModalHTMLId}
@@ -169,36 +132,32 @@ const TabbedModalInner: FC<ITabbedModalInner> = ({
       data-test-subj={props['data-test-subj']}
       css={{
         ...(modalWidth ? { width: modalWidth } : {}),
-        ...modalPositionOverrideStyles,
       }}
       aria-labelledby={tabbedModalHeadingHTMLId}
     >
+      <Global
+        styles={{
+          // overrides so modal retains a fixed position from top of viewport, despite having content of varying heights
+          ['.euiOverlayMask']: {
+            alignItems: 'flex-start !important',
+            paddingBlockStart: '20vh !important',
+          },
+        }}
+      />
       <EuiModalHeader>
         <EuiModalHeaderTitle id={tabbedModalHeadingHTMLId}>{modalTitle}</EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
-        <Fragment>
-          <Fragment>{renderTabs()}</Fragment>
-          <EuiSpacer size="m" />
-          {React.createElement(function RenderSelectedTabContent() {
-            useLayoutEffect(() => {
-              requestAnimationFrame(onTabContentRender);
-            }, []);
-            return (
-              <div
-                css={{ display: 'contents' }}
-                data-test-subj={`tabbedModal-${selectedTabId}-content`}
-              >
-                <SelectedTabContent
-                  {...{
-                    state: selectedTabState,
-                    dispatch,
-                  }}
-                />
-              </div>
-            );
-          })}
-        </Fragment>
+        <Fragment>{renderTabs()}</Fragment>
+        <EuiSpacer size="m" />
+        <div css={{ display: 'contents' }} data-test-subj={`tabbedModal-${selectedTabId}-content`}>
+          <SelectedTabContent
+            {...{
+              state: selectedTabState,
+              dispatch,
+            }}
+          />
+        </div>
       </EuiModalBody>
       {modalActionBtn?.id !== undefined && selectedTabState && (
         <EuiModalFooter>

--- a/src/platform/packages/shared/shared-ux/modal/tabbed/src/tabbed_modal.tsx
+++ b/src/platform/packages/shared/shared-ux/modal/tabbed/src/tabbed_modal.tsx
@@ -138,9 +138,9 @@ const TabbedModalInner: FC<ITabbedModalInner> = ({
       <Global
         styles={{
           // overrides so modal retains a fixed position from top of viewport, despite having content of varying heights
-          ['.euiOverlayMask']: {
-            alignItems: 'flex-start !important',
-            paddingBlockStart: '20vh !important',
+          [`.euiOverlayMask:has([id="${tabbedModalHTMLId}"])`]: {
+            alignItems: 'flex-start',
+            paddingBlockStart: '20vh',
           },
         }}
       />


### PR DESCRIPTION
## Summary


This PR switches the implementation to anchor the tabbed modals to a pure CSS solution, this solution had been suggested [previously](https://github.com/elastic/kibana/pull/189399#pullrequestreview-2207173137) however at the time it wasn't apparent we could leverage the `Global` component from emotion,  to coordinate insert and removing styles global styles. 

https://github.com/user-attachments/assets/cb67afea-a63f-40d1-9789-60ea3d99c363

<!-- 
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->