### PR TITLE
[scout] improve eui version parsing

### DIFF
--- a/src/platform/packages/shared/kbn-scout/test/scout/fixtures/eui_helpers.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/fixtures/eui_helpers.ts
@@ -19,7 +19,9 @@ const getEuiVersion = () => {
 
   const rawVersion = packageJson.dependencies['@elastic/eui'];
   // Remove semver prefixes like ^, ~, >=, etc. to get clean version number
-  const cleanVersion = rawVersion.replace(/^[\^~>=<]*/, '');
+  let cleanVersion = rawVersion.replace(/^[\^~>=<]*/, '');
+  // Remove additional version suffixes like -backport.0, -amsterdam.0, etc.
+  cleanVersion = cleanVersion.replace(/-[a-zA-Z]+\.\d+$/, '');
   return cleanVersion;
 };
 


### PR DESCRIPTION
## Summary


This PR fixes scout tests failing on 9.2 branch due to incorrect eui version parsing from package.json file