### PR TITLE
[Streams] Make feature a required property of StreamFeatureDetailsFlyout

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1541,7 +1541,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 ## Streams parts owned by Logs UX
 /x-pack/platform/plugins/shared/streams/server/routes/streams/processing @elastic/obs-ux-logs-team
 /x-pack/platform/plugins/shared/streams/server/routes/streams/schema @elastic/obs-ux-logs-team
-/x-pack/platform/plugins/shared/streams_app/public/components/data_management @elastic/obs-ux-logs-team
+/x-pack/platform/plugins/shared/streams_app/public/components/data_management @elastic/obs-ux-logs-team @elastic/streams-program-team
 
 # Infra Monitoring tests
 /x-pack/solutions/observability/test/functional/apps/infra @elastic/obs-ux-infra_services-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1541,7 +1541,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 ## Streams parts owned by Logs UX
 /x-pack/platform/plugins/shared/streams/server/routes/streams/processing @elastic/obs-ux-logs-team
 /x-pack/platform/plugins/shared/streams/server/routes/streams/schema @elastic/obs-ux-logs-team
-/x-pack/platform/plugins/shared/streams_app/public/components/data_management @elastic/obs-ux-logs-team @elastic/streams-program-team
+/x-pack/platform/plugins/shared/streams_app/public/components/data_management @elastic/obs-ux-logs-team
 
 # Infra Monitoring tests
 /x-pack/solutions/observability/test/functional/apps/infra @elastic/obs-ux-infra_services-team

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/hooks/use_stream_features.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/hooks/use_stream_features.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Streams } from '@kbn/streams-schema';
+import { useMemo } from 'react';
 import { useKibana } from '../../../../../hooks/use_kibana';
 import { useStreamsAppFetch } from '../../../../../hooks/use_streams_app_fetch';
 
@@ -25,9 +26,18 @@ export const useStreamFeatures = (definition: Streams.all.Definition) => {
     },
     [definition.name, streamsRepositoryClient]
   );
+
+  const features = useMemo(() => value?.features ?? [], [value?.features]);
+
+  const systemsByName = useMemo(
+    () => Object.fromEntries(features.map((f) => [f.name, f])),
+    [features]
+  );
+
   return {
     refresh,
-    features: value?.features ?? [],
+    features,
+    featuresByName,
     loading,
     error,
   };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/hooks/use_stream_features.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/hooks/use_stream_features.ts
@@ -29,7 +29,7 @@ export const useStreamFeatures = (definition: Streams.all.Definition) => {
 
   const features = useMemo(() => value?.features ?? [], [value?.features]);
 
-  const systemsByName = useMemo(
+  const featuresByName = useMemo(
     () => Object.fromEntries(features.map((f) => [f.name, f])),
     [features]
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_existing_features_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_existing_features_table.tsx
@@ -39,7 +39,7 @@ export function StreamExistingFeaturesTable({
 }) {
   const router = useStreamsAppRouter();
 
-  const [isDetailFlyoutOpen, setIsDetailFlyoutOpen] = useState<Feature>();
+  const [selectedFeature, setSelectedFeature] = useState<Feature>();
   const [selectedFeatures, setSelectedFeatures] = useState<Feature[]>([]);
   const { removeFeaturesFromStream } = useStreamFeaturesApi(definition);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -94,7 +94,7 @@ export function StreamExistingFeaturesTable({
           type: 'icon',
           icon: 'pencil',
           onClick: (feature) => {
-            setIsDetailFlyoutOpen(feature);
+            setSelectedFeature(feature);
           },
         },
         {
@@ -119,7 +119,7 @@ export function StreamExistingFeaturesTable({
   ];
 
   const toggleDetails = (feature: Feature) => {
-    setIsDetailFlyoutOpen(feature);
+    setSelectedFeature(feature);
   };
 
   const columnsWithExpandingRowToggle: Array<EuiBasicTableColumn<Feature>> = [
@@ -136,8 +136,8 @@ export function StreamExistingFeaturesTable({
         return (
           <EuiButtonIcon
             onClick={() => toggleDetails(feature)}
-            aria-label={isDetailFlyoutOpen ? COLLAPSE_DETAILS_LABEL : EXPAND_DETAILS_LABEL}
-            iconType={isDetailFlyoutOpen ? 'minimize' : 'expand'}
+            aria-label={selectedFeature ? COLLAPSE_DETAILS_LABEL : EXPAND_DETAILS_LABEL}
+            iconType={selectedFeature ? 'minimize' : 'expand'}
           />
         );
       },
@@ -239,12 +239,12 @@ export function StreamExistingFeaturesTable({
           },
         }}
       />
-      {isDetailFlyoutOpen && (
+      {selectedFeature && (
         <StreamFeatureDetailsFlyout
           definition={definition}
-          feature={isDetailFlyoutOpen}
+          feature={selectedFeature}
           closeFlyout={() => {
-            setIsDetailFlyoutOpen(undefined);
+            setSelectedFeature(undefined);
             refreshFeatures();
           }}
         />

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_feature_details_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_feature_details_flyout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -15,7 +15,6 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
-  EuiLoadingSpinner,
   EuiMarkdownEditor,
   EuiSpacer,
   EuiTitle,
@@ -23,42 +22,33 @@ import {
 import type { Streams, Feature } from '@kbn/streams-schema';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import { useStreamFeatures } from '../../../stream_detail_significant_events_view/add_significant_event_flyout/common/use_stream_features';
 import { ConditionPanel } from '../../shared';
 import { FeatureEventsData } from './feature_events_data';
 import { useStreamFeaturesApi } from '../../../../hooks/use_stream_features_api';
 
 export const StreamFeatureDetailsFlyout = ({
-  feature: initialFeature,
+  feature,
   definition,
   closeFlyout,
-  featureName,
 }: {
-  featureName?: string;
-  feature?: Feature;
-  closeFlyout: () => void;
+  feature: Feature;
   definition: Streams.all.Definition;
+  closeFlyout: () => void;
 }) => {
-  const [feature, setFeature] = React.useState<Feature | undefined>(initialFeature);
-  const [value, setValue] = React.useState(initialFeature?.description ?? '');
+  const [featureDescription, setFeatureDescription] = React.useState(feature.description);
   const { upsertQuery } = useStreamFeaturesApi(definition);
   const [isUpdating, setIsUpdating] = React.useState(false);
 
-  const { value: listOfFeatures } = useStreamFeatures(definition);
-
-  useEffect(() => {
-    if (featureName && !feature) {
-      const foundFeature = listOfFeatures?.features.find((s) => s.name === featureName);
-      setFeature(foundFeature);
-      setValue(foundFeature?.description ?? '');
-    } else {
-      setFeature(initialFeature);
-    }
-  }, [definition.name, listOfFeatures, initialFeature, featureName, feature]);
-
-  if (!feature && !featureName) {
-    return null;
-  }
+  const updateFeature = () => {
+    setIsUpdating(true);
+    upsertQuery(feature.name, {
+      description: featureDescription,
+      filter: feature.filter,
+    }).finally(() => {
+      setIsUpdating(false);
+      closeFlyout();
+    });
+  };
 
   return (
     <EuiFlyout
@@ -72,95 +62,74 @@ export const StreamFeatureDetailsFlyout = ({
     >
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">
-          <h2>{feature?.name ?? 'Feature details'}</h2>
+          <h2>{feature.name}</h2>
         </EuiTitle>
         <EuiSpacer size="s" />
       </EuiFlyoutHeader>
-      {feature ? (
-        <>
-          <EuiFlyoutBody>
-            <div>
-              <EuiTitle size="xs">
-                <h3>
-                  {i18n.translate(
-                    'xpack.streams.streamDetailView.featureDetailExpanded.description',
-                    {
-                      defaultMessage: 'Description',
-                    }
-                  )}
-                </h3>
-              </EuiTitle>
-              <EuiMarkdownEditor
-                aria-label={i18n.translate(
-                  'xpack.streams.streamDetailView.featureDetailExpanded.markdownEditorAriaLabel',
-                  {
-                    defaultMessage: 'Feature description markdown editor',
-                  }
-                )}
-                value={value}
-                onChange={setValue}
-                height={400}
-                readOnly={false}
-                initialViewMode="viewing"
+
+      <EuiFlyoutBody>
+        <div>
+          <EuiTitle size="xs">
+            <h3>
+              {i18n.translate('xpack.streams.streamDetailView.featureDetailExpanded.description', {
+                defaultMessage: 'Description',
+              })}
+            </h3>
+          </EuiTitle>
+          <EuiMarkdownEditor
+            aria-label={i18n.translate(
+              'xpack.streams.streamDetailView.featureDetailExpanded.markdownEditorAriaLabel',
+              {
+                defaultMessage: 'Feature description markdown editor',
+              }
+            )}
+            value={featureDescription}
+            onChange={setFeatureDescription}
+            height={400}
+            readOnly={false}
+            initialViewMode="viewing"
+          />
+          <EuiSpacer size="m" />
+          <EuiTitle size="xs">
+            <h3>
+              {i18n.translate('xpack.streams.streamDetailView.featureDetailExpanded.filter', {
+                defaultMessage: 'Filter',
+              })}
+            </h3>
+          </EuiTitle>
+          <ConditionPanel condition={feature.filter} />
+          <EuiSpacer size="m" />
+          <FeatureEventsData feature={feature} />
+        </div>
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              isLoading={isUpdating}
+              iconType="cross"
+              onClick={closeFlyout}
+              flush="left"
+              aria-label={i18n.translate('xpack.streams.featureDetails.closeButtonAriaLabel', {
+                defaultMessage: 'Close flyout',
+              })}
+            >
+              <FormattedMessage
+                id="xpack.streams.featureDetails.cancelButton"
+                defaultMessage="Cancel"
               />
-              <EuiSpacer size="m" />
-              <EuiTitle size="xs">
-                <h3>
-                  {i18n.translate('xpack.streams.streamDetailView.featureDetailExpanded.filter', {
-                    defaultMessage: 'Filter',
-                  })}
-                </h3>
-              </EuiTitle>
-              <ConditionPanel condition={feature.filter} />
-              <EuiSpacer size="m" />
-              <FeatureEventsData feature={feature} />
-            </div>
-          </EuiFlyoutBody>
-          <EuiFlyoutFooter>
-            <EuiFlexGroup justifyContent="spaceBetween">
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  isLoading={isUpdating}
-                  iconType="cross"
-                  onClick={closeFlyout}
-                  flush="left"
-                  aria-label={i18n.translate('xpack.streams.featureDetails.closeButtonAriaLabel', {
-                    defaultMessage: 'Close flyout',
-                  })}
-                >
-                  <FormattedMessage
-                    id="xpack.streams.featureDetails.cancelButton"
-                    defaultMessage="Cancel"
-                  />
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButton
-                  isLoading={isUpdating}
-                  onClick={() => {
-                    setIsUpdating(true);
-                    upsertQuery(feature.name, {
-                      description: value,
-                      filter: feature.filter,
-                    }).finally(() => {
-                      setIsUpdating(false);
-                      closeFlyout();
-                    });
-                  }}
-                  fill
-                >
-                  <FormattedMessage
-                    id="xpack.streams.featureDetails.saveChanges"
-                    defaultMessage="Save changes"
-                  />
-                </EuiButton>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlyoutFooter>
-        </>
-      ) : (
-        <EuiLoadingSpinner size="xl" />
-      )}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton isLoading={isUpdating} onClick={updateFeature} fill>
+              <FormattedMessage
+                id="xpack.streams.featureDetails.saveChanges"
+                defaultMessage="Save changes"
+              />
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
     </EuiFlyout>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/significant_events_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/significant_events_table.tsx
@@ -12,7 +12,7 @@ import { EuiBasicTable } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
 import type { TickFormatter } from '@elastic/charts';
-import type { StreamQuery, Streams } from '@kbn/streams-schema';
+import type { Feature, StreamQuery, Streams } from '@kbn/streams-schema';
 import { StreamFeatureDetailsFlyout } from '../data_management/stream_detail_management/stream_features/stream_feature_details_flyout';
 import type { SignificantEventItem } from '../../hooks/use_fetch_significant_events';
 import { useKibana } from '../../hooks/use_kibana';
@@ -20,6 +20,7 @@ import { formatChangePoint } from './utils/change_point';
 import { SignificantEventsHistogramChart } from './significant_events_histogram';
 import { buildDiscoverParams } from './utils/discover_helpers';
 import { useTimefilter } from '../../hooks/use_timefilter';
+import { useStreamFeatures } from '../data_management/stream_detail_management/stream_features/hooks/use_stream_features';
 
 export function SignificantEventsTable({
   definition,
@@ -47,7 +48,8 @@ export function SignificantEventsTable({
   const [selectedDeleteItem, setSelectedDeleteItem] = useState<SignificantEventItem>();
   const [isDeleteLoading, setIsDeleteLoading] = useState(false);
 
-  const [isFeatureDetailFlyoutOpen, setIsFeatureDetailFlyoutOpen] = useState<string>('');
+  const [selectedFeature, setSelectedFeature] = useState<Feature>();
+  const { featuresByName } = useStreamFeatures(definition);
 
   const columns: Array<EuiBasicTableColumn<SignificantEventItem>> = [
     {
@@ -85,12 +87,12 @@ export function SignificantEventsTable({
             )}
             onClick={() => {
               if (query.feature?.name) {
-                setIsFeatureDetailFlyoutOpen(query.feature.name);
+                setSelectedFeature(featuresByName[query.feature.name]);
               }
             }}
             iconOnClick={() => {
               if (query.feature?.name) {
-                setIsFeatureDetailFlyoutOpen(query.feature.name);
+                setSelectedFeature(featuresByName[query.feature.name]);
               }
             }}
             iconOnClickAriaLabel={i18n.translate(
@@ -214,12 +216,12 @@ export function SignificantEventsTable({
         tableLayout="auto"
         itemId="id"
       />
-      {isFeatureDetailFlyoutOpen && (
+      {selectedFeature && (
         <StreamFeatureDetailsFlyout
           definition={definition}
-          featureName={isFeatureDetailFlyoutOpen}
+          feature={selectedFeature}
           closeFlyout={() => {
-            setIsFeatureDetailFlyoutOpen('');
+            setSelectedFeature(undefined);
           }}
         />
       )}


### PR DESCRIPTION
Small refactor to make sure a `feature` is always passed to the `StreamFeatureDetailsFlyout` simplifying the logic inside the component.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->