### PR TITLE
[streams] strip extra "from" property in the lifecycle payloads

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -74,7 +74,11 @@ export {
   streamQuerySchema,
 } from './src/queries';
 
-export { findInheritedLifecycle, findInheritingStreams } from './src/helpers/lifecycle';
+export {
+  findInheritedLifecycle,
+  findInheritingStreams,
+  effectiveToIngestLifecycle,
+} from './src/helpers/lifecycle';
 
 export { streamObjectNameSchema } from './src/shared/stream_object_name';
 
@@ -85,6 +89,7 @@ export {
   type IlmPolicyPhase,
   type IlmPolicyHotPhase,
   type IlmPolicyDeletePhase,
+  type IngestStreamLifecycleAll,
   type IngestStreamLifecycleILM,
   type IngestStreamLifecycleDSL,
   type IngestStreamLifecycleDisabled,

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/lifecycle.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/lifecycle.ts
@@ -6,7 +6,11 @@
  */
 
 import type { Streams } from '../models/streams';
-import type { WiredIngestStreamEffectiveLifecycle } from '../models/ingest/lifecycle';
+import type {
+  IngestStreamEffectiveLifecycle,
+  IngestStreamLifecycleAll,
+  WiredIngestStreamEffectiveLifecycle,
+} from '../models/ingest/lifecycle';
 import { isInheritLifecycle } from '../models/ingest/lifecycle';
 import { isDescendantOf, isChildOf, getSegments } from '../shared/hierarchy';
 
@@ -52,4 +56,14 @@ export function findInheritingStreams(
   }
 
   return inheriting;
+}
+
+export function effectiveToIngestLifecycle(
+  effectiveLifecycle: IngestStreamEffectiveLifecycle
+): IngestStreamLifecycleAll {
+  if ('from' in effectiveLifecycle) {
+    const { from, ...lifecycle } = effectiveLifecycle;
+    return lifecycle;
+  }
+  return effectiveLifecycle;
 }

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/lifecycle/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/lifecycle/index.ts
@@ -50,6 +50,11 @@ export type ClassicIngestStreamEffectiveLifecycle =
   | IngestStreamLifecycleError
   | IngestStreamLifecycleDisabled;
 
+export type IngestStreamLifecycleAll =
+  | IngestStreamLifecycle
+  | IngestStreamLifecycleError
+  | IngestStreamLifecycleDisabled;
+
 export type IngestStreamEffectiveLifecycle =
   | WiredIngestStreamEffectiveLifecycle
   | ClassicIngestStreamEffectiveLifecycle;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/modal/dsl.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/modal/dsl.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useMemo, useState, useEffect } from 'react';
-import type { IngestStreamLifecycle } from '@kbn/streams-schema';
+import type { IngestStreamLifecycleAll, IngestStreamLifecycleDSL } from '@kbn/streams-schema';
 import { isDslLifecycle } from '@kbn/streams-schema';
 import {
   EuiButton,
@@ -22,9 +22,9 @@ import { useBoolean } from '@kbn/react-hooks';
 import { parseDuration } from '../../helpers/helpers';
 
 interface Props {
-  initialValue: IngestStreamLifecycle;
+  initialValue: IngestStreamLifecycleAll;
   isDisabled: boolean;
-  setLifecycle: (lifecycle: IngestStreamLifecycle) => void;
+  setLifecycle: (lifecycle: IngestStreamLifecycleDSL) => void;
   setSaveButtonDisabled: (isDisabled: boolean) => void;
 }
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/modal/ilm.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/modal/ilm.tsx
@@ -21,7 +21,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
-import { IngestStreamLifecycleAll } from '@kbn/streams-schema/src/models/ingest/lifecycle';
+import type { IngestStreamLifecycleAll } from '@kbn/streams-schema/src/models/ingest/lifecycle';
 import { getFormattedError } from '../../../../../util/errors';
 
 interface PhaseProps {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/modal/ilm.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/modal/ilm.tsx
@@ -8,7 +8,7 @@
 import React, { useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { Phases, PolicyFromES } from '@kbn/index-lifecycle-management-common-shared';
-import type { IngestStreamLifecycle } from '@kbn/streams-schema';
+import type { IngestStreamLifecycleILM } from '@kbn/streams-schema';
 import { isIlmLifecycle } from '@kbn/streams-schema';
 import type { EuiSelectableOption } from '@elastic/eui';
 import {
@@ -21,6 +21,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
+import { IngestStreamLifecycleAll } from '@kbn/streams-schema/src/models/ingest/lifecycle';
 import { getFormattedError } from '../../../../../util/errors';
 
 interface PhaseProps {
@@ -34,8 +35,8 @@ interface IlmOptionData {
 
 interface ModalOptions {
   getIlmPolicies: () => Promise<PolicyFromES[]>;
-  initialValue: IngestStreamLifecycle;
-  setLifecycle: (lifecycle: IngestStreamLifecycle) => void;
+  initialValue: IngestStreamLifecycleAll;
+  setLifecycle: (lifecycle: IngestStreamLifecycleILM) => void;
   setSaveButtonDisabled: (isDisabled: boolean) => void;
   readOnly: boolean;
 }
@@ -49,14 +50,14 @@ export function IlmField({
 }: ModalOptions) {
   const { euiTheme } = useEuiTheme();
   const [selectedPolicy, setSelectedPolicy] = useState(
-    isIlmLifecycle(initialValue) ? initialValue.ilm?.policy : undefined
+    isIlmLifecycle(initialValue) ? initialValue.ilm.policy : undefined
   );
   const [policies, setPolicies] = useState<Array<EuiSelectableOption<IlmOptionData>>>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
   useEffect(() => {
-    setSelectedPolicy(isIlmLifecycle(initialValue) ? initialValue.ilm?.policy : undefined);
+    setSelectedPolicy(isIlmLifecycle(initialValue) ? initialValue.ilm.policy : undefined);
   }, [initialValue]);
 
   const isBorealis = euiTheme.themeName === 'EUI_THEME_BOREALIS';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/modal/modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/modal/modal.tsx
@@ -27,6 +27,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { omit } from 'lodash';
 import { IlmField } from './ilm';
 import { DslField, DEFAULT_RETENTION_UNIT, DEFAULT_RETENTION_VALUE } from './dsl';
 import { useKibana } from '../../../../../hooks/use_kibana';
@@ -61,7 +62,7 @@ export function EditLifecycleModal({
   const [isInheritToggleOn, setIsInheritToggleOn] = useState<boolean>(isCurrentLifecycleInherit);
   const [selectedAction, setSelectedAction] = useState<LifecycleEditAction>(initialSelectedAction);
   const [lifecycle, setLifecycle] = useState<IngestStreamLifecycle>(
-    definition.effective_lifecycle as IngestStreamLifecycle
+    omit(definition.effective_lifecycle, 'from') as IngestStreamLifecycle
   );
 
   const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState<boolean>(
@@ -155,7 +156,9 @@ export function EditLifecycleModal({
                 onChange={(event) => {
                   if (event.target.checked) {
                     if (isCurrentLifecycleInherit) {
-                      setLifecycle(definition.effective_lifecycle as IngestStreamLifecycle);
+                      setLifecycle(
+                        omit(definition.effective_lifecycle, 'from') as IngestStreamLifecycle
+                      );
                       setSelectedAction(initialSelectedAction);
                     }
                     setIsInheritToggleOn(true);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/modal/modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/modal/modal.tsx
@@ -7,8 +7,19 @@
 
 import React, { useState, useMemo } from 'react';
 import type { PolicyFromES } from '@kbn/index-lifecycle-management-common-shared';
-import type { IngestStreamLifecycle, IngestStreamLifecycleDSL } from '@kbn/streams-schema';
-import { isDslLifecycle, isIlmLifecycle, isInheritLifecycle } from '@kbn/streams-schema';
+import type {
+  IngestStreamLifecycle,
+  IngestStreamLifecycleAll,
+  IngestStreamLifecycleDSL,
+} from '@kbn/streams-schema';
+import {
+  effectiveToIngestLifecycle,
+  isDisabledLifecycle,
+  isDslLifecycle,
+  isErrorLifecycle,
+  isIlmLifecycle,
+  isInheritLifecycle,
+} from '@kbn/streams-schema';
 import { Streams, isRoot } from '@kbn/streams-schema';
 import {
   EuiButton,
@@ -27,7 +38,6 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { omit } from 'lodash';
 import { IlmField } from './ilm';
 import { DslField, DEFAULT_RETENTION_UNIT, DEFAULT_RETENTION_VALUE } from './dsl';
 import { useKibana } from '../../../../../hooks/use_kibana';
@@ -61,8 +71,8 @@ export function EditLifecycleModal({
 
   const [isInheritToggleOn, setIsInheritToggleOn] = useState<boolean>(isCurrentLifecycleInherit);
   const [selectedAction, setSelectedAction] = useState<LifecycleEditAction>(initialSelectedAction);
-  const [lifecycle, setLifecycle] = useState<IngestStreamLifecycle>(
-    omit(definition.effective_lifecycle, 'from') as IngestStreamLifecycle
+  const [lifecycle, setLifecycle] = useState<IngestStreamLifecycleAll>(
+    effectiveToIngestLifecycle(definition.effective_lifecycle)
   );
 
   const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState<boolean>(
@@ -156,9 +166,7 @@ export function EditLifecycleModal({
                 onChange={(event) => {
                   if (event.target.checked) {
                     if (isCurrentLifecycleInherit) {
-                      setLifecycle(
-                        omit(definition.effective_lifecycle, 'from') as IngestStreamLifecycle
-                      );
+                      setLifecycle(effectiveToIngestLifecycle(definition.effective_lifecycle));
                       setSelectedAction(initialSelectedAction);
                     }
                     setIsInheritToggleOn(true);
@@ -260,7 +268,18 @@ export function EditLifecycleModal({
               fill
               disabled={isSaveButtonDisabled}
               isLoading={updateInProgress}
-              onClick={() => updateLifecycle(isInheritToggleOn ? { inherit: {} } : lifecycle)}
+              onClick={() => {
+                if (isInheritToggleOn) {
+                  updateLifecycle({ inherit: {} });
+                  return;
+                }
+
+                if (isDisabledLifecycle(lifecycle) || isErrorLifecycle(lifecycle)) {
+                  return;
+                }
+
+                updateLifecycle(lifecycle);
+              }}
             >
               {i18n.translate('xpack.streams.streamDetailLifecycle.saveButton', {
                 defaultMessage: 'Save',


### PR DESCRIPTION
## Summary

In some cases we use the `effective_lifecycle` in place of the `ingest.lifecycle` property of the UpsertRequest. For wired streams this `effective_lifecycle` will carry an extra `from` property which is not valid as an input.


_Recording of the issue_

https://github.com/user-attachments/assets/039c934c-8f23-48f3-b0b1-d09e697afff8







<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->