### PR TITLE
[Lens][Lens as code] Make config builder ownership viz only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -511,7 +511,7 @@ src/platform/packages/shared/kbn-interpreter @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-io-ts-utils @elastic/obs-knowledge-team
 src/platform/packages/shared/kbn-jest-benchmarks @elastic/obs-ui-devex-team
 src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations
-src/platform/packages/shared/kbn-lens-embeddable-utils @elastic/kibana-visualizations
+src/platform/packages/shared/kbn-lens-embeddable-utils @elastic/obs-ux-infra_services-team @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-licensing-types @elastic/kibana-core
 src/platform/packages/shared/kbn-lock-manager @elastic/obs-ai-assistant
 src/platform/packages/shared/kbn-logging @elastic/kibana-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -511,7 +511,7 @@ src/platform/packages/shared/kbn-interpreter @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-io-ts-utils @elastic/obs-knowledge-team
 src/platform/packages/shared/kbn-jest-benchmarks @elastic/obs-ui-devex-team
 src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations
-src/platform/packages/shared/kbn-lens-embeddable-utils @elastic/obs-ux-infra_services-team @elastic/kibana-visualizations
+src/platform/packages/shared/kbn-lens-embeddable-utils @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-licensing-types @elastic/kibana-core
 src/platform/packages/shared/kbn-lock-manager @elastic/obs-ai-assistant
 src/platform/packages/shared/kbn-logging @elastic/kibana-core

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/kibana.jsonc
@@ -2,7 +2,6 @@
   "type": "shared-common",
   "id": "@kbn/lens-embeddable-utils",
   "owner": [
-    "@elastic/obs-ux-infra_services-team",
     "@elastic/kibana-visualizations"
   ],
   "group": "platform",


### PR DESCRIPTION
## Summary

This is the missing piece of #236627 that removes the shared code ownership of the package.
