### PR TITLE
[Entity Analytics][Privmon] Enable privileged user monitoring advanced setting by default

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -477,7 +477,7 @@ export const initUiSettings = (
           defaultMessage: 'Privileged user monitoring',
         }
       ),
-      value: false,
+      value: true,
       description: i18n.translate(
         'xpack.securitySolution.uiSettings.enablePrivilegedUserMonitoringDescription',
         {


### PR DESCRIPTION
## Summary

Privileged user monitoring is behind an advanced setting, this sets that advanced setting to true meaning the feature will be enabled on all deployemnts

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->