### PR TITLE
[Security Solution][Detection Engine] skips "Detection ES|QL - Alert suppression, saves custom ES|QL field in suppression configuration" in MKI

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/esql_rule.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/esql_rule.cy.ts
@@ -45,7 +45,7 @@ const workaroundForResizeObserver = () =>
 describe(
   'Detection ES|QL - Alert suppression',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
   },
   () => {
     const rule = getEsqlRule();
@@ -55,7 +55,7 @@ describe(
       visit(CREATE_RULE_URL);
     });
 
-    it('shows custom ES|QL field in investigation fields autocomplete and saves it in rule', function () {
+    it('saves custom ES|QL field in suppression configuration', function () {
       const CUSTOM_ESQL_FIELD = '_custom_agent_name';
       const SUPPRESS_BY_FIELDS = [CUSTOM_ESQL_FIELD, 'agent.type'];
 


### PR DESCRIPTION

## Summary

 - skips flaky testin MKI. Refer to [internal MKI failures](https://elastic.slack.com/archives/C056TQ5J81Y/p1759473972595689)
 - renames test, since its name is incorrect and is duplicated from already existing test
 
