### PR TITLE
[Dashboards] Soften validation on filter schema

### DIFF
--- a/src/platform/packages/shared/kbn-es-query-server/src/filter.ts
+++ b/src/platform/packages/shared/kbn-es-query-server/src/filter.ts
@@ -20,30 +20,33 @@ const filterStateStoreSchema = schema.oneOf(
   }
 );
 
-export const filterMetaSchema = schema.object({
-  alias: schema.maybe(schema.nullable(schema.string())),
-  disabled: schema.maybe(schema.boolean()),
-  negate: schema.maybe(schema.boolean()),
-  controlledBy: schema.maybe(
-    schema.string({ meta: { description: 'Identifies the owner the filter.' } })
-  ),
-  group: schema.maybe(
-    schema.string({ meta: { description: 'The group to which this filter belongs.' } })
-  ),
-  // field is missing from the Filter type, but is stored in SerializedSearchSourceFields
-  // see the todo in src/platform/packages/shared/kbn-es-query/src/filters/helpers/update_filter.ts
-  field: schema.maybe(schema.string()),
-  index: schema.maybe(schema.string()),
-  isMultiIndex: schema.maybe(schema.boolean()),
-  type: schema.maybe(schema.string()),
-  key: schema.maybe(schema.string()),
-  // We could consider creating FilterMetaParams as a schema to match the concrete Filter type.
-  // However, this is difficult because FilterMetaParams can be a `filterSchema` which is defined below.
-  // This would require a more complex schema definition that can handle recursive types.
-  // For now, we use `schema.any()` to allow flexibility in the params field.
-  params: schema.maybe(schema.any()),
-  value: schema.maybe(schema.string()),
-});
+export const filterMetaSchema = schema.object(
+  {
+    alias: schema.maybe(schema.nullable(schema.string())),
+    disabled: schema.maybe(schema.boolean()),
+    negate: schema.maybe(schema.boolean()),
+    controlledBy: schema.maybe(
+      schema.string({ meta: { description: 'Identifies the owner the filter.' } })
+    ),
+    group: schema.maybe(
+      schema.string({ meta: { description: 'The group to which this filter belongs.' } })
+    ),
+    // field is missing from the Filter type, but is stored in SerializedSearchSourceFields
+    // see the todo in src/platform/packages/shared/kbn-es-query/src/filters/helpers/update_filter.ts
+    field: schema.maybe(schema.string()),
+    index: schema.maybe(schema.string()),
+    isMultiIndex: schema.maybe(schema.boolean()),
+    type: schema.maybe(schema.string()),
+    key: schema.maybe(schema.string()),
+    // We could consider creating FilterMetaParams as a schema to match the concrete Filter type.
+    // However, this is difficult because FilterMetaParams can be a `filterSchema` which is defined below.
+    // This would require a more complex schema definition that can handle recursive types.
+    // For now, we use `schema.any()` to allow flexibility in the params field.
+    params: schema.maybe(schema.any()),
+    value: schema.maybe(schema.string()),
+  },
+  { unknowns: 'allow' }
+);
 
 export const filterSchema = schema.object(
   {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/237472

Fixes a bug where dashboards can not be saved when a filter pill has a combined filter using OR or AND operations.

The filters schema from the package that dashboard uses in it's validation does not account for combined filters in the filter pills. I recommend we fall back to softening the validation while we work on these schemas for the public API.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->