### PR TITLE
[Security Solution] [Ai Assistant] Ensure the securitySolution:defaultAIConnector setting is not conditionally registered

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -625,15 +625,14 @@ export const initUiSettings = (
 export const getDefaultAIConnectorSetting = (
   connectors: Connector[],
   readonlyMode?: ReadonlyModeType
-): SettingsConfig | null =>
-  connectors.length > 0
-    ? {
+): SettingsConfig =>
+  ({
         [DEFAULT_AI_CONNECTOR]: {
           name: i18n.translate('xpack.securitySolution.uiSettings.defaultAIConnectorLabel', {
             defaultMessage: 'Default AI Connector',
           }),
           // TODO, make Elastic LLM the default value once fully available in serverless
-          value: connectors[0].id,
+          value: connectors.at(0)?.id,
           description: i18n.translate(
             'xpack.securitySolution.uiSettings.defaultAIConnectorDescription',
             {
@@ -651,8 +650,7 @@ export const getDefaultAIConnectorSetting = (
           readonlyMode,
           readonly: readonlyMode !== undefined,
         },
-      }
-    : null;
+      });
 
 export const getDefaultValueReportSettings = (): SettingsConfig => ({
   [DEFAULT_VALUE_REPORT_MINUTES]: {

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -625,32 +625,27 @@ export const initUiSettings = (
 export const getDefaultAIConnectorSetting = (
   connectors: Connector[],
   readonlyMode?: ReadonlyModeType
-): SettingsConfig =>
-  ({
-        [DEFAULT_AI_CONNECTOR]: {
-          name: i18n.translate('xpack.securitySolution.uiSettings.defaultAIConnectorLabel', {
-            defaultMessage: 'Default AI Connector',
-          }),
-          // TODO, make Elastic LLM the default value once fully available in serverless
-          value: connectors.at(0)?.id,
-          description: i18n.translate(
-            'xpack.securitySolution.uiSettings.defaultAIConnectorDescription',
-            {
-              defaultMessage:
-                'Default AI connector for serverless AI features (Elastic AI SOC Engine)',
-            }
-          ),
-          type: 'select',
-          options: connectors.map(({ id }) => id),
-          optionLabels: Object.fromEntries(connectors.map(({ id, name }) => [id, name])),
-          category: [APP_ID],
-          requiresPageReload: true,
-          schema: schema.string(),
-          solutionViews: ['classic', 'security'],
-          readonlyMode,
-          readonly: readonlyMode !== undefined,
-        },
-      });
+): SettingsConfig => ({
+  [DEFAULT_AI_CONNECTOR]: {
+    name: i18n.translate('xpack.securitySolution.uiSettings.defaultAIConnectorLabel', {
+      defaultMessage: 'Default AI Connector',
+    }),
+    // TODO, make Elastic LLM the default value once fully available in serverless
+    value: connectors.at(0)?.id,
+    description: i18n.translate('xpack.securitySolution.uiSettings.defaultAIConnectorDescription', {
+      defaultMessage: 'Default AI connector for serverless AI features (Elastic AI SOC Engine)',
+    }),
+    type: 'select',
+    options: connectors.map(({ id }) => id),
+    optionLabels: Object.fromEntries(connectors.map(({ id, name }) => [id, name])),
+    category: [APP_ID],
+    requiresPageReload: true,
+    schema: schema.string(),
+    solutionViews: ['classic', 'security'],
+    readonlyMode,
+    readonly: readonlyMode !== undefined,
+  },
+});
 
 export const getDefaultValueReportSettings = (): SettingsConfig => ({
   [DEFAULT_VALUE_REPORT_MINUTES]: {

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
@@ -116,8 +116,9 @@ export class SecuritySolutionServerlessPlugin
             aiConnectors,
             isNewDefaultConnectorEnabled ? 'ui' : undefined
           );
+
           coreSetup.uiSettings.register({
-            ...(defaultAIConnectorSetting !== null ? defaultAIConnectorSetting : {}),
+            ...defaultAIConnectorSetting,
             ...getDefaultValueReportSettings(),
           });
         } catch (error) {


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

This PR fixes the following bug in EASE:

https://github.com/user-attachments/assets/e672b312-e59a-4622-93b4-6d531387d763

### How to reproduce the error:
- Check out a branch before this PR
- Ensure you have no preconfigured or custom connectors
- Start/Restart Kibana serverless with EASE
- Generate an attack discovery
- Open an alert from one of the discoveries, you should see a page crash as in the video.

The issue happens when Kibana is started with no connectors. When there are no connectors, [this](https://github.com/elastic/kibana/pull/238187/files#diff-ceb93a253cac423b03b7a0969738749381cc11eaadb32d5592a97cd5d16ef854L629) setting does not get registered, resulting in an error being thrown when the setting is read.

This bug does not happen in production because in prod there is the elastic managed LLM, and therefore there is always at least 1 connector, resulting in the setting always being registered.

### The fix
To prevent the page from crashing, this PR makes a change that ensures the setting is always registered, even when there are no connectors at Kibana start time. 

Even so, in local development, there is still a bug if Kibana starts with no connectors. If you start Kibana with no connectors, then add a custom connector, generate an attack discovery and open an alert from an attack discovery, you will see this alert:

<img width="2164" height="1488" alt="image" src="https://github.com/user-attachments/assets/f434ea45-679d-4f41-9de5-1c09439c1c3d" />

Clicking on the link in the alert will take you to advanced settings but you will see an error here:

<img width="2209" height="1695" alt="image" src="https://github.com/user-attachments/assets/71120a8d-f5a4-457c-8eef-fbf7ee5ec9a1" />

This alert is shown because, although the `securitySolution:defaultAIConnector` setting is registered, when Kibana was started, there were no connectors available, resulting in no options being available for the setting. When there are no available options the setting is not rendered. To fix this locally, all you need to do is restart the Kibana server again (through a complete restart or a hot reload) and then you can select a default LLM. 

The permanent fix for this comes in this [PR](https://github.com/elastic/kibana/pull/237444). Right now, you can enable the following feature flag: `feature_flags.overrides.aiAssistant.defaultLlmSettingEnabled: true` and everything should work as expected. The feature flag will permanently be switched on in the coming weeks.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [X] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [X] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [X] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [X] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [X] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [X] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->