### PR TITLE
[Fleet] Fix export CSV permissions

### DIFF
--- a/src/platform/packages/private/kbn-generate-csv/src/generate_csv.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/generate_csv.ts
@@ -331,7 +331,10 @@ export class CsvGenerator {
       );
       logger.debug('Using search strategy: pit');
     }
+
+    logger.debug('CSV Generation: Initializing cursor...');
     await cursor.initialize();
+    logger.debug('CSV Generation: Cursor initialized successfully');
 
     // apply timezone from the job to all date field formatters
     try {
@@ -403,6 +406,10 @@ export class CsvGenerator {
         }
 
         if (!table) {
+          break;
+        }
+
+        if (table.rows.length === 0) {
           break;
         }
 

--- a/x-pack/platform/plugins/private/reporting/kibana.jsonc
+++ b/x-pack/platform/plugins/private/reporting/kibana.jsonc
@@ -1,9 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/reporting-plugin",
-  "owner": [
-    "@elastic/response-ops"
-  ],
+  "owner": ["@elastic/response-ops"],
   "group": "platform",
   "visibility": "private",
   "description": "Reporting Services enables applications to feature reports that the user can automate with Watcher and download later.",
@@ -11,10 +9,7 @@
     "id": "reporting",
     "browser": true,
     "server": true,
-    "configPath": [
-      "xpack",
-      "reporting"
-    ],
+    "configPath": ["xpack", "reporting"],
     "requiredPlugins": [
       "actions",
       "data",
@@ -32,16 +27,7 @@
       "features",
       "actions"
     ],
-    "optionalPlugins": [
-      "security",
-      "spaces",
-      "usageCollection",
-      "screenshotting"
-    ],
-    "requiredBundles": [
-      "embeddable",
-      "esUiShared",
-      "kibanaReact"
-    ]
+    "optionalPlugins": ["security", "spaces", "usageCollection", "screenshotting", "fleet"],
+    "requiredBundles": ["embeddable", "esUiShared", "kibanaReact"]
   }
 }

--- a/x-pack/platform/plugins/private/reporting/kibana.jsonc
+++ b/x-pack/platform/plugins/private/reporting/kibana.jsonc
@@ -27,7 +27,7 @@
       "features",
       "actions"
     ],
-    "optionalPlugins": ["security", "spaces", "usageCollection", "screenshotting", "fleet"],
+    "optionalPlugins": ["security", "spaces", "usageCollection", "screenshotting"],
     "requiredBundles": ["embeddable", "esUiShared", "kibanaReact"]
   }
 }

--- a/x-pack/platform/plugins/private/reporting/server/types.ts
+++ b/x-pack/platform/plugins/private/reporting/server/types.ts
@@ -30,6 +30,7 @@ import type {
 } from '@kbn/task-manager-plugin/server';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import type { PluginSetupContract as ActionsPluginSetupContract } from '@kbn/actions-plugin/server';
+import type { FleetStartContract } from '@kbn/fleet-plugin/server';
 
 import type { ExportTypesRegistry } from '@kbn/reporting-server/export_types_registry';
 import type { AuthenticatedUser } from '@kbn/core-security-common';
@@ -75,6 +76,7 @@ export interface ReportingStartDeps {
   taskManager: TaskManagerStartContract;
   security?: SecurityPluginStart;
   screenshotting?: ScreenshottingStart;
+  fleet?: FleetStartContract;
 }
 
 export type ReportingRequestHandlerContext = CustomRequestHandlerContext<{


### PR DESCRIPTION
## Summary

Will close #232193 

- Adjusts privileges used during CSV export from fleet to use `asInternalUser`
- Bypasses the existing search client and use a custom implementation that uses the `searchAsInternalUser` as to not affect the existing search functionality which may be consumed by other services. Also removes unneeded default params which aren't applicable to PIT searches, which is what we are doing here. 


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

TBD



