### PR TITLE
[Search][Accessibility] Announce changes when resetting terms in synonyms panel

### DIFF
--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_rule_flyout/synonym_rule_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_rule_flyout/synonym_rule_flyout.tsx
@@ -22,6 +22,7 @@ import {
   EuiFlyoutHeader,
   EuiFormRow,
   EuiHealth,
+  EuiScreenReaderOnly,
   EuiSpacer,
   EuiText,
   useEuiTheme,
@@ -76,6 +77,7 @@ export const SynonymRuleFlyout: React.FC<SynonymRuleFlyoutProps> = ({
     isMapToTermsInvalid,
     mapToTermErrors,
     mapToTerms,
+    announcement,
     clearFromTerms,
     onCreateOption,
     onMapToChange,
@@ -198,6 +200,21 @@ export const SynonymRuleFlyout: React.FC<SynonymRuleFlyoutProps> = ({
                           color="text"
                           onClick={() => onSortTerms()}
                           iconType={currentSortDirection === 'ascending' ? 'sortUp' : 'sortDown'}
+                          aria-label={
+                            currentSortDirection === 'ascending'
+                              ? i18n.translate(
+                                  'xpack.searchSynonyms.synonymsSetRuleFlyout.sortAscendingAriaLabel',
+                                  {
+                                    defaultMessage: 'Sort terms A to Z',
+                                  }
+                                )
+                              : i18n.translate(
+                                  'xpack.searchSynonyms.synonymsSetRuleFlyout.sortDescendingAriaLabel',
+                                  {
+                                    defaultMessage: 'Sort terms Z to A',
+                                  }
+                                )
+                          }
                         >
                           {currentSortDirection === 'ascending' ? (
                             <FormattedMessage
@@ -220,6 +237,12 @@ export const SynonymRuleFlyout: React.FC<SynonymRuleFlyoutProps> = ({
                       color="danger"
                       size="s"
                       onClick={clearFromTerms}
+                      aria-label={i18n.translate(
+                        'xpack.searchSynonyms.synonymsSetRuleFlyout.clearAllAriaLabel',
+                        {
+                          defaultMessage: 'Remove all terms',
+                        }
+                      )}
                     >
                       <FormattedMessage
                         id="xpack.searchSynonyms.synonymsSetRuleFlyout.clearAll"
@@ -327,6 +350,12 @@ export const SynonymRuleFlyout: React.FC<SynonymRuleFlyoutProps> = ({
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty
                   data-test-subj="searchSynonymsSynonymsRuleFlyoutResetChangesButton"
+                  aria-label={i18n.translate(
+                    'xpack.searchSynonyms.synonymsSetRuleFlyout.resetAriaLabel',
+                    {
+                      defaultMessage: 'Reset all changes',
+                    }
+                  )}
                   iconType="refresh"
                   disabled={!hasChanges}
                   onClick={resetChanges}
@@ -336,6 +365,11 @@ export const SynonymRuleFlyout: React.FC<SynonymRuleFlyoutProps> = ({
                   })}
                 </EuiButtonEmpty>
               </EuiFlexItem>
+              {/* Shared live region for action voiceover announcements*/}
+              <EuiScreenReaderOnly>
+                <span aria-live="polite">{announcement}</span>
+              </EuiScreenReaderOnly>
+
               <EuiFlexItem grow={false}>
                 <EuiButton
                   data-test-subj="searchSynonymsSynonymsRuleFlyoutSaveButton"

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_rule_flyout/use_flyout_state.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_rule_flyout/use_flyout_state.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { useState } from 'react';
 import type { SynonymsSynonymRule } from '@elastic/elasticsearch/lib/api/types';
 import { synonymToComboBoxOption, synonymsOptionToString } from '../../utils/synonyms_utils';
@@ -39,6 +40,12 @@ export const useSynonymRuleFlyoutState = ({
   const [fromTermErrors, setFromTermErrors] = useState<string[]>([]);
   const [mapToTermErrors, setMapToTermErrors] = useState<string[]>([]);
   const [currentSortDirection, setCurrentSortDirection] = useState<SortDirection>('ascending');
+  const [announcement, setAnnouncement] = useState('');
+
+  const announce = (message: string) => {
+    setAnnouncement(message);
+    setTimeout(() => setAnnouncement(''), 1000); // clear for next use
+  };
 
   const hasChanges =
     flyoutMode === 'create'
@@ -68,6 +75,11 @@ export const useSynonymRuleFlyoutState = ({
     setIsMapToTermsInvalid(false);
     setFromTermErrors([]);
     setMapToTermErrors([]);
+    announce(
+      i18n.translate('xpack.searchSynonyms.synonymsSetRuleFlyout.resetAnnouncement', {
+        defaultMessage: 'All changes have been reset',
+      })
+    );
   };
 
   const isValid = (value: string) => {
@@ -151,7 +163,14 @@ export const useSynonymRuleFlyoutState = ({
     setFromTerms(fromTerms.filter((t) => t.label !== term.label));
   };
 
-  const clearFromTerms = () => setFromTerms([]);
+  const clearFromTerms = () => {
+    setFromTerms([]);
+    announce(
+      i18n.translate('xpack.searchSynonyms.synonymsSetRuleFlyout.clearedAnnouncement', {
+        defaultMessage: 'All terms have been removed',
+      })
+    );
+  };
   const onMapToChange = (value: string) => {
     isMapToValid(value);
     setMapToTerms(value);
@@ -169,6 +188,7 @@ export const useSynonymRuleFlyoutState = ({
     isMapToTermsInvalid,
     mapToTermErrors,
     mapToTerms,
+    announcement,
     onCreateOption,
     onMapToChange,
     onSearchChange,


### PR DESCRIPTION
## Summary
Currently, when a user clicks `Reset changes` or `Remove all` on the Add Terms panel (for either equivalent or explicit types) in the Synonyms set editor, the terms are reset visually but the change is not announced by VoiceOver on macOS Safari. This breaks WCAG 4.1.2: Name, Role, Value (Level A).

This PR updates the Add Terms panel to use `aria-live="polite"` announcements when either buttons are clicked, so screen readers can inform users of the change.

### How to test
1. Enable VoiceOver on macOS (Cmd + F5).
2. Open Kibana and navigate to **Search → Synonyms**.
3. Create a new synonyms set and select either "equivalent" or "explicit" rule.
4. Add terms and click "Reset changes".
5. Confirm that VoiceOver announces that the terms have been reset.
6. Add terms and click "Remove all".
5. Confirm that VoiceOver announces that the terms have been removed.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release Note

Fixes an accessibility issue where resetting changes or removing all terms in the Synonyms panel was not announced by screen readers. VoiceOver users on Safari will now hear updates when terms are reset.






<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->