### PR TITLE
[SharedUX][A11y] Fix keyboard focus on Reload page button for toast notifications

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/handle_system_colormode_change.tsx
+++ b/src/core/packages/chrome/browser-internal/src/handle_system_colormode_change.tsx
@@ -121,6 +121,7 @@ export async function handleSystemColorModeChange({
                     size="s"
                     onClick={() => window.location.reload()}
                     data-test-subj="windowReloadButton"
+                    autoFocus
                   >
                     {i18n.translate(
                       'core.ui.chrome.appearanceChange.requiresPageReloadButtonLabel',

--- a/src/platform/packages/shared/kbn-management/settings/components/form/reload_page_toast.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/components/form/reload_page_toast.tsx
@@ -43,6 +43,7 @@ export const reloadPageToast = (startDeps: StartDeps): ToastInput => {
             size="s"
             onClick={() => window.location.reload()}
             data-test-subj={DATA_TEST_SUBJ_PAGE_RELOAD_BUTTON}
+            autoFocus
           >
             {i18n.translate('management.settings.form.requiresPageReloadToastButtonLabel', {
               defaultMessage: 'Reload page',

--- a/src/platform/packages/shared/kbn-user-profile-components/src/hooks/use_update_user_profile.tsx
+++ b/src/platform/packages/shared/kbn-user-profile-components/src/hooks/use_update_user_profile.tsx
@@ -84,6 +84,7 @@ export const useUpdateUserProfile = ({
                       size="s"
                       onClick={() => window.location.reload()}
                       data-test-subj="windowReloadButton"
+                      autoFocus
                     >
                       {i18n.translate(
                         'userProfileComponents.updateUserProfile.notification.requiresPageReloadButtonLabel',


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/237039

## Summary

Added `autofocus` attribute to be able to set focus on the button on its initial render. That way, after saving, users will get the toast notification and focus will be set on "Reload page" button without disrupting keyboard navigation.

Replicated and tested this for two other "Reload page" buttons on toast notifications.

### Testing

https://github.com/user-attachments/assets/1bd90992-1419-425b-9d38-8e635bc1e7c7


<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->