### PR TITLE
[Security Solution[BUG] Dashboard with 'Installed' status is showing up on filtering dashboards for 'Partially translated' status. (#237463)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/utils/filters.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/utils/filters.test.ts
@@ -21,7 +21,7 @@ describe('convertFilterOptions', () => {
 
   it('filters by `partially translated` status', () => {
     const filters = convertFilterOptions({ status: StatusFilterBase.PARTIALLY_TRANSLATED });
-    expect(filters).toEqual({ partiallyTranslated: true });
+    expect(filters).toEqual({ installed: false, partiallyTranslated: true });
   });
 
   it('filters by `untranslatable` status', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/utils/filters.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/utils/filters.ts
@@ -13,7 +13,7 @@ const STATUS_FILTERS: Record<StatusFilterBase, DashboardMigrationFilters> = {
   [StatusFilterBase.FAILED]: { failed: true },
   [StatusFilterBase.INSTALLED]: { installed: true },
   [StatusFilterBase.TRANSLATED]: { installed: false, fullyTranslated: true },
-  [StatusFilterBase.PARTIALLY_TRANSLATED]: { partiallyTranslated: true },
+  [StatusFilterBase.PARTIALLY_TRANSLATED]: { installed: false, partiallyTranslated: true },
   [StatusFilterBase.UNTRANSLATABLE]: { untranslatable: true },
 };
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/237463

These changes fix the issue where we would incorrectly filter the translated dashboards by the "Status" field. Particularly, we incorrectly show the "Installed" dashboards when user selects the "Partially translated" filter.

This happens because we do not account for the cases where the "Partially translated" dashboards already installed (which is allowed for the dashboards) by the user.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->