### PR TITLE
fix: update scout EuiComboBox single selection docs page selector

### DIFF
--- a/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/combo_box.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/combo_box.spec.ts
@@ -58,7 +58,11 @@ test.describe('EUI testing wrapper: EuiComboBox', { tag: ['@svlSecurity', '@ess'
   });
 
   test(`with the single selection`, async ({ page, log }) => {
-    const selector = { locator: '[id=":r5:-row"] .euiComboBox' };
+    // Selects the first .euiComboBox after the heading ID #single-selection-with-custom-options
+    const selector = {
+      locator:
+        "//*[@id='single-selection-with-custom-options']/following::*[contains(@class, 'euiComboBox ')][1]",
+    };
     await navigateToEuiTestPage(
       page,
       'docs/components/forms/selection/combo-box/#single-selection-with-custom-options',


### PR DESCRIPTION
## Summary

This PR fixes the selector used in EuiComboBox scout integration test. Due to the recent EUI docs update, the selector isn't valid anymore. I replaced it with an xpath selector to ensure better compatibility with future EUI documentation updates as now the selector doesn't rely on element ID generation.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->