### PR TITLE
[ObsUX][APM&Infra] Adapt visual inconsistencies with new search bar

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_groups/service_groups_list/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_groups/service_groups_list/index.tsx
@@ -89,10 +89,12 @@ export function ServiceGroupsList() {
             <EuiFlexItem>
               <EuiFormControlLayout
                 fullWidth
+                css={{ blockSize: 'auto' }}
                 clear={!isEmpty(filter) ? { onClick: clearFilterCallback } : undefined}
               >
                 <EuiFieldText
                   controlOnly
+                  compressed
                   data-test-subj="apmServiceGroupsListFieldText"
                   icon="search"
                   fullWidth

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_groups/service_groups_list/sort.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_groups/service_groups_list/sort.tsx
@@ -39,6 +39,7 @@ export function Sort({ type, onChange }: Props) {
       aria-label={i18n.translate('xpack.apm.serviceGroups.list.sort.ariaLabel', {
         defaultMessage: 'Sort service groups by',
       })}
+      compressed
       options={options}
       value={type}
       onChange={(e) => onChange(e.target.value as ServiceGroupsSortType)}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_select/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_select/index.tsx
@@ -147,6 +147,7 @@ export function EnvironmentSelect({
       <EuiComboBox
         data-test-subj="environmentFilter"
         async
+        compressed
         isClearable={false}
         isInvalid={isInvalid}
         placeholder={i18n.translate('xpack.apm.filter.environment.placeholder', {

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/table_search_bar/table_search_bar.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/table_search_bar/table_search_bar.tsx
@@ -48,6 +48,7 @@ export function TableSearchBar({
           placeholder={placeholder}
           fullWidth={true}
           defaultValue={searchQuery}
+          compressed
           isLoading={isLoading}
           onChange={(e) => {
             debouncedSearchQuery(e.target.value);

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/time_comparison/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/time_comparison/index.tsx
@@ -107,6 +107,7 @@ export function TimeComparison() {
       disabled={comparisonEnabled === false}
       options={comparisonOptions}
       value={offset}
+      compressed
       prepend={
         <PrependContainer>
           <EuiCheckbox

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/transaction_type_select.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/transaction_type_select.tsx
@@ -50,6 +50,7 @@ export function TransactionTypeSelect() {
         data-test-subj="headerFilterTransactionType"
         onChange={handleChange}
         options={options}
+        compressed
         value={transactionType}
       />
     </>

--- a/x-pack/solutions/observability/plugins/infra/public/components/saved_views/toolbar_control.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/saved_views/toolbar_control.tsx
@@ -108,6 +108,7 @@ export function SavedViewsToolbarControls<TSingleSavedViewState extends SavedVie
         data-test-subj="savedViews-popover"
         button={
           <EuiButton
+            size="s"
             onClick={togglePopoverAndLoad}
             data-test-subj="savedViews-openPopover"
             buttonRef={openPopoverButtonRef}

--- a/x-pack/solutions/observability/plugins/infra/public/components/schema_selector.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/schema_selector.tsx
@@ -249,7 +249,7 @@ export const SchemaSelector = ({
             data-test-subj="infraSchemaSelect"
             id="infraSchemaSelectorSelect"
             options={displayOptions}
-            compressed={isHostsView}
+            compressed
             valueOfSelected={isInvalid ? 'unknown' : value ?? 'semconv'}
             onChange={onSelect}
             isLoading={isLoading}

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/dropdown_button.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/dropdown_button.tsx
@@ -34,7 +34,7 @@ const ButtonLabel = ({ label, theme }: { label: string; theme?: EuiThemeComputed
   <EuiFlexItem
     grow={false}
     css={{
-      padding: 12,
+      padding: 7,
       background: theme?.colors.backgroundBaseFormsPrepend,
       borderRight: theme?.border.thin,
     }}

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_time_controls.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_time_controls.tsx
@@ -50,6 +50,7 @@ export const WaffleTimeControls = withEuiTheme(({ interval }: PropsWithTheme) =>
       iconSide="left"
       iconType="pause"
       onClick={stopAutoReload}
+      size="s"
     >
       <FormattedMessage
         id="xpack.infra.waffleTime.stopRefreshingButtonLabel"
@@ -62,6 +63,7 @@ export const WaffleTimeControls = withEuiTheme(({ interval }: PropsWithTheme) =>
       iconSide="left"
       iconType="play"
       onClick={startAutoReload}
+      size="s"
     >
       <FormattedMessage
         id="xpack.infra.waffleTime.autoRefreshButtonLabel"
@@ -102,6 +104,7 @@ export const WaffleTimeControls = withEuiTheme(({ interval }: PropsWithTheme) =>
             popoverPlacement="upRight"
             selected={currentMoment}
             shouldCloseOnSelect
+            compressed
             showTimeSelect
             timeFormat="LT"
           />

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/aggregation.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/aggregation.tsx
@@ -79,6 +79,7 @@ export const MetricsExplorerAggregationPicker = ({ options, onChange }: Props) =
       data-test-subj="infraMetricsExplorerAggregationPickerSelect"
       aria-label={label}
       fullWidth
+      compressed
       value={options.aggregation}
       options={METRIC_EXPLORER_AGGREGATIONS_WITHOUT_CUSTOM.map((k) => ({
         text: AGGREGATION_LABELS[k],

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/chart_options.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/chart_options.tsx
@@ -39,6 +39,7 @@ export const MetricsExplorerChartOptions = ({ chartOptions, onChange }: Props) =
         { defaultMessage: 'Customize' }
       )}
       iconSide="left"
+      size="s"
       iconType="eye"
       onClick={togglePopover}
       data-test-subj="metricsExplorer-customize"

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/group_by.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/group_by.tsx
@@ -38,6 +38,7 @@ export const MetricsExplorerGroupBy = ({ options, onChange }: Props) => {
 
   return (
     <EuiComboBox
+      compressed
       data-test-subj="metricsExplorer-groupBy"
       placeholder={i18n.translate('xpack.infra.metricsExplorer.groupByLabel', {
         defaultMessage: 'Everything',

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/metrics.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/metrics.tsx
@@ -124,6 +124,7 @@ export const MetricsExplorerMetrics = ({ options, onChange, autoFocus = false }:
       isDisabled={options.aggregation === 'count'}
       placeholder={placeholderText}
       fullWidth
+      compressed
       options={comboOptions}
       selectedOptions={selectedOptions}
       onChange={handleChange}

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/toolbar.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/components/toolbar.tsx
@@ -110,6 +110,7 @@ export const MetricsExplorerToolbar = ({
             <EuiSuperDatePicker
               start={timeRange.from}
               end={timeRange.to}
+              compressed
               onTimeChange={({ start, end }) => onTimeChange(start, end)}
               onRefresh={onRefresh}
               commonlyUsedRanges={commonlyUsedRanges}


### PR DESCRIPTION
## Summary

Fixes #237283

This PR adapts the changes done for the search bar in https://github.com/elastic/kibana/pull/231659 for the APM and Infra views.

| Page  | Before | After |
|--------|--------|--------|
| APM Service Overview |<img width="1437" height="764" alt="image" src="https://github.com/user-attachments/assets/d6a0f242-d164-4ef6-974f-035629b2b108" /> | <img width="1465" height="759" alt="image" src="https://github.com/user-attachments/assets/c8f0d6c4-481c-49d9-86dc-9edb9c9b564b" /> |
| APM Service Inventory | <img width="1455" height="713" alt="image" src="https://github.com/user-attachments/assets/b738380e-50d3-4549-ba69-4e09b18056a9" /> |  <img width="1456" height="738" alt="image" src="https://github.com/user-attachments/assets/b47174f2-b0d7-4012-bd8f-7f071c7fde2a" /> |
| Infra Inventory | <img width="1463" height="711" alt="image" src="https://github.com/user-attachments/assets/f53c053b-1865-4f03-8852-366704ee3efa" /> | <img width="1450" height="717" alt="image" src="https://github.com/user-attachments/assets/5172c710-a6ee-41cc-be5e-e2503b5c223c" /> |
| Metrics Explorer | <img width="1456" height="692" alt="image" src="https://github.com/user-attachments/assets/83d8860c-6734-496e-b0da-5dd99bea2a9c" /> |<img width="1454" height="690" alt="image" src="https://github.com/user-attachments/assets/1bc44cb2-722d-468e-99b6-d264c7f44b64" /> |
| Hosts | <img width="1454" height="736" alt="image" src="https://github.com/user-attachments/assets/9c596d33-c7cb-4901-a0b1-dd491a88680b" /> |<img width="1462" height="755" alt="image" src="https://github.com/user-attachments/assets/f30ce1e0-4217-44f0-81e8-121341cecb29" /> | 

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->