### PR TITLE
[Discover] Prevent the histogram from continuing to fetch the results when the request is already aborted

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/histogram.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/histogram.tsx
@@ -110,19 +110,21 @@ export function Histogram({
         data-suggestion-type={visContext.suggestionType}
         css={chartCss}
       >
-        <lens.EmbeddableComponent
-          {...lensProps}
-          // forceDSL is set to true to ensure that the Lens always uses DSL to fetch the data
-          // as some consumers (discover) rely on the total hits count which is not provided by ESQL
-          forceDSL={true}
-          abortController={abortController}
-          disableTriggers={disableTriggers}
-          disabledActions={disabledActions}
-          onFilter={onFilter}
-          onBrushEnd={onBrushEnd}
-          withDefaultActions={withDefaultActions}
-          esqlVariables={esqlVariables}
-        />
+        {!abortController?.signal?.aborted && (
+          <lens.EmbeddableComponent
+            {...lensProps}
+            // forceDSL is set to true to ensure that the Lens always uses DSL to fetch the data
+            // as some consumers (discover) rely on the total hits count which is not provided by ESQL
+            forceDSL={true}
+            abortController={abortController}
+            disableTriggers={disableTriggers}
+            disabledActions={disabledActions}
+            onFilter={onFilter}
+            onBrushEnd={onBrushEnd}
+            withDefaultActions={withDefaultActions}
+            esqlVariables={esqlVariables}
+          />
+        )}
       </div>
       {timeRangeDisplay}
     </>


### PR DESCRIPTION
- Addresses https://github.com/elastic/kibana/issues/237759
- Addresses https://github.com/elastic/kibana/issues/226313 (excluding total hits issue)

## Summary

This PR makes sure that once the request is aborted, it does not try to render a histogram. It seems to have no visual difference to the Discover page as the whole view gets replaced by "No results" view.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



