### PR TITLE
[ES|QL] Displays the solution recommended queries for queries which start with special characters

### DIFF
--- a/src/platform/plugins/shared/esql/public/plugin.ts
+++ b/src/platform/plugins/shared/esql/public/plugin.ts
@@ -163,8 +163,9 @@ export class EsqlPlugin implements Plugin<{}, EsqlPluginStart> {
       queryString: string,
       activeSolutionId: SolutionId
     ) => {
+      const encodedQuery = encodeURIComponent(queryString);
       const result = await core.http.get(
-        `${REGISTRY_EXTENSIONS_ROUTE}${activeSolutionId}/${queryString}`
+        `${REGISTRY_EXTENSIONS_ROUTE}${activeSolutionId}/${encodedQuery}`
       );
       return result;
     };


### PR DESCRIPTION
## Summary

This PR makes sure we are encoding the querystring before sending this to the server because special characters can lead to 404 (i.e. comments in the beginning)

### Release notes
This is a serverless feature, so this bug was only affecting serverless. Let's mention it only there




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->