### PR TITLE
[Security Solution] Add detection rules customization status for telemetry snapshot

### DIFF
--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_security.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_security.json
@@ -7338,6 +7338,130 @@
                       }
                     }
                   }
+                },
+                "elastic_detection_rule_customization_status": {
+                  "properties": {
+                    "alert_suppression": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized alert_suppression field"
+                      }
+                    },
+                    "anomaly_threshold": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized anomaly_threshold field"
+                      }
+                    },
+                    "data_view_id": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized data_view_id field"
+                      }
+                    },
+                    "description": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized description field"
+                      }
+                    },
+                    "filters": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized filters field"
+                      }
+                    },
+                    "from": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized from field"
+                      }
+                    },
+                    "index": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized index field"
+                      }
+                    },
+                    "interval": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized interval field"
+                      }
+                    },
+                    "investigation_fields": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized investigation_fields field"
+                      }
+                    },
+                    "name": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized name field"
+                      }
+                    },
+                    "new_terms_fields": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized new_terms_fields field"
+                      }
+                    },
+                    "note": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized note field"
+                      }
+                    },
+                    "query": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized query field"
+                      }
+                    },
+                    "risk_score": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized risk_score field"
+                      }
+                    },
+                    "severity": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized severity field"
+                      }
+                    },
+                    "setup": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized setup field"
+                      }
+                    },
+                    "tags": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized tags field"
+                      }
+                    },
+                    "threat_query": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized threat_query field"
+                      }
+                    },
+                    "threshold": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized threshold field"
+                      }
+                    },
+                    "timeline_id": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of prebuilt rules with customized timeline_id field"
+                      }
+                    }
+                  }
                 }
               }
             },

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_initial_usage.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_initial_usage.ts
@@ -10,6 +10,7 @@ import type { DetectionMetrics } from './types';
 import { getInitialMlJobUsage } from './ml_jobs/get_initial_usage';
 import {
   getInitialEventLogUsage,
+  getInitialRuleCustomizationStatus,
   getInitialRuleUpgradeStatus,
   getInitialRulesUsage,
   getInitialSpacesUsage,
@@ -30,6 +31,7 @@ export const getInitialDetectionMetrics = (): DetectionMetrics => ({
     detection_rule_usage: getInitialRulesUsage(),
     detection_rule_status: getInitialEventLogUsage(),
     elastic_detection_rule_upgrade_status: getInitialRuleUpgradeStatus(),
+    elastic_detection_rule_customization_status: getInitialRuleCustomizationStatus(),
     spaces_usage: getInitialSpacesUsage(),
   },
   legacy_siem_signals: getInitialLegacySiemSignalsUsage(),

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_metrics.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_metrics.test.ts
@@ -192,6 +192,28 @@ describe('Detections Usage and Metrics', () => {
             enabled: 0,
             disabled: 1,
           },
+          elastic_detection_rule_customization_status: {
+            alert_suppression: 0,
+            anomaly_threshold: 0,
+            data_view_id: 0,
+            description: 0,
+            filters: 0,
+            from: 0,
+            index: 0,
+            interval: 0,
+            investigation_fields: 0,
+            name: 0,
+            new_terms_fields: 0,
+            note: 0,
+            query: 0,
+            risk_score: 0,
+            severity: 0,
+            setup: 0,
+            tags: 0,
+            threat_query: 0,
+            threshold: 0,
+            timeline_id: 0,
+          },
         },
       });
     });
@@ -232,6 +254,7 @@ describe('Detections Usage and Metrics', () => {
       expect(result).toEqual<DetectionMetrics>({
         ...getInitialDetectionMetrics(),
         detection_rules: {
+          ...getInitialDetectionMetrics().detection_rules,
           spaces_usage: {
             rules_in_spaces: [1],
             total: 1,
@@ -314,6 +337,28 @@ describe('Detections Usage and Metrics', () => {
             enabled: 1,
             disabled: 0,
           },
+          elastic_detection_rule_customization_status: {
+            alert_suppression: 0,
+            anomaly_threshold: 0,
+            data_view_id: 0,
+            description: 0,
+            filters: 0,
+            from: 0,
+            index: 0,
+            interval: 0,
+            investigation_fields: 0,
+            name: 0,
+            new_terms_fields: 0,
+            note: 0,
+            query: 0,
+            risk_score: 0,
+            severity: 0,
+            setup: 0,
+            tags: 0,
+            threat_query: 0,
+            threshold: 0,
+            timeline_id: 0,
+          },
         },
       });
     });
@@ -354,6 +399,7 @@ describe('Detections Usage and Metrics', () => {
       expect(result).toEqual<DetectionMetrics>({
         ...getInitialDetectionMetrics(),
         detection_rules: {
+          ...getInitialDetectionMetrics().detection_rules,
           spaces_usage: {
             rules_in_spaces: [1],
             total: 1,
@@ -436,6 +482,28 @@ describe('Detections Usage and Metrics', () => {
             enabled: 0,
             disabled: 1,
           },
+          elastic_detection_rule_customization_status: {
+            alert_suppression: 0,
+            anomaly_threshold: 0,
+            data_view_id: 0,
+            description: 1,
+            filters: 0,
+            from: 0,
+            index: 0,
+            interval: 0,
+            investigation_fields: 0,
+            name: 1,
+            new_terms_fields: 0,
+            note: 0,
+            query: 0,
+            risk_score: 0,
+            severity: 0,
+            setup: 0,
+            tags: 1,
+            threat_query: 0,
+            threshold: 0,
+            timeline_id: 0,
+          },
         },
       });
     });
@@ -476,6 +544,7 @@ describe('Detections Usage and Metrics', () => {
       expect(result).toEqual<DetectionMetrics>({
         ...getInitialDetectionMetrics(),
         detection_rules: {
+          ...getInitialDetectionMetrics().detection_rules,
           spaces_usage: {
             rules_in_spaces: [1],
             total: 1,
@@ -558,6 +627,28 @@ describe('Detections Usage and Metrics', () => {
             enabled: 1,
             disabled: 0,
           },
+          elastic_detection_rule_customization_status: {
+            alert_suppression: 0,
+            anomaly_threshold: 0,
+            data_view_id: 0,
+            description: 1,
+            filters: 0,
+            from: 0,
+            index: 0,
+            interval: 0,
+            investigation_fields: 0,
+            name: 1,
+            new_terms_fields: 0,
+            note: 0,
+            query: 0,
+            risk_score: 0,
+            severity: 0,
+            setup: 0,
+            tags: 1,
+            threat_query: 0,
+            threshold: 0,
+            timeline_id: 0,
+          },
         },
       });
     });
@@ -570,7 +661,7 @@ describe('Detections Usage and Metrics', () => {
       savedObjectsClient.find.mockResolvedValueOnce(
         getMockRuleSearchResponse(
           true /* immutable (elastic) */,
-          true /* customized */,
+          false /* customized */,
           false /* enabled */
         )
       );
@@ -598,6 +689,7 @@ describe('Detections Usage and Metrics', () => {
       expect(result).toEqual<DetectionMetrics>({
         ...getInitialDetectionMetrics(),
         detection_rules: {
+          ...getInitialDetectionMetrics().detection_rules,
           spaces_usage: {
             rules_in_spaces: [1],
             total: 1,
@@ -609,7 +701,7 @@ describe('Detections Usage and Metrics', () => {
               cases_count_total: 1,
               created_on: '2021-03-23T17:15:59.634Z',
               elastic_rule: true,
-              is_customized: true,
+              is_customized: false,
               enabled: false,
               rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
               rule_name: 'Azure Diagnostic Settings Deletion',
@@ -660,6 +752,20 @@ describe('Detections Usage and Metrics', () => {
               response_actions: initialResponseActionsUsage,
             },
             elastic_customized_total: {
+              alerts: 0,
+              cases: 0,
+              disabled: 0,
+              enabled: 0,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+              has_exceptions: 0,
+              response_actions: initialResponseActionsUsage,
+            },
+            elastic_noncustomized_total: {
               alerts: 3400,
               cases: 1,
               disabled: 1,
@@ -679,6 +785,28 @@ describe('Detections Usage and Metrics', () => {
             customized: 0,
             enabled: 0,
             disabled: 0,
+          },
+          elastic_detection_rule_customization_status: {
+            alert_suppression: 0,
+            anomaly_threshold: 0,
+            data_view_id: 0,
+            description: 0,
+            filters: 0,
+            from: 0,
+            index: 0,
+            interval: 0,
+            investigation_fields: 0,
+            name: 0,
+            new_terms_fields: 0,
+            note: 0,
+            query: 0,
+            risk_score: 0,
+            severity: 0,
+            setup: 0,
+            tags: 0,
+            threat_query: 0,
+            threshold: 0,
+            timeline_id: 0,
           },
         },
       });
@@ -720,6 +848,7 @@ describe('Detections Usage and Metrics', () => {
       expect(result).toEqual<DetectionMetrics>({
         ...getInitialDetectionMetrics(),
         detection_rules: {
+          ...getInitialDetectionMetrics().detection_rules,
           spaces_usage: {
             rules_in_spaces: [1],
             total: 1,
@@ -802,6 +931,28 @@ describe('Detections Usage and Metrics', () => {
             enabled: 0,
             disabled: 0,
           },
+          elastic_detection_rule_customization_status: {
+            alert_suppression: 0,
+            anomaly_threshold: 0,
+            data_view_id: 0,
+            description: 0,
+            filters: 0,
+            from: 0,
+            index: 0,
+            interval: 0,
+            investigation_fields: 0,
+            name: 0,
+            new_terms_fields: 0,
+            note: 0,
+            query: 0,
+            risk_score: 0,
+            severity: 0,
+            setup: 0,
+            tags: 0,
+            threat_query: 0,
+            threshold: 0,
+            timeline_id: 0,
+          },
         },
       });
     });
@@ -842,6 +993,7 @@ describe('Detections Usage and Metrics', () => {
       expect(result).toEqual<DetectionMetrics>({
         ...getInitialDetectionMetrics(),
         detection_rules: {
+          ...getInitialDetectionMetrics().detection_rules,
           spaces_usage: {
             rules_in_spaces: [1],
             total: 1,
@@ -924,6 +1076,28 @@ describe('Detections Usage and Metrics', () => {
             enabled: 0,
             disabled: 0,
           },
+          elastic_detection_rule_customization_status: {
+            alert_suppression: 0,
+            anomaly_threshold: 0,
+            data_view_id: 0,
+            description: 1,
+            filters: 0,
+            from: 0,
+            index: 0,
+            interval: 0,
+            investigation_fields: 0,
+            name: 1,
+            new_terms_fields: 0,
+            note: 0,
+            query: 0,
+            risk_score: 0,
+            severity: 0,
+            setup: 0,
+            tags: 1,
+            threat_query: 0,
+            threshold: 0,
+            timeline_id: 0,
+          },
         },
       });
     });
@@ -964,6 +1138,7 @@ describe('Detections Usage and Metrics', () => {
       expect(result).toEqual<DetectionMetrics>({
         ...getInitialDetectionMetrics(),
         detection_rules: {
+          ...getInitialDetectionMetrics().detection_rules,
           spaces_usage: {
             rules_in_spaces: [1],
             total: 1,
@@ -1046,6 +1221,28 @@ describe('Detections Usage and Metrics', () => {
             enabled: 0,
             disabled: 0,
           },
+          elastic_detection_rule_customization_status: {
+            alert_suppression: 0,
+            anomaly_threshold: 0,
+            data_view_id: 0,
+            description: 1,
+            filters: 0,
+            from: 0,
+            index: 0,
+            interval: 0,
+            investigation_fields: 0,
+            name: 1,
+            new_terms_fields: 0,
+            note: 0,
+            query: 0,
+            risk_score: 0,
+            severity: 0,
+            setup: 0,
+            tags: 1,
+            threat_query: 0,
+            threshold: 0,
+            timeline_id: 0,
+          },
         },
       });
     });
@@ -1127,6 +1324,28 @@ describe('Detections Usage and Metrics', () => {
             },
           },
           elastic_detection_rule_upgrade_status: getInitialRuleUpgradeStatus(),
+          elastic_detection_rule_customization_status: {
+            name: 0,
+            description: 0,
+            risk_score: 0,
+            severity: 0,
+            timeline_id: 0,
+            note: 0,
+            investigation_fields: 0,
+            tags: 0,
+            interval: 0,
+            from: 0,
+            setup: 0,
+            query: 0,
+            index: 0,
+            data_view_id: 0,
+            filters: 0,
+            alert_suppression: 0,
+            threshold: 0,
+            threat_query: 0,
+            anomaly_threshold: 0,
+            new_terms_fields: 0,
+          },
         },
       });
     });
@@ -1247,6 +1466,28 @@ describe('Detections Usage and Metrics', () => {
             },
           },
           elastic_detection_rule_upgrade_status: getInitialRuleUpgradeStatus(),
+          elastic_detection_rule_customization_status: {
+            name: 0,
+            description: 0,
+            risk_score: 0,
+            severity: 0,
+            timeline_id: 0,
+            note: 0,
+            investigation_fields: 0,
+            tags: 0,
+            interval: 0,
+            from: 0,
+            setup: 0,
+            query: 0,
+            index: 0,
+            data_view_id: 0,
+            filters: 0,
+            alert_suppression: 0,
+            threshold: 0,
+            threat_query: 0,
+            anomaly_threshold: 0,
+            new_terms_fields: 0,
+          },
         },
       });
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_metrics.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_metrics.ts
@@ -13,6 +13,7 @@ import { getMlJobMetrics } from './ml_jobs/get_metrics';
 import { getRuleMetrics } from './rules/get_metrics';
 import {
   getInitialEventLogUsage,
+  getInitialRuleCustomizationStatus,
   getInitialRuleUpgradeStatus,
   getInitialRulesUsage,
   getInitialSpacesUsage,
@@ -61,6 +62,7 @@ export const getDetectionsMetrics = async ({
             detection_rule_usage: getInitialRulesUsage(),
             detection_rule_status: getInitialEventLogUsage(),
             elastic_detection_rule_upgrade_status: getInitialRuleUpgradeStatus(),
+            elastic_detection_rule_customization_status: getInitialRuleCustomizationStatus(),
             spaces_usage: getInitialSpacesUsage(),
           },
     legacy_siem_signals:

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/ml_jobs/get_metrics.mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/ml_jobs/get_metrics.mocks.ts
@@ -348,6 +348,9 @@ export const getMockRuleSearchResponse = (
               ? {
                   type: 'external',
                   isCustomized,
+                  customizedFields: isCustomized
+                    ? [{ fieldName: 'tags' }, { fieldName: 'name' }, { fieldName: 'description' }]
+                    : [],
                 }
               : { type: 'internal' },
           },
@@ -426,6 +429,9 @@ export const getMockThreatMatchRuleSO = ({
           ? {
               type: 'external',
               isCustomized,
+              customizedFields: isCustomized
+                ? [{ fieldName: 'tags' }, { fieldName: 'name' }, { fieldName: 'description' }]
+                : [],
             }
           : { type: 'internal' },
         license: '',

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_initial_usage.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_initial_usage.ts
@@ -17,6 +17,7 @@ import type {
   ResponseActionsUsage,
   UpgradeableRulesSummary,
   ThreatMatchFeatureTypeUsage,
+  RuleCustomizationCounts,
 } from './types';
 
 export const initialAlertSuppression: AlertSuppressionUsage = {
@@ -172,4 +173,27 @@ export const getInitialRuleUpgradeStatus = (): UpgradeableRulesSummary => ({
   customized: 0,
   enabled: 0,
   disabled: 0,
+});
+
+export const getInitialRuleCustomizationStatus = (): RuleCustomizationCounts => ({
+  alert_suppression: 0,
+  anomaly_threshold: 0,
+  data_view_id: 0,
+  description: 0,
+  filters: 0,
+  from: 0,
+  index: 0,
+  interval: 0,
+  investigation_fields: 0,
+  name: 0,
+  new_terms_fields: 0,
+  note: 0,
+  query: 0,
+  risk_score: 0,
+  severity: 0,
+  setup: 0,
+  tags: 0,
+  threat_query: 0,
+  threshold: 0,
+  timeline_id: 0,
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_rule_customization_status.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_rule_customization_status.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getInitialRuleCustomizationStatus } from './get_initial_usage';
+import type { RuleCustomizationCounts } from './types';
+
+export interface ExternalRuleSourceInfo {
+  is_customized: boolean;
+  customized_fields: Array<{ fieldName: string }>;
+}
+
+// we only publish a subset of most important fields that we know can be customized
+// this is to avoid telemetry issues if we add new fields to the rule schema
+// and to avoid counting fields of lesser importance
+// see https://github.com/elastic/kibana/issues/140369 for more information
+const ALLOWED_FIELDS: Set<keyof RuleCustomizationCounts> = new Set([
+  'alert_suppression',
+  'anomaly_threshold',
+  'data_view_id',
+  'description',
+  'filters',
+  'from',
+  'index',
+  'interval',
+  'investigation_fields',
+  'name',
+  'new_terms_fields',
+  'note',
+  'query',
+  'risk_score',
+  'severity',
+  'setup',
+  'tags',
+  'threat_query',
+  'threshold',
+  'timeline_id',
+]);
+
+export const getRuleCustomizationStatus = (
+  ruleSources: ReadonlyArray<ExternalRuleSourceInfo>
+): RuleCustomizationCounts => {
+  const counts = getInitialRuleCustomizationStatus();
+
+  ruleSources.forEach((ruleSource) => {
+    if (!ruleSource.is_customized) {
+      return;
+    }
+
+    ruleSource.customized_fields.forEach((field) => {
+      const fieldName = field.fieldName as keyof RuleCustomizationCounts;
+      if (ALLOWED_FIELDS.has(fieldName)) {
+        counts[fieldName] = (counts[fieldName] ?? 0) + 1;
+      }
+    });
+  });
+
+  return counts;
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/schema.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/schema.ts
@@ -11,6 +11,7 @@ import { ruleMetricsSchema } from './schemas/prebuilt_rule_detail';
 import { ruleStatusMetricsSchema } from './schemas/detection_rule_status';
 import { ruleUpgradeStatusSchema } from './schemas/detection_rule_upgrade_status';
 import type { RuleAdoption } from './types';
+import { ruleCustomizedFieldsCounts } from './schemas/detection_rule_customization_status';
 
 export const rulesMetricsSchema: MakeSchemaFrom<RuleAdoption> = {
   spaces_usage: {
@@ -33,4 +34,5 @@ export const rulesMetricsSchema: MakeSchemaFrom<RuleAdoption> = {
   },
   detection_rule_status: ruleStatusMetricsSchema,
   elastic_detection_rule_upgrade_status: ruleUpgradeStatusSchema,
+  elastic_detection_rule_customization_status: ruleCustomizedFieldsCounts,
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/schemas/detection_rule_customization_status.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/schemas/detection_rule_customization_status.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MakeSchemaFrom } from '@kbn/usage-collection-plugin/server';
+import type { RuleCustomizationCounts } from '../types';
+
+export const ruleCustomizedFieldsCounts: MakeSchemaFrom<RuleCustomizationCounts> = {
+  alert_suppression: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized alert_suppression field' },
+  },
+  anomaly_threshold: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized anomaly_threshold field' },
+  },
+  data_view_id: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized data_view_id field' },
+  },
+  description: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized description field' },
+  },
+  filters: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized filters field' },
+  },
+  from: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized from field' },
+  },
+  index: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized index field' },
+  },
+  interval: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized interval field' },
+  },
+  investigation_fields: {
+    type: 'long',
+    _meta: {
+      description: 'The number of prebuilt rules with customized investigation_fields field',
+    },
+  },
+  name: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized name field' },
+  },
+  new_terms_fields: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized new_terms_fields field' },
+  },
+  note: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized note field' },
+  },
+  query: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized query field' },
+  },
+  risk_score: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized risk_score field' },
+  },
+  severity: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized severity field' },
+  },
+  setup: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized setup field' },
+  },
+  tags: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized tags field' },
+  },
+  threat_query: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized threat_query field' },
+  },
+  threshold: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized threshold field' },
+  },
+  timeline_id: {
+    type: 'long',
+    _meta: { description: 'The number of prebuilt rules with customized timeline_id field' },
+  },
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/types.ts
@@ -53,6 +53,29 @@ export interface UpgradeableRulesSummary {
   disabled: number;
 }
 
+export interface RuleCustomizationCounts {
+  alert_suppression: number;
+  anomaly_threshold: number;
+  data_view_id: number;
+  description: number;
+  filters: number;
+  from: number;
+  index: number;
+  interval: number;
+  investigation_fields: number;
+  name: number;
+  new_terms_fields: number;
+  note: number;
+  query: number;
+  risk_score: number;
+  severity: number;
+  setup: number;
+  tags: number;
+  threat_query: number;
+  threshold: number;
+  timeline_id: number;
+}
+
 export interface RulesTypeUsage {
   query: FeatureTypeUsage;
   query_custom: FeatureTypeUsage;
@@ -84,6 +107,7 @@ export interface RuleAdoption {
   detection_rule_usage: RulesTypeUsage;
   detection_rule_status: EventLogStatusMetric;
   elastic_detection_rule_upgrade_status: UpgradeableRulesSummary;
+  elastic_detection_rule_customization_status: RuleCustomizationCounts;
   spaces_usage: SpacesUsage;
 }
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/index.ts
@@ -14,6 +14,7 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
     loadTestFile(require.resolve('./usage_collector/value_list_metrics'));
     loadTestFile(require.resolve('./usage_collector/detection_rule_status'));
     loadTestFile(require.resolve('./usage_collector/detection_rule_upgrade_status'));
+    loadTestFile(require.resolve('./usage_collector/detection_rule_customization_status'));
     loadTestFile(require.resolve('./usage_collector/detection_rules_legacy_action'));
 
     loadTestFile(require.resolve('./task_based/all_types'));

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rule_customization_status.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rule_customization_status.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { PrebuiltRuleAsset } from '@kbn/security-solution-plugin/server/lib/detection_engine/prebuilt_rules';
+import { customizeRule, getStats } from '../../../utils';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
+import {
+  deleteAllPrebuiltRuleAssets,
+  createRuleAssetSavedObject,
+  createPrebuiltRuleAssetSavedObjects,
+  installPrebuiltRules,
+} from '../../../utils';
+import { deleteAllRules } from '../../../../../config/services/detections_response';
+
+/**
+ * Test suite for detection rule customization status telemetry.
+ *
+ * This suite tests the telemetry metrics for prebuilt rules,
+ * verifying that the system correctly tracks telemetry for rule customizations.
+ */
+export default ({ getService }: FtrProviderContext): void => {
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const detectionsApi = getService('detectionsApi');
+  const log = getService('log');
+  describe('@ess @serverless @skipInServerlessMKI Snapshot telemetry for customization status', () => {
+    const ZERO_COUNTS = {
+      alert_suppression: 0,
+      anomaly_threshold: 0,
+      data_view_id: 0,
+      description: 0,
+      filters: 0,
+      from: 0,
+      index: 0,
+      interval: 0,
+      investigation_fields: 0,
+      name: 0,
+      new_terms_fields: 0,
+      note: 0,
+      query: 0,
+      risk_score: 0,
+      severity: 0,
+      setup: 0,
+      tags: 0,
+      threat_query: 0,
+      threshold: 0,
+      timeline_id: 0,
+    } as const;
+
+    beforeEach(async () => {
+      await deleteAllPrebuiltRuleAssets(es, log);
+      await deleteAllRules(supertest, log);
+    });
+
+    const defaultRuleParams = {
+      description: 'some description',
+      name: 'Query with a rule id',
+      query: 'user.name: root or user.name: admin',
+      severity: 'high',
+      type: 'query',
+      risk_score: 42,
+      language: 'kuery',
+      rule_id: 'some-random-id',
+      version: 1,
+      author: [],
+      license: 'Elastic License v2',
+      index: ['index-1', 'index-2'],
+      interval: '100m',
+    };
+
+    const getRuleAssetSavedObjects = () => [
+      createRuleAssetSavedObject({
+        ...PrebuiltRuleAsset.parse(defaultRuleParams),
+        rule_id: 'rule-1',
+      }),
+      createRuleAssetSavedObject({
+        ...PrebuiltRuleAsset.parse(defaultRuleParams),
+        rule_id: 'rule-2',
+      }),
+      createRuleAssetSavedObject({
+        ...PrebuiltRuleAsset.parse(defaultRuleParams),
+        rule_id: 'rule-3',
+      }),
+    ];
+
+    const setupInitialRules = async () => {
+      const ruleAssetSavedObjects = getRuleAssetSavedObjects();
+      await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
+      await installPrebuiltRules(es, supertest);
+      return ruleAssetSavedObjects;
+    };
+
+    const getCustomizationStatus = async () => {
+      const stats = await getStats(supertest, log);
+      return stats?.detection_rules?.elastic_detection_rule_customization_status ?? ZERO_COUNTS;
+    };
+
+    it('returns zeroed customization status when there are no customizations', async () => {
+      await setupInitialRules();
+
+      const status = await getCustomizationStatus();
+      expect(status).toEqual(ZERO_COUNTS);
+    });
+
+    it('aggregates per-field customization counts across multiple rules', async () => {
+      await setupInitialRules();
+
+      await customizeRule(detectionsApi, 'rule-1', {
+        ...defaultRuleParams,
+        rule_id: 'rule-1',
+        tags: ['a', 'b'],
+      });
+
+      await customizeRule(detectionsApi, 'rule-2', {
+        ...defaultRuleParams,
+        rule_id: 'rule-2',
+        severity: 'low',
+      });
+
+      // rule-3: no customization (control)
+
+      const status = await getCustomizationStatus();
+
+      const expected = {
+        ...ZERO_COUNTS,
+        tags: 1,
+        severity: 1,
+      };
+
+      expect(status).toEqual(expected);
+    });
+
+    it('counts multiple customizations of the same field on the same rule as a single customized field', async () => {
+      await setupInitialRules();
+
+      await customizeRule(detectionsApi, 'rule-1', {
+        ...defaultRuleParams,
+        rule_id: 'rule-1',
+        tags: ['a', 'b'],
+      });
+      await customizeRule(detectionsApi, 'rule-1', {
+        ...defaultRuleParams,
+        rule_id: 'rule-1',
+        tags: ['a', 'b', 'c'],
+      });
+      await customizeRule(detectionsApi, 'rule-1', {
+        ...defaultRuleParams,
+        rule_id: 'rule-1',
+        tags: ['a', 'b', 'c', 'd'],
+      });
+
+      await customizeRule(detectionsApi, 'rule-2', {
+        ...defaultRuleParams,
+        rule_id: 'rule-2',
+        tags: ['x', 'y'],
+      });
+      await customizeRule(detectionsApi, 'rule-2', {
+        ...defaultRuleParams,
+        rule_id: 'rule-2',
+        tags: ['x', 'y', 'z'],
+      });
+
+      const status = await getCustomizationStatus();
+
+      const expected = {
+        ...ZERO_COUNTS,
+        tags: 2,
+      };
+
+      expect(status).toEqual(expected);
+    });
+  });
+};

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rule_upgrade_status.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rule_upgrade_status.ts
@@ -7,7 +7,7 @@
 
 import expect from 'expect';
 import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
-import { getCustomQueryRuleParams, getStats } from '../../../utils';
+import { customizeRule, getStats } from '../../../utils';
 import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 import {
   deleteAllPrebuiltRuleAssets,
@@ -30,6 +30,7 @@ import { deleteAllRules } from '../../../../../config/services/detections_respon
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
   const es = getService('es');
+  const detectionsApi = getService('detectionsApi');
   const log = getService('log');
 
   describe('@ess @serverless @skipInServerlessMKI Prebuilt Rules status', () => {
@@ -68,24 +69,6 @@ export default ({ getService }: FtrProviderContext): void => {
         await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
         await installPrebuiltRules(es, supertest);
         return ruleAssetSavedObjects;
-      };
-
-      /**
-       * Customizes a rule with the given parameters.
-       * @param ruleId - The ID of the rule to customize
-       * @param customizations - Custom parameters for the rule
-       */
-      const customizeRule = async (ruleId: string, customizations: Record<string, any>) => {
-        const customRuleParams = getCustomQueryRuleParams({
-          rule_id: ruleId,
-          ...customizations,
-        });
-
-        await supertest
-          .put(`${DETECTION_ENGINE_RULES_URL}?rule_id=${ruleId}`)
-          .set('kbn-xsrf', 'true')
-          .send(customRuleParams)
-          .expect(200);
       };
 
       /**
@@ -183,7 +166,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ruleAssetSavedObjects = await setupInitialRules();
 
         // Customize rule-1 with custom name and description (remains disabled)
-        await customizeRule('rule-1', {
+        await customizeRule(detectionsApi, 'rule-1', {
           name: 'Customized Rule Name',
           description: 'This is a customized rule description',
         });
@@ -218,7 +201,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ruleAssetSavedObjects = await setupInitialRules();
 
         // Customize and enable rule-1
-        await customizeRule('rule-1', {
+        await customizeRule(detectionsApi, 'rule-1', {
           name: 'Customized Enabled Rule',
           description: 'This is a customized and enabled rule',
           enabled: true,
@@ -249,7 +232,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ruleAssetSavedObjects = await setupInitialRules();
 
         // Customize and enable one rule
-        await customizeRule('rule-1', {
+        await customizeRule(detectionsApi, 'rule-1', {
           name: 'Customized Rule',
           enabled: true,
         });
@@ -288,15 +271,15 @@ export default ({ getService }: FtrProviderContext): void => {
         const ruleAssetSavedObjects = await setupInitialRules();
 
         // Customize and enable multiple rules
-        await customizeRule('rule-1', {
+        await customizeRule(detectionsApi, 'rule-1', {
           name: 'Customized Enabled Rule 1',
           enabled: true,
         });
-        await customizeRule('rule-2', {
+        await customizeRule(detectionsApi, 'rule-2', {
           name: 'Customized Enabled Rule 2',
           enabled: true,
         });
-        await customizeRule('rule-3', {
+        await customizeRule(detectionsApi, 'rule-3', {
           name: 'Customized Enabled Rule 3',
           enabled: true,
         });
@@ -365,7 +348,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ruleAssetSavedObjects = await setupInitialRules();
 
         // rule-1: enabled + customized
-        await customizeRule('rule-1', {
+        await customizeRule(detectionsApi, 'rule-1', {
           name: 'Enabled Customized Rule',
           enabled: true,
         });
@@ -381,7 +364,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .expect(200);
 
         // rule-3: disabled + customized
-        await customizeRule('rule-3', {
+        await customizeRule(detectionsApi, 'rule-3', {
           name: 'Disabled Customized Rule',
           // enabled: false is default
         });
@@ -413,7 +396,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ruleAssetSavedObjects = await setupInitialRules();
 
         // Customize and enable only one rule
-        await customizeRule('rule-1', {
+        await customizeRule(detectionsApi, 'rule-1', {
           name: 'Single Customized Enabled Rule',
           description: 'The only upgradeable rule',
           enabled: true,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/customize_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/customize_rule.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SecuritySolutionApiProvider as DetectionsApiProvider } from '@kbn/security-solution-test-api-clients/supertest/detections.gen';
+
+import { getCustomQueryRuleParams } from '../get_rule_params';
+
+/**
+ * Customizes a rule with the given parameters.
+ * @param ruleId - The ID of the rule to customize
+ * @param customizations - Custom parameters for the rule
+ */
+export async function customizeRule(
+  detectionsApi: ReturnType<typeof DetectionsApiProvider>,
+  ruleId: string,
+  customizations: Record<string, any>
+) {
+  const customRuleParams = getCustomQueryRuleParams({
+    rule_id: ruleId,
+    ...customizations,
+  });
+
+  await detectionsApi.updateRule({ body: customRuleParams }).expect(200);
+}

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 export * from './create_prebuilt_rule_saved_objects';
+export * from './customize_rule';
 export * from './delete_all_prebuilt_rule_assets';
 export * from './delete_all_timelines';
 export * from './delete_fleet_packages';


### PR DESCRIPTION
**Partially addresses: #140369**

## Summary

This is another PR from of a series of PRs I am planning to create to cover the requirements in the https://github.com/elastic/kibana/issues/140369 ticket.


The requirement covered in this PR is: " Breakdown of which fields are being customized."

Testing:

Display the snapshot:
```
POST kbn:/internal/telemetry/clusters/_stats?apiVersion=2
{ "unencrypted": true, "refreshCache": true }
```

Send the snapshot to staging telemetry cluster.
```
POST kbn:/internal/telemetry/force_send?apiVersion=1&elasticInternalOrigin=true
{}
```

<!--ONMERGE {"backportTargets":["8.18","8.19","9.1","9.2"]} ONMERGE-->