### PR TITLE
[Background search] Disable Background search as default setting

### DIFF
--- a/src/platform/plugins/shared/data/server/config.ts
+++ b/src/platform/plugins/shared/data/server/config.ts
@@ -14,7 +14,7 @@ export const searchSessionsConfigSchema = schema.object({
   /**
    * Turns the feature on \ off (incl. removing indicator and management screens)
    */
-  enabled: schema.boolean({ defaultValue: true }),
+  enabled: schema.boolean({ defaultValue: false }),
 
   /**
    * notTouchedTimeout controls how long user can save a session after all searches completed.

--- a/x-pack/platform/test/api_integration/apis/search/config.ts
+++ b/x-pack/platform/test/api_integration/apis/search/config.ts
@@ -15,7 +15,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     testFiles: [require.resolve('.')],
     kbnTestServer: {
       ...baseIntegrationTestsConfig.get('kbnTestServer'),
-      serverArgs: [...baseIntegrationTestsConfig.get('kbnTestServer.serverArgs')],
+      serverArgs: [
+        ...baseIntegrationTestsConfig.get('kbnTestServer.serverArgs'),
+        '--data.search.sessions.enabled=true',
+      ],
     },
   };
 }

--- a/x-pack/platform/test/functional/apps/management/feature_controls/management_security.ts
+++ b/x-pack/platform/test/functional/apps/management/feature_controls/management_security.ts
@@ -86,7 +86,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           'filesManagement',
           'objects',
           'tags',
-          'search_sessions',
           'spaces',
           'settings',
         ]);


### PR DESCRIPTION
## Summary

To enable Background search , which was enabled in https://github.com/elastic/kibana/pull/236818 the addition of 

`data.search.sessions.enabled: true`

is now required to enable the background search experience.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->