### PR TITLE
[Search][Fix] pass retriever query via body param instead of query in JS tutorial

### DIFF
--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
@@ -132,11 +132,11 @@ const searchCommand: SearchCodeSnippetFunction = (
 ${createClientSnippet(args)}
 
 const index = '${args.indexName}';
-const query = ${JSON.stringify(args.queryObject, null, 2)};
+const body = ${JSON.stringify(args.queryObject, null, 2)};
 
 const result = await client.search({
   index,
-  query,
+  body,
 });
 
 console.log(result.hits.hits);`;


### PR DESCRIPTION
## Summary

This PR fixes an issue where the retriever query copied from the "Search your data" JavaScript tutorial fails with a `parsing_exception` when passed via the query parameter in the Node.js Elasticsearch client. Retriever queries must be passed via the body parameter to ensure they are serialized correctly.

### Screenshots

**BEFORE**

<img width="700" alt="Screenshot 2025-10-06 at 14 33 13" src="https://github.com/user-attachments/assets/46c33d73-2339-4047-917c-949e96b8a9b9" />

**AFTER**

<img width="700" alt="Screenshot 2025-10-06 at 14 35 20" src="https://github.com/user-attachments/assets/c9e697f6-788c-43d9-b0a6-57746ade44f7" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release Note

Fixes an issue where the retriever query copied from the "Search your data" JavaScript tutorial fails with a `parsing_exception` when passed via the query parameter in the Node.js Elasticsearch client. Retriever queries must be passed via the body parameter to ensure they are serialized correctly.



<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->