### PR TITLE
[Context Security] fix disable cloud connector tab in edit mode

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_tabs.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_tabs.tsx
@@ -43,7 +43,10 @@ export const CloudConnectorTabs: React.FC<CloudConnectorTabsProps> = ({
               onTabClick(tab);
             }}
             isSelected={tab.id === selectedTabId}
-            disabled={tab.id === TABS.EXISTING_CONNECTION && !cloudConnectorsCount}
+            disabled={
+              (tab.id === TABS.EXISTING_CONNECTION && !cloudConnectorsCount) ||
+              (isEditPage && tab.id === TABS.NEW_CONNECTION)
+            }
           >
             <FormattedMessage
               id="securitySolutionPackages.cloudSecurityPosture.cloudConnectorSetup.cloudConnectorTabs.tab"


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.
- Disables New Cloud Connection Tab when integration is in edit mode.

<img width="993" height="610" alt="image" src="https://github.com/user-attachments/assets/a9f70aa6-d3de-45a5-89b3-024ab29cd781" />



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->