### PR TITLE
🌊 Streams: Fix field name generation

### DIFF
--- a/x-pack/platform/plugins/shared/fields_metadata/common/helpers/convert_ecs_fields_to_otel.test.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/common/helpers/convert_ecs_fields_to_otel.test.ts
@@ -7,52 +7,53 @@
 
 import type { FieldMetadataPlain } from '..';
 import { getOtelFieldName } from './convert_ecs_fields_to_otel';
+import { EcsFlat } from '@elastic/ecs';
 
 describe('getOtelFieldName', () => {
   it('returns @timestamp as-is', () => {
-    expect(getOtelFieldName({ name: '@timestamp' })).toBe('@timestamp');
+    expect(getOtelFieldName(EcsFlat['@timestamp'] as FieldMetadataPlain)).toBe('@timestamp');
   });
 
   it('maps message to body.text', () => {
-    expect(getOtelFieldName({ name: 'message' })).toBe('body.text');
+    expect(getOtelFieldName(EcsFlat.message as FieldMetadataPlain)).toBe('body.text');
   });
 
   it('maps match fields with attributes prefix', () => {
-    expect(getOtelFieldName({ name: 'client.address' })).toBe('attributes.client.address');
+    expect(getOtelFieldName(EcsFlat['client.address'] as FieldMetadataPlain)).toBe(
+      'attributes.client.address'
+    );
   });
 
   it('maps OTLP fields without attributes prefix', () => {
-    expect(
-      getOtelFieldName({
-        name: 'span.id',
-        otel: [{ relation: 'otlp', otlp_field: 'span_id' }],
-      } as FieldMetadataPlain)
-    ).toBe('span_id');
+    expect(getOtelFieldName(EcsFlat['span.id'] as FieldMetadataPlain)).toBe('span_id');
   });
 
   it('maps unknown fields with attributes prefix', () => {
-    expect(getOtelFieldName({ name: 'custom.field.name' })).toBe('attributes.custom.field.name');
+    expect(getOtelFieldName({ name: 'custom.field.name' } as FieldMetadataPlain)).toBe(
+      'attributes.custom.field.name'
+    );
   });
 
   it('maps resource fields directly with resource.attributes prefix', () => {
-    expect(getOtelFieldName({ name: 'agent.type' })).toBe('resource.attributes.agent.type');
-    expect(getOtelFieldName({ name: 'cloud.availability_zone' })).toBe(
+    expect(getOtelFieldName(EcsFlat['agent.type'] as FieldMetadataPlain)).toBe(
+      'resource.attributes.agent.type'
+    );
+    expect(getOtelFieldName(EcsFlat['cloud.availability_zone'] as FieldMetadataPlain)).toBe(
       'resource.attributes.cloud.availability_zone'
     );
-    expect(getOtelFieldName({ name: 'host.name' })).toBe('resource.attributes.host.name');
+    expect(getOtelFieldName(EcsFlat['host.name'] as FieldMetadataPlain)).toBe(
+      'resource.attributes.host.name'
+    );
   });
 
   it('maps equivalent resource fields with resource.attributes prefix', () => {
-    expect(
-      getOtelFieldName({
-        name: 'cloud.service.name',
-        otel: [{ relation: 'equivalent', attribute: 'cloud.platform' }],
-      } as FieldMetadataPlain)
-    ).toBe('resource.attributes.cloud.platform');
+    expect(getOtelFieldName(EcsFlat['cloud.service.name'] as FieldMetadataPlain)).toBe(
+      'resource.attributes.cloud.platform'
+    );
   });
 
   it('handles resource fields not in MATCH_FIELDS or EQUIVALENT_FIELDS', () => {
-    expect(getOtelFieldName({ name: 'agent.build.original' })).toBe(
+    expect(getOtelFieldName(EcsFlat['agent.build.original'])).toBe(
       'resource.attributes.agent.build.original'
     );
   });

--- a/x-pack/platform/plugins/shared/fields_metadata/common/helpers/convert_ecs_fields_to_otel.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/common/helpers/convert_ecs_fields_to_otel.ts
@@ -14,7 +14,7 @@ import type { FieldMetadataPlain } from '..';
  * See https://www.elastic.co/docs/reference/ecs/ecs-otel-alignment-details for full reference.
  */
 export function getOtelFieldName(fieldMetadata: FieldMetadataPlain): string {
-  const ecsFieldName = fieldMetadata.name;
+  const ecsFieldName = fieldMetadata.flat_name || fieldMetadata.name;
   if (ecsFieldName === '@timestamp') {
     return `@timestamp`; // Special case for `@timestamp` field which should be kept as is.
   }


### PR DESCRIPTION
For grok suggestions, streams generates the stream-equivalent field names out of ECS field names. This logic was using the wrong field name from the field metadata returned from the service. 

Before:
<img width="1392" height="497" alt="Screenshot 2025-10-08 at 15 43 45" src="https://github.com/user-attachments/assets/6d43ce2a-0aaa-44dc-9902-912fd16ce96a" />

After:
<img width="1399" height="491" alt="Screenshot 2025-10-08 at 15 41 42" src="https://github.com/user-attachments/assets/cbf76344-4cea-4e6d-baed-5e19e936a0e9" />

This went unnoticed because the unit tests were using fake field metadata objects. This PR changes this to use the actual data from `@elastic/ecs`.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->