### PR TITLE
[Search][a11y] show tooltip show more or fewer fields

### DIFF
--- a/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result.tsx
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import {
   EuiButtonIcon,
@@ -67,6 +67,7 @@ export const Result: React.FC<ResultProps> = ({
 
   const showResultsFields = isExpanded ? fields.length > 0 : defaultVisibleFields > 0;
 
+  const tooltipRef = useRef<EuiToolTip>(null);
   return (
     <>
       <EuiSplitPanel.Outer hasBorder={true} data-test-subj="search-index-documents-result">
@@ -106,7 +107,7 @@ export const Result: React.FC<ResultProps> = ({
               )}
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiToolTip position="left" content={toolTipContent}>
+              <EuiToolTip position="left" content={toolTipContent} ref={tooltipRef}>
                 <EuiButtonIcon
                   size="xs"
                   iconType={isExpanded ? 'fold' : 'unfold'}
@@ -115,6 +116,7 @@ export const Result: React.FC<ResultProps> = ({
                   onClick={(e: React.MouseEvent<HTMLElement>) => {
                     e.stopPropagation();
                     setIsExpanded(!isExpanded);
+                    tooltipRef.current?.showToolTip();
                   }}
                   aria-label={tooltipText}
                 />


### PR DESCRIPTION
## Summary

Tool tip is not shown when navigated via keyboard. Adding ref helps with showing the tool tip when show more/hide button is on focus.


### Testing instructions: 
1. In Stateful. Create an Index with documents more than 3 fields. Open documents page and has more than 3 documents
2. Navigate to the first (or any) table while using only keyboard by pressing Tab key.
3. Navigate to Show more fields button.
4. Press Esc.
5. Press Enter.
6. Observe tooltips for the button.

Also test for: 
Same with the opposite: when user navigates to Show more button -> presses Enter -> presses Esc -> presses Enter. Result: no tooltip present on Show more button.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->