### PR TITLE
Publish code scanning alerts to new index

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -88,6 +88,7 @@ jobs:
         SLACK_CHANNEL: ${{secrets.CODE_SCANNING_SLACK_CHANNEL_ID}}
         CODE_SCANNING_ES_HOST: ${{secrets.CODE_SCANNING_ES_HOST}}
         CODE_SCANNING_ES_API_KEY: ${{secrets.CODE_SCANNING_ES_API_KEY}}
+        CODE_SCANNING_INDEX_NAME: appex-codeql-alerts
         CODE_SCANNING_BRANCHES: main,8.19
       run: |
         npm ci --omit=dev


### PR DESCRIPTION
## Summary

Changes the code scanning alerts destination to `appex-codeql-alerts` for consistency with other repos.