### PR TITLE
Fix Host details page doesn't show 'show more' button for ip field

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/__snapshots__/index.test.tsx.snap
@@ -283,39 +283,60 @@ exports[`IP Overview Component rendering it renders the default IP Overview 1`] 
         <dd
           class="euiDescriptionList__description emotion-euiDescriptionList__description-row-normal"
         >
-          <div
-            data-test-subj="cellActions-renderContent-host.id"
+          <span
+            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row-DefaultFieldRendererComponent"
+            data-test-subj="DefaultFieldRendererComponent"
           >
-            <div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
               <div
-                class="euiPopover emotion-euiPopover-inline-block"
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                <div>
-                  <div
-                    data-provider-id="draggableId.content.host-id-renderer-default-draggable-ip-overview-host-id"
-                    tabindex="-1"
-                  >
-                    <span
-                      class="c1"
-                      data-test-subj="render-content-host.id"
+                <div
+                  data-test-subj="cellActions-renderContent-host.id"
+                >
+                  <div>
+                    <div
+                      class="euiPopover emotion-euiPopover-inline-block"
                     >
-                      <span
-                        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-                      >
-                        <button
-                          class="euiLink emotion-euiLink-primary"
-                          data-test-subj="securitySolutionFlyoutLink"
-                          type="button"
+                      <div>
+                        <div
+                          data-provider-id="draggableId.content.default-field-renderer-default-draggable-host-overview-host_id-b19a781f683541a7a25ee345133aa399"
+                          tabindex="-1"
                         >
-                          b19a781f683541a7a25ee345133aa399
-                        </button>
-                      </span>
-                    </span>
+                          <span
+                            class="c1"
+                            data-test-subj="render-content-host.id"
+                          >
+                            <span
+                              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                            >
+                              <button
+                                class="euiLink emotion-euiLink-primary"
+                                data-test-subj="securitySolutionFlyoutLink"
+                                type="button"
+                              >
+                                b19a781f683541a7a25ee345133aa399
+                              </button>
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
+               
             </div>
-          </div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
+              />
+            </div>
+          </span>
         </dd>
         <dt
           class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"
@@ -682,39 +703,60 @@ exports[`IP Overview Component rendering it renders the side panel IP overview 1
         <dd
           class="euiDescriptionList__description emotion-euiDescriptionList__description-row-normal"
         >
-          <div
-            data-test-subj="cellActions-renderContent-host.id"
+          <span
+            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row-DefaultFieldRendererComponent"
+            data-test-subj="DefaultFieldRendererComponent"
           >
-            <div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
               <div
-                class="euiPopover emotion-euiPopover-inline-block"
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                <div>
-                  <div
-                    data-provider-id="draggableId.content.host-id-renderer-default-draggable-ip-overview-host-id"
-                    tabindex="-1"
-                  >
-                    <span
-                      class="c1"
-                      data-test-subj="render-content-host.id"
+                <div
+                  data-test-subj="cellActions-renderContent-host.id"
+                >
+                  <div>
+                    <div
+                      class="euiPopover emotion-euiPopover-inline-block"
                     >
-                      <span
-                        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-                      >
-                        <button
-                          class="euiLink emotion-euiLink-primary"
-                          data-test-subj="securitySolutionFlyoutLink"
-                          type="button"
+                      <div>
+                        <div
+                          data-provider-id="draggableId.content.default-field-renderer-default-draggable-host-overview-host_id-b19a781f683541a7a25ee345133aa399"
+                          tabindex="-1"
                         >
-                          b19a781f683541a7a25ee345133aa399
-                        </button>
-                      </span>
-                    </span>
+                          <span
+                            class="c1"
+                            data-test-subj="render-content-host.id"
+                          >
+                            <span
+                              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                            >
+                              <button
+                                class="euiLink emotion-euiLink-primary"
+                                data-test-subj="securitySolutionFlyoutLink"
+                                type="button"
+                              >
+                                b19a781f683541a7a25ee345133aa399
+                              </button>
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
+               
             </div>
-          </div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
+              />
+            </div>
+          </span>
         </dd>
         <dt
           class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/index.test.tsx
@@ -68,5 +68,14 @@ describe('IP Overview Component', () => {
 
       expect(container.children[0]).toMatchSnapshot();
     });
+
+    test('it renders host id', () => {
+      const { container } = render(
+        <TestProviders>
+          <IpOverview {...mockProps} data={mockData.complete} />
+        </TestProviders>
+      );
+      expect(container).toHaveTextContent('b19a781f683541a7a25ee345133aa399');
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/__snapshots__/index.test.tsx.snap
@@ -80,33 +80,54 @@ exports[`Host Summary Component it renders the default Host Summary 1`] = `
         <dd
           class="euiDescriptionList__description emotion-euiDescriptionList__description-row-normal"
         >
-          <div
-            data-test-subj="cellActions-renderContent-host.id"
+          <span
+            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row-DefaultFieldRendererComponent"
+            data-test-subj="DefaultFieldRendererComponent"
           >
-            <div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
               <div
-                class="euiPopover emotion-euiPopover-inline-block"
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                <div>
-                  <div
-                    data-provider-id="draggableId.content.host-id-renderer-default-draggable-ip-overview-host-id"
-                    tabindex="-1"
-                  >
-                    <span
-                      class="c1"
-                      data-test-subj="render-content-host.id"
+                <div
+                  data-test-subj="cellActions-renderContent-host.id"
+                >
+                  <div>
+                    <div
+                      class="euiPopover emotion-euiPopover-inline-block"
                     >
-                      <span
-                        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-                      >
-                        aa7ca589f1b8220002f2fc61c64cfbf1
-                      </span>
-                    </span>
+                      <div>
+                        <div
+                          data-provider-id="draggableId.content.default-field-renderer-default-draggable-host-overview-host_id-aa7ca589f1b8220002f2fc61c64cfbf1"
+                          tabindex="-1"
+                        >
+                          <span
+                            class="c1"
+                            data-test-subj="render-content-host.id"
+                          >
+                            <span
+                              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                            >
+                              aa7ca589f1b8220002f2fc61c64cfbf1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
+               
             </div>
-          </div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
+              />
+            </div>
+          </span>
         </dd>
         <dt
           class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"
@@ -760,33 +781,54 @@ exports[`Host Summary Component it renders the panel view Host Summary 1`] = `
         <dd
           class="euiDescriptionList__description emotion-euiDescriptionList__description-row-normal"
         >
-          <div
-            data-test-subj="cellActions-renderContent-host.id"
+          <span
+            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row-DefaultFieldRendererComponent"
+            data-test-subj="DefaultFieldRendererComponent"
           >
-            <div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
               <div
-                class="euiPopover emotion-euiPopover-inline-block"
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                <div>
-                  <div
-                    data-provider-id="draggableId.content.host-id-renderer-default-draggable-ip-overview-host-id"
-                    tabindex="-1"
-                  >
-                    <span
-                      class="c1"
-                      data-test-subj="render-content-host.id"
+                <div
+                  data-test-subj="cellActions-renderContent-host.id"
+                >
+                  <div>
+                    <div
+                      class="euiPopover emotion-euiPopover-inline-block"
                     >
-                      <span
-                        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-                      >
-                        aa7ca589f1b8220002f2fc61c64cfbf1
-                      </span>
-                    </span>
+                      <div>
+                        <div
+                          data-provider-id="draggableId.content.default-field-renderer-default-draggable-host-overview-host_id-aa7ca589f1b8220002f2fc61c64cfbf1"
+                          tabindex="-1"
+                        >
+                          <span
+                            class="c1"
+                            data-test-subj="render-content-host.id"
+                          >
+                            <span
+                              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                            >
+                              aa7ca589f1b8220002f2fc61c64cfbf1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
+               
             </div>
-          </div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
+              />
+            </div>
+          </span>
         </dd>
         <dt
           class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/index.test.tsx
@@ -110,4 +110,13 @@ describe('Host Summary Component', () => {
     expect(getByTestId('host-risk-overview')).toHaveTextContent(risk);
     expect(getByTestId('host-risk-overview')).toHaveTextContent(riskScore.toString());
   });
+
+  test('it renders host id', () => {
+    const { container } = render(
+      <TestProviders>
+        <HostOverview {...mockProps} data={mockData.Hosts.edges[0].node} />
+      </TestProviders>
+    );
+    expect(container).toHaveTextContent('aa7ca589f1b8220002f2fc61c64cfbf1');
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/__snapshots__/field_renderers.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/__snapshots__/field_renderers.test.tsx.snap
@@ -94,39 +94,60 @@ exports[`Field Renderers #hostIdRenderer it renders correctly against snapshot 1
   display: inline-block;
 }
 
-<div
-    data-test-subj="cellActions-renderContent-host.id"
+<span
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row-DefaultFieldRendererComponent"
+    data-test-subj="DefaultFieldRendererComponent"
   >
-    <div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
       <div
-        class="euiPopover emotion-euiPopover-inline-block"
+        class="euiFlexItem emotion-euiFlexItem-growZero"
       >
-        <div>
-          <div
-            data-provider-id="draggableId.content.host-id-renderer-default-draggable-ip-overview-host-id"
-            tabindex="-1"
-          >
-            <span
-              class="c0"
-              data-test-subj="render-content-host.id"
+        <div
+          data-test-subj="cellActions-renderContent-host.id"
+        >
+          <div>
+            <div
+              class="euiPopover emotion-euiPopover-inline-block"
             >
-              <span
-                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-              >
-                <button
-                  class="euiLink emotion-euiLink-primary"
-                  data-test-subj="securitySolutionFlyoutLink"
-                  type="button"
+              <div>
+                <div
+                  data-provider-id="draggableId.content.default-field-renderer-default-draggable-host-overview-host_id-b19a781f683541a7a25ee345133aa399"
+                  tabindex="-1"
                 >
-                  b19a781f683541a7a25ee345133aa399
-                </button>
-              </span>
-            </span>
+                  <span
+                    class="c0"
+                    data-test-subj="render-content-host.id"
+                  >
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    >
+                      <button
+                        class="euiLink emotion-euiLink-primary"
+                        data-test-subj="securitySolutionFlyoutLink"
+                        type="button"
+                      >
+                        b19a781f683541a7a25ee345133aa399
+                      </button>
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
+       
     </div>
-  </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <div
+        class="euiFlexItem emotion-euiFlexItem-growZero"
+      />
+    </div>
+  </span>
 </DocumentFragment>
 `;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.test.tsx
@@ -162,6 +162,20 @@ describe('Field Renderers', () => {
       );
       expect(screen.getByText(getEmptyValue())).toBeInTheDocument();
     });
+
+    test('it renders multiple host ids', () => {
+      render(
+        <TestProviders>
+          {hostIdRenderer({
+            scopeId,
+            host: { ...emptyIdHost, id: ['test1', 'test2'] },
+            isFlyoutOpen: false,
+          })}
+        </TestProviders>
+      );
+      expect(screen.getByText('test1')).toBeInTheDocument();
+      expect(screen.getByText('+1 More')).toBeInTheDocument();
+    });
   });
 
   describe('#hostNameRenderer', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.tsx
@@ -21,6 +21,7 @@ import { ReputationLink, WhoIsLink } from '../../../common/components/links';
 import * as i18n from '../../../explore/network/components/details/translations';
 import type { SourcererScopeName } from '../../../sourcerer/store/model';
 import { FlyoutLink } from '../../../flyout/shared/components/flyout_link';
+import { DefaultFieldRenderer } from './default_renderer';
 
 export const IpOverviewId = 'ip-overview';
 
@@ -104,33 +105,31 @@ export const hostIdRenderer = ({
   noLink,
   scopeId,
   isFlyoutOpen,
-}: HostIdRendererTypes): React.ReactElement =>
-  host.id && host.ip && (ipFilter == null || host.ip.includes(ipFilter)) ? (
+}: HostIdRendererTypes): React.ReactElement => {
+  const hostName = host.name && host.name[0];
+  return host.id && host.ip && (ipFilter == null || host.ip.includes(ipFilter)) ? (
     <>
-      {host.name && host.name[0] != null ? (
-        <DefaultDraggable
-          id={`host-id-renderer-default-draggable-${IpOverviewId}-${
-            contextID ? `${contextID}-` : ''
-          }host-id`}
-          field="host.id"
-          value={host.id[0]}
-          isAggregatable={true}
-          fieldType={'keyword'}
+      {hostName != null ? (
+        <DefaultFieldRenderer
+          rowItems={host.id}
+          attrName={'host.id'}
+          idPrefix={contextID ? `host-overview-${contextID}` : 'host-overview'}
           scopeId={scopeId}
-        >
-          {noLink ? (
-            <>{host.id}</>
-          ) : (
-            <FlyoutLink
-              field={'host.name'}
-              value={host.name[0]}
-              scopeId={scopeId}
-              isFlyoutOpen={isFlyoutOpen}
-            >
-              {host.id}
-            </FlyoutLink>
-          )}
-        </DefaultDraggable>
+          render={(id) =>
+            noLink ? (
+              <>{id}</>
+            ) : (
+              <FlyoutLink
+                field={'host.name'}
+                value={hostName}
+                scopeId={scopeId}
+                isFlyoutOpen={isFlyoutOpen}
+              >
+                {id}
+              </FlyoutLink>
+            )
+          }
+        />
       ) : (
         <>{host.id}</>
       )}
@@ -138,6 +137,7 @@ export const hostIdRenderer = ({
   ) : (
     getEmptyTagValue()
   );
+};
 
 interface HostNameRendererTypes {
   scopeId: SourcererScopeName;

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helper.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helper.test.ts
@@ -6,120 +6,161 @@
  */
 
 import { Direction } from '../../../../../../common/search_strategy/common';
-import type { AggregationRequest } from '../../../../../../common/search_strategy/security_solution/hosts';
-import { buildFieldsTermAggregation } from './helpers';
+import type {
+  AggregationRequest,
+  HostAggEsItem,
+} from '../../../../../../common/search_strategy/security_solution/hosts';
+import { buildFieldsTermAggregation, formatHostItem } from './helpers';
 
-describe('#buildFieldsTermAggregation', () => {
-  test('it convert fields to aggregation terms', () => {
-    const fields: readonly string[] = [
-      'host.architecture',
-      'host.id',
-      'host.ip',
-      'host.name',
-      'host.os.family',
-      'host.os.name',
-    ];
-    const expected: AggregationRequest = {
-      host_architecture: {
-        terms: {
-          field: 'host.architecture',
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
+describe('#Host details search strategy helpers', () => {
+  describe('#buildFieldsTermAggregation', () => {
+    test('it convert fields to aggregation terms', () => {
+      const fields: readonly string[] = [
+        'host.architecture',
+        'host.id',
+        'host.ip',
+        'host.name',
+        'host.os.family',
+        'host.os.name',
+      ];
+      const expected: AggregationRequest = {
+        host_architecture: {
+          terms: {
+            field: 'host.architecture',
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-      host_id: {
-        terms: {
-          field: 'host.id',
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
+        host_id: {
+          terms: {
+            field: 'host.id',
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-      host_ip: {
-        terms: {
-          script: {
-            source: "doc['host.ip']",
-            lang: 'painless',
+        host_ip: {
+          terms: {
+            script: {
+              source: "doc['host.ip']",
+              lang: 'painless',
+            },
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
-          },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-      host_name: {
-        terms: {
-          field: 'host.name',
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
+        host_name: {
+          terms: {
+            field: 'host.name',
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-      host_os_family: {
-        terms: {
-          field: 'host.os.family',
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
+        host_os_family: {
+          terms: {
+            field: 'host.os.family',
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-      host_os_name: {
-        terms: {
-          field: 'host.os.name',
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
+        host_os_name: {
+          terms: {
+            field: 'host.os.name',
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-    };
-    expect(buildFieldsTermAggregation(fields)).toEqual(expected);
+      };
+      expect(buildFieldsTermAggregation(fields)).toEqual(expected);
+    });
+  });
+
+  const defaultTimestamp = { value: 1, value_as_string: 'timestamp' };
+  describe('#getHostFieldValue', () => {
+    test('it gets the host field value', () => {
+      const bucket: HostAggEsItem = {
+        host_name: {
+          buckets: [{ key: 'host1', doc_count: 1, timestamp: defaultTimestamp }],
+        },
+        host_ip: {
+          buckets: [{ key: 'ip1', doc_count: 1, timestamp: defaultTimestamp }],
+        },
+      };
+      expect(formatHostItem(bucket)).toEqual({
+        _id: 'host1',
+        host: { name: ['host1'], ip: ['ip1'] },
+      });
+    });
+
+    test('it returns multiple values when multiple buckets are present', () => {
+      const bucket: HostAggEsItem = {
+        host_name: {
+          buckets: [{ key: 'host1', doc_count: 1, timestamp: defaultTimestamp }],
+        },
+        host_ip: {
+          buckets: [
+            { key: 'ip1', doc_count: 1, timestamp: defaultTimestamp },
+            { key: 'ip2', doc_count: 1, timestamp: defaultTimestamp },
+          ],
+        },
+      };
+      expect(formatHostItem(bucket)).toEqual({
+        _id: 'host1',
+        host: { name: ['host1'], ip: ['ip1', 'ip2'] },
+      });
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helpers.ts
@@ -19,6 +19,7 @@ import type {
   AggregationRequest,
   EndpointFields,
   HostAggEsItem,
+  HostBucketItem,
   HostBuckets,
   HostItem,
   HostValue,
@@ -132,7 +133,7 @@ const getHostFieldValue = (fieldName: string, bucket: HostAggEsItem): string | s
     : fieldName.replace(/\./g, '_');
 
   if (has(`${aggField}.buckets`, bucket)) {
-    return getFirstItem(get(`${aggField}`, bucket));
+    return get(`${aggField}.buckets`, bucket).map((item: HostBucketItem) => item.key);
   } else if (fieldName === 'endpoint.id') {
     return get('endpoint_id.value.buckets[0].key', bucket) || null;
   } else if (has(aggField, bucket)) {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helpers.ts
@@ -133,7 +133,8 @@ const getHostFieldValue = (fieldName: string, bucket: HostAggEsItem): string | s
     : fieldName.replace(/\./g, '_');
 
   if (has(`${aggField}.buckets`, bucket)) {
-    return get(`${aggField}.buckets`, bucket).map((item: HostBucketItem) => item.key);
+    const buckets = get(`${aggField}.buckets`, bucket);
+    return buckets.length > 0 ? buckets.map((item: HostBucketItem) => item.key) : null;
   } else if (fieldName === 'endpoint.id') {
     return get('endpoint_id.value.buckets[0].key', bucket) || null;
   } else if (has(aggField, bucket)) {


### PR DESCRIPTION
## Summary

Fix Host details page doesn't show the 'show more' button for the IP field.

* It updates the host details endpoint to return multiple values for a field.
* It updates the host ID renderer in the UI to support multiple values

### What is not included?
* Refactor host details API; it really needs a refactor, but I am not doing it in this bug fix scope.
* Network details. Network modal also only displays one value per field, but it is out of the scope.

<img width="300" height="682" alt="Screenshot 2025-10-09 at 13 33 33" src="https://github.com/user-attachments/assets/05f942fd-4bc5-482a-bdf9-23c1d39d3a02" />

<img width="800" height="1002" alt="Screenshot 2025-10-09 at 11 05 09" src="https://github.com/user-attachments/assets/582e3a6b-868a-4114-ad97-94f0d4654507" />
<img width="800" height="1066" alt="Screenshot 2025-10-09 at 11 05 04" src="https://github.com/user-attachments/assets/4b0b69c5-290b-4dbf-b1df-899964a235c3" />


### Checklist

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
### Identify risks



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->