### PR TITLE
[8.19] [a11y] Fix focus on generate API keys in connectors config (#237918)

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/generated_config_fields.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/generated_config_fields.tsx
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
+
+import { defer } from 'lodash';
 
 import {
   EuiButtonIcon,
@@ -83,11 +85,24 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
   generateApiKey,
   isGenerateLoading,
 }) => {
+  const apiKeyContainerRef = useRef<HTMLDivElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
   const [isModalVisible, setIsModalVisible] = useState(false);
 
   const refreshButtonClick = () => {
+    restoreFocusRef.current = document.activeElement as HTMLElement;
     setIsModalVisible(true);
   };
+  const restoreFocus = () => {
+    if (!restoreFocusRef.current || (restoreFocusRef.current as HTMLButtonElement).disabled) {
+      apiKeyContainerRef.current?.focus();
+      return;
+    } else {
+      restoreFocusRef.current?.focus();
+    }
+    restoreFocusRef.current = null;
+  };
+
   const onCancel = () => {
     setIsModalVisible(false);
   };
@@ -95,6 +110,7 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
   const onConfirm = () => {
     if (generateApiKey) generateApiKey();
     setIsModalVisible(false);
+    defer(restoreFocus);
   };
 
   return (
@@ -223,6 +239,8 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
               gutterSize="xs"
               justifyContent="flexEnd"
               alignItems="center"
+              ref={apiKeyContainerRef}
+              tabIndex={-1}
             >
               {apiKey?.encoded ? (
                 <EuiFlexItem>


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.1` to `8.19`:
 - [[9.1][a11y] Fix focus on generate API keys in connectors config (#237918)](https://github.com/elastic/kibana/pull/237918)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dennis Tismenko","email":"dennis.tismenko@elastic.co"},"sourceCommit":{"committedDate":"2025-10-08T14:07:33Z","message":"[9.1][a11y] Fix focus on generate API keys in connectors config (#237918)\n\n## Summary\n\nThis implements a workaround solution to the one introduced in #237522\nsince `EuiConfirmModal` doesn't support the `focusTrapProps` prop until\nEUI v106.4.0 (currently on `104.0.2`).\n\nThe previous attempt at an automated backport for reference: #237722.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"652d68e1a8d99eac6b6b14d25ef93d9d172a4ae3","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.1.6"],"title":"[9.1][a11y] Fix focus on generate API keys in connectors config","number":237918,"url":"https://github.com/elastic/kibana/pull/237918","mergeCommit":{"message":"[9.1][a11y] Fix focus on generate API keys in connectors config (#237918)\n\n## Summary\n\nThis implements a workaround solution to the one introduced in #237522\nsince `EuiConfirmModal` doesn't support the `focusTrapProps` prop until\nEUI v106.4.0 (currently on `104.0.2`).\n\nThe previous attempt at an automated backport for reference: #237722.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"652d68e1a8d99eac6b6b14d25ef93d9d172a4ae3"}},"sourceBranch":"9.1","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237918","number":237918,"mergeCommit":{"message":"[9.1][a11y] Fix focus on generate API keys in connectors config (#237918)\n\n## Summary\n\nThis implements a workaround solution to the one introduced in #237522\nsince `EuiConfirmModal` doesn't support the `focusTrapProps` prop until\nEUI v106.4.0 (currently on `104.0.2`).\n\nThe previous attempt at an automated backport for reference: #237722.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"652d68e1a8d99eac6b6b14d25ef93d9d172a4ae3"}}]}] BACKPORT-->