### PR TITLE
[8.19] [Docs] Add 8.18.8 release notes (#237396)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -672,9 +672,6 @@ Search::
 * Fixes an issue in Search Playground where context limit errors were not handled well when using the Elastic Managed LLM ({kibana-pull}225360[#225360]).
 * Adjusts the `z-index` of the app menu header to not conflict with the Persistent Console ({kibana-pull}224708[#224708]).
 
-Management::
-* Fixes privilege requirements when reindexing indices through Upgrade Assistant. Previously, the `superuser` role was required, but now the `cluster: manage` and `all` privileges are sufficient ({kibana-pull}237055[#237055]).
-
 [[release-notes-8.18.8]]
 == {kib} 8.18.8
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -16,6 +16,7 @@ Review important information about the {kib} 8.x releases.
 * <<release-notes-8.19.2>>
 * <<release-notes-8.19.1>>
 * <<release-notes-8.19.0>>
+* <<release-notes-8.18.8>>
 * <<release-notes-8.18.7>>
 * <<release-notes-8.18.6>>
 * <<release-notes-8.18.5>>
@@ -140,22 +141,7 @@ Elastic Observability solution::
 * Prevents synthetics package policies from becoming malformed and reporting {agents} as unhealthy ({kibana-pull}236104[#236104]).
 * Cleans up extra synthetics package policies ({kibana-pull}235200[#235200]).
 Elastic Security solution::
-For the Elastic Security 8.19.5 release information, refer to [Elastic Security Solution Release Notes](docs-content://release-notes/elastic-security/index.md).
-Kibana security::
-* Allows `xpack.spaces.defaultSolution` to be configured through environment variables for Docker deployments ({kibana-pull}236570[#236570]).
-* Adds the ability to do partial matches and searches in the **API keys** section of Stack Management ({kibana-pull}221959[#221959]).
-Machine Learning::
-* Improves trained model performance by adding filters to the request to fetch all index settings ({kibana-pull}237072[#237072]).
-* Hides the show forecast checkbox when selecting a new job in the Single Metric Viewer ({kibana-pull}236724[#236724]).
-* Makes alerts visible in Anomaly Explorer to all Machine Learning-only users regardless of where they create rules ({kibana-pull}236289[#236289]).
-* Fixes the **Job details** flyout on the **Analytics Map** page ({kibana-pull}236131[#236131]).
-* Limits log rate analysis category requests to reduce `msearch` usage ({kibana-pull}235611[#235611]).
-* Fixes rendering of the dashboard panel in PDF reporting for the Anomaly Swim Lane ({kibana-pull}235475[#235475]).
-Search solution::
-* Adds search functionality to the **Query rules** details page ({kibana-pull}232579[#232579]).
-Management::
-* Fixes privilege requirements when reindexing indices through Upgrade Assistant. Previously, the `superuser` role was required, but now the `cluster: manage` and `all` privileges are sufficient ({kibana-pull}237055[#237055]).
-
+For the Elastic Security 8.19.5 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
 
 [[release-notes-8.19.4]]
 == {kib} 8.19.4
@@ -671,6 +657,46 @@ Management::
 Search::
 * Fixes an issue in Search Playground where context limit errors were not handled well when using the Elastic Managed LLM ({kibana-pull}225360[#225360]).
 * Adjusts the `z-index` of the app menu header to not conflict with the Persistent Console ({kibana-pull}224708[#224708]).
+
+Management::
+* Fixes privilege requirements when reindexing indices through Upgrade Assistant. Previously, the `superuser` role was required, but now the `cluster: manage` and `all` privileges are sufficient ({kibana-pull}237055[#237055]).
+
+[[release-notes-8.18.8]]
+== {kib} 8.18.8
+
+The 8.18.8 release includes the following fixes.
+
+[float]
+[[fixes-v8.18.8]]
+=== Fixes
+Dashboards and Visualizations::
+* Fixes text kerning issues in PDF/PNG exports of dashboards and visualizations ({kibana-pull}235516[#235516]).
+* Updates dashboards to wait until controls are ready before rendering panels to prevent a double fetch of data ({kibana-pull}237169[#237169]).
+* Fixes an issue with the Lens table's column sort order being different in the dashboard and the exported CSV ({kibana-pull}236673[#236673]).
+* Fixes an issue where the dashboard title would not get updated in the breadcrumb when edited from the list of dashboards ({kibana-pull}236561[#236561]).
+Data ingestion and Fleet::
+* Adds a unique count to improve accuracy of the number of transforms on the integrations overview page ({kibana-pull}236177[#236177]).
+* Validates the Logstash pipeline ID at the {kib} API level ({kibana-pull}236347[#236347]).
+Discover::
+* Clears sort by `timestamp` when navigating from classic to ES|QL mode ({kibana-pull}235338[#235338]).
+Elastic Observability solution::
+* Removes span documents from the `getServiceAgent` function ({kibana-pull}236732[#236732]).
+Elastic Security solution::
+For the Elastic Security 8.18.8 release information, refer to [Elastic Security Solution Release Notes](docs-content://release-notes/elastic-security/index.md).
+Kibana security::
+* Allows `xpack.spaces.defaultSolution` to be configured through environment variables for Docker deployments ({kibana-pull}236570[#236570]).
+* Adds the ability to do partial matches and searches in the **API keys** section of Stack Management ({kibana-pull}221959[#221959]).
+Machine Learning::
+* Improves trained model performance by adding filters to the request to fetch all index settings ({kibana-pull}237072[#237072]).
+* Hides the show forecast checkbox when selecting a new job in the Single Metric Viewer ({kibana-pull}236724[#236724]).
+* Makes alerts visible in Anomaly Explorer to all Machine Learning-only users regardless of where they create rules ({kibana-pull}236289[#236289]).
+* Fixes the **Job details** flyout on the **Analytics Map** page ({kibana-pull}236131[#236131]).
+* Limits log rate analysis category requests to reduce `msearch` usage ({kibana-pull}235611[#235611]).
+* Fixes rendering of the dashboard panel in PDF reporting for the Anomaly Swim Lane ({kibana-pull}235475[#235475]).
+Search solution::
+* Adds search functionality to the **Query rules** details page ({kibana-pull}232579[#232579]).
+Management::
+* Fixes privilege requirements when reindexing indices through Upgrade Assistant. Previously, the `superuser` role was required, but now the `cluster: manage` and `all` privileges are sufficient ({kibana-pull}237055[#237055]).
 
 [[release-notes-8.18.7]]
 == {kib} 8.18.7

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -157,6 +157,7 @@ Search solution::
 Management::
 * Fixes privilege requirements when reindexing indices through Upgrade Assistant. Previously, the `superuser` role was required, but now the `cluster: manage` and `all` privileges are sufficient ({kibana-pull}237055[#237055]).
 
+
 [[release-notes-8.19.4]]
 == {kib} 8.19.4
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -142,6 +142,20 @@ Elastic Observability solution::
 * Cleans up extra synthetics package policies ({kibana-pull}235200[#235200]).
 Elastic Security solution::
 For the Elastic Security 8.19.5 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
+Kibana security::
+* Allows `xpack.spaces.defaultSolution` to be configured through environment variables for Docker deployments ({kibana-pull}236570[#236570]).
+* Adds the ability to do partial matches and searches in the **API keys** section of Stack Management ({kibana-pull}221959[#221959]).
+Machine Learning::
+* Improves trained model performance by adding filters to the request to fetch all index settings ({kibana-pull}237072[#237072]).
+* Hides the show forecast checkbox when selecting a new job in the Single Metric Viewer ({kibana-pull}236724[#236724]).
+* Makes alerts visible in Anomaly Explorer to all Machine Learning-only users regardless of where they create rules ({kibana-pull}236289[#236289]).
+* Fixes the **Job details** flyout on the **Analytics Map** page ({kibana-pull}236131[#236131]).
+* Limits log rate analysis category requests to reduce `msearch` usage ({kibana-pull}235611[#235611]).
+* Fixes rendering of the dashboard panel in PDF reporting for the Anomaly Swim Lane ({kibana-pull}235475[#235475]).
+Search solution::
+* Adds search functionality to the **Query rules** details page ({kibana-pull}232579[#232579]).
+Management::
+* Fixes privilege requirements when reindexing indices through Upgrade Assistant. Previously, the `superuser` role was required, but now the `cluster: manage` and `all` privileges are sufficient ({kibana-pull}237055[#237055]).
 
 [[release-notes-8.19.4]]
 == {kib} 8.19.4


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.18` to `8.19`:
 - [[Docs] Add 8.18.8 release notes (#237396)](https://github.com/elastic/kibana/pull/237396)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"wajihaparvez","email":"wajiha.parvez@elastic.co"},"sourceCommit":{"committedDate":"2025-10-03T19:00:59Z","message":"[Docs] Add 8.18.8 release notes (#237396)\n\nCloses https://github.com/elastic/docs-content/issues/3299","sha":"5d4d27fbf6b2d9d34d092f11e127bc32ecd48a60","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","backport:version","v8.19.0"],"title":"[Docs] Add 8.18.8 release notes","number":237396,"url":"https://github.com/elastic/kibana/pull/237396","mergeCommit":{"message":"[Docs] Add 8.18.8 release notes (#237396)\n\nCloses https://github.com/elastic/docs-content/issues/3299","sha":"5d4d27fbf6b2d9d34d092f11e127bc32ecd48a60"}},"sourceBranch":"8.18","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->