### PR TITLE
[Files] Remove histogram bar styles

### DIFF
--- a/src/platform/plugins/private/files_management/public/components/diagnostics_flyout.tsx
+++ b/src/platform/plugins/private/files_management/public/components/diagnostics_flyout.tsx
@@ -23,7 +23,7 @@ import {
   EuiFlexItem,
   useGeneratedHtmlId,
 } from '@elastic/eui';
-import { Chart, Axis, Position, HistogramBarSeries, ScaleType, Settings } from '@elastic/charts';
+import { Chart, Axis, Position, BarSeries, ScaleType, Settings } from '@elastic/charts';
 import numeral from '@elastic/numeral';
 import type { FunctionComponent } from 'react';
 import React from 'react';
@@ -104,7 +104,7 @@ export const DiagnosticsFlyout: FunctionComponent<Props> = ({ onClose }) => {
                 <Settings baseTheme={chartBaseTheme} />
                 <Axis id="y" position={Position.Left} showOverlappingTicks />
                 <Axis id="x" position={Position.Bottom} showOverlappingTicks />
-                <HistogramBarSeries
+                <BarSeries
                   data={Object.entries(data.countByStatus).map(([key, count]) => ({
                     key,
                     count,
@@ -126,7 +126,7 @@ export const DiagnosticsFlyout: FunctionComponent<Props> = ({ onClose }) => {
                 <Settings baseTheme={chartBaseTheme} />
                 <Axis id="y" position={Position.Left} showOverlappingTicks />
                 <Axis id="x" position={Position.Bottom} showOverlappingTicks />
-                <HistogramBarSeries
+                <BarSeries
                   data={Object.entries(data.countByExtension).map(([key, count]) => ({
                     key,
                     count,


### PR DESCRIPTION
## Summary

Improve chart styles, removes histogram styles for ordinal chart.

| Before | After |
|--------|--------|
| ![Files - Elastic 2025-10-07 at 10 02 05 AM](https://github.com/user-attachments/assets/4c495698-7e93-4ef7-b2a6-ed82b0f5bfb0) | ![Files - Elastic 2025-10-07 at 10 01 39 AM](https://github.com/user-attachments/assets/ac2354e1-c8ed-47d4-98d7-d53151f9f376) |

Related to #235534


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->