### PR TITLE
[8.19] [Fleet] Fix error when deleting orphaned integration policies (#237875)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -3331,7 +3331,6 @@ describe('Package policy service', () => {
       const soClient = savedObjectsClientMock.create();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
-
       soClient.bulkGet.mockResolvedValueOnce({
         saved_objects: [{ ...mockPackagePolicy }],
       });

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -3154,7 +3154,7 @@ describe('Package policy service', () => {
     };
 
     it('should allow to delete package policies from ES index', async () => {
-      const soClient = createSavedObjectClientMock();
+      const soClient = savedObjectsClientMock.create();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
       soClient.bulkGet.mockResolvedValue({
@@ -3200,7 +3200,7 @@ describe('Package policy service', () => {
       );
     });
     it('should allow to delete orphaned package policies from ES index', async () => {
-      const soClient = createSavedObjectClientMock();
+      const soClient = savedObjectsClientMock.create();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
       soClient.bulkGet.mockResolvedValue({
@@ -3224,7 +3224,7 @@ describe('Package policy service', () => {
         output: { statusCode: 404, payload: { message: 'policy not found' } },
       });
 
-      mockAgentPolicyService.getByIds.mockResolvedValueOnce([
+      mockAgentPolicyService.getByIDs.mockResolvedValueOnce([
         {
           id: 'agentPolicy1',
           name: 'Test Agent Policy',
@@ -3265,7 +3265,7 @@ describe('Package policy service', () => {
     });
 
     it('should not allow to delete managed package policies', async () => {
-      const soClient = createSavedObjectClientMock();
+      const soClient = savedObjectsClientMock.create();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
       soClient.bulkGet.mockResolvedValue({
@@ -3298,7 +3298,7 @@ describe('Package policy service', () => {
       // agent policy not found
       mockAgentPolicyService.get.mockResolvedValueOnce(managedAgentPolicy);
 
-      mockAgentPolicyService.getByIds.mockResolvedValueOnce([managedAgentPolicy]);
+      mockAgentPolicyService.getByIDs.mockResolvedValueOnce([managedAgentPolicy]);
 
       (getPackageInfo as jest.Mock).mockImplementation(async (params) => {
         return Promise.resolve({
@@ -3359,7 +3359,7 @@ describe('Package policy service', () => {
     });
 
     it('should return empty array if no package policies are found', async () => {
-      const soClient = createSavedObjectClientMock();
+      const soClient = savedObjectsClientMock.create();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
       const res = await packagePolicyService.delete(soClient, esClient, ['test-package-policy']);
       expect(res).toEqual([]);

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -3331,12 +3331,7 @@ describe('Package policy service', () => {
       const soClient = savedObjectsClientMock.create();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
-      const mockPackagePolicy = {
-        id: 'test-package-policy',
-        type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
-        attributes: {},
-        references: [],
-      };
+
       soClient.bulkGet.mockResolvedValueOnce({
         saved_objects: [{ ...mockPackagePolicy }],
       });

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -213,7 +213,7 @@ const mockedAuditLoggingService = auditLoggingService as jest.Mocked<typeof audi
 
 type CombinedExternalCallback = PutPackagePolicyUpdateCallback | PostPackagePolicyCreateCallback;
 
-const mockAgentPolicyGet = (spaceIds: string[] = ['default']) => {
+const mockAgentPolicyGet = (spaceIds: string[] = ['default'], additionalProps?: any) => {
   mockAgentPolicyService.get.mockImplementation(
     (_soClient: SavedObjectsClientContract, id: string, _force = false, _errorMessage?: string) => {
       return Promise.resolve({
@@ -3146,8 +3146,186 @@ describe('Package policy service', () => {
   });
 
   describe('delete', () => {
-    // TODO: Add tests
-    it('should allow to delete a package policy', async () => {});
+    const mockPackagePolicy = {
+      id: 'test-package-policy',
+      type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+      attributes: createPackagePolicyMock(),
+      references: [],
+    };
+
+    it('should allow to delete package policies from ES index', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'test',
+            type: 'abcd',
+            references: [],
+            version: 'test',
+            attributes: createPackagePolicyMock(),
+          },
+        ],
+      });
+
+      soClient.get.mockResolvedValueOnce({
+        ...mockPackagePolicy,
+      });
+
+      mockAgentPolicyGet();
+
+      (getPackageInfo as jest.Mock).mockImplementation(async (params) => {
+        return Promise.resolve({
+          ...(await mockedGetPackageInfo(params)),
+          elasticsearch: {
+            privileges: {
+              cluster: ['monitor'],
+            },
+          },
+        } as PackageInfo);
+      });
+      const idToDelete = 'c6d16e42-c32d-4dce-8a88-113cfe276ad1';
+      soClient.bulkDelete.mockResolvedValue({
+        statuses: [
+          { id: idToDelete, type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE, success: true },
+        ],
+      });
+
+      await packagePolicyService.delete(soClient, esClient, [idToDelete]);
+
+      expect(soClient.bulkDelete).toHaveBeenCalledWith(
+        [{ id: idToDelete, type: 'ingest-package-policies' }],
+        { force: true }
+      );
+    });
+    it('should allow to delete orphaned package policies from ES index', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'test',
+            type: 'abcd',
+            references: [],
+            version: 'test',
+            attributes: createPackagePolicyMock(),
+          },
+        ],
+      });
+
+      soClient.get.mockResolvedValueOnce({
+        ...mockPackagePolicy,
+      });
+
+      // agent policy not found
+      mockAgentPolicyService.get.mockRejectedValueOnce({
+        output: { statusCode: 404, payload: { message: 'policy not found' } },
+      });
+
+      mockAgentPolicyService.getByIds.mockResolvedValueOnce([
+        {
+          id: 'agentPolicy1',
+          name: 'Test Agent Policy',
+          namespace: 'test',
+          status: 'active',
+          is_managed: false,
+          updated_at: new Date().toISOString(),
+          updated_by: 'test',
+          revision: 1,
+          is_protected: false,
+          space_ids: ['default'],
+        },
+      ]);
+
+      (getPackageInfo as jest.Mock).mockImplementation(async (params) => {
+        return Promise.resolve({
+          ...(await mockedGetPackageInfo(params)),
+          elasticsearch: {
+            privileges: {
+              cluster: ['monitor'],
+            },
+          },
+        } as PackageInfo);
+      });
+      const idToDelete = 'c6d16e42-c32d-4dce-8a88-113cfe276ad1';
+      soClient.bulkDelete.mockResolvedValue({
+        statuses: [
+          { id: idToDelete, type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE, success: true },
+        ],
+      });
+
+      await packagePolicyService.delete(soClient, esClient, [idToDelete]);
+
+      expect(soClient.bulkDelete).toHaveBeenCalledWith(
+        [{ id: idToDelete, type: 'ingest-package-policies' }],
+        { force: true }
+      );
+    });
+
+    it('should not allow to delete managed package policies', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'test',
+            type: 'abcd',
+            references: [],
+            version: 'test',
+            attributes: createPackagePolicyMock(),
+          },
+        ],
+      });
+
+      soClient.get.mockResolvedValueOnce({
+        ...mockPackagePolicy,
+      });
+      const managedAgentPolicy = {
+        id: 'agentPolicy1',
+        name: 'Test Agent Policy',
+        namespace: 'test',
+        status: 'active',
+        is_managed: true,
+        updated_at: new Date().toISOString(),
+        updated_by: 'test',
+        revision: 1,
+        is_protected: false,
+        space_ids: ['default'],
+      } as any;
+      // agent policy not found
+      mockAgentPolicyService.get.mockResolvedValueOnce(managedAgentPolicy);
+
+      mockAgentPolicyService.getByIds.mockResolvedValueOnce([managedAgentPolicy]);
+
+      (getPackageInfo as jest.Mock).mockImplementation(async (params) => {
+        return Promise.resolve({
+          ...(await mockedGetPackageInfo(params)),
+          elasticsearch: {
+            privileges: {
+              cluster: ['monitor'],
+            },
+          },
+        } as PackageInfo);
+      });
+      const idToDelete = 'c6d16e42-c32d-4dce-8a88-113cfe276ad1';
+
+      expect(await packagePolicyService.delete(soClient, esClient, [idToDelete])).toEqual([
+        {
+          body: {
+            message:
+              'Cannot remove integrations of hosted agent policy in Fleet because the agent policy is managed by an external orchestration solution, such as Elastic Cloud, Kubernetes, etc. Please make changes using your orchestration solution.',
+          },
+          id: 'c6d16e42-c32d-4dce-8a88-113cfe276ad1',
+          statusCode: 400,
+          success: false,
+        },
+      ]);
+
+      expect(soClient.bulkDelete).not.toHaveBeenCalled();
+    });
 
     it('should call audit logger', async () => {
       const soClient = savedObjectsClientMock.create();
@@ -3159,6 +3337,9 @@ describe('Package policy service', () => {
         attributes: {},
         references: [],
       };
+      soClient.bulkGet.mockResolvedValueOnce({
+        saved_objects: [{ ...mockPackagePolicy }],
+      });
 
       soClient.get.mockResolvedValueOnce({
         ...mockPackagePolicy,
@@ -3175,6 +3356,13 @@ describe('Package policy service', () => {
         id: 'test-package-policy',
         savedObjectType: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
       });
+    });
+
+    it('should return empty array if no package policies are found', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      const res = await packagePolicyService.delete(soClient, esClient, ['test-package-policy']);
+      expect(res).toEqual([]);
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -1425,7 +1425,9 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     const packagePolicies = await this.getByIDs(soClient, ids, {
       ignoreMissing: true,
     });
+
     if (!packagePolicies || packagePolicies.length === 0) {
+      logger.debug(`No package policies to delete`);
       return [];
     }
 
@@ -1466,7 +1468,11 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
           agentlessAgentPolicies.push(agentPolicyId);
         }
       } catch (e) {
-        hostedAgentPolicies.push(agentPolicyId);
+        logger.error(
+          `An error occurred while checking if policies are hosted: ${e?.output?.payload?.message}`
+        );
+        // in case of orphaned policies don't add the id to the hostedAgentPolicies array
+        if (e?.output?.statusCode !== 404) hostedAgentPolicies.push(agentPolicyId);
       }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Fleet] Fix error when deleting orphaned integration policies (#237875)](https://github.com/elastic/kibana/pull/237875)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-08T13:21:22Z","message":"[Fleet] Fix error when deleting orphaned integration policies (#237875)\n\nFixes https://github.com/elastic/kibana/issues/237700\n\n## Summary\nAttempting to delete an orphaned integration policy fails with a\nmisleading error. This PR fixes this case and allows the user to force\ndelete orphaned integration policies from Fleet APIs\n\n\n### Repro steps\n- Have an agent policy with an installed integration policy. For\ninstance `system`\n- Get the ids of both the agent policy and the integration policy.\nManually delete the agent policy (it may require a `superuser` user):\n```\n DELETE .kibana_ingest/_doc/fleet-agent-policies:<agent-policy-id>\n```\n- At this point the integration policy should be \"orphaned\". Try to\nforce delete it with fleet APIs:\n```\nDELETE kbn:/api/fleet/package_policies/<integration-policy-id>?force=true\n```\nThe deletion should succeed - previously it was failing with an error.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"14fdb329e952918bf7f6d2ead15fbcc235932851","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:version","v9.1.0","v9.2.0","v9.3.0","v8.19.6"],"title":"[Fleet] Fix error when deleting orphaned integration policies","number":237875,"url":"https://github.com/elastic/kibana/pull/237875","mergeCommit":{"message":"[Fleet] Fix error when deleting orphaned integration policies (#237875)\n\nFixes https://github.com/elastic/kibana/issues/237700\n\n## Summary\nAttempting to delete an orphaned integration policy fails with a\nmisleading error. This PR fixes this case and allows the user to force\ndelete orphaned integration policies from Fleet APIs\n\n\n### Repro steps\n- Have an agent policy with an installed integration policy. For\ninstance `system`\n- Get the ids of both the agent policy and the integration policy.\nManually delete the agent policy (it may require a `superuser` user):\n```\n DELETE .kibana_ingest/_doc/fleet-agent-policies:<agent-policy-id>\n```\n- At this point the integration policy should be \"orphaned\". Try to\nforce delete it with fleet APIs:\n```\nDELETE kbn:/api/fleet/package_policies/<integration-policy-id>?force=true\n```\nThe deletion should succeed - previously it was failing with an error.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"14fdb329e952918bf7f6d2ead15fbcc235932851"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238045","number":238045,"state":"OPEN"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238046","number":238046,"state":"OPEN"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237875","number":237875,"mergeCommit":{"message":"[Fleet] Fix error when deleting orphaned integration policies (#237875)\n\nFixes https://github.com/elastic/kibana/issues/237700\n\n## Summary\nAttempting to delete an orphaned integration policy fails with a\nmisleading error. This PR fixes this case and allows the user to force\ndelete orphaned integration policies from Fleet APIs\n\n\n### Repro steps\n- Have an agent policy with an installed integration policy. For\ninstance `system`\n- Get the ids of both the agent policy and the integration policy.\nManually delete the agent policy (it may require a `superuser` user):\n```\n DELETE .kibana_ingest/_doc/fleet-agent-policies:<agent-policy-id>\n```\n- At this point the integration policy should be \"orphaned\". Try to\nforce delete it with fleet APIs:\n```\nDELETE kbn:/api/fleet/package_policies/<integration-policy-id>?force=true\n```\nThe deletion should succeed - previously it was failing with an error.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"14fdb329e952918bf7f6d2ead15fbcc235932851"}},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->