### PR TITLE
[9.2] [Metrics][Discover] Fix the value filter issue (#238048)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.test.ts
@@ -6,7 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import type { MetricField } from '@kbn/metrics-experience-plugin/common/types';
+import type { Dimension, MetricField } from '@kbn/metrics-experience-plugin/common/types';
 import { DIMENSIONS_COLUMN } from './constants';
 import { createESQLQuery } from './create_esql_query';
 import { ES_FIELD_TYPES } from '@kbn/field-types';
@@ -160,6 +160,65 @@ TS metrics-*
       `
 TS custom-metrics-*
   | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+`.trim()
+    );
+  });
+
+  it('should handle undefined dimensions without throwing error', () => {
+    const query = createESQLQuery({
+      metric: mockMetric,
+      dimensions: undefined,
+    });
+
+    expect(query).toBe(
+      `
+TS metrics-*
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+`.trim()
+    );
+  });
+  it('should handle undefined both dimensions and metrics dimensions without throwing error', () => {
+    const query = createESQLQuery({
+      metric: { ...mockMetric, dimensions: undefined as unknown as Dimension[] },
+      dimensions: undefined,
+    });
+
+    expect(query).toBe(
+      `
+TS metrics-*
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+`.trim()
+    );
+  });
+
+  it('should handle undefined dimensions with filters', () => {
+    const query = createESQLQuery({
+      metric: mockMetric,
+      dimensions: undefined,
+      filters: [{ field: 'host.name', value: 'host-1' }],
+    });
+
+    expect(query).toBe(
+      `
+TS metrics-*
+  | WHERE host.name IN ("host-1")
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+`.trim()
+    );
+  });
+  it('should handle undefined metrics dimensions with dimensions and filters', () => {
+    const query = createESQLQuery({
+      metric: { ...mockMetric, dimensions: undefined as unknown as Dimension[] },
+      dimensions: ['host.name'],
+      filters: [{ field: 'host.name', value: 'host-1' }],
+    });
+
+    expect(query).toBe(
+      `
+TS metrics-*
+  | WHERE host.name IN ("host-1")
+  | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend), host.name
+  | RENAME host.name AS ${DIMENSIONS_COLUMN}
 `.trim()
     );
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Metrics][Discover] Fix the value filter issue (#238048)](https://github.com/elastic/kibana/pull/238048)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-10-09T07:32:32Z","message":"[Metrics][Discover] Fix the value filter issue (#238048)\n\nCloses #238000 \n\n## Summary\n\nThis PR fixes the issue with the `WHERE` clause mentioned. When looking\nat the browser console, I saw `Uncaught TypeError: Cannot read\nproperties of undefined (reading 'filter')` so we have `undefined`\ninstead of an array\n\n<img width=\"3838\" height=\"1334\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b9338473-c1bf-46ea-8df0-b6ee0a063eb2\"\n/>\n\nSo the issue occurs when:\n- The dimensions are selected (`dimensions.length > 0`)\n- But the value filters for ALL dimensions, so the `.filter((dim) =>\n!valuesByField.has(dim))` removes all dimensions\n- This results in an empty array and `.join(' AND ')` returns an empty\nstring\n- This creates `where('')` which generates an invalid ES|QL WHERE clause\n\nTo fix that, I extracted the filter and checked the array lenght first,\nand now it works as expected\n\n## Testing: \n\n\nhttps://github.com/user-attachments/assets/82fa4435-c0f0-4b42-bb9e-de5d2107070d","sha":"30c7c22cef8b0e84f55e9e507daed1ec76a36e11","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.2.0","v9.3.0"],"title":"[Metrics][Discover] Fix the value filter issue","number":238048,"url":"https://github.com/elastic/kibana/pull/238048","mergeCommit":{"message":"[Metrics][Discover] Fix the value filter issue (#238048)\n\nCloses #238000 \n\n## Summary\n\nThis PR fixes the issue with the `WHERE` clause mentioned. When looking\nat the browser console, I saw `Uncaught TypeError: Cannot read\nproperties of undefined (reading 'filter')` so we have `undefined`\ninstead of an array\n\n<img width=\"3838\" height=\"1334\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b9338473-c1bf-46ea-8df0-b6ee0a063eb2\"\n/>\n\nSo the issue occurs when:\n- The dimensions are selected (`dimensions.length > 0`)\n- But the value filters for ALL dimensions, so the `.filter((dim) =>\n!valuesByField.has(dim))` removes all dimensions\n- This results in an empty array and `.join(' AND ')` returns an empty\nstring\n- This creates `where('')` which generates an invalid ES|QL WHERE clause\n\nTo fix that, I extracted the filter and checked the array lenght first,\nand now it works as expected\n\n## Testing: \n\n\nhttps://github.com/user-attachments/assets/82fa4435-c0f0-4b42-bb9e-de5d2107070d","sha":"30c7c22cef8b0e84f55e9e507daed1ec76a36e11"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238048","number":238048,"mergeCommit":{"message":"[Metrics][Discover] Fix the value filter issue (#238048)\n\nCloses #238000 \n\n## Summary\n\nThis PR fixes the issue with the `WHERE` clause mentioned. When looking\nat the browser console, I saw `Uncaught TypeError: Cannot read\nproperties of undefined (reading 'filter')` so we have `undefined`\ninstead of an array\n\n<img width=\"3838\" height=\"1334\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b9338473-c1bf-46ea-8df0-b6ee0a063eb2\"\n/>\n\nSo the issue occurs when:\n- The dimensions are selected (`dimensions.length > 0`)\n- But the value filters for ALL dimensions, so the `.filter((dim) =>\n!valuesByField.has(dim))` removes all dimensions\n- This results in an empty array and `.join(' AND ')` returns an empty\nstring\n- This creates `where('')` which generates an invalid ES|QL WHERE clause\n\nTo fix that, I extracted the filter and checked the array lenght first,\nand now it works as expected\n\n## Testing: \n\n\nhttps://github.com/user-attachments/assets/82fa4435-c0f0-4b42-bb9e-de5d2107070d","sha":"30c7c22cef8b0e84f55e9e507daed1ec76a36e11"}}]}] BACKPORT-->