### PR TITLE
Fix the chart tooltips in the metrics grid full screen mode

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/hooks/use_metrics_grid_fullscreen.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/hooks/use_metrics_grid_fullscreen.ts
@@ -27,6 +27,9 @@ export const useFullScreenStyles = () => {
         position: fixed;
         inset: 0;
         background-color: ${euiTheme.colors.backgroundBasePlain};
+        [id^='echAnchorMainTooltip'] {
+          z-index: ${fullScreenZIndex + 1} !important;
+        }
       `,
       [METRICS_GRID_RESTRICT_BODY_CLASS]: css`
         ${logicalCSS('height', '100vh')}
@@ -57,7 +60,7 @@ const fullScreenBodyStyles = css`
       [data-euiportal='true'],
       [data-euiportal='true'] *
     ) {
-    z-index: unset !important;
+    z-index: unset;
   }
 `;
 


### PR DESCRIPTION
Closes #237668 

## Summary

This PR fixes the issue with the charts' tooltip not showing in metrics grid full-screen mode

## Testing 

- Open Discover in the Observability space and use ESQL mode
- Search for  `FROM metrics-*` (Or in case of edge cluster `FROM remote_cluster:metrics-*`)
- Check the metrics grid
  - Verify that the chart's tooltip is visible on chart hover 
- Click on the metrics grid full-screen button
   - Verify that the chart's tooltip is visible on chart hover

<img width="3834" height="2030" alt="image" src="https://github.com/user-attachments/assets/ebff9c3f-14fd-40ba-a488-0952b503a299" />

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->