### PR TITLE
[Workspace Chrome] Fix browser print for grid layout

### DIFF
--- a/src/core/packages/chrome/layout/core-chrome-layout-components/application/layout_application.tsx
+++ b/src/core/packages/chrome/layout/core-chrome-layout-components/application/layout_application.tsx
@@ -10,6 +10,7 @@
 import type { ReactNode } from 'react';
 import React from 'react';
 
+import { css } from '@emotion/react';
 import { useEuiOverflowScroll } from '@elastic/eui';
 import { APP_MAIN_SCROLL_CONTAINER_ID } from '@kbn/core-chrome-layout-constants';
 
@@ -30,7 +31,12 @@ export const LayoutApplication = ({
   topBar?: ReactNode;
   bottomBar?: ReactNode;
 }) => {
-  const overflow = useEuiOverflowScroll('y');
+  // only restrict overflow scroll on screen (not print) to allow for full page printing
+  const overflow = css`
+    @media screen {
+      ${useEuiOverflowScroll('y')};
+    }
+  `;
 
   return (
     <div


### PR DESCRIPTION
## Summary

close https://github.com/elastic/kibana/issues/234770

Print/reporting related fixes for grid layout

```
feature_flags.overrides:
  core.chrome.layoutType: 'grid'
```

- Fix brower print by not limiting scroll to app container 
- ~Hide chrome when performing reporting redirect~ (Needed to fix https://github.com/elastic/kibana/issues/227187 for grid layout) I'll open another pr... some complications with TSVB there

