### PR TITLE
[8.18] [Docs] Security advisory for 8.18.8 and 8.19.5 in Kibana release notes (#237663)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -111,6 +111,8 @@ include::upgrade-notes.asciidoc[]
 
 The 8.18.8 release includes the following fixes.
 
+IMPORTANT: This release contains fixes for potential security vulnerabilities. Check our link:https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
+
 [float]
 [[fixes-v8.18.8]]
 === Fixes


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.18`:
 - [[Docs] Security advisory for 8.18.8 and 8.19.5 in Kibana release notes (#237663)](https://github.com/elastic/kibana/pull/237663)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"florent-leborgne","email":"florent.leborgne@elastic.co"},"sourceCommit":{"committedDate":"2025-10-06T14:37:52Z","message":"[Docs] Security advisory for 8.18.8 and 8.19.5 in Kibana release notes (#237663)\n\nAs requested by @ismisepaul\nSimilar to https://github.com/elastic/kibana/pull/237605","sha":"286b9fd557c373fc4fe29e6258a2e7ece5306c3e","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","backport:version","v8.18.8"],"title":"[Docs] Security advisory for 8.18.8 and 8.19.5 in Kibana release notes","number":237663,"url":"https://github.com/elastic/kibana/pull/237663","mergeCommit":{"message":"[Docs] Security advisory for 8.18.8 and 8.19.5 in Kibana release notes (#237663)\n\nAs requested by @ismisepaul\nSimilar to https://github.com/elastic/kibana/pull/237605","sha":"286b9fd557c373fc4fe29e6258a2e7ece5306c3e"}},"sourceBranch":"8.19","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->