### PR TITLE
fix: error handling for index privilege issues in csv reports

### DIFF
--- a/src/platform/packages/private/kbn-generate-csv/src/generate_csv.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/generate_csv.ts
@@ -26,6 +26,7 @@ import type { CancellationToken, ReportingError } from '@kbn/reporting-common';
 import {
   AuthenticationExpiredError,
   byteSizeValueToNumber,
+  IndexPrivilegeError,
   ReportingSavedObjectNotFoundError,
 } from '@kbn/reporting-common';
 import type { TaskInstanceFields, TaskRunResult } from '@kbn/reporting-common/types';
@@ -433,7 +434,10 @@ export class CsvGenerator {
       }
     } catch (err) {
       logger.error(err);
-      if (err instanceof esErrors.ResponseError) {
+      if (err instanceof IndexPrivilegeError) {
+        reportingError = err;
+        warnings.push(err.humanFriendlyMessage?.() || err.message);
+      } else if (err instanceof esErrors.ResponseError) {
         if ([401, 403].includes(err.statusCode ?? 0)) {
           reportingError = new AuthenticationExpiredError();
           warnings.push(i18nTexts.authenticationError.partialResultsMessage);

--- a/src/platform/packages/private/kbn-reporting/common/errors.ts
+++ b/src/platform/packages/private/kbn-reporting/common/errors.ts
@@ -166,3 +166,16 @@ export class ReportingSavedObjectNotFoundError extends ReportingError {
     return ReportingSavedObjectNotFoundError.code;
   }
 }
+
+export class IndexPrivilegeError extends ReportingError {
+  static code = 'index_privilege_error' as const;
+  public get code(): string {
+    return IndexPrivilegeError.code;
+  }
+
+  public humanFriendlyMessage() {
+    return i18n.translate('reporting.common.indexPrivilegeErrorMessage', {
+      defaultMessage: `Unable to generate CSV report due to insufficient index privileges. Please ensure your user has the necessary permissions to read from the specified indices.`,
+    });
+  }
+}

--- a/x-pack/platform/plugins/private/reporting/common/errors/map_to_reporting_error.test.ts
+++ b/x-pack/platform/plugins/private/reporting/common/errors/map_to_reporting_error.test.ts
@@ -9,6 +9,7 @@ import {
   BrowserCouldNotLaunchError,
   BrowserScreenshotError,
   BrowserUnexpectedlyClosedError,
+  IndexPrivilegeError,
   InvalidLayoutParametersError,
   UnknownError,
   VisualReportingSoftDisabledError,
@@ -63,6 +64,18 @@ describe('mapToReportingError', () => {
     expect(
       mapToReportingError(createCustomError('InsufficientMemoryAvailableOnCloudError'))
     ).toBeInstanceOf(VisualReportingSoftDisabledError);
+  });
+
+  test('IndexPrivilegeError', () => {
+    const createCustomError = (name: string) => {
+      const e = new Error('Test index privilege error');
+      e.name = name;
+      return e;
+    };
+
+    expect(mapToReportingError(createCustomError('IndexPrivilegeError'))).toBeInstanceOf(
+      IndexPrivilegeError
+    );
   });
 
   test('unknown error', () => {

--- a/x-pack/platform/plugins/private/reporting/common/errors/map_to_reporting_error.ts
+++ b/x-pack/platform/plugins/private/reporting/common/errors/map_to_reporting_error.ts
@@ -11,6 +11,7 @@ import {
   BrowserScreenshotError,
   BrowserUnexpectedlyClosedError,
   DisallowedOutgoingUrl,
+  IndexPrivilegeError,
   InvalidLayoutParametersError,
   PdfWorkerOutOfMemoryError,
   ReportingError,
@@ -68,6 +69,8 @@ export function mapToReportingError(error: ExecutionError | unknown): ReportingE
     case error instanceof errors.InsufficientMemoryAvailableOnCloudError ||
       errorName === 'InsufficientMemoryAvailableOnCloudError':
       return new VisualReportingSoftDisabledError();
+    case errorName === 'IndexPrivilegeError':
+      return new IndexPrivilegeError((error as Error).message);
   }
   return new UnknownError((error as Error)?.message);
 }


### PR DESCRIPTION
### Summary

fixes: #237566

- replaces generic "Could not receive a PIT ID!" error with user-friendly message when index privilege issues occur during CSV report generation in CCS environments.

**Before:** `ReportingError(code: unknown_error) "Could not receive a PIT ID!"`  
**After:** `Unable to generate CSV report due to insufficient index privileges. Please ensure your user has the necessary permissions to read from the specified indices.`

### Checklist

- [x] Text follows EUI guidelines and includes i18n support
- [x] Unit tests added for error mapping

### Bug Fixes
- Fixed unclear error message when CSV reports fail due to insufficient index privileges in CCS environments