### PR TITLE
[Streams] prompt improvements, sanitize name

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/workflows/partition_stream/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/workflows/partition_stream/index.ts
@@ -93,8 +93,14 @@ export async function partitionStream({
     response?.toolCalls
       ?.flatMap((toolCall) => toolCall.function.arguments.partitions ?? [])
       .map(({ name, condition }) => {
+        // Sanitize name to be alphanumeric with dashes only, lowercase
+        const sanitizedName = name
+          .toLowerCase()
+          .replace(/[^a-z0-9-]/g, '-')
+          .replace(/-+/g, '-')
+          .replace(/^-+|-+$/g, '');
         return {
-          name: `${definition.name}.${name}`,
+          name: `${definition.name}.${sanitizedName}`,
           condition: condition as Condition,
         };
       }) ?? [];

--- a/x-pack/platform/packages/shared/kbn-streams-ai/workflows/partition_stream/system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/workflows/partition_stream/system_prompt.text
@@ -63,14 +63,14 @@ You start with a broad hypothesis based on a common field like `resource.attribu
     "index": "logs-generic-v1",
     "partitions": [
       {
-        "name": "apache-logs",
+        "name": "apache",
         "condition": {
           "field": "resource.attributes.service.name",
           "eq": "apache"
         }
       },
       {
-        "name": "system-logs",
+        "name": "system",
         "condition": {
           "field": "resource.attributes.service.name",
           "eq": "system"
@@ -83,14 +83,14 @@ You start with a broad hypothesis based on a common field like `resource.attribu
 
 #### **Reasoning and Refinement**
 
-The tool returns results. The `apache-logs` partition has 3 distinct clusters, and the "unmatched" bucket is large. This means your initial partition is too coarse.
+The tool returns results. The `apache` partition has 3 distinct clusters, and the "unmatched" bucket is large. This means your initial partition is too coarse.
 
 ```text
 {"tool":"reason","arguments":{}}
 # Orchestrator returns stepsLeft
 <<<BEGIN_INTERNAL>>>
 [stepsLeft = 8]
-REFLECT> The initial call showed that the `apache-logs` partition is not pure; its three clusters suggest it contains multiple distinct web applications. The large 'unmatched' bucket, which seems to contain redis logs, also needs to be addressed.
+REFLECT> The initial call showed that the `apache` partition is not pure; its three clusters suggest it contains multiple distinct web applications. The large 'unmatched' bucket, which seems to contain redis logs, also needs to be addressed.
 GATHER> I will split the 'apache' partition into three more specific ones by looking for additional fields like `virtualhost` or `log_source_id`. I will also add a new partition for Redis based on the `process.name` field I observed in the unmatched logs.
 continue = yes
 <<<END_INTERNAL>>>
@@ -141,7 +141,7 @@ You now submit a more detailed and complete set of partitions.
         }
       },
       {
-        "name": "system-logs",
+        "name": "system",
         "condition": {
           "field": "resource.attributes.service.name",
           "eq": "system"
@@ -166,7 +166,7 @@ You now submit a more detailed and complete set of partitions.
 ### **Error => Repair Examples**
 
 *   **Error: Partition is too broad.**
-    *   **Bad Partition:** `{"name": "database-logs", "condition": {"field": "log.type", "eq": "database"}}`
+    *   **Bad Partition:** `{"name": "database", "condition": {"field": "log.type", "eq": "database"}}`
     *   **Symptom:** The `partition_logs` tool returns 5 clusters for this partition.
     *   **Reasoning:** "database" is a category, not a system. The clusters likely correspond to `mysql`, `redis`, `postgres`, etc.
     *   **Repair:** Replace the single partition with multiple, specific partitions: one for `mysql` (e.g., matching `process.name: 'mysqld'`), one for `redis` (`process.name: 'redis-server'`), etc.


### PR DESCRIPTION
The existing partitioning prompting was prone to call any Sub Streams `logs.nginx-logs`, `logs.apache-logs`, often adding `-logs` to their name. 
This is because our prompts had lots of examples of this. 

We also did not do any name sanitization or validation prior, which could cause problems when the LLM decided to name a Sub Stream `logs.postgresDatabase` with an uppercase letter as one example. 

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->