### PR TITLE
[ObsUX][Infra] Remove 'ecs' from schema selector if APM-only hosts are available

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/common/metrics_sources/get_has_data.ts
+++ b/x-pack/solutions/observability/plugins/infra/common/metrics_sources/get_has_data.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isoToEpochRt, jsonRt } from '@kbn/io-ts-utils';
+import { isoToEpochRt, jsonRt, toBooleanRt } from '@kbn/io-ts-utils';
 import * as rt from 'io-ts';
 import { SupportedEntityTypesRT } from '../http_api/shared/entity_type';
 import { DataSchemaFormatRT } from '../http_api/shared';
@@ -22,6 +22,7 @@ export const getTimeRangeMetadataQueryParamsRT = rt.intersection([
   rt.partial({
     kuery: rt.string,
     filters: jsonRt.pipe(rt.UnknownRecord),
+    isInventoryView: toBooleanRt,
   }),
   rt.type({
     dataSource: SupportedEntityTypesRT,

--- a/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range_metadata.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range_metadata.ts
@@ -20,12 +20,14 @@ export const useTimeRangeMetadata = ({
   filters,
   start,
   end,
+  isInventoryView = false,
 }: {
   kuery?: string;
   filters?: string;
   dataSource: EntityTypes;
   start: string;
   end: string;
+  isInventoryView?: boolean;
 }): FetcherResult<GetTimeRangeMetadataResponse> => {
   const { data, refetch, status } = useFetcher(
     async (callApi) => {
@@ -37,12 +39,13 @@ export const useTimeRangeMetadata = ({
           kuery,
           dataSource,
           filters,
+          isInventoryView,
         },
       });
 
       return decodeOrThrow(getTimeRangeMetadataResponseRT)(response);
     },
-    [start, end, kuery, filters, dataSource],
+    [start, end, kuery, filters, dataSource, isInventoryView],
     {
       reloadRequestTimeUpdateEnabled: false,
     }

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/providers/inventory_timerange_metadata_provider.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/providers/inventory_timerange_metadata_provider.tsx
@@ -32,6 +32,7 @@ export const InventoryTimeRangeMetadataProvider = ({ children }: { children: Rea
       kuery={filterQuery.query}
       start={start}
       end={end}
+      isInventoryView
     >
       {children}
     </TimeRangeMetadataProvider>

--- a/x-pack/solutions/observability/plugins/infra/server/routes/metrics_sources/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/metrics_sources/index.ts
@@ -278,7 +278,7 @@ export const initMetricsSourceConfigurationRoutes = (libs: InfraBackendLibs) => 
     },
     async (context, request, response) => {
       try {
-        const { from, to, dataSource, kuery, filters } = request.query;
+        const { from, to, dataSource, kuery, filters, isInventoryView } = request.query;
         const infraMetricsClient = await getInfraMetricsClient({
           request,
           libs,
@@ -309,7 +309,7 @@ export const initMetricsSourceConfigurationRoutes = (libs: InfraBackendLibs) => 
                   should: [
                     ...termsQuery(EVENT_MODULE, inventoryModel.requiredIntegration.beats),
                     ...termsQuery(METRICSET_MODULE, inventoryModel.requiredIntegration.beats),
-                    ...termsQuery(DATASTREAM_DATASET, 'apm*'),
+                    ...(!isInventoryView ? termsQuery(DATASTREAM_DATASET, 'apm*') : []),
                   ],
                   minimum_should_match: 1,
                   filter: [


### PR DESCRIPTION
## Summary

Closes #237412

This PR fixes a scenario where a user could see `There are hosts available in another schema` when APM-only hosts were available. Since Inventory UI doesn't support APM-only hosts, this was needed to avoid showing the schema as available.

## Before

![Image](https://github.com/user-attachments/assets/312d935d-5c76-482f-add0-e393b0a8e3e0)

## After

https://github.com/user-attachments/assets/685ed96f-e24d-44e7-b194-19cb4bbf68ca

## Testing instructions
- Connect to `edge-oblt` cluster with local Kibana
- Go to the infra inventory ui

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->