### PR TITLE
[Spaces] Deleted obsolete test for session expiration toast

### DIFF
--- a/x-pack/platform/plugins/shared/security/public/session/session_expiration_toast.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/session/session_expiration_toast.test.tsx
@@ -68,19 +68,4 @@ describe('SessionExpirationToast', () => {
     );
     getByText(/You will be logged out in [0-9]+ seconds/);
   });
-
-  it('does not render extend button if session cannot be extended', () => {
-    const sessionState$ = of<SessionState>({
-      lastExtensionTime: Date.now(),
-      expiresInMs: 60 * 1000,
-      canBeExtended: false,
-    });
-
-    const { queryByRole } = render(
-      <I18nProvider>
-        <SessionExpirationToast sessionState$={sessionState$} />
-      </I18nProvider>
-    );
-    expect(queryByRole('button', { name: 'Stay logged in' })).toBeNull();
-  });
 });


### PR DESCRIPTION
## Summary

In scope of https://github.com/elastic/kibana/pull/235957 session timeout toast with `Extend` button has been moved to a modal. Deleted obsolete test that is no longer valid.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

__Related: https://github.com/elastic/kibana/issues/138333__



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->