### PR TITLE
[Metrics][Discover] Fix date range losing sync 

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/types.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/types.ts
@@ -8,7 +8,7 @@
  */
 
 import type React from 'react';
-import type { AggregateQuery, Query } from '@kbn/es-query';
+import type { AggregateQuery, Query, TimeRange } from '@kbn/es-query';
 import type { IUiSettingsClient, Capabilities } from '@kbn/core/public';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
@@ -253,6 +253,10 @@ export interface ChartSectionProps {
    * Controls whether or not the chart is visible (used for Show and Hide toggle)
    */
   isComponentVisible: boolean;
+  /**
+   * The current time range
+   */
+  timeRange?: TimeRange;
 }
 /**
  * Supports customizing the chart (UnifiedHistogram) section in Discover

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.tsx
@@ -49,12 +49,13 @@ export const MetricsExperienceGrid = ({
   isChartLoading: isDiscoverLoading,
   isComponentVisible,
   abortController,
+  timeRange,
 }: ChartSectionProps) => {
   const euiThemeContext = useEuiTheme();
   const { euiTheme } = euiThemeContext;
 
   const { currentPage, dimensions, valueFilters, onPageChange, searchTerm } = useMetricsGridState();
-  const { getTimeRange, updateTimeRange } = requestParams;
+  const { updateTimeRange } = requestParams;
 
   const input$ = useMemo(
     () => originalInput$ ?? new Subject<UnifiedHistogramInputMessage>(),
@@ -69,7 +70,7 @@ export const MetricsExperienceGrid = ({
   const indexPattern = useMemo(() => dataView?.getIndexPattern() ?? 'metrics-*', [dataView]);
   const { data: fields = [], isFetching: isFieldsLoading } = useMetricFieldsQuery({
     index: indexPattern,
-    timeRange: getTimeRange(),
+    timeRange,
   });
 
   const {

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/hooks/use_metric_fields_query.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/hooks/use_metric_fields_query.ts
@@ -16,7 +16,7 @@ import { useMetricsExperience } from './use_metrics_experience';
 export const useMetricFieldsQuery = (params?: {
   fields?: string[];
   index: string;
-  timeRange: TimeRange;
+  timeRange: TimeRange | undefined;
 }) => {
   const { client } = useMetricsExperience();
 
@@ -26,8 +26,8 @@ export const useMetricFieldsQuery = (params?: {
         'metricFields',
         params?.fields,
         params?.index,
-        params?.timeRange.from,
-        params?.timeRange.to,
+        params?.timeRange?.from,
+        params?.timeRange?.to,
       ],
       queryFn: async ({
         queryKey,


### PR DESCRIPTION
## Summary

Closes #236773

This PR resolves the issue of the date range being retrieved too soon. This resulted in the Fields API not retrieving any data because of the old range. 

## How to test
- Clone https://github.com/simianhacker/simian-forge/tree/main
- Run ` ./forge --dataset hosts --count 25 --interval 30s`
  - For beats metrics, the system integration package MUST be installed (after installing it, make sure to delete all existing metrics data streams)
- Set the following config to `kibana.dev.yml`
```yml
feature_flags.overrides:
  metricsExperienceEnabled: true
 ```
- Navigate to Discover and Switch to ESQL mode


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->