### PR TITLE
[8.19] [Obs AI Assistant] Update tooltip behaviour to close on mouse out (#237202)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
@@ -14,6 +14,7 @@ import {
   EuiLoadingSpinner,
   EuiToolTip,
 } from '@elastic/eui';
+import type { EuiToolTip as EuiToolTipRef } from '@elastic/eui';
 import { v4 } from 'uuid';
 import useObservable from 'react-use/lib/useObservable';
 import { i18n } from '@kbn/i18n';
@@ -153,6 +154,8 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
   }, [service.conversations]);
 
   const EuiButtonBasicOrEmpty = isServerless ? EuiButtonEmpty : EuiButton;
+  const tooltipRef = useRef<EuiToolTipRef | null>(null);
+  const hideToolTip = () => tooltipRef.current?.hideToolTip();
 
   const buttonContent: React.ReactNode = (
     <EuiFlexGroup gutterSize="s" alignItems="center">
@@ -170,10 +173,13 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
   return (
     <>
       <EuiToolTip
+        ref={tooltipRef}
         content={i18n.translate(
           'xpack.observabilityAiAssistant.navControl.openTheAIAssistantPopoverLabel',
           { defaultMessage: 'Keyboard shortcut Ctrl ;' }
         )}
+        disableScreenReaderOutput
+        onMouseOut={hideToolTip}
       >
         <EuiButtonBasicOrEmpty
           aria-label={i18n.translate(
@@ -182,6 +188,7 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
           )}
           data-test-subj="observabilityAiAssistantAppNavControlButton"
           onClick={() => {
+            hideToolTip();
             service.conversations.openNewConversation({
               messages: [],
             });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Obs AI Assistant] Update tooltip behaviour to close on mouse out (#237202)](https://github.com/elastic/kibana/pull/237202)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2025-10-03T13:38:29Z","message":"[Obs AI Assistant] Update tooltip behaviour to close on mouse out (#237202)\n\nCloses https://github.com/elastic/kibana/issues/237336\n\n## Summary\n\n### Problem\nThe AI Assistant button tooltip is persistent even when the button is\nnot being hovered. This appears to be an issue in the `EuiTooltip`. The\nEUI team has a task to improve this -\nhttps://github.com/elastic/eui/issues/5666\n\nMore context:\n\n- This doesn't seem to happen in Firefox or Safari, only Chromium\n- In Chromium, when clicking the AI button, the flyout opens but the\nbutton doesn't fire the blur event which would trigger it to close\n- Clicking the button again closes it. After that the button seems to\nbehave correctly\n\nThe issue is the `isLoading` state on the button. When it's loading the\nbutton is set to disabled which results in it not being focusable but\nmore importantly it doesn't trigger the blur event in Chromium.\n\n### Fix\nManually close the tooltip on mouse out until a fix is implemented on\nthe EUI side.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/f71a222e-fd9e-4af3-83f9-fe57960f61c9\n\nAfter: \n\n\nhttps://github.com/user-attachments/assets/d9b727e2-917f-46a2-ab00-f39e798a64bc\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\nFixes the AI Assistant button tooltip by closing the tooltip (on mouse\nout) when the button is not being hovered.","sha":"fca9d65a7065b61547b3018a1b21bf55d3c1dc9c","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v9.2.0","v8.19.5","v9.1.5","v9.3.0"],"title":"[Obs AI Assistant] Update tooltip behaviour to close on mouse out","number":237202,"url":"https://github.com/elastic/kibana/pull/237202","mergeCommit":{"message":"[Obs AI Assistant] Update tooltip behaviour to close on mouse out (#237202)\n\nCloses https://github.com/elastic/kibana/issues/237336\n\n## Summary\n\n### Problem\nThe AI Assistant button tooltip is persistent even when the button is\nnot being hovered. This appears to be an issue in the `EuiTooltip`. The\nEUI team has a task to improve this -\nhttps://github.com/elastic/eui/issues/5666\n\nMore context:\n\n- This doesn't seem to happen in Firefox or Safari, only Chromium\n- In Chromium, when clicking the AI button, the flyout opens but the\nbutton doesn't fire the blur event which would trigger it to close\n- Clicking the button again closes it. After that the button seems to\nbehave correctly\n\nThe issue is the `isLoading` state on the button. When it's loading the\nbutton is set to disabled which results in it not being focusable but\nmore importantly it doesn't trigger the blur event in Chromium.\n\n### Fix\nManually close the tooltip on mouse out until a fix is implemented on\nthe EUI side.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/f71a222e-fd9e-4af3-83f9-fe57960f61c9\n\nAfter: \n\n\nhttps://github.com/user-attachments/assets/d9b727e2-917f-46a2-ab00-f39e798a64bc\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\nFixes the AI Assistant button tooltip by closing the tooltip (on mouse\nout) when the button is not being hovered.","sha":"fca9d65a7065b61547b3018a1b21bf55d3c1dc9c"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/237481","number":237481,"state":"OPEN"},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237202","number":237202,"mergeCommit":{"message":"[Obs AI Assistant] Update tooltip behaviour to close on mouse out (#237202)\n\nCloses https://github.com/elastic/kibana/issues/237336\n\n## Summary\n\n### Problem\nThe AI Assistant button tooltip is persistent even when the button is\nnot being hovered. This appears to be an issue in the `EuiTooltip`. The\nEUI team has a task to improve this -\nhttps://github.com/elastic/eui/issues/5666\n\nMore context:\n\n- This doesn't seem to happen in Firefox or Safari, only Chromium\n- In Chromium, when clicking the AI button, the flyout opens but the\nbutton doesn't fire the blur event which would trigger it to close\n- Clicking the button again closes it. After that the button seems to\nbehave correctly\n\nThe issue is the `isLoading` state on the button. When it's loading the\nbutton is set to disabled which results in it not being focusable but\nmore importantly it doesn't trigger the blur event in Chromium.\n\n### Fix\nManually close the tooltip on mouse out until a fix is implemented on\nthe EUI side.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/f71a222e-fd9e-4af3-83f9-fe57960f61c9\n\nAfter: \n\n\nhttps://github.com/user-attachments/assets/d9b727e2-917f-46a2-ab00-f39e798a64bc\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\nFixes the AI Assistant button tooltip by closing the tooltip (on mouse\nout) when the button is not being hovered.","sha":"fca9d65a7065b61547b3018a1b21bf55d3c1dc9c"}}]}] BACKPORT-->