### PR TITLE
[Security Solution] Fix naming inconsistency for telemetry events

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/index.ts
@@ -18,7 +18,7 @@ export const ruleUpgradeFlyoutButtonClickEvent: RuleUpgradeTelemetryEvent = {
         optional: false,
       },
     },
-    hasMissingBaseVersion: {
+    hasBaseVersion: {
       type: 'boolean',
       _meta: {
         description: 'Indicates if the rule has a missing base version',
@@ -44,7 +44,7 @@ export const ruleUpgradeSingleButtonClickEvent: RuleUpgradeTelemetryEvent = {
 export const ruleUpgradeOpenFlyoutEvent: RuleUpgradeTelemetryEvent = {
   eventType: RuleUpgradeEventTypes.RuleUpgradeFlyoutOpen,
   schema: {
-    hasMissingBaseVersion: {
+    hasBaseVersion: {
       type: 'boolean',
       _meta: {
         description: 'Indicates if the rule has a missing base version',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/types.ts
@@ -7,13 +7,13 @@
 import type { RootSchema } from '@kbn/core/public';
 
 export enum RuleUpgradeEventTypes {
-  RuleUpgradeFlyoutButtonClick = 'Click Rule Upgrade Flyout Button',
+  RuleUpgradeFlyoutButtonClick = 'Click Rule Upgrade Flyout Button v2',
   RuleUpgradeSingleButtonClick = 'Click Rule Upgrade Single Button',
-  RuleUpgradeFlyoutOpen = 'Open Rule Upgrade Flyout',
+  RuleUpgradeFlyoutOpen = 'Open Rule Upgrade Flyout v2',
 }
 interface ReportRuleUpgradeFlyoutButtonClickParams {
   type: 'update' | 'dismiss';
-  hasMissingBaseVersion: boolean;
+  hasBaseVersion: boolean;
 }
 
 interface ReportRuleUpgradeSingleButtonClickParams {
@@ -21,7 +21,7 @@ interface ReportRuleUpgradeSingleButtonClickParams {
 }
 
 interface ReportRuleUpgradeFlyoutOpenParams {
-  hasMissingBaseVersion: boolean;
+  hasBaseVersion: boolean;
 }
 
 export interface RuleUpgradeTelemetryEventsMap {

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
@@ -364,16 +364,16 @@ export function usePrebuiltRulesUpgrade({
   );
   const closeRulePreviewAction = (rule: RuleResponse, reason: RulePreviewFlyoutCloseReason) => {
     const ruleUpgradeState = rulesUpgradeState[rule.rule_id];
-    const hasMissingBaseVersion = ruleUpgradeState.has_base_version === false;
+    const hasBaseVersion = ruleUpgradeState.has_base_version === true;
     if (reason === 'dismiss') {
       telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick, {
         type: 'dismiss',
-        hasMissingBaseVersion,
+        hasBaseVersion,
       });
     } else {
       telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick, {
         type: 'update',
-        hasMissingBaseVersion,
+        hasBaseVersion,
       });
     }
   };
@@ -393,9 +393,9 @@ export function usePrebuiltRulesUpgrade({
     (ruleId: string) => {
       openRulePreviewDefault(ruleId);
       const ruleUpgradeState = rulesUpgradeState[ruleId];
-      const hasMissingBaseVersion = ruleUpgradeState.has_base_version === false;
+      const hasBaseVersion = ruleUpgradeState.has_base_version === true;
       telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutOpen, {
-        hasMissingBaseVersion,
+        hasBaseVersion,
       });
     },
     [openRulePreviewDefault, rulesUpgradeState, telemetry]


### PR DESCRIPTION
**Partially resolves: #140369**

## Summary

This PR fixes naming inconsistency that creeped in my previous PRs. We should use always 'hasBaseVersion' (currently there is a mixture of hasBaseVersion and hasMissingBaseVersion).
In order to be sure that the visualizations (which need to be updated) use only the event with the new shape, I am adding 'v2' to the name.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.1","9.2"]} ONMERGE-->