### PR TITLE
Skip streams significant events and queries tests for MKI

### DIFF
--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/queries.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/queries.ts
@@ -45,6 +45,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   };
 
   describe('Queries API', function () {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/237572
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('admin');
       apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/significant_events.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/significant_events.ts
@@ -31,6 +31,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   let apiClient: StreamsSupertestRepositoryClient;
 
   describe('Significant Events', function () {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/237572
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('admin');
       apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);


### PR DESCRIPTION
## Summary

This PR skips the streams significant events and queries tests for MKI runs.
Details on the failure in #237572