### PR TITLE
[Security Solution][BUG] Fields sorting not working on translated dashboards page. (#237473)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/name.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/name.test.tsx
@@ -13,7 +13,7 @@ describe('createNameColumn', () => {
 
     expect(column).toEqual({
       align: 'left',
-      field: 'elastic_dashboard.title',
+      field: 'original_dashboard.title',
       name: 'Name',
       render: expect.any(Function),
       sortable: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/name.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/name.tsx
@@ -47,7 +47,7 @@ export const createNameColumn = ({
   openDashboardDetailsFlyout,
 }: CreateNameColumnParams): TableColumn => {
   return {
-    field: 'elastic_dashboard.title',
+    field: 'original_dashboard.title',
     name: i18n.COLUMN_NAME,
     render: (_, dashboard: DashboardMigrationDashboard) => (
       <Name dashboard={dashboard} openDashboardDetailsFlyout={openDashboardDetailsFlyout} />

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/data/sort.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/data/sort.ts
@@ -44,6 +44,9 @@ const sortOptionsMap: {
   ],
   'original_dashboard.splunk_properties.app': sortOptions.splunkApp,
   updated: sortOptions.updated,
+  translation_result: (direction?: estypes.SortOrder) => [
+    ...sortOptions.translationResult(direction),
+  ],
 };
 
 export const getSortingOptions = (sort?: SiemMigrationSort): estypes.Sort => {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/237473

These changes fix the issue in the "Translated dashboards" table where the sorting does not work for the "Name" and "Status" columns.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->