### PR TITLE
[Background search] Update warning icons

### DIFF
--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
@@ -8,12 +8,13 @@
  */
 
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiFlexGroup, EuiIconTip, EuiLink, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiIconTip, EuiLink, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import type { CoreStart } from '@kbn/core/public';
+import { css } from '@emotion/react';
 import { SearchSessionStatus } from '../../../../../../../common';
 import type { SearchUsageCollector } from '../../../../../collectors';
 import type { BackgroundSearchOpenedHandler, UISession } from '../../../types';
@@ -75,7 +76,7 @@ export const nameColumn = ({
     const trackAction = isRestorable
       ? searchUsageCollector.trackSessionViewRestored
       : searchUsageCollector.trackSessionReloaded;
-    const notRestorableWarning = isRestorable ? null : (
+    const notRestorableWarning = false ? null : (
       <EuiIconTip
         type="warning"
         content={
@@ -120,10 +121,18 @@ export const nameColumn = ({
           }}
         >
           <TableText data-test-subj="sessionManagementNameCol">
-            <EuiFlexGroup gutterSize="s">
-              {name}
-              {notRestorableWarning}
-              {versionIncompatibleWarning}
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              <EuiFlexItem grow={false}>{name}</EuiFlexItem>
+              {notRestorableWarning && (
+                <EuiFlexItem css={iconCss} grow={false}>
+                  {notRestorableWarning}
+                </EuiFlexItem>
+              )}
+              {versionIncompatibleWarning && (
+                <EuiFlexItem css={iconCss} grow={false}>
+                  {versionIncompatibleWarning}
+                </EuiFlexItem>
+              )}
             </EuiFlexGroup>
           </TableText>
         </NameColumnText>
@@ -131,3 +140,7 @@ export const nameColumn = ({
     );
   },
 });
+
+const iconCss = css`
+  line-height: 1;
+`;

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
@@ -76,17 +76,15 @@ export const nameColumn = ({
       ? searchUsageCollector.trackSessionViewRestored
       : searchUsageCollector.trackSessionReloaded;
     const notRestorableWarning = isRestorable ? null : (
-      <>
-        <EuiIconTip
-          type="warning"
-          content={
-            <FormattedMessage
-              id="data.mgmt.searchSessions.table.notRestorableWarning"
-              defaultMessage="The background search will be executed again. You can then save it for future use."
-            />
-          }
-        />
-      </>
+      <EuiIconTip
+        type="warning"
+        content={
+          <FormattedMessage
+            id="data.mgmt.searchSessions.table.notRestorableWarning"
+            defaultMessage="The background search will be executed again. You can then save it for future use."
+          />
+        }
+      />
     );
 
     // show version warning only if:
@@ -95,19 +93,16 @@ export const nameColumn = ({
     // 2. if still can restore this session: it has IN_PROGRESS or COMPLETE status.
     const versionIncompatibleWarning =
       isRestorable && version !== kibanaVersion ? (
-        <>
-          {' '}
-          <EuiIconTip
-            type="warning"
-            iconProps={{ 'data-test-subj': 'versionIncompatibleWarningTestSubj' }}
-            content={
-              <FormattedMessage
-                id="data.mgmt.searchSessions.table.versionIncompatibleWarning"
-                defaultMessage="This background search was created in a Kibana instance running a different version. It may not restore correctly."
-              />
-            }
-          />
-        </>
+        <EuiIconTip
+          type="warning"
+          iconProps={{ 'data-test-subj': 'versionIncompatibleWarningTestSubj' }}
+          content={
+            <FormattedMessage
+              id="data.mgmt.searchSessions.table.versionIncompatibleWarning"
+              defaultMessage="This background search was created in a Kibana instance running a different version. It may not restore correctly."
+            />
+          }
+        />
       ) : null;
 
     return (

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
@@ -76,7 +76,7 @@ export const nameColumn = ({
     const trackAction = isRestorable
       ? searchUsageCollector.trackSessionViewRestored
       : searchUsageCollector.trackSessionReloaded;
-    const notRestorableWarning = false ? null : (
+    const notRestorableWarning = isRestorable ? null : (
       <EuiIconTip
         type="warning"
         content={

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/columns/name.tsx
@@ -8,7 +8,7 @@
  */
 
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiIconTip, EuiLink, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiIconTip, EuiLink, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -82,7 +82,7 @@ export const nameColumn = ({
           content={
             <FormattedMessage
               id="data.mgmt.searchSessions.table.notRestorableWarning"
-              defaultMessage="The search session will be executed again. You can then save it for future use."
+              defaultMessage="The background search will be executed again. You can then save it for future use."
             />
           }
         />
@@ -103,7 +103,7 @@ export const nameColumn = ({
             content={
               <FormattedMessage
                 id="data.mgmt.searchSessions.table.versionIncompatibleWarning"
-                defaultMessage="This search session was created in a Kibana instance running a different version. It may not restore correctly."
+                defaultMessage="This background search was created in a Kibana instance running a different version. It may not restore correctly."
               />
             }
           />
@@ -125,9 +125,11 @@ export const nameColumn = ({
           }}
         >
           <TableText data-test-subj="sessionManagementNameCol">
-            {name}
-            {notRestorableWarning}
-            {versionIncompatibleWarning}
+            <EuiFlexGroup gutterSize="s">
+              {name}
+              {notRestorableWarning}
+              {versionIncompatibleWarning}
+            </EuiFlexGroup>
           </TableText>
         </NameColumnText>
       </RedirectAppLinks>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/237280

This adds a flex group to the background search name / warning icons so they gave some gutter between them.
This also updates the tooltips for the warnings to say "background search" instead of "search session"

| Before | After |
|--------|------|
| <img width="267" height="79" alt="image" src="https://github.com/user-attachments/assets/368dbbcd-be36-4416-92b7-83fb3917f9f6" /> | <img width="290" height="83" alt="image" src="https://github.com/user-attachments/assets/fae14034-93e7-4db1-8a9d-10b81164c1e0" /> |
| <img width="386" height="137" alt="Captura de pantalla 2025-10-06 a las 17 14 32" src="https://github.com/user-attachments/assets/18c46c40-27f5-46e8-ae98-1748e1e59c71" /> | <img width="403" height="145" alt="image" src="https://github.com/user-attachments/assets/bc00e0e8-2404-41f3-8c07-233746ec640f" /> |
| <img width="395" height="155" alt="image" src="https://github.com/user-attachments/assets/03b93e27-c86c-42f6-a4d1-9ef241868666" /> | <img width="405" height="158" alt="image" src="https://github.com/user-attachments/assets/c6b372b4-9e7f-4d45-8468-2cbec2152867" /> |

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->