### PR TITLE
Skipping new Basic License Nav tests for FIPS pipeline

### DIFF
--- a/x-pack/solutions/search/test/functional_search/tests/classic_navigation.basic.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/classic_navigation.basic.ts
@@ -15,7 +15,8 @@ export default function searchClassicNavigationTests({
   const searchSpace = getService('searchSpace');
   const testSubjects = getService('testSubjects');
 
-  describe('Search Classic Navigation', () => {
+  describe('Search Classic Navigation', function () {
+    this.tags('skipFIPS');
     let cleanUp: () => Promise<unknown>;
     let spaceCreated: { id: string } = { id: '' };
 

--- a/x-pack/solutions/search/test/functional_search/tests/solution_navigation.basic.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/solution_navigation.basic.ts
@@ -20,7 +20,8 @@ export default function searchSolutionNavigation({
   const testSubjects = getService('testSubjects');
   const esArchiver = getService('esArchiver');
 
-  describe('Elasticsearch Solution Navigation', () => {
+  describe('Elasticsearch Solution Navigation', function () {
+    this.tags('skipFIPS');
     let cleanUp: () => Promise<unknown>;
     let spaceCreated: { id: string } = { id: '' };
 


### PR DESCRIPTION
## Summary

These are new tests that were added to check the nav menu for their solution/basic license.

Then need to be skipped in the FIPS pipeline since it forces a Trial/Platinum license