### PR TITLE
Fix: Enhance rrule suggestion logic in YAML editor to show only if we are …

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_completion_item_provider.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_completion_item_provider.test.ts
@@ -351,6 +351,151 @@ steps:
         expect.arrayContaining(['["api-url"]'])
       );
     });
+
+    it('should provide rrule suggestions in empty scheduled trigger with block', async () => {
+      const yamlContent = `
+version: "1"
+name: "test"
+triggers:
+  - type: scheduled
+    enabled: true
+    with:
+      |<-
+steps: []
+`.trim();
+
+      const suggestions = await getSuggestions(completionProvider, yamlContent);
+      expect(suggestions.map((s) => s.label)).toEqual(
+        expect.arrayContaining([
+          'Daily at 9 AM',
+          'Business hours (weekdays 8 AM & 5 PM)',
+          'Monthly on 1st and 15th',
+          'Custom RRule',
+        ])
+      );
+    });
+
+    it('should provide rrule suggestions in scheduled trigger with block with proper YAML', async () => {
+      const yamlContent = `
+version: "1"
+name: "test"
+triggers:
+  - type: scheduled
+    enabled: true
+    with:
+      |<-
+steps: []
+`.trim();
+
+      const suggestions = await getSuggestions(completionProvider, yamlContent);
+      expect(suggestions.map((s) => s.label)).toEqual(
+        expect.arrayContaining([
+          'Daily at 9 AM',
+          'Business hours (weekdays 8 AM & 5 PM)',
+          'Monthly on 1st and 15th',
+          'Custom RRule',
+        ])
+      );
+    });
+
+    it('should provide rrule suggestions in scheduled trigger with block with empty map', async () => {
+      const yamlContent = `
+version: "1"
+name: "test"
+triggers:
+  - type: scheduled
+    enabled: true
+    with:
+      |<-
+steps: []
+`.trim();
+
+      const suggestions = await getSuggestions(completionProvider, yamlContent);
+      expect(suggestions.map((s) => s.label)).toEqual(
+        expect.arrayContaining([
+          'Daily at 9 AM',
+          'Business hours (weekdays 8 AM & 5 PM)',
+          'Monthly on 1st and 15th',
+          'Custom RRule',
+        ])
+      );
+    });
+
+    it('should provide rrule suggestions in scheduled trigger with block with cursor inside', async () => {
+      const yamlContent = `
+version: "1"
+name: "test"
+triggers:
+  - type: scheduled
+    enabled: true
+    with:
+      |<-
+steps: []
+`.trim();
+
+      const suggestions = await getSuggestions(completionProvider, yamlContent);
+      expect(suggestions.map((s) => s.label)).toEqual(
+        expect.arrayContaining([
+          'Daily at 9 AM',
+          'Business hours (weekdays 8 AM & 5 PM)',
+          'Monthly on 1st and 15th',
+          'Custom RRule',
+        ])
+      );
+    });
+
+    it('should NOT provide rrule suggestions when rrule already exists', async () => {
+      const yamlContent = `
+version: "1"
+name: "test"
+triggers:
+  - type: scheduled
+    enabled: true
+    with:
+      rrule:
+        freq: DAILY
+        interval: 1
+        tzid: UTC
+        byhour: [9]
+        byminute: [0]
+      |<-
+steps: []
+`.trim();
+
+      const suggestions = await getSuggestions(completionProvider, yamlContent);
+      expect(suggestions.map((s) => s.label)).not.toEqual(
+        expect.arrayContaining([
+          'Daily at 9 AM',
+          'Business hours (weekdays 8 AM & 5 PM)',
+          'Monthly on 1st and 15th',
+          'Custom RRule',
+        ])
+      );
+    });
+
+    it('should NOT provide rrule suggestions when every already exists', async () => {
+      const yamlContent = `
+version: "1"
+name: "test"
+triggers:
+  - type: scheduled
+    enabled: true
+    with:
+      every: "5m"
+      |<-
+steps: []
+`.trim();
+
+      const suggestions = await getSuggestions(completionProvider, yamlContent);
+      expect(suggestions.map((s) => s.label)).not.toEqual(
+        expect.arrayContaining([
+          'Daily at 9 AM',
+          'Business hours (weekdays 8 AM & 5 PM)',
+          'Monthly on 1st and 15th',
+          'Custom RRule',
+        ])
+      );
+    });
   });
 
   describe('parseLineForCompletion', () => {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_completion_item_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_completion_item_provider.ts
@@ -198,6 +198,13 @@ function isInScheduledTriggerWithBlock(yamlDocument: Document, absolutePosition:
           absolutePosition >= withPair.value.range[0] &&
           absolutePosition <= withPair.value.range[2]
         ) {
+          // Check if there's already an existing rrule or every configuration
+          if (hasExistingScheduleConfiguration(withPair.value)) {
+            // Don't show rrule suggestions if there's already a schedule configuration
+            result = false;
+            return visit.BREAK;
+          }
+
           result = true;
           return visit.BREAK;
         }
@@ -206,6 +213,29 @@ function isInScheduledTriggerWithBlock(yamlDocument: Document, absolutePosition:
   });
 
   return result;
+}
+
+/**
+ * Check if there's already an existing schedule configuration (rrule or every) in the with block
+ */
+function hasExistingScheduleConfiguration(withNode: Node): boolean {
+  if (!withNode) {
+    return false;
+  }
+
+  // Check for existing 'rrule' or 'every' properties
+  const items = (withNode as any).items || [];
+
+  for (const item of items) {
+    if (isPair(item) && isScalar(item.key)) {
+      const keyValue = item.key.value;
+      if (keyValue === 'rrule' || keyValue === 'every') {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 export interface LineParseResult {


### PR DESCRIPTION
…outside of nested items

## Summary

closes https://github.com/elastic/security-team/issues/14186

Autocomplete now suggest Rrule only if we are inside "with", but not in nested rrule/every blocks

