### PR TITLE
[kbn/bench] Change config cwd to process.cwd

### DIFF
--- a/src/platform/packages/shared/kbn-bench/src/collect_and_run.ts
+++ b/src/platform/packages/shared/kbn-bench/src/collect_and_run.ts
@@ -21,7 +21,7 @@ export async function collectAndRun({
   context: GlobalRunContext;
   configGlob?: string | string[];
 }): Promise<ConfigResult[]> {
-  const { log, globalConfig, runtimeOverrides, workspace } = context;
+  const { log, globalConfig, runtimeOverrides } = context;
 
   const startAll = performance.now();
 
@@ -29,7 +29,7 @@ export async function collectAndRun({
 
   const patterns = castArray(configGlob ?? []);
 
-  const configPaths = await collectConfigPaths({ patterns, cwd: workspace.getDir() });
+  const configPaths = await collectConfigPaths({ patterns, cwd: process.cwd() });
 
   log.debug(`Discovered ${configPaths.length} config path(s)`);
 

--- a/src/platform/packages/shared/kbn-bench/src/collect_and_run_for_right_hand_side.ts
+++ b/src/platform/packages/shared/kbn-bench/src/collect_and_run_for_right_hand_side.ts
@@ -21,13 +21,13 @@ export async function collectAndRunForRightHandSide({
   context: GlobalRunContext;
   leftResults: ConfigResult[];
 }): Promise<ConfigResult[]> {
-  const { log, globalConfig, runtimeOverrides, workspace } = context;
+  const { log, globalConfig, runtimeOverrides } = context;
 
   const startAll = performance.now();
 
   log.debug('Collecting benchmark configs');
 
-  const configPaths = await collectConfigPaths({ patterns: [], cwd: workspace.getDir() });
+  const configPaths = await collectConfigPaths({ patterns: [], cwd: process.cwd() });
 
   log.debug(`Discovered ${configPaths.length} config path(s)`);
 


### PR DESCRIPTION
## Summary

When running kbn/bench command using --right, --left and --config options, it will load the config from the related workspace. The change in this PR makes the command read the config from the main repo to also consider temporary changes that we have there.

#### Example command
```
node scripts/bench.js --left 31984a26989850bba91e8e6308429b5b4Cf99e01 --right 8f01a41c470abaa8b7b2a048ad16fd21126d8f95 --config src/platform/packages/shared/kbn-jest-benchmarks/benchmark.config.ts
```