### PR TITLE
[Metrics][Discover] Fix the value filter issue

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.test.ts
@@ -6,7 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import type { MetricField } from '@kbn/metrics-experience-plugin/common/types';
+import type { Dimension, MetricField } from '@kbn/metrics-experience-plugin/common/types';
 import { DIMENSIONS_COLUMN } from './constants';
 import { createESQLQuery } from './create_esql_query';
 import { ES_FIELD_TYPES } from '@kbn/field-types';
@@ -160,6 +160,65 @@ TS metrics-*
       `
 TS custom-metrics-*
   | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+`.trim()
+    );
+  });
+
+  it('should handle undefined dimensions without throwing error', () => {
+    const query = createESQLQuery({
+      metric: mockMetric,
+      dimensions: undefined,
+    });
+
+    expect(query).toBe(
+      `
+TS metrics-*
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+`.trim()
+    );
+  });
+  it('should handle undefined both dimensions and metrics dimensions without throwing error', () => {
+    const query = createESQLQuery({
+      metric: { ...mockMetric, dimensions: undefined as unknown as Dimension[] },
+      dimensions: undefined,
+    });
+
+    expect(query).toBe(
+      `
+TS metrics-*
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+`.trim()
+    );
+  });
+
+  it('should handle undefined dimensions with filters', () => {
+    const query = createESQLQuery({
+      metric: mockMetric,
+      dimensions: undefined,
+      filters: [{ field: 'host.name', value: 'host-1' }],
+    });
+
+    expect(query).toBe(
+      `
+TS metrics-*
+  | WHERE host.name IN ("host-1")
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+`.trim()
+    );
+  });
+  it('should handle undefined metrics dimensions with dimensions and filters', () => {
+    const query = createESQLQuery({
+      metric: { ...mockMetric, dimensions: undefined as unknown as Dimension[] },
+      dimensions: ['host.name'],
+      filters: [{ field: 'host.name', value: 'host-1' }],
+    });
+
+    expect(query).toBe(
+      `
+TS metrics-*
+  | WHERE host.name IN ("host-1")
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend), host.name
+  | RENAME host.name AS ${DIMENSIONS_COLUMN}
 `.trim()
     );
   });

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
@@ -69,7 +69,7 @@ export function createESQLQuery({ metric, dimensions = [], filters }: CreateESQL
     });
   }
 
-  const dimensionTypeMap = new Map(metricDimensions.map((dim) => [dim.name, dim.type]));
+  const dimensionTypeMap = new Map(metricDimensions?.map((dim) => [dim.name, dim.type]));
 
   const unfilteredDimensions = (dimensions ?? []).filter((dim) => !valuesByField.has(dim));
   const queryPipeline = source.pipe(
@@ -82,13 +82,13 @@ export function createESQLQuery({ metric, dimensions = [], filters }: CreateESQL
         instrument,
         placeholderName: 'metricField',
       })} BY ${createTimeBucketAggregation({})}${
-        dimensions.length > 0 ? `, ${dimensions.join(',')}` : ''
+        (dimensions ?? []).length > 0 ? `, ${dimensions.join(',')}` : ''
       }`,
       {
         metricField,
       }
     ),
-    ...(dimensions.length > 0
+    ...((dimensions ?? []).length > 0
       ? dimensions.length === 1
         ? [rename(`??dim as ${DIMENSIONS_COLUMN}`, { dim: dimensions[0] })]
         : [

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
@@ -71,15 +71,11 @@ export function createESQLQuery({ metric, dimensions = [], filters }: CreateESQL
 
   const dimensionTypeMap = new Map(metricDimensions.map((dim) => [dim.name, dim.type]));
 
+  const unfilteredDimensions = (dimensions ?? []).filter((dim) => !valuesByField.has(dim));
   const queryPipeline = source.pipe(
     ...whereConditions,
-    dimensions.length > 0
-      ? where(
-          dimensions
-            .filter((dim) => !valuesByField.has(dim))
-            .map((dim) => `${dim} IS NOT NULL`)
-            .join(' AND ')
-        )
+    unfilteredDimensions.length > 0
+      ? where(unfilteredDimensions.map((dim) => `${dim} IS NOT NULL`).join(' AND '))
       : (query) => query,
     stats(
       `${createMetricAggregation({


### PR DESCRIPTION
Closes #238000 

## Summary

This PR fixes the issue with the `WHERE` clause mentioned. When looking at the browser console, I saw `Uncaught TypeError: Cannot read properties of undefined (reading 'filter')` so we have `undefined` instead of an array

<img width="3838" height="1334" alt="image" src="https://github.com/user-attachments/assets/b9338473-c1bf-46ea-8df0-b6ee0a063eb2" />

So the issue occurs when:
- The dimensions are selected (`dimensions.length > 0`)
- But the value filters for ALL dimensions, so the `.filter((dim) => !valuesByField.has(dim))` removes all dimensions
- This results in an empty array and `.join(' AND ')` returns an empty string
-  This creates `where('')`  which generates an invalid ES|QL WHERE clause

To fix that, I extracted the filter and checked the array lenght first, and now it works as expected

## Testing: 

https://github.com/user-attachments/assets/82fa4435-c0f0-4b42-bb9e-de5d2107070d



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->