### PR TITLE
[Cases] Observables - update ui copy

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/common/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/translations.ts
@@ -363,14 +363,22 @@ export const CASE_ALERT_SUCCESS_TOAST = (title: string, quantity: number = 1) =>
 export const CASE_ALERT_SUCCESS_SYNC_TEXT = i18n.translate(
   'xpack.cases.actions.caseAlertSuccessSyncText',
   {
-    defaultMessage: 'The alert statuses are synched with the case status.',
+    defaultMessage: "Alert statuses were synced with the case's status.",
   }
 );
 
 export const CASE_ALERT_SUCCESS_OBSERVABLES_TEXT = i18n.translate(
   'xpack.cases.actions.caseAlertSuccessObservablesText',
   {
-    defaultMessage: 'Observables are extracted and added to the case.',
+    defaultMessage: 'Observables were extracted and added to the case.',
+  }
+);
+
+export const CASE_ALERT_SUCCESS_SYNC_AND_EXTRACT_TEXT = i18n.translate(
+  'xpack.cases.actions.caseAlertSuccessSyncAndExtractText',
+  {
+    defaultMessage:
+      "Alert statuses were synced with the case's status and observables were extracted and added to the case.",
   }
 );
 

--- a/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.test.tsx
@@ -174,10 +174,10 @@ describe('Use cases toast hook', () => {
           { wrapper: TestProviders }
         );
         result.current.showSuccessAttach({
-          theCase: mockCase,
+          theCase: { ...mockCase, settings: { syncAlerts: true } },
           attachments: [alertComment as SupportedCaseAttachment],
         });
-        validateContent('The alert statuses are synched with the case status.');
+        validateContent("Alert statuses were synced with the case's status.");
       });
 
       it('renders empty content when called with an alert attachment and sync off', () => {

--- a/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.tsx
@@ -26,6 +26,7 @@ import type { CaseAttachmentsWithoutOwner, ServerError } from '../types';
 import {
   CASE_ALERT_SUCCESS_SYNC_TEXT,
   CASE_ALERT_SUCCESS_OBSERVABLES_TEXT,
+  CASE_ALERT_SUCCESS_SYNC_AND_EXTRACT_TEXT,
   CASE_ALERT_SUCCESS_TOAST,
   CASE_SUCCESS_TOAST,
   VIEW_CASE,
@@ -90,7 +91,7 @@ function getToastContent({
     for (const attachment of attachments) {
       if (attachment.type === AttachmentType.alert) {
         if (theCase.settings.syncAlerts && theCase.settings.extractObservables) {
-          toastContent = `${CASE_ALERT_SUCCESS_SYNC_TEXT} ${CASE_ALERT_SUCCESS_OBSERVABLES_TEXT}`;
+          toastContent = CASE_ALERT_SUCCESS_SYNC_AND_EXTRACT_TEXT;
         } else if (theCase.settings.syncAlerts) {
           toastContent = CASE_ALERT_SUCCESS_SYNC_TEXT;
         } else if (theCase.settings.extractObservables) {

--- a/x-pack/platform/plugins/shared/cases/public/components/observables/default_observable_types_modal.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/observables/default_observable_types_modal.tsx
@@ -20,7 +20,6 @@ import {
   EuiButtonIcon,
   useGeneratedHtmlId,
 } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { EXTRACT_OBSERVABLES_LABEL } from '../create/translations';
 import * as i18n from './translations';
 
@@ -91,12 +90,7 @@ export const DefaultObservableTypesModal = () => {
           </EuiModalHeaderTitle>
         </EuiModalHeader>
         <EuiModalBody data-test-subj="default-observable-types-modal-body">
-          <EuiText size="s">
-            <FormattedMessage
-              id="xpack.cases.caseView.observables.observablesTable.popoverDescription"
-              defaultMessage="These ECS fields are automatically extracted if auto-extract observerable is turned on."
-            />
-          </EuiText>
+          <EuiText size="s">{i18n.DEFAULT_OBSERVABLE_TYPES_MODAL_DESCRIPTION}</EuiText>
           <EuiSpacer size="s" />
           <EuiFlexGroup direction="column" gutterSize="s">
             {defaultObservableTypes.map((observableType) => (

--- a/x-pack/platform/plugins/shared/cases/public/components/observables/translations.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/observables/translations.tsx
@@ -77,7 +77,7 @@ export const CANCEL = i18n.translate('xpack.cases.caseView.observables.cancel', 
 export const SELECT_OBSERVABLE_VALUE_PLACEHOLDER = i18n.translate(
   'xpack.cases.caseView.observables.addObservableModal.selectValue',
   {
-    defaultMessage: 'Name',
+    defaultMessage: 'Enter value name',
   }
 );
 
@@ -91,7 +91,7 @@ export const SELECT_OBSERVABLE_TYPE_PLACEHOLDER = i18n.translate(
 export const SELECT_OBSERVABLE_DESCRIPTION_PLACEHOLDER = i18n.translate(
   'xpack.cases.caseView.observables.addObservableModal.selectDescription',
   {
-    defaultMessage: 'Describe what was observed',
+    defaultMessage: 'Provide additional information about the observable',
   }
 );
 
@@ -175,5 +175,13 @@ export const DEFAULT_OBSERVABLE_TYPES_MODAL_BUTTON_ARIA_LABEL = i18n.translate(
   'xpack.cases.caseView.observables.defaultObservableTypesModalButtonAriaLabel',
   {
     defaultMessage: 'Default observable types modal button',
+  }
+);
+
+export const DEFAULT_OBSERVABLE_TYPES_MODAL_DESCRIPTION = i18n.translate(
+  'xpack.cases.caseView.observables.defaultObservableTypesModalDescription',
+  {
+    defaultMessage:
+      'When auto-extracting observables is on, available values from the following ECS fields are added as observables.',
   }
 );

--- a/x-pack/platform/plugins/shared/cases/public/components/observables/translations.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/observables/translations.tsx
@@ -182,6 +182,6 @@ export const DEFAULT_OBSERVABLE_TYPES_MODAL_DESCRIPTION = i18n.translate(
   'xpack.cases.caseView.observables.defaultObservableTypesModalDescription',
   {
     defaultMessage:
-      'When auto-extracting observables is on, available values from the following ECS fields are added as observables.',
+      'When auto-extract observables is on, available values from the following ECS fields are added as observables.',
   }
 );

--- a/x-pack/platform/plugins/shared/cases/public/containers/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/translations.ts
@@ -98,5 +98,5 @@ export const OBSERVABLE_MAX_REACHED = (maxObservables: number) =>
   i18n.translate('xpack.cases.caseView.observables.maxReached', {
     values: { maxObservables },
     defaultMessage:
-      'The maximum number of observables is {maxObservables}. Some observables were not added.',
+      "You've reached the maximum number of observables {maxObservables} that can be added to a case. Some observables were not added.",
   });


### PR DESCRIPTION
## Summary

Update copy based on feedback in https://github.com/elastic/docs-content/issues/3159


<img width="340" height="326" alt="image" src="https://github.com/user-attachments/assets/e8e10b57-5330-456e-856a-0c8654896da2" />

<img width="388" height="461" alt="image" src="https://github.com/user-attachments/assets/3cd733b3-b2ed-4070-a2ff-0a27de818470" />


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
