### PR TITLE
[Security solution][Alerts] Fix grouping in alerts table

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
@@ -98,7 +98,7 @@ describe('group selector', () => {
           def groupValues = [];
           if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
             groupValues = doc[params['selectedGroup']];
-          }  
+          }
           int count = groupValues.size();
           if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
           else {
@@ -126,7 +126,7 @@ describe('group selector', () => {
           def groupValues = [];
           if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
             groupValues = doc[params['selectedGroup']];
-          }  
+          }
           int count = groupValues.size();
           if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
           else {

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
@@ -25,8 +25,6 @@ export const MAX_RUNTIME_FIELD_SIZE = 100;
  * Composes grouping query and aggregations
  * @param additionalFilters Global filtering applicable to the grouping component.
  * Array of {@link BoolAgg} to be added to the query
- * @param from starting timestamp
- * @param groupByFields array of field names to group by
  * @param pageNumber starting grouping results page number
  * @param rootAggregations Top level aggregations to get the groups number or overall groups metrics.
  * Array of {@link NamedAggregation}
@@ -34,8 +32,10 @@ export const MAX_RUNTIME_FIELD_SIZE = 100;
  * @param size number of grouping results per page
  * @param sort add one or more sorts on specific fields
  * @param statsAggregations group level aggregations which correspond to {@link GroupStatsRenderer} configuration
- * @param to ending timestamp
  * @param uniqueValue unique value to use for crazy query magic
+ * @param timeRange timerange object for the query (from - to)
+ * @param multiValueFieldsToFlatten list of multi-value field to be flattened when grouping
+ * @param countByKeyForMultiValueFields field ES should use to count the documents (defaults to 'groupByField')
  *
  * @returns query dsl {@link GroupingQuery}
  */
@@ -84,7 +84,7 @@ export const getGroupingQuery = ({
               def groupValues = [];
               if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
                 groupValues = doc[params['selectedGroup']];
-              }  
+              }
               int count = groupValues.size();
               if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
               else {
@@ -123,7 +123,7 @@ export const getGroupingQuery = ({
       // if shouldFlattenMultiValueField = true its preferable to pass countByKeyForMultiValueFields
       // this field will be used to count the number of documents
       // if not passed the counting will have duplicates since we are counting the number of values
-      // of the groupByField stores instead of the actuall documents count
+      // of the groupByField stores instead of the actual documents count
       // else , shouldFlattenMultiValueField = false - count documents by groupByField
       unitsCount: {
         value_count: {

--- a/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
@@ -91,6 +91,7 @@ export interface GroupingArgs<T> {
     event: string | string[],
     count?: number | undefined
   ) => void;
+  multiValueFields?: string[];
 }
 
 /**
@@ -106,6 +107,7 @@ export interface GroupingArgs<T> {
  * @param onOptionsChange callback executed when grouping options are changed, used for consumer grouping selector
  * @param tracker telemetry handler
  * @param title of the grouping selector component
+ * @param multiValueFields the field size of the fields specified here will be ignored when creating filters
  * @returns {@link Grouping} the grouping constructor { getGrouping, groupSelector, pagination, selectedGroups }
  */
 export const useGrouping = <T,>({
@@ -120,6 +122,7 @@ export const useGrouping = <T,>({
   tracker,
   title,
   onOpenTracker,
+  multiValueFields,
 }: GroupingArgs<T>): UseGrouping<T> => {
   const [groupingState, dispatch] = useReducer(
     groupsReducerWithStorage,
@@ -171,9 +174,10 @@ export const useGrouping = <T,>({
           groupSelector={groupSelector}
           groupingId={groupingId}
           tracker={tracker}
+          multiValueFields={multiValueFields}
         />
       ),
-    [componentProps, groupSelector, groupingId, tracker]
+    [componentProps, groupSelector, groupingId, tracker, multiValueFields]
   );
 
   return useMemo(

--- a/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
@@ -106,7 +106,6 @@ export interface GroupingArgs<T> {
  * @param onOptionsChange callback executed when grouping options are changed, used for consumer grouping selector
  * @param tracker telemetry handler
  * @param title of the grouping selector component
- * @param multiValueFields the field size of the fields specified here will be ignored when creating filters
  * @returns {@link Grouping} the grouping constructor { getGrouping, groupSelector, pagination, selectedGroups }
  */
 export const useGrouping = <T,>({

--- a/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
@@ -91,7 +91,6 @@ export interface GroupingArgs<T> {
     event: string | string[],
     count?: number | undefined
   ) => void;
-  multiValueFields?: string[];
 }
 
 /**
@@ -122,7 +121,6 @@ export const useGrouping = <T,>({
   tracker,
   title,
   onOpenTracker,
-  multiValueFields,
 }: GroupingArgs<T>): UseGrouping<T> => {
   const [groupingState, dispatch] = useReducer(
     groupsReducerWithStorage,
@@ -174,10 +172,9 @@ export const useGrouping = <T,>({
           groupSelector={groupSelector}
           groupingId={groupingId}
           tracker={tracker}
-          multiValueFields={multiValueFields}
         />
       ),
-    [componentProps, groupSelector, groupingId, tracker, multiValueFields]
+    [componentProps, groupSelector, groupingId, tracker]
   );
 
   return useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
@@ -188,6 +188,11 @@ const GroupedAlertsTableComponent: React.FC<AlertsTableComponentProps> = (props)
     [newDataViewPickerEnabled, props.dataView?.fields, props.dataViewSpec.fields]
   );
 
+  const multiValueFieldsToFlatten = useMemo(
+    () => fields.filter((field) => field.aggregatable).map((field) => field.name),
+    [fields]
+  );
+
   const runtimeMappings = useMemo(
     () =>
       newDataViewPickerEnabled
@@ -363,6 +368,7 @@ const GroupedAlertsTableComponent: React.FC<AlertsTableComponentProps> = (props)
           setPageIndex={(newIndex: number) => setPageVar(newIndex, level, 'index')}
           setPageSize={(newSize: number) => setPageVar(newSize, level, 'size')}
           signalIndexName={dataViewTitle}
+          multiValueFieldsToFlatten={multiValueFieldsToFlatten}
         />
       );
     },
@@ -376,6 +382,7 @@ const GroupedAlertsTableComponent: React.FC<AlertsTableComponentProps> = (props)
       runtimeMappings,
       selectedGroups,
       setPageVar,
+      multiValueFieldsToFlatten,
     ]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
@@ -235,6 +235,7 @@ const GroupedAlertsTableComponent: React.FC<AlertsTableComponentProps> = (props)
     onGroupChange,
     onOptionsChange,
     tracker: track,
+    multiValueFields: multiValueFieldsToFlatten,
   });
   const groupId = useMemo(() => groupIdSelector(), []);
   const groupInRedux = useDeepEqualSelector((state) => groupId(state, props.tableId));

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
@@ -227,6 +227,7 @@ const GroupedAlertsTableComponent: React.FC<AlertsTableComponentProps> = (props)
       getGroupStats: groupStatsRenderer,
       onGroupToggle,
       unit: defaultUnit,
+      multiValueFields: multiValueFieldsToFlatten,
     },
     defaultGroupingOptions: groupingOptions,
     fields,
@@ -235,7 +236,6 @@ const GroupedAlertsTableComponent: React.FC<AlertsTableComponentProps> = (props)
     onGroupChange,
     onOptionsChange,
     tracker: track,
-    multiValueFields: multiValueFieldsToFlatten,
   });
   const groupId = useMemo(() => groupIdSelector(), []);
   const groupInRedux = useDeepEqualSelector((state) => groupId(state, props.tableId));

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -71,6 +71,20 @@ interface OwnProps {
   signalIndexName: string | undefined;
   tableId: TableIdLiteral;
   to: string;
+
+  /**
+   * By default, multi-value fields will be transformed into a string
+   * and grouped by that value. For instance, if an object has a property
+   * called "mac" with value ['mac1', 'mac2'], the query will stringify that value
+   * to "mac1, mac2" and then group by it.
+   *
+   * This property allows you to specify exceptions for this rule. For insance, if
+   * you pass ['mac'], then the query will not stringify the value for that field.
+   * Instead, every single value will be bucketed correctly.
+   *
+   * In the end, you will have two groups: "mac1" and "mac2"
+   */
+  multiValueFieldsToFlatten?: string[];
 }
 
 export type AlertsTableComponentProps = OwnProps;
@@ -97,6 +111,7 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
   signalIndexName,
   tableId,
   to,
+  multiValueFieldsToFlatten,
 }) => {
   const {
     services: { uiSettings },
@@ -176,6 +191,7 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
       to,
       pageSize,
       pageIndex,
+      multiValueFieldsToFlatten,
     });
   }, [
     additionalFilters,
@@ -187,6 +203,7 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
     selectedGroup,
     to,
     uniqueValue,
+    multiValueFieldsToFlatten,
   ]);
 
   const emptyGlobalQuery = useMemo(() => getGlobalQuery([]), [getGlobalQuery]);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -73,16 +73,14 @@ interface OwnProps {
   to: string;
 
   /**
-   * By default, multi-value fields will be transformed into a string
+   * If you're not using this property, multi-value fields will be transformed into a string
    * and grouped by that value. For instance, if an object has a property
    * called "mac" with value ['mac1', 'mac2'], the query will stringify that value
    * to "mac1, mac2" and then group by it.
    *
-   * This property allows you to specify exceptions for this rule. For insance, if
-   * you pass ['mac'], then the query will not stringify the value for that field.
-   * Instead, every single value will be bucketed correctly.
-   *
-   * In the end, you will have two groups: "mac1" and "mac2"
+   * Using this property will create a bucket for each value of the multi-value fields in question.
+   * Following the example above, a field with the ['mac1', 'mac2'] value will be grouped
+   * in 2 groups: one for mac1 and a second formac2.
    */
   multiValueFieldsToFlatten?: string[];
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
@@ -102,7 +102,7 @@ export const getQuery = (
           def groupValues = [];
           if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
             groupValues = doc[params['selectedGroup']];
-          }  
+          }
           int count = groupValues.size();
           if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
           else {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/query_builder.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/query_builder.ts
@@ -25,6 +25,7 @@ export interface AlertsGroupingQueryParams {
   selectedGroup: string;
   uniqueValue: string;
   to: string;
+  multiValueFieldsToFlatten?: string[];
 }
 
 export const getAlertsGroupingQuery = ({
@@ -37,6 +38,7 @@ export const getAlertsGroupingQuery = ({
   selectedGroup,
   uniqueValue,
   to,
+  multiValueFieldsToFlatten,
 }: AlertsGroupingQueryParams) =>
   getGroupingQuery({
     additionalFilters,
@@ -51,4 +53,5 @@ export const getAlertsGroupingQuery = ({
     uniqueValue,
     size: pageSize,
     sort: [{ unitsCount: { order: 'desc' } }],
+    multiValueFieldsToFlatten,
   });


### PR DESCRIPTION
## Summary

Addresses #237545 

## 🛑 Problem

When grouping the alert's table by multi-value fields we encounter the following behaviour:

- the value gets stringified (e.g. from `['value1', 'value2']` to `'value1, value2'`
- alerts gets grouped by that stringified value

<details>
<summary>Screenshot 📷  </summary>

<img width="1080" height="309" alt="image" src="https://github.com/user-attachments/assets/8e8dd1f6-b0e1-408e-b5ff-53c5beb81b66" />

</details>

## 💡 Solution

Luckily, we can provide a list of fields for which this logic should be skipped while grouping by using a prop called `multiValueFields`.

If users decide to group by any of the fields that are defined in `multiValueFields`, the query will create one bucket for each value in the field rather than stringify it.

## 💭 Considerations

1. This could have significant performance issues
2. This groundwork is key for the development of the new Attack Discovery page