### PR TITLE
[9.1] [UII] Add "Show agentless resources" toggle (#237528)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/details_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/details_page/index.tsx
@@ -25,6 +25,7 @@ import {
   useFleetStatus,
   useIntraAppState,
   useUrlParams,
+  useAgentlessResources,
 } from '../../../hooks';
 import { Loading, Error, AgentEnrollmentFlyout } from '../../../components';
 import { WithHeaderLayout } from '../../../layouts';
@@ -42,10 +43,10 @@ export const AgentPolicyDetailsPage: React.FunctionComponent = () => {
   } = useRouteMatch<{ policyId: string; tabId?: string }>();
   const { getHref } = useLink();
   const { urlParams } = useUrlParams();
-  const showAgentless = urlParams.showAgentless === 'true';
+  const { showAgentless } = useAgentlessResources();
 
   const agentPolicyRequest = useGetOneAgentPolicy(policyId);
-  // If the agent policy is agentless, hide it by default unless `showAgentless` url param is true
+  // If the agent policy is agentless, hide it by default unless showAgentless toggle is enabled
   const agentPolicy =
     agentPolicyRequest.data?.item &&
     (!agentPolicyRequest.data.item.supports_agentless || showAgentless)

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/list_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/list_page/index.tsx
@@ -38,6 +38,7 @@ import {
   useUrlParams,
   useBreadcrumbs,
   useGetAgentPoliciesQuery,
+  useAgentlessResources,
 } from '../../../hooks';
 import { SearchBar } from '../../../components';
 import { AgentPolicySummaryLine } from '../../../../../components';
@@ -56,7 +57,7 @@ export const AgentPolicyListPage: React.FunctionComponent<{}> = () => {
 
   // Table and search states
   const { urlParams, toUrlParams } = useUrlParams();
-  const showAgentless = urlParams.showAgentless === 'true';
+  const { showAgentless } = useAgentlessResources();
   const [search, setSearch] = useState<string>(
     Array.isArray(urlParams.kuery)
       ? urlParams.kuery[urlParams.kuery.length - 1]
@@ -85,7 +86,7 @@ export const AgentPolicyListPage: React.FunctionComponent<{}> = () => {
     [getPath, history, isCreateAgentPolicyFlyoutOpen, toUrlParams, urlParams]
   );
 
-  // Hide agentless policies by default unless `showAgentless` url param is true
+  // Hide agentless policies by default unless showAgentless toggle is enabled
   const getSearchWithDefaults = (newSearch: string) => {
     if (showAgentless) {
       return newSearch;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
@@ -23,7 +23,7 @@ import {
   useBreadcrumbs,
   useStartServices,
   useIntraAppState,
-  useUrlParams,
+  useAgentlessResources,
 } from '../../../hooks';
 import { WithHeaderLayout } from '../../../layouts';
 
@@ -41,8 +41,7 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
     params: { agentId, tabId = '' },
   } = useRouteMatch<{ agentId: string; tabId?: string }>();
   const { getHref } = useLink();
-  const { urlParams } = useUrlParams();
-  const showAgentless = urlParams.showAgentless === 'true';
+  const { showAgentless } = useAgentlessResources();
   const {
     isLoading,
     isInitialRequest,
@@ -74,11 +73,9 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
     }
   }, [routeState, navigateToApp]);
 
+  const isAgentlessAgent = agentPolicyData?.item.supports_agentless;
   const agent =
-    agentData?.item &&
-    (showAgentless || !agentData.item.local_metadata?.host?.hostname?.startsWith('agentless-')) // Hide agentless agents
-      ? agentData.item
-      : null;
+    agentData?.item && (isAgentlessAgent ? showAgentless : true) ? agentData.item : null;
   const host = agent && agent.local_metadata?.host;
 
   const headerLeftContent = useMemo(

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.tsx
@@ -24,6 +24,7 @@ import {
   useAuthz,
   sendGetActionStatus,
   sendBulkGetAgentPolicies,
+  useAgentlessResources,
 } from '../../../../hooks';
 import { AgentStatusKueryHelper } from '../../../../services';
 import { LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE, SO_SEARCH_LIMIT } from '../../../../constants';
@@ -101,7 +102,7 @@ export function useFetchAgentsData() {
 
   const history = useHistory();
   const { urlParams, toUrlParams } = useUrlParams();
-  const showAgentless = urlParams.showAgentless === 'true';
+  const { showAgentless } = useAgentlessResources();
   const defaultKuery: string = (urlParams.kuery as string) || '';
   const urlHasInactive = (urlParams.showInactive as string) === 'true';
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/settings_page/advanced_section.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/settings_page/advanced_section.tsx
@@ -14,7 +14,6 @@ import {
   EuiButton,
   EuiDescribedFormGroup,
   EuiSwitch,
-  EuiForm,
   EuiFormRow,
   EuiToolTip,
 } from '@elastic/eui';
@@ -29,6 +28,7 @@ import {
   useMigrateSpaceAwarenessMutation,
   usePutSettingsMutation,
   useStartServices,
+  useAgentlessResources,
 } from '../../../../hooks';
 
 export const AdvancedSection: React.FunctionComponent<{}> = ({}) => {
@@ -42,6 +42,9 @@ export const AdvancedSection: React.FunctionComponent<{}> = ({}) => {
   const [deleteUnenrolledAgentsChecked, setDeleteUnenrolledAgentsChecked] =
     React.useState<boolean>(deleteUnenrolledAgents);
   const { mutateAsync: mutateSettingsAsync } = usePutSettingsMutation();
+
+  // Agentless resources toggle state
+  const { showAgentless, setShowAgentless } = useAgentlessResources();
 
   const { mutateAsync: mutateSpaceAwarenessAsync, isLoading: mutateSpaceAwarenessIsLoading } =
     useMigrateSpaceAwarenessMutation();
@@ -134,95 +137,132 @@ export const AdvancedSection: React.FunctionComponent<{}> = ({}) => {
       {fleetStatus.isSpaceAwarenessEnabled ? null : (
         <>
           <EuiSpacer size="m" />
-          <EuiForm component="form">
-            <EuiDescribedFormGroup
-              title={
-                <h3>
-                  <FormattedMessage
-                    id="xpack.fleet.settings.migrateSpaceAwarenessLabel"
-                    defaultMessage="Migrate to Space-Aware agent policies"
-                  />
-                </h3>
-              }
-              description={
-                <p>
-                  <FormattedMessage
-                    id="xpack.fleet.settings.advancedSection.switchLabel"
-                    defaultMessage="Take advantage of improved isolation and management by enabling space-specific agent policies."
-                  />
-                </p>
-              }
-            >
-              <EuiFormRow label="">
-                <EuiButton
-                  onClick={onClickEnableSpaceAwareness}
-                  isLoading={mutateSpaceAwarenessIsLoading}
-                >
-                  <FormattedMessage
-                    id="xpack.fleet.settings.deleteUnenrolledAgentsLabel"
-                    defaultMessage="Start migration"
-                  />
-                </EuiButton>
-              </EuiFormRow>
-            </EuiDescribedFormGroup>
-          </EuiForm>
+
+          <EuiDescribedFormGroup
+            title={
+              <h3>
+                <FormattedMessage
+                  id="xpack.fleet.settings.migrateSpaceAwarenessLabel"
+                  defaultMessage="Migrate to space-aware agent policies"
+                />
+              </h3>
+            }
+            description={
+              <p>
+                <FormattedMessage
+                  id="xpack.fleet.settings.advancedSection.switchLabel"
+                  defaultMessage="Take advantage of improved isolation and management by enabling space-specific agent policies."
+                />
+              </p>
+            }
+          >
+            <EuiFormRow>
+              <EuiButton
+                onClick={onClickEnableSpaceAwareness}
+                isLoading={mutateSpaceAwarenessIsLoading}
+              >
+                <FormattedMessage
+                  id="xpack.fleet.settings.deleteUnenrolledAgentsLabel"
+                  defaultMessage="Start migration"
+                />
+              </EuiButton>
+            </EuiFormRow>
+          </EuiDescribedFormGroup>
         </>
       )}
+
       <EuiSpacer size="m" />
-      <EuiForm component="form">
-        <EuiDescribedFormGroup
-          title={
-            <h3>
-              <FormattedMessage
-                id="xpack.fleet.settings.deleteUnenrolledAgentsLabel"
-                defaultMessage="Delete unenrolled agents"
-              />
-            </h3>
-          }
-          description={
-            <p>
-              <FormattedMessage
-                id="xpack.fleet.settings.advancedSection.switchLabel"
-                defaultMessage="Switching on this setting will enable auto deletion of unenrolled agents. For more information see our {docLink}."
-                values={{
-                  docLink: (
-                    <EuiLink target="_blank" external href={docLinks.links.fleet.settings}>
-                      <FormattedMessage
-                        id="xpack.fleet.settings.advancedSection.link"
-                        defaultMessage="docs"
-                      />
-                    </EuiLink>
-                  ),
-                }}
-              />
-            </p>
-          }
-        >
-          <EuiFormRow label="">
-            <EuiToolTip
-              content={
-                isPreconfigured
-                  ? i18n.translate('xpack.fleet.settings.advancedSection.preconfiguredTitle', {
-                      defaultMessage: 'This setting is preconfigured and cannot be updated.',
-                    })
-                  : undefined
+
+      <EuiDescribedFormGroup
+        title={
+          <h3>
+            <FormattedMessage
+              id="xpack.fleet.settings.deleteUnenrolledAgentsLabel"
+              defaultMessage="Delete unenrolled agents"
+            />
+          </h3>
+        }
+        description={
+          <p>
+            <FormattedMessage
+              id="xpack.fleet.settings.advancedSection.switchLabel"
+              defaultMessage="Switching on this setting will enable auto-deletion of unenrolled agents. For more information, refer to the {docLink}."
+              values={{
+                docLink: (
+                  <EuiLink target="_blank" external href={docLinks.links.fleet.settings}>
+                    <FormattedMessage
+                      id="xpack.fleet.settings.advancedSection.link"
+                      defaultMessage="docs"
+                    />
+                  </EuiLink>
+                ),
+              }}
+            />
+          </p>
+        }
+      >
+        <EuiFormRow>
+          <EuiToolTip
+            content={
+              isPreconfigured
+                ? i18n.translate('xpack.fleet.settings.advancedSection.preconfiguredTitle', {
+                    defaultMessage: 'This setting is preconfigured and cannot be updated.',
+                  })
+                : undefined
+            }
+          >
+            <EuiSwitch
+              label={
+                <FormattedMessage
+                  id="xpack.fleet.settings.deleteUnenrolledAgentsLabel"
+                  defaultMessage="Delete unenrolled agents"
+                />
               }
-            >
-              <EuiSwitch
-                label={
-                  <FormattedMessage
-                    id="xpack.fleet.settings.deleteUnenrolledAgentsLabel"
-                    defaultMessage="Delete unenrolled agents"
-                  />
-                }
-                checked={deleteUnenrolledAgentsChecked}
-                onChange={(e) => updateSettings(e.target.checked)}
-                disabled={!authz.fleet.allSettings || isPreconfigured}
+              checked={deleteUnenrolledAgentsChecked}
+              onChange={(e) => updateSettings(e.target.checked)}
+              disabled={!authz.fleet.allSettings || isPreconfigured}
+            />
+          </EuiToolTip>
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+
+      <EuiSpacer size="m" />
+
+      <EuiDescribedFormGroup
+        title={
+          <h3>
+            <FormattedMessage
+              id="xpack.fleet.settings.showAgentlessResourcesLabel"
+              defaultMessage="Show agentless resources"
+            />
+          </h3>
+        }
+        description={
+          <p>
+            <FormattedMessage
+              id="xpack.fleet.settings.showAgentlessResourcesDescription"
+              defaultMessage="Enable this toggle to display agentless agents and policies in Fleet for debugging and diagnostics purposes. This setting is stored locally and is only visible to you."
+            />
+          </p>
+        }
+      >
+        <EuiFormRow>
+          <EuiSwitch
+            label={
+              <FormattedMessage
+                id="xpack.fleet.settings.showAgentlessResourcesLabel"
+                defaultMessage="Show agentless resources"
               />
-            </EuiToolTip>
-          </EuiFormRow>
-        </EuiDescribedFormGroup>
-      </EuiForm>
+            }
+            checked={showAgentless}
+            onChange={(e) => {
+              setShowAgentless(e.target.checked);
+              setShowAgentless(e.target.checked);
+            }}
+            data-test-subj="showAgentlessResourcesSwitch"
+          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
 
       <EuiSpacer size="m" />
     </>

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/index.ts
@@ -37,3 +37,4 @@ export * from './use_fleet_server_agents';
 export * from './use_multiple_agent_policies';
 export * from './use_tour_manager';
 export * from './use_dismissable_tour';
+export * from './use_agentless_resources';

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_agentless_resources.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_agentless_resources.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+
+import { useStartServices } from './use_core';
+import { useAgentlessResources } from './use_agentless_resources';
+
+jest.mock('./use_core');
+
+const mockStorage = {
+  get: jest.fn(),
+  set: jest.fn(),
+};
+
+const mockUseStartServices = useStartServices as jest.MockedFunction<typeof useStartServices>;
+
+describe('useAgentlessResources hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseStartServices.mockReturnValue({
+      storage: mockStorage,
+    } as any);
+  });
+
+  it('should initialize with false by default', () => {
+    mockStorage.get.mockReturnValue(undefined);
+    const { result } = renderHook(() => useAgentlessResources());
+
+    expect(result.current.showAgentless).toBe(false);
+    expect(typeof result.current.setShowAgentless).toBe('function');
+  });
+
+  it('should initialize with stored value when available', () => {
+    mockStorage.get.mockReturnValue(true);
+    const { result } = renderHook(() => useAgentlessResources());
+
+    expect(result.current.showAgentless).toBe(true);
+  });
+
+  it('should update both state and storage when setting value', () => {
+    mockStorage.get.mockReturnValue(false);
+    const { result } = renderHook(() => useAgentlessResources());
+
+    expect(result.current.showAgentless).toBe(false);
+
+    act(() => {
+      result.current.setShowAgentless(true);
+    });
+
+    expect(result.current.showAgentless).toBe(true);
+    expect(mockStorage.set).toHaveBeenCalledWith('fleet:showAgentlessResources', true);
+  });
+
+  it('should handle storage errors gracefully but still update state', () => {
+    mockStorage.get.mockReturnValue(false);
+    mockStorage.set.mockImplementation(() => {
+      throw new Error('Storage not available');
+    });
+
+    const { result } = renderHook(() => useAgentlessResources());
+
+    expect(() => {
+      act(() => {
+        result.current.setShowAgentless(true);
+      });
+    }).not.toThrow();
+
+    // State should still be updated even if storage fails
+    expect(result.current.showAgentless).toBe(true);
+  });
+
+  it('should handle storage read errors gracefully', () => {
+    mockStorage.get.mockImplementation(() => {
+      throw new Error('Storage not available');
+    });
+
+    const { result } = renderHook(() => useAgentlessResources());
+    expect(result.current.showAgentless).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_agentless_resources.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_agentless_resources.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+
+import { useStartServices } from './use_core';
+
+const AGENTLESS_TOGGLE_STORAGE_KEY = 'fleet:showAgentlessResources';
+
+/**
+ * Hook to manage the agentless resources toggle state
+ * @returns object with current state and setter function
+ */
+export function useAgentlessResources() {
+  const { storage } = useStartServices();
+
+  const initialValue = useMemo(() => {
+    try {
+      const stored = storage.get(AGENTLESS_TOGGLE_STORAGE_KEY);
+      return stored === true;
+    } catch (error) {
+      // In case storage is not available (e.g., in tests or restricted environments)
+      return false;
+    }
+  }, [storage]);
+
+  const [showAgentless, setShowAgentlessState] = useState<boolean>(initialValue);
+
+  const setShowAgentless = useCallback(
+    (enabled: boolean) => {
+      try {
+        storage.set(AGENTLESS_TOGGLE_STORAGE_KEY, enabled);
+        setShowAgentlessState(enabled);
+      } catch (error) {
+        // Silently fail if storage is not available, but still update state
+        setShowAgentlessState(enabled);
+      }
+    },
+    [storage]
+  );
+
+  return { showAgentless, setShowAgentless };
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[UII] Add "Show agentless resources" toggle (#237528)](https://github.com/elastic/kibana/pull/237528)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2025-10-07T20:39:03Z","message":"[UII] Add \"Show agentless resources\" toggle (#237528)\n\n## Summary\n\nResolves https://github.com/elastic/ingest-dev/issues/5932.\n\nThis PR replaces the `?showAgentless` query param (implemented in\nhttps://github.com/elastic/kibana/pull/219175) with a local storage\nsetting called `fleet:showAgentlessResources` that can be toggled from\nFleet > Settings. When enabled, agentless agents and policies are\nvisible in the Fleet UI:\n\n![Oct-03-2025\n11-56-35](https://github.com/user-attachments/assets/ebba0964-698c-4556-8798-2317fce938df)\n\n## Release note\n\"Show agentless resources\" toggle added to Fleet > Settings for\ndebugging and diagnostics purposes.\n\n## To-do\n- [ ] Public documentation:\nhttps://github.com/elastic/ingest-docs/issues/1865\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Visha Angelova <91186315+vishaangelova@users.noreply.github.com>","sha":"187465307bd8605687049a773116bcc4f7940ca0","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Fleet","backport:version","v9.2.0","v9.3.0","v9.1.6"],"title":"[UII] Add \"Show agentless resources\" toggle","number":237528,"url":"https://github.com/elastic/kibana/pull/237528","mergeCommit":{"message":"[UII] Add \"Show agentless resources\" toggle (#237528)\n\n## Summary\n\nResolves https://github.com/elastic/ingest-dev/issues/5932.\n\nThis PR replaces the `?showAgentless` query param (implemented in\nhttps://github.com/elastic/kibana/pull/219175) with a local storage\nsetting called `fleet:showAgentlessResources` that can be toggled from\nFleet > Settings. When enabled, agentless agents and policies are\nvisible in the Fleet UI:\n\n![Oct-03-2025\n11-56-35](https://github.com/user-attachments/assets/ebba0964-698c-4556-8798-2317fce938df)\n\n## Release note\n\"Show agentless resources\" toggle added to Fleet > Settings for\ndebugging and diagnostics purposes.\n\n## To-do\n- [ ] Public documentation:\nhttps://github.com/elastic/ingest-docs/issues/1865\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Visha Angelova <91186315+vishaangelova@users.noreply.github.com>","sha":"187465307bd8605687049a773116bcc4f7940ca0"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/237922","number":237922,"state":"OPEN"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237528","number":237528,"mergeCommit":{"message":"[UII] Add \"Show agentless resources\" toggle (#237528)\n\n## Summary\n\nResolves https://github.com/elastic/ingest-dev/issues/5932.\n\nThis PR replaces the `?showAgentless` query param (implemented in\nhttps://github.com/elastic/kibana/pull/219175) with a local storage\nsetting called `fleet:showAgentlessResources` that can be toggled from\nFleet > Settings. When enabled, agentless agents and policies are\nvisible in the Fleet UI:\n\n![Oct-03-2025\n11-56-35](https://github.com/user-attachments/assets/ebba0964-698c-4556-8798-2317fce938df)\n\n## Release note\n\"Show agentless resources\" toggle added to Fleet > Settings for\ndebugging and diagnostics purposes.\n\n## To-do\n- [ ] Public documentation:\nhttps://github.com/elastic/ingest-docs/issues/1865\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Visha Angelova <91186315+vishaangelova@users.noreply.github.com>","sha":"187465307bd8605687049a773116bcc4f7940ca0"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->