### PR TITLE
[9.2] [scout] add euiToastWrapper and update streams_app tests (#236559)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/index.ts
+++ b/src/platform/packages/shared/kbn-scout/index.ts
@@ -53,3 +53,6 @@ export { mergeTests, test as playwrightTest } from 'playwright/test';
 export { measurePerformance, measurePerformanceAsync } from './src/common';
 
 export type { RoleApiCredentials } from './src/playwright/fixtures/scope/worker/api_key';
+
+// EUI wrappers
+export * from './src/playwright/eui_components';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/combo_box.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/combo_box.ts
@@ -20,6 +20,7 @@ export class EuiComboBoxWrapper {
   private readonly comboBoxMainInput: Locator;
   private readonly comboBoxSearchInput: Locator;
   private readonly comboBoxClearButton: Locator;
+  private readonly comboBoxSelectedOptions: Locator;
 
   /**
    * Create a new EuiComboBoxWrapper instance.
@@ -34,15 +35,14 @@ export class EuiComboBoxWrapper {
     this.comboBoxMainInput = this.comboBoxWrapper.locator(subj('comboBoxInput'));
     this.comboBoxSearchInput = this.comboBoxWrapper.locator(subj('comboBoxSearchInput'));
     this.comboBoxClearButton = this.comboBoxWrapper.locator(subj('comboBoxClearButton'));
+    this.comboBoxSelectedOptions = this.comboBoxMainInput.locator('.euiComboBoxPill');
   }
 
   async getSelectedMultiOptions(): Promise<string[]> {
     await this.comboBoxWrapper.waitFor({ state: 'attached' });
     await this.comboBoxMainInput.waitFor({ state: 'attached' });
 
-    const selectedOptions = await this.comboBoxMainInput
-      .locator('.euiComboBoxPill')
-      .allInnerTexts();
+    const selectedOptions = await this.comboBoxSelectedOptions.allInnerTexts();
     return selectedOptions;
   }
 
@@ -122,6 +122,13 @@ export class EuiComboBoxWrapper {
   }
 
   async clear() {
+    const inputValue = await this.getSelectedValue();
+    const inputPillsCount = await this.comboBoxSelectedOptions.count();
+    // multi-selection combobox input has no value, but only "pills", so we need to check both
+    if (inputValue === '' && inputPillsCount === 0) {
+      // no need to clean, it is empty
+      return;
+    }
     await this.comboBoxClearButton.click();
     await this.page.keyboard.press('Escape');
     // Wait for the input to be cleared with a timeout

--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/index.ts
@@ -11,5 +11,12 @@ import { EuiComboBoxWrapper } from './combo_box';
 import { EuiSelectableWrapper } from './selectable';
 import { EuiCheckBoxWrapper } from './check_box';
 import { EuiDataGridWrapper } from './data_grid';
+import { EuiToastWrapper } from './toast';
 
-export { EuiComboBoxWrapper, EuiSelectableWrapper, EuiCheckBoxWrapper, EuiDataGridWrapper };
+export {
+  EuiComboBoxWrapper,
+  EuiSelectableWrapper,
+  EuiCheckBoxWrapper,
+  EuiDataGridWrapper,
+  EuiToastWrapper,
+};

--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/toast.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/toast.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Locator } from '@playwright/test';
+import { expect } from '@playwright/test';
+import type { ScoutPage } from '../fixtures/scope/test/scout_page';
+import { resolveSelector, type SelectorInput } from '../utils';
+
+// https://eui.elastic.co/next/docs/display/toast/
+export class EuiToastWrapper {
+  private readonly toastWrapper: Locator;
+  private readonly toastHeaderTitle: Locator;
+  private readonly toastBody: Locator;
+  private readonly toastCloseButton: Locator;
+
+  /**
+   * Create a new EuiToastWrapper instance.
+   * new EuiToastWrapper(page, { dataTestSubj: 'myToast' })
+   * new EuiToastWrapper(page, 'myToast') // backward compatibility
+   * new EuiToastWrapper(page, { locator: 'role=alert[name="I am a toast"]' })
+   */
+  constructor(page: ScoutPage, selector: SelectorInput) {
+    this.toastWrapper = resolveSelector(page, selector);
+    this.toastHeaderTitle = this.toastWrapper.getByTestId('euiToastHeader__title');
+    this.toastBody = this.toastWrapper.getByTestId('euiToastBody');
+    this.toastCloseButton = this.toastWrapper.getByTestId('toastCloseButton');
+  }
+
+  async getCount(): Promise<number> {
+    return await this.toastWrapper.count();
+  }
+
+  getWrapper(): Locator {
+    return this.toastWrapper;
+  }
+
+  async getHeaderTitle(): Promise<string> {
+    return (await this.toastHeaderTitle.textContent()) || '';
+  }
+
+  async getBody(): Promise<string> {
+    const paragraphs = await this.toastBody.locator('p').all();
+    return (await Promise.all(paragraphs.map((p) => p.textContent()))).join('');
+  }
+
+  async close(): Promise<void> {
+    await this.toastCloseButton.click();
+  }
+
+  async closeAllToasts() {
+    // Get an array of all locators and loop through them
+    for (const button of await this.toastCloseButton.all()) {
+      await button.click();
+    }
+
+    await expect(this.toastCloseButton).toHaveCount(0);
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/index.ts
@@ -17,6 +17,7 @@ import { DiscoverApp } from './discover_app';
 import { FilterBar } from './fiter_bar';
 import { MapsPage } from './maps_page';
 import { RenderablePage } from './renderable_page';
+import { Toasts } from './toasts';
 import { createLazyPageObject } from './utils';
 
 export interface PageObjectsFixtures {
@@ -33,6 +34,7 @@ export interface PageObjects {
   maps: MapsPage;
   renderable: RenderablePage;
   collapsibleNav: CollapsibleNav;
+  toasts: Toasts;
 }
 
 /**
@@ -50,6 +52,7 @@ export function createCorePageObjects(fixtures: PageObjectsFixtures): PageObject
     maps: createLazyPageObject(MapsPage, fixtures.page),
     renderable: createLazyPageObject(RenderablePage, fixtures.page),
     collapsibleNav: createLazyPageObject(CollapsibleNav, fixtures.page, fixtures.config),
+    toasts: createLazyPageObject(Toasts, fixtures.page),
     // Add new page objects here
   };
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/toasts.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/toasts.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiToastWrapper } from '../eui_components';
+import type { ScoutPage } from '../fixtures/scope/test';
+
+export class Toasts {
+  private readonly toast: EuiToastWrapper;
+  constructor(private readonly page: ScoutPage) {
+    this.toast = new EuiToastWrapper(this.page, {
+      locator: '.euiToast',
+    });
+  }
+
+  async waitFor() {
+    await this.toast.getWrapper().waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  async getHeaderText() {
+    return await this.toast.getHeaderTitle();
+  }
+
+  async getMessageText() {
+    return await this.toast.getBody();
+  }
+
+  async closeAll() {
+    await this.waitFor();
+    await this.toast.closeAllToasts();
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/test/scout/fixtures/eui_helpers.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/fixtures/eui_helpers.ts
@@ -10,23 +10,40 @@
 import fs from 'fs';
 import path from 'path';
 import { REPO_ROOT } from '@kbn/repo-info';
+import type { ScoutLogger } from '../../../src/common';
 import type { ScoutPage } from '../../../src/playwright';
 
 const getEuiVersion = () => {
   const packageJsonPath = path.join(REPO_ROOT, 'package.json');
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
-  return packageJson.dependencies['@elastic/eui'];
+  const rawVersion = packageJson.dependencies['@elastic/eui'];
+  // Remove semver prefixes like ^, ~, >=, etc. to get clean version number
+  const cleanVersion = rawVersion.replace(/^[\^~>=<]*/, '');
+  return cleanVersion;
 };
 
 export const getEuiBaseUrlWithVersion = () => {
   const currentVersion = getEuiVersion();
-  return `https://eui.elastic.co/v${currentVersion}`;
+  // Basic validation - package.json should have valid version
+  if (!currentVersion) {
+    throw new Error('EUI version not found in package.json');
+  }
+  const baseUrl = `https://eui.elastic.co/v${currentVersion}/`;
+  return baseUrl;
 };
 
-export const navigateToEuiTestPage = async (page: ScoutPage, route: string) => {
+export const navigateToEuiTestPage = async (page: ScoutPage, route: string, log: ScoutLogger) => {
   const euiBaseUrl = getEuiBaseUrlWithVersion();
   const url = new URL(route, euiBaseUrl).toString();
+
+  // Validate that version is preserved in the final URL
+  const versionMatch = url.match(/\/v(\d+\.\d+\.\d+)\//);
+  if (!versionMatch) {
+    throw new Error(`Version not found in constructed URL: ${url}`);
+  }
+
+  log.info(`Navigating to EUI test page: ${url}`);
   await page.goto(url);
   const acceptButton = page.getByRole('button', { name: 'Accept' });
   if (await acceptButton.isVisible({ timeout: 2500 })) {

--- a/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/check_box.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/check_box.spec.ts
@@ -16,7 +16,7 @@ import { EuiCheckBoxWrapper } from '../../../../src/playwright/eui_components';
 import { navigateToEuiTestPage } from '../../fixtures/eui_helpers';
 
 test.describe('EUI testing wrapper: EuiCheckBox', { tag: ['@svlSecurity', '@ess'] }, () => {
-  test(`checkbox`, async ({ page }) => {
+  test(`checkbox`, async ({ page, log }) => {
     const selector = {
       locator:
         'xpath=(//div[contains(@class, "euiCheckbox") and div[contains(@class, "euiCheckbox__square")]])[1]',
@@ -24,7 +24,8 @@ test.describe('EUI testing wrapper: EuiCheckBox', { tag: ['@svlSecurity', '@ess'
 
     await navigateToEuiTestPage(
       page,
-      'docs/components/forms/selection/checkbox-and-checkbox-group/#checkbox'
+      'docs/components/forms/selection/checkbox-and-checkbox-group/#checkbox',
+      log
     );
 
     await test.step('should be checked', async () => {

--- a/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/combo_box.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/combo_box.spec.ts
@@ -12,9 +12,9 @@ import { EuiComboBoxWrapper } from '../../../../src/playwright/eui_components';
 import { navigateToEuiTestPage } from '../../fixtures/eui_helpers';
 
 test.describe('EUI testing wrapper: EuiComboBox', { tag: ['@svlSecurity', '@ess'] }, () => {
-  test(`with multiple selections (pills)`, async ({ page }) => {
+  test(`with multiple selections (pills)`, async ({ page, log }) => {
     const dataTestSubj = 'demoComboBox';
-    await navigateToEuiTestPage(page, 'docs/components/forms/selection/combo-box/');
+    await navigateToEuiTestPage(page, 'docs/components/forms/selection/combo-box/', log);
 
     await test.step('read selected options', async () => {
       const comboBox = new EuiComboBoxWrapper(page, dataTestSubj);
@@ -57,7 +57,7 @@ test.describe('EUI testing wrapper: EuiComboBox', { tag: ['@svlSecurity', '@ess'
     });
   });
 
-  test(`with the single selection`, async ({ page }) => {
+  test(`with the single selection`, async ({ page, log }) => {
     // Selects the first .euiComboBox after the heading ID #single-selection-with-custom-options
     const selector = {
       locator:
@@ -65,7 +65,8 @@ test.describe('EUI testing wrapper: EuiComboBox', { tag: ['@svlSecurity', '@ess'
     };
     await navigateToEuiTestPage(
       page,
-      'docs/components/forms/selection/combo-box/#single-selection-with-custom-options'
+      'docs/components/forms/selection/combo-box/#single-selection-with-custom-options',
+      log
     );
 
     await test.step('should select option from dropdown', async () => {

--- a/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/data_grid.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/data_grid.spec.ts
@@ -12,11 +12,11 @@ import { EuiDataGridWrapper } from '../../../../src/playwright/eui_components';
 import { navigateToEuiTestPage } from '../../fixtures/eui_helpers';
 
 test.describe('EUI testing wrapper: EuiDataGrid', { tag: ['@svlSecurity', '@ess'] }, () => {
-  test(`data grid, run`, async ({ page }) => {
+  test(`data grid, run`, async ({ page, log }) => {
     const selector = {
       locator: '.euiDataGrid',
     };
-    await navigateToEuiTestPage(page, 'docs/components/data-grid/#core-concepts');
+    await navigateToEuiTestPage(page, 'docs/components/data-grid/#core-concepts', log);
 
     await test.step('should return column names', async () => {
       const dataGrid = new EuiDataGridWrapper(page, selector);

--- a/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/selectable.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/selectable.spec.ts
@@ -12,11 +12,15 @@ import { EuiSelectableWrapper } from '../../../../src/playwright/eui_components'
 import { navigateToEuiTestPage } from '../../fixtures/eui_helpers';
 
 test.describe('EUI testing wrapper: EuiSelectable', { tag: ['@svlSecurity', '@ess'] }, () => {
-  test(`selectable with search field`, async ({ page }) => {
+  test(`selectable with search field`, async ({ page, log }) => {
     const selector = {
       locator: 'xpath=//h2[@id="searchable"]/following::div[contains(@class, "euiSelectable")][1]',
     };
-    await navigateToEuiTestPage(page, 'docs/components/forms/selection/selectable/#searchable');
+    await navigateToEuiTestPage(
+      page,
+      'docs/components/forms/selection/selectable/#searchable',
+      log
+    );
 
     await test.step('read selected options', async () => {
       const selectable = new EuiSelectableWrapper(page, selector);

--- a/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/toast.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/tests/eui_wrappers/toast.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { test, expect } from '../../../../src/playwright';
+import { EuiToastWrapper } from '../../../../src/playwright/eui_components';
+import { navigateToEuiTestPage } from '../../fixtures/eui_helpers';
+
+test.describe('EUI testing wrapper: EuiToast', { tag: ['@svlSecurity', '@ess'] }, () => {
+  test(`toast`, async ({ page, log }) => {
+    const selector = {
+      locator: '.euiToast[type="info"]',
+    };
+    await navigateToEuiTestPage(page, 'docs/components/display/toast/#info', log);
+
+    await test.step('should read header title and body', async () => {
+      const toast = new EuiToastWrapper(page, selector);
+      expect(await toast.getHeaderTitle()).toBe('Icons should be rare');
+      expect(await toast.getBody()).toBe(
+        'Icons should be used rarely. They are good for warnings, but when paired with long titles they look out of place.'
+      );
+    });
+
+    await test.step('should close', async () => {
+      const toast = new EuiToastWrapper(page, selector);
+      await toast.close();
+      // way to verify the toast is closed, we just check the action
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -9,11 +9,23 @@
 
 import type { ScoutPage } from '@kbn/scout';
 import { expect } from '@kbn/scout';
+import { EuiComboBoxWrapper } from '@kbn/scout';
 import type { ProcessorType } from '@kbn/streamlang';
 import type { FieldTypeOption } from '../../../../../public/components/data_management/schema_editor/constants';
 
 export class StreamsApp {
-  constructor(private readonly page: ScoutPage) {}
+  public readonly processorFieldComboBox;
+  public readonly conditionEditorFieldComboBox;
+  constructor(private readonly page: ScoutPage) {
+    this.processorFieldComboBox = new EuiComboBoxWrapper(
+      this.page,
+      'streamsAppProcessorFieldSelectorComboFieldText'
+    );
+    this.conditionEditorFieldComboBox = new EuiComboBoxWrapper(
+      this.page,
+      'streamsAppConditionEditorFieldText'
+    );
+  }
 
   async goto() {
     await this.page.gotoApp('streams');
@@ -167,7 +179,7 @@ export class StreamsApp {
     operator?: string;
   }) {
     if (field) {
-      await this.fillConditionFieldInput(field);
+      await this.conditionEditorFieldComboBox.setCustomSingleOption(field);
     }
     if (value) {
       await this.page.getByTestId('streamsAppConditionEditorValueText').fill(value);
@@ -259,11 +271,6 @@ export class StreamsApp {
 
   async expectPreviewPanelVisible() {
     await expect(this.page.getByTestId('routingPreviewPanelWithResults')).toBeVisible();
-  }
-
-  async expectToastVisible() {
-    // Check if at least one element appears and is visible.
-    await expect(this.page.getByTestId('toastCloseButton').first()).toBeVisible();
   }
 
   async saveRuleOrder() {
@@ -398,25 +405,12 @@ export class StreamsApp {
     await this.page.getByRole('dialog').getByRole('option').getByText(value).click();
   }
 
-  async fillProcessorFieldInput(value: string) {
-    await this.fillFieldInput('streamsAppProcessorFieldSelectorComboFieldText', value);
-  }
-
-  async fillConditionFieldInput(value: string) {
-    await this.fillFieldInput('streamsAppConditionEditorFieldText', value);
-  }
-
-  // Utility function to fill eui combobox inputs
-  async fillFieldInput(dataTestSubj: string, value: string) {
-    const comboBoxInput = this.page.getByTestId(dataTestSubj);
-    await comboBoxInput.click();
-    // Clear the combo box input
-    // We need the below check for headed tests on MacOS to work around a Playwright issue
-    await this.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
-    await this.page.keyboard.press('Backspace');
-
-    // Now type new stuff
-    await comboBoxInput.pressSequentially(value, { delay: 50 });
+  async fillProcessorFieldInput(value: string, options?: { isCustomValue: boolean }) {
+    const isCustomValue = options?.isCustomValue || false;
+    if (isCustomValue) {
+      return await this.processorFieldComboBox.setCustomSingleOption(value);
+    }
+    await this.processorFieldComboBox.selectSingleOption(value);
   }
 
   async fillGrokPatternInput(value: string) {
@@ -441,7 +435,7 @@ export class StreamsApp {
   }
 
   async fillCondition(field: string, operator: string, value: string) {
-    await this.fillConditionFieldInput(field);
+    await this.conditionEditorFieldComboBox.setCustomSingleOption(field);
     await this.page.getByTestId('streamsAppConditionEditorOperator').selectOption(operator);
     await this.page.getByTestId('streamsAppConditionEditorValueText').fill(value);
   }
@@ -455,28 +449,36 @@ export class StreamsApp {
     await this.page.getByRole('button', { name: 'Save changes' }).click();
   }
 
-  async getProcessorsListItems() {
+  private async getStepListItems(testId: string, expectItems: boolean = true) {
+    const timeout = expectItems ? 15_000 : 2_000;
+
     try {
       await expect(this.page.getByTestId('streamsAppStreamDetailEnrichmentRootSteps')).toBeVisible({
-        timeout: 15_000,
+        timeout,
       });
     } catch {
       // If the list is not visible, it might be empty or not rendered yet
       return [];
     }
-    return this.page.getByTestId('streamsAppProcessorBlock').all();
+    return this.page.getByTestId(testId).all();
   }
 
-  async getConditionsListItems() {
-    try {
-      await expect(this.page.getByTestId('streamsAppStreamDetailEnrichmentRootSteps')).toBeVisible({
-        timeout: 15_000,
-      });
-    } catch {
-      // If the list is not visible, it might be empty or not rendered yet
-      return [];
-    }
-    return this.page.getByTestId('streamsAppConditionBlock').all();
+  async getProcessorsListItems(expectProcessors: boolean = true) {
+    return this.getStepListItems('streamsAppProcessorBlock', expectProcessors);
+  }
+
+  async getProcessorsListItemsFast() {
+    // Fast method for when no processors are expected - uses minimal timeout
+    return this.getProcessorsListItems(false);
+  }
+
+  async getConditionsListItems(expectConditions: boolean = true) {
+    return this.getStepListItems('streamsAppConditionBlock', expectConditions);
+  }
+
+  async getConditionsListItemsFast() {
+    // Fast method for when no conditions are expected - uses minimal timeout
+    return this.getConditionsListItems(false);
   }
 
   async expectProcessorsOrder(expectedOrder: string[]) {
@@ -623,18 +625,6 @@ export class StreamsApp {
   /**
    * Share utility methods
    */
-  async closeToasts() {
-    await this.expectToastVisible();
-    // Check if at least one element appears and is visible.
-
-    // Get an array of all locators and loop through them
-    const allCloseButtons = this.page.getByTestId('toastCloseButton');
-    for (const button of await allCloseButtons.all()) {
-      await button.click();
-    }
-
-    await expect(this.page.getByTestId('toastCloseButton')).toHaveCount(0);
-  }
 
   async closeFlyout() {
     await this.page.getByTestId('euiFlyoutCloseButton').click();

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping.spec.ts
@@ -196,7 +196,7 @@ test.describe('Stream data mapping - schema editor', { tag: ['@ess', '@svlOblt']
 
     await pageObjects.streams.reviewStagedFieldMappingChanges();
     await pageObjects.streams.submitSchemaChanges();
-    await pageObjects.streams.closeToasts();
+    await pageObjects.toasts.closeAll();
 
     // Verify the field is now mapped
     await pageObjects.streams.expectCellValueContains({
@@ -258,7 +258,7 @@ test.describe('Stream data mapping - schema editor', { tag: ['@ess', '@svlOblt']
     await pageObjects.streams.reviewStagedFieldMappingChanges();
     await pageObjects.streams.submitSchemaChanges();
 
-    await pageObjects.streams.closeToasts();
+    await pageObjects.toasts.closeAll();
     await pageObjects.streams.expectSchemaEditorTableVisible();
     // Search for the newly added field
     await pageObjects.streams.searchFields(fieldName);

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
@@ -108,7 +108,7 @@ test.describe('Stream data processing - creating steps', { tag: ['@ess', '@svlOb
     await expect(page.getByRole('button', { name: 'Save changes' })).toBeEnabled();
   });
 
-  test('should cancel creating a new processor', async ({ page, pageObjects }) => {
+  test('should cancel creating a new processor', async ({ pageObjects }) => {
     await pageObjects.streams.clickAddProcessor();
 
     // Fill in some data
@@ -120,7 +120,7 @@ test.describe('Stream data processing - creating steps', { tag: ['@ess', '@svlOb
     await pageObjects.streams.confirmDiscardInModal();
 
     // Verify we're back to idle state
-    expect(await pageObjects.streams.getProcessorsListItems()).toHaveLength(0);
+    expect(await pageObjects.streams.getProcessorsListItemsFast()).toHaveLength(0);
   });
 
   test('should show validation errors for invalid processors configuration', async ({
@@ -129,7 +129,7 @@ test.describe('Stream data processing - creating steps', { tag: ['@ess', '@svlOb
   }) => {
     await pageObjects.streams.clickAddProcessor();
     // Field can be automatically filled based on the samples, empty it.
-    await pageObjects.streams.fillProcessorFieldInput('');
+    await pageObjects.streams.processorFieldComboBox.clear();
 
     await pageObjects.streams.fillProcessorFieldInput('message');
     await pageObjects.streams.clickSaveProcessor();

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/edit_steps.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/edit_steps.spec.ts
@@ -90,7 +90,7 @@ test.describe('Stream data processing - editing steps', { tag: ['@ess', '@svlObl
     // Confirm deletion in modal
     await pageObjects.streams.confirmDeleteInModal();
 
-    expect(await pageObjects.streams.getProcessorsListItems()).toHaveLength(0);
+    expect(await pageObjects.streams.getProcessorsListItemsFast()).toHaveLength(0);
     await expect(page.getByTestId('fullText')).toBeHidden();
   });
 

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/error_handling.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/error_handling.spec.ts
@@ -50,9 +50,11 @@ test.describe(
       await pageObjects.streams.confirmChangesInReviewModal();
 
       // Should show error and stay in creating state
-      await pageObjects.streams.expectToastVisible();
-      await expect(page.getByText("An issue occurred saving processors' changes")).toBeVisible();
-      await pageObjects.streams.closeToasts();
+      await pageObjects.toasts.waitFor();
+      expect(await pageObjects.toasts.getHeaderText()).toBe(
+        "An issue occurred saving processors' changes."
+      );
+      await pageObjects.toasts.closeAll();
 
       // Restore network and retry
       await page.route('**/streams/**/_ingest', async (route) => {
@@ -74,9 +76,10 @@ test.describe(
       await pageObjects.streams.fillProcessorFieldInput('message');
       await pageObjects.streams.fillGrokPatternInput('%{WORD:attributes.method}');
       await pageObjects.streams.clickSaveProcessor();
+
       await pageObjects.streams.saveStepsListChanges();
       await pageObjects.streams.confirmChangesInReviewModal();
-      await pageObjects.streams.closeToasts();
+      await pageObjects.toasts.closeAll();
 
       // Edit the processor
       await pageObjects.streams.clickEditProcessor(0);
@@ -92,9 +95,11 @@ test.describe(
       await pageObjects.streams.saveStepsListChanges();
 
       // Should show error and return to editing state
-      await pageObjects.streams.expectToastVisible();
-      await expect(page.getByText("An issue occurred saving processors' changes")).toBeVisible();
-      await pageObjects.streams.closeToasts();
+      await pageObjects.toasts.waitFor();
+      expect(await pageObjects.toasts.getHeaderText()).toBe(
+        "An issue occurred saving processors' changes."
+      );
+      await pageObjects.toasts.closeAll();
 
       // Restore network and retry
       await page.route('**/streams/**/_ingest', async (route) => {
@@ -103,8 +108,8 @@ test.describe(
       await pageObjects.streams.saveStepsListChanges();
 
       // Should succeed
-      await pageObjects.streams.expectToastVisible();
-      await expect(page.getByText("Stream's processors updated")).toBeVisible();
+      await pageObjects.toasts.waitFor();
+      expect(await pageObjects.toasts.getHeaderText()).toBe("Stream's processors updated");
     });
   }
 );

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/processing_simulation_preview.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/processing_simulation_preview.spec.ts
@@ -149,7 +149,7 @@ test.describe('Stream data processing - simulation preview', { tag: ['@ess', '@s
 
     await pageObjects.streams.clickAddProcessor();
     await pageObjects.streams.selectProcessorType('set');
-    await pageObjects.streams.fillProcessorFieldInput('custom_threshold');
+    await pageObjects.streams.fillProcessorFieldInput('custom_threshold', { isCustomValue: true });
     await page.locator('input[name="value"]').fill('1024');
     await pageObjects.streams.clickSaveProcessor();
 

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/data_retention.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/data_retention.spec.ts
@@ -48,7 +48,6 @@ test.describe(
       await page.getByTestId('streamsAppDslModalDaysField').fill('7');
       await page.getByRole('button', { name: 'Save' }).click();
       await expect(page.getByTestId('retention-metric').getByText('7 days')).toBeVisible();
-      await pageObjects.streams.closeToasts();
     });
 
     test('should reset a stream data retention policy successfully', async ({
@@ -65,7 +64,7 @@ test.describe(
       await page.getByTestId('streamsAppDslModalDaysField').fill('7');
       await page.getByRole('button', { name: 'Save' }).click();
       await expect(page.getByTestId('retention-metric').getByText('7 days')).toBeVisible();
-      await pageObjects.streams.closeToasts();
+      await pageObjects.toasts.closeAll();
 
       // Reset the retention policy
       await page.getByTestId('streamsAppRetentionMetadataEditDataRetentionButton').click();
@@ -76,7 +75,6 @@ test.describe(
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(page.getByTestId('retention-metric').getByText('∞')).toBeVisible();
-      await pageObjects.streams.closeToasts();
     });
   }
 );

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/failure_store.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/failure_store.spec.ts
@@ -65,7 +65,6 @@ test.describe(
           .getByTestId('failureStoreRetention-metric-subtitle')
           .getByText('Custom retention period')
       ).toBeVisible();
-      await pageObjects.streams.closeToasts();
     });
 
     test('should disable failure store for classic streams', async ({ page, pageObjects }) => {
@@ -78,7 +77,6 @@ test.describe(
       await expect(
         page.getByTestId('disabledFailureStorePanel').getByText('Failure store disabled')
       ).toBeVisible();
-      await pageObjects.streams.closeToasts();
     });
 
     test('should enable failure store for classic streams', async ({ page, pageObjects }) => {
@@ -96,7 +94,6 @@ test.describe(
           .getByTestId('failureStoreRetention-metric-subtitle')
           .getByText('Default retention period')
       ).toBeVisible();
-      await pageObjects.streams.closeToasts();
     });
 
     test('should not allow edit failure store for wired streams', async ({

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/create_routing_rules.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/create_routing_rules.spec.ts
@@ -88,7 +88,7 @@ test.describe('Stream data routing - creating routing rules', { tag: ['@ess', '@
       await pageObjects.streams.saveRoutingRule();
 
       // Wait for the error toast to appear
-      await pageObjects.streams.expectToastVisible();
+      await pageObjects.toasts.waitFor();
 
       // Should stay in creating state due to validation error
       await expect(page.getByTestId('streamsAppRoutingStreamEntryNameField')).toBeVisible();

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/edit_routing_rules.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/edit_routing_rules.spec.ts
@@ -91,7 +91,7 @@ test.describe('Stream data routing - editing routing rules', { tag: ['@ess', '@s
     await pageObjects.streams.confirmStreamDeleteInModal('logs.edit-test');
 
     await pageObjects.streams.expectRoutingRuleHidden('logs.edit-test');
-    await pageObjects.streams.expectToastVisible();
+    await pageObjects.toasts.waitFor();
   });
 
   test('should cancel rule removal', async ({ page, pageObjects }) => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/error_handling.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/error_handling.spec.ts
@@ -16,7 +16,7 @@ test.describe(
       await apiServices.streams.enable();
     });
 
-    test.beforeEach(async ({ apiServices, browserAuth, pageObjects }) => {
+    test.beforeEach(async ({ browserAuth, pageObjects }) => {
       await browserAuth.loginAsAdmin();
       await pageObjects.streams.gotoPartitioningTab('logs');
     });
@@ -41,9 +41,9 @@ test.describe(
       await pageObjects.streams.saveRoutingRule();
 
       // Should show error and stay in creating state
-      await pageObjects.streams.expectToastVisible();
-      await expect(page.getByTestId('errorToastMessage')).toContainText('Failed to fetch');
-      await pageObjects.streams.closeToasts();
+      await pageObjects.toasts.waitFor();
+      expect(await pageObjects.toasts.getMessageText()).toBe('Failed to fetch');
+      await pageObjects.toasts.closeAll();
       await expect(page.getByTestId('streamsAppRoutingStreamEntryNameField')).toBeVisible();
 
       // Restore network and retry
@@ -63,7 +63,7 @@ test.describe(
       await pageObjects.streams.clickCreateRoutingRule();
       await pageObjects.streams.fillRoutingRuleName('logs.error-test');
       await pageObjects.streams.saveRoutingRule();
-      await pageObjects.streams.closeToasts();
+      await pageObjects.toasts.closeAll();
 
       // Edit the rule
       await pageObjects.streams.clickEditRoutingRule('logs.error-test');
@@ -74,17 +74,17 @@ test.describe(
       await pageObjects.streams.updateRoutingRule();
 
       // Should show error and return to editing state
-      await pageObjects.streams.expectToastVisible();
-      await expect(page.getByTestId('errorToastMessage')).toContainText('Failed to fetch');
-      await pageObjects.streams.closeToasts();
+      await pageObjects.toasts.waitFor();
+      expect(await pageObjects.toasts.getMessageText()).toBe('Failed to fetch');
+      await pageObjects.toasts.closeAll();
 
       // Restore network and retry
       await context.setOffline(false);
       await pageObjects.streams.updateRoutingRule();
 
       // Should succeed
-      await pageObjects.streams.expectToastVisible();
-      await expect(page.getByText('Stream saved')).toBeVisible();
+      await pageObjects.toasts.waitFor();
+      expect(await pageObjects.toasts.getHeaderText()).toBe('Stream saved');
     });
   }
 );

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/reorder_routing_rules.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/reorder_routing_rules.spec.ts
@@ -46,7 +46,7 @@ test.describe(
       await pageObjects.streams.dragRoutingRule('logs.first', 2);
 
       await pageObjects.streams.saveRuleOrder();
-      await pageObjects.streams.expectToastVisible();
+      await pageObjects.toasts.waitFor();
 
       await pageObjects.streams.expectRoutingOrder(['logs.second', 'logs.third', 'logs.first']);
     });
@@ -72,7 +72,7 @@ test.describe(
 
       // Save all changes
       await pageObjects.streams.saveRuleOrder();
-      await pageObjects.streams.expectToastVisible();
+      await pageObjects.toasts.waitFor();
 
       await pageObjects.streams.expectRoutingOrder(['logs.third', 'logs.second', 'logs.first']);
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[scout] add euiToastWrapper and update streams_app tests (#236559)](https://github.com/elastic/kibana/pull/236559)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-10-06T13:54:58Z","message":"[scout] add euiToastWrapper and update streams_app tests (#236559)\n\n## Summary\n\nThis PR exposes Scout wrappers for EUI components (similar to FTR UI\nservices), that can be used in page objects to avoid repeatable logic\nfor the most common elements like comboBox, selectable, dataGrid, toast,\netc.\n\nThis PR also update `stream_app` tests to use few of those wrappers with\nfew tweaks to speedup overall test execution.\n\nThis PR:\n```\n2 skipped\n66 passed (7.9m)\n```\n\nMain\n```\n2 skipped\n66 passed (8.5m)\n```","sha":"771d592f57cac4faeec62beda110b225918019c1","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","test:scout","v9.2.0","v9.3.0","v9.1.6","v8.19.6"],"title":"[scout] add euiToastWrapper and update streams_app tests","number":236559,"url":"https://github.com/elastic/kibana/pull/236559","mergeCommit":{"message":"[scout] add euiToastWrapper and update streams_app tests (#236559)\n\n## Summary\n\nThis PR exposes Scout wrappers for EUI components (similar to FTR UI\nservices), that can be used in page objects to avoid repeatable logic\nfor the most common elements like comboBox, selectable, dataGrid, toast,\netc.\n\nThis PR also update `stream_app` tests to use few of those wrappers with\nfew tweaks to speedup overall test execution.\n\nThis PR:\n```\n2 skipped\n66 passed (7.9m)\n```\n\nMain\n```\n2 skipped\n66 passed (8.5m)\n```","sha":"771d592f57cac4faeec62beda110b225918019c1"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.1","8.19"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236559","number":236559,"mergeCommit":{"message":"[scout] add euiToastWrapper and update streams_app tests (#236559)\n\n## Summary\n\nThis PR exposes Scout wrappers for EUI components (similar to FTR UI\nservices), that can be used in page objects to avoid repeatable logic\nfor the most common elements like comboBox, selectable, dataGrid, toast,\netc.\n\nThis PR also update `stream_app` tests to use few of those wrappers with\nfew tweaks to speedup overall test execution.\n\nThis PR:\n```\n2 skipped\n66 passed (7.9m)\n```\n\nMain\n```\n2 skipped\n66 passed (8.5m)\n```","sha":"771d592f57cac4faeec62beda110b225918019c1"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->