### PR TITLE
[8.18] [Discover][ES|QL mode] Clear time field sorting after going from Classic to ES|QL mode (#235338)

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
@@ -23,7 +23,7 @@ import {
   savedSearchMockWithESQL,
 } from '../../../__mocks__/saved_search';
 import { discoverServiceMock } from '../../../__mocks__/services';
-import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
+import { dataViewMock, dataViewMockWithTimeField } from '@kbn/discover-utils/src/__mocks__';
 import type { DiscoverAppStateContainer } from './discover_app_state_container';
 import { waitFor } from '@testing-library/react';
 import { FetchStatus } from '../../types';
@@ -774,11 +774,18 @@ describe('Test discover state actions', () => {
     savedSearchWithQuery.searchSource.setField('filter', filters);
     const { state } = await getState('/', { savedSearch: savedSearchWithQuery });
     state.globalState?.set({ filters });
-    state.appState.set({ query });
-    await state.actions.transitionFromDataViewToESQL(dataViewMock);
+    state.appState.set({
+      query,
+      sort: [
+        ['@timestamp', 'asc'],
+        ['bytes', 'desc'],
+      ],
+    });
+    await state.actions.transitionFromDataViewToESQL(dataViewMockWithTimeField);
     expect(state.appState.getState().query).toStrictEqual({
       esql: 'FROM the-data-view-title | WHERE KQL("""foo: \'bar\'""") | LIMIT 10',
     });
+    expect(state.appState.getState().sort).toEqual([['bytes', 'desc']]);
     expect(state.globalState?.get?.()?.filters).toStrictEqual([]);
     expect(state.appState.getState().filters).toStrictEqual([]);
   });

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
@@ -392,11 +392,23 @@ export function getDiscoverStateContainer({
     });
   };
 
+  const clearTimeFieldFromSort = (
+    sort: DiscoverAppState['sort'],
+    timeFieldName: string | undefined
+  ) => {
+    if (!Array.isArray(sort) || !timeFieldName) return sort;
+
+    const filteredSort = sort.filter(([field]) => field !== timeFieldName);
+
+    return filteredSort;
+  };
+
   const transitionFromDataViewToESQL = (dataView: DataView) => {
     const appState = appStateContainer.get();
-    const { query } = appState;
+    const { query, sort } = appState;
     const filterQuery = query && isOfQueryType(query) ? query : undefined;
     const queryString = getInitialESQLQuery(dataView, filterQuery);
+    const clearedSort = clearTimeFieldFromSort(sort, dataView?.timeFieldName);
 
     appStateContainer.update({
       query: { esql: queryString },
@@ -405,6 +417,7 @@ export function getDiscoverStateContainer({
         type: DataSourceType.Esql,
       },
       columns: [],
+      sort: clearedSort,
     });
     // clears pinned filters
     const globalState = globalStateContainer.get();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Discover][ES|QL mode] Clear time field sorting after going from Classic to ES|QL mode (#235338)](https://github.com/elastic/kibana/pull/235338)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miłosz Radzyński","email":"mradzynski.elastic@gmail.com"},"sourceCommit":{"committedDate":"2025-09-19T11:38:35Z","message":"[Discover][ES|QL mode] Clear time field sorting after going from Classic to ES|QL mode (#235338)\n\n## Summary\n\nThis PR clears the time field sorting state after navigating from\nclassic discover mode to the ES|QL mode. It leaves all other sorting as\nthey were.\nResolves: #233019\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"86d87272c623e9ea8071b882493cc4644c5baca6","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","Team:DataDiscovery","backport:version","v9.2.0","v8.18.8","v8.19.5","v9.0.8","v9.1.5"],"title":"[Discover][ES|QL mode] Clear time field sorting after going from Classic to ES|QL mode","number":235338,"url":"https://github.com/elastic/kibana/pull/235338","mergeCommit":{"message":"[Discover][ES|QL mode] Clear time field sorting after going from Classic to ES|QL mode (#235338)\n\n## Summary\n\nThis PR clears the time field sorting state after navigating from\nclassic discover mode to the ES|QL mode. It leaves all other sorting as\nthey were.\nResolves: #233019\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"86d87272c623e9ea8071b882493cc4644c5baca6"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.19","9.0","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/235338","number":235338,"mergeCommit":{"message":"[Discover][ES|QL mode] Clear time field sorting after going from Classic to ES|QL mode (#235338)\n\n## Summary\n\nThis PR clears the time field sorting state after navigating from\nclassic discover mode to the ES|QL mode. It leaves all other sorting as\nthey were.\nResolves: #233019\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"86d87272c623e9ea8071b882493cc4644c5baca6"}},{"branch":"8.18","label":"v8.18.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->