### PR TITLE
Workflow detail page cleanup

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.test.tsx
@@ -35,7 +35,6 @@ describe('WorkflowDetailHeader', () => {
     handleSave: () => {},
     isEnabled: true,
     handleToggleWorkflow: () => {},
-    canTestWorkflow: true,
     isValid: true,
     hasUnsavedChanges: false,
     highlightDiff: false,

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
@@ -133,7 +133,7 @@ export const WorkflowDetailHeader = ({
                   css={styles.skeletonTitle}
                 >
                   <EuiTitle size="m" css={styles.title}>
-                    <h1>{name}</h1>
+                    <h2>{name}</h2>
                   </EuiTitle>
                 </EuiSkeletonTitle>
               </EuiFlexItem>

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
@@ -44,7 +44,6 @@ export interface WorkflowDetailHeaderProps {
   handleSave: () => void;
   isEnabled: boolean;
   handleToggleWorkflow: () => void;
-  canTestWorkflow: boolean;
   isValid: boolean;
   hasUnsavedChanges: boolean;
   // TODO: manage it in a workflow state context
@@ -63,7 +62,6 @@ export const WorkflowDetailHeader = ({
   canSaveWorkflow,
   isEnabled,
   handleToggleWorkflow,
-  canTestWorkflow,
   handleTabChange,
   isValid,
   hasUnsavedChanges,
@@ -78,13 +76,17 @@ export const WorkflowDetailHeader = ({
     () => [
       {
         id: 'workflow',
-        label: 'Workflow',
+        label: i18n.translate('workflows.workflowDetailHeader.workflowTab', {
+          defaultMessage: 'Workflow',
+        }),
         iconType: 'grid',
         type: 'button',
       },
       {
         id: 'executions',
-        label: 'Executions',
+        label: i18n.translate('workflows.workflowDetailHeader.executionsTab', {
+          defaultMessage: 'Executions',
+        }),
         iconType: 'play',
       },
     ],

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
@@ -10,6 +10,7 @@
 import type { EuiButtonGroupOptionProps, UseEuiTheme } from '@elastic/eui';
 import {
   EuiButton,
+  EuiButtonEmpty,
   EuiButtonGroup,
   EuiButtonIcon,
   EuiConfirmModal,
@@ -29,6 +30,8 @@ import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useMemo, useState } from 'react';
+import { PLUGIN_ID } from '../../../../common';
+import { useKibana } from '../../../hooks/use_kibana';
 import { WorkflowUnsavedChangesBadge } from '../../../widgets/workflow_yaml_editor/ui/workflow_unsaved_changes_badge';
 import type { WorkflowUrlStateTabType } from '../../../hooks/use_workflow_url_state';
 import { getRunWorkflowTooltipContent } from '../../../shared/ui';
@@ -69,6 +72,7 @@ export const WorkflowDetailHeader = ({
   setHighlightDiff,
   lastUpdatedAt,
 }: WorkflowDetailHeaderProps) => {
+  const { application } = useKibana().services;
   const styles = useMemoCss(componentStyles);
   const [showRunConfirmation, setShowRunConfirmation] = useState(false);
 
@@ -114,11 +118,26 @@ export const WorkflowDetailHeader = ({
     setShowRunConfirmation(false);
   };
 
+  const backLinkLabel = i18n.translate('workflows.workflowDetailHeader.backLink', {
+    defaultMessage: 'Back to Workflows',
+  });
+
   return (
     <>
       <EuiPageTemplate offset={0} minHeight={0} grow={false} css={styles.pageTemplate}>
         <EuiPageTemplate.Header css={styles.header} restrictWidth={false} bottomBorder={false}>
           <EuiPageHeaderSection css={styles.headerSection}>
+            <EuiButtonEmpty
+              iconType="sortLeft"
+              size="s"
+              flush="left"
+              onClick={() => {
+                application.navigateToApp(PLUGIN_ID);
+              }}
+              aria-label={backLinkLabel}
+            >
+              {backLinkLabel}
+            </EuiButtonEmpty>
             <EuiFlexGroup
               alignItems="center"
               responsive={false}

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
@@ -54,7 +54,6 @@ export function WorkflowDetailPage({ id }: { id: string }) {
 
   const canSaveWorkflow = Boolean(application?.capabilities.workflowsManagement.updateWorkflow);
   const canRunWorkflow = Boolean(application?.capabilities.workflowsManagement.executeWorkflow);
-  const canTestWorkflow = Boolean(application?.capabilities.workflowsManagement.executeWorkflow);
 
   const handleSave = () => {
     if (!id) {
@@ -203,7 +202,6 @@ export function WorkflowDetailPage({ id }: { id: string }) {
             handleRunClick={handleRunClick}
             handleSave={handleSave}
             handleToggleWorkflow={handleToggleWorkflow}
-            canTestWorkflow={canTestWorkflow}
             handleTabChange={setActiveTab}
             hasUnsavedChanges={hasChanges}
             highlightDiff={highlightDiff}


### PR DESCRIPTION
## Summary

1. Add back to list link
2. Reduces header text size from h1 to h2

<img width="399" height="97" alt="image" src="https://github.com/user-attachments/assets/cc62d95f-cdfa-40de-921a-cd3bd72a6bab" />

3. Make tab-selector i18n-compatible

<img width="279" height="66" alt="image" src="https://github.com/user-attachments/assets/6a90932c-4d49-4bce-b2d8-e0508168239a" />

