### PR TITLE
[9.1] [Security Solution] [AI Assistant] Replace old defaultLlm setting (#237444)

### DIFF
--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.test.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.test.ts
@@ -91,7 +91,7 @@ describe('plugin', () => {
         expect.objectContaining({
           [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: expect.objectContaining({
             readonlyMode: 'ui',
-            readonly: false,
+            readonly: true,
             value: NO_DEFAULT_CONNECTOR,
           }),
         })
@@ -100,7 +100,7 @@ describe('plugin', () => {
         expect.objectContaining({
           [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: expect.objectContaining({
             readonlyMode: 'ui',
-            readonly: false,
+            readonly: true,
             value: false,
           }),
         })
@@ -136,7 +136,7 @@ describe('plugin', () => {
         expect.objectContaining({
           [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: expect.objectContaining({
             readonlyMode: 'ui',
-            readonly: false,
+            readonly: true,
             value: NO_DEFAULT_CONNECTOR,
           }),
         })
@@ -145,7 +145,7 @@ describe('plugin', () => {
         expect.objectContaining({
           [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: expect.objectContaining({
             readonlyMode: 'ui',
-            readonly: false,
+            readonly: true,
             value: false,
           }),
         })
@@ -179,7 +179,7 @@ describe('plugin', () => {
         expect.objectContaining({
           [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: expect.objectContaining({
             readonlyMode: 'ui',
-            readonly: false,
+            readonly: true,
             value: NO_DEFAULT_CONNECTOR,
           }),
         })
@@ -188,7 +188,7 @@ describe('plugin', () => {
         expect.objectContaining({
           [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: expect.objectContaining({
             readonlyMode: 'ui',
-            readonly: false,
+            readonly: true,
             value: false,
           }),
         })
@@ -250,7 +250,7 @@ describe('plugin', () => {
         expect.objectContaining({
           [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: expect.objectContaining({
             readonlyMode: 'ui',
-            readonly: false,
+            readonly: true,
             value: NO_DEFAULT_CONNECTOR,
           }),
         })
@@ -259,7 +259,7 @@ describe('plugin', () => {
         expect.objectContaining({
           [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: expect.objectContaining({
             readonlyMode: 'ui',
-            readonly: false,
+            readonly: true,
             value: false,
           }),
         })

--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.ts
@@ -115,7 +115,7 @@ export class AIAssistantManagementSelectionPlugin
     core.uiSettings.register({
       [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: {
         readonlyMode: 'ui',
-        readonly: false,
+        readonly: true,
         schema: schema.string(),
         value: NO_DEFAULT_CONNECTOR,
       },
@@ -124,7 +124,7 @@ export class AIAssistantManagementSelectionPlugin
     core.uiSettings.register({
       [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: {
         readonlyMode: 'ui',
-        readonly: false,
+        readonly: true,
         schema: schema.boolean(),
         value: false,
       },

--- a/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/components/default_ai_connector.tsx
+++ b/x-pack/platform/packages/shared/ai-assistant-default-llm-setting/src/components/default_ai_connector.tsx
@@ -311,7 +311,6 @@ export const DefaultAIConnector: React.FC<Props> = ({ connectors, settings }) =>
                   options={options}
                   selectedOptions={selectedOptions}
                   onChange={onChangeDefaultLlm}
-                  isDisabled={fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]?.isReadOnly}
                   isLoading={connectors.loading}
                   isInvalid={
                     (selectedOptions.length === 0 && !connectors.loading) ||
@@ -326,9 +325,6 @@ export const DefaultAIConnector: React.FC<Props> = ({ connectors, settings }) =>
                     <EuiCheckbox
                       id="defaultAiConnectorCheckbox"
                       data-test-subj="defaultAiConnectorCheckbox"
-                      disabled={
-                        fields[GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]?.isReadOnly
-                      }
                       label={
                         <FormattedMessage
                           id="genAiSettings.gen_ai_settings.settings.defaultLlmOnly.checkbox.label"

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/advanced_settings.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/advanced_settings.ts
@@ -8,7 +8,17 @@
 import expect from '@kbn/expect';
 import { SEARCH_PROJECT_SETTINGS } from '@kbn/serverless-search-settings';
 import { isEditorFieldSetting } from '@kbn/test-suites-xpack-platform/serverless/functional/test_suites/management/advanced_settings';
-import { FtrProviderContext } from '../ftr_provider_context';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+// readOnly settings with readonlyMode set to ui are not available on the advanced settings page
+const READ_ONLY_SETTINGS: string[] = [
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+];
 
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
@@ -35,6 +45,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       for (const settingId of SEARCH_PROJECT_SETTINGS) {
         // Code editors don't have their test subjects rendered
         if (isEditorFieldSetting(settingId)) {
+          continue;
+        }
+        // readOnly settings won't appear on the advanced settings page
+        if (READ_ONLY_SETTINGS.includes(settingId)) {
           continue;
         }
         it('renders ' + settingId + ' edit field', async () => {

--- a/x-pack/solutions/search/test/tsconfig.json
+++ b/x-pack/solutions/search/test/tsconfig.json
@@ -36,5 +36,6 @@
     "@kbn/dev-utils",
     "@kbn/cases-plugin",
     "@kbn/serverless-search-settings",
+    "@kbn/management-settings-ids",
   ]
 }

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -177,7 +177,7 @@ export const DEFAULT_AI_CONNECTOR = 'securitySolution:defaultAIConnector' as con
 /** Feature flag for the default AI connector setting */
 export const AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED =
   'aiAssistant.defaultLlmSettingEnabled' as const;
-  
+
 /** This Kibana Advanced Setting allows users to enable/disable querying cold and frozen data tiers in analyzer */
 export const EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ANALYZER =
   'securitySolution:excludeColdAndFrozenTiersInAnalyzer' as const;

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -174,6 +174,10 @@ export const ENABLE_NEWS_FEED_SETTING = 'securitySolution:enableNewsFeed' as con
 /** This Kibana Advanced Setting sets a default AI connector for serverless AI features (AI for SOC) */
 export const DEFAULT_AI_CONNECTOR = 'securitySolution:defaultAIConnector' as const;
 
+/** Feature flag for the default AI connector setting */
+export const AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED =
+  'aiAssistant.defaultLlmSettingEnabled' as const;
+  
 /** This Kibana Advanced Setting allows users to enable/disable querying cold and frozen data tiers in analyzer */
 export const EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ANALYZER =
   'securitySolution:excludeColdAndFrozenTiersInAnalyzer' as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_default_ai_connector_id.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_default_ai_connector_id.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useDefaultAIConnectorId } from './use_default_ai_connector_id';
+import { useKibana } from '../lib/kibana';
+import { useAIConnectors } from './use_ai_connectors';
+import { getDefaultConnector } from '@kbn/elastic-assistant/impl/assistant/helpers';
+import {
+  AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED,
+  DEFAULT_AI_CONNECTOR,
+} from '../../../common/constants';
+
+jest.mock('../lib/kibana');
+jest.mock('./use_ai_connectors');
+jest.mock('@kbn/elastic-assistant/impl/assistant/helpers');
+
+const mockUseKibana = useKibana as jest.Mock;
+const mockUseAIConnectors = useAIConnectors as jest.Mock;
+const mockGetDefaultConnector = getDefaultConnector as jest.Mock;
+
+describe('useDefaultAIConnectorId', () => {
+  const mockSettings = {};
+  const mockUiSettings = {
+    get: jest.fn(),
+  };
+  const mockFeatureFlags = {
+    getBooleanValue: jest.fn(),
+  };
+  const mockConnectors = [
+    { id: 'connector-1', name: 'Connector 1' },
+    { id: 'connector-2', name: 'Connector 2' },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseKibana.mockReturnValue({
+      services: {
+        settings: mockSettings,
+        uiSettings: mockUiSettings,
+        featureFlags: mockFeatureFlags,
+      },
+    });
+
+    mockUseAIConnectors.mockReturnValue({
+      aiConnectors: mockConnectors,
+      isLoading: false,
+    });
+
+    mockUiSettings.get.mockReturnValue('legacy-connector-id');
+    mockFeatureFlags.getBooleanValue.mockReturnValue(false);
+    mockGetDefaultConnector.mockReturnValue({ id: 'new-connector-id' });
+  });
+
+  it('should return legacy connector id when new default connector feature is disabled', () => {
+    mockFeatureFlags.getBooleanValue.mockReturnValue(false);
+
+    const { result } = renderHook(() => useDefaultAIConnectorId());
+
+    expect(result.current.defaultConnectorId).toBe('legacy-connector-id');
+  });
+
+  it('should return new connector id when new default connector feature is enabled', () => {
+    mockFeatureFlags.getBooleanValue.mockReturnValue(true);
+
+    const { result } = renderHook(() => useDefaultAIConnectorId());
+
+    expect(result.current.defaultConnectorId).toBe('new-connector-id');
+  });
+
+  it('should return undefined when new default connector feature is enabled but getDefaultConnector returns undefined', () => {
+    mockFeatureFlags.getBooleanValue.mockReturnValue(true);
+    mockGetDefaultConnector.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useDefaultAIConnectorId());
+
+    expect(result.current.defaultConnectorId).toBeUndefined();
+  });
+
+  it('should return undefined when new default connector feature is enabled but getDefaultConnector returns null', () => {
+    mockFeatureFlags.getBooleanValue.mockReturnValue(true);
+    mockGetDefaultConnector.mockReturnValue(null);
+
+    const { result } = renderHook(() => useDefaultAIConnectorId());
+
+    expect(result.current.defaultConnectorId).toBeUndefined();
+  });
+
+  it('should call getBooleanValue with correct parameters', () => {
+    renderHook(() => useDefaultAIConnectorId());
+
+    expect(mockFeatureFlags.getBooleanValue).toHaveBeenCalledWith(
+      AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED,
+      false
+    );
+  });
+
+  it('should call uiSettings.get with correct parameter', () => {
+    renderHook(() => useDefaultAIConnectorId());
+
+    expect(mockUiSettings.get).toHaveBeenCalledWith(DEFAULT_AI_CONNECTOR);
+  });
+
+  it('should call getDefaultConnector with correct parameters', () => {
+    renderHook(() => useDefaultAIConnectorId());
+
+    expect(mockGetDefaultConnector).toHaveBeenCalledWith(mockConnectors, mockSettings);
+  });
+
+  it('should return undefined when legacy connector id is undefined and new feature is disabled', () => {
+    mockUiSettings.get.mockReturnValue(undefined);
+    mockFeatureFlags.getBooleanValue.mockReturnValue(false);
+
+    const { result } = renderHook(() => useDefaultAIConnectorId());
+
+    expect(result.current.defaultConnectorId).toBeUndefined();
+  });
+
+  it('should return isLoading true when connectors are loading', () => {
+    mockUseAIConnectors.mockReturnValue({
+      aiConnectors: mockConnectors,
+      isLoading: true,
+    });
+
+    const { result } = renderHook(() => useDefaultAIConnectorId());
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('should return isLoading false when connectors are not loading', () => {
+    mockUseAIConnectors.mockReturnValue({
+      aiConnectors: mockConnectors,
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useDefaultAIConnectorId());
+
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_default_ai_connector_id.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_default_ai_connector_id.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getDefaultConnector } from '@kbn/elastic-assistant/impl/assistant/helpers';
+import { useMemo } from 'react';
+import {
+  AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED,
+  DEFAULT_AI_CONNECTOR,
+} from '../../../common/constants';
+import { useAIConnectors } from './use_ai_connectors';
+import { useKibana } from '../lib/kibana';
+
+export const useDefaultAIConnectorId = () => {
+  const { settings, uiSettings, featureFlags } = useKibana().services;
+
+  const { aiConnectors: connectors, isLoading: isLoadingConnectors } = useAIConnectors();
+  const legacyDefaultConnectorId = uiSettings.get<string>(DEFAULT_AI_CONNECTOR);
+  const useNewDefaultConnector = featureFlags.getBooleanValue(
+    AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED,
+    false
+  );
+  const newDefaultConnectorId = getDefaultConnector(connectors, settings)?.id;
+
+  return useMemo(
+    () => ({
+      defaultConnectorId: useNewDefaultConnector ? newDefaultConnectorId : legacyDefaultConnectorId,
+      isLoading: isLoadingConnectors,
+    }),
+    [useNewDefaultConnector, newDefaultConnectorId, legacyDefaultConnectorId, isLoadingConnectors]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/alert_summary.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/alert_summary.tsx
@@ -56,7 +56,7 @@ export interface AlertSummaryProps {
   /**
    * Value of securitySolution:defaultAIConnector
    */
-  defaultConnectorId: string;
+  defaultConnectorId: string | undefined;
   /**
    * The context for the prompt
    */
@@ -93,7 +93,7 @@ export const AlertSummary = memo(
       messageAndReplacements,
     } = useAlertSummary({
       alertId,
-      defaultConnectorId,
+      defaultConnectorId: defaultConnectorId || '',
       promptContext,
       showAnonymizedValues,
     });
@@ -101,6 +101,11 @@ export const AlertSummary = memo(
     useEffect(() => {
       setHasAlertSummary(hasAlertSummary);
     }, [hasAlertSummary, setHasAlertSummary]);
+
+    // Don't render the summary UI if no connector ID is available
+    if (!defaultConnectorId) {
+      return <ConnectorMissingCallout canSeeAdvancedSettings={canSeeAdvancedSettings} />;
+    }
 
     return (
       <>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/alert_summary_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/alert_summary_section.test.tsx
@@ -13,6 +13,20 @@ import { ALERT_SUMMARY_SECTION_TEST_ID, AlertSummarySection } from './alert_summ
 import { ALERT_SUMMARY_OPTIONS_MENU_BUTTON_TEST_ID } from './settings_menu';
 import { useKibana as mockUseKibana } from '../../../common/lib/kibana/__mocks__';
 
+jest.mock('../../../common/hooks/use_ai_connectors', () => ({
+  useAIConnectors: jest.fn().mockReturnValue({
+    aiConnectors: [
+      {
+        id: 'test-connector-id',
+        name: 'Test Connector',
+        actionTypeId: '.gen-ai',
+      },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
 jest.mock('../context');
 
 const mockedUseKibana = {
@@ -31,6 +45,9 @@ const mockedUseKibana = {
     },
     uiSettings: {
       get: jest.fn().mockReturnValue('default-connector-id'),
+    },
+    featureFlags: {
+      getBooleanValue: jest.fn().mockReturnValue(false),
     },
   },
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/alert_summary_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/alert_summary_section.tsx
@@ -6,15 +6,14 @@
  */
 
 import React, { memo, useMemo, useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
-import type { PromptContext } from '@kbn/elastic-assistant';
+import { EuiFlexGroup, EuiFlexItem, EuiSkeletonText, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { type PromptContext } from '@kbn/elastic-assistant';
 import { i18n } from '@kbn/i18n';
 import { AlertSummary } from './alert_summary';
 import { AlertSummaryOptionsMenu } from './settings_menu';
 import { useKibana } from '../../../common/lib/kibana';
 import { useAIForSOCDetailsContext } from '../context';
-import { DEFAULT_AI_CONNECTOR } from '../../../../common/constants';
-
+import { useDefaultAIConnectorId } from '../../../common/hooks/use_default_ai_connector_id';
 export const ALERT_SUMMARY_SECTION_TEST_ID = 'ai-for-soc-alert-flyout-alert-summary-section';
 
 const AI_SUMMARY = i18n.translate('xpack.securitySolution.alertSummary.aiSummarySection.title', {
@@ -37,13 +36,12 @@ export const AlertSummarySection = memo(({ getPromptContext }: AlertSummarySecti
 
   const {
     application: { capabilities },
-    uiSettings,
   } = useKibana().services;
 
   const { eventId, showAnonymizedValues } = useAIForSOCDetailsContext();
+  const { defaultConnectorId, isLoading: isLoadingDefaultConnectorId } = useDefaultAIConnectorId();
 
   const canSeeAdvancedSettings = capabilities.management.kibana.settings ?? false;
-  const defaultConnectorId = uiSettings.get<string>(DEFAULT_AI_CONNECTOR);
 
   const promptContext: PromptContext = useMemo(
     () => ({
@@ -69,14 +67,18 @@ export const AlertSummarySection = memo(({ getPromptContext }: AlertSummarySecti
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="s" />
-      <AlertSummary
-        alertId={eventId}
-        canSeeAdvancedSettings={canSeeAdvancedSettings}
-        defaultConnectorId={defaultConnectorId}
-        promptContext={promptContext}
-        setHasAlertSummary={setHasAlertSummary}
-        showAnonymizedValues={showAnonymizedValues}
-      />
+      {isLoadingDefaultConnectorId ? (
+        <EuiSkeletonText lines={3} size="s" />
+      ) : (
+        <AlertSummary
+          alertId={eventId}
+          canSeeAdvancedSettings={canSeeAdvancedSettings}
+          defaultConnectorId={defaultConnectorId}
+          promptContext={promptContext}
+          setHasAlertSummary={setHasAlertSummary}
+          showAnonymizedValues={showAnonymizedValues}
+        />
+      )}
     </>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/connector_missing_callout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/connector_missing_callout.test.tsx
@@ -14,7 +14,21 @@ import {
 } from './connector_missing_callout';
 import { useNavigateTo } from '@kbn/security-solution-navigation';
 
+const mockedUseKibana = {
+  services: {
+    featureFlags: {
+      getBooleanValue: jest.fn().mockReturnValue(false),
+    },
+  },
+};
+
 jest.mock('@kbn/security-solution-navigation');
+jest.mock('../../../common/lib/kibana', () => {
+  return {
+    ...jest.requireActual('../../../common/lib/kibana'),
+    useKibana: () => mockedUseKibana,
+  };
+});
 
 describe('ConnectorMissingCallout', () => {
   it('should render component', () => {
@@ -46,6 +60,23 @@ describe('ConnectorMissingCallout', () => {
     expect(navigateTo).toHaveBeenCalledWith({
       appId: 'management',
       path: '/kibana/settings?query=defaultAIConnector',
+    });
+  });
+
+  it('should call navigateTo genAiSettings when clicking on link and useNewDefaultConnector is true', () => {
+    const navigateTo = jest.fn();
+    (useNavigateTo as jest.Mock).mockReturnValue({
+      navigateTo,
+    });
+    mockedUseKibana.services.featureFlags.getBooleanValue.mockReturnValue(true);
+
+    const { getByTestId } = render(<ConnectorMissingCallout canSeeAdvancedSettings={true} />);
+
+    getByTestId(MISSING_CONNECTOR_CALLOUT_LINK_TEST_ID).click();
+
+    expect(navigateTo).toHaveBeenCalledWith({
+      appId: 'management',
+      path: '/ai/genAiSettings',
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/connector_missing_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/connector_missing_callout.tsx
@@ -9,6 +9,8 @@ import React, { memo, useCallback } from 'react';
 import { EuiCallOut, EuiLink } from '@elastic/eui';
 import { useNavigateTo } from '@kbn/security-solution-navigation';
 import { i18n } from '@kbn/i18n';
+import { useKibana } from '../../../common/lib/kibana';
+import { AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED } from '../../../../common/constants';
 
 const MISSING_CONNECTOR = i18n.translate('xpack.securitySolution.alertSummary.missingConnector', {
   defaultMessage: 'Missing connector',
@@ -51,10 +53,21 @@ export interface ConnectorMissingCalloutProps {
  */
 export const ConnectorMissingCallout = memo(
   ({ canSeeAdvancedSettings }: ConnectorMissingCalloutProps) => {
+    const { featureFlags } = useKibana().services;
+    const useNewDefaultConnector = featureFlags.getBooleanValue(
+      AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED,
+      false
+    );
     const { navigateTo } = useNavigateTo();
     const goToKibanaSettings = useCallback(
-      () => navigateTo({ appId: 'management', path: '/kibana/settings?query=defaultAIConnector' }),
-      [navigateTo]
+      () =>
+        navigateTo({
+          appId: 'management',
+          path: useNewDefaultConnector
+            ? '/ai/genAiSettings'
+            : '/kibana/settings?query=defaultAIConnector',
+        }),
+      [navigateTo, useNewDefaultConnector]
     );
 
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/index.test.tsx
@@ -27,6 +27,20 @@ jest.mock('@kbn/expandable-flyout', () => ({
   useExpandableFlyoutState: jest.fn().mockReturnValue({ left: {} }),
 }));
 
+jest.mock('../../common/hooks/use_ai_connectors', () => ({
+  useAIConnectors: jest.fn().mockReturnValue({
+    aiConnectors: [
+      {
+        id: 'test-connector-id',
+        name: 'Test Connector',
+        actionTypeId: '.gen-ai',
+      },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
 jest.mock('./context');
 jest.mock('./components/attack_discovery_widget', () => ({
   AttackDiscoveryWidget: jest.fn(),

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -10,9 +10,9 @@ import { schema } from '@kbn/config-schema';
 
 import type { CoreSetup, UiSettingsParams } from '@kbn/core/server';
 import type { Connector } from '@kbn/actions-plugin/server/application/connector/types';
+import type { ReadonlyModeType } from '@kbn/core-ui-settings-common';
 import {
   APP_ID,
-  DEFAULT_AI_CONNECTOR,
   DEFAULT_ALERT_TAGS_KEY,
   DEFAULT_ALERT_TAGS_VALUE,
   DEFAULT_ANOMALY_SCORE,
@@ -44,6 +44,7 @@ import {
   NEWS_FEED_URL_SETTING_DEFAULT,
   SHOW_RELATED_INTEGRATIONS_SETTING,
   ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+  DEFAULT_AI_CONNECTOR,
 } from '../common/constants';
 import type { ExperimentalFeatures } from '../common/experimental_features';
 import { LogLevelSetting } from '../common/api/detection_engine/rule_monitoring';
@@ -531,7 +532,11 @@ export const initUiSettings = (
 
   uiSettings.register(orderSettings(securityUiSettings));
 };
-export const getDefaultAIConnectorSetting = (connectors: Connector[]): SettingsConfig | null =>
+
+export const getDefaultAIConnectorSetting = (
+  connectors: Connector[],
+  readonlyMode?: ReadonlyModeType
+): SettingsConfig | null =>
   connectors.length > 0
     ? {
         [DEFAULT_AI_CONNECTOR]: {
@@ -555,6 +560,8 @@ export const getDefaultAIConnectorSetting = (connectors: Connector[]): SettingsC
           requiresPageReload: true,
           schema: schema.string(),
           solution: 'security',
+          readonlyMode,
+          readonly: readonlyMode !== undefined,
         },
       }
     : null;

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -258,5 +258,6 @@
     "@kbn/spaces-utils",
     "@kbn/core-metrics-server",
     "@kbn/ai-assistant-default-llm-setting",
+    "@kbn/core-ui-settings-common",
   ]
 }

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
@@ -17,6 +17,7 @@ import { SECURITY_PROJECT_SETTINGS } from '@kbn/serverless-security-settings';
 import { isSupportedConnector } from '@kbn/inference-common';
 import { getDefaultAIConnectorSetting } from '@kbn/security-solution-plugin/server/ui_settings';
 import type { Connector } from '@kbn/actions-plugin/server/application/connector/types';
+import { AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED } from '@kbn/security-solution-plugin/common/constants';
 import { getEnabledProductFeatures } from '../common/pli/pli_features';
 
 import type { ServerlessSecurityConfig } from './config';
@@ -95,14 +96,19 @@ export class SecuritySolutionServerlessPlugin
       // Serverless Advanced Settings setup
       coreSetup
         .getStartServices()
-        .then(async ([_, depsStart]) => {
+        .then(async ([coreStart, depsStart]) => {
+          const isNewDefaultConnectorEnabled = await coreStart.featureFlags.getBooleanValue(
+          AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED,
+          false
+        );
+
           try {
             const unsecuredActionsClient = depsStart.actions.getUnsecuredActionsClient();
             // using "default" space actually forces the api to use undefined space (see getAllUnsecured)
             const aiConnectors = (await unsecuredActionsClient.getAll('default')).filter(
               (connector: Connector) => isSupportedConnector(connector)
             );
-            const defaultAIConnectorSetting = getDefaultAIConnectorSetting(aiConnectors);
+            const defaultAIConnectorSetting = getDefaultAIConnectorSetting(aiConnectors, isNewDefaultConnectorEnabled ? 'ui' : undefined);
             if (defaultAIConnectorSetting !== null) {
               coreSetup.uiSettings.register(defaultAIConnectorSetting);
             }

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
@@ -98,9 +98,9 @@ export class SecuritySolutionServerlessPlugin
         .getStartServices()
         .then(async ([coreStart, depsStart]) => {
           const isNewDefaultConnectorEnabled = await coreStart.featureFlags.getBooleanValue(
-          AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED,
-          false
-        );
+            AI_ASSISTANT_DEFAULT_LLM_SETTING_ENABLED,
+            false
+          );
 
           try {
             const unsecuredActionsClient = depsStart.actions.getUnsecuredActionsClient();
@@ -108,7 +108,10 @@ export class SecuritySolutionServerlessPlugin
             const aiConnectors = (await unsecuredActionsClient.getAll('default')).filter(
               (connector: Connector) => isSupportedConnector(connector)
             );
-            const defaultAIConnectorSetting = getDefaultAIConnectorSetting(aiConnectors, isNewDefaultConnectorEnabled ? 'ui' : undefined);
+            const defaultAIConnectorSetting = getDefaultAIConnectorSetting(
+              aiConnectors,
+              isNewDefaultConnectorEnabled ? 'ui' : undefined
+            );
             if (defaultAIConnectorSetting !== null) {
               coreSetup.uiSettings.register(defaultAIConnectorSetting);
             }

--- a/x-pack/solutions/security/plugins/security_solution_serverless/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/tsconfig.json
@@ -46,8 +46,8 @@
     "@kbn/automatic-import-plugin",
     "@kbn/cloud-security-posture-common",
     "@kbn/dev-utils",
-    "@kbn/inference-common",
     "@kbn/ai-assistant-icon",
     "@kbn/core-application-browser",
+    "@kbn/inference-common",
   ]
 }

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/advanced_settings.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/advanced_settings.ts
@@ -8,13 +8,23 @@
 import expect from '@kbn/expect';
 import { SECURITY_PROJECT_SETTINGS } from '@kbn/serverless-security-settings';
 import { isEditorFieldSetting } from '@kbn/test-suites-xpack-platform/serverless/functional/test_suites/management/advanced_settings';
-import { FtrProviderContext } from '../../ftr_provider_context';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
+import type { FtrProviderContext } from '../../ftr_provider_context';
 
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
   const pageObjects = getPageObjects(['svlCommonPage', 'common']);
   const browser = getService('browser');
   const retry = getService('retry');
+
+  // readOnly settings with readonlyMode set to ui are not available on the advanced settings page
+  const READ_ONLY_SETTINGS: string[] = [
+    GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+    GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+  ];
 
   describe('Security advanced settings', function () {
     before(async () => {
@@ -35,6 +45,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       for (const settingId of SECURITY_PROJECT_SETTINGS) {
         // Code editors don't have their test subjects rendered
         if (isEditorFieldSetting(settingId)) {
+          continue;
+        }
+        // readOnly settings wont appear on the advanced settings page
+        if (READ_ONLY_SETTINGS.includes(settingId)) {
           continue;
         }
         it('renders ' + settingId + ' edit field', async () => {

--- a/x-pack/solutions/security/test/tsconfig.json
+++ b/x-pack/solutions/security/test/tsconfig.json
@@ -62,5 +62,6 @@
     "@kbn/serverless-security-settings",
     "@kbn/rison",
     "@kbn/core-chrome-browser",
+    "@kbn/management-settings-ids",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution] [AI Assistant] Replace old defaultLlm setting (#237444)](https://github.com/elastic/kibana/pull/237444)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kenneth Kreindler","email":"42113355+KDKHD@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-08T13:40:25Z","message":"[Security Solution] [AI Assistant] Replace old defaultLlm setting (#237444)\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\nReplace the old default LLM setting with the new one that supports\nlimiting the LLM connectors to only the default.\n\nThe old default LLM setting also had an issue where only preconfigured\nLLMs could be selected. The new defaultLLm setting fixes this.\n\n### How to test:\n- Enable feature flag in Kibana.dev.yml:\n```\nfeature_flags.overrides.aiAssistant.defaultLlmSettingEnabled: true\n```\n- Start Kibana in the EASE variant. Ping me if you need instructions.\n- Add alert data using\nhttps://github.com/enriquesanchez-elastic/security-documents-generator\nand the command `yarn start generate-alerts -n 10000 -h 100 -u 100\n--start-date 60d --end-date now`. You will need to use a config like\nthis one:\n```\n{\n  \"elastic\": {\n    \"node\": \"https://localhost:9200\",\n    \"username\": \"elastic_serverless\",\n    \"password\": \"changeme\"\n  },\n  \"kibana\": {\n    \"node\": \"https://localhost:5601\",\n    \"apiKey\": \"<your api key>\"\n  }\n}\n```\n- Log into Kibana using the `_search_ai_lake_soc_manager` user.\n- Generate an attack discovery\n- Go to Stack Management > GenAi Settings. Set one of your LLM\nconnectors as the default LLM. (for this you need to be logged in with\n`user: elastic_serverless pass: changeme`)\n- Go to the Value report page and check that all of the content on the\npage loads. (you need to log in as `_search_ai_lake_soc_manager` again)\n- Check the dev console and ensure the default LLM that you set is used\nfor the LLM-generated content:\n\n<img width=\"3135\" height=\"1139\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/59fec53b-e82e-46c7-9942-c71e17e1055d\"\n/>\n\n(When no default LLM is configured, it will use the Elastic LLM instead.\nSee code\n[here](https://github.com/elastic/kibana/pull/237444/files#diff-843fa4c77bd12030069f3ce75732006697f719150111649b2bcac2a84f942de9R68-R83)\n)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [X] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c809a954c20b6ab39780a65056b7a8c8ed7b6f16","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Security Generative AI","backport:version","v9.2.0","v9.0.8","v9.3.0","v9.1.6","v8.19.6"],"title":"[Security Solution] [AI Assistant] Replace old defaultLlm setting","number":237444,"url":"https://github.com/elastic/kibana/pull/237444","mergeCommit":{"message":"[Security Solution] [AI Assistant] Replace old defaultLlm setting (#237444)\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\nReplace the old default LLM setting with the new one that supports\nlimiting the LLM connectors to only the default.\n\nThe old default LLM setting also had an issue where only preconfigured\nLLMs could be selected. The new defaultLLm setting fixes this.\n\n### How to test:\n- Enable feature flag in Kibana.dev.yml:\n```\nfeature_flags.overrides.aiAssistant.defaultLlmSettingEnabled: true\n```\n- Start Kibana in the EASE variant. Ping me if you need instructions.\n- Add alert data using\nhttps://github.com/enriquesanchez-elastic/security-documents-generator\nand the command `yarn start generate-alerts -n 10000 -h 100 -u 100\n--start-date 60d --end-date now`. You will need to use a config like\nthis one:\n```\n{\n  \"elastic\": {\n    \"node\": \"https://localhost:9200\",\n    \"username\": \"elastic_serverless\",\n    \"password\": \"changeme\"\n  },\n  \"kibana\": {\n    \"node\": \"https://localhost:5601\",\n    \"apiKey\": \"<your api key>\"\n  }\n}\n```\n- Log into Kibana using the `_search_ai_lake_soc_manager` user.\n- Generate an attack discovery\n- Go to Stack Management > GenAi Settings. Set one of your LLM\nconnectors as the default LLM. (for this you need to be logged in with\n`user: elastic_serverless pass: changeme`)\n- Go to the Value report page and check that all of the content on the\npage loads. (you need to log in as `_search_ai_lake_soc_manager` again)\n- Check the dev console and ensure the default LLM that you set is used\nfor the LLM-generated content:\n\n<img width=\"3135\" height=\"1139\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/59fec53b-e82e-46c7-9942-c71e17e1055d\"\n/>\n\n(When no default LLM is configured, it will use the Elastic LLM instead.\nSee code\n[here](https://github.com/elastic/kibana/pull/237444/files#diff-843fa4c77bd12030069f3ce75732006697f719150111649b2bcac2a84f942de9R68-R83)\n)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [X] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c809a954c20b6ab39780a65056b7a8c8ed7b6f16"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","9.1","8.19"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238055","number":238055,"state":"OPEN"},{"branch":"9.0","label":"v9.0.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237444","number":237444,"mergeCommit":{"message":"[Security Solution] [AI Assistant] Replace old defaultLlm setting (#237444)\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\nReplace the old default LLM setting with the new one that supports\nlimiting the LLM connectors to only the default.\n\nThe old default LLM setting also had an issue where only preconfigured\nLLMs could be selected. The new defaultLLm setting fixes this.\n\n### How to test:\n- Enable feature flag in Kibana.dev.yml:\n```\nfeature_flags.overrides.aiAssistant.defaultLlmSettingEnabled: true\n```\n- Start Kibana in the EASE variant. Ping me if you need instructions.\n- Add alert data using\nhttps://github.com/enriquesanchez-elastic/security-documents-generator\nand the command `yarn start generate-alerts -n 10000 -h 100 -u 100\n--start-date 60d --end-date now`. You will need to use a config like\nthis one:\n```\n{\n  \"elastic\": {\n    \"node\": \"https://localhost:9200\",\n    \"username\": \"elastic_serverless\",\n    \"password\": \"changeme\"\n  },\n  \"kibana\": {\n    \"node\": \"https://localhost:5601\",\n    \"apiKey\": \"<your api key>\"\n  }\n}\n```\n- Log into Kibana using the `_search_ai_lake_soc_manager` user.\n- Generate an attack discovery\n- Go to Stack Management > GenAi Settings. Set one of your LLM\nconnectors as the default LLM. (for this you need to be logged in with\n`user: elastic_serverless pass: changeme`)\n- Go to the Value report page and check that all of the content on the\npage loads. (you need to log in as `_search_ai_lake_soc_manager` again)\n- Check the dev console and ensure the default LLM that you set is used\nfor the LLM-generated content:\n\n<img width=\"3135\" height=\"1139\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/59fec53b-e82e-46c7-9942-c71e17e1055d\"\n/>\n\n(When no default LLM is configured, it will use the Elastic LLM instead.\nSee code\n[here](https://github.com/elastic/kibana/pull/237444/files#diff-843fa4c77bd12030069f3ce75732006697f719150111649b2bcac2a84f942de9R68-R83)\n)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [X] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c809a954c20b6ab39780a65056b7a8c8ed7b6f16"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->