### PR TITLE
[Discover BS] Fix the alignment for the status icon

### DIFF
--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/status.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/status.tsx
@@ -11,6 +11,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiLoadingSpinner, EuiToolTip } fro
 import { i18n } from '@kbn/i18n';
 import type { ReactElement } from 'react';
 import React from 'react';
+import { css } from '@emotion/react';
 import { SearchSessionStatus } from '../../../../../common';
 import { dateString } from '../lib/date_string';
 import type { UISession } from '../types';
@@ -184,7 +185,9 @@ export const StatusIndicator = (props: StatusIndicatorProps) => {
 
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
-          <EuiFlexItem grow={false}>{icon}</EuiFlexItem>
+          <EuiFlexItem grow={false} css={iconCss}>
+            {icon}
+          </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <TableText
               color={statusDef.textColor}
@@ -205,3 +208,7 @@ export const StatusIndicator = (props: StatusIndicatorProps) => {
   // Exception has been caught
   return <TableText>{props.session.status}</TableText>;
 };
+
+const iconCss = css`
+  line-height: 1;
+`;


### PR DESCRIPTION
## Summary

Before:
<img width="469" height="99" alt="Screenshot 2025-10-07 at 17 55 33" src="https://github.com/user-attachments/assets/41895cdf-640a-4998-8e43-e4f62ade70f7" />

After:
<img width="549" height="96" alt="Screenshot 2025-10-07 at 18 00 38" src="https://github.com/user-attachments/assets/ad913340-745d-4931-b99b-8b703b955855" />



### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->