### PR TITLE
[Cloud Security] Fix CSPM AWS Agentless MKI-Only test

### DIFF
--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/mki_only/agentless/mki_create_agent.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/mki_only/agentless/mki_create_agent.ts
@@ -25,8 +25,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   // This test suite is only running in the Serverless Quality Gates environment
   describe('Agentless API Serverless MKI only', function () {
-    // failsOnMKI, see https://github.com/elastic/kibana/issues/236699
-    this.tags(['cloud_security_posture_agentless', 'failsOnMKI']);
+    this.tags(['cloud_security_posture_agentless']);
     let cisIntegration: typeof pageObjects.cisAddIntegration;
 
     before(async () => {

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/mki_only/agentless/mki_create_agent.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/mki_only/agentless/mki_create_agent.ts
@@ -10,6 +10,7 @@ import {
   AWS_PROVIDER_TEST_SUBJ,
   AWS_SINGLE_ACCOUNT_TEST_SUBJ,
   AWS_INPUT_TEST_SUBJECTS,
+  AWS_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ,
 } from '@kbn/cloud-security-posture-common';
 import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
@@ -43,9 +44,26 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await cisIntegration.inputIntegrationName(integrationPolicyName);
 
       await cisIntegration.selectSetupTechnology('agentless');
-      await cisIntegration.selectAwsCredentials('direct');
+
+      try {
+        const credentialsSelector = await testSubjects.find(
+          AWS_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ
+        );
+        const currentValue = await credentialsSelector.getAttribute('value');
+
+        if (currentValue !== 'direct_access_keys') {
+          await cisIntegration.selectAwsCredentials('direct');
+        }
+      } catch (error) {
+        // Fallback: try to select direct credentials anyway
+        await cisIntegration.selectAwsCredentials('direct');
+      }
 
       await pageObjects.header.waitUntilLoadingHasFinished();
+
+      expect(
+        (await cisIntegration.cisAws.showLaunchCloudFormationAgentlessButton()) !== undefined
+      ).to.be(true);
 
       if (process.env.CSPM_AWS_ACCOUNT_ID && process.env.CSPM_AWS_SECRET_KEY) {
         await cisIntegration.fillInTextField(

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/mki_only/agentless/mki_create_agent.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/mki_only/agentless/mki_create_agent.ts
@@ -44,18 +44,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await cisIntegration.inputIntegrationName(integrationPolicyName);
 
       await cisIntegration.selectSetupTechnology('agentless');
+      const credentialsSelector = await testSubjects.find(AWS_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ);
+      const currentValue = await credentialsSelector.getAttribute('value');
 
-      try {
-        const credentialsSelector = await testSubjects.find(
-          AWS_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ
-        );
-        const currentValue = await credentialsSelector.getAttribute('value');
-
-        if (currentValue !== 'direct_access_keys') {
-          await cisIntegration.selectAwsCredentials('direct');
-        }
-      } catch (error) {
-        // Fallback: try to select direct credentials anyway
+      if (currentValue !== 'direct_access_keys') {
         await cisIntegration.selectAwsCredentials('direct');
       }
 


### PR DESCRIPTION
This pull request updates the agentless API test suite for Serverless MKI in the Cloud Security Posture module. The main changes improve test reliability and robustness by updating test tags and making the AWS credentials selection step more resilient to UI changes.

- fixes https://github.com/elastic/kibana/issues/236699

Test robustness improvements:

* Added a fallback mechanism for selecting AWS credentials: the test now checks the current value of the credentials selector and tries to select "direct" credentials only if necessary, with a fallback in case of errors. (`mki_create_agent.ts`)
* Added `AWS_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ` to the imports to support the new credentials selector logic. (`mki_create_agent.ts`)

Test tagging update:

* Removed the `failsOnMKI` tag from the test suite, reflecting that the test is no longer expected to fail on MKI. (`mki_create_agent.ts`)## Summary

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

