### PR TITLE
[Discover] Skip "no data" tests for security

### DIFF
--- a/x-pack/platform/test/serverless/functional/test_suites/discover/group5/_no_data.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/group5/_no_data.ts
@@ -23,7 +23,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   ]);
 
   describe('discover no data', function () {
-    this.tags(['skipSvlOblt']);
+    this.tags(['skipSvlOblt', 'skipSvlSec']);
 
     const kbnDirectory = 'src/platform/test/functional/fixtures/kbn_archiver/discover';
 


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/237229

## Summary

This PR skips running "no data" test suite for Security project type as they create default data views.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->