### PR TITLE
[a11y] [Search] Make reorderable table component accessible

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-
 import { useActions, useValues } from 'kea';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -21,8 +20,6 @@ import {
   EuiText,
 } from '@elastic/eui';
 
-import { i18n } from '@kbn/i18n';
-
 import type { FilteringRule } from '@kbn/search-connectors';
 import {
   filteringPolicyToText,
@@ -31,6 +28,18 @@ import {
 } from '@kbn/search-connectors';
 
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import {
+  BASIC_TABLE_FIELD_TITLE,
+  BASIC_TABLE_POLICY_TITLE,
+  BASIC_TABLE_RULE_TITLE,
+  BASIC_TABLE_VALUE_TITLE,
+  getSyncRulesDescription,
+  SYNC_RULES_LEARN_MORE_LINK,
+  SYNC_RULES_TABLE_ADD_RULE_LABEL,
+  SYNC_RULES_TABLE_ARIA_LABEL,
+  REGEX_ERROR,
+  INCLUDE_EVERYTHING_ELSE_MESSAGE,
+} from '../../translations';
 import { IndexViewLogic } from '../../index_view_logic';
 
 import { ConnectorFilteringLogic } from './connector_filtering_logic';
@@ -46,21 +55,6 @@ import type {
 
 const instanceId = 'FilteringRulesTable';
 
-const i18nMessages = {
-  field: i18n.translate('xpack.contentConnectors.index.connector.syncRules.basicTable.fieldTitle', {
-    defaultMessage: 'Field',
-  }),
-  policy: i18n.translate('xpack.contentConnectors.index.connector.rule.basicTable.policyTitle', {
-    defaultMessage: 'Policy',
-  }),
-  rule: i18n.translate('xpack.contentConnectors.index.connector.syncRules.basicTable.ruleTitle', {
-    defaultMessage: 'Rule',
-  }),
-  value: i18n.translate('xpack.contentConnectors.index.connector.syncRules.basicTable.valueTitle', {
-    defaultMessage: 'Value',
-  }),
-};
-
 function validateItem(filteringRule: FilteringRule): FormErrors {
   if (filteringRule.rule === 'regex') {
     try {
@@ -68,10 +62,7 @@ function validateItem(filteringRule: FilteringRule): FormErrors {
       return {};
     } catch {
       return {
-        value: i18n.translate(
-          'xpack.contentConnectors.content.index.connector.filteringRules.regExError',
-          { defaultMessage: 'Value should be a regular expression' }
-        ),
+        value: REGEX_ERROR,
       };
     }
   }
@@ -89,16 +80,10 @@ export const SyncRulesTable: React.FC = () => {
 
   const description = (
     <EuiText size="s" color="default">
-      {i18n.translate('xpack.contentConnectors.content.index.connector.syncRules.description', {
-        defaultMessage:
-          'Add a sync rule to customize what data is synchronized from {indexName}. Everything is included by default, and documents are validated against the configured set of sync rules in the listed order.',
-        values: { indexName },
-      })}
+      {getSyncRulesDescription(indexName)}
       <EuiSpacer />
       <EuiLink href={docLinks.syncRules} external target="_blank">
-        {i18n.translate('xpack.contentConnectors.content.index.connector.syncRules.link', {
-          defaultMessage: 'Learn more about customizing your sync rules.',
-        })}
+        {SYNC_RULES_LEARN_MORE_LINK}
       </EuiLink>
     </EuiText>
   );
@@ -120,11 +105,11 @@ export const SyncRulesTable: React.FC = () => {
               value: 'exclude',
             },
           ]}
-          aria-label={i18nMessages.policy}
+          aria-label={BASIC_TABLE_POLICY_TITLE}
         />
       ),
       field: 'policy',
-      name: i18nMessages.policy,
+      name: BASIC_TABLE_POLICY_TITLE,
       render: (indexingRule: any) => (
         <EuiText size="s">{filteringPolicyToText(indexingRule.policy)}</EuiText>
       ),
@@ -137,13 +122,13 @@ export const SyncRulesTable: React.FC = () => {
               fullWidth
               value={rule.field}
               onChange={(e) => onChange(e.target.value)}
-              aria-label={i18nMessages.field}
+              aria-label={BASIC_TABLE_FIELD_TITLE}
             />
           </EuiFlexItem>
         </EuiFlexGroup>
       ),
       field: 'field',
-      name: i18nMessages.field,
+      name: BASIC_TABLE_FIELD_TITLE,
       render: (rule: any) => (
         <EuiText size="s">
           <EuiCode>{rule.field}</EuiCode>
@@ -160,11 +145,11 @@ export const SyncRulesTable: React.FC = () => {
             text: filteringRuleToText(rule),
             value: rule,
           }))}
-          aria-label={i18nMessages.rule}
+          aria-label={BASIC_TABLE_RULE_TITLE}
         />
       ),
       field: 'rule',
-      name: i18nMessages.rule,
+      name: BASIC_TABLE_RULE_TITLE,
       render: (rule: any) => <EuiText size="s">{filteringRuleToText(rule.rule)}</EuiText>,
     },
     {
@@ -175,13 +160,13 @@ export const SyncRulesTable: React.FC = () => {
               fullWidth
               value={rule.value}
               onChange={(e) => onChange(e.target.value)}
-              aria-label={i18nMessages.value}
+              aria-label={BASIC_TABLE_VALUE_TITLE}
             />
           </EuiFlexItem>
         </EuiFlexGroup>
       ),
       field: 'value',
-      name: i18nMessages.value,
+      name: BASIC_TABLE_VALUE_TITLE,
       render: (rule: any) => (
         <EuiText size="s">
           <EuiCode>{rule.value}</EuiCode>
@@ -192,14 +177,8 @@ export const SyncRulesTable: React.FC = () => {
 
   return (
     <InlineEditableTable
-      addButtonText={i18n.translate(
-        'xpack.contentConnectors.content.index.connector.syncRules.table.addRuleLabel',
-        { defaultMessage: 'Add sync rule' }
-      )}
-      ariaLabel={i18n.translate(
-        'xpack.contentConnectors.content.index.connector.syncRules.table.ariaLabel',
-        { defaultMessage: 'Sync rules' }
-      )}
+      addButtonText={SYNC_RULES_TABLE_ADD_RULE_LABEL}
+      ariaLabel={SYNC_RULES_TABLE_ARIA_LABEL}
       columns={columns}
       defaultItem={{
         policy: 'include',
@@ -234,16 +213,7 @@ export const SyncRulesTable: React.FC = () => {
       onReorder={reorderFilteringRules}
       title=""
       validateItem={validateItem}
-      bottomRows={[
-        <EuiText size="s">
-          {i18n.translate(
-            'xpack.contentConnectors.content.sources.basicRulesTable.includeEverythingMessage',
-            {
-              defaultMessage: 'Include everything else from this source',
-            }
-          )}
-        </EuiText>,
-      ]}
+      bottomRows={[<EuiText size="s">{INCLUDE_EVERYTHING_ELSE_MESSAGE}</EuiText>]}
       canRemoveLastItem
       emptyPropertyAllowed
       showRowIndex

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
@@ -186,7 +186,7 @@ export const SyncRulesTable: React.FC = () => {
       )}
       ariaLabel={i18n.translate(
         'xpack.contentConnectors.content.index.connector.syncRules.table.ariaLabel',
-        { defaultMessage: 'Sync rules table' }
+        { defaultMessage: 'Sync rules' }
       )}
       columns={columns}
       defaultItem={{

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
@@ -184,6 +184,10 @@ export const SyncRulesTable: React.FC = () => {
         'xpack.contentConnectors.content.index.connector.syncRules.table.addRuleLabel',
         { defaultMessage: 'Add sync rule' }
       )}
+      ariaLabel={i18n.translate(
+        'xpack.contentConnectors.content.index.connector.syncRules.table.ariaLabel',
+        { defaultMessage: 'Sync rules table' }
+      )}
       columns={columns}
       defaultItem={{
         policy: 'include',

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
@@ -46,6 +46,21 @@ import type {
 
 const instanceId = 'FilteringRulesTable';
 
+const i18nMessages = {
+  field: i18n.translate('xpack.contentConnectors.index.connector.syncRules.basicTable.fieldTitle', {
+    defaultMessage: 'Field',
+  }),
+  policy: i18n.translate('xpack.contentConnectors.index.connector.rule.basicTable.policyTitle', {
+    defaultMessage: 'Policy',
+  }),
+  rule: i18n.translate('xpack.contentConnectors.index.connector.syncRules.basicTable.ruleTitle', {
+    defaultMessage: 'Rule',
+  }),
+  value: i18n.translate('xpack.contentConnectors.index.connector.syncRules.basicTable.valueTitle', {
+    defaultMessage: 'Value',
+  }),
+};
+
 function validateItem(filteringRule: FilteringRule): FormErrors {
   if (filteringRule.rule === 'regex') {
     try {
@@ -105,12 +120,11 @@ export const SyncRulesTable: React.FC = () => {
               value: 'exclude',
             },
           ]}
+          aria-label={i18nMessages.policy}
         />
       ),
       field: 'policy',
-      name: i18n.translate('xpack.contentConnectors.index.connector.rule.basicTable.policyTitle', {
-        defaultMessage: 'Policy',
-      }),
+      name: i18nMessages.policy,
       render: (indexingRule: any) => (
         <EuiText size="s">{filteringPolicyToText(indexingRule.policy)}</EuiText>
       ),
@@ -119,15 +133,17 @@ export const SyncRulesTable: React.FC = () => {
       editingRender: (rule, onChange) => (
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
           <EuiFlexItem>
-            <EuiFieldText fullWidth value={rule.field} onChange={(e) => onChange(e.target.value)} />
+            <EuiFieldText
+              fullWidth
+              value={rule.field}
+              onChange={(e) => onChange(e.target.value)}
+              aria-label={i18nMessages.field}
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       ),
       field: 'field',
-      name: i18n.translate(
-        'xpack.contentConnectors.index.connector.syncRules.basicTable.fieldTitle',
-        { defaultMessage: 'Field' }
-      ),
+      name: i18nMessages.field,
       render: (rule: any) => (
         <EuiText size="s">
           <EuiCode>{rule.field}</EuiCode>
@@ -144,32 +160,28 @@ export const SyncRulesTable: React.FC = () => {
             text: filteringRuleToText(rule),
             value: rule,
           }))}
+          aria-label={i18nMessages.rule}
         />
       ),
       field: 'rule',
-      name: i18n.translate(
-        'xpack.contentConnectors.index.connector.syncRules.basicTable.ruleTitle',
-        {
-          defaultMessage: 'Rule',
-        }
-      ),
+      name: i18nMessages.rule,
       render: (rule: any) => <EuiText size="s">{filteringRuleToText(rule.rule)}</EuiText>,
     },
     {
       editingRender: (rule, onChange) => (
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
           <EuiFlexItem>
-            <EuiFieldText fullWidth value={rule.value} onChange={(e) => onChange(e.target.value)} />
+            <EuiFieldText
+              fullWidth
+              value={rule.value}
+              onChange={(e) => onChange(e.target.value)}
+              aria-label={i18nMessages.value}
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       ),
       field: 'value',
-      name: i18n.translate(
-        'xpack.contentConnectors.index.connector.syncRules.basicTable.valueTitle',
-        {
-          defaultMessage: 'Value',
-        }
-      ),
+      name: i18nMessages.value,
       render: (rule: any) => (
         <EuiText size="s">
           <EuiCode>{rule.value}</EuiCode>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/translations.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/translations.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const BASIC_TABLE_FIELD_TITLE = i18n.translate(
+  'xpack.contentConnectors.index.connector.syncRules.basicTable.fieldTitle',
+  { defaultMessage: 'Field' }
+);
+
+export const BASIC_TABLE_POLICY_TITLE = i18n.translate(
+  'xpack.contentConnectors.index.connector.rule.basicTable.policyTitle',
+  { defaultMessage: 'Policy' }
+);
+
+export const BASIC_TABLE_RULE_TITLE = i18n.translate(
+  'xpack.contentConnectors.index.connector.syncRules.basicTable.ruleTitle',
+  { defaultMessage: 'Rule' }
+);
+
+export const BASIC_TABLE_VALUE_TITLE = i18n.translate(
+  'xpack.contentConnectors.index.connector.syncRules.basicTable.valueTitle',
+  { defaultMessage: 'Value' }
+);
+
+export const getSyncRulesDescription = (indexName: string): string =>
+  i18n.translate('xpack.contentConnectors.content.index.connector.syncRules.description', {
+    defaultMessage:
+      'Add a sync rule to customize what data is synchronized from {indexName}. Everything is included by default, and documents are validated against the configured set of sync rules in the listed order.',
+    values: { indexName },
+  });
+
+export const SYNC_RULES_LEARN_MORE_LINK = i18n.translate(
+  'xpack.contentConnectors.content.index.connector.syncRules.link',
+  { defaultMessage: 'Learn more about customizing your sync rules.' }
+);
+
+export const SYNC_RULES_TABLE_ADD_RULE_LABEL = i18n.translate(
+  'xpack.contentConnectors.content.index.connector.syncRules.table.addRuleLabel',
+  { defaultMessage: 'Add sync rule' }
+);
+
+export const SYNC_RULES_TABLE_ARIA_LABEL = i18n.translate(
+  'xpack.contentConnectors.content.index.connector.syncRules.table.ariaLabel',
+  { defaultMessage: 'Sync rules' }
+);
+
+export const REGEX_ERROR = i18n.translate(
+  'xpack.contentConnectors.content.index.connector.filteringRules.regExError',
+  { defaultMessage: 'Value should be a regular expression' }
+);
+
+export const INCLUDE_EVERYTHING_ELSE_MESSAGE = i18n.translate(
+  'xpack.contentConnectors.content.sources.basicRulesTable.includeEverythingMessage',
+  { defaultMessage: 'Include everything else from this source' }
+);

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/action_column.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/action_column.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import type { MutableRefObject } from 'react';
 
 import { useActions, useValues } from 'kea';
 
@@ -28,6 +29,7 @@ interface ActionColumnProps<Item extends ItemWithAnID> {
   item: Item;
   canRemoveLastItem?: boolean;
   lastItemWarning?: string;
+  prevFocusRef?: MutableRefObject<HTMLElement | null>;
   uneditableItems?: Item[];
 }
 
@@ -39,6 +41,7 @@ export const ActionColumn = <Item extends ItemWithAnID>({
   item,
   canRemoveLastItem,
   lastItemWarning,
+  prevFocusRef,
   uneditableItems,
 }: ActionColumnProps<Item>) => {
   const { doesEditingItemValueContainEmptyProperty, fieldErrors, rowErrors, isEditingUnsavedItem } =
@@ -50,6 +53,13 @@ export const ActionColumn = <Item extends ItemWithAnID>({
     return null;
   }
 
+  const handleEditExistingItem = () => {
+    if (prevFocusRef) {
+      prevFocusRef.current = document.activeElement as HTMLElement;
+    }
+    editExistingItem(item);
+  };
+
   const isInvalid = Object.keys(fieldErrors).length > 0 || rowErrors.length > 0;
 
   if (isActivelyEditing(item)) {
@@ -57,6 +67,7 @@ export const ActionColumn = <Item extends ItemWithAnID>({
       <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
         <EuiFlexItem>
           <EuiButtonEmpty
+            aria-label={SAVE_BUTTON_LABEL}
             data-test-subj="saveButton"
             color="primary"
             iconType="checkInCircleFilled"
@@ -72,6 +83,7 @@ export const ActionColumn = <Item extends ItemWithAnID>({
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiButtonEmpty
+            aria-label={CANCEL_BUTTON_LABEL}
             data-test-subj="cancelButton"
             color="danger"
             iconType="cross"
@@ -89,9 +101,10 @@ export const ActionColumn = <Item extends ItemWithAnID>({
     <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
       <EuiFlexItem grow={null}>
         <EuiButtonEmpty
+          aria-label={EDIT_BUTTON_LABEL}
           data-test-subj="editButton"
           size="xs"
-          onClick={() => editExistingItem(item)}
+          onClick={handleEditExistingItem}
         >
           {EDIT_BUTTON_LABEL}
         </EuiButtonEmpty>
@@ -99,12 +112,17 @@ export const ActionColumn = <Item extends ItemWithAnID>({
       <EuiFlexItem grow={null}>
         {!canRemoveLastItem && displayedItems.length === 1 ? (
           <EuiToolTip content={lastItemWarning}>
-            <EuiButtonEmpty size="xs" disabled>
+            <EuiButtonEmpty aria-label={DELETE_BUTTON_LABEL} size="xs" disabled>
               {DELETE_BUTTON_LABEL}
             </EuiButtonEmpty>
           </EuiToolTip>
         ) : (
-          <EuiButtonEmpty data-test-subj="deleteButton" size="xs" onClick={() => deleteItem(item)}>
+          <EuiButtonEmpty
+            aria-label={DELETE_BUTTON_LABEL}
+            data-test-subj="deleteButton"
+            size="xs"
+            onClick={() => deleteItem(item)}
+          >
             {DELETE_BUTTON_LABEL}
           </EuiButtonEmpty>
         )}

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/get_updated_columns.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/get_updated_columns.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import type { MutableRefObject } from 'react';
 
 import { ActionColumn } from './action_column';
 import { EditingColumn } from './editing_column';
@@ -20,6 +21,7 @@ interface GetUpdatedColumnProps<Item extends ItemWithAnID> {
   canRemoveLastItem?: boolean;
   isLoading?: boolean;
   lastItemWarning?: string;
+  prevFocusRef?: MutableRefObject<HTMLElement | null>;
   uneditableItems?: Item[];
 }
 
@@ -31,6 +33,7 @@ export const getUpdatedColumns = <Item extends ItemWithAnID>({
   canRemoveLastItem,
   isLoading = false,
   lastItemWarning,
+  prevFocusRef,
   uneditableItems,
 }: GetUpdatedColumnProps<Item>): Array<Column<Item>> => {
   return [
@@ -57,6 +60,7 @@ export const getUpdatedColumns = <Item extends ItemWithAnID>({
           isLoading={isLoading}
           canRemoveLastItem={canRemoveLastItem}
           lastItemWarning={lastItemWarning}
+          prevFocusRef={prevFocusRef}
           uneditableItems={uneditableItems}
           item={item}
         />

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/inline_editable_table.test.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/inline_editable_table.test.tsx
@@ -222,6 +222,8 @@ describe('InlineEditableTable', () => {
       isLoading,
       lastItemWarning,
       uneditableItems,
+      prevFocusRef: expect.objectContaining({ current: null }),
+      emptyPropertyAllowed: undefined,
     });
   });
 });

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/inline_editable_table.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/inline_editable_table.tsx
@@ -24,6 +24,7 @@ import type { ItemWithAnID } from '../../types';
 import { PageIntroduction } from '../../page_introduction/page_introduction';
 
 export interface InlineEditableTableProps<Item extends ItemWithAnID> {
+  ariaLabel?: string;
   columns: Array<InlineEditableTableColumn<Item>>;
   items: Item[];
   defaultItem?: Partial<Item>;
@@ -86,6 +87,7 @@ export const InlineEditableTable = <Item extends ItemWithAnID>(
 };
 
 export const InlineEditableTableContents = <Item extends ItemWithAnID>({
+  ariaLabel,
   columns,
   emptyPropertyAllowed,
   items,
@@ -149,6 +151,7 @@ export const InlineEditableTableContents = <Item extends ItemWithAnID>({
       />
       <EuiSpacer size="l" />
       <ReorderableTable
+        ariaLabel={ariaLabel}
         className={classNames(className, 'editableTable')}
         items={displayedItems}
         unreorderableItems={uneditableItems}

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/inline_editable_table.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/inline_editable_table.tsx
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 
 import classNames from 'classnames';
 
 import { useActions, useValues, BindLogic } from 'kea';
 
-import { EuiButton, EuiSpacer } from '@elastic/eui';
+import { EuiButton, EuiSpacer, useUpdateEffect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { ReorderableTable } from '../reorderable_table';
@@ -105,6 +105,14 @@ export const InlineEditableTableContents = <Item extends ItemWithAnID>({
   const { editingItemId, isEditing, isEditingUnsavedItem, rowErrors } =
     useValues(InlineEditableTableLogic);
   const { editNewItem, reorderItems } = useActions(InlineEditableTableLogic);
+  const addButtonRef = useRef<HTMLButtonElement>(null);
+
+  useUpdateEffect(() => {
+    if (!isEditing) {
+      // Editing just ended, focus the add button
+      addButtonRef.current?.focus();
+    }
+  }, [isEditing]);
 
   // TODO These two things shoud just be selectors
   const isEditingItem = (item: Item) => item.id === editingItemId;
@@ -135,6 +143,7 @@ export const InlineEditableTableContents = <Item extends ItemWithAnID>({
         title={title || ''}
         actions={[
           <EuiButton
+            buttonRef={addButtonRef}
             size="s"
             iconType="plusInCircle"
             disabled={isEditing}

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/inline_editable_table.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/inline_editable_table/inline_editable_table.tsx
@@ -105,14 +105,21 @@ export const InlineEditableTableContents = <Item extends ItemWithAnID>({
   const { editingItemId, isEditing, isEditingUnsavedItem, rowErrors } =
     useValues(InlineEditableTableLogic);
   const { editNewItem, reorderItems } = useActions(InlineEditableTableLogic);
-  const addButtonRef = useRef<HTMLButtonElement>(null);
+
+  // A11y - restore focus when editing ends
+  const prevFocusRef = useRef<HTMLElement | null>(null);
 
   useUpdateEffect(() => {
-    if (!isEditing) {
-      // Editing just ended, focus the add button
-      addButtonRef.current?.focus();
+    if (!isEditing && prevFocusRef.current) {
+      prevFocusRef.current.focus();
+      prevFocusRef.current = null;
     }
   }, [isEditing]);
+
+  const handleEditNewItem = () => {
+    prevFocusRef.current = document.activeElement as HTMLElement;
+    editNewItem();
+  };
 
   // TODO These two things shoud just be selectors
   const isEditingItem = (item: Item) => item.id === editingItemId;
@@ -133,6 +140,7 @@ export const InlineEditableTableContents = <Item extends ItemWithAnID>({
     canRemoveLastItem,
     isLoading,
     lastItemWarning,
+    prevFocusRef,
     uneditableItems,
   });
 
@@ -143,11 +151,10 @@ export const InlineEditableTableContents = <Item extends ItemWithAnID>({
         title={title || ''}
         actions={[
           <EuiButton
-            buttonRef={addButtonRef}
             size="s"
             iconType="plusInCircle"
             disabled={isEditing}
-            onClick={editNewItem}
+            onClick={handleEditNewItem}
             color="primary"
             data-test-subj="inlineEditableTableActionButton"
           >
@@ -171,7 +178,7 @@ export const InlineEditableTableContents = <Item extends ItemWithAnID>({
           }),
         })}
         rowErrors={(item) => (isActivelyEditing(item) ? rowErrors : undefined)}
-        noItemsMessage={noItemsMessage(editNewItem)}
+        noItemsMessage={noItemsMessage(handleEditNewItem)}
         onReorder={reorderItems}
         disableDragging={isEditing}
         {...rest}

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/body_row.test.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/body_row.test.tsx
@@ -45,9 +45,13 @@ describe('BodyRow', () => {
       children: 1,
       flexBasis: 'foo',
       flexGrow: 0,
+      role: 'cell',
+      ariaColindex: 1,
     });
     expect(cells.at(1).props()).toEqual({
       children: 'Whatever',
+      role: 'cell',
+      ariaColindex: 2,
     });
   });
 

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/body_row.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/body_row.tsx
@@ -7,38 +7,72 @@
 
 import React from 'react';
 
-import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiText, EuiToken } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+import {
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiToken,
+  useEuiTheme,
+} from '@elastic/eui';
 
 import { Cell } from './cell';
 import { DRAGGABLE_UX_STYLE } from './constants';
 import type { Column } from './types';
 
 export interface BodyRowProps<Item> {
-  columns: Array<Column<Item>>;
-  item: Item;
   additionalProps?: object;
+  ariaRowindex?: number;
+  columns: Array<Column<Item>>;
+  errors?: string[];
+  item: Item;
   // Cell to put in first column before other columns
   leftAction?: React.ReactNode;
-  errors?: string[];
   rowIdentifier?: string;
 }
 
 export const BodyRow = <Item extends object>({
-  columns,
-  item,
   additionalProps,
-  leftAction,
+  ariaRowindex,
+  columns,
   errors = [],
+  item,
+  leftAction,
   rowIdentifier,
 }: BodyRowProps<Item>) => {
+  const { euiTheme } = useEuiTheme();
+  // Calculate column index offset based on presence of leftAction and rowIdentifier
+  const columnIndexOffset = (leftAction ? 1 : 0) + (rowIdentifier ? 1 : 0);
+
   return (
     <div className="reorderableTableRow">
-      <EuiFlexGroup data-test-subj="row" alignItems="center" {...(additionalProps || {})}>
-        <EuiFlexItem>
+      <EuiFlexGroup
+        data-test-subj="row"
+        alignItems="center"
+        role="row"
+        aria-rowindex={ariaRowindex}
+        {...(additionalProps || {})}
+      >
+        <EuiFlexItem
+          css={css`
+            margin: ${euiTheme.size.m} 0;
+          `}
+        >
           <EuiFlexGroup alignItems="center">
-            {leftAction && <Cell {...DRAGGABLE_UX_STYLE}>{leftAction}</Cell>}
+            {leftAction && (
+              <Cell {...DRAGGABLE_UX_STYLE} role="cell" ariaColindex={1}>
+                {leftAction}
+              </Cell>
+            )}
             {rowIdentifier && (
-              <Cell {...DRAGGABLE_UX_STYLE} flexBasis="24px">
+              <Cell
+                {...DRAGGABLE_UX_STYLE}
+                flexBasis="24px"
+                role="cell"
+                ariaColindex={leftAction ? 2 : 1}
+              >
                 <EuiToken
                   size="m"
                   iconType={() => (
@@ -55,6 +89,8 @@ export const BodyRow = <Item extends object>({
                 alignItems={column.alignItems}
                 flexBasis={column.flexBasis}
                 flexGrow={column.flexGrow}
+                role="cell"
+                ariaColindex={columnIndex + columnIndexOffset + 1}
               >
                 {column.render(item)}
               </Cell>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/body_row.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/body_row.tsx
@@ -7,8 +7,6 @@
 
 import React from 'react';
 
-import { css } from '@emotion/react';
-
 import {
   EuiCallOut,
   EuiFlexGroup,
@@ -21,6 +19,7 @@ import {
 import { Cell } from './cell';
 import { DRAGGABLE_UX_STYLE } from './constants';
 import type { Column } from './types';
+import * as Styles from './styles';
 
 export interface BodyRowProps<Item> {
   additionalProps?: object;
@@ -55,11 +54,7 @@ export const BodyRow = <Item extends object>({
         aria-rowindex={ariaRowindex}
         {...(additionalProps || {})}
       >
-        <EuiFlexItem
-          css={css`
-            margin: ${euiTheme.size.m} 0;
-          `}
-        >
+        <EuiFlexItem css={Styles.bodyRowItemStyles(euiTheme)}>
           <EuiFlexGroup alignItems="center">
             {leftAction && (
               <Cell {...DRAGGABLE_UX_STYLE} role="cell" ariaColindex={1}>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/body_rows.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/body_rows.tsx
@@ -13,5 +13,5 @@ export interface BodyRowsProps<Item> {
 }
 
 export const BodyRows = <Item extends object>({ items, renderItem }: BodyRowsProps<Item>) => (
-  <>{items.map(renderItem)}</>
+  <div role="rowgroup">{items.map(renderItem)}</div>
 );

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/cell.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/cell.tsx
@@ -11,19 +11,29 @@ import { EuiFlexItem } from '@elastic/eui';
 
 import type { DraggableUXStyles } from './types';
 
+interface CellProps extends DraggableUXStyles {
+  ariaColindex?: number;
+  children?: React.ReactNode;
+  role?: 'cell' | 'columnheader';
+}
+
 export const Cell = ({
+  ariaColindex,
   children,
   alignItems,
   flexBasis,
   flexGrow,
-}: DraggableUXStyles & { children?: React.ReactNode }) => {
+  role,
+}: CellProps) => {
   return (
     <EuiFlexItem
       style={{
+        alignItems,
         flexBasis,
         flexGrow,
-        alignItems,
       }}
+      role={role}
+      aria-colindex={ariaColindex}
     >
       {children}
     </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/draggable_body_row.test.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/draggable_body_row.test.tsx
@@ -50,8 +50,12 @@ describe('DraggableBodyRow', () => {
     // It adds an index and unique draggable id from the provided rowIndex
     expect(euiDraggable.prop('index')).toEqual(1);
     expect(euiDraggable.prop('draggableId')).toEqual('draggable_row_1');
+    expect(euiDraggable.prop('customDragHandle')).toBe(true);
+    expect(euiDraggable.prop('hasInteractiveChildren')).toBe(true);
 
-    const bodyRow = wrapper.find(BodyRow);
+    const childrenFn = euiDraggable.prop('children');
+    const bodyRowWrapper = shallow(<div>{childrenFn({ dragHandleProps: {} })}</div>);
+    const bodyRow = bodyRowWrapper.find(BodyRow);
     expect(bodyRow.exists()).toEqual(true);
     expect(bodyRow.props()).toEqual(expect.objectContaining({ columns, item, additionalProps }));
     const leftAction = shallow(<div>{bodyRow.prop('leftAction')}</div>);
@@ -65,6 +69,6 @@ describe('DraggableBodyRow', () => {
 
     const euiDraggable = wrapper.find(EuiDraggable);
     expect(euiDraggable.prop('isDragDisabled')).toBe(true);
-    expect(euiDraggable.prop('disableInteractiveElementBlocking')).toBe(true);
+    expect(euiDraggable.prop('customDragHandle')).toBe(false);
   });
 });

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/draggable_body_row.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/draggable_body_row.tsx
@@ -8,28 +8,31 @@
 import React from 'react';
 
 import { EuiDraggable, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { BodyRow } from './body_row';
 import type { Column } from './types';
 
 export interface DraggableBodyRowProps<Item> {
-  columns: Array<Column<Item>>;
-  item: Item;
-  rowIndex: number;
   additionalProps?: object;
+  ariaRowindex?: number;
+  columns: Array<Column<Item>>;
   disableDragging?: boolean;
   errors?: string[];
+  item: Item;
   rowIdentifier?: string;
+  rowIndex: number;
 }
 
 export const DraggableBodyRow = <Item extends object>({
-  columns,
-  item,
-  rowIndex,
   additionalProps,
+  ariaRowindex,
+  columns,
   disableDragging = false,
   errors,
+  item,
   rowIdentifier,
+  rowIndex,
 }: DraggableBodyRowProps<Item>) => {
   const draggableId = `draggable_row_${rowIndex}`;
 
@@ -38,23 +41,40 @@ export const DraggableBodyRow = <Item extends object>({
       index={rowIndex}
       draggableId={draggableId}
       isDragDisabled={disableDragging}
-      disableInteractiveElementBlocking={disableDragging}
+      customDragHandle={!disableDragging}
+      hasInteractiveChildren
+      usePortal
       {...additionalProps}
     >
-      <BodyRow
-        columns={columns}
-        item={item}
-        additionalProps={additionalProps}
-        leftAction={
-          <EuiFlexGroup justifyContent="spaceBetween">
-            <EuiFlexItem>
-              {disableDragging ? <div style={{ width: '16px' }} /> : <EuiIcon type="grab" />}
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        }
-        rowIdentifier={rowIdentifier}
-        errors={errors}
-      />
+      {(provided) => (
+        <BodyRow
+          columns={columns}
+          item={item}
+          additionalProps={additionalProps}
+          leftAction={
+            <EuiFlexGroup justifyContent="spaceBetween">
+              <EuiFlexItem>
+                {disableDragging ? (
+                  <div style={{ width: '16px' }} />
+                ) : (
+                  <div
+                    {...provided.dragHandleProps}
+                    aria-label={i18n.translate(
+                      'xpack.contentConnectors.draggableBodyRow.dragHandleLabel',
+                      { defaultMessage: 'Drag handle' }
+                    )}
+                  >
+                    <EuiIcon type="grab" />
+                  </div>
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          }
+          rowIdentifier={rowIdentifier}
+          errors={errors}
+          ariaRowindex={ariaRowindex}
+        />
+      )}
     </EuiDraggable>
   );
 };

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/draggable_body_rows.test.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/draggable_body_rows.test.tsx
@@ -11,7 +11,6 @@ import { shallow } from 'enzyme';
 
 import { EuiDragDropContext } from '@elastic/eui';
 
-import { BodyRows } from './body_rows';
 import { DraggableBodyRows } from './draggable_body_rows';
 
 describe('DraggableBodyRows', () => {
@@ -29,12 +28,7 @@ describe('DraggableBodyRows', () => {
     );
 
     expect(wrapper.find(EuiDragDropContext).exists()).toBe(true);
-
-    const bodyRows = wrapper.find(BodyRows);
-    expect(bodyRows.props()).toEqual({
-      items,
-      renderItem,
-    });
+    expect(wrapper.find('[role="rowgroup"]').exists()).toBe(true);
   });
 
   it('will call the provided onReorder function whenever items are reordered', () => {

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/draggable_body_rows.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/draggable_body_rows.tsx
@@ -9,8 +9,6 @@ import React from 'react';
 
 import { EuiDragDropContext, euiDragDropReorder, EuiDroppable } from '@elastic/eui';
 
-import { BodyRows } from './body_rows';
-
 interface DraggableBodyRowsProps<Item> {
   items: Item[];
   onReorder: (reorderedItems: Item[], items: Item[]) => void;
@@ -23,17 +21,19 @@ export const DraggableBodyRows = <Item extends object>({
   renderItem,
 }: DraggableBodyRowsProps<Item>) => {
   return (
-    <EuiDragDropContext
-      onDragEnd={({ source, destination }) => {
-        if (source && destination) {
-          const reorderedItems = euiDragDropReorder(items, source.index, destination?.index);
-          onReorder(reorderedItems, items);
-        }
-      }}
-    >
-      <EuiDroppable droppableId="ReorderingArea" grow={false}>
-        <BodyRows items={items} renderItem={renderItem} />
-      </EuiDroppable>
-    </EuiDragDropContext>
+    <div role="rowgroup">
+      <EuiDragDropContext
+        onDragEnd={({ source, destination }) => {
+          if (source && destination) {
+            const reorderedItems = euiDragDropReorder(items, source.index, destination?.index);
+            onReorder(reorderedItems, items);
+          }
+        }}
+      >
+        <EuiDroppable droppableId="ReorderingArea" grow={false}>
+          <>{items.map(renderItem)}</>
+        </EuiDroppable>
+      </EuiDragDropContext>
+    </div>
   );
 };

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/header_row.test.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/header_row.test.tsx
@@ -41,6 +41,6 @@ describe('HeaderRow', () => {
     const wrapper = shallow(<HeaderRow columns={columns} spacingForRowIdentifier />);
     const cells = wrapper.find(Cell);
     expect(cells.length).toBe(3);
-    expect(cells.at(0).children()).toHaveLength(0);
+    expect(cells.at(0).children()).toHaveLength(1);
   });
 });

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/header_row.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/header_row.tsx
@@ -7,7 +7,9 @@
 
 import React from 'react';
 
-import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiScreenReaderOnly, EuiText } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
 
 import { Cell } from './cell';
 import { DRAGGABLE_UX_STYLE } from './constants';
@@ -25,15 +27,43 @@ export const HeaderRow = <Item extends object>({
   leftAction,
   spacingForRowIdentifier = false,
 }: HeaderRowProps<Item>) => {
+  // Calculate column index offset based on presence of leftAction and rowIdentifier
+  const columnIndexOffset = (leftAction ? 1 : 0) + (spacingForRowIdentifier ? 1 : 0);
+
   return (
-    <div className="reorderableTableHeader">
-      <EuiFlexGroup>
+    <div className="reorderableTableHeader" role="rowgroup">
+      <EuiFlexGroup role="row" aria-rowindex={1}>
         <EuiFlexItem>
           <EuiFlexGroup>
-            {leftAction && <Cell {...DRAGGABLE_UX_STYLE}>{leftAction}</Cell>}
-            {spacingForRowIdentifier && <Cell {...DRAGGABLE_UX_STYLE} flexBasis="24px" />}
+            {leftAction && (
+              <Cell {...DRAGGABLE_UX_STYLE} role="columnheader" ariaColindex={1}>
+                {leftAction}
+              </Cell>
+            )}
+            {spacingForRowIdentifier && (
+              <Cell
+                {...DRAGGABLE_UX_STYLE}
+                flexBasis="24px"
+                role="columnheader"
+                ariaColindex={leftAction ? 2 : 1}
+              >
+                <EuiScreenReaderOnly>
+                  <p>
+                    {i18n.translate(
+                      'xpack.contentConnectors.reorderableTable.rowIdentifierScreenReaderOnlyLabel',
+                      { defaultMessage: 'Row identifier' }
+                    )}
+                  </p>
+                </EuiScreenReaderOnly>
+              </Cell>
+            )}
             {columns.map((column, columnIndex) => (
-              <Cell key={`table_header_cell_${columnIndex}`} {...column}>
+              <Cell
+                key={`table_header_cell_${columnIndex}`}
+                {...column}
+                role="columnheader"
+                ariaColindex={columnIndex + columnIndexOffset + 1}
+              >
                 <EuiText size="s">
                   <strong>{column.name}</strong>
                 </EuiText>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/reorderable_table.test.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/reorderable_table.test.tsx
@@ -52,6 +52,9 @@ describe('ReorderableTable', () => {
         additionalProps: {},
         disableDragging: false,
         rowIndex: 0,
+        ariaRowindex: 2,
+        errors: undefined,
+        rowIdentifier: undefined,
       });
     });
 
@@ -127,6 +130,9 @@ describe('ReorderableTable', () => {
         item: { id: 1 },
         additionalProps: {},
         leftAction: expect.anything(),
+        ariaRowindex: 4,
+        errors: undefined,
+        rowIdentifier: undefined,
       });
     });
 
@@ -165,6 +171,9 @@ describe('ReorderableTable', () => {
         columns,
         item: { id: 1 },
         additionalProps: {},
+        ariaRowindex: 2,
+        errors: undefined,
+        rowIdentifier: undefined,
       });
     });
 

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/reorderable_table.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/reorderable_table.tsx
@@ -9,7 +9,8 @@ import React from 'react';
 
 import classNames from 'classnames';
 
-import { EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiScreenReaderOnly, useEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { BodyRow } from './body_row';
 import { BodyRows } from './body_rows';
@@ -20,40 +21,61 @@ import type { Column } from './types';
 import * as Styles from './styles';
 
 interface ReorderableTableProps<Item> {
-  columns: Array<Column<Item>>;
-  items: Item[];
-  noItemsMessage: React.ReactNode;
-  unreorderableItems?: Item[];
+  ariaLabel?: string;
   bottomRows?: React.ReactNode[];
   className?: string;
+  columns: Array<Column<Item>>;
   disableDragging?: boolean;
   disableReordering?: boolean;
-  showRowIndex?: boolean;
+  items: Item[];
+  noItemsMessage: React.ReactNode;
   onReorder?: (items: Item[], oldItems: Item[]) => void;
-  rowProps?: (item: Item) => object;
   rowErrors?: (item: Item) => string[] | undefined;
+  rowProps?: (item: Item) => object;
+  showRowIndex?: boolean;
+  unreorderableItems?: Item[];
 }
 
 export const ReorderableTable = <Item extends object>({
-  columns,
-  items,
-  noItemsMessage,
-  unreorderableItems = [],
+  ariaLabel = 'Reorderable table',
   bottomRows = [],
   className = '',
+  columns,
   disableDragging = false,
   disableReordering = false,
+  items,
+  noItemsMessage,
   onReorder = () => undefined,
-  rowProps = () => ({}),
   rowErrors = () => undefined,
+  rowProps = () => ({}),
   showRowIndex = false,
+  unreorderableItems = [],
 }: ReorderableTableProps<Item>) => {
   const { euiTheme } = useEuiTheme();
+  // Calculate row index offset (header row = 1)
+  const rowIndexOffset = 2; // Start body rows at index 2
+
   return (
-    <div className={classNames(className)} css={Styles.reorderableTableStyles(euiTheme)}>
+    <div
+      className={classNames(className)}
+      css={Styles.reorderableTableStyles(euiTheme)}
+      role="table"
+      aria-label={ariaLabel}
+    >
       <HeaderRow
         columns={columns}
-        leftAction={disableReordering ? undefined : <></>}
+        leftAction={
+          disableReordering ? undefined : (
+            <EuiScreenReaderOnly>
+              <p>
+                {i18n.translate(
+                  'xpack.contentConnectors.reorderableTable.grabHandleScreenReaderOnlyLabel',
+                  { defaultMessage: 'Grab handle' }
+                )}
+              </p>
+            </EuiScreenReaderOnly>
+          )
+        }
         spacingForRowIdentifier={showRowIndex}
       />
 
@@ -76,6 +98,7 @@ export const ReorderableTable = <Item extends object>({
               additionalProps={rowProps(item)}
               errors={rowErrors(item)}
               rowIdentifier={showRowIndex ? `${itemIndex + 1}` : undefined}
+              ariaRowindex={itemIndex + rowIndexOffset}
             />
           )}
         />
@@ -95,6 +118,7 @@ export const ReorderableTable = <Item extends object>({
                 rowIndex={itemIndex}
                 errors={rowErrors(item)}
                 rowIdentifier={showRowIndex ? `${itemIndex + 1}` : undefined}
+                ariaRowindex={itemIndex + rowIndexOffset}
               />
             )}
             onReorder={onReorder}
@@ -105,30 +129,38 @@ export const ReorderableTable = <Item extends object>({
         {unreorderableItems.length > 0 && (
           <BodyRows
             items={unreorderableItems}
-            renderItem={(item, itemIndex) => (
-              <BodyRow
-                key={`table_draggable_row_${itemIndex}`}
-                columns={columns}
-                item={item}
-                additionalProps={rowProps(item)}
-                errors={rowErrors(item)}
-                leftAction={disableReordering ? undefined : <> </>}
-                rowIdentifier={showRowIndex ? '∞' : undefined}
-              />
-            )}
+            renderItem={(item, itemIndex) => {
+              const rowIndex = items.length + itemIndex + rowIndexOffset;
+              return (
+                <BodyRow
+                  key={`table_draggable_row_${itemIndex}`}
+                  columns={columns}
+                  item={item}
+                  additionalProps={rowProps(item)}
+                  errors={rowErrors(item)}
+                  leftAction={disableReordering ? undefined : <> </>}
+                  rowIdentifier={showRowIndex ? '∞' : undefined}
+                  ariaRowindex={rowIndex}
+                />
+              );
+            }}
           />
         )}
 
-        {bottomRows.map((row, rowIndex) => (
-          <BodyRow // Shoving a generic ReactNode into a BodyRow is kind of a hack
-            key={rowIndex}
-            rowIdentifier={showRowIndex ? '∞' : undefined}
-            columns={[{ render: () => row }]}
-            item={{}}
-            leftAction={disableReordering ? undefined : <> </>}
-            data-test-subj="BottomRow"
-          />
-        ))}
+        {bottomRows.map((row, rowIndex) => {
+          const ariaRowIndex = items.length + unreorderableItems.length + rowIndex + rowIndexOffset;
+          return (
+            <BodyRow // Shoving a generic ReactNode into a BodyRow is kind of a hack
+              key={rowIndex}
+              rowIdentifier={showRowIndex ? '∞' : undefined}
+              columns={[{ render: () => row }]}
+              item={{}}
+              leftAction={disableReordering ? undefined : <> </>}
+              data-test-subj="BottomRow"
+              ariaRowindex={ariaRowIndex}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/styles.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/styles.ts
@@ -38,3 +38,8 @@ export const reorderableTableStyles = (euiTheme: EuiThemeComputed<{}>) =>
       backgroundColor: euiTheme.colors.lightestShade,
     },
   });
+
+export const bodyRowItemStyles = (euiTheme: EuiThemeComputed<{}>) =>
+  css({
+    margin: `${euiTheme.size.m} 0`,
+  });

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/styles.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/styles.ts
@@ -29,9 +29,6 @@ export const reorderableTableStyles = (euiTheme: EuiThemeComputed<{}>) =>
 
     // Row
     '.reorderableTableRow': {
-      '> .euiFlexGroup > .euiFlexItem': {
-        margin: `${euiTheme.size.m} 0`,
-      },
       backgroundColor: euiTheme.colors.emptyShade,
       borderTop: euiTheme.border.thin,
     },

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
@@ -47,6 +47,21 @@ import { ConnectorFilteringLogic } from './connector_filtering_logic';
 
 const instanceId = 'FilteringRulesTable';
 
+const i18nMessages = {
+  field: i18n.translate('xpack.enterpriseSearch.index.connector.syncRules.basicTable.fieldTitle', {
+    defaultMessage: 'Field',
+  }),
+  policy: i18n.translate('xpack.enterpriseSearch.index.connector.rule.basicTable.policyTitle', {
+    defaultMessage: 'Policy',
+  }),
+  rule: i18n.translate('xpack.enterpriseSearch.index.connector.syncRules.basicTable.ruleTitle', {
+    defaultMessage: 'Rule',
+  }),
+  value: i18n.translate('xpack.enterpriseSearch.index.connector.syncRules.basicTable.valueTitle', {
+    defaultMessage: 'Value',
+  }),
+};
+
 function validateItem(filteringRule: FilteringRule): FormErrors {
   if (filteringRule.rule === 'regex') {
     try {
@@ -90,6 +105,7 @@ export const SyncRulesTable: React.FC = () => {
     {
       editingRender: (filteringRule, onChange) => (
         <EuiSelect
+          autoFocus
           fullWidth
           value={filteringRule.policy}
           onChange={(e) => onChange(e.target.value)}
@@ -103,12 +119,11 @@ export const SyncRulesTable: React.FC = () => {
               value: 'exclude',
             },
           ]}
+          aria-label={i18nMessages.policy}
         />
       ),
       field: 'policy',
-      name: i18n.translate('xpack.enterpriseSearch.index.connector.rule.basicTable.policyTitle', {
-        defaultMessage: 'Policy',
-      }),
+      name: i18nMessages.policy,
       render: (indexingRule) => (
         <EuiText size="s">{filteringPolicyToText(indexingRule.policy)}</EuiText>
       ),
@@ -117,15 +132,17 @@ export const SyncRulesTable: React.FC = () => {
       editingRender: (rule, onChange) => (
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
           <EuiFlexItem>
-            <EuiFieldText fullWidth value={rule.field} onChange={(e) => onChange(e.target.value)} />
+            <EuiFieldText
+              fullWidth
+              value={rule.field}
+              onChange={(e) => onChange(e.target.value)}
+              aria-label={i18nMessages.field}
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       ),
       field: 'field',
-      name: i18n.translate(
-        'xpack.enterpriseSearch.index.connector.syncRules.basicTable.fieldTitle',
-        { defaultMessage: 'Field' }
-      ),
+      name: i18nMessages.field,
       render: (rule) => (
         <EuiText size="s">
           <EuiCode>{rule.field}</EuiCode>
@@ -142,30 +159,28 @@ export const SyncRulesTable: React.FC = () => {
             text: filteringRuleToText(rule),
             value: rule,
           }))}
+          aria-label={i18nMessages.rule}
         />
       ),
       field: 'rule',
-      name: i18n.translate(
-        'xpack.enterpriseSearch.index.connector.syncRules.basicTable.ruleTitle',
-        { defaultMessage: 'Rule' }
-      ),
+      name: i18nMessages.rule,
       render: (rule) => <EuiText size="s">{filteringRuleToText(rule.rule)}</EuiText>,
     },
     {
       editingRender: (rule, onChange) => (
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
           <EuiFlexItem>
-            <EuiFieldText fullWidth value={rule.value} onChange={(e) => onChange(e.target.value)} />
+            <EuiFieldText
+              fullWidth
+              value={rule.value}
+              onChange={(e) => onChange(e.target.value)}
+              aria-label={i18nMessages.value}
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       ),
       field: 'value',
-      name: i18n.translate(
-        'xpack.enterpriseSearch.index.connector.syncRules.basicTable.valueTitle',
-        {
-          defaultMessage: 'Value',
-        }
-      ),
+      name: i18nMessages.value,
       render: (rule) => (
         <EuiText size="s">
           <EuiCode>{rule.value}</EuiCode>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
@@ -180,6 +180,10 @@ export const SyncRulesTable: React.FC = () => {
         'xpack.enterpriseSearch.content.index.connector.syncRules.table.addRuleLabel',
         { defaultMessage: 'Add sync rule' }
       )}
+      ariaLabel={i18n.translate(
+        'xpack.enterpriseSearch.content.index.connector.syncRules.table.ariaLabel',
+        { defaultMessage: 'Sync rules table' }
+      )}
       columns={columns}
       defaultItem={{
         policy: 'include',

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
@@ -20,9 +20,6 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
-
-import { i18n } from '@kbn/i18n';
-
 import type { FilteringRule } from '@kbn/search-connectors';
 import {
   filteringPolicyToText,
@@ -42,25 +39,22 @@ import type {
 import type { ItemWithAnID } from '../../../../../shared/tables/types';
 
 import { IndexViewLogic } from '../../index_view_logic';
+import {
+  BASIC_TABLE_FIELD_TITLE,
+  BASIC_TABLE_POLICY_TITLE,
+  BASIC_TABLE_RULE_TITLE,
+  BASIC_TABLE_VALUE_TITLE,
+  getSyncRulesDescription,
+  SYNC_RULES_LEARN_MORE_LINK,
+  SYNC_RULES_TABLE_ADD_RULE_LABEL,
+  SYNC_RULES_TABLE_ARIA_LABEL,
+  REGEX_ERROR,
+  INCLUDE_EVERYTHING_ELSE_MESSAGE,
+} from '../../translations';
 
 import { ConnectorFilteringLogic } from './connector_filtering_logic';
 
 const instanceId = 'FilteringRulesTable';
-
-const i18nMessages = {
-  field: i18n.translate('xpack.enterpriseSearch.index.connector.syncRules.basicTable.fieldTitle', {
-    defaultMessage: 'Field',
-  }),
-  policy: i18n.translate('xpack.enterpriseSearch.index.connector.rule.basicTable.policyTitle', {
-    defaultMessage: 'Policy',
-  }),
-  rule: i18n.translate('xpack.enterpriseSearch.index.connector.syncRules.basicTable.ruleTitle', {
-    defaultMessage: 'Rule',
-  }),
-  value: i18n.translate('xpack.enterpriseSearch.index.connector.syncRules.basicTable.valueTitle', {
-    defaultMessage: 'Value',
-  }),
-};
 
 function validateItem(filteringRule: FilteringRule): FormErrors {
   if (filteringRule.rule === 'regex') {
@@ -69,10 +63,7 @@ function validateItem(filteringRule: FilteringRule): FormErrors {
       return {};
     } catch {
       return {
-        value: i18n.translate(
-          'xpack.enterpriseSearch.content.index.connector.filteringRules.regExError',
-          { defaultMessage: 'Value should be a regular expression' }
-        ),
+        value: REGEX_ERROR,
       };
     }
   }
@@ -87,16 +78,10 @@ export const SyncRulesTable: React.FC = () => {
 
   const description = (
     <EuiText size="s" color="default">
-      {i18n.translate('xpack.enterpriseSearch.content.index.connector.syncRules.description', {
-        defaultMessage:
-          'Add a sync rule to customize what data is synchronized from {indexName}. Everything is included by default, and documents are validated against the configured set of sync rules in the listed order.',
-        values: { indexName },
-      })}
+      {getSyncRulesDescription(indexName)}
       <EuiSpacer />
       <EuiLink href={docLinks.syncRules} external target="_blank">
-        {i18n.translate('xpack.enterpriseSearch.content.index.connector.syncRules.link', {
-          defaultMessage: 'Learn more about customizing your sync rules.',
-        })}
+        {SYNC_RULES_LEARN_MORE_LINK}
       </EuiLink>
     </EuiText>
   );
@@ -119,11 +104,11 @@ export const SyncRulesTable: React.FC = () => {
               value: 'exclude',
             },
           ]}
-          aria-label={i18nMessages.policy}
+          aria-label={BASIC_TABLE_POLICY_TITLE}
         />
       ),
       field: 'policy',
-      name: i18nMessages.policy,
+      name: BASIC_TABLE_POLICY_TITLE,
       render: (indexingRule) => (
         <EuiText size="s">{filteringPolicyToText(indexingRule.policy)}</EuiText>
       ),
@@ -136,13 +121,13 @@ export const SyncRulesTable: React.FC = () => {
               fullWidth
               value={rule.field}
               onChange={(e) => onChange(e.target.value)}
-              aria-label={i18nMessages.field}
+              aria-label={BASIC_TABLE_FIELD_TITLE}
             />
           </EuiFlexItem>
         </EuiFlexGroup>
       ),
       field: 'field',
-      name: i18nMessages.field,
+      name: BASIC_TABLE_FIELD_TITLE,
       render: (rule) => (
         <EuiText size="s">
           <EuiCode>{rule.field}</EuiCode>
@@ -159,11 +144,11 @@ export const SyncRulesTable: React.FC = () => {
             text: filteringRuleToText(rule),
             value: rule,
           }))}
-          aria-label={i18nMessages.rule}
+          aria-label={BASIC_TABLE_RULE_TITLE}
         />
       ),
       field: 'rule',
-      name: i18nMessages.rule,
+      name: BASIC_TABLE_RULE_TITLE,
       render: (rule) => <EuiText size="s">{filteringRuleToText(rule.rule)}</EuiText>,
     },
     {
@@ -174,13 +159,13 @@ export const SyncRulesTable: React.FC = () => {
               fullWidth
               value={rule.value}
               onChange={(e) => onChange(e.target.value)}
-              aria-label={i18nMessages.value}
+              aria-label={BASIC_TABLE_VALUE_TITLE}
             />
           </EuiFlexItem>
         </EuiFlexGroup>
       ),
       field: 'value',
-      name: i18nMessages.value,
+      name: BASIC_TABLE_VALUE_TITLE,
       render: (rule) => (
         <EuiText size="s">
           <EuiCode>{rule.value}</EuiCode>
@@ -191,14 +176,8 @@ export const SyncRulesTable: React.FC = () => {
 
   return (
     <InlineEditableTable
-      addButtonText={i18n.translate(
-        'xpack.enterpriseSearch.content.index.connector.syncRules.table.addRuleLabel',
-        { defaultMessage: 'Add sync rule' }
-      )}
-      ariaLabel={i18n.translate(
-        'xpack.enterpriseSearch.content.index.connector.syncRules.table.ariaLabel',
-        { defaultMessage: 'Sync rules' }
-      )}
+      addButtonText={SYNC_RULES_TABLE_ADD_RULE_LABEL}
+      ariaLabel={SYNC_RULES_TABLE_ARIA_LABEL}
       columns={columns}
       defaultItem={{
         policy: 'include',
@@ -233,16 +212,7 @@ export const SyncRulesTable: React.FC = () => {
       onReorder={reorderFilteringRules}
       title=""
       validateItem={validateItem}
-      bottomRows={[
-        <EuiText size="s">
-          {i18n.translate(
-            'xpack.enterpriseSearch.content.sources.basicRulesTable.includeEverythingMessage',
-            {
-              defaultMessage: 'Include everything else from this source',
-            }
-          )}
-        </EuiText>,
-      ]}
+      bottomRows={[<EuiText size="s">{INCLUDE_EVERYTHING_ELSE_MESSAGE}</EuiText>]}
       canRemoveLastItem
       emptyPropertyAllowed
       showRowIndex

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
@@ -182,7 +182,7 @@ export const SyncRulesTable: React.FC = () => {
       )}
       ariaLabel={i18n.translate(
         'xpack.enterpriseSearch.content.index.connector.syncRules.table.ariaLabel',
-        { defaultMessage: 'Sync rules table' }
+        { defaultMessage: 'Sync rules' }
       )}
       columns={columns}
       defaultItem={{

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/translations.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/translations.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const BASIC_TABLE_FIELD_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.index.connector.syncRules.basicTable.fieldTitle',
+  { defaultMessage: 'Field' }
+);
+
+export const BASIC_TABLE_POLICY_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.index.connector.rule.basicTable.policyTitle',
+  { defaultMessage: 'Policy' }
+);
+
+export const BASIC_TABLE_RULE_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.index.connector.syncRules.basicTable.ruleTitle',
+  { defaultMessage: 'Rule' }
+);
+
+export const BASIC_TABLE_VALUE_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.index.connector.syncRules.basicTable.valueTitle',
+  { defaultMessage: 'Value' }
+);
+
+export const getSyncRulesDescription = (indexName: string): string =>
+  i18n.translate('xpack.enterpriseSearch.content.index.connector.syncRules.description', {
+    defaultMessage:
+      'Add a sync rule to customize what data is synchronized from {indexName}. Everything is included by default, and documents are validated against the configured set of sync rules in the listed order.',
+    values: { indexName },
+  });
+
+export const SYNC_RULES_LEARN_MORE_LINK = i18n.translate(
+  'xpack.enterpriseSearch.content.index.connector.syncRules.link',
+  { defaultMessage: 'Learn more about customizing your sync rules.' }
+);
+
+export const SYNC_RULES_TABLE_ADD_RULE_LABEL = i18n.translate(
+  'xpack.enterpriseSearch.content.index.connector.syncRules.table.addRuleLabel',
+  { defaultMessage: 'Add sync rule' }
+);
+
+export const SYNC_RULES_TABLE_ARIA_LABEL = i18n.translate(
+  'xpack.enterpriseSearch.content.index.connector.syncRules.table.ariaLabel',
+  { defaultMessage: 'Sync rules' }
+);
+
+export const REGEX_ERROR = i18n.translate(
+  'xpack.enterpriseSearch.content.index.connector.filteringRules.regExError',
+  { defaultMessage: 'Value should be a regular expression' }
+);
+
+export const INCLUDE_EVERYTHING_ELSE_MESSAGE = i18n.translate(
+  'xpack.enterpriseSearch.content.sources.basicRulesTable.includeEverythingMessage',
+  { defaultMessage: 'Include everything else from this source' }
+);

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/action_column.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/action_column.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import type { MutableRefObject } from 'react';
 
 import { useActions, useValues } from 'kea';
 
@@ -30,6 +31,7 @@ interface ActionColumnProps<Item extends ItemWithAnID> {
   item: Item;
   canRemoveLastItem?: boolean;
   lastItemWarning?: string;
+  prevFocusRef?: MutableRefObject<HTMLElement | null>;
   uneditableItems?: Item[];
 }
 
@@ -42,6 +44,7 @@ export const ActionColumn = <Item extends ItemWithAnID>({
   canRemoveLastItem,
   lastItemWarning,
   uneditableItems,
+  prevFocusRef,
 }: ActionColumnProps<Item>) => {
   const { doesEditingItemValueContainEmptyProperty, fieldErrors, rowErrors, isEditingUnsavedItem } =
     useValues(InlineEditableTableLogic);
@@ -52,6 +55,13 @@ export const ActionColumn = <Item extends ItemWithAnID>({
     return null;
   }
 
+  const handleEditExistingItem = () => {
+    if (prevFocusRef) {
+      prevFocusRef.current = document.activeElement as HTMLElement;
+    }
+    editExistingItem(item);
+  };
+
   const isInvalid = Object.keys(fieldErrors).length > 0 || rowErrors.length > 0;
 
   if (isActivelyEditing(item)) {
@@ -59,6 +69,7 @@ export const ActionColumn = <Item extends ItemWithAnID>({
       <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
         <EuiFlexItem>
           <EuiButtonEmpty
+            aria-label={SAVE_BUTTON_LABEL}
             data-test-subj="saveButton"
             color="primary"
             iconType="checkInCircleFilled"
@@ -74,6 +85,7 @@ export const ActionColumn = <Item extends ItemWithAnID>({
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiButtonEmpty
+            aria-label={CANCEL_BUTTON_LABEL}
             data-test-subj="cancelButton"
             color="danger"
             iconType="cross"
@@ -91,9 +103,10 @@ export const ActionColumn = <Item extends ItemWithAnID>({
     <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
       <EuiFlexItem grow={null}>
         <EuiButtonEmpty
+          aria-label={EDIT_BUTTON_LABEL}
           data-test-subj="editButton"
           size="xs"
-          onClick={() => editExistingItem(item)}
+          onClick={handleEditExistingItem}
         >
           {EDIT_BUTTON_LABEL}
         </EuiButtonEmpty>
@@ -101,12 +114,17 @@ export const ActionColumn = <Item extends ItemWithAnID>({
       <EuiFlexItem grow={null}>
         {!canRemoveLastItem && displayedItems.length === 1 ? (
           <EuiToolTip content={lastItemWarning}>
-            <EuiButtonEmpty size="xs" disabled>
+            <EuiButtonEmpty aria-label={DELETE_BUTTON_LABEL} size="xs" disabled>
               {DELETE_BUTTON_LABEL}
             </EuiButtonEmpty>
           </EuiToolTip>
         ) : (
-          <EuiButtonEmpty data-test-subj="deleteButton" size="xs" onClick={() => deleteItem(item)}>
+          <EuiButtonEmpty
+            aria-label={DELETE_BUTTON_LABEL}
+            data-test-subj="deleteButton"
+            size="xs"
+            onClick={() => deleteItem(item)}
+          >
             {DELETE_BUTTON_LABEL}
           </EuiButtonEmpty>
         )}

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/get_updated_columns.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/get_updated_columns.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import type { MutableRefObject } from 'react';
 
 import type { Column } from '../reorderable_table/types';
 import type { ItemWithAnID } from '../types';
@@ -22,6 +23,7 @@ interface GetUpdatedColumnProps<Item extends ItemWithAnID> {
   canRemoveLastItem?: boolean;
   isLoading?: boolean;
   lastItemWarning?: string;
+  prevFocusRef?: MutableRefObject<HTMLElement | null>;
   uneditableItems?: Item[];
 }
 
@@ -34,6 +36,7 @@ export const getUpdatedColumns = <Item extends ItemWithAnID>({
   isLoading = false,
   lastItemWarning,
   uneditableItems,
+  prevFocusRef,
 }: GetUpdatedColumnProps<Item>): Array<Column<Item>> => {
   return [
     ...columns.map((column) => {
@@ -61,6 +64,7 @@ export const getUpdatedColumns = <Item extends ItemWithAnID>({
           lastItemWarning={lastItemWarning}
           uneditableItems={uneditableItems}
           item={item}
+          prevFocusRef={prevFocusRef}
         />
       ),
     },

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.test.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.test.tsx
@@ -223,6 +223,8 @@ describe('InlineEditableTable', () => {
       isLoading,
       lastItemWarning,
       uneditableItems,
+      prevFocusRef: expect.objectContaining({ current: null }),
+      emptyPropertyAllowed: undefined,
     });
   });
 });

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 
 import classNames from 'classnames';
 
 import { useActions, useValues, BindLogic } from 'kea';
 
-import { EuiButton, EuiSpacer } from '@elastic/eui';
+import { EuiButton, EuiSpacer, useUpdateEffect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { PageIntroduction } from '../../page_introduction/page_introduction';
@@ -105,6 +105,14 @@ export const InlineEditableTableContents = <Item extends ItemWithAnID>({
   const { editingItemId, isEditing, isEditingUnsavedItem, rowErrors } =
     useValues(InlineEditableTableLogic);
   const { editNewItem, reorderItems } = useActions(InlineEditableTableLogic);
+  const addButtonRef = useRef<HTMLButtonElement>(null);
+
+  useUpdateEffect(() => {
+    if (!isEditing) {
+      // Editing just ended, focus the add button
+      addButtonRef.current?.focus();
+    }
+  }, [isEditing]);
 
   // TODO These two things shoud just be selectors
   const isEditingItem = (item: Item) => item.id === editingItemId;
@@ -135,6 +143,7 @@ export const InlineEditableTableContents = <Item extends ItemWithAnID>({
         title={title || ''}
         actions={[
           <EuiButton
+            buttonRef={addButtonRef}
             size="s"
             iconType="plusInCircle"
             disabled={isEditing}

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
@@ -25,6 +25,7 @@ import { InlineEditableTableLogic } from './inline_editable_table_logic';
 import type { FormErrors, InlineEditableTableColumn } from './types';
 
 export interface InlineEditableTableProps<Item extends ItemWithAnID> {
+  ariaLabel?: string;
   columns: Array<InlineEditableTableColumn<Item>>;
   items: Item[];
   defaultItem?: Partial<Item>;

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.test.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.test.tsx
@@ -45,9 +45,13 @@ describe('BodyRow', () => {
       children: 1,
       flexBasis: 'foo',
       flexGrow: 0,
+      role: 'cell',
+      ariaColindex: 1,
     });
     expect(cells.at(1).props()).toEqual({
       children: 'Whatever',
+      role: 'cell',
+      ariaColindex: 2,
     });
   });
 

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
@@ -7,38 +7,72 @@
 
 import React from 'react';
 
-import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiText, EuiToken } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+import {
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiToken,
+  useEuiTheme,
+} from '@elastic/eui';
 
 import { Cell } from './cell';
 import { DRAGGABLE_UX_STYLE } from './constants';
 import type { Column } from './types';
 
 export interface BodyRowProps<Item> {
-  columns: Array<Column<Item>>;
-  item: Item;
   additionalProps?: object;
+  ariaRowindex?: number;
+  columns: Array<Column<Item>>;
+  errors?: string[];
+  item: Item;
   // Cell to put in first column before other columns
   leftAction?: React.ReactNode;
-  errors?: string[];
   rowIdentifier?: string;
 }
 
 export const BodyRow = <Item extends object>({
-  columns,
-  item,
   additionalProps,
-  leftAction,
+  ariaRowindex,
+  columns,
   errors = [],
+  item,
+  leftAction,
   rowIdentifier,
 }: BodyRowProps<Item>) => {
+  const { euiTheme } = useEuiTheme();
+  // Calculate column index offset based on presence of leftAction and rowIdentifier
+  const columnIndexOffset = (leftAction ? 1 : 0) + (rowIdentifier ? 1 : 0);
+
   return (
     <div className="reorderableTableRow">
-      <EuiFlexGroup data-test-subj="row" alignItems="center" {...(additionalProps || {})}>
-        <EuiFlexItem>
+      <EuiFlexGroup
+        data-test-subj="row"
+        alignItems="center"
+        role="row"
+        aria-rowindex={ariaRowindex}
+        {...(additionalProps || {})}
+      >
+        <EuiFlexItem
+          css={css`
+            margin: ${euiTheme.size.m} 0;
+          `}
+        >
           <EuiFlexGroup alignItems="center">
-            {leftAction && <Cell {...DRAGGABLE_UX_STYLE}>{leftAction}</Cell>}
+            {leftAction && (
+              <Cell {...DRAGGABLE_UX_STYLE} role="cell" ariaColindex={1}>
+                {leftAction}
+              </Cell>
+            )}
             {rowIdentifier && (
-              <Cell {...DRAGGABLE_UX_STYLE} flexBasis="24px">
+              <Cell
+                {...DRAGGABLE_UX_STYLE}
+                flexBasis="24px"
+                role="cell"
+                ariaColindex={leftAction ? 2 : 1}
+              >
                 <EuiToken
                   size="m"
                   iconType={() => (
@@ -55,6 +89,8 @@ export const BodyRow = <Item extends object>({
                 alignItems={column.alignItems}
                 flexBasis={column.flexBasis}
                 flexGrow={column.flexGrow}
+                role="cell"
+                ariaColindex={columnIndex + columnIndexOffset + 1}
               >
                 {column.render(item)}
               </Cell>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
@@ -7,8 +7,6 @@
 
 import React from 'react';
 
-import { css } from '@emotion/react';
-
 import {
   EuiCallOut,
   EuiFlexGroup,
@@ -20,6 +18,7 @@ import {
 
 import { Cell } from './cell';
 import { DRAGGABLE_UX_STYLE } from './constants';
+import * as Styles from './styles';
 import type { Column } from './types';
 
 export interface BodyRowProps<Item> {
@@ -55,11 +54,7 @@ export const BodyRow = <Item extends object>({
         aria-rowindex={ariaRowindex}
         {...(additionalProps || {})}
       >
-        <EuiFlexItem
-          css={css`
-            margin: ${euiTheme.size.m} 0;
-          `}
-        >
+        <EuiFlexItem css={Styles.bodyRowItemStyles(euiTheme)}>
           <EuiFlexGroup alignItems="center">
             {leftAction && (
               <Cell {...DRAGGABLE_UX_STYLE} role="cell" ariaColindex={1}>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_rows.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_rows.tsx
@@ -13,5 +13,5 @@ export interface BodyRowsProps<Item> {
 }
 
 export const BodyRows = <Item extends object>({ items, renderItem }: BodyRowsProps<Item>) => (
-  <>{items.map(renderItem)}</>
+  <div role="rowgroup">{items.map(renderItem)}</div>
 );

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/cell.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/cell.tsx
@@ -11,19 +11,29 @@ import { EuiFlexItem } from '@elastic/eui';
 
 import type { DraggableUXStyles } from './types';
 
+interface CellProps extends DraggableUXStyles {
+  ariaColindex?: number;
+  children?: React.ReactNode;
+  role?: 'cell' | 'columnheader';
+}
+
 export const Cell = ({
+  ariaColindex,
   children,
   alignItems,
   flexBasis,
   flexGrow,
-}: DraggableUXStyles & { children?: React.ReactNode }) => {
+  role,
+}: CellProps) => {
   return (
     <EuiFlexItem
       style={{
+        alignItems,
         flexBasis,
         flexGrow,
-        alignItems,
       }}
+      role={role}
+      aria-colindex={ariaColindex}
     >
       {children}
     </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.test.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.test.tsx
@@ -50,8 +50,12 @@ describe('DraggableBodyRow', () => {
     // It adds an index and unique draggable id from the provided rowIndex
     expect(euiDraggable.prop('index')).toEqual(1);
     expect(euiDraggable.prop('draggableId')).toEqual('draggable_row_1');
+    expect(euiDraggable.prop('customDragHandle')).toBe(true);
+    expect(euiDraggable.prop('hasInteractiveChildren')).toBe(true);
 
-    const bodyRow = wrapper.find(BodyRow);
+    const childrenFn = euiDraggable.prop('children');
+    const bodyRowWrapper = shallow(<div>{childrenFn({ dragHandleProps: {} })}</div>);
+    const bodyRow = bodyRowWrapper.find(BodyRow);
     expect(bodyRow.exists()).toEqual(true);
     expect(bodyRow.props()).toEqual(expect.objectContaining({ columns, item, additionalProps }));
     const leftAction = shallow(<div>{bodyRow.prop('leftAction')}</div>);
@@ -65,6 +69,6 @@ describe('DraggableBodyRow', () => {
 
     const euiDraggable = wrapper.find(EuiDraggable);
     expect(euiDraggable.prop('isDragDisabled')).toBe(true);
-    expect(euiDraggable.prop('disableInteractiveElementBlocking')).toBe(true);
+    expect(euiDraggable.prop('customDragHandle')).toBe(false);
   });
 });

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.tsx
@@ -8,28 +8,31 @@
 import React from 'react';
 
 import { EuiDraggable, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { BodyRow } from './body_row';
 import type { Column } from './types';
 
 export interface DraggableBodyRowProps<Item> {
-  columns: Array<Column<Item>>;
-  item: Item;
-  rowIndex: number;
   additionalProps?: object;
+  ariaRowindex?: number;
+  columns: Array<Column<Item>>;
   disableDragging?: boolean;
   errors?: string[];
+  item: Item;
   rowIdentifier?: string;
+  rowIndex: number;
 }
 
 export const DraggableBodyRow = <Item extends object>({
-  columns,
-  item,
-  rowIndex,
   additionalProps,
+  ariaRowindex,
+  columns,
   disableDragging = false,
   errors,
+  item,
   rowIdentifier,
+  rowIndex,
 }: DraggableBodyRowProps<Item>) => {
   const draggableId = `draggable_row_${rowIndex}`;
 
@@ -38,23 +41,40 @@ export const DraggableBodyRow = <Item extends object>({
       index={rowIndex}
       draggableId={draggableId}
       isDragDisabled={disableDragging}
-      disableInteractiveElementBlocking={disableDragging}
+      customDragHandle={!disableDragging}
+      hasInteractiveChildren
+      usePortal
       {...additionalProps}
     >
-      <BodyRow
-        columns={columns}
-        item={item}
-        additionalProps={additionalProps}
-        leftAction={
-          <EuiFlexGroup justifyContent="spaceBetween">
-            <EuiFlexItem>
-              {disableDragging ? <div style={{ width: '16px' }} /> : <EuiIcon type="grab" />}
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        }
-        rowIdentifier={rowIdentifier}
-        errors={errors}
-      />
+      {(provided) => (
+        <BodyRow
+          columns={columns}
+          item={item}
+          additionalProps={additionalProps}
+          leftAction={
+            <EuiFlexGroup justifyContent="spaceBetween">
+              <EuiFlexItem>
+                {disableDragging ? (
+                  <div style={{ width: '16px' }} />
+                ) : (
+                  <div
+                    {...provided.dragHandleProps}
+                    aria-label={i18n.translate(
+                      'xpack.enterpriseSearch.draggableBodyRow.dragHandleLabel',
+                      { defaultMessage: 'Drag handle' }
+                    )}
+                  >
+                    <EuiIcon type="grab" />
+                  </div>
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          }
+          rowIdentifier={rowIdentifier}
+          errors={errors}
+          ariaRowindex={ariaRowindex}
+        />
+      )}
     </EuiDraggable>
   );
 };

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_rows.test.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_rows.test.tsx
@@ -11,7 +11,6 @@ import { shallow } from 'enzyme';
 
 import { EuiDragDropContext } from '@elastic/eui';
 
-import { BodyRows } from './body_rows';
 import { DraggableBodyRows } from './draggable_body_rows';
 
 describe('DraggableBodyRows', () => {
@@ -29,12 +28,7 @@ describe('DraggableBodyRows', () => {
     );
 
     expect(wrapper.find(EuiDragDropContext).exists()).toBe(true);
-
-    const bodyRows = wrapper.find(BodyRows);
-    expect(bodyRows.props()).toEqual({
-      items,
-      renderItem,
-    });
+    expect(wrapper.find('[role="rowgroup"]').exists()).toBe(true);
   });
 
   it('will call the provided onReorder function whenever items are reordered', () => {

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_rows.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_rows.tsx
@@ -9,8 +9,6 @@ import React from 'react';
 
 import { EuiDragDropContext, euiDragDropReorder, EuiDroppable } from '@elastic/eui';
 
-import { BodyRows } from './body_rows';
-
 interface DraggableBodyRowsProps<Item> {
   items: Item[];
   onReorder: (reorderedItems: Item[], items: Item[]) => void;
@@ -23,17 +21,19 @@ export const DraggableBodyRows = <Item extends object>({
   renderItem,
 }: DraggableBodyRowsProps<Item>) => {
   return (
-    <EuiDragDropContext
-      onDragEnd={({ source, destination }) => {
-        if (source && destination) {
-          const reorderedItems = euiDragDropReorder(items, source.index, destination?.index);
-          onReorder(reorderedItems, items);
-        }
-      }}
-    >
-      <EuiDroppable droppableId="ReorderingArea" grow={false}>
-        <BodyRows items={items} renderItem={renderItem} />
-      </EuiDroppable>
-    </EuiDragDropContext>
+    <div role="rowgroup">
+      <EuiDragDropContext
+        onDragEnd={({ source, destination }) => {
+          if (source && destination) {
+            const reorderedItems = euiDragDropReorder(items, source.index, destination?.index);
+            onReorder(reorderedItems, items);
+          }
+        }}
+      >
+        <EuiDroppable droppableId="ReorderingArea" grow={false}>
+          <>{items.map(renderItem)}</>
+        </EuiDroppable>
+      </EuiDragDropContext>
+    </div>
   );
 };

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/header_row.test.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/header_row.test.tsx
@@ -41,6 +41,6 @@ describe('HeaderRow', () => {
     const wrapper = shallow(<HeaderRow columns={columns} spacingForRowIdentifier />);
     const cells = wrapper.find(Cell);
     expect(cells.length).toBe(3);
-    expect(cells.at(0).children()).toHaveLength(0);
+    expect(cells.at(0).children()).toHaveLength(1);
   });
 });

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/header_row.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/header_row.tsx
@@ -7,7 +7,9 @@
 
 import React from 'react';
 
-import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiScreenReaderOnly, EuiText } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
 
 import { Cell } from './cell';
 import { DRAGGABLE_UX_STYLE } from './constants';
@@ -25,15 +27,43 @@ export const HeaderRow = <Item extends object>({
   leftAction,
   spacingForRowIdentifier = false,
 }: HeaderRowProps<Item>) => {
+  // Calculate column index offset based on presence of leftAction and rowIdentifier
+  const columnIndexOffset = (leftAction ? 1 : 0) + (spacingForRowIdentifier ? 1 : 0);
+
   return (
-    <div className="reorderableTableHeader">
-      <EuiFlexGroup>
+    <div className="reorderableTableHeader" role="rowgroup">
+      <EuiFlexGroup role="row" aria-rowindex={1}>
         <EuiFlexItem>
           <EuiFlexGroup>
-            {leftAction && <Cell {...DRAGGABLE_UX_STYLE}>{leftAction}</Cell>}
-            {spacingForRowIdentifier && <Cell {...DRAGGABLE_UX_STYLE} flexBasis="24px" />}
+            {leftAction && (
+              <Cell {...DRAGGABLE_UX_STYLE} role="columnheader" ariaColindex={1}>
+                {leftAction}
+              </Cell>
+            )}
+            {spacingForRowIdentifier && (
+              <Cell
+                {...DRAGGABLE_UX_STYLE}
+                flexBasis="24px"
+                role="columnheader"
+                ariaColindex={leftAction ? 2 : 1}
+              >
+                <EuiScreenReaderOnly>
+                  <p>
+                    {i18n.translate(
+                      'xpack.enterpriseSearch.reorderableTable.rowIdentifierScreenReaderOnlyLabel',
+                      { defaultMessage: 'Row identifier' }
+                    )}
+                  </p>
+                </EuiScreenReaderOnly>
+              </Cell>
+            )}
             {columns.map((column, columnIndex) => (
-              <Cell key={`table_header_cell_${columnIndex}`} {...column}>
+              <Cell
+                key={`table_header_cell_${columnIndex}`}
+                {...column}
+                role="columnheader"
+                ariaColindex={columnIndex + columnIndexOffset + 1}
+              >
                 <EuiText size="s">
                   <strong>{column.name}</strong>
                 </EuiText>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.test.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.test.tsx
@@ -52,6 +52,9 @@ describe('ReorderableTable', () => {
         additionalProps: {},
         disableDragging: false,
         rowIndex: 0,
+        ariaRowindex: 2,
+        errors: undefined,
+        rowIdentifier: undefined,
       });
     });
 
@@ -127,6 +130,9 @@ describe('ReorderableTable', () => {
         item: { id: 1 },
         additionalProps: {},
         leftAction: expect.anything(),
+        ariaRowindex: 4,
+        errors: undefined,
+        rowIdentifier: undefined,
       });
     });
 
@@ -165,6 +171,9 @@ describe('ReorderableTable', () => {
         columns,
         item: { id: 1 },
         additionalProps: {},
+        ariaRowindex: 2,
+        errors: undefined,
+        rowIdentifier: undefined,
       });
     });
 

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.tsx
@@ -9,7 +9,8 @@ import React from 'react';
 
 import classNames from 'classnames';
 
-import { EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiScreenReaderOnly, useEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { BodyRow } from './body_row';
 import { BodyRows } from './body_rows';
@@ -20,40 +21,61 @@ import * as Styles from './styles';
 import type { Column } from './types';
 
 interface ReorderableTableProps<Item> {
-  columns: Array<Column<Item>>;
-  items: Item[];
-  noItemsMessage: React.ReactNode;
-  unreorderableItems?: Item[];
+  ariaLabel?: string;
   bottomRows?: React.ReactNode[];
   className?: string;
+  columns: Array<Column<Item>>;
   disableDragging?: boolean;
   disableReordering?: boolean;
-  showRowIndex?: boolean;
+  items: Item[];
+  noItemsMessage: React.ReactNode;
   onReorder?: (items: Item[], oldItems: Item[]) => void;
-  rowProps?: (item: Item) => object;
   rowErrors?: (item: Item) => string[] | undefined;
+  rowProps?: (item: Item) => object;
+  showRowIndex?: boolean;
+  unreorderableItems?: Item[];
 }
 
 export const ReorderableTable = <Item extends object>({
-  columns,
-  items,
-  noItemsMessage,
-  unreorderableItems = [],
+  ariaLabel = 'Reorderable table',
   bottomRows = [],
   className = '',
+  columns,
   disableDragging = false,
   disableReordering = false,
+  items,
+  noItemsMessage,
   onReorder = () => undefined,
-  rowProps = () => ({}),
   rowErrors = () => undefined,
+  rowProps = () => ({}),
   showRowIndex = false,
+  unreorderableItems = [],
 }: ReorderableTableProps<Item>) => {
   const { euiTheme } = useEuiTheme();
+  // Calculate row index offset (header row = 1)
+  const rowIndexOffset = 2; // Start body rows at index 2
+
   return (
-    <div className={classNames(className)} css={Styles.reorderableTableStyles(euiTheme)}>
+    <div
+      className={classNames(className)}
+      css={Styles.reorderableTableStyles(euiTheme)}
+      role="table"
+      aria-label={ariaLabel}
+    >
       <HeaderRow
         columns={columns}
-        leftAction={disableReordering ? undefined : <></>}
+        leftAction={
+          disableReordering ? undefined : (
+            <EuiScreenReaderOnly>
+              <p>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.reorderableTable.grabHandleScreenReaderOnlyLabel',
+                  { defaultMessage: 'Grab handle' }
+                )}
+              </p>
+            </EuiScreenReaderOnly>
+          )
+        }
         spacingForRowIdentifier={showRowIndex}
       />
 
@@ -76,6 +98,7 @@ export const ReorderableTable = <Item extends object>({
               additionalProps={rowProps(item)}
               errors={rowErrors(item)}
               rowIdentifier={showRowIndex ? `${itemIndex + 1}` : undefined}
+              ariaRowindex={itemIndex + rowIndexOffset}
             />
           )}
         />
@@ -95,6 +118,7 @@ export const ReorderableTable = <Item extends object>({
                 rowIndex={itemIndex}
                 errors={rowErrors(item)}
                 rowIdentifier={showRowIndex ? `${itemIndex + 1}` : undefined}
+                ariaRowindex={itemIndex + rowIndexOffset}
               />
             )}
             onReorder={onReorder}
@@ -105,30 +129,38 @@ export const ReorderableTable = <Item extends object>({
         {unreorderableItems.length > 0 && (
           <BodyRows
             items={unreorderableItems}
-            renderItem={(item, itemIndex) => (
-              <BodyRow
-                key={`table_draggable_row_${itemIndex}`}
-                columns={columns}
-                item={item}
-                additionalProps={rowProps(item)}
-                errors={rowErrors(item)}
-                leftAction={disableReordering ? undefined : <> </>}
-                rowIdentifier={showRowIndex ? '∞' : undefined}
-              />
-            )}
+            renderItem={(item, itemIndex) => {
+              const rowIndex = items.length + itemIndex + rowIndexOffset;
+              return (
+                <BodyRow
+                  key={`table_draggable_row_${itemIndex}`}
+                  columns={columns}
+                  item={item}
+                  additionalProps={rowProps(item)}
+                  errors={rowErrors(item)}
+                  leftAction={disableReordering ? undefined : <> </>}
+                  rowIdentifier={showRowIndex ? '∞' : undefined}
+                  ariaRowindex={rowIndex}
+                />
+              );
+            }}
           />
         )}
 
-        {bottomRows.map((row, rowIndex) => (
-          <BodyRow // Shoving a generic ReactNode into a BodyRow is kind of a hack
-            key={rowIndex}
-            rowIdentifier={showRowIndex ? '∞' : undefined}
-            columns={[{ render: () => row }]}
-            item={{}}
-            leftAction={disableReordering ? undefined : <> </>}
-            data-test-subj="BottomRow"
-          />
-        ))}
+        {bottomRows.map((row, rowIndex) => {
+          const ariaRowIndex = items.length + unreorderableItems.length + rowIndex + rowIndexOffset;
+          return (
+            <BodyRow // Shoving a generic ReactNode into a BodyRow is kind of a hack
+              key={rowIndex}
+              rowIdentifier={showRowIndex ? '∞' : undefined}
+              columns={[{ render: () => row }]}
+              item={{}}
+              leftAction={disableReordering ? undefined : <> </>}
+              data-test-subj="BottomRow"
+              ariaRowindex={ariaRowIndex}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/styles.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/styles.ts
@@ -38,3 +38,8 @@ export const reorderableTableStyles = (euiTheme: EuiThemeComputed<{}>) =>
       backgroundColor: euiTheme.colors.lightestShade,
     },
   });
+
+export const bodyRowItemStyles = (euiTheme: EuiThemeComputed<{}>) =>
+  css({
+    margin: `${euiTheme.size.m} 0`,
+  });

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/styles.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/styles.ts
@@ -29,9 +29,6 @@ export const reorderableTableStyles = (euiTheme: EuiThemeComputed<{}>) =>
 
     // Row
     '.reorderableTableRow': {
-      '> .euiFlexGroup > .euiFlexItem': {
-        margin: `${euiTheme.size.m} 0`,
-      },
       backgroundColor: euiTheme.colors.emptyShade,
       borderTop: euiTheme.border.thin,
     },


### PR DESCRIPTION
## Summary

Closes #198135, closes #198042, closes #197972, closes #199265.

Addresses several accessibility issues found in the sync rules table:
1. Sync rules table now has the appropriate `role="table"` (and relevant descendants ie. `rowgroup`, `row`, etc.). We can't make this an actual `<table>` since we're leveraging EUI drag & drop components which are implemented with `<div>`s and can't be part of a table, so we're doing the next best thing.
2. Input fields are automatically focused after pressing "Add sync rule", with each input field having an appropriate `aria-label`.
3. Add screen-reader only column headings for invisible headings (eg. drag handle).
4. Fixed a visual bug with `usePortal` that was causing D&D to render incorrectly in the flyout.
5. Properly handles navigation sequencing after editing is done (pressing either "Save" or "Cancel" re-focuses the button the user was previously on).

__Demo__


https://github.com/user-attachments/assets/c84d6011-d73b-4740-b814-90c55b385615



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->