### PR TITLE
Pass stream description to feature identification

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/systems/identify_systems.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/systems/identify_systems.ts
@@ -76,6 +76,7 @@ export async function identifySystems({
     input: {
       stream: {
         name: stream.name,
+        description: stream.description || 'This stream has no description.',
       },
       dataset_analysis: JSON.stringify(
         sortAndTruncateAnalyzedFields(analysis, { dropEmpty: true, dropUnmapped })

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/systems/prompt.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/systems/prompt.ts
@@ -64,6 +64,7 @@ export const IdentifySystemsPrompt = createPrompt({
   input: z.object({
     stream: z.object({
       name: z.string(),
+      description: z.string(),
     }),
     dataset_analysis: z.string(),
     initial_clustering: z.string(),

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/systems/user_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/systems/user_prompt.text
@@ -1,6 +1,9 @@
 `stream.name`:
 {{{stream.name}}}
 
+`stream.description`:
+{{{stream.description}}}
+
 `dataset_analysis`:
 {{{dataset_analysis}}}
 


### PR DESCRIPTION
## Summary

Fixes #238035

Adds the stream description to the user prompt for feature identification.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->