### PR TITLE
[Automatic Migrations] Make dashboards card last in onboarding

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/body_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/body_config.ts
@@ -72,8 +72,8 @@ export const siemMigrationsBodyConfig: OnboardingGroupConfig[] = [
     }),
     cards: [
       startRuleMigrationCardConfig,
-      startDashboardMigrationCardConfig,
       siemMigrationIntegrationsCardConfig,
+      startDashboardMigrationCardConfig,
     ],
   },
 ];


### PR DESCRIPTION
## Summary

<img width="2558" height="1312" alt="image" src="https://github.com/user-attachments/assets/2983052d-90a9-47d4-8fb3-2d707969a3ee" />

Small 1 liner, just swaps the ordering of the cards on the onboarding page so that the dashboards migrations card is now last.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->