### PR TITLE
fix: Add sync check for saved objects for trained models.

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -229,6 +229,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
       let inferenceToModelIdMap = state.inferenceToModelIdMap;
       setIsUpdatingMappings(true);
       try {
+        await ml?.mlApi?.savedObjects.syncSavedObjects();
         if (isSemanticTextEnabled && hasMLPermissions && hasSemanticText && !forceSaveMappings) {
           inferenceToModelIdMap = await fetchInferenceToModelIdMap();
         }
@@ -388,6 +389,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
   const errorSavingMappings = saveMappingError && (
     <EuiFlexItem grow={false}>
       <EuiCallOut
+        announceOnMount
         color="danger"
         data-test-subj="indexDetailsSaveMappingsError"
         iconType="error"

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
@@ -49,6 +49,7 @@ export function TrainedModelsDeploymentModal({
   forceSaveMappings,
   saveMappings,
   saveMappingsLoading,
+  setErrorsInTrainedModelDeployment,
 }: TrainedModelsDeploymentModalProps) {
   const modalTitleId = useGeneratedHtmlId();
   const { fields, inferenceToModelIdMap } = useMappingsState();

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
@@ -49,7 +49,6 @@ export function TrainedModelsDeploymentModal({
   forceSaveMappings,
   saveMappings,
   saveMappingsLoading,
-  setErrorsInTrainedModelDeployment,
 }: TrainedModelsDeploymentModalProps) {
   const modalTitleId = useGeneratedHtmlId();
   const { fields, inferenceToModelIdMap } = useMappingsState();
@@ -173,6 +172,7 @@ export function TrainedModelsDeploymentModal({
         </ul>
         <EuiSpacer />
         <EuiCallOut
+          announceOnMount
           iconType="warning"
           color="warning"
           title={i18n.translate(
@@ -208,7 +208,15 @@ export function TrainedModelsDeploymentModal({
       <EuiModalFooter>
         <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={closeModal}>
+            <EuiButtonEmpty
+              onClick={closeModal}
+              aria-label={i18n.translate(
+                'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.cancelButtonAriaLabel',
+                {
+                  defaultMessage: 'Cancel and close modal',
+                }
+              )}
+            >
               {i18n.translate(
                 'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.cancelButtonLabel',
                 {


### PR DESCRIPTION
## Summary

While a model is deploying we prevent user to use an infenence endpoint in mappings editor with a modal. The modal either asks for a force writing (which would end up working eventually) or there is a try again button if user wants to wait.

The try again button wouldn't work because the status of the models are checked and synced to the Saved Objects only when Trained Models page is visited or refresh button is pressed.

This commit adds sync call to the try again button so we are certain that we get the latest data from the Saved Object.




Before:

https://github.com/user-attachments/assets/aac31225-7708-4d6b-85a2-5a3cd5ceace8

After:

https://github.com/user-attachments/assets/bea62bad-6cca-4b56-a771-f17b72780195




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


## Release note
Index management mappings editor now syncs model deployment status correctly. This fixes a case where user couldn't save `semantic_text` fields during deployment without forcing.


<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->