### PR TITLE
[kbn-evals] Assign meaningful experiment and task names for Agent Builder evals

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/kibana_phoenix_client/client.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/kibana_phoenix_client/client.ts
@@ -112,6 +112,7 @@ export class KibanaPhoenixClient {
       const ranExperiment = await experiments.runExperiment({
         client: this.phoenixClient,
         dataset: { datasetId },
+        experimentName: `Run ID: ${this.options.runId} - Dataset: ${dataset.name}`,
         task,
         experimentMetadata: {
           model: this.options.model,

--- a/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/src/evaluate_dataset.ts
+++ b/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/src/evaluate_dataset.ts
@@ -13,6 +13,8 @@ import {
   type EvaluationDataset,
   createQuantitativeGroundednessEvaluator,
 } from '@kbn/evals';
+import type { ExperimentTask } from '@kbn/evals/src/types';
+import type { TaskOutput } from '@arizeai/phoenix-client/dist/esm/types/experiments';
 import type { OnechatEvaluationChatClient } from './chat_client';
 
 interface DatasetExample extends Example {
@@ -58,39 +60,45 @@ export function createEvaluateDataset({
       examples,
     } satisfies EvaluationDataset;
 
+    const callConverseAndEvaluate: ExperimentTask<DatasetExample, TaskOutput> = async ({
+      input,
+      output,
+      metadata,
+    }) => {
+      const response = await chatClient.converse({
+        messages: [{ message: input.question }],
+      });
+
+      // Running correctness and groundedness evaluators as part of the task since their respective quantitative evaluators need their output
+      const [correctnessResult, groundednessResult] = await Promise.all([
+        evaluators.correctnessAnalysis().evaluate({
+          input,
+          expected: output,
+          output: response,
+          metadata,
+        }),
+        evaluators.groundednessAnalysis().evaluate({
+          input,
+          expected: output,
+          output: response,
+          metadata,
+        }),
+      ]);
+      const correctnessAnalysis = correctnessResult.metadata;
+      const groundednessAnalysis = groundednessResult.metadata;
+
+      return {
+        errors: response.errors,
+        messages: response.messages,
+        correctnessAnalysis,
+        groundednessAnalysis,
+      };
+    };
+
     await phoenixClient.runExperiment(
       {
         dataset,
-        task: async ({ input, output, metadata }) => {
-          const response = await chatClient.converse({
-            messages: [{ message: input.question }],
-          });
-
-          // Running correctness and groundedness evaluators as part of the task since their respective quantitative evaluators need their output
-          const [correctnessResult, groundednessResult] = await Promise.all([
-            evaluators.correctnessAnalysis().evaluate({
-              input,
-              expected: output,
-              output: response,
-              metadata,
-            }),
-            evaluators.groundednessAnalysis().evaluate({
-              input,
-              expected: output,
-              output: response,
-              metadata,
-            }),
-          ]);
-          const correctnessAnalysis = correctnessResult.metadata;
-          const groundednessAnalysis = groundednessResult.metadata;
-
-          return {
-            errors: response.errors,
-            messages: response.messages,
-            correctnessAnalysis,
-            groundednessAnalysis,
-          };
-        },
+        task: callConverseAndEvaluate,
       },
       [...createQuantitativeCorrectnessEvaluators(), createQuantitativeGroundednessEvaluator()]
     );


### PR DESCRIPTION

## Summary

- Assign experiment name in the format of `Run ID: <test_run_id> Dataset: <phoenix dataset name>`.
  - Will make it easier to understand which dataset experiment is running against in the terminal
  - The run id is common for all evaluations in the same run. It will be used for exporting results to Elasticsearch and building reports.
- Providing a task as a named function in Agent Builder's `createEvaluateDataset` assigns the function name as the task name in the Phoenix experiment, providing more meaningful logs.


## Testing
- Ran Agent Builder evals and confirmed the logs use the new names:
```bash
 info [scout-worker] 🔗 View this experiment: http://localhost:6006/datasets/RGF0YXNldDo0/compare?experimentId=RXhwZXJpbWVudDoxMTE=
 info [scout-worker] 🧪 Starting experiment "Run ID: 874bf4bdbf34a60d - Dataset: onechat: default-agent-unanswerable-queries" on dataset "RGF0YXNldDo0" with task "callConverseAndEvaluate" and 4 evaluators and 5 concurrent runs
 info [scout-worker] 🔧 Running task "callConverseAndEvaluate" on dataset "RGF0YXNldDo0"
 info [scout-worker] 🔧 Running task "callConverseAndEvaluate" on example "RGF0YXNldEV4YW1wbGU6NTQ= of dataset "RGF0YXNldDo0"
```
- New naming makes comparisons within Phoenix UI a bit more intuitive since names use the test run IDs. The same run IDs will be used for reporting (see [here](https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/kbn-evals/src/utils/score_repository.ts#L285))
<img width="642" height="233" alt="image" src="https://github.com/user-attachments/assets/1bfdd555-1103-45af-b3d8-7b87c08e29a0" />




