### PR TITLE
[Discover Tabs] Fix mixing query and filters between tabs for histogram requests

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useQuerySubscriber } from '@kbn/unified-field-list/src/hooks/use_query_subscriber';
 import type {
   UnifiedHistogramApi,
   UnifiedHistogramState,
@@ -207,7 +206,6 @@ export const useDiscoverHistogram = (
   /**
    * Request params
    */
-  const { query, filters } = useQuerySubscriber({ data: services.data });
   const requestParams = useCurrentTabSelector((state) => state.dataRequestParams);
   const {
     timeRangeRelative: relativeTimeRange,
@@ -299,13 +297,18 @@ export const useDiscoverHistogram = (
 
   const histogramCustomization = useDiscoverCustomization('unified_histogram');
 
+  const query = useAppStateSelector((state) => state.query);
+  const appFilters = useAppStateSelector((state) => state.filters);
+  const { filters: globalFilters } = useCurrentTabSelector((state) => state.globalState);
+
   const filtersMemoized = useMemo(() => {
-    const allFilters = [...(filters ?? [])];
+    const allFilters = [...(globalFilters ?? []), ...(appFilters ?? [])];
     return allFilters.length ? allFilters : EMPTY_FILTERS;
-  }, [filters]);
+  }, [appFilters, globalFilters]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const timeRangeMemoized = useMemo(() => timeRange, [timeRange?.from, timeRange?.to]);
+
   const setOverriddenVisContextAfterInvalidation = useCurrentTabAction(
     internalStateActions.setOverriddenVisContextAfterInvalidation
   );

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_histogram_layout.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_histogram_layout.test.tsx
@@ -56,6 +56,7 @@ function getStateContainer({
     dataSource: createDataViewDataSource({ dataViewId: dataView?.id! }),
     interval: 'auto',
     hideChart: false,
+    query: { query: '', language: 'kuery' },
   };
 
   stateContainer.appState.update(appState);

--- a/src/platform/test/functional/apps/discover/tabs2/_filters.ts
+++ b/src/platform/test/functional/apps/discover/tabs2/_filters.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const { discover, unifiedTabs } = getPageObjects(['discover', 'unifiedTabs']);
+  const queryBar = getService('queryBar');
+  const filterBar = getService('filterBar');
+  const esql = getService('esql');
+  const testSubjects = getService('testSubjects');
+
+  describe('tab filters', function () {
+    it('uses the correct query and filters', async () => {
+      const checkTab0 = async () => {
+        expect(await queryBar.getQueryString()).to.be('');
+        expect(await filterBar.getFilterCount()).to.be(0);
+        expect(await discover.getHitCount()).to.be('14,004');
+        await testSubjects.existOrFail('xyVisChart');
+      };
+
+      const checkTab1 = async () => {
+        expect(await queryBar.getQueryString()).to.be('bytes > 100');
+        expect(await filterBar.getFilterCount()).to.be(1);
+        expect(await filterBar.hasFilter('extension.raw', 'gif', true, false)).to.be(true);
+        expect(await discover.getHitCount()).to.be('795');
+        await testSubjects.existOrFail('xyVisChart');
+      };
+
+      const checkTab2 = async () => {
+        expect(await queryBar.getQueryString()).to.be('machine.os: "ios"');
+        expect(await filterBar.getFilterCount()).to.be(2);
+        expect(await filterBar.hasFilter('@message', 'exists', true, false)).to.be(true);
+        expect(await filterBar.hasFilter('extension.raw', 'jpg', true, true)).to.be(true);
+        expect(await discover.getHitCount()).to.be('1,813');
+        await testSubjects.existOrFail('xyVisChart');
+      };
+
+      const checkTab3 = async () => {
+        expect(await esql.getEsqlEditorQuery()).to.be(
+          'FROM logstash-* | WHERE extension.raw == "png" and bytes > 10000'
+        );
+        expect(await filterBar.getFilterCount()).to.be(0);
+        expect(await discover.getHitCount()).to.be('721');
+        await testSubjects.existOrFail('xyVisChart');
+      };
+
+      await unifiedTabs.editTabLabel(0, 'no filters');
+      await discover.waitUntilTabIsLoaded();
+      await checkTab0();
+
+      await unifiedTabs.createNewTab();
+      await discover.waitUntilTabIsLoaded();
+      await unifiedTabs.editTabLabel(1, 'query and app filters');
+      await queryBar.setQuery('bytes > 100');
+      await queryBar.submitQuery();
+      await filterBar.addFilter({ field: 'extension.raw', operation: 'is', value: 'gif' });
+      await discover.waitUntilTabIsLoaded();
+      await discover.waitUntilTabIsLoaded();
+      await checkTab1();
+
+      await unifiedTabs.createNewTab();
+      await discover.waitUntilTabIsLoaded();
+      await unifiedTabs.editTabLabel(2, 'query, global and app filters');
+      expect(await queryBar.getQueryString()).to.be('');
+      expect(await filterBar.getFilterCount()).to.be(0);
+      await filterBar.addFilter({ field: '@message', operation: 'exists' });
+      await discover.waitUntilTabIsLoaded();
+      await filterBar.addFilter({ field: 'extension.raw', operation: 'is', value: 'jpg' });
+      await filterBar.toggleFilterPinned('extension.raw');
+      await discover.waitUntilTabIsLoaded();
+      await queryBar.setQuery('machine.os: "ios"');
+      await queryBar.submitQuery();
+      await discover.waitUntilTabIsLoaded();
+      await checkTab2();
+
+      await unifiedTabs.createNewTab();
+      await discover.waitUntilTabIsLoaded();
+      await unifiedTabs.editTabLabel(3, 'esql and no filters');
+      expect(await queryBar.getQueryString()).to.be('');
+      expect(await filterBar.getFilterCount()).to.be(1);
+      expect(await filterBar.hasFilter('extension.raw', 'jpg', true, true)).to.be(true);
+      expect(await discover.getHitCount()).to.be('9,109');
+      await discover.selectTextBaseLang();
+      await discover.waitUntilTabIsLoaded();
+      await esql.setEsqlEditorQuery(
+        'FROM logstash-* | WHERE extension.raw == "png" and bytes > 10000'
+      );
+      await esql.submitEsqlEditorQuery();
+      await discover.waitUntilTabIsLoaded();
+      await checkTab3();
+
+      await unifiedTabs.selectTab(0);
+      await discover.waitUntilTabIsLoaded();
+      await checkTab0();
+
+      await unifiedTabs.selectTab(1);
+      await discover.waitUntilTabIsLoaded();
+      await checkTab1();
+
+      await unifiedTabs.selectTab(2);
+      await discover.waitUntilTabIsLoaded();
+      await checkTab2();
+
+      await unifiedTabs.selectTab(3);
+      await discover.waitUntilTabIsLoaded();
+      await checkTab3();
+    });
+  });
+}

--- a/src/platform/test/functional/apps/discover/tabs2/index.ts
+++ b/src/platform/test/functional/apps/discover/tabs2/index.ts
@@ -64,6 +64,7 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await kibanaServer.savedObjects.cleanStandardList();
     });
 
+    loadTestFile(require.resolve('./_filters'));
     loadTestFile(require.resolve('./_navigation'));
     loadTestFile(require.resolve('./_sharing'));
     loadTestFile(require.resolve('./_recently_closed_tabs'));


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/237759

## Summary

Previously [useQuerySubscriber](https://github.com/elastic/kibana/blob/f82a8621a9754fda7f766d247891af608ccc2873/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts#L210) was used when rendering the histogram. This hook existed way before the tabs feature was introduced. It uses a direct subscription to query and filters from the "data" services. Since "data" services work as a singleton, query and filters started getting mixed up in histogram requests once we introduced tabs to Discover. 

This PR switches to using query and filters from a tab state. This way histogram requests stay isolated in the respected tabs.

When testing please double check that correct filters are present in Inspect flyout (Request tab) for both Table and Vis Data requests.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->