### PR TITLE
[8.19] [Synthetics] Disable max attempts for private locations sync task  (#237784)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
@@ -96,8 +96,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
           title: 'Synthetics Sync Global Params Task',
           description:
             'This task is executed so that we can sync private location monitors for example when global params are updated',
-          timeout: '3m',
-          maxAttempts: 3,
+          timeout: '5m',
+          maxAttempts: 1,
           createTaskRunner: expect.any(Function),
         }),
       });
@@ -107,18 +107,20 @@ describe('SyncPrivateLocationMonitorsTask', () => {
   describe('start', () => {
     it('should schedule the task correctly', async () => {
       await task.start();
-      expect(mockLogger.debug).toHaveBeenCalledWith('Scheduling private location task');
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        '[SyncPrivateLocationMonitorsTask] Scheduling private location task'
+      );
       expect(mockTaskManagerStart.ensureScheduled).toHaveBeenCalledWith({
         id: 'Synthetics:Sync-Private-Location-Monitors-single-instance',
         state: {},
         schedule: {
-          interval: '5m',
+          interval: '10m',
         },
         taskType: 'Synthetics:Sync-Private-Location-Monitors',
         params: {},
       });
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        'Sync private location monitors task scheduled successfully'
+        '[SyncPrivateLocationMonitorsTask] Sync private location monitors task scheduled successfully'
       );
     });
   });
@@ -174,16 +176,16 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const result = await task.runTask({ taskInstance });
       expect(mockLogger.debug).toHaveBeenNthCalledWith(
         2,
-        '[SyncPrivateLocationMonitorsTask] Starting cleanup of duplicated package policies '
+        '[SyncPrivateLocationMonitorsTask] Starting cleanup of duplicated package policies'
       );
 
       expect(mockLogger.debug).toHaveBeenNthCalledWith(
         3,
-        '[SyncPrivateLocationMonitorsTask] Syncing private location monitors because data has changed '
+        '[SyncPrivateLocationMonitorsTask] Syncing private location monitors because data has changed'
       );
       expect(mockLogger.debug).toHaveBeenNthCalledWith(
         4,
-        '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded '
+        '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded'
       );
       expect(task.syncGlobalParams).toHaveBeenCalled();
       expect(result.error).toBeUndefined();
@@ -210,7 +212,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(getPrivateLocationsModule.getPrivateLocations).toHaveBeenCalled();
       expect(task.syncGlobalParams).not.toHaveBeenCalled();
       expect(mockLogger.debug).toHaveBeenLastCalledWith(
-        '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded '
+        '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded'
       );
     });
 
@@ -533,7 +535,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, state as any);
       expect(result.performSync).toBe(false);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as it has already been done once '
+        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as it has already been done once'
       );
     });
 
@@ -544,7 +546,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(state.hasAlreadyDoneCleanup).toBe(true);
       expect(state.maxCleanUpRetries).toBe(3);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as max retries have been reached '
+        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as max retries have been reached'
       );
     });
 
@@ -560,7 +562,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(state.hasAlreadyDoneCleanup).toBe(true);
       expect(state.maxCleanUpRetries).toBe(3);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as max retries have been reached '
+        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as max retries have been reached'
       );
     });
   });

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
@@ -12,7 +12,11 @@ import {
 } from '@kbn/core-saved-objects-api-server';
 import { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
 import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
-import { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
+import type {
+  ConcreteTaskInstance,
+  IntervalSchedule,
+  RruleSchedule,
+} from '@kbn/task-manager-plugin/server';
 import moment from 'moment';
 import { MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/common';
 import pRetry from 'p-retry';
@@ -38,7 +42,7 @@ import { SyntheticsPrivateLocation } from '../synthetics_service/private_locatio
 
 const TASK_TYPE = 'Synthetics:Sync-Private-Location-Monitors';
 export const PRIVATE_LOCATIONS_SYNC_TASK_ID = `${TASK_TYPE}-single-instance`;
-const TASK_SCHEDULE = '5m';
+const TASK_SCHEDULE = '10m';
 
 interface TaskState extends Record<string, unknown> {
   lastStartedAt: string;
@@ -63,8 +67,8 @@ export class SyncPrivateLocationMonitorsTask {
         title: 'Synthetics Sync Global Params Task',
         description:
           'This task is executed so that we can sync private location monitors for example when global params are updated',
-        timeout: '3m',
-        maxAttempts: 3,
+        timeout: '5m',
+        maxAttempts: 1,
         createTaskRunner: ({ taskInstance }) => {
           return {
             run: async () => {
@@ -80,7 +84,7 @@ export class SyncPrivateLocationMonitorsTask {
     taskInstance,
   }: {
     taskInstance: CustomTaskInstance;
-  }): Promise<{ state: TaskState; error?: Error }> {
+  }): Promise<{ state: TaskState; error?: Error; schedule?: IntervalSchedule | RruleSchedule }> {
     const {
       coreStart: { savedObjects },
       encryptedSavedObjects,
@@ -140,19 +144,24 @@ export class SyncPrivateLocationMonitorsTask {
       return {
         error,
         state: taskState,
+        schedule: {
+          interval: TASK_SCHEDULE,
+        },
       };
     }
     return {
       state: taskState,
+      schedule: {
+        interval: TASK_SCHEDULE,
+      },
     };
   }
 
   start = async () => {
     const {
-      logger,
       pluginsStart: { taskManager },
     } = this.serverSetup;
-    logger.debug(`Scheduling private location task`);
+    this.debugLog(`Scheduling private location task`);
     await taskManager.ensureScheduled({
       id: PRIVATE_LOCATIONS_SYNC_TASK_ID,
       state: {},
@@ -162,7 +171,7 @@ export class SyncPrivateLocationMonitorsTask {
       taskType: TASK_TYPE,
       params: {},
     });
-    logger.debug(`Sync private location monitors task scheduled successfully`);
+    this.debugLog(`Sync private location monitors task scheduled successfully`);
   };
 
   hasAnyDataChanged = async ({
@@ -403,7 +412,7 @@ export class SyncPrivateLocationMonitorsTask {
   }
 
   debugLog = (message: string) => {
-    this.serverSetup.logger.debug(`[SyncPrivateLocationMonitorsTask] ${message} `);
+    this.serverSetup.logger.debug(`[SyncPrivateLocationMonitorsTask] ${message}`);
   };
 
   async cleanUpDuplicatedPackagePolicies(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Disable max attempts for private locations sync task  (#237784)](https://github.com/elastic/kibana/pull/237784)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2025-10-08T06:23:54Z","message":"[Synthetics] Disable max attempts for private locations sync task  (#237784)\n\n## Summary\n\nDisable max attempts for private locations sync task. Since task is a\nscheduled task, if it fails, we don't need to retry, it will just retry\nnext time when it runs, in current state, if it retries, the multiple\ntask keeps doing the same work.\n\n\nAlso increased the timeout to 5 minutes and schedule to be less\naggressive to 10 minutes instead of 5 minutes.","sha":"b592fcc021aeebe94156233443ff90e097b5c0dc","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","Team:obs-ux-management","backport:version","author:obs-ux-management","v9.2.0","v9.3.0","v9.1.6","v8.19.6"],"title":"[Synthetics] Disable max attempts for private locations sync task ","number":237784,"url":"https://github.com/elastic/kibana/pull/237784","mergeCommit":{"message":"[Synthetics] Disable max attempts for private locations sync task  (#237784)\n\n## Summary\n\nDisable max attempts for private locations sync task. Since task is a\nscheduled task, if it fails, we don't need to retry, it will just retry\nnext time when it runs, in current state, if it retries, the multiple\ntask keeps doing the same work.\n\n\nAlso increased the timeout to 5 minutes and schedule to be less\naggressive to 10 minutes instead of 5 minutes.","sha":"b592fcc021aeebe94156233443ff90e097b5c0dc"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.1","8.19"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237784","number":237784,"mergeCommit":{"message":"[Synthetics] Disable max attempts for private locations sync task  (#237784)\n\n## Summary\n\nDisable max attempts for private locations sync task. Since task is a\nscheduled task, if it fails, we don't need to retry, it will just retry\nnext time when it runs, in current state, if it retries, the multiple\ntask keeps doing the same work.\n\n\nAlso increased the timeout to 5 minutes and schedule to be less\naggressive to 10 minutes instead of 5 minutes.","sha":"b592fcc021aeebe94156233443ff90e097b5c0dc"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->