### PR TITLE
[Agent Bulder] [PoC] Flyout

### DIFF
--- a/src/platform/plugins/shared/dashboard/kibana.jsonc
+++ b/src/platform/plugins/shared/dashboard/kibana.jsonc
@@ -39,7 +39,8 @@
       "serverless",
       "noDataPage",
       "observabilityAIAssistant",
-      "lens"
+      "lens",
+      "onechat"
     ],
     "requiredBundles": [
       "kibanaReact",

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/_dashboard_app_strings.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/_dashboard_app_strings.ts
@@ -157,6 +157,14 @@ export const getDashboardBreadcrumb = () =>
   });
 
 export const topNavStrings = {
+  chat: {
+    label: i18n.translate('dashboard.topNav.chatButtonAriaLabel', {
+      defaultMessage: 'AI chat',
+    }),
+    description: i18n.translate('dashboard.topNav.chatConfigDescription', {
+      defaultMessage: 'Open AI chat assistant',
+    }),
+  },
   fullScreen: {
     label: i18n.translate('dashboard.topNave.fullScreenButtonAriaLabel', {
       defaultMessage: 'full screen',

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -161,10 +161,31 @@ export const useDashboardMenuItems = ({
       panel_titles: panelTitles,
     });
 
+    // Define client-side tools available to the AI
+    const clientTools = {
+      alert_tool: {
+        description: 'Call this when you want to show an alert message to the user',
+        input: {
+          type: 'object' as const,
+          properties: {
+            message: {
+              type: 'string',
+              description: 'The message to display in the alert',
+            },
+          },
+          required: ['message'],
+        },
+        fn: (params: { message: string }) => {
+          alert(params.message);
+        },
+      },
+    };
+
     try {
       onechatService.openConversationFlyout({
         agentId: 'dashboard',
         additionalContext,
+        clientTools,
       });
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -189,12 +210,33 @@ export const useDashboardMenuItems = ({
       panel_titles: panelTitles,
     });
 
+    // Define client-side tools available to the AI
+    const clientTools = {
+      alert_tool: {
+        description: 'Call this when you want to show an alert message to the user',
+        input: {
+          type: 'object' as const,
+          properties: {
+            message: {
+              type: 'string',
+              description: 'The message to display in the alert',
+            },
+          },
+          required: ['message'],
+        },
+        fn: (params: { message: string }) => {
+          alert(params.message);
+        },
+      },
+    };
+
     try {
       onechatService.openConversationFlyout({
         agentId: 'dashboard',
         additionalContext,
         customMessage: 'Please provide a summary of this dashboard',
         newChat: true,
+        clientTools,
       });
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -263,7 +263,7 @@ export const useDashboardMenuItems = ({
         label: 'Dashboard summary',
         description: 'Get an AI-generated summary of this dashboard',
         id: 'chat-summary',
-        iconType: 'editorComment',
+        iconType: 'visText',
         iconOnly: true,
         testId: 'dashboardChatSummaryButton',
         disableButton:

--- a/src/platform/plugins/shared/dashboard/public/plugin.tsx
+++ b/src/platform/plugins/shared/dashboard/public/plugin.tsx
@@ -44,6 +44,7 @@ import type {
   ObservabilityAIAssistantPublicSetup,
   ObservabilityAIAssistantPublicStart,
 } from '@kbn/observability-ai-assistant-plugin/public';
+import type { OnechatPluginStart } from '@kbn/onechat-plugin/public';
 import type { PresentationUtilPluginStart } from '@kbn/presentation-util-plugin/public';
 import type { SavedObjectsManagementPluginStart } from '@kbn/saved-objects-management-plugin/public';
 import type { SavedObjectTaggingOssPluginStart } from '@kbn/saved-objects-tagging-oss-plugin/public';
@@ -112,6 +113,7 @@ export interface DashboardStartDependencies {
   noDataPage?: NoDataPagePluginStart;
   lens?: LensPublicStart;
   observabilityAIAssistant?: ObservabilityAIAssistantPublicStart;
+  onechat?: OnechatPluginStart;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/platform/plugins/shared/dashboard/public/services/kibana_services.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/kibana_services.ts
@@ -19,6 +19,7 @@ import type { NavigationPublicPluginStart } from '@kbn/navigation-plugin/public'
 import type { NoDataPagePluginStart } from '@kbn/no-data-page-plugin/public';
 import type { ObservabilityAIAssistantPublicStart } from '@kbn/observability-ai-assistant-plugin/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
+import type { OnechatPluginStart } from '@kbn/onechat-plugin/public';
 import type { PresentationUtilPluginStart } from '@kbn/presentation-util-plugin/public';
 import type { SavedObjectTaggingOssPluginStart } from '@kbn/saved-objects-tagging-oss-plugin/public';
 import type { ScreenshotModePluginStart } from '@kbn/screenshot-mode-plugin/public';
@@ -41,6 +42,7 @@ export let navigationService: NavigationPublicPluginStart;
 export let noDataPageService: NoDataPagePluginStart | undefined;
 export let observabilityAssistantService: ObservabilityAIAssistantPublicStart | undefined;
 export let lensService: LensPublicStart | undefined;
+export let onechatService: OnechatPluginStart | undefined;
 export let presentationUtilService: PresentationUtilPluginStart;
 export let savedObjectsTaggingService: SavedObjectTaggingOssPluginStart | undefined;
 export let screenshotModeService: ScreenshotModePluginStart;
@@ -64,6 +66,7 @@ export const setKibanaServices = (kibanaCore: CoreStart, deps: DashboardStartDep
   noDataPageService = deps.noDataPage;
   observabilityAssistantService = deps.observabilityAIAssistant;
   lensService = deps.lens;
+  onechatService = deps.onechat;
   presentationUtilService = deps.presentationUtil;
   savedObjectsTaggingService = deps.savedObjectsTaggingOss;
   serverlessService = deps.serverless;

--- a/x-pack/platform/packages/shared/onechat/onechat-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/chat/conversation.ts
@@ -16,6 +16,11 @@ export interface RoundInput {
    * A text message from the user.
    */
   message: string;
+  /**
+   * Optional additional context to provide to the agent.
+   * This is sent separately from the message and not displayed to the user.
+   */
+  additionalContext?: string;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/onechat/common/http_api/chat.ts
+++ b/x-pack/platform/plugins/shared/onechat/common/http_api/chat.ts
@@ -20,6 +20,11 @@ export interface ChatRequestBodyPayload {
   conversation_id?: string;
   capabilities?: AgentCapabilities;
   input: string;
+  /**
+   * Optional additional context to provide to the agent.
+   * This is sent separately from the input and not displayed to the user.
+   */
+  additional_context?: string;
 }
 
 export interface ChatResponse {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/auto_submit_message.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/auto_submit_message.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useCustomMessage } from '../../context/custom_message_context';
+import { useSendMessage } from '../../context/send_message/send_message_context';
+import { useAdditionalContext } from '../../context/additional_context/additional_context';
+
+/**
+ * Component that automatically submits a custom message when the conversation is ready.
+ * This is used for auto-submitting messages when opening the flyout with a predefined message.
+ */
+export const AutoSubmitMessage: React.FC = () => {
+  const { consumeCustomMessage } = useCustomMessage();
+  const { sendMessage, isResponseLoading } = useSendMessage();
+  const { consumeAdditionalContext } = useAdditionalContext();
+  const hasSubmittedRef = useRef(false);
+
+  useEffect(() => {
+    // Only auto-submit once
+    if (hasSubmittedRef.current) {
+      return;
+    }
+
+    // Don't auto-submit if already loading a response
+    if (isResponseLoading) {
+      return;
+    }
+
+    const customMessage = consumeCustomMessage();
+    if (!customMessage) {
+      return;
+    }
+
+    // Mark as submitted before sending to prevent duplicate submissions
+    hasSubmittedRef.current = true;
+
+    // Get additional context if available
+    const additionalContext = consumeAdditionalContext();
+
+    // Submit the custom message
+    sendMessage({ message: customMessage, additionalContext });
+  }, [consumeCustomMessage, sendMessage, consumeAdditionalContext, isResponseLoading]);
+
+  // This component doesn't render anything
+  return null;
+};
+

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
@@ -20,6 +20,7 @@ import { useConversationScrollActions } from '../../hooks/use_conversation_scrol
 import { useConversationStatus } from '../../hooks/use_conversation';
 import { ConversationContent } from './conversation_grid';
 import type { LocationState } from '../../hooks/use_navigation';
+import { useEmbeddableMode } from '../../context/embeddable_mode_context';
 
 const fullHeightStyles = css`
   height: 100%;
@@ -35,6 +36,7 @@ export const Conversation: React.FC<{}> = () => {
   const { euiTheme } = useEuiTheme();
   const { isResponseLoading } = useSendMessage();
   const { isFetched } = useConversationStatus();
+  const { isEmbeddedMode } = useEmbeddableMode();
   const location = useLocation<LocationState>();
 
   const shouldStickToBottom = location.state?.shouldStickToBottom ?? true;

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_grid.styles.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_grid.styles.ts
@@ -6,9 +6,15 @@
  */
 
 import { useEuiTheme } from '@elastic/eui';
+import { useEmbeddableMode } from '../../context/embeddable_mode_context';
 
 export const useConversationGridCenterColumnWidth = () => {
   const { euiTheme } = useEuiTheme();
-  const contentMaxWidth = `calc(${euiTheme.size.xl} * 25)`;
+  const { isEmbeddedMode } = useEmbeddableMode();
+
+  // In embeddable mode (like flyouts), use a more flexible width
+  // In standalone mode, use a fixed max width for better readability
+  const contentMaxWidth = isEmbeddedMode ? '100%' : `calc(${euiTheme.size.xl} * 25)`;
+
   return contentMaxWidth;
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_grid.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_grid.tsx
@@ -9,6 +9,7 @@ import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React from 'react';
 import { useConversationGridCenterColumnWidth } from './conversation_grid.styles';
+import { useEmbeddableMode } from '../../context/embeddable_mode_context';
 
 // Main grid
 
@@ -19,17 +20,27 @@ interface ConversationGridProps {
 
 export const ConversationGrid: React.FC<ConversationGridProps> = ({ children, className }) => {
   const { euiTheme } = useEuiTheme();
+  const { isEmbeddedMode } = useEmbeddableMode();
   const sideColumnWidth = `minmax(calc(${euiTheme.size.xxl} * 2), 1fr)`;
   const contentMarginWidth = euiTheme.size.l;
   const centerColumnWidth = useConversationGridCenterColumnWidth();
-  const gridStyles = css`
-    display: grid;
-    grid-template-columns:
-      ${sideColumnWidth} ${contentMarginWidth} minmax(auto, ${centerColumnWidth})
-      ${contentMarginWidth} ${sideColumnWidth};
-    align-items: center;
-    width: 100%;
-  `;
+  
+  // In embeddable mode, use a simpler grid without side margins
+  const gridStyles = isEmbeddedMode
+    ? css`
+        display: grid;
+        grid-template-columns: ${contentMarginWidth} 1fr ${contentMarginWidth};
+        align-items: center;
+        width: 100%;
+      `
+    : css`
+        display: grid;
+        grid-template-columns:
+          ${sideColumnWidth} ${contentMarginWidth} minmax(auto, ${centerColumnWidth})
+          ${contentMarginWidth} ${sideColumnWidth};
+        align-items: center;
+        width: 100%;
+      `;
 
   return (
     <div css={gridStyles} className={className}>
@@ -45,14 +56,20 @@ interface ConversationGridContainerProps {
 
 // Left side column
 
-const leftContainerStyles = css`
-  grid-column: 1;
-`;
-
 export const ConversationLeft: React.FC<ConversationGridContainerProps> = ({
   children,
   className,
 }) => {
+  const { isEmbeddedMode } = useEmbeddableMode();
+  // In embeddable mode, there's no left column, so hide it
+  if (isEmbeddedMode) {
+    return null;
+  }
+  
+  const leftContainerStyles = css`
+    grid-column: 1;
+  `;
+  
   return (
     <div css={leftContainerStyles} className={className}>
       {children}
@@ -62,14 +79,17 @@ export const ConversationLeft: React.FC<ConversationGridContainerProps> = ({
 
 // Center column without the margins
 
-const centerContainerStyles = css`
-  grid-column: 3;
-`;
-
 export const ConversationCenter: React.FC<ConversationGridContainerProps> = ({
   children,
   className,
 }) => {
+  const { isEmbeddedMode } = useEmbeddableMode();
+  
+  // In embeddable mode, center content is in column 2; in standalone mode it's in column 3
+  const centerContainerStyles = css`
+    grid-column: ${isEmbeddedMode ? '2' : '3'};
+  `;
+  
   return (
     <div css={centerContainerStyles} className={className}>
       {children}
@@ -79,14 +99,20 @@ export const ConversationCenter: React.FC<ConversationGridContainerProps> = ({
 
 // Right side column
 
-const rightContainerStyles = css`
-  grid-column: 5;
-`;
-
 export const ConversationRight: React.FC<ConversationGridContainerProps> = ({
   children,
   className,
 }) => {
+  const { isEmbeddedMode } = useEmbeddableMode();
+  // In embeddable mode, there's no right column, so hide it
+  if (isEmbeddedMode) {
+    return null;
+  }
+  
+  const rightContainerStyles = css`
+    grid-column: 5;
+  `;
+  
   return (
     <div css={rightContainerStyles} className={className}>
       {children}
@@ -109,14 +135,17 @@ export const ConversationContent: React.FC<ConversationGridContainerProps> = ({
 
 // Shorthand for using centered content with margins in the grid
 
-const contentWithMarginsStyles = css`
-  grid-column: 2 / 5;
-`;
-
 export const ConversationContentWithMargins: React.FC<ConversationGridContainerProps> = ({
   children,
   className,
 }) => {
+  const { isEmbeddedMode } = useEmbeddableMode();
+  
+  // In embeddable mode, span all 3 columns; in standalone mode, span columns 2-5
+  const contentWithMarginsStyles = css`
+    grid-column: ${isEmbeddedMode ? '1 / 4' : '2 / 5'};
+  `;
+  
   return (
     <ConversationGrid className={className}>
       <div css={contentWithMarginsStyles}>{children}</div>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_form.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_form.tsx
@@ -16,6 +16,7 @@ import { useAgentId } from '../../../hooks/use_conversation';
 import { useOnechatAgents } from '../../../hooks/agents/use_agents';
 import { useValidateAgentId } from '../../../hooks/agents/use_validate_agent_id';
 import { ConversationInputActions } from './conversation_input_actions';
+import { useAdditionalContext } from '../../../context/additional_context/additional_context';
 
 interface ConversationInputFormProps {
   onSubmit?: () => void;
@@ -32,6 +33,7 @@ export const ConversationInputForm: React.FC<ConversationInputFormProps> = ({ on
   const { euiTheme } = useEuiTheme();
   const { isFetched } = useOnechatAgents();
   const agentId = useAgentId();
+  const { consumeAdditionalContext } = useAdditionalContext();
 
   const validateAgentId = useValidateAgentId();
   const isAgentIdValid = validateAgentId(agentId);
@@ -43,7 +45,11 @@ export const ConversationInputForm: React.FC<ConversationInputFormProps> = ({ on
     if (isSubmitDisabled) {
       return;
     }
-    sendMessage({ message: input });
+    
+    // Consume additional context if available and send it as a separate parameter
+    const additionalContext = consumeAdditionalContext();
+    
+    sendMessage({ message: input, additionalContext });
     setInput('');
     onSubmit?.();
   };

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/chat_message_text.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/chat_message_text.tsx
@@ -30,8 +30,11 @@ import {
   createVisualizationRenderer,
   loadingCursorPlugin,
   visualizationTagParser,
+  clientToolCallTagParser,
+  clientToolCallElement,
 } from './markdown_plugins';
 import { useStepsFromPrevRounds } from '../../../hooks/use_conversation';
+import { ClientToolCall } from './client_tool_call';
 
 interface Props {
   content: string;
@@ -123,6 +126,9 @@ export function ChatMessageText({ content, steps: stepsFromCurrentRound }: Props
         stepsFromCurrentRound,
         stepsFromPrevRounds,
       }),
+      [clientToolCallElement.tagName]: (props: any) => {
+        return <ClientToolCall id={props.clientToolId} params={props.clientToolParams} />;
+      },
     };
 
     return {
@@ -130,6 +136,7 @@ export function ChatMessageText({ content, steps: stepsFromCurrentRound }: Props
         loadingCursorPlugin,
         esqlLanguagePlugin,
         visualizationTagParser,
+        clientToolCallTagParser,
         ...parsingPlugins,
       ],
       processingPluginList: processingPlugins,

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/client_tool_call.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/client_tool_call.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { EuiCallOut, EuiButton, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useClientTools } from '../../../context/client_tools_context';
+
+export interface ClientToolCallAttributes {
+  id?: string;
+  params?: string;
+}
+
+export const ClientToolCall: React.FC<ClientToolCallAttributes> = ({ id, params }) => {
+  const clientTools = useClientTools();
+  const [executed, setExecuted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isExecuting, setIsExecuting] = useState(false);
+
+  const executeToolCall = useCallback(async () => {
+    if (!id || !clientTools || executed || isExecuting) return;
+
+    const tool = clientTools[id];
+    if (!tool) {
+      setError(
+        i18n.translate('xpack.onechat.clientToolCall.toolNotFound', {
+          defaultMessage: 'Tool "{toolId}" not found',
+          values: { toolId: id },
+        })
+      );
+      return;
+    }
+
+    setIsExecuting(true);
+    try {
+      // Parse params
+      let parsedParams = {};
+      if (params) {
+        try {
+          parsedParams = JSON.parse(params);
+        } catch (e) {
+          throw new Error(
+            i18n.translate('xpack.onechat.clientToolCall.invalidParams', {
+              defaultMessage: 'Invalid parameters format',
+            })
+          );
+        }
+      }
+
+      // Execute the tool
+      await tool.fn(parsedParams);
+      setExecuted(true);
+      setError(null);
+    } catch (e) {
+      setError(
+        i18n.translate('xpack.onechat.clientToolCall.executionError', {
+          defaultMessage: 'Error executing tool: {error}',
+          values: { error: e instanceof Error ? e.message : String(e) },
+        })
+      );
+    } finally {
+      setIsExecuting(false);
+    }
+  }, [id, params, clientTools, executed, isExecuting]);
+
+  // Auto-execute on mount
+  useEffect(() => {
+    executeToolCall();
+  }, [executeToolCall]);
+
+  if (!id) {
+    return (
+      <EuiCallOut
+        announceOnMount
+        title={i18n.translate('xpack.onechat.clientToolCall.missingId', {
+          defaultMessage: 'Client tool call missing id attribute',
+        })}
+        color="danger"
+        iconType="error"
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <>
+        <EuiCallOut
+          announceOnMount
+          title={i18n.translate('xpack.onechat.clientToolCall.errorTitle', {
+            defaultMessage: 'Tool execution failed',
+          })}
+          color="danger"
+          iconType="error"
+        >
+          <p>{error}</p>
+          <EuiButton
+            size="s"
+            color="danger"
+            onClick={executeToolCall}
+            isLoading={isExecuting}
+            disabled={isExecuting}
+          >
+            {i18n.translate('xpack.onechat.clientToolCall.retry', {
+              defaultMessage: 'Retry',
+            })}
+          </EuiButton>
+        </EuiCallOut>
+        <EuiSpacer size="m" />
+      </>
+    );
+  }
+
+  if (executed) {
+    return (
+      <>
+        <EuiCallOut
+          announceOnMount
+          title={i18n.translate('xpack.onechat.clientToolCall.executed', {
+            defaultMessage: 'Tool "{toolId}" executed successfully',
+            values: { toolId: id },
+          })}
+          color="success"
+          iconType="check"
+        />
+        <EuiSpacer size="m" />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <EuiCallOut
+        title={i18n.translate('xpack.onechat.clientToolCall.executing', {
+          defaultMessage: 'Executing tool "{toolId}"...',
+          values: { toolId: id },
+        })}
+        color="primary"
+        iconType="iInCircle"
+      />
+      <EuiSpacer size="m" />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_layout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_layout.tsx
@@ -10,6 +10,7 @@ import { css } from '@emotion/react';
 import type { ReactNode } from 'react';
 import React, { useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
+import { useEmbeddableMode } from '../../../context/embeddable_mode_context';
 
 interface RoundLayoutProps {
   input: ReactNode;
@@ -38,14 +39,22 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
   scrollContainerHeight,
 }) => {
   const [roundContainerMinHeight, setRoundContainerMinHeight] = useState(0);
+  const { isEmbeddedMode } = useEmbeddableMode();
 
   useEffect(() => {
+    // Disable min-height behavior in embeddable mode (e.g., flyouts)
+    // as the scroll container height calculation doesn't work correctly
+    if (isEmbeddedMode) {
+      setRoundContainerMinHeight(0);
+      return;
+    }
+
     if (isCurrentRound && isResponseLoading) {
       setRoundContainerMinHeight(scrollContainerHeight);
     } else if (!isCurrentRound) {
       setRoundContainerMinHeight(0);
     }
-  }, [isCurrentRound, isResponseLoading, scrollContainerHeight]);
+  }, [isCurrentRound, isResponseLoading, scrollContainerHeight, isEmbeddedMode]);
 
   const { euiTheme } = useEuiTheme();
   const inputContainerStyles = css`

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/new_conversation_prompt.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/new_conversation_prompt.tsx
@@ -24,6 +24,7 @@ import { ConversationInputForm } from './conversation_input/conversation_input_f
 import { useConversationGridCenterColumnWidth } from './conversation_grid.styles';
 import { docLinks } from '../../../../common/doc_links';
 import { WelcomeText } from '../common/welcome_text';
+import { useEmbeddableMode } from '../../context/embeddable_mode_context';
 
 const fullHeightStyles = css`
   height: 100%;
@@ -178,12 +179,23 @@ export const NewConversationPrompt: React.FC<{}> = () => {
   const { euiTheme } = useEuiTheme();
   const centerColumnWidth = useConversationGridCenterColumnWidth();
   const inputRowHeight = `calc(${euiTheme.size.l} * 7)`;
-  const gridStyles = css`
-    display: grid;
-    grid-template-columns: 1fr ${centerColumnWidth} 1fr;
-    grid-template-rows: auto ${inputRowHeight} auto;
-    row-gap: ${euiTheme.size.l};
-  `;
+  const { isEmbeddedMode } = useEmbeddableMode();
+  
+  // In embeddable mode, use a single column layout; in standalone mode, use a 3-column layout
+  const gridStyles = isEmbeddedMode
+    ? css`
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-template-rows: auto ${inputRowHeight} auto;
+        row-gap: ${euiTheme.size.l};
+      `
+    : css`
+        display: grid;
+        grid-template-columns: 1fr ${centerColumnWidth} 1fr;
+        grid-template-rows: auto ${inputRowHeight} auto;
+        row-gap: ${euiTheme.size.l};
+      `;
+  
   return (
     <ConversationContentWithMargins css={fullHeightStyles}>
       <div css={gridStyles} data-test-subj="agentBuilderWelcomePage">

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/additional_context/additional_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/additional_context/additional_context.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
+
+interface AdditionalContextState {
+  additionalContext: string | undefined;
+  consumeAdditionalContext: () => string | undefined;
+}
+
+const AdditionalContextContext = createContext<AdditionalContextState | null>(null);
+
+export const AdditionalContextProvider: React.FC<
+  React.PropsWithChildren<{ additionalContext?: string }>
+> = ({ children, additionalContext: initialContext }) => {
+  const [additionalContext, setAdditionalContext] = useState<string | undefined>(initialContext);
+
+  const consumeAdditionalContext = useCallback(() => {
+    const context = additionalContext;
+    setAdditionalContext(undefined); // Clear after consumption
+    return context;
+  }, [additionalContext]);
+
+  const value = useMemo(
+    () => ({
+      additionalContext,
+      consumeAdditionalContext,
+    }),
+    [additionalContext, consumeAdditionalContext]
+  );
+
+  return (
+    <AdditionalContextContext.Provider value={value}>
+      {children}
+    </AdditionalContextContext.Provider>
+  );
+};
+
+export const useAdditionalContext = () => {
+  const context = useContext(AdditionalContextContext);
+  if (!context) {
+    // Return a no-op implementation if provider is not available (standalone app mode)
+    return {
+      additionalContext: undefined,
+      consumeAdditionalContext: () => undefined,
+    };
+  }
+  return context;
+};
+

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/client_tools_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/client_tools_context.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useContext, type PropsWithChildren } from 'react';
+import type { ClientToolsMap } from '../../embeddable/types';
+
+interface ClientToolsContextValue {
+  clientTools?: ClientToolsMap;
+}
+
+const ClientToolsContext = createContext<ClientToolsContextValue>({
+  clientTools: undefined,
+});
+
+export const ClientToolsProvider: React.FC<PropsWithChildren<ClientToolsContextValue>> = ({
+  children,
+  clientTools,
+}) => {
+  return (
+    <ClientToolsContext.Provider value={{ clientTools }}>
+      {children}
+    </ClientToolsContext.Provider>
+  );
+};
+
+export const useClientTools = () => {
+  const context = useContext(ClientToolsContext);
+  return context.clientTools;
+};
+

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/conversation_id_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/conversation_id_context.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
+
+interface ConversationIdContextValue {
+  conversationId: string | undefined;
+  setConversationId: (id: string | undefined) => void;
+}
+
+const ConversationIdContext = createContext<ConversationIdContextValue | null>(null);
+
+interface ConversationIdProviderProps {
+  conversationId?: string;
+  children: React.ReactNode;
+}
+
+export const ConversationIdProvider: React.FC<ConversationIdProviderProps> = ({
+  conversationId: initialConversationId,
+  children,
+}) => {
+  const [conversationId, setConversationIdState] = useState<string | undefined>(
+    initialConversationId
+  );
+
+  const setConversationId = useCallback((id: string | undefined) => {
+    setConversationIdState(id);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      conversationId,
+      setConversationId,
+    }),
+    [conversationId, setConversationId]
+  );
+
+  return <ConversationIdContext.Provider value={value}>{children}</ConversationIdContext.Provider>;
+};
+
+export const useConversationIdFromContext = (): ConversationIdContextValue | null => {
+  return useContext(ConversationIdContext);
+};
+

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/custom_message_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/custom_message_context.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useContext, useRef } from 'react';
+
+interface CustomMessageContextType {
+  customMessage: string | undefined;
+  consumeCustomMessage: () => string | undefined;
+}
+
+export const CustomMessageContext = createContext<CustomMessageContextType | null>(null);
+
+export const CustomMessageProvider: React.FC<
+  React.PropsWithChildren<{ customMessage?: string }>
+> = ({ children, customMessage: initialCustomMessage }) => {
+  // Use a ref to store the custom message so it can be consumed once
+  const customMessageRef = useRef<string | undefined>(initialCustomMessage);
+
+  const consumeCustomMessage = () => {
+    const message = customMessageRef.current;
+    customMessageRef.current = undefined; // Clear after consumption
+    return message;
+  };
+
+  const contextValue = {
+    customMessage: customMessageRef.current,
+    consumeCustomMessage,
+  };
+
+  return (
+    <CustomMessageContext.Provider value={contextValue}>
+      {children}
+    </CustomMessageContext.Provider>
+  );
+};
+
+export const useCustomMessage = () => {
+  const context = useContext(CustomMessageContext);
+  if (!context) {
+    // Return a no-op implementation if provider is not available
+    return {
+      customMessage: undefined,
+      consumeCustomMessage: () => undefined,
+    };
+  }
+  return context;
+};
+

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/embeddable_mode_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/embeddable_mode_context.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useContext } from 'react';
+
+interface EmbeddableModeContextValue {
+  isEmbeddedMode: boolean;
+  onConversationCreated?: (conversationId: string) => void;
+}
+
+const EmbeddableModeContext = createContext<EmbeddableModeContextValue>({
+  isEmbeddedMode: false,
+});
+
+interface EmbeddableModeProviderProps {
+  isEmbeddedMode: boolean;
+  onConversationCreated?: (conversationId: string) => void;
+  children: React.ReactNode;
+}
+
+export const EmbeddableModeProvider: React.FC<EmbeddableModeProviderProps> = ({
+  isEmbeddedMode,
+  onConversationCreated,
+  children,
+}) => {
+  return (
+    <EmbeddableModeContext.Provider value={{ isEmbeddedMode, onConversationCreated }}>
+      {children}
+    </EmbeddableModeContext.Provider>
+  );
+};
+
+export const useEmbeddableMode = (): EmbeddableModeContextValue => {
+  return useContext(EmbeddableModeContext);
+};
+

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/send_message/send_message_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/send_message/send_message_context.tsx
@@ -9,7 +9,13 @@ import React, { createContext, useContext } from 'react';
 import { useSendMessageMutation } from './use_send_message_mutation';
 
 interface SendMessageState {
-  sendMessage: ({ message }: { message: string }) => void;
+  sendMessage: ({
+    message,
+    additionalContext,
+  }: {
+    message: string;
+    additionalContext?: string;
+  }) => void;
   isResponseLoading: boolean;
   error: unknown;
   pendingMessage: string | undefined;

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/send_message/use_send_message_mutation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/send_message/use_send_message_mutation.ts
@@ -43,7 +43,13 @@ export const useSendMessageMutation = ({ connectorId }: UseSendMessageMutationPr
     isAborted: () => Boolean(messageControllerRef?.current?.signal?.aborted),
   });
 
-  const sendMessage = ({ message }: { message: string }) => {
+  const sendMessage = ({
+    message,
+    additionalContext,
+  }: {
+    message: string;
+    additionalContext?: string;
+  }) => {
     const signal = messageControllerRef.current?.signal;
     if (!signal) {
       return Promise.reject(new Error('Abort signal not present'));
@@ -54,6 +60,7 @@ export const useSendMessageMutation = ({ connectorId }: UseSendMessageMutationPr
       conversationId,
       agentId,
       connectorId,
+      additionalContext,
     });
 
     return subscribeToChatEvents(events$);

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation_id.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation_id.ts
@@ -8,13 +8,24 @@
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { newConversationId } from '../utils/new_conversation';
+import { useConversationIdFromContext } from '../context/conversation_id_context';
 
 export const useConversationId = () => {
+  // Try to get conversationId from context first (for embeddable mode)
+  const contextValue = useConversationIdFromContext();
+
+  // Fallback to router params (for standalone app mode)
   const { conversationId: conversationIdParam } = useParams<{ conversationId?: string }>();
 
   const conversationId = useMemo(() => {
+    // If context is available, use it (embeddable mode)
+    if (contextValue !== null) {
+      return contextValue.conversationId;
+    }
+
+    // Otherwise use router params (standalone app mode)
     return conversationIdParam === newConversationId ? undefined : conversationIdParam;
-  }, [conversationIdParam]);
+  }, [contextValue, conversationIdParam]);
 
   return conversationId;
 };

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/components/conversation_with_agent.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/components/conversation_with_agent.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useMemo } from 'react';
+import { oneChatDefaultAgentId } from '@kbn/onechat-common';
+import { Conversation } from '../../application/components/conversations/conversation';
+import { AutoSubmitMessage } from '../../application/components/conversations/auto_submit_message';
+import { useValidateAgentId } from '../../application/hooks/agents/use_validate_agent_id';
+import { useConversationActions } from '../../application/hooks/use_conversation_actions';
+import { useConversationId } from '../../application/hooks/use_conversation_id';
+
+interface ConversationWithAgentProps {
+  /**
+   * Requested agent ID - will fall back to default if not found
+   */
+  agentId?: string;
+}
+
+/**
+ * Wrapper component that validates and sets the agent ID before rendering the conversation.
+ * This component must be used within all necessary providers (QueryClient, OnechatServices, etc.)
+ */
+export const ConversationWithAgent: React.FC<ConversationWithAgentProps> = ({
+  agentId: requestedAgentId,
+}) => {
+  const validateAgentId = useValidateAgentId();
+  const { setAgentId } = useConversationActions();
+  const conversationId = useConversationId();
+
+  // Validate the requested agent ID and fall back to default if not valid
+  const validatedAgentId = useMemo(() => {
+    if (requestedAgentId && validateAgentId(requestedAgentId)) {
+      return requestedAgentId;
+    }
+    // Fall back to default agent if requested agent doesn't exist
+    return oneChatDefaultAgentId;
+  }, [requestedAgentId, validateAgentId]);
+
+  // Set the agent ID for new conversations
+  useEffect(() => {
+    // Only set agent ID for new conversations (no existing conversationId)
+    if (!conversationId && validatedAgentId) {
+      setAgentId(validatedAgentId);
+    }
+  }, [conversationId, validatedAgentId, setAgentId]);
+
+  return (
+    <>
+      <AutoSubmitMessage />
+      <Conversation />
+    </>
+  );
+};
+

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/create_embeddable_conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/create_embeddable_conversation.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { CoreStart } from '@kbn/core/public';
+import type { OnechatInternalService } from '../services';
+import { EmbeddableConversationInternal } from './embeddable_conversation';
+import type { EmbeddableConversationProps } from './types';
+
+interface CreateEmbeddableConversationParams {
+  services: OnechatInternalService;
+  coreStart: CoreStart;
+}
+
+/**
+ * Factory function that creates an embeddable Conversation component
+ * with services injected via closure.
+ *
+ * @param services - Internal onechat services
+ * @param coreStart - Kibana core start services
+ * @returns A configured Conversation component ready for external consumption
+ */
+export const createEmbeddableConversation = ({
+  services,
+  coreStart,
+}: CreateEmbeddableConversationParams): React.ComponentType<EmbeddableConversationProps> => {
+  return (props: EmbeddableConversationProps) => (
+    <EmbeddableConversationInternal {...props} services={services} coreStart={coreStart} />
+  );
+};
+

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/embeddable_conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/embeddable_conversation.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** @jsx jsx */
+import { jsx } from '@emotion/react';
+import React, { useMemo } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { CoreStart } from '@kbn/core/public';
+import { css } from '@emotion/react';
+import { Router } from '@kbn/shared-ux-router';
+import { createMemoryHistory } from 'history';
+import type { OnechatInternalService } from '../services';
+import { OnechatServicesContext } from '../application/context/onechat_services_context';
+import { SendMessageProvider } from '../application/context/send_message/send_message_context';
+import { ConversationIdProvider } from '../application/context/conversation_id_context';
+import { EmbeddableModeProvider } from '../application/context/embeddable_mode_context';
+import { Conversation } from '../application/components/conversations/conversation';
+import { useEmbeddableConversationState } from './hooks/use_embeddable_conversation_state';
+import type { EmbeddableConversationProps } from './types';
+
+interface EmbeddableConversationInternalProps extends EmbeddableConversationProps {
+  services: OnechatInternalService;
+  coreStart: CoreStart;
+}
+
+const EmbeddableConversationInternal: React.FC<EmbeddableConversationInternalProps> = ({
+  conversationId: initialConversationId,
+  agentId,
+  height = '600px',
+  onConversationCreated,
+  className,
+  services,
+  coreStart,
+}) => {
+  // Create a new QueryClient instance for this embeddable
+  const queryClient = useMemo(() => new QueryClient(), []);
+
+  // Create a memory history for the router
+  const history = useMemo(() => createMemoryHistory(), []);
+
+  // Manage conversation ID state
+  const { conversationId, setConversationId } = useEmbeddableConversationState({
+    initialConversationId,
+    onConversationCreated,
+  });
+
+  // Prepare Kibana services context
+  const kibanaServices = useMemo(
+    () => ({
+      ...coreStart,
+      plugins: services.startDependencies,
+    }),
+    [coreStart, services.startDependencies]
+  );
+
+  // Container styles
+  const containerHeight = typeof height === 'number' ? `${height}px` : height;
+  const containerStyles = css`
+    height: ${containerHeight};
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  `;
+
+  return (
+    <div css={containerStyles} className={className}>
+      <KibanaContextProvider services={kibanaServices}>
+        <I18nProvider>
+          <QueryClientProvider client={queryClient}>
+            <OnechatServicesContext.Provider value={services}>
+              <Router history={history}>
+                <EmbeddableModeProvider
+                  isEmbeddedMode={true}
+                  onConversationCreated={setConversationId}
+                >
+                  <ConversationIdProvider conversationId={conversationId}>
+                    <SendMessageProvider>
+                      <Conversation />
+                    </SendMessageProvider>
+                  </ConversationIdProvider>
+                </EmbeddableModeProvider>
+              </Router>
+            </OnechatServicesContext.Provider>
+          </QueryClientProvider>
+        </I18nProvider>
+      </KibanaContextProvider>
+    </div>
+  );
+};
+
+export { EmbeddableConversationInternal };

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/embeddable_conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/embeddable_conversation.tsx
@@ -22,6 +22,7 @@ import { ConversationIdProvider } from '../application/context/conversation_id_c
 import { EmbeddableModeProvider } from '../application/context/embeddable_mode_context';
 import { AdditionalContextProvider } from '../application/context/additional_context/additional_context';
 import { CustomMessageProvider } from '../application/context/custom_message_context';
+import { ClientToolsProvider } from '../application/context/client_tools_context';
 import { useEmbeddableConversationState } from './hooks/use_embeddable_conversation_state';
 import type { EmbeddableConversationProps } from './types';
 import { ConversationWithAgent } from './components/conversation_with_agent';
@@ -39,6 +40,7 @@ const EmbeddableConversationInternal: React.FC<EmbeddableConversationInternalPro
   height = '600px',
   onConversationCreated,
   className,
+  clientTools,
   services,
   coreStart,
 }) => {
@@ -80,20 +82,22 @@ const EmbeddableConversationInternal: React.FC<EmbeddableConversationInternalPro
           <QueryClientProvider client={queryClient}>
             <OnechatServicesContext.Provider value={services}>
               <Router history={history}>
-                <EmbeddableModeProvider
-                  isEmbeddedMode={true}
-                  onConversationCreated={setConversationId}
-                >
-                  <ConversationIdProvider conversationId={conversationId}>
-                    <AdditionalContextProvider additionalContext={additionalContext}>
-                      <CustomMessageProvider customMessage={customMessage}>
-                        <SendMessageProvider>
-                          <ConversationWithAgent agentId={agentId} />
-                        </SendMessageProvider>
-                      </CustomMessageProvider>
-                    </AdditionalContextProvider>
-                  </ConversationIdProvider>
-                </EmbeddableModeProvider>
+                <ClientToolsProvider clientTools={clientTools}>
+                  <EmbeddableModeProvider
+                    isEmbeddedMode={true}
+                    onConversationCreated={setConversationId}
+                  >
+                    <ConversationIdProvider conversationId={conversationId}>
+                      <AdditionalContextProvider additionalContext={additionalContext}>
+                        <CustomMessageProvider customMessage={customMessage}>
+                          <SendMessageProvider>
+                            <ConversationWithAgent agentId={agentId} />
+                          </SendMessageProvider>
+                        </CustomMessageProvider>
+                      </AdditionalContextProvider>
+                    </ConversationIdProvider>
+                  </EmbeddableModeProvider>
+                </ClientToolsProvider>
               </Router>
             </OnechatServicesContext.Provider>
           </QueryClientProvider>

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/embeddable_conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/embeddable_conversation.tsx
@@ -20,9 +20,11 @@ import { OnechatServicesContext } from '../application/context/onechat_services_
 import { SendMessageProvider } from '../application/context/send_message/send_message_context';
 import { ConversationIdProvider } from '../application/context/conversation_id_context';
 import { EmbeddableModeProvider } from '../application/context/embeddable_mode_context';
-import { Conversation } from '../application/components/conversations/conversation';
+import { AdditionalContextProvider } from '../application/context/additional_context/additional_context';
+import { CustomMessageProvider } from '../application/context/custom_message_context';
 import { useEmbeddableConversationState } from './hooks/use_embeddable_conversation_state';
 import type { EmbeddableConversationProps } from './types';
+import { ConversationWithAgent } from './components/conversation_with_agent';
 
 interface EmbeddableConversationInternalProps extends EmbeddableConversationProps {
   services: OnechatInternalService;
@@ -32,6 +34,8 @@ interface EmbeddableConversationInternalProps extends EmbeddableConversationProp
 const EmbeddableConversationInternal: React.FC<EmbeddableConversationInternalProps> = ({
   conversationId: initialConversationId,
   agentId,
+  additionalContext,
+  customMessage,
   height = '600px',
   onConversationCreated,
   className,
@@ -81,9 +85,13 @@ const EmbeddableConversationInternal: React.FC<EmbeddableConversationInternalPro
                   onConversationCreated={setConversationId}
                 >
                   <ConversationIdProvider conversationId={conversationId}>
-                    <SendMessageProvider>
-                      <Conversation />
-                    </SendMessageProvider>
+                    <AdditionalContextProvider additionalContext={additionalContext}>
+                      <CustomMessageProvider customMessage={customMessage}>
+                        <SendMessageProvider>
+                          <ConversationWithAgent agentId={agentId} />
+                        </SendMessageProvider>
+                      </CustomMessageProvider>
+                    </AdditionalContextProvider>
                   </ConversationIdProvider>
                 </EmbeddableModeProvider>
               </Router>

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/hooks/use_embeddable_conversation_state.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/hooks/use_embeddable_conversation_state.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+
+interface UseEmbeddableConversationStateProps {
+  initialConversationId?: string;
+  onConversationCreated?: (conversationId: string) => void;
+}
+
+export const useEmbeddableConversationState = ({
+  initialConversationId,
+  onConversationCreated,
+}: UseEmbeddableConversationStateProps) => {
+  const [conversationId, setConversationId] = useState<string | undefined>(initialConversationId);
+  const callbackFiredRef = useRef(false);
+
+  // Reset when initialConversationId changes
+  useEffect(() => {
+    setConversationId(initialConversationId);
+    callbackFiredRef.current = false;
+  }, [initialConversationId]);
+
+  const handleConversationCreated = useCallback(
+    (newConversationId: string) => {
+      setConversationId(newConversationId);
+
+      // Only fire callback once per conversation creation
+      if (onConversationCreated && !callbackFiredRef.current) {
+        callbackFiredRef.current = true;
+        onConversationCreated(newConversationId);
+      }
+    },
+    [onConversationCreated]
+  );
+
+  return {
+    conversationId,
+    setConversationId: handleConversationCreated,
+  };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/index.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { createEmbeddableConversation } from './create_embeddable_conversation';
+export type { EmbeddableConversationProps } from './types';
+

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/types.ts
@@ -6,6 +6,47 @@
  */
 
 /**
+ * Schema definition for client-side tool parameters
+ */
+export interface ClientToolInputSchema {
+  type: 'object';
+  properties: Record<string, {
+    type: string;
+    description: string;
+    [key: string]: any;
+  }>;
+  required?: string[];
+}
+
+/**
+ * Definition of a client-side tool that can be called by the AI
+ */
+export interface ClientTool<TParams = any> {
+  /**
+   * Human-readable description of what this tool does.
+   * The AI uses this to decide when to call the tool.
+   */
+  description: string;
+  
+  /**
+   * JSON schema defining the input parameters for this tool.
+   */
+  input: ClientToolInputSchema;
+  
+  /**
+   * Function to execute when the AI calls this tool.
+   * @param params - The parameters passed by the AI
+   * @returns Optional return value or Promise
+   */
+  fn: (params: TParams) => void | Promise<void>;
+}
+
+/**
+ * Map of client-side tools available to the AI
+ */
+export type ClientToolsMap = Record<string, ClientTool>;
+
+/**
  * Props for the embeddable Conversation component
  */
 export interface EmbeddableConversationProps {
@@ -50,5 +91,11 @@ export interface EmbeddableConversationProps {
    * This message will be sent immediately after the component is ready.
    */
   customMessage?: string;
+
+  /**
+   * Optional map of client-side tools that the AI can invoke.
+   * The AI can call these tools by rendering <clientToolCall id="tool_id" params={...}> in its response.
+   */
+  clientTools?: ClientToolsMap;
 }
 

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/types.ts
@@ -22,6 +22,12 @@ export interface EmbeddableConversationProps {
   agentId?: string;
 
   /**
+   * Optional additional context to prepend to the first user message.
+   * This context will be automatically included when the user sends their first message.
+   */
+  additionalContext?: string;
+
+  /**
    * Optional height for the conversation container.
    * Can be a CSS string (e.g., '500px', '100%') or a number (pixels).
    * Defaults to '600px'.
@@ -38,5 +44,11 @@ export interface EmbeddableConversationProps {
    * Optional CSS class name for custom styling.
    */
   className?: string;
+
+  /**
+   * Optional custom message to automatically submit when the component mounts.
+   * This message will be sent immediately after the component is ready.
+   */
+  customMessage?: string;
 }
 

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/types.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Props for the embeddable Conversation component
+ */
+export interface EmbeddableConversationProps {
+  /**
+   * Optional conversation ID to load an existing conversation.
+   * If not provided, a new conversation will be started.
+   */
+  conversationId?: string;
+
+  /**
+   * Optional agent ID to use for new conversations.
+   * If not provided, the default agent will be used.
+   */
+  agentId?: string;
+
+  /**
+   * Optional height for the conversation container.
+   * Can be a CSS string (e.g., '500px', '100%') or a number (pixels).
+   * Defaults to '600px'.
+   */
+  height?: string | number;
+
+  /**
+   * Optional callback that fires when a new conversation is created.
+   * Receives the new conversation ID.
+   */
+  onConversationCreated?: (conversationId: string) => void;
+
+  /**
+   * Optional CSS class name for custom styling.
+   */
+  className?: string;
+}
+

--- a/x-pack/platform/plugins/shared/onechat/public/flyout/conversation_flyout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/flyout/conversation_flyout.tsx
@@ -32,6 +32,7 @@ export const ConversationFlyout: React.FC<ConversationFlyoutInternalProps> = ({
   agentId,
   additionalContext,
   customMessage,
+  clientTools,
   onConversationCreated,
   onClose,
   ConversationComponent,
@@ -136,6 +137,7 @@ export const ConversationFlyout: React.FC<ConversationFlyoutInternalProps> = ({
             agentId={agentId}
             additionalContext={additionalContext}
             customMessage={customMessage}
+            clientTools={clientTools}
             height="100%"
             onConversationCreated={handleConversationCreated}
           />

--- a/x-pack/platform/plugins/shared/onechat/public/flyout/conversation_flyout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/flyout/conversation_flyout.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** @jsx jsx */
+import { jsx } from '@emotion/react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  EuiFlyoutResizable,
+  EuiFlyoutHeader,
+  EuiFlyoutBody,
+  EuiTitle,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { EmbeddableConversationProps } from '../embeddable';
+import type { ConversationFlyoutProps } from './types';
+
+interface ConversationFlyoutInternalProps extends ConversationFlyoutProps {
+  ConversationComponent: React.ComponentType<EmbeddableConversationProps>;
+}
+
+export const ConversationFlyout: React.FC<ConversationFlyoutInternalProps> = ({
+  conversationId: initialConversationId,
+  agentId,
+  additionalContext,
+  onConversationCreated,
+  onClose,
+  ConversationComponent,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const [conversationId, setConversationId] = useState<string | undefined>(initialConversationId);
+
+  // Handle conversation creation
+  const handleConversationCreated = useCallback(
+    (id: string) => {
+      setConversationId(id);
+      onConversationCreated?.(id);
+    },
+    [onConversationCreated]
+  );
+
+  // TODO: Handle additional context by sending an initial message
+  // This would require extending the Conversation component to accept an initial message
+  useEffect(() => {
+    if (additionalContext) {
+      // For now, we just log it. In a future iteration, we could:
+      // 1. Add an initialMessage prop to EmbeddableConversation
+      // 2. Or use a ref to programmatically send a message
+      console.log('Additional context provided:', additionalContext);
+    }
+  }, [additionalContext]);
+
+  const flyoutHeaderStyles = css`
+    background-color: ${euiTheme.colors.emptyShade};
+    border-bottom: ${euiTheme.border.thin};
+  `;
+
+  const flyoutBodyStyles = css`
+    padding: 0;
+    overflow: hidden;
+    .euiFlyoutBody__overflowContent {
+      padding: 0;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+  `;
+
+  const conversationContainerStyles = css`
+    flex: 1;
+    overflow: hidden;
+  `;
+
+  return (
+    <EuiFlyoutResizable
+      onClose={onClose}
+      aria-labelledby="conversation-flyout-title"
+      size="m"
+      minWidth={400}
+      paddingSize="none"
+      ownFocus
+      data-test-subj="onechat-conversation-flyout"
+    >
+      <EuiFlyoutHeader hasBorder css={flyoutHeaderStyles}>
+        <EuiFlexGroup gutterSize="m" alignItems="center" justifyContent="spaceBetween">
+          <EuiFlexItem grow={true}>
+            <EuiTitle size="m">
+              <h2 id="conversation-flyout-title">
+                {conversationId
+                  ? i18n.translate('xpack.onechat.flyout.existingConversationTitle', {
+                      defaultMessage: 'Conversation',
+                    })
+                  : i18n.translate('xpack.onechat.flyout.newConversationTitle', {
+                      defaultMessage: 'New Conversation',
+                    })}
+              </h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon
+              iconType="cross"
+              onClick={onClose}
+              aria-label={i18n.translate('xpack.onechat.flyout.closeButtonAriaLabel', {
+                defaultMessage: 'Close conversation flyout',
+              })}
+              data-test-subj="onechat-conversation-flyout-close-button"
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutHeader>
+
+      <EuiFlyoutBody css={flyoutBodyStyles}>
+        <div css={conversationContainerStyles}>
+          <ConversationComponent
+            conversationId={conversationId}
+            agentId={agentId}
+            height="100%"
+            onConversationCreated={handleConversationCreated}
+          />
+        </div>
+      </EuiFlyoutBody>
+    </EuiFlyoutResizable>
+  );
+};
+

--- a/x-pack/platform/plugins/shared/onechat/public/flyout/flyout_conversation_storage.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/flyout/flyout_conversation_storage.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Manages persistence of the last conversation used in the flyout
+ */
+
+const STORAGE_KEY = 'onechat:flyout:lastConversation';
+
+interface FlyoutConversationState {
+  conversationId: string;
+  agentId?: string;
+}
+
+/**
+ * Store the last conversation ID and agent ID used in the flyout
+ */
+export const storeFlyoutConversation = (conversationId: string, agentId?: string): void => {
+  try {
+    const state: FlyoutConversationState = {
+      conversationId,
+      agentId,
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    // Silently fail if localStorage is not available
+  }
+};
+
+/**
+ * Retrieve the last conversation state from the flyout
+ */
+export const getFlyoutConversation = (): FlyoutConversationState | null => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+    return JSON.parse(stored) as FlyoutConversationState;
+  } catch (error) {
+    return null;
+  }
+};
+
+/**
+ * Clear the stored flyout conversation
+ */
+export const clearFlyoutConversation = (): void => {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    // Silently fail if localStorage is not available
+  }
+};
+
+/**
+ * Determine the conversation ID to use when opening the flyout
+ */
+export const resolveConversationId = ({
+  conversationId,
+  agentId,
+  newChat,
+}: {
+  conversationId?: string;
+  agentId?: string;
+  newChat?: boolean;
+}): string | undefined => {
+  // If conversationId is explicitly provided, use it
+  if (conversationId) {
+    return conversationId;
+  }
+
+  // If newChat is true, start a new conversation
+  if (newChat) {
+    return undefined;
+  }
+
+  // Try to restore the last conversation
+  const lastConversation = getFlyoutConversation();
+  if (!lastConversation) {
+    return undefined;
+  }
+
+  // If agentId is specified and differs from the stored agent, start a new conversation
+  if (agentId && lastConversation.agentId && agentId !== lastConversation.agentId) {
+    return undefined;
+  }
+
+  // Restore the last conversation
+  return lastConversation.conversationId;
+};
+

--- a/x-pack/platform/plugins/shared/onechat/public/flyout/index.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/flyout/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { openConversationFlyout } from './open_conversation_flyout';
+export { ConversationFlyout } from './conversation_flyout';
+export type { OpenConversationFlyoutOptions, ConversationFlyoutProps } from './types';

--- a/x-pack/platform/plugins/shared/onechat/public/flyout/open_conversation_flyout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/flyout/open_conversation_flyout.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { distinctUntilChanged, from, skip, takeUntil } from 'rxjs';
+import type { CoreStart } from '@kbn/core/public';
+import { toMountPoint } from '@kbn/react-kibana-mount';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import type { OverlayRef } from '@kbn/core-mount-utils-browser';
+import { ConversationFlyout } from './conversation_flyout';
+import type { OpenConversationFlyoutOptions } from './types';
+import type { OnechatInternalService } from '../services';
+import type { OnechatStartDependencies } from '../types';
+import type { EmbeddableConversationProps } from '../embeddable';
+import { OnechatServicesContext } from '../application/context/onechat_services_context';
+
+interface OpenConversationFlyoutParams {
+  coreStart: CoreStart;
+  services: OnechatInternalService;
+  startDependencies: OnechatStartDependencies;
+  ConversationComponent: React.ComponentType<EmbeddableConversationProps>;
+}
+
+/**
+ * Opens a conversation flyout.
+ *
+ * @param options - Configuration options for the flyout
+ * @param params - Internal parameters (services, core, etc.)
+ * @returns A Promise that resolves when the flyout is closed, and an OverlayRef to close it programmatically
+ */
+export function openConversationFlyout(
+  options: OpenConversationFlyoutOptions,
+  { coreStart, services, startDependencies, ConversationComponent }: OpenConversationFlyoutParams
+): { flyoutRef: OverlayRef; promise: Promise<void> } {
+  const {
+    overlays,
+    application: { currentAppId$ },
+    ...startServices
+  } = coreStart;
+
+  return new Promise<{ flyoutRef: OverlayRef; promise: Promise<void> }>((resolve, reject) => {
+    try {
+      // Prepare Kibana services context
+      const kibanaServices = {
+        ...coreStart,
+        plugins: startDependencies,
+      };
+
+      const flyoutRef = overlays.openFlyout(
+        toMountPoint(
+          <KibanaContextProvider services={kibanaServices}>
+            <OnechatServicesContext.Provider value={services}>
+              <ConversationFlyout
+                {...options}
+                onClose={() => flyoutRef.close()}
+                ConversationComponent={ConversationComponent}
+              />
+            </OnechatServicesContext.Provider>
+          </KibanaContextProvider>,
+          startServices
+        ),
+        {
+          'data-test-subj': 'onechat-conversation-flyout-wrapper',
+          ownFocus: true,
+          onClose: () => flyoutRef.close(),
+          isResizable: true,
+        }
+      );
+
+      // Close the flyout when user navigates out of the current plugin
+      currentAppId$
+        .pipe(skip(1), takeUntil(from(flyoutRef.onClose)), distinctUntilChanged())
+        .subscribe(() => {
+          flyoutRef.close();
+        });
+
+      resolve({
+        flyoutRef,
+        promise: flyoutRef.onClose.then(() => {}),
+      });
+    } catch (error) {
+      reject(error);
+    }
+  }) as any; // TypeScript workaround for the Promise wrapping
+}

--- a/x-pack/platform/plugins/shared/onechat/public/flyout/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/flyout/types.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { ClientToolsMap } from '../embeddable/types';
+
 /**
  * Options for opening a conversation flyout
  */
@@ -44,6 +46,12 @@ export interface OpenConversationFlyoutOptions {
    * This message will be sent immediately after the flyout is rendered.
    */
   customMessage?: string;
+
+  /**
+   * Optional map of client-side tools that the AI can invoke.
+   * The AI can call these tools by rendering <clientToolCall id="tool_id" params={...}> in its response.
+   */
+  clientTools?: ClientToolsMap;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/onechat/public/flyout/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/flyout/types.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Options for opening a conversation flyout
+ */
+export interface OpenConversationFlyoutOptions {
+  /**
+   * Optional conversation ID to load an existing conversation.
+   * If not provided, a new conversation will be started.
+   */
+  conversationId?: string;
+
+  /**
+   * Optional agent ID to use for the conversation.
+   * If not provided, the default agent will be used.
+   */
+  agentId?: string;
+
+  /**
+   * Optional additional context to provide to the conversation.
+   * This can be used to pass relevant information to the AI assistant.
+   */
+  additionalContext?: string;
+
+  /**
+   * Optional callback that fires when a new conversation is created.
+   */
+  onConversationCreated?: (conversationId: string) => void;
+}
+
+/**
+ * Props for the internal ConversationFlyout component
+ */
+export interface ConversationFlyoutProps extends OpenConversationFlyoutOptions {
+  /**
+   * Callback to close the flyout
+   */
+  onClose: () => void;
+}

--- a/x-pack/platform/plugins/shared/onechat/public/flyout/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/flyout/types.ts
@@ -11,7 +11,8 @@
 export interface OpenConversationFlyoutOptions {
   /**
    * Optional conversation ID to load an existing conversation.
-   * If not provided, a new conversation will be started.
+   * If not provided, will try to load the last conversation from the flyout
+   * (unless newChat is true or agentId doesn't match).
    */
   conversationId?: string;
 
@@ -28,9 +29,21 @@ export interface OpenConversationFlyoutOptions {
   additionalContext?: string;
 
   /**
+   * If true, always start a new conversation (don't restore previous flyout conversation).
+   * Defaults to false.
+   */
+  newChat?: boolean;
+
+  /**
    * Optional callback that fires when a new conversation is created.
    */
   onConversationCreated?: (conversationId: string) => void;
+
+  /**
+   * Optional custom message to automatically submit when the flyout opens.
+   * This message will be sent immediately after the flyout is rendered.
+   */
+  customMessage?: string;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/onechat/public/index.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/index.ts
@@ -16,6 +16,7 @@ import type {
 import { OnechatPlugin } from './plugin';
 
 export type { OnechatPluginSetup, OnechatPluginStart };
+export type { EmbeddableConversationProps } from './embeddable';
 
 export const plugin: PluginInitializer<
   OnechatPluginSetup,

--- a/x-pack/platform/plugins/shared/onechat/public/index.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/index.ts
@@ -17,6 +17,7 @@ import { OnechatPlugin } from './plugin';
 
 export type { OnechatPluginSetup, OnechatPluginStart };
 export type { EmbeddableConversationProps } from './embeddable';
+export type { OpenConversationFlyoutOptions } from './flyout';
 
 export const plugin: PluginInitializer<
   OnechatPluginSetup,

--- a/x-pack/platform/plugins/shared/onechat/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/plugin.tsx
@@ -26,6 +26,7 @@ import type {
   OnechatStartDependencies,
 } from './types';
 import { createPublicToolContract } from './services/tools';
+import { createEmbeddableConversation } from './embeddable';
 
 import { registerLocators } from './locator/register_locators';
 
@@ -101,6 +102,12 @@ export class OnechatPlugin
 
     return {
       tools: createPublicToolContract({ toolsService }),
+      components: {
+        Conversation: createEmbeddableConversation({
+          services: this.internalServices,
+          coreStart: core,
+        }),
+      },
     };
   }
 }

--- a/x-pack/platform/plugins/shared/onechat/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/plugin.tsx
@@ -27,6 +27,7 @@ import type {
 } from './types';
 import { createPublicToolContract } from './services/tools';
 import { createEmbeddableConversation } from './embeddable';
+import { openConversationFlyout } from './flyout';
 
 import { registerLocators } from './locator/register_locators';
 
@@ -92,7 +93,7 @@ export class OnechatPlugin
     const conversationsService = new ConversationsService({ http });
     const toolsService = new ToolsService({ http });
 
-    this.internalServices = {
+    const internalServices: OnechatInternalService = {
       agentService,
       chatService,
       conversationsService,
@@ -100,14 +101,25 @@ export class OnechatPlugin
       startDependencies,
     };
 
+    this.internalServices = internalServices;
+
+    const ConversationComponent = createEmbeddableConversation({
+      services: internalServices,
+      coreStart: core,
+    });
+
     return {
       tools: createPublicToolContract({ toolsService }),
       components: {
-        Conversation: createEmbeddableConversation({
-          services: this.internalServices,
-          coreStart: core,
-        }),
+        Conversation: ConversationComponent,
       },
+      openConversationFlyout: (options) =>
+        openConversationFlyout(options, {
+          coreStart: core,
+          services: internalServices,
+          startDependencies,
+          ConversationComponent,
+        }),
     };
   }
 }

--- a/x-pack/platform/plugins/shared/onechat/public/services/chat/chat_service.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/services/chat/chat_service.ts
@@ -22,6 +22,11 @@ export interface ChatParams {
   conversationId?: string;
   capabilities?: AgentCapabilities;
   input: string;
+  /**
+   * Optional additional context to provide to the agent.
+   * This is sent separately from the input and not displayed to the user.
+   */
+  additionalContext?: string;
 }
 
 export class ChatService {
@@ -38,6 +43,7 @@ export class ChatService {
       conversation_id: params.conversationId,
       connector_id: params.connectorId,
       capabilities: params.capabilities ?? getKibanaDefaultAgentCapabilities(),
+      additional_context: params.additionalContext,
     };
     return defer(() => {
       return this.http.post(`${publicApiPath}/converse/async`, {

--- a/x-pack/platform/plugins/shared/onechat/public/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/types.ts
@@ -15,8 +15,10 @@ import type { ManagementSetup } from '@kbn/management-plugin/public';
 import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import type { ToolServiceStartContract } from '@kbn/onechat-browser';
 import type { UiActionsSetup, UiActionsStart } from '@kbn/ui-actions-plugin/public';
-import type { EmbeddableConversationProps } from './embeddable';
+import type { OverlayRef } from '@kbn/core-mount-utils-browser';
 import type React from 'react';
+import type { EmbeddableConversationProps } from './embeddable';
+import type { OpenConversationFlyoutOptions } from './flyout';
 
 /* eslint-disable @typescript-eslint/no-empty-interface*/
 
@@ -67,5 +69,32 @@ export interface OnechatPluginStart {
      * ```
      */
     Conversation: React.ComponentType<EmbeddableConversationProps>;
+  };
+
+  /**
+   * Opens a conversation flyout.
+   *
+   * @param options - Configuration options for the flyout
+   * @returns An object containing the flyout reference and a promise that resolves when the flyout is closed
+   *
+   * @example
+   * ```tsx
+   * // Open a new conversation with additional context
+   * const { flyoutRef, promise } = plugins.onechat.openConversationFlyout({
+   *   agentId: 'my-agent',
+   *   additionalContext: 'User is viewing dashboard X',
+   *   onConversationCreated: (id) => console.log('Conversation created:', id)
+   * });
+   *
+   * // Programmatically close the flyout
+   * flyoutRef.close();
+   *
+   * // Wait for the flyout to close
+   * await promise;
+   * ```
+   */
+  openConversationFlyout: (options: OpenConversationFlyoutOptions) => {
+    flyoutRef: OverlayRef;
+    promise: Promise<void>;
   };
 }

--- a/x-pack/platform/plugins/shared/onechat/public/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/types.ts
@@ -15,6 +15,8 @@ import type { ManagementSetup } from '@kbn/management-plugin/public';
 import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import type { ToolServiceStartContract } from '@kbn/onechat-browser';
 import type { UiActionsSetup, UiActionsStart } from '@kbn/ui-actions-plugin/public';
+import type { EmbeddableConversationProps } from './embeddable';
+import type React from 'react';
 
 /* eslint-disable @typescript-eslint/no-empty-interface*/
 
@@ -46,4 +48,24 @@ export interface OnechatPluginStart {
    * Tool service contract, can be used to list or execute tools.
    */
   tools: ToolServiceStartContract;
+
+  /**
+   * Embeddable components that can be used in other plugins.
+   */
+  components: {
+    /**
+     * Embeddable Conversation component.
+     * Renders a chat conversation interface that can be embedded in other applications.
+     *
+     * @example
+     * ```tsx
+     * // Start a new conversation
+     * <Conversation onConversationCreated={(id) => console.log('Created:', id)} />
+     *
+     * // Load an existing conversation
+     * <Conversation conversationId="existing-id" height="800px" />
+     * ```
+     */
+    Conversation: React.ComponentType<EmbeddableConversationProps>;
+  };
 }

--- a/x-pack/platform/plugins/shared/onechat/server/routes/chat.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/chat.ts
@@ -58,6 +58,14 @@ export function registerChatRoutes({
     input: schema.string({
       meta: { description: 'The user input message to send to the agent.' },
     }),
+    additional_context: schema.maybe(
+      schema.string({
+        meta: {
+          description:
+            'Optional additional context to provide to the agent. This is sent separately from the input and not displayed to the user.',
+        },
+      })
+    ),
     capabilities: schema.maybe(
       schema.object(
         {
@@ -96,6 +104,7 @@ export function registerChatRoutes({
       connector_id: connectorId,
       conversation_id: conversationId,
       input,
+      additional_context: additionalContext,
       capabilities,
     } = payload;
 
@@ -105,7 +114,7 @@ export function registerChatRoutes({
       conversationId,
       capabilities,
       abortSignal,
-      nextInput: { message: input },
+      nextInput: { message: input, additionalContext },
       request,
     });
   };

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/add_round_complete_event.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/add_round_complete_event.ts
@@ -108,9 +108,11 @@ const createRoundFromEvents = ({
     throw new Error(`Unknown event type: ${(event as any).type}`);
   };
 
+  // Store the round without additionalContext (only the user's actual message)
+  // The additionalContext is only used for the AI but not stored in conversation history
   const round: ConversationRound = {
     id: uuidv4(),
-    input,
+    input: { message: input.message },
     steps: stepEvents.map(eventToStep),
     trace_id: getCurrentTraceId(),
     response: { message: messages[messages.length - 1].message_content },

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/to_langchain_messages.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/to_langchain_messages.ts
@@ -29,7 +29,12 @@ export const conversationToLangchainMessages = ({
     messages.push(...roundToLangchain(round, { ignoreSteps }));
   }
 
-  messages.push(createUserMessage({ content: nextInput.message }));
+  // Create user message with additional context if provided
+  const userMessageContent = nextInput.additionalContext
+    ? `${nextInput.additionalContext}\n\n${nextInput.message}`
+    : nextInput.message;
+
+  messages.push(createUserMessage({ content: userMessageContent }));
 
   return messages;
 };


### PR DESCRIPTION
## Summary

Implements Agent Builder flyout which can be opened anywhere

- [x] Refactors Conversations component
- [x] Adds Conversations component wrapper (EmbeddableConversations)
- [x] Adds Flyout with Conversation component, New chat button, 
- [x] adds utility function on plugin start contract that brings up the new flyout
- [x] integrates in dashboard application so that Agent Builder sidebar can be opened
- [x] integrartes in dashboard with example button that runs specific prompt

left button opens the flyout, right one runs predefined prompt 
<img width="1072" height="460" alt="image" src="https://github.com/user-attachments/assets/4f795b88-76ba-4a84-9aae-e4e8cb623cee" />

<img width="3024" height="1476" alt="image" src="https://github.com/user-attachments/assets/276d5149-89d0-4201-96aa-606b0f8a6e9f" />

consumers (apps) can:
- [x] open the flyout
- [x] select which agent to use by default
- [x] request new conversation
- [x] open existing conversation (by default last conversation is loaded)
- [x] provide additionalContext to the flyout
- [x] run provided prompt directly

