### PR TITLE
[CI] Prefer local moon cache

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -17,6 +17,17 @@ steps:
           limit: 1
   - wait
 
+  - command: .buildkite/scripts/steps/store_cache.sh
+    label: Store Cache for build
+    timeout_in_minutes: 10
+    id: store_cache
+    soft_fail: true
+    depends_on:
+      - terrazzo-initial-pipeline-upload
+    agents:
+      machineType: n2-standard-2
+      diskSizeGb: 95
+
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh
     label: Build Kibana Distribution
     agents:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -2,6 +2,7 @@ steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh
     label: Pre-Build
     timeout_in_minutes: 10
+    id: pre_build
     agents:
       machineType: n2-standard-2
       diskSizeGb: 100

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -7,16 +7,18 @@ steps:
       machineType: n2-standard-2
       diskSizeGb: 100
 
+  - wait
+
   - command: .buildkite/scripts/steps/store_cache.sh
-    label: Pre-Build
+    label: Store Cache for build
     timeout_in_minutes: 10
     id: store_cache
     soft_fail: true
+    depends_on:
+      - terrazzo-initial-pipeline-upload
     agents:
       machineType: n2-standard-2
       diskSizeGb: 95
-
-  - wait
 
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -7,6 +7,15 @@ steps:
       machineType: n2-standard-2
       diskSizeGb: 100
 
+  - command: .buildkite/scripts/steps/store_cache.sh
+    label: Pre-Build
+    timeout_in_minutes: 10
+    id: store_cache
+    soft_fail: true
+    agents:
+      machineType: n2-standard-2
+      diskSizeGb: 95
+
   - wait
 
   - command: .buildkite/scripts/steps/build_kibana.sh

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -23,7 +23,8 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
     echo "Using ~/.kibana/.yarn-local-mirror as a starting point"
     mv ~/.kibana/.yarn-local-mirror ./
   fi
-  if [[ buildkite-agent artifact download "moon-cache.tar.gz" ~/moon-cache.tar.gz ]]; then
+  # Check if the download succeeds before trying to extract the cache
+  if (buildkite-agent artifact download "moon-cache.tar.gz" ~/moon-cache.tar.gz); then
     echo "Found moon-cache.tar.gz artifact, extracting to ./.moon/cache"
     mkdir -p ./.moon/cache
     tar -xzf ~/moon-cache.tar.gz -C ./.moon/cache

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -32,7 +32,7 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
   elif [[ -d ~/.kibana-moon-cache ]]; then
     echo "Using ~/.moon/cache as a starting point"
     mkdir -p ./.moon/cache
-    mv ~/.kibana-moon-cache ./.moon/cache
+    mv ~/.kibana-moon-cache/* ./.moon/cache
   fi
 fi
 

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -26,6 +26,8 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
   # Check if the download succeeds before trying to extract the cache
   if (buildkite-agent artifact download --step "pre_build" "**/moon-cache.tar.gz" ~/); then
     echo "Found moon-cache.tar.gz artifact, extracting to ./.moon/cache"
+    ls -la ~/
+    pwd
     mkdir -p ./.moon/cache
     tar -xzf ~/moon-cache.tar.gz -C ./.moon/cache
   elif [[ -d ~/.kibana-moon-cache ]]; then

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -26,11 +26,14 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
   # Check if the download succeeds before trying to extract the cache
   if (buildkite-agent artifact download --step "pre_build" "moon-cache.tar.gz" ~/); then
     echo "Found moon-cache.tar.gz artifact, extracting to ./.moon/cache"
+    ls -la ~/.kibana-moon-cache || echo "No ~/.kibana-moon-cache directory found"
+    ls -la ./.moon/cache/.kibana-moon-cache || echo "No .kibana-moon-cache directory found inside the moon cache"
     mkdir -p ./.moon/cache
+    echo "Extracting moon-cache.tar.gz to ./.moon/cache"
     tar -xzf ~/moon-cache.tar.gz -C ./
     ls -la ./.moon/cache
-    ls -la ./.moon/cache/.kibana-moon-cache || echo "No .kibana-moon-cache directory found inside the moon cache"
     ls -la ~/.kibana-moon-cache || echo "No ~/.kibana-moon-cache directory found"
+    ls -la ./.moon/cache/.kibana-moon-cache || echo "No .kibana-moon-cache directory found inside the moon cache"
   elif [[ -d ~/.kibana-moon-cache ]]; then
     echo "Using ~/.moon/cache as a starting point"
     mkdir -p ./.moon/cache

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -24,7 +24,7 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
     mv ~/.kibana/.yarn-local-mirror ./
   fi
   # Check if the download succeeds before trying to extract the cache
-  if (buildkite-agent artifact download "moon-cache.tar.gz" ~/moon-cache.tar.gz); then
+  if (buildkite-agent artifact download "/opt/buildkite-agent/moon-cache.tar.gz" ~/); then
     echo "Found moon-cache.tar.gz artifact, extracting to ./.moon/cache"
     mkdir -p ./.moon/cache
     tar -xzf ~/moon-cache.tar.gz -C ./.moon/cache

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -29,6 +29,8 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
     mkdir -p ./.moon/cache
     tar -xzf ~/moon-cache.tar.gz -C ./
     ls -la ./.moon/cache
+    ls -la ./.moon/cache/.kibana-moon-cache || echo "No .kibana-moon-cache directory found inside the moon cache"
+    ls -la ~/.kibana-moon-cache || echo "No ~/.kibana-moon-cache directory found"
   elif [[ -d ~/.kibana-moon-cache ]]; then
     echo "Using ~/.moon/cache as a starting point"
     mkdir -p ./.moon/cache

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -26,11 +26,9 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
   # Check if the download succeeds before trying to extract the cache
   if (buildkite-agent artifact download --step "pre_build" "moon-cache.tar.gz" ~/); then
     echo "Found moon-cache.tar.gz artifact, extracting to ./.moon/cache"
-    ls -la ~/
-    pwd
-    ls -la
     mkdir -p ./.moon/cache
     tar -xzf ~/moon-cache.tar.gz -C ./.moon/cache
+    ls -la ./.moon/cache
   elif [[ -d ~/.kibana-moon-cache ]]; then
     echo "Using ~/.moon/cache as a starting point"
     mkdir -p ./.moon/cache

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -24,10 +24,11 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
     mv ~/.kibana/.yarn-local-mirror ./
   fi
   # Check if the download succeeds before trying to extract the cache
-  if (buildkite-agent artifact download --step "pre_build" "**/moon-cache.tar.gz" ~/); then
+  if (buildkite-agent artifact download --step "pre_build" "moon-cache.tar.gz" ~/); then
     echo "Found moon-cache.tar.gz artifact, extracting to ./.moon/cache"
     ls -la ~/
     pwd
+    ls -la
     mkdir -p ./.moon/cache
     tar -xzf ~/moon-cache.tar.gz -C ./.moon/cache
   elif [[ -d ~/.kibana-moon-cache ]]; then

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -24,7 +24,7 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
     mv ~/.kibana/.yarn-local-mirror ./
   fi
   # Check if the download succeeds before trying to extract the cache
-  if (buildkite-agent artifact download "/opt/buildkite-agent/moon-cache.tar.gz" ~/); then
+  if (buildkite-agent artifact download --step "pre_build" "**/moon-cache.tar.gz" ~/); then
     echo "Found moon-cache.tar.gz artifact, extracting to ./.moon/cache"
     mkdir -p ./.moon/cache
     tar -xzf ~/moon-cache.tar.gz -C ./.moon/cache

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -23,7 +23,11 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
     echo "Using ~/.kibana/.yarn-local-mirror as a starting point"
     mv ~/.kibana/.yarn-local-mirror ./
   fi
-  if [[ -d ~/.kibana-moon-cache ]]; then
+  if [[ buildkite-agent artifact download "moon-cache.tar.gz" ~/moon-cache.tar.gz ]]; then
+    echo "Found moon-cache.tar.gz artifact, extracting to ./.moon/cache"
+    mkdir -p ./.moon/cache
+    tar -xzf ~/moon-cache.tar.gz -C ./.moon/cache
+  elif [[ -d ~/.kibana-moon-cache ]]; then
     echo "Using ~/.moon/cache as a starting point"
     mkdir -p ./.moon/cache
     mv ~/.kibana-moon-cache ./.moon/cache

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -23,17 +23,12 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
     echo "Using ~/.kibana/.yarn-local-mirror as a starting point"
     mv ~/.kibana/.yarn-local-mirror ./
   fi
-  # Check if the download succeeds before trying to extract the cache
-  if (buildkite-agent artifact download --step "pre_build" "moon-cache.tar.gz" ~/); then
+  # Check if there's a cache artifact uploaded from a previous step
+  if (buildkite-agent artifact download --step "store_cache" "moon-cache.tar.gz" ~/); then
     echo "Found moon-cache.tar.gz artifact, extracting to ./.moon/cache"
-    ls -la ~/.kibana-moon-cache || echo "No ~/.kibana-moon-cache directory found"
-    ls -la ./.moon/cache/.kibana-moon-cache || echo "No .kibana-moon-cache directory found inside the moon cache"
     mkdir -p ./.moon/cache
     echo "Extracting moon-cache.tar.gz to ./.moon/cache"
     tar -xzf ~/moon-cache.tar.gz -C ./
-    ls -la ./.moon/cache
-    ls -la ~/.kibana-moon-cache || echo "No ~/.kibana-moon-cache directory found"
-    ls -la ./.moon/cache/.kibana-moon-cache || echo "No .kibana-moon-cache directory found inside the moon cache"
   elif [[ -d ~/.kibana-moon-cache ]]; then
     echo "Using ~/.moon/cache as a starting point"
     mkdir -p ./.moon/cache

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -27,7 +27,7 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
   if (buildkite-agent artifact download --step "pre_build" "moon-cache.tar.gz" ~/); then
     echo "Found moon-cache.tar.gz artifact, extracting to ./.moon/cache"
     mkdir -p ./.moon/cache
-    tar -xzf ~/moon-cache.tar.gz -C ./.moon/cache
+    tar -xzf ~/moon-cache.tar.gz -C ./
     ls -la ./.moon/cache
   elif [[ -d ~/.kibana-moon-cache ]]; then
     echo "Using ~/.moon/cache as a starting point"

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -37,6 +37,7 @@ if [[ ! -d .moon/cache ]]; then
   exit 0
 else
   tar -czf ~/moon-cache.tar.gz .moon/cache || echo "Failed to archive moon cache"
-  buildkite-agent artifact upload ~/moon-cache.tar.gz || echo "Failed to upload moon cache"
+  cd ~/
+  buildkite-agent artifact upload moon-cache.tar.gz || echo "Failed to upload moon cache"
   echo "Moon cache archived as moon-cache.tar.gz"
 fi

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -30,6 +30,7 @@ fi
 # Bootstrap and archive moon cache to avoid remote cache accesses in every step
 buildkite-agent step update outcome passed || echo "Can't set step to passed, maybe it's already passed?"
 buildkite-agent step update state finished || echo "Can't set step to finished, maybe it's already finished?"
+export MOON_CACHE=write
 .buildkite/scripts/bootstrap.sh
 echo "--- Archive moon cache"
 if [[ ! -d .moon/cache ]]; then

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -32,7 +32,7 @@ buildkite-agent step update outcome passed || echo "Can't set step to passed, ma
 buildkite-agent step update state finished || echo "Can't set step to finished, maybe it's already finished?"
 .buildkite/scripts/bootstrap.sh
 echo "--- Archive moon cache"
-if [[ ! -d ~/.moon/cache ]]; then
+if [[ ! -d .moon/cache ]]; then
   echo "No moon cache directory found, skipping archive"
   exit 0
 else

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -26,3 +26,15 @@ if [[ "${KIBANA_BUILD_ID:-}" && "${KIBANA_REUSABLE_BUILD_JOB_URL:-}" ]]; then
   See job here: $KIBANA_REUSABLE_BUILD_JOB_URL
 EOF
 fi
+
+# Bootstrap and archive moon cache to avoid remote cache accesses in every step
+.buildkite/scripts/bootstrap.sh
+echo "--- Archive moon cache"
+if [[ ! -d ~/.moon/cache ]]; then
+  echo "No moon cache directory found, skipping archive"
+  exit 0
+else
+  tar -czf ~/moon-cache.tar.gz .moon/cache || echo "Failed to archive moon cache"
+  buildkite-agent artifact upload ~/moon-cache.tar.gz || echo "Failed to upload moon cache"
+  echo "Moon cache archived as moon-cache.tar.gz"
+fi

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -26,19 +26,3 @@ if [[ "${KIBANA_BUILD_ID:-}" && "${KIBANA_REUSABLE_BUILD_JOB_URL:-}" ]]; then
   See job here: $KIBANA_REUSABLE_BUILD_JOB_URL
 EOF
 fi
-
-# Bootstrap and archive moon cache to avoid remote cache accesses in every step
-buildkite-agent step update outcome passed || echo "Can't set step to passed, maybe it's already passed?"
-buildkite-agent step update state finished || echo "Can't set step to finished, maybe it's already finished?"
-export MOON_CACHE=write
-.buildkite/scripts/bootstrap.sh
-echo "--- Archive moon cache"
-if [[ ! -d .moon/cache ]]; then
-  echo "No moon cache directory found, skipping archive"
-  exit 0
-else
-  tar -czf ~/moon-cache.tar.gz .moon/cache || echo "Failed to archive moon cache"
-  cd ~/
-  buildkite-agent artifact upload moon-cache.tar.gz || echo "Failed to upload moon cache"
-  echo "Moon cache archived as moon-cache.tar.gz"
-fi

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -28,6 +28,8 @@ EOF
 fi
 
 # Bootstrap and archive moon cache to avoid remote cache accesses in every step
+buildkite-agent step update outcome passed || echo "Can't set step to passed, maybe it's already passed?"
+buildkite-agent step update state finished || echo "Can't set step to finished, maybe it's already finished?"
 .buildkite/scripts/bootstrap.sh
 echo "--- Archive moon cache"
 if [[ ! -d ~/.moon/cache ]]; then

--- a/.buildkite/scripts/steps/store_cache.sh
+++ b/.buildkite/scripts/steps/store_cache.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/common/util.sh
+
+export MOON_CACHE=write
+.buildkite/scripts/bootstrap.sh
+echo "--- Archive moon cache"
+if [[ ! -d .moon/cache ]]; then
+  echo "No moon cache directory found, skipping archive"
+  exit 0
+else
+  tar -czf ~/moon-cache.tar.gz .moon/cache || echo "Failed to archive moon cache"
+  cd ~/
+  buildkite-agent artifact upload moon-cache.tar.gz || echo "Failed to upload moon cache"
+  echo "Moon cache archived as moon-cache.tar.gz"
+fi


### PR DESCRIPTION
## Summary
This PR adds a new step to PR builds - a step to run a local bootstrap, and archive the moon cache as a .zip, so subsequent job steps can get a good-for-local cache state, avoiding the remote cache access, and the network traffic.

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1","9.2"]} ONMERGE-->