### PR TITLE
[Security Solution] Allow partial matches on rule name when searching installed rules.

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
@@ -25,15 +25,56 @@ describe('convertRulesFilterToKQL', () => {
     const kql = convertRulesFilterToKQL({ ...filterOptions, filter: 'foo' });
 
     expect(kql).toBe(
-      '(alert.attributes.name: "foo" OR alert.attributes.params.index: "foo" OR alert.attributes.params.threat.tactic.id: "foo" OR alert.attributes.params.threat.tactic.name: "foo" OR alert.attributes.params.threat.technique.id: "foo" OR alert.attributes.params.threat.technique.name: "foo" OR alert.attributes.params.threat.technique.subtechnique.id: "foo" OR alert.attributes.params.threat.technique.subtechnique.name: "foo")'
+      '(' +
+        'alert.attributes.name.keyword: *foo* ' +
+        'OR alert.attributes.params.index: "foo" ' +
+        'OR alert.attributes.params.threat.tactic.id: "foo" ' +
+        'OR alert.attributes.params.threat.tactic.name: "foo" ' +
+        'OR alert.attributes.params.threat.technique.id: "foo" ' +
+        'OR alert.attributes.params.threat.technique.name: "foo" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.id: "foo" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.name: "foo"' +
+        ')'
     );
   });
 
-  it('escapes "filter" value properly', () => {
-    const kql = convertRulesFilterToKQL({ ...filterOptions, filter: '" OR (foo: bar)' });
+  it('escapes "filter" value for single term searches', () => {
+    const kql = convertRulesFilterToKQL({
+      ...filterOptions,
+      filter: '"a<detection\\-rule*with)a<surprise:',
+    });
 
     expect(kql).toBe(
-      '(alert.attributes.name: "\\" OR (foo: bar)" OR alert.attributes.params.index: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo: bar)")'
+      '(' +
+        'alert.attributes.name.keyword: *\\"a\\<detection\\\\-rule\\*with\\)a\\<surprise\\:* ' +
+        'OR alert.attributes.params.index: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.name: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.name: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.name: "\\"a<detection\\\\-rule*with)a<surprise:"' +
+        ')'
+    );
+  });
+
+  it('escapes "filter" value for multiple term searches', () => {
+    const kql = convertRulesFilterToKQL({
+      ...filterOptions,
+      filter: '"a <detection rule with)\\a< surprise:',
+    });
+
+    expect(kql).toBe(
+      '(' +
+        'alert.attributes.name: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.index: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.id: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.name: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.id: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.name: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.id: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.name: "\\"a <detection rule with)\\\\a< surprise:"' +
+        ')'
     );
   });
 
@@ -74,7 +115,19 @@ describe('convertRulesFilterToKQL', () => {
     });
 
     expect(kql).toBe(
-      `(alert.attributes.name: "foo" OR alert.attributes.params.index: "foo" OR alert.attributes.params.threat.tactic.id: "foo" OR alert.attributes.params.threat.tactic.name: "foo" OR alert.attributes.params.threat.technique.id: "foo" OR alert.attributes.params.threat.technique.name: "foo" OR alert.attributes.params.threat.technique.subtechnique.id: "foo" OR alert.attributes.params.threat.technique.subtechnique.name: "foo") AND alert.attributes.params.immutable: true AND alert.attributes.tags:(\"tag1\" AND \"tag2\")`
+      `(` +
+        `alert.attributes.name.keyword: *foo* OR ` +
+        `alert.attributes.params.index: "foo" OR ` +
+        `alert.attributes.params.threat.tactic.id: "foo" OR ` +
+        `alert.attributes.params.threat.tactic.name: "foo" OR ` +
+        `alert.attributes.params.threat.technique.id: "foo" OR ` +
+        `alert.attributes.params.threat.technique.name: "foo" OR ` +
+        `alert.attributes.params.threat.technique.subtechnique.id: "foo" OR ` +
+        `alert.attributes.params.threat.technique.subtechnique.name: "foo")` +
+        ` AND ` +
+        `alert.attributes.params.immutable: true` +
+        ` AND ` +
+        `alert.attributes.tags:(\"tag1\" AND \"tag2\")`
     );
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.ts
@@ -8,7 +8,7 @@
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import type { RuleExecutionStatus } from '../../api/detection_engine';
 import { RuleCustomizationStatus, RuleExecutionStatusEnum } from '../../api/detection_engine';
-import { prepareKQLStringParam } from '../../utils/kql';
+import { fullyEscapeKQLStringParam, prepareKQLStringParam } from '../../utils/kql';
 import {
   ENABLED_FIELD,
   IS_CUSTOMIZED_FIELD,
@@ -106,7 +106,6 @@ export function convertRulesFilterToKQL({
 }
 
 const SEARCHABLE_RULE_ATTRIBUTES = [
-  RULE_NAME_FIELD,
   RULE_PARAMS_FIELDS.INDEX,
   RULE_PARAMS_FIELDS.TACTIC_ID,
   RULE_PARAMS_FIELDS.TACTIC_NAME,
@@ -116,11 +115,36 @@ const SEARCHABLE_RULE_ATTRIBUTES = [
   RULE_PARAMS_FIELDS.SUBTECHNIQUE_NAME,
 ];
 
-export function convertRuleSearchTermToKQL(
-  searchTerm: string,
-  attributes = SEARCHABLE_RULE_ATTRIBUTES
-): string {
-  return attributes.map((param) => `${param}: ${prepareKQLStringParam(searchTerm)}`).join(' OR ');
+/**
+ * Build KQL search terms.
+ *
+ * Note that RULE_NAME_FIELD is special, for single term searches
+ * it includes partial matches, supporting special characters.
+ *
+ * Ie - "sql" =KQL=> *sql* --matches-->  sql, Postgreslq, SQLCMD.EXE
+ *    - "sql:" =KQL=> *sql\:* --matches-->  sql:x64, but NOT sql_x64
+ *
+ * Whereas the rest of the fields, and multiple term searches,
+ * we use exact term match with quotations.
+ *
+ * Ie - "sql" =KQL=> "sql" --matches--> sql server, but NOT mssql or SQLCMD.EXE
+ *
+ * @param searchTerm search term (ie from the search bar)
+ * @returns KQL String
+ */
+export function convertRuleSearchTermToKQL(searchTerm: string): string {
+  const searchableConditions = SEARCHABLE_RULE_ATTRIBUTES.map(
+    (attribute) => `${attribute}: ${prepareKQLStringParam(searchTerm)}`
+  );
+  const escapedTerm = fullyEscapeKQLStringParam(searchTerm);
+  const isSingleTerm = escapedTerm.split(' ').length === 1;
+  let ruleNameCondition = '';
+  if (isSingleTerm) {
+    ruleNameCondition = `${RULE_NAME_FIELD}.keyword: *${escapedTerm}*`;
+  } else {
+    ruleNameCondition = `${RULE_NAME_FIELD}: ${prepareKQLStringParam(searchTerm)}`;
+  }
+  return [ruleNameCondition].concat(searchableConditions).join(' OR ');
 }
 
 export function convertRuleTagsToKQL(tags: string[]): string {

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.ts
@@ -60,7 +60,7 @@ export function convertRulesFilterToKQL({
 }: Partial<RulesFilterOptions>): string {
   const kql: string[] = [];
 
-  if (searchTerm?.length) {
+  if (searchTerm?.trim().length) {
     kql.push(`(${convertRuleSearchTermToKQL(searchTerm)})`);
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/common/utils/kql.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/utils/kql.ts
@@ -75,12 +75,16 @@ export function fullyEscapeKQLStringParam(value = ''): string {
 }
 
 const SPECIAL_KQL_CHARACTERS = '\\(){}:<>"*';
+const SPECIAL_KQL_CHARACTERS_REGEX = new RegExp(
+  `[${SPECIAL_KQL_CHARACTERS.split('').join('\\')}]`,
+  'g'
+);
 
-const escapeSpecialCharacters = (val: string) =>
-  val.replace(new RegExp(`[${SPECIAL_KQL_CHARACTERS.split('').join('\\')}]`, 'g'), '\\$&');
+const escapeSpecialKQLCharacters = (val: string) =>
+  val.replace(SPECIAL_KQL_CHARACTERS_REGEX, '\\$&');
 
 const simplifyWhitespace = (val: string) => val.replace(/\s+/g, ' ');
 
 const trim = (val: string) => val.trim();
 
-const fullyEscapeStringValue = flow(escapeSpecialCharacters, simplifyWhitespace, trim);
+const fullyEscapeStringValue = flow(escapeSpecialKQLCharacters, simplifyWhitespace, trim);

--- a/x-pack/solutions/security/plugins/security_solution/common/utils/kql.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/utils/kql.ts
@@ -33,23 +33,54 @@ export function prepareKQLStringParam(value: string): string {
 }
 
 /**
- * Escapes string param intended to be passed to KQL. As official docs
- * [here](https://www.elastic.co/guide/en/kibana/current/kuery-query.html) say
- * `Certain characters must be escaped by a backslash (unless surrounded by quotes).` and
- * `You must escape following characters: \():<>"*`.
+ * Partially escapes string param intended to be passed to KQL.
  *
- * This function assumes the value is surrounded by quotes so it escapes quotes, tabs and new line symbols.
+ * This is intended to be used for KQL search terms surrounded by quotes.
+ * It escapes quotes, backslashes, tabs and new line symbols.
  *
  * @param param a string param value intended to be passed to KQL
- * @returns an escaped string param value
+ * @returns a partially escaped KQL string param
  */
 export function escapeKQLStringParam(value = ''): string {
-  return escapeStringValue(value);
+  return partiallyEscapeStringValue(value);
 }
 
 const escapeQuotes = (val: string) => val.replace(/["]/g, '\\$&'); // $& means the whole matched string
 
+const escapeBackslash = (val: string) => val.replace(/\\/g, '\\$&');
+
 const escapeTabs = (val: string) =>
   val.replace(/\t/g, '\\t').replace(/\r/g, '\\r').replace(/\n/g, '\\n');
 
-const escapeStringValue = flow(escapeQuotes, escapeTabs);
+const partiallyEscapeStringValue = flow(escapeBackslash, escapeQuotes, escapeTabs);
+
+/**
+ * Fully escapes special characters to improve matching on KQL.
+ *
+ * As per official docs [here](https://www.elastic.co/guide/en/kibana/current/kuery-query.html)
+ * `Certain characters must be escaped by a backslash (unless surrounded by quotes).` and
+ * `You must escape following characters: \():<>"*`.
+ *
+ * This is intended to be used on KQL search terms WITHOUT quotes.
+ *
+ * @example "a \"user-agent+ \t }with \n a *\:(surprise!) " => "a \\\\"user-agent+ \\}with a \\*\\\\:\\(surprise!\\)"
+ *
+ * @see https://www.elastic.co/docs/reference/query-languages/kql
+ *
+ * @param param a string param value intended to be passed to KQL
+ * @returns a fully escaped KQL string value
+ */
+export function fullyEscapeKQLStringParam(value = ''): string {
+  return fullyEscapeStringValue(value);
+}
+
+const SPECIAL_KQL_CHARACTERS = '\\(){}:<>"*';
+
+const escapeSpecialCharacters = (val: string) =>
+  val.replace(new RegExp(`[${SPECIAL_KQL_CHARACTERS.split('').join('\\')}]`, 'g'), '\\$&');
+
+const simplifyWhitespace = (val: string) => val.replace(/\s+|\t+|\r+|\n+/g, ' ');
+
+const trim = (val: string) => val.trim();
+
+const fullyEscapeStringValue = flow(escapeSpecialCharacters, simplifyWhitespace, trim);

--- a/x-pack/solutions/security/plugins/security_solution/common/utils/kql.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/utils/kql.ts
@@ -79,7 +79,7 @@ const SPECIAL_KQL_CHARACTERS = '\\(){}:<>"*';
 const escapeSpecialCharacters = (val: string) =>
   val.replace(new RegExp(`[${SPECIAL_KQL_CHARACTERS.split('').join('\\')}]`, 'g'), '\\$&');
 
-const simplifyWhitespace = (val: string) => val.replace(/\s+|\t+|\r+|\n+/g, ' ');
+const simplifyWhitespace = (val: string) => val.replace(/\s+/g, ' ');
 
 const trim = (val: string) => val.trim();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { buildEsQuery } from '@kbn/es-query';
+import { fromKueryExpression } from '@kbn/es-query';
 import { KibanaServices } from '../../../common/lib/kibana';
 
 import { DETECTION_ENGINE_RULES_EXCEPTIONS_REFERENCE_URL } from '../../../../common/api/detection_engine/rule_exceptions';
@@ -179,7 +179,16 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: "hello world" OR alert.attributes.params.index: "hello world" OR alert.attributes.params.threat.tactic.id: "hello world" OR alert.attributes.params.threat.tactic.name: "hello world" OR alert.attributes.params.threat.technique.id: "hello world" OR alert.attributes.params.threat.technique.name: "hello world" OR alert.attributes.params.threat.technique.subtechnique.id: "hello world" OR alert.attributes.params.threat.technique.subtechnique.name: "hello world")',
+              '(' +
+              'alert.attributes.name: "hello world" ' +
+              'OR alert.attributes.params.index: "hello world" ' +
+              'OR alert.attributes.params.threat.tactic.id: "hello world" ' +
+              'OR alert.attributes.params.threat.tactic.name: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.id: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.name: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "hello world"' +
+              ')',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',
@@ -189,7 +198,46 @@ describe('Detections Rules API', () => {
       );
     });
 
-    test('check parameter url, query with a filter get escaped correctly', async () => {
+    test('check parameter url, query with a filter get escaped correctly (single term)', async () => {
+      await fetchRules({
+        filterOptions: {
+          filter: '"user\\-agent*with)a<surprise:',
+          showCustomRules: false,
+          showElasticRules: false,
+          tags: [],
+        },
+        sortingOptions: {
+          field: 'enabled',
+          order: 'desc',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_find',
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            filter:
+              '(' +
+              'alert.attributes.name.keyword: *\\"user\\\\-agent\\*with\\)a\\<surprise\\:* ' +
+              'OR alert.attributes.params.index: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.tactic.id: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.tactic.name: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.id: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.name: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "\\"user\\\\-agent*with)a<surprise:"' +
+              ')',
+            page: 1,
+            per_page: 20,
+            sort_field: 'enabled',
+            sort_order: 'desc',
+          },
+        })
+      );
+    });
+
+    test('check parameter url, query with a filter get escaped correctly (multiple terms)', async () => {
       await fetchRules({
         filterOptions: {
           filter: '" OR (foo:bar)',
@@ -209,7 +257,16 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: "\\" OR (foo:bar)" OR alert.attributes.params.index: "\\" OR (foo:bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo:bar)")',
+              '(' +
+              'alert.attributes.name: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.index: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.tactic.id: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.tactic.name: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.id: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.name: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo:bar)"' +
+              ')',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',
@@ -352,7 +409,7 @@ describe('Detections Rules API', () => {
           },
         ],
       ] = fetchMock.mock.calls;
-      expect(() => buildEsQuery(undefined, { query: filter, language: 'kuery' }, [])).not.toThrow();
+      expect(() => fromKueryExpression(filter)).not.toThrow();
     });
 
     test('query KQL parses without errors when filter contains characters such as double quotes', async () => {
@@ -376,7 +433,7 @@ describe('Detections Rules API', () => {
           },
         ],
       ] = fetchMock.mock.calls;
-      expect(() => buildEsQuery(undefined, { query: filter, language: 'kuery' }, [])).not.toThrow();
+      expect(() => fromKueryExpression(filter)).not.toThrow();
     });
 
     test('query KQL parses without errors when tags contains characters such as double quotes', async () => {
@@ -400,7 +457,7 @@ describe('Detections Rules API', () => {
           },
         ],
       ] = fetchMock.mock.calls;
-      expect(() => buildEsQuery(undefined, { query: filter, language: 'kuery' }, [])).not.toThrow();
+      expect(() => fromKueryExpression(filter)).not.toThrow();
     });
 
     test('check parameter url, query with all options', async () => {
@@ -422,7 +479,16 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: "ruleName" OR alert.attributes.params.index: "ruleName" OR alert.attributes.params.threat.tactic.id: "ruleName" OR alert.attributes.params.threat.tactic.name: "ruleName" OR alert.attributes.params.threat.technique.id: "ruleName" OR alert.attributes.params.threat.technique.name: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.id: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.name: "ruleName") AND alert.attributes.tags:("hello" AND "world")',
+              '(' +
+              'alert.attributes.name.keyword: *ruleName* ' +
+              'OR alert.attributes.params.index: "ruleName" ' +
+              'OR alert.attributes.params.threat.tactic.id: "ruleName" ' +
+              'OR alert.attributes.params.threat.tactic.name: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.id: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.name: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "ruleName") ' +
+              'AND alert.attributes.tags:("hello" AND "world")',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/filters_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/filters_panel.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
-  EuiSearchBar,
+  EuiFieldSearch,
 } from '@elastic/eui';
 import React, { memo, useCallback } from 'react';
 import { css } from '@emotion/css';
@@ -36,8 +36,8 @@ const CoverageOverviewFiltersPanelComponent = () => {
   const handleCollapseCellsFilterClick = () => setShowExpandedCells(false);
 
   const handleRuleSearchOnChange = useCallback(
-    ({ queryText }: { queryText: string }) => {
-      setRuleSearchFilter(queryText);
+    (queryText: string) => {
+      setRuleSearchFilter(queryText?.trim());
     },
     [setRuleSearchFilter]
   );
@@ -64,12 +64,12 @@ const CoverageOverviewFiltersPanelComponent = () => {
           </EuiFlexGroup>
           <EuiFlexGroup alignItems="center">
             <EuiFlexItem>
-              <EuiSearchBar
-                box={{
-                  placeholder: i18n.CoverageOverviewSearchBarPlaceholder,
-                  'data-test-subj': 'coverageOverviewFilterSearchBar',
-                }}
-                onChange={handleRuleSearchOnChange}
+              <EuiFieldSearch
+                fullWidth
+                incremental={false}
+                data-test-subj="coverageOverviewFilterSearchBar"
+                placeholder={i18n.CoverageOverviewSearchBarPlaceholder}
+                onSearch={handleRuleSearchOnChange}
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/translations.ts
@@ -152,7 +152,7 @@ export const CoverageOverviewSearchBarPlaceholder = i18n.translate(
   'xpack.securitySolution.coverageOverviewDashboard.searchBarPlaceholder',
   {
     defaultMessage:
-      'Search for the tactic, technique (e.g.,"defense evasion" or "TA0005") or rule name',
+      'Search for the tactic, technique (e.g.,"Defense Evasion" or "TA0005") or rule name',
   }
 );
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/basic_license_essentials_tier/coverage_overview.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/basic_license_essentials_tier/coverage_overview.ts
@@ -249,6 +249,167 @@ export default ({ getService }: FtrProviderContext): void => {
             });
           });
 
+          it('returns partial matches on rule name (when using a single term)', async () => {
+            const expectedRule1 = await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({
+                rule_id: 'rule-1',
+                name: 'Linux SMP aarch64 GNU/Linux',
+              })
+            );
+            const expectedRule2 = await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({ rule_id: 'rule-2', name: 'Windows 10 x64:IA32-e' })
+            );
+            const expectedRule3 = await createRule(
+              supertest,
+              log,
+              // here
+              getCustomQueryRuleParams({ rule_id: 'rule-3', name: 'iOS Darwin x64:IA32-e' })
+            );
+
+            const body1 = await getCoverageOverview(supertest, {
+              search_term: 'win',
+            });
+
+            expect(body1).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule2.id, expectedRule3.id],
+              rules_data: {
+                [expectedRule2.id]: {
+                  activity: 'disabled',
+                  name: 'Windows 10 x64:IA32-e',
+                },
+                [expectedRule3.id]: {
+                  activity: 'disabled',
+                  name: 'iOS Darwin x64:IA32-e',
+                },
+              },
+            });
+
+            const body2 = await getCoverageOverview(supertest, {
+              search_term: '64:IA',
+            });
+
+            expect(body2).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule2.id, expectedRule3.id],
+              rules_data: {
+                [expectedRule2.id]: {
+                  activity: 'disabled',
+                  name: 'Windows 10 x64:IA32-e',
+                },
+                [expectedRule3.id]: {
+                  activity: 'disabled',
+                  name: 'iOS Darwin x64:IA32-e',
+                },
+              },
+            });
+
+            const body3 = await getCoverageOverview(supertest, {
+              search_term: 'GNU/Linux',
+            });
+
+            expect(body3).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule1.id],
+              rules_data: {
+                [expectedRule1.id]: {
+                  activity: 'disabled',
+                  name: 'Linux SMP aarch64 GNU/Linux',
+                },
+              },
+            });
+          });
+
+          it('returns exact term matches on rule name (when using multiple terms)', async () => {
+            const expectedRule1 = await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({
+                rule_id: 'rule-1',
+                name: 'User-Agent rule1',
+              })
+            );
+
+            const expectedRule2 = await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({
+                rule_id: 'rule-2',
+                name: 'User Agent rule2',
+              })
+            );
+
+            const body1 = await getCoverageOverview(supertest, {
+              search_term: 'User-Agent rule1',
+            });
+
+            expect(body1).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule1.id],
+              rules_data: {
+                [expectedRule1.id]: {
+                  activity: 'disabled',
+                  name: 'User-Agent rule1',
+                },
+              },
+            });
+
+            const body2 = await getCoverageOverview(supertest, {
+              search_term: 'User Agent rule2',
+            });
+
+            expect(body2).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule2.id],
+              rules_data: {
+                [expectedRule2.id]: {
+                  activity: 'disabled',
+                  name: 'User Agent rule2',
+                },
+              },
+            });
+
+            const body3 = await getCoverageOverview(supertest, {
+              search_term: 'User Agent rule',
+            });
+
+            expect(body3).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [],
+              rules_data: {},
+            });
+          });
+
+          it('Can find special character matches on rule name', async () => {
+            const expectedRule = await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({
+                rule_id: 'rule-1',
+                name: 'Rule name with a semi:colon',
+              })
+            );
+
+            const body = await getCoverageOverview(supertest, {
+              search_term: 'semi:colon',
+            });
+
+            expect(body).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule.id],
+              rules_data: {
+                [expectedRule.id]: {
+                  activity: 'disabled',
+                  name: 'Rule name with a semi:colon',
+                },
+              },
+            });
+          });
+
           it('returns response filtered by index pattern', async () => {
             await createRule(
               supertest,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/basic_license_essentials_tier/coverage_overview.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/basic_license_essentials_tier/coverage_overview.ts
@@ -384,18 +384,20 @@ export default ({ getService }: FtrProviderContext): void => {
             });
           });
 
-          it('Can find special character matches on rule name', async () => {
+          it('returns special character matches on rule name', async () => {
+            await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({ rule_id: 'rule-1', name: 'Rule name without backslash' })
+            );
             const expectedRule = await createRule(
               supertest,
               log,
-              getCustomQueryRuleParams({
-                rule_id: 'rule-1',
-                name: 'Rule name with a semi:colon',
-              })
+              getCustomQueryRuleParams({ rule_id: 'rule-2', name: 'Rule name with backslash(\\)' })
             );
 
             const body = await getCoverageOverview(supertest, {
-              search_term: 'semi:colon',
+              search_term: 'backslash(\\)',
             });
 
             expect(body).to.eql({
@@ -404,7 +406,7 @@ export default ({ getService }: FtrProviderContext): void => {
               rules_data: {
                 [expectedRule.id]: {
                   activity: 'disabled',
-                  name: 'Rule name with a semi:colon',
+                  name: 'Rule name with backslash(\\)',
                 },
               },
             });


### PR DESCRIPTION
**Fixes: #237278**
**Fixes: #97094**
**Fixes: #194066**

## Summary

When a user navigates to `Rules` > `Detection Rules (SIEM)` and wishes to find all rules matching a partial string on the rule name (like `win` to get all rules about `Windows`) they receive 0 matches. This is in contrast to the behavior they experience when searching available prebuilt "Elastic Rules", where partial name searches are available.

This PR fixes this UX inconsistency by modifying the KQL output generated by the search query.

Whereas previously a search for `"win"` would have generated the following KQL:

```sql
(alert.attributes.name: "win" OR
  alert.attributes.params.index: "win" OR
  alert.attributes.params.threat.tactic.id: "win" OR
  ...
```

It now treats the `alert.attributes.name` differently, allowing it to match on partial terms (ie `*win*` instead of `"win"`) and using `.keyword` index for better special character support.

```sql
(alert.attributes.name.keyword: *win* OR      # <-- here
  alert.attributes.params.index: "win" OR 
  alert.attributes.params.threat.tactic.id: "win" OR 
  ...
```

### 🕵️ BUT! .. We only do this for single term searches!

Please note that this approach only applies to single term searches. For multiple term searches we maintain the "old" way of searching with quotations `"windows 10 patch"` instead of `*windows 10 patch*` or even `*windows* *10* *patch*`.

The reasoning here is that since search results are NOT sorted by score, we want to avoid returning too many matches (wildcard searches match on _any_ combination of the terms, ie those with `windows` or `10` or `patch`) which would confuse the user just as they are trying to narrow down their search results!! (ie 🤔 why am I getting `Linux patch` rules when I'm asking for `windows 10 patch`??).

## How to test:

To test this PR please checkout the relevant branch and run an instance of kibana/elasticsearch locally.

1. `Security App` > `Rules` > `Detection Rules (SIEM)` 
2. A table of installed rules should appear. Remove all installed Elastic rules.
3. `Elastic Rules` (filter) > Tick to select all > `Select all X Rules` > `Bulk actions` > `Delete` > `Delete`
4. Go to `Add Elastic Rules`
5. `Search rules by name` > `win` > `Enter`
6. You should see 5 pages of results (~84 rules)
7. `Install All`
8. All Elastic rules have been installed > `Go back to installed Elastic rules`
9. Search by rule name > `win` > `Enter`
10. You should see 5 pages of results (~84 rules - same as in Step 6.)

Please feel free to try some additional search queries. 

<details>
<summary>

### 👉 Click for additional testing ideas

</summary>

Here are some single term searches:
  - `goog`
  - `proc`
  - `sql` (should include `Postgresql` and `MSSQL`)
  - `shell` (should include `Powershell`)
  - `inject` (should include `injection`)
  - `git` (should include `GitHub`)
  - `.exe`
  - `pub/sub` (exact matches only)
  - `user-agent` (exact matches only)
  - `/bin`
  - `CVE-2025` (should include partial matches)
  - `-` (should return matches with dash in the name like `user-agent`)
  - `_` (should return matches with dash in the name like `CAP_SYS_ADMIN`)
  - `|` (should return no matches - no elastic rules with this)

And behavior for multiple term searches:
  - `AWS` (check the count), then `AWS IAM` (there should be less results for `AWS IAM`)
  - `pub/sub topic` (should be less than for `pub/sub`, note that `pub/sub top` partial match has no matches!)
  - `root` then `root cert` then `root certificate` (the second has no results, `root certificate` should only return exact matches)
  - `proc`, then `process`, then `process injection`, then `potential process injection` (each should return less results)


</details>

## Screenshots


![497230260-e8badac1-85dd-41ff-b905-1a0a3d4bc53d](https://github.com/user-attachments/assets/69e39370-c31c-4f24-84d5-a84386929612)


## Special character support

Note that by switching to wildcard searches (ie `*win*`) on the `.keyword` index and fully escaping special characters in KQL we'll **_ALSO_** be allowing special character searches on single search terms.

For example, searching by `user-agent` will return results that only match `User-Agent` but not `user` or `agent` individually.

Some other useful example of these approach are searches for: `Pub/Sub`, `CVE-2025`, `/bin`, `_`, `.exe`.

This support, in addition for escaping the backslash `\` character will allow us to close the next TWO ISSUES in this epic  🥳 wohoo!! 

👉  #97094 (special chars in rule name) and,
👉  #194066 (special chars in tags)

<img width="800" alt="image" src="https://github.com/user-attachments/assets/5411d8e8-b3f7-4a3f-9863-c64cc2a7df2c" />

<img width="800" alt="image" src="https://github.com/user-attachments/assets/c3589add-9f80-4646-807a-3f0c8a2ec5a7" />



### Testing special character support.

In addition to the steps above (installing all elastic rules), we can:

1. Create a rule with special characters: ie `Rule with special chars (&, *, #, $, ?, >, @, \, /, ", ‘, {, [, ;)`
2. Try some single term matches:
  - `@`
  - `&` (additional elastic rules with this term should appear).
  - `*` 
  - `"`
  - `:`
  - `>`
  - `{`
  - `\` (backslash, this used to break the search under #97094)

## Risks

These are some of the risks that could be identified by using this approach.

### 1. Dependencies that reuse query logic

Note that the `searchTerm -> KQL` conversion for searching for rules is used a few places.

- Installed Rules
- Rule Monitoring
- Bulk actions

**Note**: All these paths are tested manually, and form part of the automated tests.

### 2. Performance (ie `allowLeadingWildcards`)

We're using wildcard searches before and after the search term (ie `*win*`) in order to replicate the behavior across both 'prebuilt' and 'installed' rules tables. The wildcard AFTER the term (`win*` => matching terms like `Windows`) is no problem but the one BEFORE (`*win` => matching terms like `Darwin`) could create an issue.

Our [KQL documentation](https://www.elastic.co/docs/reference/query-languages/kql#_filter_for_documents_using_wildcards) warns that Kibana UI Advanced Settings have `query:allowLeadingWildcards` turned off by default. This is for performance reasons as a leading wildcard can have a large impact when searching indexes that have millions of terms associated with them.

<img width="2784" height="2120" alt="image" src="https://github.com/user-attachments/assets/9e0a754c-c30b-453e-a3ae-60a104b13fde" />

> By default, leading wildcards are not allowed for performance reasons. You can modify this with the [query:allowLeadingWildcards](https://www.elastic.co/docs/reference/kibana/advanced-settings#query-allowleadingwildcards) advanced setting.

Please note that the [Query DSL docs also warn](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard) about avoiding this approach.

There is also more info and additional warnings under [Lucene API docs](https://lucene.apache.org/core/9_12_3/core/org/apache/lucene/search/WildcardQuery.html). 

The risk here is two pronged:

1. Users with a lot (millions?) of detection rules will likely have a degraded search experience as queries will take longer to execute.

2. Leading wildcards appear to be working by default (in contrast to what is stated in the documentation). But the mere _existence_ of various settings to avoid them ([`allowLeadingWildcards`](https://www.elastic.co/docs/reference/kibana/advanced-settings#query-allowleadingwildcards), [`allow_leading_wildcard`](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard), [`analyze_wildcards`](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard)) is a risk, because some users may have a special setup we've not been able to anticipate in our testing, leading to potential issues like this one: https://github.com/elastic/kibana/issues/57828

### Mitigating factors:

1. Please note that in the case of security detection rules, the prebuilt rules package is _only ~1500 rules_! Users do not manage millions of rules, they generally manage low thousands or even hundreds. We've tested 100K rules successfully and there was [_no perceivable difference in terms of search performance_](https://github.com/elastic/kibana/pull/237496#issuecomment-3389956730). And this seems to be a realistic test when checking actual usage stats (our 10 largest users in Sep'25 had between 60-160K installed). Also, due to current limits on pagination and bulk action logic we would likely hit different kinds of problems here _before_ search performance becomes an issue. 

2. We've tested all the documented ways to disable leading wildcards, including disabling them manually (under `Server Management > Advanced Settings`) and explicitly in the `kibana.yml`. None of them seemed to affect searches carried out on Saved Objects. This is because our solution uses the [`alerting`](http://github.com/elastic/kibana/tree/main/x-pack/platform/plugins/shared/alerting) plugin under the hood which [converts the filter to KQL without referring to any UI Advanced Settings](https://github.com/elastic/kibana/blob/91cab0e1369473846dc2712aa7dfe38b8580a9a5/x-pack/platform/plugins/shared/alerting/server/rules_client/common/build_kuery_node_filter.ts#L23). And since there is no explicit setting for `allowLeadingWildcards` the default setting of `true` gets applied instead [inside the `grammar.peggy` file](https://github.com/elastic/kibana/blob/91cab0e1369473846dc2712aa7dfe38b8580a9a5/src/platform/packages/shared/kbn-es-query/src/kuery/grammar/grammar.peggy#L12).

### Risks that were found acceptable

In the search for any possible settings that might affect the rollout of changes under this PR [we did find a setting](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-wildcard-query#_allow_expensive_queries_7) inside `elasticsearch.yml` that causes problems with the proposed solution.

**TL/DR** 👉 `search.allow_expensive_queries=false` breaks the search.💥🤯

<img width="600" alt="image" src="https://github.com/user-attachments/assets/8d523d15-f832-4488-8c78-4ed60c474d44" />

However we also found bigger problems, _this setting also prevents the installation of prebuilt rules_ (see below), which are a cornerstone of our security solution.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/2b8d91e8-29b9-4f06-9f76-6b1edb999fd1" />

In other words, the setting `search.allow_expensive_queries=true` has become _a de-facto requirement of Detection Rules_, that has not yet been documented. Hence we including it to the [documentation](https://www.elastic.co/docs/solutions/security/detect-and-alert/detections-requirements) as part of this PR.

Note also that the errors here are not limited to detection rules.

We found that the setting _also compromised or outright broke a lot of functionality in Kibana_ 💥🤯 (including Fleet, API Keys, Timelines, Saved Object search, Tags, Server Monitoring etc). More about this is [documented in this internal document](https://docs.google.com/document/d/1HLOXQZFcm1-KBj9DHTqwcF3wDdLOE6CcgUzqzZA2CAg/edit?tab=t.0). And in this [internal slack thread](https://elastic.slack.com/archives/C02HA9E8221/p1760694975799469). So we're assuming that most if not all of our users will have it set to `true`.

## Checklist

Check the PR satisfies following conditions. 

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Follow the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
- [x] Changes have been socialized with the PM and rest of the team.
- [x] All identified Risks have been properly documented and investigated. ([internal investigation](https://docs.google.com/document/d/1HLOXQZFcm1-KBj9DHTqwcF3wDdLOE6CcgUzqzZA2CAg/edit?tab=t.0))
- [x] New requirements added to the technical docs (PR [#3543](https://github.com/elastic/docs-content/pull/3543), see [here](https://www.elastic.co/docs/solutions/security/detect-and-alert/detections-requirements))



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->