### PR TITLE
[Entity Analytics][Risk Score] Use ESQL for calculating risk scores

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -111,7 +111,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Disables ESQL-based risk scoring
    */
-  disableESQLRiskScoring: true,
+  disableESQLRiskScoring: false,
 
   /**
    * Enable resetting risk scores to zero for outdated entities

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/__snapshots__/calculate_esql_risk_scores.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/__snapshots__/calculate_esql_risk_scores.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Calculate risk scores with ESQL ESQL query matches snapshot 1`] = `
 "
   FROM .alerts-security.alerts-default METADATA _index
-    | WHERE kibana.alert.risk_score IS NOT NULL AND KQL(\\"host.name >= abel and host.name <= zuzanna\\")
+    | WHERE kibana.alert.risk_score IS NOT NULL AND KQL(\\"host.name > abel and host.name <= zuzanna\\")
     | RENAME kibana.alert.risk_score as risk_score,
              kibana.alert.rule.name as rule_name,
              kibana.alert.rule.uuid as rule_id,
@@ -13,10 +13,10 @@ exports[`Calculate risk scores with ESQL ESQL query matches snapshot 1`] = `
     | EVAL input = CONCAT(\\"\\"\\" {\\"score\\": \\"\\"\\"\\", risk_score::keyword, \\"\\"\\"\\", \\"time\\": \\"\\"\\"\\", time::keyword, \\"\\"\\"\\", \\"index\\": \\"\\"\\"\\", _index, \\"\\"\\"\\", \\"rule_name\\": \\"\\"\\"\\", rule_name, \\"\\"\\"\\", \\"category\\": \\"\\"\\"\\", category, \\"\\"\\"\\", \\"id\\": \\"\\"\\"\\", alert_id, \\"\\"\\"\\" } \\"\\"\\")
     | STATS
         alert_count = count(risk_score),
-        scores = MV_PSERIES_WEIGHTED_SUM(TOP(risk_score, 10000, \\"desc\\"), 1.5),
+        scores = 1 * MV_PSERIES_WEIGHTED_SUM(TOP(risk_score, 10000, \\"desc\\"), 1.5),
         risk_inputs = TOP(input, 10, \\"desc\\")
     BY host.name
-    | SORT scores DESC
+    | SORT scores DESC, host.name ASC
     | LIMIT 3500
   "
 `;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.test.ts
@@ -49,8 +49,8 @@ describe('Calculate risk scores with ESQL', () => {
               score: riskScore,
               normalized_score: riskScore / RIEMANN_ZETA_VALUE,
               notes: [],
-              category_1_score: riskScore / RIEMANN_ZETA_VALUE,
-              category_1_count: 1,
+              category_1_score: riskScore,
+              category_1_count: 10,
               risk_inputs: [
                 {
                   index: '.alerts-security.alerts-default',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.test.ts
@@ -14,7 +14,14 @@ import { RIEMANN_ZETA_S_VALUE, RIEMANN_ZETA_VALUE } from './constants';
 describe('Calculate risk scores with ESQL', () => {
   describe('ESQL query', () => {
     it('matches snapshot', () => {
-      const q = getESQL(EntityType.host, { lower: 'abel', upper: 'zuzanna' }, 10000, 3500);
+      const q = getESQL({
+        entityType: EntityType.host,
+        bounds: { lower: 'abel', upper: 'zuzanna' },
+        sampleSize: 10000,
+        pageSize: 3500,
+        index: '.alerts-security.alerts-default',
+        weight: 1,
+      });
       expect(q).toMatchSnapshot();
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.ts
@@ -242,7 +242,7 @@ export const getESQL = (
 ) => {
   const identifierField = EntityTypeToIdentifierField[entityType];
 
-  const lower = afterKeys.lower ? `${identifierField} >= ${afterKeys.lower}` : undefined;
+  const lower = afterKeys.lower ? `${identifierField} > ${afterKeys.lower}` : undefined;
   const upper = afterKeys.upper ? `${identifierField} <= ${afterKeys.upper}` : undefined;
   if (!lower && !upper) {
     throw new Error('Either lower or upper after key must be provided for pagination');

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.ts
@@ -53,7 +53,17 @@ export const calculateScoresWithESQL = async (
   } & CalculateScoresParams
 ): Promise<CalculateResults> =>
   withSecuritySpan('calculateRiskScores', async () => {
-    const { identifierType, logger, esClient } = params;
+    const {
+      afterKeys,
+      alertSampleSizePerShard,
+      assetCriticalityService,
+      esClient,
+      identifierType,
+      index,
+      logger,
+      pageSize,
+      weights,
+    } = params;
     const now = new Date().toISOString();
 
     const filter = getFilters(params);
@@ -101,19 +111,20 @@ export const calculateScoresWithESQL = async (
           ] satisfies ESQLResults[number]);
         }
         const bounds = {
-          lower: params.afterKeys[entityType]?.[EntityTypeToIdentifierField[entityType]],
+          lower: afterKeys[entityType]?.[EntityTypeToIdentifierField[entityType]],
           upper: afterKey?.[EntityTypeToIdentifierField[entityType]],
         };
 
-        const weight = getGlobalWeightForIdentifierType(entityType as EntityType, params.weights);
+        const weight = getGlobalWeightForIdentifierType(entityType as EntityType, weights) || 1;
 
-        const query = getESQL(
-          entityType as EntityType,
+        const query = getESQL({
+          entityType: entityType as EntityType,
           bounds,
-          params.alertSampleSizePerShard || 10000,
-          params.pageSize,
-          weight
-        );
+          sampleSize: alertSampleSizePerShard || 10000,
+          pageSize,
+          index,
+          weight,
+        });
 
         return esClient.esql
           .query({
@@ -121,12 +132,12 @@ export const calculateScoresWithESQL = async (
             filter: { bool: { filter } },
           })
           .then((rs) =>
-            rs.values.map(buildRiskScoreBucket(entityType as EntityType, params.index, weight))
+            rs.values.map(buildRiskScoreBucket(entityType as EntityType, index, weight))
           )
 
           .then((riskScoreBuckets) => {
             return processScores({
-              assetCriticalityService: params.assetCriticalityService,
+              assetCriticalityService,
               buckets: riskScoreBuckets,
               identifierField: EntityTypeToIdentifierField[entityType],
               logger,
@@ -201,11 +212,12 @@ export const getCompositeQuery = (
   filter: QueryDslQueryContainer[],
   params: CalculateScoresParams
 ) => {
+  const { index, pageSize, runtimeMappings, afterKeys } = params;
   return {
     size: 0,
-    index: params.index,
+    index,
     ignore_unavailable: true,
-    runtime_mappings: params.runtimeMappings,
+    runtime_mappings: runtimeMappings,
     query: {
       function_score: {
         query: {
@@ -229,9 +241,9 @@ export const getCompositeQuery = (
         ...aggs,
         [entityType]: {
           composite: {
-            size: params.pageSize,
+            size: pageSize,
             sources: [{ [idField]: { terms: { field: idField } } }],
-            after: params.afterKeys[entityType],
+            after: afterKeys[entityType],
           },
         },
       };
@@ -239,27 +251,37 @@ export const getCompositeQuery = (
   };
 };
 
-export const getESQL = (
-  entityType: EntityType,
-  afterKeys: {
+export interface GetESQLParams {
+  bounds: {
     lower?: string;
     upper?: string;
-  },
-  sampleSize: number,
-  pageSize: number,
-  weight: number = 1
-) => {
+  };
+  entityType: EntityType;
+  index: string;
+  pageSize: number;
+  sampleSize: number;
+  weight: number;
+}
+
+export const getESQL = ({
+  entityType,
+  bounds,
+  sampleSize,
+  pageSize,
+  index,
+  weight,
+}: GetESQLParams) => {
   const identifierField = EntityTypeToIdentifierField[entityType];
 
-  const lower = afterKeys.lower ? `${identifierField} > ${afterKeys.lower}` : undefined;
-  const upper = afterKeys.upper ? `${identifierField} <= ${afterKeys.upper}` : undefined;
+  const lower = bounds.lower ? `${identifierField} > ${bounds.lower}` : undefined;
+  const upper = bounds.upper ? `${identifierField} <= ${bounds.upper}` : undefined;
   if (!lower && !upper) {
     throw new Error('Either lower or upper after key must be provided for pagination');
   }
   const rangeClause = [lower, upper].filter(Boolean).join(' and ');
 
-  const query = /* SQL */ `
-  FROM .alerts-security.alerts-default METADATA _index
+  const query = /* ESQL */ `
+  FROM ${index} METADATA _index
     | WHERE kibana.alert.risk_score IS NOT NULL AND KQL("${rangeClause}")
     | RENAME kibana.alert.risk_score as risk_score,
              kibana.alert.rule.name as rule_name,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.ts
@@ -264,7 +264,7 @@ export const getESQL = (
         scores = MV_PSERIES_WEIGHTED_SUM(TOP(risk_score, ${sampleSize}, "desc"), ${RIEMANN_ZETA_S_VALUE}),
         risk_inputs = TOP(input, 10, "desc")
     BY ${identifierField}
-    | SORT scores DESC
+    | SORT scores DESC, ${identifierField} ASC
     | LIMIT ${pageSize}
   `;
 
@@ -303,8 +303,8 @@ export const buildRiskScoreBucket =
             score,
             normalized_score: score / RIEMANN_ZETA_VALUE, // normalize value to be between 0-100
             notes: [],
-            category_1_score: score / RIEMANN_ZETA_VALUE, // normalize value to be between 0-100
-            category_1_count: 1,
+            category_1_score: score,
+            category_1_count: count,
             risk_inputs: inputs,
           },
         },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_risk_scores.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_risk_scores.ts
@@ -44,6 +44,8 @@ import { RIEMANN_ZETA_VALUE, RIEMANN_ZETA_S_VALUE } from './constants';
 import { getPainlessScripts, type PainlessScripts } from './painless';
 import { EntityTypeToIdentifierField } from '../../../../common/entity_analytics/types';
 
+const max10DecimalPlaces = (num: number) => Math.round(num * 1e10) / 1e10;
+
 const formatForResponse = ({
   bucket,
   criticality,
@@ -69,7 +71,7 @@ const formatForResponse = ({
   const categoryTwoCount = criticalityModifier ? 1 : 0;
 
   const newFields = {
-    category_2_score: categoryTwoScore,
+    category_2_score: max10DecimalPlaces(categoryTwoScore),
     category_2_count: categoryTwoCount,
     criticality_level: criticality?.criticality_level,
     criticality_modifier: criticalityModifier,
@@ -80,9 +82,9 @@ const formatForResponse = ({
     id_field: identifierField,
     id_value: bucket.key[identifierField],
     calculated_level: calculatedLevel,
-    calculated_score: riskDetails.value.score,
-    calculated_score_norm: normalizedScoreWithCriticality,
-    category_1_score: riskDetails.value.category_1_score / RIEMANN_ZETA_VALUE, // normalize value to be between 0-100
+    calculated_score: max10DecimalPlaces(riskDetails.value.score),
+    calculated_score_norm: max10DecimalPlaces(normalizedScoreWithCriticality),
+    category_1_score: max10DecimalPlaces(riskDetails.value.category_1_score / RIEMANN_ZETA_VALUE), // normalize value to be between 0-100
     category_1_count: riskDetails.value.category_1_count,
     notes: riskDetails.value.notes,
     inputs: riskDetails.value.risk_inputs.map((riskInput) => ({

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_entity_calculation.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_entity_calculation.ts
@@ -33,6 +33,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const esArchiver = getService('esArchiver');
   const es = getService('es');
   const log = getService('log');
+  const kibanaServer = getService('kibanaServer');
 
   const riskEngineRoutes = riskEngineRouteHelpersFactory(supertest);
 
@@ -73,9 +74,7 @@ export default ({ getService }: FtrProviderContext): void => {
     });
   };
 
-  describe('@ess @serverless @serverlessQA Risk Scoring Entity Calculation API', function () {
-    this.tags(['esGate']);
-
+  const doTests = () => {
     context('with auditbeat data', () => {
       const { indexListOfDocuments } = dataGeneratorFactory({
         es,
@@ -119,8 +118,8 @@ export default ({ getService }: FtrProviderContext): void => {
         const expectedScore = {
           calculated_level: 'Unknown',
           calculated_score: 21,
-          calculated_score_norm: 8.10060175898781,
-          category_1_score: 8.10060175898781,
+          calculated_score_norm: 8.100601759,
+          category_1_score: 8.100601759,
           category_1_count: 1,
           id_field: 'host.name',
           id_value: 'host-1',
@@ -171,8 +170,8 @@ export default ({ getService }: FtrProviderContext): void => {
             criticality_modifier: 1.5,
             calculated_level: 'Unknown',
             calculated_score: 21,
-            calculated_score_norm: 11.677912063468526,
-            category_1_score: 8.10060175898781,
+            calculated_score_norm: 11.6779120635,
+            category_1_score: 8.100601759,
             category_1_count: 1,
             id_field: 'host.name',
             id_value: 'host-1',
@@ -214,8 +213,8 @@ export default ({ getService }: FtrProviderContext): void => {
           const expectedScore = {
             calculated_level: 'Unknown',
             calculated_score: 21,
-            calculated_score_norm: 8.10060175898781,
-            category_1_score: 8.10060175898781,
+            calculated_score_norm: 8.100601759,
+            category_1_score: 8.100601759,
             category_1_count: 1,
             id_field: 'host.name',
             id_value: 'host-1',
@@ -243,6 +242,29 @@ export default ({ getService }: FtrProviderContext): void => {
           );
         });
       });
+    });
+  };
+
+  describe('@ess @serverless @serverlessQA Risk Scoring Entity Calculation API', function () {
+    this.tags(['esGate']);
+
+    describe('ESQL based risk scoring', () => {
+      doTests();
+    });
+
+    describe('scripted metric based risk scoring', () => {
+      before(async () => {
+        await kibanaServer.uiSettings.update({
+          ['securitySolution:enableEsqlRiskScoring']: false,
+        });
+      });
+
+      after(async () => {
+        await kibanaServer.uiSettings.update({
+          ['securitySolution:enableEsqlRiskScoring']: true,
+        });
+      });
+      doTests();
     });
   });
 };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
@@ -113,9 +113,9 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(score).to.eql({
             calculated_level: 'Unknown',
             calculated_score: 21,
-            calculated_score_norm: 8.10060175898781,
+            calculated_score_norm: 8.100601759,
             category_1_count: 1,
-            category_1_score: 8.10060175898781,
+            category_1_score: 8.100601759,
             id_field: 'host.name',
             id_value: 'host-1',
           });
@@ -141,18 +141,18 @@ export default ({ getService }: FtrProviderContext): void => {
             {
               calculated_level: 'Unknown',
               calculated_score: 21,
-              calculated_score_norm: 8.10060175898781,
+              calculated_score_norm: 8.100601759,
               category_1_count: 1,
-              category_1_score: 8.10060175898781,
+              category_1_score: 8.100601759,
               id_field: 'host.name',
               id_value: 'host-1',
             },
             {
               calculated_level: 'Unknown',
               calculated_score: 21,
-              calculated_score_norm: 8.10060175898781,
+              calculated_score_norm: 8.100601759,
               category_1_count: 1,
-              category_1_score: 8.10060175898781,
+              category_1_score: 8.100601759,
               id_field: 'host.name',
               id_value: 'host-2',
             },
@@ -173,10 +173,10 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(body.scores.host!)).to.eql([
             {
               calculated_level: 'Unknown',
-              calculated_score: 28.42462120245875,
-              calculated_score_norm: 10.964596976723788,
+              calculated_score: 28.4246212025,
+              calculated_score_norm: 10.9645969767,
               category_1_count: 2,
-              category_1_score: 10.964596976723788,
+              category_1_score: 10.9645969767,
               id_field: 'host.name',
               id_value: 'host-1',
             },
@@ -195,10 +195,10 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(body.scores.host!)).to.eql([
             {
               calculated_level: 'Unknown',
-              calculated_score: 47.25513506055279,
-              calculated_score_norm: 18.228334771081926,
+              calculated_score: 47.2551350606,
+              calculated_score_norm: 18.2283347711,
               category_1_count: 30,
-              category_1_score: 18.228334771081926,
+              category_1_score: 18.2283347711,
               id_field: 'host.name',
               id_value: 'host-1',
             },
@@ -220,19 +220,19 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(body.scores.host!)).to.eql([
             {
               calculated_level: 'Unknown',
-              calculated_score: 47.25513506055279,
-              calculated_score_norm: 18.228334771081926,
+              calculated_score: 47.2551350606,
+              calculated_score_norm: 18.2283347711,
               category_1_count: 30,
-              category_1_score: 18.228334771081926,
+              category_1_score: 18.2283347711,
               id_field: 'host.name',
               id_value: 'host-1',
             },
             {
               calculated_level: 'Unknown',
               calculated_score: 21,
-              calculated_score_norm: 8.10060175898781,
+              calculated_score_norm: 8.100601759,
               category_1_count: 1,
-              category_1_score: 8.10060175898781,
+              category_1_score: 8.100601759,
               id_field: 'host.name',
               id_value: 'host-2',
             },
@@ -251,10 +251,10 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(body.scores.host!)).to.eql([
             {
               calculated_level: 'Unknown',
-              calculated_score: 50.67035607277805,
-              calculated_score_norm: 19.545732168175455,
+              calculated_score: 50.6703560728,
+              calculated_score_norm: 19.5457321682,
               category_1_count: 100,
-              category_1_score: 19.545732168175455,
+              category_1_score: 19.5457321682,
               id_field: 'host.name',
               id_value: 'host-1',
             },
@@ -276,10 +276,10 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(body.scores.host!)).to.eql([
             {
               calculated_level: 'Unknown',
-              calculated_score: 41.90206636025764,
-              calculated_score_norm: 16.163426307767953,
+              calculated_score: 41.9020663603,
+              calculated_score_norm: 16.1634263078,
               category_1_count: 10,
-              category_1_score: 16.163426307767953,
+              category_1_score: 16.1634263078,
               id_field: 'host.name',
               id_value: 'host-1',
             },
@@ -305,10 +305,10 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(body.scores.host!)).to.eql([
             {
               calculated_level: 'Unknown',
-              calculated_score: 41.90206636025764,
-              calculated_score_norm: 16.163426307767953,
+              calculated_score: 41.9020663603,
+              calculated_score_norm: 16.1634263078,
               category_1_count: 10,
-              category_1_score: 16.163426307767953,
+              category_1_score: 16.1634263078,
               id_field: 'host.name',
               id_value: 'host-1',
             },
@@ -330,10 +330,10 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(body.scores.host!)).to.eql([
             {
               calculated_level: 'Critical',
-              calculated_score: 241.2874098703716,
-              calculated_score_norm: 93.07491508654975,
+              calculated_score: 241.2874098704,
+              calculated_score_norm: 93.0749150865,
               category_1_count: 100,
-              category_1_score: 93.07491508654975,
+              category_1_score: 93.0749150865,
               id_field: 'host.name',
               id_value: 'host-1',
             },
@@ -361,10 +361,10 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(body.scores.host!)).to.eql([
             {
               calculated_level: 'Critical',
-              calculated_score: 254.91456029175757,
-              calculated_score_norm: 98.33149216623883,
+              calculated_score: 254.9145602918,
+              calculated_score_norm: 98.3314921662,
               category_1_count: 1000,
-              category_1_score: 98.33149216623883,
+              category_1_score: 98.3314921662,
               id_field: 'host.name',
               id_value: 'host-1',
             },
@@ -457,10 +457,10 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(scores.host!)).to.eql([
             {
               calculated_level: 'High',
-              calculated_score: 225.1106801442913,
-              calculated_score_norm: 86.83485578779946,
+              calculated_score: 225.1106801443,
+              calculated_score_norm: 86.8348557878,
               category_1_count: 100,
-              category_1_score: 86.83485578779946,
+              category_1_score: 86.8348557878,
               id_field: 'host.name',
               id_value: 'host-1',
             },
@@ -469,7 +469,7 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       context('with global risk weights', () => {
-        it('weights host scores differently when host risk weight is configured', async () => {
+        it.skip('weights host scores differently when host risk weight is configured', async () => {
           const documentId = uuidv4();
           const doc = buildDocument({ host: { name: 'host-1' } }, documentId);
           await indexListOfDocuments(Array(100).fill(doc));
@@ -489,14 +489,14 @@ export default ({ getService }: FtrProviderContext): void => {
               calculated_score: 120.6437049351858,
               calculated_score_norm: 46.537457543274876,
               category_1_count: 100,
-              category_1_score: 93.07491508654975,
+              category_1_score: 93.0749150865,
               id_field: 'host.name',
               id_value: 'host-1',
             },
           ]);
         });
 
-        it('weights user scores differently if user risk weight is configured', async () => {
+        it.skip('weights user scores differently if user risk weight is configured', async () => {
           const documentId = uuidv4();
           const doc = buildDocument({ user: { name: 'user-1' } }, documentId);
           await indexListOfDocuments(Array(100).fill(doc));
@@ -516,14 +516,14 @@ export default ({ getService }: FtrProviderContext): void => {
               calculated_score: 168.9011869092601,
               calculated_score_norm: 65.15244056058482,
               category_1_count: 100,
-              category_1_score: 93.07491508654975,
+              category_1_score: 93.0749150865,
               id_field: 'user.name',
               id_value: 'user-1',
             },
           ]);
         });
 
-        it('weights entity scores differently when host and user risk weights are configured', async () => {
+        it.skip('weights entity scores differently when host and user risk weights are configured', async () => {
           const usersId = uuidv4();
           const hostsId = uuidv4();
           const userDocs = buildDocument({ 'user.name': 'user-1' }, usersId);
@@ -543,9 +543,9 @@ export default ({ getService }: FtrProviderContext): void => {
             {
               calculated_level: 'Low',
               calculated_score: 93.23759116471251,
-              calculated_score_norm: 35.96574261869793,
+              calculated_score_norm: 35.965742618697,
               category_1_count: 50,
-              category_1_score: 89.91435654674481,
+              category_1_score: 89.9143565467,
               id_field: 'host.name',
               id_value: 'host-1',
             },
@@ -557,7 +557,7 @@ export default ({ getService }: FtrProviderContext): void => {
               calculated_score: 186.47518232942502,
               calculated_score_norm: 71.93148523739586,
               category_1_count: 50,
-              category_1_score: 89.91435654674481,
+              category_1_score: 89.9143565467,
               id_field: 'user.name',
               id_value: 'user-1',
             },
@@ -598,18 +598,18 @@ export default ({ getService }: FtrProviderContext): void => {
               criticality_modifier: 2.0,
               calculated_level: 'Unknown',
               calculated_score: 21,
-              calculated_score_norm: 14.987153868113044,
+              calculated_score_norm: 14.9871538681,
               category_1_count: 1,
-              category_1_score: 8.10060175898781,
+              category_1_score: 8.100601759,
               id_field: 'host.name',
               id_value: 'host-1',
             },
             {
               calculated_level: 'Unknown',
               calculated_score: 21,
-              calculated_score_norm: 8.10060175898781,
+              calculated_score_norm: 8.100601759,
               category_1_count: 1,
-              category_1_score: 8.10060175898781,
+              category_1_score: 8.100601759,
               id_field: 'host.name',
               id_value: 'host-2',
             },
@@ -632,7 +632,7 @@ export default ({ getService }: FtrProviderContext): void => {
   };
 
   describe('@ess @serverless Risk Scoring Preview API', () => {
-    describe('ESQL based risk scoring', () => {
+    describe.only('ESQL based risk scoring', () => {
       doTests();
     });
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
@@ -469,7 +469,7 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       context('with global risk weights', () => {
-        it.skip('weights host scores differently when host risk weight is configured', async () => {
+        it('weights host scores differently when host risk weight is configured', async () => {
           const documentId = uuidv4();
           const doc = buildDocument({ host: { name: 'host-1' } }, documentId);
           await indexListOfDocuments(Array(100).fill(doc));
@@ -486,8 +486,8 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(scores.host!)).to.eql([
             {
               calculated_level: 'Moderate',
-              calculated_score: 120.6437049351858,
-              calculated_score_norm: 46.537457543274876,
+              calculated_score: 120.6437049352,
+              calculated_score_norm: 46.5374575433,
               category_1_count: 100,
               category_1_score: 93.0749150865,
               id_field: 'host.name',
@@ -496,7 +496,7 @@ export default ({ getService }: FtrProviderContext): void => {
           ]);
         });
 
-        it.skip('weights user scores differently if user risk weight is configured', async () => {
+        it('weights user scores differently if user risk weight is configured', async () => {
           const documentId = uuidv4();
           const doc = buildDocument({ user: { name: 'user-1' } }, documentId);
           await indexListOfDocuments(Array(100).fill(doc));
@@ -513,8 +513,8 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(scores.user!)).to.eql([
             {
               calculated_level: 'Moderate',
-              calculated_score: 168.9011869092601,
-              calculated_score_norm: 65.15244056058482,
+              calculated_score: 168.9011869093,
+              calculated_score_norm: 65.1524405606,
               category_1_count: 100,
               category_1_score: 93.0749150865,
               id_field: 'user.name',
@@ -523,7 +523,7 @@ export default ({ getService }: FtrProviderContext): void => {
           ]);
         });
 
-        it.skip('weights entity scores differently when host and user risk weights are configured', async () => {
+        it('weights entity scores differently when host and user risk weights are configured', async () => {
           const usersId = uuidv4();
           const hostsId = uuidv4();
           const userDocs = buildDocument({ 'user.name': 'user-1' }, usersId);
@@ -542,8 +542,8 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(scores.host!)).to.eql([
             {
               calculated_level: 'Low',
-              calculated_score: 93.23759116471251,
-              calculated_score_norm: 35.965742618697,
+              calculated_score: 93.2375911647,
+              calculated_score_norm: 35.9657426187,
               category_1_count: 50,
               category_1_score: 89.9143565467,
               id_field: 'host.name',
@@ -632,7 +632,7 @@ export default ({ getService }: FtrProviderContext): void => {
   };
 
   describe('@ess @serverless Risk Scoring Preview API', () => {
-    describe.only('ESQL based risk scoring', () => {
+    describe('ESQL based risk scoring', () => {
       doTests();
     });
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
@@ -523,7 +523,7 @@ export default ({ getService }: FtrProviderContext): void => {
           ]);
         });
 
-        it('weights entity scores differently when host and user risk weights are configured', async () => {
+        it.only('weights entity scores differently when host and user risk weights are configured', async () => {
           const usersId = uuidv4();
           const hostsId = uuidv4();
           const userDocs = buildDocument({ 'user.name': 'user-1' }, usersId);
@@ -554,8 +554,8 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(sanitizeScores(scores.user!)).to.eql([
             {
               calculated_level: 'High',
-              calculated_score: 186.47518232942502,
-              calculated_score_norm: 71.93148523739586,
+              calculated_score: 186.4751823294,
+              calculated_score_norm: 71.9314852374,
               category_1_count: 50,
               category_1_score: 89.9143565467,
               id_field: 'user.name',
@@ -631,7 +631,7 @@ export default ({ getService }: FtrProviderContext): void => {
     });
   };
 
-  describe('@ess @serverless Risk Scoring Preview API', () => {
+  describe.only('@ess @serverless Risk Scoring Preview API', () => {
     describe('ESQL based risk scoring', () => {
       doTests();
     });

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
@@ -638,21 +638,15 @@ export default ({ getService }: FtrProviderContext): void => {
 
     describe('scripted metric based risk scoring', () => {
       before(async () => {
-        await kibanaServer.uiSettings.update(
-          {
-            ['securitySolution:enableEsqlRiskScoring']: false,
-          },
-          { space }
-        );
+        await kibanaServer.uiSettings.update({
+          ['securitySolution:enableEsqlRiskScoring']: false,
+        });
       });
 
       after(async () => {
-        await kibanaServer.uiSettings.update(
-          {
-            ['securitySolution:enableEsqlRiskScoring']: true,
-          },
-          { space }
-        );
+        await kibanaServer.uiSettings.update({
+          ['securitySolution:enableEsqlRiskScoring']: true,
+        });
       });
 
       doTests();

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
@@ -523,7 +523,7 @@ export default ({ getService }: FtrProviderContext): void => {
           ]);
         });
 
-        it.only('weights entity scores differently when host and user risk weights are configured', async () => {
+        it('weights entity scores differently when host and user risk weights are configured', async () => {
           const usersId = uuidv4();
           const hostsId = uuidv4();
           const userDocs = buildDocument({ 'user.name': 'user-1' }, usersId);
@@ -631,7 +631,7 @@ export default ({ getService }: FtrProviderContext): void => {
     });
   };
 
-  describe.only('@ess @serverless Risk Scoring Preview API', () => {
+  describe('@ess @serverless Risk Scoring Preview API', () => {
     describe('ESQL based risk scoring', () => {
       doTests();
     });

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution.ts
@@ -38,7 +38,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const createAndSyncRuleAndAlerts = createAndSyncRuleAndAlertsFactory({ supertest, log });
   const riskEngineRoutes = riskEngineRouteHelpersFactory(supertest);
 
-  describe('@ess @serverless @serverlessQA Risk Scoring Task Execution', () => {
+  const doTests = () => {
     context('with auditbeat data', () => {
       const { indexListOfDocuments } = dataGeneratorFactory({
         es,
@@ -323,6 +323,27 @@ export default ({ getService }: FtrProviderContext): void => {
           });
         });
       });
+    });
+  };
+
+  describe('@ess @serverless @serverlessQA Risk Scoring Task Execution', () => {
+    describe('ESQL', () => {
+      doTests();
+    });
+
+    describe('Scripted metric', () => {
+      before(async () => {
+        await kibanaServer.uiSettings.update({
+          ['securitySolution:enableEsqlRiskScoring']: false,
+        });
+      });
+
+      after(async () => {
+        await kibanaServer.uiSettings.update({
+          ['securitySolution:enableEsqlRiskScoring']: true,
+        });
+      });
+      doTests();
     });
   });
 };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution.ts
@@ -101,10 +101,15 @@ export default ({ getService }: FtrProviderContext): void => {
             await waitForRiskScoresToBePresent({ es, log, scoreCount: 10 });
 
             const scores = await readRiskScores(es);
-            expect(normalizeScores(scores).map(({ id_value: idValue }) => idValue)).to.eql(
+            expect(
+              normalizeScores(scores)
+                .map(({ id_value: idValue }) => idValue)
+                .sort()
+            ).to.eql(
               Array(10)
                 .fill(0)
                 .map((_, index) => `host-${index}`)
+                .sort()
             );
           });
 
@@ -146,7 +151,9 @@ export default ({ getService }: FtrProviderContext): void => {
                 ({ id_value: idValue }) => idValue
               );
 
-              expect(actualHostNames).to.eql([...expectedHostNames, ...expectedHostNames]);
+              expect(actualHostNames.sort()).to.eql(
+                [...expectedHostNames, ...expectedHostNames].sort()
+              );
             });
           });
 
@@ -280,10 +287,10 @@ export default ({ getService }: FtrProviderContext): void => {
                 criticality_level: 'extreme_impact',
                 criticality_modifier: 2,
                 calculated_level: 'Moderate',
-                calculated_score: 79.81345973382406,
-                calculated_score_norm: 47.08016240063269,
+                calculated_score: 79.8134597338,
+                calculated_score_norm: 47.0801624006,
                 category_1_count: 10,
-                category_1_score: 30.787478681462762,
+                category_1_score: 30.7874786815,
               },
             ]);
           });

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution_nondefault_spaces.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution_nondefault_spaces.ts
@@ -29,7 +29,7 @@ export default ({ getService }: FtrProviderContextWithSpaces): void => {
   const es = getService('es');
   const log = getService('log');
 
-  describe('@ess Risk Scoring Task in non-default space', () => {
+  const doTests = () => {
     describe('with alerts in a non-default space', () => {
       const { indexListOfDocuments } = dataGeneratorFactory({
         es,
@@ -116,6 +116,27 @@ export default ({ getService }: FtrProviderContextWithSpaces): void => {
             .sort()
         );
       });
+    });
+  };
+
+  describe('@ess Risk Scoring Task in non-default space', () => {
+    describe('ESQL', () => {
+      doTests();
+    });
+
+    describe('Scripted metric', () => {
+      before(async () => {
+        await kibanaServer.uiSettings.update({
+          ['securitySolution:enableEsqlRiskScoring']: false,
+        });
+      });
+
+      after(async () => {
+        await kibanaServer.uiSettings.update({
+          ['securitySolution:enableEsqlRiskScoring']: true,
+        });
+      });
+      doTests();
     });
   });
 };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution_nondefault_spaces.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution_nondefault_spaces.ts
@@ -105,10 +105,15 @@ export default ({ getService }: FtrProviderContextWithSpaces): void => {
         });
 
         const scores = await readRiskScores(es, index);
-        expect(normalizeScores(scores).map(({ id_value: idValue }) => idValue)).to.eql(
+        expect(
+          normalizeScores(scores)
+            .map(({ id_value: idValue }) => idValue)
+            .sort()
+        ).to.eql(
           Array(10)
             .fill(0)
             .map((_, _index) => `host-${_index}`)
+            .sort()
         );
       });
     });

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution_nondefault_spaces.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution_nondefault_spaces.ts
@@ -20,7 +20,6 @@ import {
   normalizeScores,
   riskEngineRouteHelpersFactory,
 } from '../../../utils';
-
 import type { FtrProviderContextWithSpaces } from '../../../../../ftr_provider_context_with_spaces';
 
 export default ({ getService }: FtrProviderContextWithSpaces): void => {
@@ -28,6 +27,7 @@ export default ({ getService }: FtrProviderContextWithSpaces): void => {
   const esArchiver = getService('esArchiver');
   const es = getService('es');
   const log = getService('log');
+  const kibanaServer = getService('kibanaServer');
 
   const doTests = () => {
     describe('with alerts in a non-default space', () => {


### PR DESCRIPTION
## Summary

Entity risk scoring now uses ESQL to calculate the scores, removing our dependency on the deprecated scripted metric aggregation.


Changes:

- risk score now limited to 10 decimal places
- added global weights to esql risk scoring
- bug: after keys was adding an entity in esql risk scoring
- bug: category_1_score was being normalised
- bug: category_1_count was always 1
- bug: ESQL risk scoring did not work in non-default space



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->