### PR TITLE
`yarn kbn clean` should also clean `.moon/cache`

### DIFF
--- a/kbn_pm/src/commands/clean_command.mjs
+++ b/kbn_pm/src/commands/clean_command.mjs
@@ -38,6 +38,7 @@ export const command = {
     await cleanPaths(log, [
       ...(await findPluginCleanPaths(log)),
       ...collectBazelPaths(),
+      Path.resolve(REPO_ROOT, '.moon', 'cache'),
       Path.resolve(REPO_ROOT, '.es', 'cache'),
     ]);
   },


### PR DESCRIPTION
## Summary
As the title says. 



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->