### PR TITLE
[Agent Builder] ES|QL tools: support a default value for optional parameters

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-common/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/index.ts
@@ -30,6 +30,7 @@ export {
   type EsqlToolConfig,
   type EsqlToolFieldTypes,
   type EsqlToolParam,
+  type EsqlToolParamValue,
   type EsqlToolDefinition,
   type EsqlToolDefinitionWithSchema,
   EsqlToolFieldType,

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/index.ts
@@ -28,6 +28,7 @@ export {
   EsqlToolFieldType,
   type EsqlToolFieldTypes,
   type EsqlToolParam,
+  type EsqlToolParamValue,
   type EsqlToolDefinition,
   type EsqlToolDefinitionWithSchema,
   isEsqlTool,

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/types/esql.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/types/esql.ts
@@ -35,7 +35,7 @@ export type EsqlToolParamValue =
   | Record<string, unknown>
   | Array<Record<string, unknown>>;
 
-export interface EsqlToolParamBase {
+export interface EsqlToolParam {
   /**
    * The data types of the parameter. Must be one of these
    */
@@ -44,32 +44,16 @@ export interface EsqlToolParamBase {
    * Description of the parameter's purpose or expected values.
    */
   description: string;
-}
-
-export interface EsqlToolParamRequired extends EsqlToolParamBase {
   /**
    * Whether the parameter is optional.
    */
-  optional?: false;
-  /**
-   * Default value is not allowed for required parameters.
-   */
-  defaultValue?: never;
-}
-
-export interface EsqlToolParamOptional extends EsqlToolParamBase {
-  /**
-   * Whether the parameter is optional.
-   */
-  optional: true;
+  optional?: boolean;
   /**
    * Default value for the parameter when it's optional and not provided.
    * Must be compatible with the parameter's type (see EsqlToolParamValue).
    */
   defaultValue?: EsqlToolParamValue;
 }
-
-export type EsqlToolParam = EsqlToolParamRequired | EsqlToolParamOptional;
 
 // To make compatible with ToolDefinition['configuration']
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/types/esql.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/types/esql.ts
@@ -25,7 +25,17 @@ export enum EsqlToolFieldType {
 
 export type EsqlToolFieldTypes = `${EsqlToolFieldType}`;
 
-export interface EsqlToolParam {
+/**
+ * Valid types for parameter values and default values
+ */
+export type EsqlToolParamValue =
+  | string
+  | number
+  | boolean
+  | Record<string, unknown>
+  | Array<Record<string, unknown>>;
+
+export interface EsqlToolParamBase {
   /**
    * The data types of the parameter. Must be one of these
    */
@@ -34,11 +44,32 @@ export interface EsqlToolParam {
    * Description of the parameter's purpose or expected values.
    */
   description: string;
+}
+
+export interface EsqlToolParamRequired extends EsqlToolParamBase {
   /**
    * Whether the parameter is optional.
    */
-  optional?: boolean;
+  optional?: false;
+  /**
+   * Default value is not allowed for required parameters.
+   */
+  defaultValue?: never;
 }
+
+export interface EsqlToolParamOptional extends EsqlToolParamBase {
+  /**
+   * Whether the parameter is optional.
+   */
+  optional: true;
+  /**
+   * Default value for the parameter when it's optional and not provided.
+   * Must be compatible with the parameter's type (see EsqlToolParamValue).
+   */
+  defaultValue?: EsqlToolParamValue;
+}
+
+export type EsqlToolParam = EsqlToolParamRequired | EsqlToolParamOptional;
 
 // To make compatible with ToolDefinition['configuration']
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/create_handler.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/create_handler.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createHandler } from './create_handler';
+import type { EsqlToolConfig } from '@kbn/onechat-common';
+
+// Mock the ES client
+const mockEsClient = {
+  asCurrentUser: {
+    esql: {
+      query: jest.fn(),
+    },
+  },
+};
+
+const mockContext = {
+  esClient: mockEsClient,
+};
+
+describe('createHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEsClient.asCurrentUser.esql.query.mockResolvedValue({
+      columns: [{ name: 'count', type: 'long' }],
+      values: [[42]],
+    });
+  });
+
+  describe('default value handling', () => {
+    it('should use default values when LLM omits parameters', async () => {
+      const config: EsqlToolConfig = {
+        query: 'FROM users | WHERE status == ?status AND name == ?name',
+        params: {
+          status: { type: 'keyword', description: 'User status', optional: true },
+          name: {
+            type: 'text',
+            description: 'User name',
+            optional: true,
+            defaultValue: 'John Doe',
+          },
+        },
+      };
+
+      const handler = createHandler(config);
+      const llmParams = { status: 'active' }; // LLM omits 'name'
+
+      await handler(llmParams, mockContext as any);
+
+      // Verify ES|QL was called with both parameters (LLM value + default)
+      expect(mockEsClient.asCurrentUser.esql.query).toHaveBeenCalledWith({
+        query: 'FROM users | WHERE status == ?status AND name == ?name',
+        params: [{ status: 'active' }, { name: 'John Doe' }],
+      });
+    });
+
+    it('should use LLM values when provided, overriding defaults', async () => {
+      const config: EsqlToolConfig = {
+        query: 'FROM users | WHERE status == ?status AND name == ?name',
+        params: {
+          status: { type: 'keyword', description: 'User status', optional: true },
+          name: {
+            type: 'text',
+            description: 'User name',
+            optional: true,
+            defaultValue: 'John Doe',
+          },
+        },
+      };
+
+      const handler = createHandler(config);
+      const llmParams = { status: 'active', name: 'Jane Smith' }; // LLM provides both
+
+      await handler(llmParams, mockContext as any);
+
+      // Verify ES|QL was called with LLM values (not defaults)
+      expect(mockEsClient.asCurrentUser.esql.query).toHaveBeenCalledWith({
+        query: 'FROM users | WHERE status == ?status AND name == ?name',
+        params: [{ status: 'active' }, { name: 'Jane Smith' }],
+      });
+    });
+
+    it('should use null for optional parameters without defaults', async () => {
+      const config: EsqlToolConfig = {
+        query: 'FROM users | WHERE status == ?status',
+        params: {
+          status: { type: 'keyword', description: 'User status', optional: true },
+          name: { type: 'text', description: 'User name', optional: true }, // No default
+        },
+      };
+
+      const handler = createHandler(config);
+      const llmParams = { status: 'active' }; // LLM omits 'name'
+
+      await handler(llmParams, mockContext as any);
+
+      // Verify ES|QL was called with null for missing parameter
+      expect(mockEsClient.asCurrentUser.esql.query).toHaveBeenCalledWith({
+        query: 'FROM users | WHERE status == ?status',
+        params: [{ status: 'active' }, { name: null }],
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/create_handler.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/create_handler.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { createHandler } from './create_handler';
+import { createHandler, resolveToolParameters } from './create_handler';
 import type { EsqlToolConfig } from '@kbn/onechat-common';
 
 // Mock the ES client
@@ -102,6 +102,52 @@ describe('createHandler', () => {
         query: 'FROM users | WHERE status == ?status',
         params: [{ status: 'active' }, { name: null }],
       });
+    });
+  });
+});
+
+describe('resolveToolParameters', () => {
+  const mockParamDefinitions: EsqlToolConfig['params'] = {
+    status: {
+      type: 'keyword',
+      description: 'User status',
+      optional: true,
+      defaultValue: 'active',
+    },
+    name: {
+      type: 'text',
+      description: 'User name',
+      optional: true,
+    },
+  };
+
+  it('should use provided values when available', () => {
+    const providedParams = { status: 'inactive', name: 'Jane Smith' };
+    const result = resolveToolParameters(mockParamDefinitions, providedParams);
+
+    expect(result).toEqual({
+      status: 'inactive',
+      name: 'Jane Smith',
+    });
+  });
+
+  it('should apply default values for missing optional parameters', () => {
+    const providedParams = { name: 'Jane Smith' };
+    const result = resolveToolParameters(mockParamDefinitions, providedParams);
+
+    expect(result).toEqual({
+      status: 'active', // default value
+      name: 'Jane Smith',
+    });
+  });
+
+  it('should use null for missing optional parameters without defaults', () => {
+    const providedParams = { status: 'inactive' };
+    const result = resolveToolParameters(mockParamDefinitions, providedParams);
+
+    expect(result).toEqual({
+      status: 'inactive',
+      name: null, // no default, so null
     });
   });
 });

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/create_handler.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/create_handler.ts
@@ -12,6 +12,35 @@ import { interpolateEsqlQuery } from '@kbn/onechat-genai-utils/tools/utils';
 import { type EsqlToolConfig, ToolResultType } from '@kbn/onechat-common';
 import { getToolResultId } from '@kbn/onechat-server/tools';
 
+/**
+ * Resolves parameter values by applying defaults for missing parameters.
+ * @param paramDefinitions - The parameter definitions from the tool configuration
+ * @param providedParams - The parameters provided by the LLM
+ * @returns Resolved parameters with defaults applied
+ */
+export const resolveToolParameters = (
+  paramDefinitions: EsqlToolConfig['params'],
+  providedParams: Record<string, unknown>
+): Record<string, unknown> => {
+  return Object.keys(paramDefinitions).reduce((acc, paramName) => {
+    const param = paramDefinitions[paramName];
+    const providedValue = providedParams[paramName];
+
+    if (providedValue !== undefined) {
+      // LLM provided a value, use it
+      acc[paramName] = providedValue;
+    } else if (param.optional && param.defaultValue !== undefined) {
+      // LLM didn't provide a value, but we have a default
+      acc[paramName] = param.defaultValue;
+    } else {
+      // No value provided and no default, use null
+      acc[paramName] = null;
+    }
+
+    return acc;
+  }, {} as Record<string, unknown>);
+};
+
 export const createHandler = (
   configuration: EsqlToolConfig
 ): ToolHandlerFn<z.infer<ZodObject<any>>> => {
@@ -19,23 +48,7 @@ export const createHandler = (
     const client = esClient.asCurrentUser;
 
     // Apply default values for parameters that weren't provided by the LLM
-    const resolvedParams = Object.keys(configuration.params).reduce((acc, paramName) => {
-      const param = configuration.params[paramName];
-      const providedValue = params[paramName];
-
-      if (providedValue !== undefined) {
-        // LLM provided a value, use it
-        acc[paramName] = providedValue;
-      } else if (param.optional && param.defaultValue !== undefined) {
-        // LLM didn't provide a value, but we have a default
-        acc[paramName] = param.defaultValue;
-      } else {
-        // No value provided and no default, use null
-        acc[paramName] = null;
-      }
-
-      return acc;
-    }, {} as Record<string, unknown>);
+    const resolvedParams = resolveToolParameters(configuration.params, params);
 
     const paramArray = Object.keys(configuration.params).map((param) => ({
       [param]: resolvedParams[param] ?? null,

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/create_schema.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/create_schema.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createSchemaFromParams } from './create_schema';
+import type { EsqlToolConfig } from '@kbn/onechat-common';
+
+const TEST_VALUES = {
+  name: 'John',
+  status: 'active',
+  age: 25,
+  count: 10,
+  price: 19.99,
+  score: 8.5,
+  active: true,
+  created: '2023-01-01T00:00:00.000Z',
+  config: { timeout: 5000 },
+  tags: [{ name: 'tag1' }, { name: 'tag2' }],
+  jane: 'Jane',
+  janeAge: 30,
+  bob: 'Bob',
+  johnDoe: 'John Doe',
+};
+
+describe('createSchemaFromParams', () => {
+  it('should create schema for string types', () => {
+    const params: EsqlToolConfig['params'] = {
+      name: { type: 'text', description: 'User name' },
+      status: { type: 'keyword', description: 'User status' },
+    };
+
+    const schema = createSchemaFromParams(params);
+    const result = schema.parse({ name: TEST_VALUES.name, status: TEST_VALUES.status });
+
+    expect(result).toEqual({ name: TEST_VALUES.name, status: TEST_VALUES.status });
+  });
+
+  it('should create schema for number types', () => {
+    const params: EsqlToolConfig['params'] = {
+      age: { type: 'long', description: 'User age' },
+      count: { type: 'integer', description: 'Item count' },
+      price: { type: 'double', description: 'Item price' },
+      score: { type: 'float', description: 'User score' },
+    };
+
+    const schema = createSchemaFromParams(params);
+    const result = schema.parse({
+      age: TEST_VALUES.age,
+      count: TEST_VALUES.count,
+      price: TEST_VALUES.price,
+      score: TEST_VALUES.score,
+    });
+
+    expect(result).toEqual({
+      age: TEST_VALUES.age,
+      count: TEST_VALUES.count,
+      price: TEST_VALUES.price,
+      score: TEST_VALUES.score,
+    });
+  });
+
+  it('should create schema for boolean and date types', () => {
+    const params: EsqlToolConfig['params'] = {
+      active: { type: 'boolean', description: 'Is active' },
+      created: { type: 'date', description: 'Creation date' },
+    };
+
+    const schema = createSchemaFromParams(params);
+    const result = schema.parse({
+      active: TEST_VALUES.active,
+      created: TEST_VALUES.created,
+    });
+
+    expect(result).toEqual({
+      active: TEST_VALUES.active,
+      created: TEST_VALUES.created,
+    });
+  });
+
+  it('should create schema for object and nested types', () => {
+    const params: EsqlToolConfig['params'] = {
+      config: { type: 'object', description: 'Configuration object' },
+      tags: { type: 'nested', description: 'Array of tags' },
+    };
+
+    const schema = createSchemaFromParams(params);
+    const result = schema.parse({
+      config: TEST_VALUES.config,
+      tags: TEST_VALUES.tags,
+    });
+
+    expect(result).toEqual({
+      config: TEST_VALUES.config,
+      tags: TEST_VALUES.tags,
+    });
+  });
+
+  it('should handle optional parameters with default values', () => {
+    const params: EsqlToolConfig['params'] = {
+      name: {
+        type: 'text',
+        description: 'User name',
+        optional: true,
+        defaultValue: TEST_VALUES.johnDoe,
+      },
+      age: {
+        type: 'long',
+        description: 'User age',
+        optional: true,
+      },
+    };
+
+    const schema = createSchemaFromParams(params);
+    // Test with all parameters provided
+    const result1 = schema.parse({ name: TEST_VALUES.jane, age: TEST_VALUES.janeAge });
+    expect(result1).toEqual({ name: TEST_VALUES.jane, age: TEST_VALUES.janeAge });
+
+    // Test with default value applied
+    const result2 = schema.parse({ age: TEST_VALUES.age });
+    expect(result2).toEqual({ name: TEST_VALUES.johnDoe, age: TEST_VALUES.age });
+
+    // Test with optional parameter omitted
+    const result3 = schema.parse({ name: TEST_VALUES.bob });
+    expect(result3).toEqual({ name: TEST_VALUES.bob, age: undefined });
+  });
+
+  it('should handle empty parameters', () => {
+    const schema = createSchemaFromParams({});
+    const result = schema.parse({});
+
+    expect(result).toEqual({});
+  });
+
+  it('should validate required parameters', () => {
+    const params: EsqlToolConfig['params'] = {
+      name: { type: 'text', description: 'User name' },
+      age: { type: 'long', description: 'User age' },
+    };
+
+    const schema = createSchemaFromParams(params);
+
+    // Should pass with all required parameters
+    expect(() => schema.parse({ name: TEST_VALUES.name, age: TEST_VALUES.age })).not.toThrow();
+
+    // Should fail with missing required parameter
+    expect(() => schema.parse({ name: TEST_VALUES.name })).toThrow();
+  });
+});

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/create_schema.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/create_schema.ts
@@ -41,7 +41,13 @@ export function createSchemaFromParams(params: EsqlToolConfig['params']): z.ZodO
     }
 
     if (param.optional) {
-      field = field.optional();
+      if (param.defaultValue !== undefined) {
+        // Use default value instead of making it optional
+        field = field.default(param.defaultValue);
+      } else {
+        // No default value, make it optional
+        field = field.optional();
+      }
     }
 
     field = field.describe(param.description);

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/schemas.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/schemas.ts
@@ -24,6 +24,20 @@ export const paramSchema = schema.object({
   type: paramValueTypeSchema,
   description: schema.string(),
   optional: schema.maybe(schema.boolean()),
+  defaultValue: schema.conditional(
+    schema.siblingRef('optional'),
+    true,
+    schema.maybe(
+      schema.oneOf([
+        schema.string(),
+        schema.number(),
+        schema.boolean(),
+        schema.recordOf(schema.string(), schema.any()),
+        schema.arrayOf(schema.recordOf(schema.string(), schema.any())),
+      ])
+    ),
+    schema.never()
+  ),
 });
 
 export const configurationSchema = schema.object({

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/validate_configuration.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/tool_types/esql/validate_configuration.ts
@@ -6,9 +6,74 @@
  */
 
 import { validateQuery } from '@kbn/esql-validation-autocomplete';
-import type { EsqlToolConfig } from '@kbn/onechat-common';
+import type { EsqlToolConfig, EsqlToolFieldTypes, EsqlToolParamValue } from '@kbn/onechat-common';
 import { createBadRequestError } from '@kbn/onechat-common';
 import { getESQLQueryVariables } from '@kbn/esql-utils';
+
+const validateDefaultValueType = (
+  type: EsqlToolFieldTypes,
+  defaultValue: EsqlToolParamValue,
+  paramName: string
+): void => {
+  switch (type) {
+    case 'text':
+    case 'keyword':
+      if (typeof defaultValue !== 'string') {
+        throw createBadRequestError(
+          `Parameter '${paramName}' has type '${type}' but defaultValue is not a string`
+        );
+      }
+      break;
+    case 'long':
+    case 'integer':
+      if (typeof defaultValue !== 'number' || !Number.isInteger(defaultValue)) {
+        throw createBadRequestError(
+          `Parameter '${paramName}' has type '${type}' but defaultValue is not an integer`
+        );
+      }
+      break;
+    case 'double':
+    case 'float':
+      if (typeof defaultValue !== 'number') {
+        throw createBadRequestError(
+          `Parameter '${paramName}' has type '${type}' but defaultValue is not a number`
+        );
+      }
+      break;
+    case 'boolean':
+      if (typeof defaultValue !== 'boolean') {
+        throw createBadRequestError(
+          `Parameter '${paramName}' has type '${type}' but defaultValue is not a boolean`
+        );
+      }
+      break;
+    case 'date':
+      if (typeof defaultValue !== 'string') {
+        throw createBadRequestError(
+          `Parameter '${paramName}' has type '${type}' but defaultValue is not a string`
+        );
+      }
+      break;
+    case 'object':
+      if (
+        typeof defaultValue !== 'object' ||
+        defaultValue === null ||
+        Array.isArray(defaultValue)
+      ) {
+        throw createBadRequestError(
+          `Parameter '${paramName}' has type '${type}' but defaultValue is not an object`
+        );
+      }
+      break;
+    case 'nested':
+      if (!Array.isArray(defaultValue)) {
+        throw createBadRequestError(
+          `Parameter '${paramName}' has type '${type}' but defaultValue is not an array`
+        );
+      }
+      break;
+  }
+};
 
 export const validateConfig = async (configuration: EsqlToolConfig) => {
   // Ensure query is proper ES|QL syntax
@@ -41,5 +106,12 @@ export const validateConfig = async (configuration: EsqlToolConfig) => {
       `Defined parameters not used in query: ${unusedParams.join(', ')}\n` +
         `Query parameters: ${queryParams.join(', ') || 'none'}`
     );
+  }
+
+  // Validate defaultValue type matches parameter type
+  for (const [paramName, param] of Object.entries(configuration.params)) {
+    if (param.defaultValue !== undefined) {
+      validateDefaultValueType(param.type, param.defaultValue, paramName);
+    }
   }
 };


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/search-team/issues/11481

Server-side
- [x] Update the schema (add an optional defaultValue property to EsqlToolParam)
- [x] Update the server-side validation (the defaultValue, when present, should be compatible with the parameter's type)
- [x] Update the esql tool schema generation (so that we set the default value in the generated tool schema)
- [x] Update the esql tool query interpolation (so that we use that default value for interpolation when the LLM didn't call the tool with an explicit one)



