### PR TITLE
[Metrics][Discover] Fix focus navigation when closing the metric detail flyout

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
@@ -34,7 +34,8 @@ export type ChartProps = Pick<ChartSectionProps, 'searchSessionId' | 'requestPar
     filters?: Array<{ field: string; value: string }>;
     discoverFetch$: Observable<UnifiedHistogramInputMessage>;
     metric: MetricField;
-    onViewDetails: (esqlQuery: string, metric: MetricField) => void;
+    onViewDetails: (esqlQuery: string, metric: MetricField, chartId: string) => void;
+    chartId: string;
   };
 
 const LensWrapperMemo = React.memo(LensWrapper);
@@ -52,6 +53,7 @@ export const Chart = ({
   dimensions = [],
   size = 'm',
   filters = [],
+  chartId,
 }: ChartProps) => {
   const { euiTheme } = useEuiTheme();
   const chartRef = useRef<HTMLDivElement>(null);
@@ -87,8 +89,8 @@ export const Chart = ({
   });
 
   const handleViewDetails = useCallback(() => {
-    onViewDetails(esqlQuery, metric);
-  }, [onViewDetails, esqlQuery, metric]);
+    onViewDetails(esqlQuery, metric, chartId);
+  }, [onViewDetails, esqlQuery, metric, chartId]);
 
   return (
     <div

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/flyout/metrics_insights_flyout.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/flyout/metrics_insights_flyout.tsx
@@ -36,12 +36,13 @@ interface MetricInsightsFlyoutProps {
   esqlQuery?: string;
   isOpen: boolean;
   onClose: () => void;
+  chartRef: { current: HTMLDivElement | null };
 }
 
 export const MetricInsightsFlyout = ({
   metric,
   esqlQuery,
-
+  chartRef,
   isOpen,
   onClose,
 }: MetricInsightsFlyoutProps) => {
@@ -85,6 +86,15 @@ export const MetricInsightsFlyout = ({
           { defaultMessage: 'Metric Insights Flyout' }
         )}
         ownFocus
+        focusTrapProps={{
+          returnFocus: () => {
+            if (chartRef.current) {
+              chartRef.current.focus();
+              return false;
+            }
+            return true;
+          },
+        }}
         minWidth={minWidth}
         maxWidth={maxWidth}
         onResize={setFlyoutWidth}

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.tsx
@@ -56,11 +56,15 @@ export const MetricsGrid = ({
 }: MetricsGridProps) => {
   const { euiTheme } = useEuiTheme();
   const gridRef = useRef<HTMLDivElement>(null);
+  const chartRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const [expandedMetric, setExpandedMetric] = useState<
     | {
         metric: MetricField;
         esqlQuery: string;
+        chartId: string;
+        rowIndex: number;
+        colIndex: number;
       }
     | undefined
   >();
@@ -81,21 +85,52 @@ export const MetricsGrid = ({
   const gridColumns = columns || 1;
   const gridRows = Math.ceil(rows.length / gridColumns);
 
-  const { focusedCell, handleKeyDown, handleCellClick, getRowColFromIndex } = useGridNavigation({
-    gridColumns,
-    gridRows,
-    totalRows: rows.length,
-    gridRef,
-  });
+  const { focusedCell, handleKeyDown, getRowColFromIndex, handleFocusCell, focusCell } =
+    useGridNavigation({
+      gridColumns,
+      gridRows,
+      totalRows: rows.length,
+      gridRef,
+    });
 
-  const handleViewDetails = useCallback((esqlQuery: string, metric: MetricField) => {
-    setExpandedMetric({ metric, esqlQuery });
-    dismissAllFlyoutsExceptFor(DiscoverFlyouts.metricInsights);
+  const setChartRef = useCallback((chartId: string, element: HTMLDivElement | null) => {
+    if (element) {
+      chartRefs.current.set(chartId, element);
+    } else {
+      chartRefs.current.delete(chartId);
+    }
   }, []);
+
+  const handleViewDetails = useCallback(
+    (esqlQuery: string, metric: MetricField, chartId: string) => {
+      const chartIndex = rows.findIndex((row) => `chart-${row.key}` === chartId);
+      const { rowIndex, colIndex } = getRowColFromIndex(chartIndex);
+
+      setExpandedMetric({ metric, esqlQuery, chartId, rowIndex, colIndex });
+      dismissAllFlyoutsExceptFor(DiscoverFlyouts.metricInsights);
+    },
+    [rows, getRowColFromIndex]
+  );
 
   const handleCloseFlyout = useCallback(() => {
+    if (expandedMetric) {
+      // Use setTimeout to ensure the flyout is fully closed before focusing
+      setTimeout(() => {
+        focusCell(expandedMetric.rowIndex, expandedMetric.colIndex);
+      }, 0);
+    }
     setExpandedMetric(undefined);
-  }, []);
+  }, [expandedMetric, focusCell]);
+
+  const getChartRefForFocus = useCallback(() => {
+    if (expandedMetric?.chartId) {
+      const chartElement = chartRefs.current.get(expandedMetric.chartId);
+      if (chartElement) {
+        return { current: chartElement };
+      }
+    }
+    return { current: null };
+  }, [expandedMetric?.chartId]);
 
   const normalizedFields = useMemo(() => (Array.isArray(fields) ? fields : [fields]), [fields]);
 
@@ -125,23 +160,19 @@ export const MetricsGrid = ({
             const { rowIndex, colIndex } = getRowColFromIndex(index);
             const isFocused =
               focusedCell.rowIndex === rowIndex && focusedCell.colIndex === colIndex;
+            const chartId = `chart-${key}`;
 
             return (
               <EuiFlexItem key={key}>
                 <div
+                  ref={(element) => setChartRef(chartId, element)}
                   role="gridcell"
-                  aria-rowindex={rowIndex + 1} // 1-based for ARIA
-                  aria-colindex={colIndex + 1} // 1-based for ARIA
+                  aria-rowindex={rowIndex + 1}
+                  aria-colindex={colIndex + 1}
                   data-grid-cell={`${rowIndex}-${colIndex}`}
                   data-chart-index={index}
                   tabIndex={isFocused ? 0 : -1}
-                  onClick={() => handleCellClick(rowIndex, colIndex)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      handleCellClick(rowIndex, colIndex);
-                    }
-                  }}
+                  onFocus={() => handleFocusCell(rowIndex, colIndex)}
                   style={{
                     outline: 'none',
                     cursor: 'pointer',
@@ -152,6 +183,7 @@ export const MetricsGrid = ({
                   }}
                 >
                   <Chart
+                    chartId={chartId}
                     metric={metric}
                     size={chartSize}
                     color={colorPalette[index % colorPalette.length]}
@@ -174,6 +206,7 @@ export const MetricsGrid = ({
       </div>
       {expandedMetric && (
         <MetricInsightsFlyout
+          chartRef={getChartRefForFocus()}
           metric={expandedMetric.metric}
           esqlQuery={expandedMetric.esqlQuery}
           isOpen

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/hooks/use_grid_navigation.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/hooks/use_grid_navigation.ts
@@ -104,14 +104,15 @@ export const useGridNavigation = ({
     [focusedCell, gridRows, gridColumns, totalRows, getIndexFromRowCol, focusCell]
   );
 
-  const handleCellClick = useCallback((rowIndex: number, colIndex: number) => {
+  const handleFocusCell = useCallback((rowIndex: number, colIndex: number) => {
     setFocusedCell({ rowIndex, colIndex });
   }, []);
 
   return {
     focusedCell,
     handleKeyDown,
-    handleCellClick,
+    handleFocusCell,
+    focusCell,
     getRowColFromIndex,
   };
 };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/236603

## Summary
This PR improves keyboard accessibility for the metrics grid by implementing proper focus management when opening and closing the metric insights flyout.

### Changes Made
#### Focus Management & Accessibility:

- Added proper focus return functionality when closing the metric insights flyout
- Implemented grid position tracking to remember which chart cell opened the flyout
- Added `chartId`, `rowIndex`, and `colIndex` tracking to the `expandedMetric` state
- Enhanced the flyout close handler to programmatically return focus to the originating chart cell using `focusCell()`

#### Keyboard Navigation Fix:

- Removed `onClick` and `onKeyDown` handlers from grid cells that were interfering with chart interactions
- Added `onFocus` handler to maintain grid navigation state synchronization
- Updated grid navigation hook to export both `handleFocusCell `(state-only) and `focusCell` (state + DOM focus) functions
- Ensured proper coordination between passive focus tracking and active focus management

#### Flyout Interaction Improvements:

- Added chart reference management using a `Map<string, HTMLDivElement>` to track individual chart elements
- Implemented `getChartRefForFocus()` to provide the correct element reference to the flyout's focus trap
- Added flyout dismissal functionality when inspector buttons are clicked to prevent flyout conflicts

### Technical Details
The solution uses a two-phase approach:

1. State tracking: `handleFocusCell` updates grid navigation state when cells receive focus naturally
2. Programmatic focusing: `focusCell` both updates state and sets DOM focus when needed (e.g., flyout close)

### Accessibility Impact
✅ Screen reader users can now navigate back to the correct chart after closing the flyout
✅ Keyboard users maintain their position in the grid when using flyout interactions
✅ Focus indicators remain consistent with actual focused elements
✅ Grid navigation works properly without interference from chart-level click handlers


https://github.com/user-attachments/assets/f7cdb61d-72e3-4889-9ed6-45f429acc1ae



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->