### PR TITLE
[8.18] [a11y] Add missing aria-label to button in content connectors (#237383)

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/generated_config_fields.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/generated_config_fields.tsx
@@ -274,6 +274,10 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
                       isLoading={isGenerateLoading}
                       onClick={refreshButtonClick}
                       disabled={!connector.index_name}
+                      aria-label={i18n.translate(
+                        'xpack.enterpriseSearch.connectorDeployment.generateAPIKey',
+                        { defaultMessage: 'Generate an Elasticsearch API key' }
+                      )}
                     />
                   </EuiFlexItem>
                 )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[a11y] Add missing aria-label to button in content connectors (#237383)](https://github.com/elastic/kibana/pull/237383)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dennis Tismenko","email":"dennis.tismenko@elastic.co"},"sourceCommit":{"committedDate":"2025-10-02T22:58:30Z","message":"[a11y] Add missing aria-label to button in content connectors (#237383)\n\n## Summary\nCloses #234823.\n\nAdding a missing `aria-label` to an `EuiButtonIcon` for generating API\nkeys in the content connectors configuration flow.\n\n<img width=\"1512\" height=\"683\" alt=\"Screenshot 2025-10-02 at 4 44 41 PM\"\nsrc=\"https://github.com/user-attachments/assets/790c450c-8937-41f6-a110-5646333c13c0\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions.\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4ef2db3683f0a17ba69b5351c19f1f36cf1b86ae","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.2.0","v9.3.0"],"title":"[a11y] Add missing aria-label to button in content connectors","number":237383,"url":"https://github.com/elastic/kibana/pull/237383","mergeCommit":{"message":"[a11y] Add missing aria-label to button in content connectors (#237383)\n\n## Summary\nCloses #234823.\n\nAdding a missing `aria-label` to an `EuiButtonIcon` for generating API\nkeys in the content connectors configuration flow.\n\n<img width=\"1512\" height=\"683\" alt=\"Screenshot 2025-10-02 at 4 44 41 PM\"\nsrc=\"https://github.com/user-attachments/assets/790c450c-8937-41f6-a110-5646333c13c0\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions.\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4ef2db3683f0a17ba69b5351c19f1f36cf1b86ae"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/237389","number":237389,"state":"MERGED","mergeCommit":{"sha":"4a6c913e554ec066b06bffd6101597645c945fb5","message":"[9.2] [a11y] Add missing aria-label to button in content connectors (#237383) (#237389)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[a11y] Add missing aria-label to button in content connectors\n(#237383)](https://github.com/elastic/kibana/pull/237383)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dennis Tismenko <dennis.tismenko@elastic.co>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237383","number":237383,"mergeCommit":{"message":"[a11y] Add missing aria-label to button in content connectors (#237383)\n\n## Summary\nCloses #234823.\n\nAdding a missing `aria-label` to an `EuiButtonIcon` for generating API\nkeys in the content connectors configuration flow.\n\n<img width=\"1512\" height=\"683\" alt=\"Screenshot 2025-10-02 at 4 44 41 PM\"\nsrc=\"https://github.com/user-attachments/assets/790c450c-8937-41f6-a110-5646333c13c0\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions.\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4ef2db3683f0a17ba69b5351c19f1f36cf1b86ae"}},{"url":"https://github.com/elastic/kibana/pull/237883","number":237883,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->