### PR TITLE
[AI Infra] Fixes Preferred AI Assistant setting in Serverless

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -1,7 +1,7 @@
 pageLoadAssetSize:
   actions: 20000
   advancedSettings: 6196
-  aiAssistantManagementSelection: 8988
+  aiAssistantManagementSelection: 9214
   aiops: 19890
   alerting: 28395
   apm: 38573

--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/components/navigation_control/lazy_nav_control.tsx
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/components/navigation_control/lazy_nav_control.tsx
@@ -10,7 +10,6 @@
 import type { CoreStart } from '@kbn/core/public';
 import { dynamic } from '@kbn/shared-ux-utility';
 import React from 'react';
-import { I18nProvider } from '@kbn/i18n-react';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { useIsNavControlVisible } from '../../hooks/use_is_nav_control_visible';
 import type { AIAssistantType } from '../../../common/ai_assistant_type';
@@ -39,13 +38,11 @@ export const NavControlInitiator = ({
   }
 
   return (
-    <I18nProvider>
-      <LazyNavControl
-        isSecurityAIAssistantEnabled={isSecurityAIAssistantEnabled}
-        isObservabilityAIAssistantEnabled={isObservabilityAIAssistantEnabled}
-        coreStart={coreStart}
-        triggerOpenChat={triggerOpenChat}
-      />
-    </I18nProvider>
+    <LazyNavControl
+      isSecurityAIAssistantEnabled={isSecurityAIAssistantEnabled}
+      isObservabilityAIAssistantEnabled={isObservabilityAIAssistantEnabled}
+      coreStart={coreStart}
+      triggerOpenChat={triggerOpenChat}
+    />
   );
 };

--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/hooks/use_is_nav_control_visible.tsx
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/hooks/use_is_nav_control_visible.tsx
@@ -13,7 +13,7 @@ import type { CoreStart } from '@kbn/core/public';
 import { DEFAULT_APP_CATEGORIES, type PublicAppInfo } from '@kbn/core/public';
 import type { Space, SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { PREFERRED_AI_ASSISTANT_TYPE_SETTING_KEY } from '../../common/ui_setting_keys';
-import type { AIAssistantType } from '../../common/ai_assistant_type';
+import { AIAssistantType } from '../../common/ai_assistant_type';
 
 function getVisibility(
   appId: string | undefined,
@@ -47,7 +47,8 @@ export function useIsNavControlVisible(coreStart: CoreStart, spaces?: SpacesPlug
   const { currentAppId$, applications$ } = coreStart.application;
 
   const uiSetting$ = coreStart.uiSettings.get$<AIAssistantType>(
-    PREFERRED_AI_ASSISTANT_TYPE_SETTING_KEY
+    PREFERRED_AI_ASSISTANT_TYPE_SETTING_KEY,
+    AIAssistantType.Default
   );
 
   const activeSpace$ = useMemo(


### PR DESCRIPTION
The setting `aiAssistant:preferredAIAssistantType` is not registered in serverless and so any call to get the settings without providing a default value will throw an error.

This fix provides the default value when retrieving the setting.

Also hides the AI assistant selector button on serverless.

Additionally, it adds a theme provider for the nav selector so that the dark theme displays properly:

Before:

<img width="1022" height="1022" alt="image" src="https://github.com/user-attachments/assets/039c39da-e8a0-4ec1-82d8-2ac4cdeaf6cb" />


After:

<img width="1024" height="1020" alt="image" src="https://github.com/user-attachments/assets/0dea9331-edf0-4d0a-8e8d-957c6be9941a" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->