### PR TITLE
[Streams] Fix delete step button enabled state

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/stream_enrichment_state_machine.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/stream_enrichment_state_machine.ts
@@ -474,6 +474,7 @@ export const streamEnrichmentMachine = setup({
                     },
                     'step.delete': {
                       target: 'idle',
+                      guard: 'hasManagePrivileges',
                       actions: [
                         stopChild(({ event }) => event.id),
                         { type: 'deleteStep', params: ({ event }) => event },
@@ -504,6 +505,7 @@ export const streamEnrichmentMachine = setup({
                     },
                     'step.delete': {
                       target: 'idle',
+                      guard: 'hasManagePrivileges',
                       actions: [
                         stopChild(({ event }) => event.id),
                         { type: 'deleteStep', params: ({ event }) => event },
@@ -527,6 +529,7 @@ export const streamEnrichmentMachine = setup({
                     'step.cancel': 'idle',
                     'step.delete': {
                       target: 'idle',
+                      guard: 'hasManagePrivileges',
                       actions: [
                         stopChild(({ event }) => event.id),
                         { type: 'deleteStep', params: ({ event }) => event },

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/context_menu.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/context_menu.tsx
@@ -73,9 +73,9 @@ export const StepContextMenu: React.FC<StepContextMenuProps> = ({
       snapshot.can({ type: 'step.reorder', stepId: stepRef.id, direction: 'up' }) ||
       snapshot.can({ type: 'step.reorder', stepId: stepRef.id, direction: 'down' })
   );
-  const canDelete = useSelector(stepRef, (snapshot) => {
-    return snapshot.can({ type: 'step.delete' });
-  });
+  const canDelete = useStreamEnrichmentSelector((snapshot) =>
+    snapshot.can({ type: 'step.delete', id: stepRef.id })
+  );
 
   const stepRefs = useStreamEnrichmentSelector((snapshot) => snapshot.context.stepRefs);
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/237453.

The button should not be enabled unless `manage` permissions are available.

It would be nice to cascade some of these guards to the individual step state machines too, but it means passing the definition down etc, so this just uses the main state machine same as the other permission checks.

(We may also just want to put this behind a `hasSimulatePrivileges` guard, the same as many other events, which would let the step be deleted and simulated, and the save button would still be behind the `manage` permissions check).

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->