### PR TITLE
[ObsUX][APM] Sanitize `kuery` before creating KQL query in Discover links

### DIFF
--- a/src/platform/packages/shared/kbn-esql-composer/src/transformers/parameter_replacer.test.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/transformers/parameter_replacer.test.ts
@@ -69,6 +69,22 @@ describe('ParameterReplacer', () => {
     expect(substituted).toEqual(Builder.expression.literal.string('bar'));
   });
 
+  it('allows replacing falsy values', () => {
+    const params = { baz: 0, qux: false, empty: '' };
+    const replacer = new ParameterReplacer(params);
+
+    const zeroNode = createParamLiteral('named', 'baz');
+    const falseNode = createParamLiteral('named', 'qux');
+    const emptyNode = createParamLiteral('named', 'empty');
+    const zeroSubstituted = replacer.replace(zeroNode);
+    const falseSubstituted = replacer.replace(falseNode);
+    const emptySubstituted = replacer.replace(emptyNode);
+
+    expect(zeroSubstituted).toEqual(Builder.expression.literal.integer(0));
+    expect(falseSubstituted).toEqual(Builder.expression.literal.string('false'));
+    expect(emptySubstituted).toEqual(Builder.expression.literal.string(''));
+  });
+
   it('replaces positional parameters in literals', () => {
     const params = ['positional_value'];
     const replacer = new ParameterReplacer(params);

--- a/src/platform/packages/shared/kbn-esql-composer/src/transformers/parameter_replacer.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/transformers/parameter_replacer.ts
@@ -115,7 +115,7 @@ export class ParameterReplacer {
 
     const value = this.resolveParamValue(node);
 
-    if (!value) {
+    if (value === null || value === undefined) {
       return node;
     }
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/base_discover_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/base_discover_button.tsx
@@ -9,8 +9,73 @@ import React from 'react';
 import { EuiButtonEmpty } from '@elastic/eui';
 import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { FETCH_STATUS } from '@kbn/observability-shared-plugin/public';
+import { where } from '@kbn/esql-composer';
+import {
+  ERROR_GROUP_ID,
+  SERVICE_ENVIRONMENT,
+  SERVICE_NAME,
+  SPAN_DESTINATION_SERVICE_RESOURCE,
+  SPAN_DURATION,
+  SPAN_ID,
+  SPAN_NAME,
+  TRANSACTION_DURATION,
+  TRANSACTION_NAME,
+  TRANSACTION_TYPE,
+} from '@kbn/apm-types';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
+
+export const filterByKuery = (kuery: string) => {
+  return where(
+    `KQL("${kuery.trim().replaceAll('"', '\\"').replaceAll(/\s+/g, ' ').replaceAll(/\n+/g, ' ')}")`
+  );
+};
+
+export const filterByServiceName = (serviceName: string) => {
+  return where(`${SERVICE_NAME} == ?serviceName`, { serviceName });
+};
+
+export const filterByErrorGroupId = (errorGroupId: string) => {
+  return where(`${ERROR_GROUP_ID} == ?errorGroupId`, { errorGroupId });
+};
+
+export const filterByEnvironment = (environment: string) => {
+  return where(`${SERVICE_ENVIRONMENT} == ?environment`, { environment });
+};
+
+export const filterByTransactionNameOrSpanName = (
+  transactionName: string | undefined,
+  spanName: string | undefined
+) => {
+  return where(`??nameField == ?name`, {
+    nameField: transactionName ? TRANSACTION_NAME : SPAN_NAME,
+    name: (transactionName ?? spanName) as string,
+  });
+};
+
+export const filterByTransactionType = (transactionType: string) => {
+  return where(`${TRANSACTION_TYPE} == ?transactionType`, { transactionType });
+};
+
+export const filterByDependencyName = (dependencyName: string) => {
+  return where(`${SPAN_DESTINATION_SERVICE_RESOURCE} == ?dependencyName`, { dependencyName });
+};
+
+export const filterBySpanId = (spanId: string) => {
+  return where(`${SPAN_ID} == ?spanId`, { spanId });
+};
+
+export const filterBySampleRange = (
+  sampleRangeFrom: number,
+  sampleRangeTo: number,
+  transactionName: string | undefined
+) => {
+  return where(`??durationField >= ?sampleRangeFrom AND ??durationField <= ?sampleRangeTo`, {
+    durationField: transactionName ? TRANSACTION_DURATION : SPAN_DURATION,
+    sampleRangeFrom,
+    sampleRangeTo,
+  });
+};
 
 export function BaseDiscoverButton({
   dataTestSubj,

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/base_discover_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/base_discover_button.tsx
@@ -9,73 +9,8 @@ import React from 'react';
 import { EuiButtonEmpty } from '@elastic/eui';
 import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { FETCH_STATUS } from '@kbn/observability-shared-plugin/public';
-import { where } from '@kbn/esql-composer';
-import {
-  ERROR_GROUP_ID,
-  SERVICE_ENVIRONMENT,
-  SERVICE_NAME,
-  SPAN_DESTINATION_SERVICE_RESOURCE,
-  SPAN_DURATION,
-  SPAN_ID,
-  SPAN_NAME,
-  TRANSACTION_DURATION,
-  TRANSACTION_NAME,
-  TRANSACTION_TYPE,
-} from '@kbn/apm-types';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
-
-export const filterByKuery = (kuery: string) => {
-  return where(
-    `KQL("${kuery.trim().replaceAll('"', '\\"').replaceAll(/\s+/g, ' ').replaceAll(/\n+/g, ' ')}")`
-  );
-};
-
-export const filterByServiceName = (serviceName: string) => {
-  return where(`${SERVICE_NAME} == ?serviceName`, { serviceName });
-};
-
-export const filterByErrorGroupId = (errorGroupId: string) => {
-  return where(`${ERROR_GROUP_ID} == ?errorGroupId`, { errorGroupId });
-};
-
-export const filterByEnvironment = (environment: string) => {
-  return where(`${SERVICE_ENVIRONMENT} == ?environment`, { environment });
-};
-
-export const filterByTransactionNameOrSpanName = (
-  transactionName: string | undefined,
-  spanName: string | undefined
-) => {
-  return where(`??nameField == ?name`, {
-    nameField: transactionName ? TRANSACTION_NAME : SPAN_NAME,
-    name: (transactionName ?? spanName) as string,
-  });
-};
-
-export const filterByTransactionType = (transactionType: string) => {
-  return where(`${TRANSACTION_TYPE} == ?transactionType`, { transactionType });
-};
-
-export const filterByDependencyName = (dependencyName: string) => {
-  return where(`${SPAN_DESTINATION_SERVICE_RESOURCE} == ?dependencyName`, { dependencyName });
-};
-
-export const filterBySpanId = (spanId: string) => {
-  return where(`${SPAN_ID} == ?spanId`, { spanId });
-};
-
-export const filterBySampleRange = (
-  sampleRangeFrom: number,
-  sampleRangeTo: number,
-  transactionName: string | undefined
-) => {
-  return where(`??durationField >= ?sampleRangeFrom AND ??durationField <= ?sampleRangeTo`, {
-    durationField: transactionName ? TRANSACTION_DURATION : SPAN_DURATION,
-    sampleRangeFrom,
-    sampleRangeTo,
-  });
-};
 
 export function BaseDiscoverButton({
   dataTestSubj,

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/filters.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/filters.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  filterByKuery,
+  filterByServiceName,
+  filterByErrorGroupId,
+  filterByEnvironment,
+  filterByTransactionNameOrSpanName,
+  filterByTransactionType,
+  filterByDependencyName,
+  filterBySpanId,
+  filterBySampleRange,
+} from './filters';
+import { from } from '@kbn/esql-composer';
+
+const INDEX = 'traces-*';
+
+describe('APM Discover Link Filters', () => {
+  describe('filterByKuery', () => {
+    it('should create a KQL filter with escaped quotes', () => {
+      const kuery = 'service.name:"my-service"';
+      const result = from(INDEX).pipe(filterByKuery(kuery)).toString();
+
+      expect(result.toString()).toContain('KQL("service.name:\\"my-service\\"")');
+    });
+
+    it('should trim whitespace from kuery', () => {
+      const kuery = '  service.name:my-service  ';
+      const result = from(INDEX).pipe(filterByKuery(kuery)).toString();
+
+      expect(result.toString()).toContain('KQL("service.name:my-service")');
+    });
+
+    it('should replace multiple consecutive spaces with single space', () => {
+      const kuery = 'service.name:my-service    AND    host.name:my-host';
+      const result = from(INDEX).pipe(filterByKuery(kuery)).toString();
+
+      expect(result.toString()).toContain('KQL("service.name:my-service AND host.name:my-host")');
+    });
+
+    it('should replace newlines with spaces', () => {
+      const kuery = 'service.name:my-service\nAND\nhost.name:my-host';
+      const result = from(INDEX).pipe(filterByKuery(kuery)).toString();
+
+      expect(result.toString()).toContain('KQL("service.name:my-service AND host.name:my-host")');
+    });
+
+    it('should handle multiple newlines and spaces together', () => {
+      const kuery = 'service.name:my-service\n\n  AND  \n\nhost.name:my-host';
+      const result = from(INDEX).pipe(filterByKuery(kuery)).toString();
+
+      expect(result.toString()).toContain('KQL("service.name:my-service AND host.name:my-host")');
+    });
+
+    it('should handle empty kuery after trimming', () => {
+      const kuery = '   ';
+      const result = from(INDEX).pipe(filterByKuery(kuery)).toString();
+
+      expect(result.toString()).toContain('KQL("")');
+    });
+  });
+
+  describe('filterByServiceName', () => {
+    it('should create a service name filter', () => {
+      const serviceName = 'my-service';
+      const result = from(INDEX).pipe(filterByServiceName(serviceName)).toString();
+
+      expect(result).toContain(`service.name == "${serviceName}"`);
+    });
+
+    it('should handle special characters in service name', () => {
+      const serviceName = 'my-service-with-dashes_and_underscores';
+      const result = from(INDEX).pipe(filterByServiceName(serviceName)).toString();
+
+      expect(result).toContain(`service.name == "${serviceName}"`);
+    });
+  });
+
+  describe('filterByErrorGroupId', () => {
+    it('should create an error group ID filter', () => {
+      const errorGroupId = 'error-group-123';
+      const result = from(INDEX).pipe(filterByErrorGroupId(errorGroupId)).toString();
+
+      expect(result).toContain(`error.grouping_key == "${errorGroupId}"`);
+    });
+  });
+
+  describe('filterByEnvironment', () => {
+    it('should create an environment filter', () => {
+      const environment = 'production';
+      const result = from(INDEX).pipe(filterByEnvironment(environment)).toString();
+
+      expect(result).toContain(`service.environment == "${environment}"`);
+    });
+  });
+
+  describe('filterByTransactionNameOrSpanName', () => {
+    it('should create a transaction name filter when transactionName is provided', () => {
+      const transactionName = 'GET /api/users';
+      const result = from(INDEX)
+        .pipe(filterByTransactionNameOrSpanName(transactionName, undefined))
+        .toString();
+
+      expect(result).toContain(`transaction.name == "${transactionName}"`);
+    });
+
+    it('should create a span name filter when spanName is provided and transactionName is undefined', () => {
+      const spanName = 'database-query';
+      const result = from(INDEX)
+        .pipe(filterByTransactionNameOrSpanName(undefined, spanName))
+        .toString();
+
+      expect(result).toContain(`span.name == "${spanName}"`);
+    });
+
+    it('should prioritize transactionName when both are provided', () => {
+      const transactionName = 'GET /api/users';
+      const spanName = 'database-query';
+      const result = from(INDEX)
+        .pipe(filterByTransactionNameOrSpanName(transactionName, spanName))
+        .toString();
+
+      expect(result).toContain(`transaction.name == "${transactionName}"`);
+    });
+  });
+
+  describe('filterByTransactionType', () => {
+    it('should create a transaction type filter', () => {
+      const transactionType = 'request';
+      const result = from(INDEX).pipe(filterByTransactionType(transactionType)).toString();
+
+      expect(result).toContain(`transaction.type == "${transactionType}"`);
+    });
+  });
+
+  describe('filterByDependencyName', () => {
+    it('should create a dependency name filter', () => {
+      const dependencyName = 'elasticsearch';
+      const result = from(INDEX).pipe(filterByDependencyName(dependencyName)).toString();
+
+      expect(result).toContain(`span.destination.service.resource == "${dependencyName}"`);
+    });
+  });
+
+  describe('filterBySpanId', () => {
+    it('should create a span ID filter', () => {
+      const spanId = 'span-123-456';
+      const result = from(INDEX).pipe(filterBySpanId(spanId)).toString();
+
+      expect(result).toContain(`span.id == "${spanId}"`);
+    });
+  });
+
+  describe('filterBySampleRange', () => {
+    it('should create a sample range filter for transactions', () => {
+      const sampleRangeFrom = 1000;
+      const sampleRangeTo = 5000;
+      const transactionName = 'GET /api/users';
+      const result = from(INDEX)
+        .pipe(filterBySampleRange(sampleRangeFrom, sampleRangeTo, transactionName))
+        .toString();
+
+      expect(result).toContain(
+        `transaction.duration.us >= ${sampleRangeFrom} AND transaction.duration.us <= ${sampleRangeTo}`
+      );
+    });
+
+    it('should create a sample range filter for spans when transactionName is undefined', () => {
+      const sampleRangeFrom = 500;
+      const sampleRangeTo = 2000;
+      const result = from(INDEX)
+        .pipe(filterBySampleRange(sampleRangeFrom, sampleRangeTo, undefined))
+        .toString();
+
+      expect(result).toContain(
+        `span.duration.us >= ${sampleRangeFrom} AND span.duration.us <= ${sampleRangeTo}`
+      );
+    });
+
+    it('should handle zero values for sample range', () => {
+      const sampleRangeFrom = 0;
+      const sampleRangeTo = 1000;
+      const result = from(INDEX)
+        .pipe(filterBySampleRange(sampleRangeFrom, sampleRangeTo, undefined))
+        .toString();
+
+      expect(result).toContain(
+        `span.duration.us >= ${sampleRangeFrom} AND span.duration.us <= ${sampleRangeTo}`
+      );
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/filters.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/filters.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { where } from '@kbn/esql-composer';
+import {
+  ERROR_GROUP_ID,
+  SERVICE_ENVIRONMENT,
+  SERVICE_NAME,
+  SPAN_DESTINATION_SERVICE_RESOURCE,
+  SPAN_DURATION,
+  SPAN_ID,
+  SPAN_NAME,
+  TRANSACTION_DURATION,
+  TRANSACTION_NAME,
+  TRANSACTION_TYPE,
+} from '@kbn/apm-types';
+
+export const filterByKuery = (kuery: string) => {
+  return where(
+    `KQL("${kuery.trim().replaceAll('"', '\\"').replaceAll(/\s+/g, ' ').replaceAll(/\n+/g, ' ')}")`
+  );
+};
+
+export const filterByServiceName = (serviceName: string) => {
+  return where(`${SERVICE_NAME} == ?serviceName`, { serviceName });
+};
+
+export const filterByErrorGroupId = (errorGroupId: string) => {
+  return where(`${ERROR_GROUP_ID} == ?errorGroupId`, { errorGroupId });
+};
+
+export const filterByEnvironment = (environment: string) => {
+  return where(`${SERVICE_ENVIRONMENT} == ?environment`, { environment });
+};
+
+export const filterByTransactionNameOrSpanName = (
+  transactionName: string | undefined,
+  spanName: string | undefined
+) => {
+  return where(`??nameField == ?name`, {
+    nameField: transactionName ? TRANSACTION_NAME : SPAN_NAME,
+    name: (transactionName ?? spanName) as string,
+  });
+};
+
+export const filterByTransactionType = (transactionType: string) => {
+  return where(`${TRANSACTION_TYPE} == ?transactionType`, { transactionType });
+};
+
+export const filterByDependencyName = (dependencyName: string) => {
+  return where(`${SPAN_DESTINATION_SERVICE_RESOURCE} == ?dependencyName`, { dependencyName });
+};
+
+export const filterBySpanId = (spanId: string) => {
+  return where(`${SPAN_ID} == ?spanId`, { spanId });
+};
+
+export const filterBySampleRange = (
+  sampleRangeFrom: number,
+  sampleRangeTo: number,
+  transactionName: string | undefined
+) => {
+  return where(`??durationField >= ?sampleRangeFrom AND ??durationField <= ?sampleRangeTo`, {
+    durationField: transactionName ? TRANSACTION_DURATION : SPAN_DURATION,
+    sampleRangeFrom,
+    sampleRangeTo,
+  });
+};

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.test.tsx
@@ -139,10 +139,7 @@ describe('OpenErrorInDiscoverButton', () => {
 
   it('should generate ESQL query with error group id and kuery filter', () => {
     const query = {
-      kuery: `user.id: "123"
-       AND
-       status_code: 200
-        `,
+      kuery: 'user.id: "123" AND status_code: 200',
       rangeFrom: 'now-15m',
       rangeTo: 'now',
     };

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.test.tsx
@@ -139,7 +139,10 @@ describe('OpenErrorInDiscoverButton', () => {
 
   it('should generate ESQL query with error group id and kuery filter', () => {
     const query = {
-      kuery: 'user.id: "123" AND status_code: 200',
+      kuery: `user.id: "123"
+       AND
+       status_code: 200
+        `,
       rangeFrom: 'now-15m',
       rangeTo: 'now',
     };

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.tsx
@@ -14,11 +14,15 @@
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import type { ApmIndexSettingsResponse } from '@kbn/apm-sources-access-plugin/server/routes/settings';
-import { from, where } from '@kbn/esql-composer';
-import { ERROR_GROUP_ID, SERVICE_NAME } from '@kbn/apm-types';
+import { from } from '@kbn/esql-composer';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
-import { BaseDiscoverButton } from './base_discover_button';
+import {
+  BaseDiscoverButton,
+  filterByErrorGroupId,
+  filterByKuery,
+  filterByServiceName,
+} from './base_discover_button';
 
 export const getESQLQuery = ({
   params,
@@ -45,23 +49,15 @@ export const getESQLQuery = ({
   const filters = [];
 
   if (errorGroupId) {
-    filters.push(where(`${ERROR_GROUP_ID} == ?errorGroupId`, { errorGroupId }));
+    filters.push(filterByErrorGroupId(errorGroupId));
   }
 
   if (serviceName) {
-    filters.push(where(`${SERVICE_NAME} == ?serviceName`, { serviceName }));
+    filters.push(filterByServiceName(serviceName));
   }
 
   if (kuery) {
-    filters.push(
-      where(
-        `KQL("${kuery
-          .trim()
-          .replaceAll('"', '\\"')
-          .replaceAll(/\s+/g, ' ')
-          .replaceAll(/\n+/g, ' ')}")`
-      )
-    );
+    filters.push(filterByKuery(kuery));
   }
 
   return from(dedupedIndices)

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.tsx
@@ -53,7 +53,15 @@ export const getESQLQuery = ({
   }
 
   if (kuery) {
-    filters.push(where(`KQL("${kuery.replaceAll('"', '\\"')}")`));
+    filters.push(
+      where(
+        `KQL("${kuery
+          .trim()
+          .replaceAll('"', '\\"')
+          .replaceAll(/\s+/g, ' ')
+          .replaceAll(/\n+/g, ' ')}")`
+      )
+    );
   }
 
   return from(dedupedIndices)

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.tsx
@@ -17,12 +17,8 @@ import type { ApmIndexSettingsResponse } from '@kbn/apm-sources-access-plugin/se
 import { from } from '@kbn/esql-composer';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
-import {
-  BaseDiscoverButton,
-  filterByErrorGroupId,
-  filterByKuery,
-  filterByServiceName,
-} from './base_discover_button';
+import { BaseDiscoverButton } from './base_discover_button';
+import { filterByErrorGroupId, filterByKuery, filterByServiceName } from './filters';
 
 export const getESQLQuery = ({
   params,

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.test.tsx
@@ -217,7 +217,10 @@ describe('OpenInDiscoverButton', () => {
 
   it('should generate ESQL query with kuery filter', () => {
     const query = {
-      kuery: 'user.id: "123" AND status_code: 200',
+      kuery: `user.id: "123"
+       AND
+       status_code: 200
+        `,
       rangeFrom: 'now-15m',
       rangeTo: 'now',
     };

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.test.tsx
@@ -217,10 +217,7 @@ describe('OpenInDiscoverButton', () => {
 
   it('should generate ESQL query with kuery filter', () => {
     const query = {
-      kuery: `user.id: "123"
-       AND
-       status_code: 200
-        `,
+      kuery: 'user.id: "123" AND status_code: 200',
       rangeFrom: 'now-15m',
       rangeTo: 'now',
     };

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.tsx
@@ -15,8 +15,8 @@ import {
   ENVIRONMENT_ALL_VALUE,
   ENVIRONMENT_NOT_DEFINED_VALUE,
 } from '../../../../../common/environment_filter_values';
+import { BaseDiscoverButton } from './base_discover_button';
 import {
-  BaseDiscoverButton,
   filterByDependencyName,
   filterByEnvironment,
   filterByKuery,
@@ -24,7 +24,7 @@ import {
   filterByServiceName,
   filterByTransactionNameOrSpanName,
   filterByTransactionType,
-} from './base_discover_button';
+} from './filters';
 
 const getESQLQuery = ({
   params,

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.tsx
@@ -8,24 +8,23 @@
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import type { ApmIndexSettingsResponse } from '@kbn/apm-sources-access-plugin/server/routes/settings';
-import { from, where } from '@kbn/esql-composer';
-import {
-  SERVICE_ENVIRONMENT,
-  SERVICE_NAME,
-  SPAN_DESTINATION_SERVICE_RESOURCE,
-  SPAN_DURATION,
-  SPAN_NAME,
-  TRANSACTION_DURATION,
-  TRANSACTION_NAME,
-  TRANSACTION_TYPE,
-} from '@kbn/apm-types';
+import { from } from '@kbn/esql-composer';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
 import {
   ENVIRONMENT_ALL_VALUE,
   ENVIRONMENT_NOT_DEFINED_VALUE,
 } from '../../../../../common/environment_filter_values';
-import { BaseDiscoverButton } from './base_discover_button';
+import {
+  BaseDiscoverButton,
+  filterByDependencyName,
+  filterByEnvironment,
+  filterByKuery,
+  filterBySampleRange,
+  filterByServiceName,
+  filterByTransactionNameOrSpanName,
+  filterByTransactionType,
+} from './base_discover_button';
 
 const getESQLQuery = ({
   params,
@@ -70,7 +69,7 @@ const getESQLQuery = ({
   const filters = [];
 
   if (serviceName) {
-    filters.push(where(`${SERVICE_NAME} == ?serviceName`, { serviceName }));
+    filters.push(filterByServiceName(serviceName));
   }
 
   if (
@@ -78,48 +77,27 @@ const getESQLQuery = ({
     environment !== ENVIRONMENT_ALL_VALUE &&
     environment !== ENVIRONMENT_NOT_DEFINED_VALUE
   ) {
-    filters.push(where(`${SERVICE_ENVIRONMENT} == ?environment`, { environment }));
+    filters.push(filterByEnvironment(environment));
   }
 
   if (transactionName || spanName) {
-    filters.push(
-      where(`??nameField == ?name`, {
-        nameField: transactionName ? TRANSACTION_NAME : SPAN_NAME,
-        name: (transactionName ?? spanName) as string,
-      })
-    );
+    filters.push(filterByTransactionNameOrSpanName(transactionName, spanName));
   }
 
   if (transactionType) {
-    filters.push(where(`${TRANSACTION_TYPE} == ?transactionType`, { transactionType }));
+    filters.push(filterByTransactionType(transactionType));
   }
 
   if (dependencyName) {
-    filters.push(
-      where(`${SPAN_DESTINATION_SERVICE_RESOURCE} == ?dependencyName`, { dependencyName })
-    );
+    filters.push(filterByDependencyName(dependencyName));
   }
 
   if (sampleRangeFrom && sampleRangeTo) {
-    filters.push(
-      where(`??durationField >= ?sampleRangeFrom AND ??durationField <= ?sampleRangeTo`, {
-        durationField: transactionName ? TRANSACTION_DURATION : SPAN_DURATION,
-        sampleRangeFrom,
-        sampleRangeTo,
-      })
-    );
+    filters.push(filterBySampleRange(sampleRangeFrom, sampleRangeTo, transactionName));
   }
 
   if (kuery) {
-    filters.push(
-      where(
-        `KQL("${kuery
-          .trim()
-          .replaceAll('"', '\\"')
-          .replaceAll(/\s+/g, ' ')
-          .replaceAll(/\n+/g, ' ')}")`
-      )
-    );
+    filters.push(filterByKuery(kuery));
   }
 
   return from(dedupedIndices)

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.tsx
@@ -111,7 +111,15 @@ const getESQLQuery = ({
   }
 
   if (kuery) {
-    filters.push(where(`KQL("${kuery.replaceAll('"', '\\"')}")`));
+    filters.push(
+      where(
+        `KQL("${kuery
+          .trim()
+          .replaceAll('"', '\\"')
+          .replaceAll(/\s+/g, ' ')
+          .replaceAll(/\n+/g, ' ')}")`
+      )
+    );
   }
 
   return from(dedupedIndices)

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.test.tsx
@@ -103,7 +103,10 @@ describe('OpenSpanInDiscoverLink', () => {
 
   it('should generate ESQL query with span id and kuery filter', () => {
     const query = {
-      kuery: 'user.id: "123" AND status_code: 200',
+      kuery: `user.id: "123"
+       AND
+       status_code: 200
+        `,
       rangeFrom: 'now-15m',
       rangeTo: 'now',
     };

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.test.tsx
@@ -103,10 +103,7 @@ describe('OpenSpanInDiscoverLink', () => {
 
   it('should generate ESQL query with span id and kuery filter', () => {
     const query = {
-      kuery: `user.id: "123"
-       AND
-       status_code: 200
-        `,
+      kuery: 'user.id: "123" AND status_code: 200',
       rangeFrom: 'now-15m',
       rangeTo: 'now',
     };

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.tsx
@@ -48,7 +48,15 @@ export const getESQLQuery = ({
   }
 
   if (kuery) {
-    filters.push(where(`KQL("${kuery.replaceAll('"', '\\"')}")`));
+    filters.push(
+      where(
+        `KQL("${kuery
+          .trim()
+          .replaceAll('"', '\\"')
+          .replaceAll(/\s+/g, ' ')
+          .replaceAll(/\n+/g, ' ')}")`
+      )
+    );
   }
 
   return from(dedupedIndices)

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.tsx
@@ -17,7 +17,8 @@ import type { ApmIndexSettingsResponse } from '@kbn/apm-sources-access-plugin/se
 import { from } from '@kbn/esql-composer';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
-import { BaseDiscoverButton, filterByKuery, filterBySpanId } from './base_discover_button';
+import { BaseDiscoverButton } from './base_discover_button';
+import { filterByKuery, filterBySpanId } from './filters';
 
 export const getESQLQuery = ({
   params,

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.tsx
@@ -14,11 +14,10 @@
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import type { ApmIndexSettingsResponse } from '@kbn/apm-sources-access-plugin/server/routes/settings';
-import { from, where } from '@kbn/esql-composer';
-import { SPAN_ID } from '@kbn/apm-types';
+import { from } from '@kbn/esql-composer';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
-import { BaseDiscoverButton } from './base_discover_button';
+import { BaseDiscoverButton, filterByKuery, filterBySpanId } from './base_discover_button';
 
 export const getESQLQuery = ({
   params,
@@ -44,19 +43,11 @@ export const getESQLQuery = ({
   const filters = [];
 
   if (spanId) {
-    filters.push(where(`${SPAN_ID} == ?spanId`, { spanId }));
+    filters.push(filterBySpanId(spanId));
   }
 
   if (kuery) {
-    filters.push(
-      where(
-        `KQL("${kuery
-          .trim()
-          .replaceAll('"', '\\"')
-          .replaceAll(/\s+/g, ' ')
-          .replaceAll(/\n+/g, ' ')}")`
-      )
-    );
+    filters.push(filterByKuery(kuery));
   }
 
   return from(dedupedIndices)


### PR DESCRIPTION
## Summary

Fixes #237286

This PR sanitizes the `kuery` param before creating the KQL query in Discover links, this prevents wrong `kuery` formats as:
```
event.outcome : "success"     
   or
 event.outcome : "success"

```
to not crash.

## Before

https://github.com/user-attachments/assets/10184a97-4a4c-4f58-931f-f0f1c1ad547f

## After

https://github.com/user-attachments/assets/d78bc7b4-0f97-4928-be4e-04e26173935f



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->