### PR TITLE
[9.2] fix: update scout EuiComboBox single selection docs page selector (#237702)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/combo_box.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/combo_box.spec.ts
@@ -57,8 +57,17 @@ test.describe('EUI testing wrapper: EuiComboBox', { tag: ['@svlSecurity', '@ess'
     });
   });
 
+<<<<<<< HEAD
   test(`with the single selection`, async ({ page }) => {
     const selector = { locator: '[id=":r5:-row"] .euiComboBox' };
+=======
+  test(`with the single selection`, async ({ page, log }) => {
+    // Selects the first .euiComboBox after the heading ID #single-selection-with-custom-options
+    const selector = {
+      locator:
+        "//*[@id='single-selection-with-custom-options']/following::*[contains(@class, 'euiComboBox ')][1]",
+    };
+>>>>>>> 9a43d33ef56 (fix: update scout EuiComboBox single selection docs page selector (#237702))
     await navigateToEuiTestPage(
       page,
       'docs/components/forms/selection/combo-box/#single-selection-with-custom-options'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [fix: update scout EuiComboBox single selection docs page selector (#237702)](https://github.com/elastic/kibana/pull/237702)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Kajtoch","email":"tomasz.kajtoch@elastic.co"},"sourceCommit":{"committedDate":"2025-10-06T19:03:23Z","message":"fix: update scout EuiComboBox single selection docs page selector (#237702)\n\n## Summary\n\nThis PR fixes the selector used in EuiComboBox scout integration test.\nDue to the recent EUI docs update, the selector isn't valid anymore. I\nreplaced it with an xpath selector to ensure better compatibility with\nfuture EUI documentation updates as now the selector doesn't rely on\nelement ID generation.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"9a43d33ef56aa137532e6ad474d01b923841319a","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.3.0"],"title":"fix: update scout EuiComboBox single selection docs page selector","number":237702,"url":"https://github.com/elastic/kibana/pull/237702","mergeCommit":{"message":"fix: update scout EuiComboBox single selection docs page selector (#237702)\n\n## Summary\n\nThis PR fixes the selector used in EuiComboBox scout integration test.\nDue to the recent EUI docs update, the selector isn't valid anymore. I\nreplaced it with an xpath selector to ensure better compatibility with\nfuture EUI documentation updates as now the selector doesn't rely on\nelement ID generation.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"9a43d33ef56aa137532e6ad474d01b923841319a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237702","number":237702,"mergeCommit":{"message":"fix: update scout EuiComboBox single selection docs page selector (#237702)\n\n## Summary\n\nThis PR fixes the selector used in EuiComboBox scout integration test.\nDue to the recent EUI docs update, the selector isn't valid anymore. I\nreplaced it with an xpath selector to ensure better compatibility with\nfuture EUI documentation updates as now the selector doesn't rely on\nelement ID generation.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"9a43d33ef56aa137532e6ad474d01b923841319a"}},{"url":"https://github.com/elastic/kibana/pull/237737","number":237737,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->