### PR TITLE
[Test/Synthetics] fix monitor name validation test

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.test.tsx
@@ -6,8 +6,7 @@
  */
 
 import React from 'react';
-import { fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { act, fireEvent, waitFor } from '@testing-library/react';
 import { render } from '../../utils/testing/rtl_helpers';
 import { MonitorEditPage } from './monitor_edit_page';
 import { useMonitorName } from '../../hooks/use_monitor_name';
@@ -32,8 +31,16 @@ jest.mock('../../../../hooks/use_kibana_space', () => ({
 }));
 
 // Failing: See https://github.com/elastic/kibana/issues/234711
-describe.skip('MonitorEditPage', () => {
+describe('MonitorEditPage', () => {
   const { FETCH_STATUS } = observabilitySharedPublic;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 
   it('renders correctly', async () => {
     jest.spyOn(observabilitySharedPublic, 'useFetcher').mockReturnValue({
@@ -233,9 +240,12 @@ describe.skip('MonitorEditPage', () => {
 
       const inputField = getByTestId('syntheticsMonitorConfigName');
       fireEvent.focus(inputField);
-      await userEvent.type(inputField, 'any value'); // Hook is made to return duplicate error as true
+      fireEvent.change(inputField, { target: { value: 'any value' } }); // Hook is made to return duplicate error as true
       fireEvent.blur(inputField);
 
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
       if (nameAlreadyExists) {
         await waitFor(() => getByText('Monitor name already exists'));
       } else {


### PR DESCRIPTION
## Summary

Fixes #234711

This PR modifies an existing synthetics validation test to fake timers and use fireEvent for debounced name field to help avoid test timeout


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->