### PR TITLE
[8.19] [ResponseOps][Slack] Allow configuring and accessing only slack web api or webhook (#237640)

### DIFF
--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/types/action_types.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/types/action_types.ts
@@ -11,7 +11,7 @@ import type { ComponentType, ReactNode } from 'react';
 import type { RuleActionParam, ActionVariable } from '@kbn/alerting-types';
 import type { IconType, RecursivePartial } from '@elastic/eui';
 import type { PublicMethodsOf } from '@kbn/utility-types';
-import type { SubFeature } from '@kbn/actions-types';
+import type { ActionType, SubFeature } from '@kbn/actions-types';
 import type { TypeRegistry } from '../type_registry';
 import type { RuleFormParamsErrors } from './rule_types';
 
@@ -129,7 +129,7 @@ export interface ActionTypeModel<ActionConfig = any, ActionSecrets = any, Action
   isExperimental?: boolean;
   subtype?: Array<{ id: string; name: string }>;
   convertParamsBetweenGroups?: (params: ActionParams) => ActionParams | {};
-  hideInUi?: boolean;
+  getHideInUi?: (actionTypes: ActionType[]) => boolean;
   modalWidth?: number;
   isSystemActionType?: boolean;
   subFeature?: SubFeature;

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_connectors_body.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_connectors_body.tsx
@@ -211,9 +211,10 @@ export const RuleActionsConnectorsBody = ({
       const actionTypeModel = actionTypeRegistry.get(actionTypeId);
       const subtype = actionTypeModel.subtype;
 
-      const shownActionTypeId = actionTypeModel.hideInUi
-        ? subtype?.filter((type) => type.id !== actionTypeId)[0].id
-        : undefined;
+      const shownActionTypeId =
+        actionTypeModel.getHideInUi != null && actionTypeModel.getHideInUi(connectorTypes)
+          ? subtype?.filter((type) => type.id !== actionTypeId)[0].id
+          : undefined;
 
       const currentActionTypeId = shownActionTypeId ? shownActionTypeId : actionTypeId;
 

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_connectors_modal.test.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_connectors_modal.test.tsx
@@ -137,7 +137,9 @@ describe('ruleActionsConnectorsModal', () => {
   test('should not render connector if hideInUi is true', () => {
     const actionTypeRegistry = new TypeRegistry<ActionTypeModel>();
     actionTypeRegistry.register(getActionTypeModel('1', { id: 'actionType-1' }));
-    actionTypeRegistry.register(getActionTypeModel('2', { id: 'actionType-2', hideInUi: true }));
+    actionTypeRegistry.register(
+      getActionTypeModel('2', { id: 'actionType-2', getHideInUi: () => true })
+    );
 
     useRuleFormState.mockReturnValue({
       plugins: {
@@ -169,7 +171,7 @@ describe('ruleActionsConnectorsModal', () => {
     actionTypeRegistry.register(
       getActionTypeModel('2', {
         id: 'actionType-2',
-        hideInUi: true,
+        getHideInUi: () => true,
         subtype: [
           { id: 'actionType-1', name: 'connector-1' },
           { id: 'actionType-2', name: 'connector-2' },
@@ -210,7 +212,7 @@ describe('ruleActionsConnectorsModal', () => {
     actionTypeRegistry.register(
       getActionTypeModel('2', {
         id: 'actionType-2',
-        hideInUi: true,
+        getHideInUi: () => true,
         subtype: [
           { id: 'actionType-1', name: 'connector-1' },
           { id: 'actionType-2', name: 'connector-2' },
@@ -235,6 +237,51 @@ describe('ruleActionsConnectorsModal', () => {
     expect(screen.getAllByTestId('ruleActionsConnectorsModalCard').length).toEqual(2);
     expect(screen.getByText('connector-1')).toBeInTheDocument();
     expect(screen.getByText('connector-2')).toBeInTheDocument();
+  });
+
+  test('should display only subtype connector when only one of the subtype is enabled in config', async () => {
+    const actionTypeRegistry = new TypeRegistry<ActionTypeModel>();
+    actionTypeRegistry.register(
+      getActionTypeModel('1', {
+        id: 'actionType-1',
+        getHideInUi: () => false,
+        subtype: [
+          { id: 'actionType-1', name: 'connector-1' },
+          { id: 'actionType-2', name: 'connector-2' },
+        ],
+      })
+    );
+    actionTypeRegistry.register(
+      getActionTypeModel('2', {
+        id: 'actionType-2',
+        getHideInUi: () => true,
+        subtype: [
+          { id: 'actionType-1', name: 'connector-1' },
+          { id: 'actionType-2', name: 'connector-2' },
+        ],
+      })
+    );
+    useRuleFormState.mockReturnValue({
+      plugins: {
+        actionTypeRegistry,
+      },
+      formData: {
+        actions: [],
+      },
+      connectors: mockConnectors,
+      connectorTypes: [
+        getActionType('1', { enabledInConfig: true }),
+        getActionType('2', { enabledInConfig: false }),
+      ],
+    });
+
+    render(<RuleActionsConnectorsModal />);
+    const filterButtonGroup = screen.getByTestId('ruleActionsConnectorsModalFilterButtonGroup');
+
+    await userEvent.click(within(filterButtonGroup).getByText('actionType: 1'));
+    expect(screen.getAllByTestId('ruleActionsConnectorsModalCard').length).toEqual(1);
+    expect(screen.getByText('connector-1')).toBeInTheDocument();
+    expect(screen.queryByText('connector-2')).not.toBeInTheDocument();
   });
 
   test('should not render connector if actionsParamsField doesnt exist', () => {

--- a/x-pack/platform/plugins/shared/stack_connectors/common/slack/constants.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/slack/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const SLACK_CONNECTOR_ID = '.slack';

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/slack/slack.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/slack/slack.tsx
@@ -13,16 +13,18 @@ import type {
 } from '@kbn/triggers-actions-ui-plugin/public/types';
 import { SlackActionParams, SlackSecrets } from '../types';
 import { PostMessageParams } from '../../../common/slack_api/types';
+import { SLACK_CONNECTOR_ID } from '../../../common/slack/constants';
+import { SLACK_API_CONNECTOR_ID } from '../../../common/slack_api/constants';
 
 export const subtype = [
   {
-    id: '.slack',
+    id: SLACK_CONNECTOR_ID,
     name: i18n.translate('xpack.stackConnectors.components.slack.webhook', {
       defaultMessage: 'Webhook',
     }),
   },
   {
-    id: '.slack_api',
+    id: SLACK_API_CONNECTOR_ID,
     name: i18n.translate('xpack.stackConnectors.components.slack.webApi', {
       defaultMessage: 'Web API',
     }),
@@ -31,7 +33,7 @@ export const subtype = [
 
 export function getConnectorType(): ConnectorTypeModel<unknown, SlackSecrets, SlackActionParams> {
   return {
-    id: '.slack',
+    id: SLACK_CONNECTOR_ID,
     subtype,
     modalWidth: 675,
     iconClass: 'logoSlack',

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/slack_api/slack_api.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/slack_api/slack_api.test.tsx
@@ -41,6 +41,38 @@ describe('connectorTypeRegistry.get works', () => {
   });
 });
 
+describe('hideInUi', () => {
+  test('should return true when slack is enabled in config', () => {
+    expect(
+      // @ts-expect-error
+      connectorTypeModel.getHideInUi([
+        // @ts-expect-error necessary fields only
+        { id: '.slack', enabledInConfig: true, enabledInLicense: true, name: 'Slack' },
+      ])
+    ).toEqual(true);
+  });
+
+  test('should return false when slack is disabled in config', () => {
+    expect(
+      // @ts-expect-error
+      connectorTypeModel.getHideInUi([
+        // @ts-expect-error necessary fields only
+        { id: '.slack', enabledInConfig: false, enabledInLicense: true, name: 'Slack' },
+      ])
+    ).toEqual(false);
+  });
+
+  test('should return false when slack is not found in config', () => {
+    expect(
+      // @ts-expect-error
+      connectorTypeModel.getHideInUi([
+        // @ts-expect-error necessary fields only
+        { id: '.cases', enabledInConfig: true, enabledInLicense: true, name: 'Cases' },
+      ])
+    ).toEqual(false);
+  });
+});
+
 describe('Slack action params validation', () => {
   describe('postMessage', () => {
     test('should succeed when action params include valid message and channels list', async () => {

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/slack_api/slack_api.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/slack_api/slack_api.tsx
@@ -26,6 +26,7 @@ import type {
   PostBlockkitParams,
 } from '../../../common/slack_api/types';
 import { SLACK_API_CONNECTOR_ID } from '../../../common/slack_api/constants';
+import { SLACK_CONNECTOR_ID } from '../../../common/slack/constants';
 import { SlackActionParams } from '../types';
 import { subtype } from '../slack/slack';
 
@@ -47,7 +48,10 @@ export const getConnectorType = (): ConnectorTypeModel<
 > => ({
   id: SLACK_API_CONNECTOR_ID,
   subtype,
-  hideInUi: true,
+  // Hide slack api connector in UI when when slack connector is enabled in config
+  getHideInUi: (actionTypes) =>
+    actionTypes.find((actionType) => actionType.id === SLACK_CONNECTOR_ID)?.enabledInConfig ===
+    true,
   modalWidth: 675,
   iconClass: 'logoSlack',
   selectMessage: SELECT_MESSAGE,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_form.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_form.test.tsx
@@ -310,6 +310,15 @@ describe('action_form', () => {
         supportedFeatureIds: ['alerting'],
       },
       {
+        id: 'hidden-in-ui',
+        name: 'Hidden in UI',
+        enabled: false,
+        enabledInConfig: true,
+        enabledInLicense: true,
+        minimumLicenseRequired: 'gold',
+        supportedFeatureIds: ['alerting'],
+      },
+      {
         id: 'disabled-by-license',
         name: 'Disabled by license',
         enabled: false,
@@ -447,6 +456,14 @@ describe('action_form', () => {
       const wrapper = await setup();
       const actionOption = wrapper.find(
         '[data-test-subj="disabled-by-config-alerting-ActionTypeSelectOption"]'
+      );
+      expect(actionOption.exists()).toBeFalsy();
+    });
+
+    it('does not render action types hidden in ui', async () => {
+      const wrapper = await setup();
+      const actionOption = wrapper.find(
+        '[data-test-subj="hidden-in-ui-alerting-ActionTypeSelectOption"]'
       );
       expect(actionOption.exists()).toBeFalsy();
     });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
@@ -296,7 +296,9 @@ export const ActionForm = ({
     const preconfiguredConnectors = connectors.filter((connector) => connector.isPreconfigured);
     actionTypeNodes = actionTypeRegistry
       .list()
-      .filter((item) => actionTypesIndex[item.id] && !item.hideInUi)
+      .filter(
+        (item) => actionTypesIndex[item.id] && !item.getHideInUi?.(Object.values(actionTypesIndex))
+      )
       .filter((item) => !!item.actionParamsFields)
       .sort((a, b) =>
         actionTypeCompare(actionTypesIndex[a.id], actionTypesIndex[b.id], preconfiguredConnectors)

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.test.tsx
@@ -6,14 +6,14 @@
  */
 
 import * as React from 'react';
-import { act, screen } from '@testing-library/react';
-import { mountWithIntl, nextTick } from '@kbn/test-jest-helpers';
+import { screen } from '@testing-library/react';
 import { coreMock } from '@kbn/core/public/mocks';
 import { actionTypeRegistryMock } from '../../action_type_registry.mock';
 import { ActionTypeMenu } from './action_type_menu';
 import { GenericValidationResult } from '../../../types';
 import { useKibana } from '../../../common/lib/kibana';
 import { AppMockRenderer, createAppMockRenderer } from '../test_utils';
+
 jest.mock('../../../common/lib/kibana');
 
 jest.mock('../../lib/action_connector_api', () => ({
@@ -26,7 +26,9 @@ const actionTypeRegistry = actionTypeRegistryMock.create();
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 
 describe('connector_add_flyout', () => {
+  let appMockRenderer: AppMockRenderer;
   beforeAll(async () => {
+    appMockRenderer = createAppMockRenderer();
     const mockes = coreMock.createSetup();
     const [
       {
@@ -42,6 +44,7 @@ describe('connector_add_flyout', () => {
       },
     };
   });
+
   afterEach(() => {
     actionTypeRegistry.get.mockReset();
     jest.clearAllMocks();
@@ -73,18 +76,14 @@ describe('connector_add_flyout', () => {
         },
       ]);
 
-      const wrapper = mountWithIntl(
+      appMockRenderer.render(
         <ActionTypeMenu
           onActionTypeChange={onActionTypeChange}
           actionTypeRegistry={actionTypeRegistry}
         />
       );
-      await act(async () => {
-        await nextTick();
-        wrapper.update();
-      });
 
-      expect(wrapper.find('[data-test-subj="my-action-type-card"]').exists()).toBeTruthy();
+      expect(await screen.findByTestId('my-action-type-card')).toBeInTheDocument();
     });
 
     it(`doesn't renders action types that are disabled via config`, async () => {
@@ -112,18 +111,14 @@ describe('connector_add_flyout', () => {
         },
       ]);
 
-      const wrapper = mountWithIntl(
+      appMockRenderer.render(
         <ActionTypeMenu
           onActionTypeChange={onActionTypeChange}
           actionTypeRegistry={actionTypeRegistry}
         />
       );
-      await act(async () => {
-        await nextTick();
-        wrapper.update();
-      });
 
-      expect(wrapper.find('[data-test-subj="my-action-type-card"]').exists()).toBeFalsy();
+      expect(screen.queryByTestId('my-action-type-card')).not.toBeInTheDocument();
     });
 
     it(`renders action types as disabled when disabled by license`, async () => {
@@ -151,25 +146,82 @@ describe('connector_add_flyout', () => {
         },
       ]);
 
-      const wrapper = mountWithIntl(
+      appMockRenderer.render(
         <ActionTypeMenu
           onActionTypeChange={onActionTypeChange}
           actionTypeRegistry={actionTypeRegistry}
         />
       );
-      await act(async () => {
-        await nextTick();
-        wrapper.update();
+
+      expect(await screen.findByTestId('my-action-type-card')).toBeInTheDocument();
+    });
+
+    it('renders action type based on hideInUi flag', async () => {
+      const onActionTypeChange = jest.fn();
+      const actionType1 = actionTypeRegistryMock.createMockActionTypeModel({
+        id: 'my-action-type-1',
+        iconClass: 'test',
+        selectMessage: 'test 1',
+        validateParams: (): Promise<GenericValidationResult<unknown>> => {
+          const validationResult = { errors: {} };
+          return Promise.resolve(validationResult);
+        },
+        getHideInUi: () => true,
+        actionConnectorFields: null,
+      });
+      const actionType2 = actionTypeRegistryMock.createMockActionTypeModel({
+        id: 'my-action-type-2',
+        iconClass: 'test',
+        selectMessage: 'test 2',
+        validateParams: (): Promise<GenericValidationResult<unknown>> => {
+          const validationResult = { errors: {} };
+          return Promise.resolve(validationResult);
+        },
+        getHideInUi: () => false,
+        actionConnectorFields: null,
       });
 
-      expect(
-        wrapper.find('EuiToolTip [data-test-subj="my-action-type-card"]').exists()
-      ).toBeTruthy();
+      // mock get return for filter
+      actionTypeRegistry.get.mockReturnValueOnce(actionType1);
+      actionTypeRegistry.get.mockReturnValueOnce(actionType2);
+      // mock get return for map
+      actionTypeRegistry.get.mockReturnValueOnce(actionType1);
+      actionTypeRegistry.get.mockReturnValueOnce(actionType2);
+
+      loadActionTypes.mockResolvedValueOnce([
+        {
+          id: actionType1.id,
+          enabled: true,
+          name: 'Test',
+          enabledInConfig: true,
+          enabledInLicense: true,
+          minimumLicenseRequired: 'gold',
+          supportedFeatureIds: ['alerting'],
+        },
+        {
+          id: actionType2.id,
+          enabled: true,
+          name: 'Test',
+          enabledInConfig: true,
+          enabledInLicense: true,
+          minimumLicenseRequired: 'gold',
+          supportedFeatureIds: ['alerting'],
+        },
+      ]);
+
+      appMockRenderer.render(
+        <ActionTypeMenu
+          onActionTypeChange={onActionTypeChange}
+          actionTypeRegistry={actionTypeRegistry}
+        />
+      );
+
+      expect(screen.queryByTestId('my-action-type-1-card')).not.toBeInTheDocument();
+      expect(await screen.findByTestId('my-action-type-2-card')).toBeInTheDocument();
     });
   });
 
   describe('filtering', () => {
-    let appMockRenderer: AppMockRenderer;
     const onActionTypeChange = jest.fn();
 
     const actionType1 = actionTypeRegistryMock.createMockActionTypeModel({
@@ -199,7 +251,6 @@ describe('connector_add_flyout', () => {
     });
 
     it('Filters connectors based on name search', async () => {
-      appMockRenderer = createAppMockRenderer();
       loadActionTypes.mockResolvedValue([
         {
           id: actionType1.id,
@@ -238,7 +289,6 @@ describe('connector_add_flyout', () => {
     });
 
     it('Filters connectors based on selectMessage search', async () => {
-      appMockRenderer = createAppMockRenderer();
       loadActionTypes.mockResolvedValue([
         {
           id: actionType1.id,
@@ -303,20 +353,14 @@ describe('connector_add_flyout', () => {
         },
       ]);
 
-      const wrapper = mountWithIntl(
+      appMockRenderer.render(
         <ActionTypeMenu
           onActionTypeChange={onActionTypeChange}
           actionTypeRegistry={actionTypeRegistry}
         />
       );
-      await act(async () => {
-        await nextTick();
-        wrapper.update();
-      });
 
-      expect(
-        wrapper.find('EuiToolTip [data-test-subj="my-action-type-card"] EuiBetaBadge').exists()
-      ).toBeFalsy();
+      expect(screen.queryByTestId('my-action-type-card')).not.toBeInTheDocument();
     });
     it(`does not render beta badge when isExperimental=false`, async () => {
       const onActionTypeChange = jest.fn();
@@ -344,20 +388,14 @@ describe('connector_add_flyout', () => {
         },
       ]);
 
-      const wrapper = mountWithIntl(
+      appMockRenderer.render(
         <ActionTypeMenu
           onActionTypeChange={onActionTypeChange}
           actionTypeRegistry={actionTypeRegistry}
         />
       );
-      await act(async () => {
-        await nextTick();
-        wrapper.update();
-      });
 
-      expect(
-        wrapper.find('EuiToolTip [data-test-subj="my-action-type-card"] EuiBetaBadge').exists()
-      ).toBeFalsy();
+      expect(screen.queryByTestId('my-action-type-card')).not.toBeInTheDocument();
     });
 
     it(`renders beta badge when isExperimental=true`, async () => {
@@ -386,20 +424,14 @@ describe('connector_add_flyout', () => {
         },
       ]);
 
-      const wrapper = mountWithIntl(
+      appMockRenderer.render(
         <ActionTypeMenu
           onActionTypeChange={onActionTypeChange}
           actionTypeRegistry={actionTypeRegistry}
         />
       );
-      await act(async () => {
-        await nextTick();
-        wrapper.update();
-      });
 
-      expect(
-        wrapper.find('EuiToolTip [data-test-subj="my-action-type-card"] EuiBetaBadge').exists()
-      ).toBeTruthy();
+      expect(screen.queryByTestId('my-action-type-card')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
@@ -105,12 +105,14 @@ export const ActionTypeMenu = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const registeredActionTypes = Object.entries(actionTypesIndex ?? [])
-    .filter(
-      ([id, details]) =>
-        actionTypeRegistry.has(id) &&
-        details.enabledInConfig === true &&
-        !actionTypeRegistry.get(id).hideInUi
-    )
+    .filter(([id, details]) => {
+      const actionTypeModel = actionTypeRegistry.has(id) ? actionTypeRegistry.get(id) : undefined;
+      const shouldHideInUi = actionTypeModel?.getHideInUi?.(
+        actionTypesIndex ? Object.values(actionTypesIndex) : []
+      );
+
+      return details.enabledInConfig === true && !shouldHideInUi;
+    })
     .map(([id, actionType]) => {
       const actionTypeModel = actionTypeRegistry.get(id);
       return {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_modal.test.tsx
@@ -6,20 +6,39 @@
  */
 
 import * as React from 'react';
-import { mountWithIntl, nextTick } from '@kbn/test-jest-helpers';
-import { act } from 'react-dom/test-utils';
+import { screen } from '@testing-library/react';
 import ConnectorAddModal from './connector_add_modal';
 import { actionTypeRegistryMock } from '../../action_type_registry.mock';
 import { ActionType, GenericValidationResult } from '../../../types';
 import { useKibana } from '../../../common/lib/kibana';
 import { coreMock } from '@kbn/core/public/mocks';
+import type { AppMockRenderer } from '../test_utils';
+import { createAppMockRenderer } from '../test_utils';
 
 jest.mock('../../../common/lib/kibana');
+jest.mock('../../lib/action_connector_api', () => ({
+  ...(jest.requireActual('../../lib/action_connector_api') as any),
+  loadActionTypes: jest.fn(),
+}));
+
+const { loadActionTypes } = jest.requireMock('../../lib/action_connector_api');
 const actionTypeRegistry = actionTypeRegistryMock.create();
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 
 describe('connector_add_modal', () => {
+  let appMockRenderer: AppMockRenderer;
+  const actionType: ActionType = {
+    id: 'my-action-type',
+    name: 'test',
+    enabled: true,
+    enabledInConfig: true,
+    enabledInLicense: true,
+    minimumLicenseRequired: 'basic',
+    supportedFeatureIds: ['alerting'],
+    isSystemActionType: false,
+  };
   beforeAll(async () => {
+    appMockRenderer = createAppMockRenderer();
     const mockes = coreMock.createSetup();
     const [
       {
@@ -34,6 +53,7 @@ describe('connector_add_modal', () => {
         delete: true,
       },
     };
+    loadActionTypes.mockResolvedValue([actionType]);
   });
 
   it('renders connector modal form if addModalVisible is true', async () => {
@@ -50,18 +70,7 @@ describe('connector_add_modal', () => {
     actionTypeRegistry.get.mockReturnValue(actionTypeModel);
     actionTypeRegistry.has.mockReturnValue(true);
 
-    const actionType: ActionType = {
-      id: 'my-action-type',
-      name: 'test',
-      enabled: true,
-      enabledInConfig: true,
-      enabledInLicense: true,
-      minimumLicenseRequired: 'basic',
-      supportedFeatureIds: ['alerting'],
-      isSystemActionType: false,
-    };
-
-    const wrapper = mountWithIntl(
+    appMockRenderer.render(
       <ConnectorAddModal
         onClose={() => {}}
         actionType={actionType}
@@ -69,12 +78,53 @@ describe('connector_add_modal', () => {
       />
     );
 
-    await act(async () => {
-      await nextTick();
-      wrapper.update();
+    expect(await screen.findByTestId('saveActionButtonModal')).toBeInTheDocument();
+  });
+
+  it('filters out sub type connector when disabled in config', async () => {
+    const newActionType: ActionType = {
+      id: 'my-action-type-1',
+      name: 'Test 1',
+      enabled: false,
+      enabledInConfig: false,
+      enabledInLicense: true,
+      minimumLicenseRequired: 'basic',
+      supportedFeatureIds: ['alerting'],
+      isSystemActionType: false,
+    };
+
+    loadActionTypes.mockResolvedValue([actionType, newActionType]);
+
+    const actionTypeModel = actionTypeRegistryMock.createMockActionTypeModel({
+      id: 'my-action-type',
+      iconClass: 'test',
+      selectMessage: 'test',
+      validateParams: (): Promise<GenericValidationResult<unknown>> => {
+        const validationResult = { errors: {} };
+        return Promise.resolve(validationResult);
+      },
+      actionConnectorFields: null,
+      subtype: [
+        { id: 'my-action-type', name: 'Test' },
+        { id: 'my-action-type-1', name: 'Test 1' },
+      ],
     });
-    expect(wrapper.exists('.euiModalHeader')).toBeTruthy();
-    expect(wrapper.exists('[data-test-subj="saveActionButtonModal"]')).toBeTruthy();
+    actionTypeRegistry.get.mockReturnValue(actionTypeModel);
+    actionTypeRegistry.has.mockReturnValue(true);
+
+    appMockRenderer.render(
+      <ConnectorAddModal
+        onClose={() => {}}
+        actionType={actionType}
+        actionTypeRegistry={actionTypeRegistry}
+      />
+    );
+
+    expect(await screen.findByText('test connector')).toBeInTheDocument();
+    expect(screen.queryByText('test 1 connector')).not.toBeInTheDocument();
+
+    expect(screen.queryByTestId('my-action-type-1Button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('my-action-typeButton')).not.toBeInTheDocument();
   });
 
   describe('beta badge', () => {
@@ -92,30 +142,15 @@ describe('connector_add_modal', () => {
       });
       actionTypeRegistry.get.mockReturnValue(actionTypeModel);
       actionTypeRegistry.has.mockReturnValue(true);
-
-      const actionType: ActionType = {
-        id: 'my-action-type',
-        name: 'test',
-        enabled: true,
-        enabledInConfig: true,
-        enabledInLicense: true,
-        minimumLicenseRequired: 'basic',
-        supportedFeatureIds: ['alerting'],
-        isSystemActionType: false,
-      };
-      const wrapper = mountWithIntl(
+      appMockRenderer.render(
         <ConnectorAddModal
           onClose={() => {}}
           actionType={actionType}
           actionTypeRegistry={actionTypeRegistry}
         />
       );
-      await act(async () => {
-        await nextTick();
-        wrapper.update();
-      });
 
-      expect(wrapper.find('EuiBetaBadge').exists()).toBeFalsy();
+      expect(screen.queryByTestId('betaBadge')).not.toBeInTheDocument();
     });
 
     it(`renders beta badge when isExperimental=true`, async () => {
@@ -132,30 +167,15 @@ describe('connector_add_modal', () => {
       });
       actionTypeRegistry.get.mockReturnValue(actionTypeModel);
       actionTypeRegistry.has.mockReturnValue(true);
-
-      const actionType: ActionType = {
-        id: 'my-action-type',
-        name: 'test',
-        enabled: true,
-        enabledInConfig: true,
-        enabledInLicense: true,
-        minimumLicenseRequired: 'basic',
-        supportedFeatureIds: ['alerting'],
-        isSystemActionType: false,
-      };
-      const wrapper = mountWithIntl(
+      appMockRenderer.render(
         <ConnectorAddModal
           onClose={() => {}}
           actionType={actionType}
           actionTypeRegistry={actionTypeRegistry}
         />
       );
-      await act(async () => {
-        await nextTick();
-        wrapper.update();
-      });
 
-      expect(wrapper.find('EuiBetaBadge').exists()).toBeTruthy();
+      expect(await screen.findByTestId('betaBadge')).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_modal.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_modal.tsx
@@ -75,19 +75,24 @@ const ConnectorAddModal = ({
 
   const canSave = hasSaveActionsCapability(capabilities);
   const actionTypeModel = actionTypeRegistry.get(actionType.id);
-  const groupActionTypeModel: Array<ActionTypeModel & { name: string }> =
-    actionTypeModel && actionTypeModel.subtype
-      ? (actionTypeModel?.subtype ?? []).map((subtypeAction) => ({
+
+  const groupActionTypeModel: Array<ActionTypeModel & { name: string }> = actionTypeModel
+    ? (actionTypeModel?.subtype ?? [])
+        .filter((item) => allActionTypes?.[item.id]?.enabledInConfig)
+        .map((subtypeAction) => ({
           ...actionTypeRegistry.get(subtypeAction.id),
           name: subtypeAction.name,
         }))
-      : [];
+    : [];
 
-  const groupActionButtons = groupActionTypeModel.map((gAction) => ({
-    id: gAction.id,
-    label: gAction.name,
-    'data-test-subj': `${gAction.id}Button`,
-  }));
+  const groupActionButtons =
+    groupActionTypeModel?.length > 1
+      ? groupActionTypeModel.map((gAction) => ({
+          id: gAction.id,
+          label: gAction.name,
+          'data-test-subj': `${gAction.id}Button`,
+        }))
+      : [];
 
   const resetConnectorForm = useRef<ResetForm | undefined>();
 
@@ -267,6 +272,7 @@ const ConnectorAddModal = ({
                 {actionTypeModel && actionTypeModel.isExperimental && (
                   <EuiFlexItem className="betaBadgeFlexItem" grow={false}>
                     <EuiBetaBadge
+                      data-test-subj="betaBadge"
                       label={TECH_PREVIEW_LABEL}
                       tooltipContent={TECH_PREVIEW_DESCRIPTION}
                     />

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.test.tsx
@@ -9,7 +9,7 @@ import React, { lazy } from 'react';
 
 import { actionTypeRegistryMock } from '../../../action_type_registry.mock';
 import userEvent from '@testing-library/user-event';
-import { waitFor, act, screen } from '@testing-library/react';
+import { waitFor, screen } from '@testing-library/react';
 import CreateConnectorFlyout from '.';
 import { AppMockRenderer, createAppMockRenderer } from '../../test_utils';
 import { TECH_PREVIEW_LABEL } from '../../translations';
@@ -68,7 +68,7 @@ describe('CreateConnectorFlyout', () => {
   });
 
   it('renders', async () => {
-    const { getByTestId } = appMockRenderer.render(
+    appMockRenderer.render(
       <CreateConnectorFlyout
         actionTypeRegistry={actionTypeRegistry}
         onClose={onClose}
@@ -76,15 +76,14 @@ describe('CreateConnectorFlyout', () => {
         onTestConnector={onTestConnector}
       />
     );
-    await act(() => Promise.resolve());
 
-    expect(getByTestId('create-connector-flyout')).toBeInTheDocument();
-    expect(getByTestId('create-connector-flyout-header')).toBeInTheDocument();
-    expect(getByTestId('create-connector-flyout-footer')).toBeInTheDocument();
+    expect(await screen.findByTestId('create-connector-flyout')).toBeInTheDocument();
+    expect(screen.getByTestId('create-connector-flyout-header')).toBeInTheDocument();
+    expect(screen.getByTestId('create-connector-flyout-footer')).toBeInTheDocument();
   });
 
   it('renders action type menu on flyout open', async () => {
-    const { getByTestId } = appMockRenderer.render(
+    appMockRenderer.render(
       <CreateConnectorFlyout
         actionTypeRegistry={actionTypeRegistry}
         onClose={onClose}
@@ -93,13 +92,11 @@ describe('CreateConnectorFlyout', () => {
       />
     );
 
-    await act(() => Promise.resolve());
-
-    expect(await getByTestId(`${actionTypeModel.id}-card`)).toBeInTheDocument();
+    expect(await screen.findByTestId(`${actionTypeModel.id}-card`)).toBeInTheDocument();
   });
 
   it('shows the correct buttons without an action type selected', async () => {
-    const { getByTestId, queryByTestId } = appMockRenderer.render(
+    appMockRenderer.render(
       <CreateConnectorFlyout
         actionTypeRegistry={actionTypeRegistry}
         onClose={onClose}
@@ -107,15 +104,14 @@ describe('CreateConnectorFlyout', () => {
         onTestConnector={onTestConnector}
       />
     );
-    await act(() => Promise.resolve());
 
-    expect(getByTestId('create-connector-flyout-close-btn')).toBeInTheDocument();
-    expect(queryByTestId('create-connector-flyout-save-test-btn')).toBe(null);
-    expect(queryByTestId('create-connector-flyout-save-btn')).toBe(null);
+    expect(await screen.findByTestId('create-connector-flyout-close-btn')).toBeInTheDocument();
+    expect(screen.queryByTestId('create-connector-flyout-save-test-btn')).toBe(null);
+    expect(screen.queryByTestId('create-connector-flyout-save-btn')).toBe(null);
   });
 
   it('shows the correct buttons when selecting an action type', async () => {
-    const { getByTestId } = appMockRenderer.render(
+    appMockRenderer.render(
       <CreateConnectorFlyout
         actionTypeRegistry={actionTypeRegistry}
         onClose={onClose}
@@ -123,19 +119,18 @@ describe('CreateConnectorFlyout', () => {
         onTestConnector={onTestConnector}
       />
     );
-    await act(() => Promise.resolve());
 
-    await userEvent.click(getByTestId(`${actionTypeModel.id}-card`));
+    await userEvent.click(await screen.findByTestId(`${actionTypeModel.id}-card`));
 
     await waitFor(() => {
-      expect(getByTestId('create-connector-flyout-back-btn')).toBeInTheDocument();
-      expect(getByTestId('create-connector-flyout-save-test-btn')).toBeInTheDocument();
-      expect(getByTestId('create-connector-flyout-save-btn')).toBeInTheDocument();
+      expect(screen.getByTestId('create-connector-flyout-back-btn')).toBeInTheDocument();
+      expect(screen.getByTestId('create-connector-flyout-save-test-btn')).toBeInTheDocument();
+      expect(screen.getByTestId('create-connector-flyout-save-btn')).toBeInTheDocument();
     });
   });
 
   it('does not show the save and test button if the onTestConnector is not provided', async () => {
-    const { queryByTestId } = appMockRenderer.render(
+    appMockRenderer.render(
       <CreateConnectorFlyout
         actionTypeRegistry={actionTypeRegistry}
         onClose={onClose}
@@ -143,7 +138,7 @@ describe('CreateConnectorFlyout', () => {
       />
     );
 
-    expect(queryByTestId('create-connector-flyout-save-test-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('create-connector-flyout-save-test-btn')).not.toBeInTheDocument();
   });
 
   it('disables the buttons when the user does not have permissions to create a connector', async () => {
@@ -152,7 +147,7 @@ describe('CreateConnectorFlyout', () => {
       actions: { save: false, show: true },
     };
 
-    const { getByTestId } = appMockRenderer.render(
+    appMockRenderer.render(
       <CreateConnectorFlyout
         actionTypeRegistry={actionTypeRegistry}
         onClose={onClose}
@@ -160,13 +155,12 @@ describe('CreateConnectorFlyout', () => {
         onTestConnector={onTestConnector}
       />
     );
-    await act(() => Promise.resolve());
 
-    expect(getByTestId('create-connector-flyout-close-btn')).not.toBeDisabled();
+    expect(await screen.findByTestId('create-connector-flyout-close-btn')).not.toBeDisabled();
   });
 
   it('disables the buttons when there are error on the form', async () => {
-    const { getByTestId } = appMockRenderer.render(
+    appMockRenderer.render(
       <CreateConnectorFlyout
         actionTypeRegistry={actionTypeRegistry}
         onClose={onClose}
@@ -174,20 +168,79 @@ describe('CreateConnectorFlyout', () => {
         onTestConnector={onTestConnector}
       />
     );
-    await act(() => Promise.resolve());
 
-    await userEvent.click(getByTestId(`${actionTypeModel.id}-card`));
+    await userEvent.click(await screen.findByTestId(`${actionTypeModel.id}-card`));
 
     await waitFor(() => {
-      expect(getByTestId('test-connector-text-field')).toBeInTheDocument();
+      expect(screen.getByTestId('test-connector-text-field')).toBeInTheDocument();
     });
 
-    await userEvent.click(getByTestId('create-connector-flyout-save-btn'));
+    await userEvent.click(await screen.findByTestId('create-connector-flyout-save-btn'));
 
     await waitFor(() => {
-      expect(getByTestId('create-connector-flyout-back-btn')).not.toBeDisabled();
-      expect(getByTestId('create-connector-flyout-save-test-btn')).toBeDisabled();
-      expect(getByTestId('create-connector-flyout-save-btn')).toBeDisabled();
+      expect(screen.getByTestId('create-connector-flyout-back-btn')).not.toBeDisabled();
+      expect(screen.getByTestId('create-connector-flyout-save-test-btn')).toBeDisabled();
+      expect(screen.getByTestId('create-connector-flyout-save-btn')).toBeDisabled();
+    });
+  });
+
+  it('shows the correct buttons when selecting an action type with subtype', async () => {
+    actionTypeRegistry.get.mockReturnValue({
+      ...actionTypeModel,
+      subtype: [
+        { id: 'my-action-type', name: 'My Action Type' },
+        { id: 'my-action-type-1', name: 'My Action Type 1' },
+      ],
+    });
+
+    loadActionTypes.mockResolvedValueOnce([
+      {
+        id: actionTypeModel.id,
+        enabled: true,
+        name: 'Test',
+        enabledInConfig: true,
+        enabledInLicense: true,
+        minimumLicenseRequired: 'basic' as const,
+        supportedFeatureIds: ['alerting', 'siem'],
+      },
+      {
+        id: 'my-action-type',
+        name: 'Test 1',
+        enabled: false,
+        enabledInConfig: false,
+        enabledInLicense: true,
+        minimumLicenseRequired: 'basic' as const,
+        supportedFeatureIds: ['alerting', 'siem'],
+      },
+      {
+        id: 'my-action-type-1',
+        name: 'My Action Type 1',
+        enabled: true,
+        enabledInConfig: true,
+        minimumLicenseRequired: 'basic' as const,
+        supportedFeatureIds: ['alerting', 'siem'],
+        enabledInLicense: true,
+      },
+    ]);
+
+    appMockRenderer.render(
+      <CreateConnectorFlyout
+        actionTypeRegistry={actionTypeRegistry}
+        onClose={onClose}
+        onConnectorCreated={onConnectorCreated}
+        onTestConnector={onTestConnector}
+      />
+    );
+
+    await userEvent.click(await screen.findByTestId(`${actionTypeModel.id}-card`));
+
+    await waitFor(() => {
+      expect(screen.getByText('Test connector')).toBeInTheDocument();
+      expect(screen.queryByText('Test 1 connector')).not.toBeInTheDocument();
+      expect(screen.queryByText('My Action Type 1 connector')).not.toBeInTheDocument();
+
+      expect(screen.queryByTestId('my-action-type-1Button')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('my-action-typeButton')).not.toBeInTheDocument();
     });
   });
 
@@ -215,7 +268,7 @@ describe('CreateConnectorFlyout', () => {
           supportedFeatureIds: ['alerting'],
         },
       ]);
-      const { getByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -224,9 +277,7 @@ describe('CreateConnectorFlyout', () => {
         />
       );
 
-      await act(() => Promise.resolve());
-
-      expect(getByTestId('upgrade-your-license-callout')).toBeInTheDocument();
+      expect(await screen.findByTestId('upgrade-your-license-callout')).toBeInTheDocument();
     });
 
     it('does not render banner with subscription links when only platinum features are disabled due to licensing', async () => {
@@ -252,7 +303,7 @@ describe('CreateConnectorFlyout', () => {
           minimumLicenseRequired: 'platinum',
         },
       ]);
-      const { queryByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -261,9 +312,7 @@ describe('CreateConnectorFlyout', () => {
         />
       );
 
-      await act(() => Promise.resolve());
-
-      expect(queryByTestId('upgrade-your-license-callout')).toBeFalsy();
+      expect(screen.queryByTestId('upgrade-your-license-callout')).not.toBeInTheDocument();
     });
 
     it('does not render banner with subscription links when only enterprise features are disabled due to licensing', async () => {
@@ -289,7 +338,7 @@ describe('CreateConnectorFlyout', () => {
           supportedFeatureIds: ['alerting'],
         },
       ]);
-      const { queryByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -298,15 +347,13 @@ describe('CreateConnectorFlyout', () => {
         />
       );
 
-      await act(() => Promise.resolve());
-
-      expect(queryByTestId('upgrade-your-license-callout')).toBeFalsy();
+      expect(screen.queryByTestId('upgrade-your-license-callout')).not.toBeInTheDocument();
     });
   });
 
   describe('Header', () => {
     it('does not shows the icon when selection connector type', async () => {
-      const { queryByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -315,13 +362,11 @@ describe('CreateConnectorFlyout', () => {
         />
       );
 
-      await act(() => Promise.resolve());
-
-      expect(queryByTestId('create-connector-flyout-header-icon')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('create-connector-flyout-header-icon')).not.toBeInTheDocument();
     });
 
     it('shows the correct title when selecting connector type', async () => {
-      const { getByText } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -330,13 +375,11 @@ describe('CreateConnectorFlyout', () => {
         />
       );
 
-      await act(() => Promise.resolve());
-
-      expect(getByText('Select a connector')).toBeInTheDocument();
+      expect(await screen.findByText('Select a connector')).toBeInTheDocument();
     });
 
     it('shows the compatibility badges when the connector type is selected', async () => {
-      const { getByTestId, getByText } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -345,20 +388,20 @@ describe('CreateConnectorFlyout', () => {
         />
       );
 
-      await act(() => Promise.resolve());
-
-      await userEvent.click(getByTestId(`${actionTypeModel.id}-card`));
+      await userEvent.click(await screen.findByTestId(`${actionTypeModel.id}-card`));
 
       await waitFor(() => {
-        expect(getByTestId('test-connector-text-field')).toBeInTheDocument();
+        expect(screen.getByTestId('test-connector-text-field')).toBeInTheDocument();
       });
 
-      expect(getByTestId('create-connector-flyout-header-compatibility')).toBeInTheDocument();
-      expect(getByText('Alerting Rules')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('create-connector-flyout-header-compatibility')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Alerting Rules')).toBeInTheDocument();
     });
 
     it('shows the icon when the connector type is selected', async () => {
-      const { getByTestId, getByText, queryByText } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -367,22 +410,20 @@ describe('CreateConnectorFlyout', () => {
         />
       );
 
-      await act(() => Promise.resolve());
-
-      await userEvent.click(getByTestId(`${actionTypeModel.id}-card`));
+      await userEvent.click(await screen.findByTestId(`${actionTypeModel.id}-card`));
 
       await waitFor(() => {
-        expect(getByTestId('test-connector-text-field')).toBeInTheDocument();
+        expect(screen.getByTestId('test-connector-text-field')).toBeInTheDocument();
       });
 
-      expect(queryByText('Select a connector')).not.toBeInTheDocument();
-      expect(getByTestId('create-connector-flyout-header-icon')).toBeInTheDocument();
-      expect(getByText('Test connector')).toBeInTheDocument();
-      expect(getByText(`selectMessage-${actionTypeModel.id}`)).toBeInTheDocument();
+      expect(screen.queryByText('Select a connector')).not.toBeInTheDocument();
+      expect(screen.getByTestId('create-connector-flyout-header-icon')).toBeInTheDocument();
+      expect(screen.getByText('Test connector')).toBeInTheDocument();
+      expect(screen.getByText(`selectMessage-${actionTypeModel.id}`)).toBeInTheDocument();
     });
 
     it('does not show beta badge when isExperimental is undefined', async () => {
-      const { queryByText } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -390,13 +431,13 @@ describe('CreateConnectorFlyout', () => {
           onTestConnector={onTestConnector}
         />
       );
-      await act(() => Promise.resolve());
-      expect(queryByText(TECH_PREVIEW_LABEL)).not.toBeInTheDocument();
+
+      expect(screen.queryByText(TECH_PREVIEW_LABEL)).not.toBeInTheDocument();
     });
 
     it('does not show beta badge when isExperimental is false', async () => {
       actionTypeRegistry.get.mockReturnValue({ ...actionTypeModel, isExperimental: false });
-      const { queryByText } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -404,13 +445,13 @@ describe('CreateConnectorFlyout', () => {
           onTestConnector={onTestConnector}
         />
       );
-      await act(() => Promise.resolve());
-      expect(queryByText(TECH_PREVIEW_LABEL)).not.toBeInTheDocument();
+
+      expect(screen.queryByText(TECH_PREVIEW_LABEL)).not.toBeInTheDocument();
     });
 
     it('shows beta badge when isExperimental is true', async () => {
       actionTypeRegistry.get.mockReturnValue({ ...actionTypeModel, isExperimental: true });
-      const { getByText } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -418,8 +459,8 @@ describe('CreateConnectorFlyout', () => {
           onTestConnector={onTestConnector}
         />
       );
-      await act(() => Promise.resolve());
-      expect(getByText(TECH_PREVIEW_LABEL)).toBeInTheDocument();
+
+      expect(await screen.findByText(TECH_PREVIEW_LABEL)).toBeInTheDocument();
     });
   });
 
@@ -449,13 +490,13 @@ describe('CreateConnectorFlyout', () => {
       expect(await screen.findByTestId('createConnectorsModalSearch')).toBeInTheDocument();
 
       await userEvent.click(await screen.findByTestId(`${actionTypeModel.id}-card`));
-      expect(await screen.queryByTestId('createConnectorsModalSearch')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('createConnectorsModalSearch')).not.toBeInTheDocument();
     });
   });
 
   describe('Submitting', () => {
     it('creates a connector correctly', async () => {
-      const { getByTestId, queryByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -463,22 +504,20 @@ describe('CreateConnectorFlyout', () => {
           onTestConnector={onTestConnector}
         />
       );
-      await act(() => Promise.resolve());
 
-      await userEvent.click(getByTestId(`${actionTypeModel.id}-card`));
+      await userEvent.click(await screen.findByTestId(`${actionTypeModel.id}-card`));
 
       await waitFor(() => {
-        expect(getByTestId('test-connector-text-field')).toBeInTheDocument();
+        expect(screen.getByTestId('test-connector-text-field')).toBeInTheDocument();
       });
 
-      await userEvent.type(getByTestId('nameInput'), 'My test', {
-        delay: 100,
-      });
-      await userEvent.type(getByTestId('test-connector-text-field'), 'My text field', {
-        delay: 100,
-      });
+      await userEvent.click(await screen.findByTestId('nameInput'));
+      await userEvent.paste('My test');
 
-      await userEvent.click(getByTestId('create-connector-flyout-save-btn'));
+      await userEvent.click(screen.getByTestId('test-connector-text-field'));
+      await userEvent.paste('My text field');
+
+      await userEvent.click(screen.getByTestId('create-connector-flyout-save-btn'));
 
       await waitFor(() => {
         expect(appMockRenderer.coreStart.http.post).toHaveBeenCalledWith('/api/actions/connector', {
@@ -498,7 +537,7 @@ describe('CreateConnectorFlyout', () => {
         name: 'My test',
         secrets: {},
       });
-      expect(queryByTestId('connector-form-header-error-label')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('connector-form-header-error-label')).not.toBeInTheDocument();
     });
 
     it('show error message in the form header', async () => {
@@ -512,15 +551,11 @@ describe('CreateConnectorFlyout', () => {
       );
 
       await userEvent.click(await screen.findByTestId(`${actionTypeModel.id}-card`));
-      expect(await screen.findByTestId('test-connector-text-field')).toBeInTheDocument();
+      const testConnectorTextField = await screen.findByTestId('test-connector-text-field');
+      expect(testConnectorTextField).toBeInTheDocument();
 
-      await userEvent.type(
-        await screen.findByTestId('test-connector-text-field'),
-        'My text field',
-        {
-          delay: 100,
-        }
-      );
+      await userEvent.click(testConnectorTextField);
+      await userEvent.paste('My text field');
 
       await userEvent.click(await screen.findByTestId('create-connector-flyout-save-btn'));
       expect(onClose).not.toHaveBeenCalled();
@@ -539,24 +574,20 @@ describe('CreateConnectorFlyout', () => {
       );
 
       await userEvent.click(await screen.findByTestId(`${actionTypeModel.id}-card`));
-      expect(await screen.findByTestId('test-connector-text-field')).toBeInTheDocument();
+      const testConnectorTextField = await screen.findByTestId('test-connector-text-field');
+      expect(testConnectorTextField).toBeInTheDocument();
 
-      await userEvent.type(
-        await screen.findByTestId('test-connector-text-field'),
-        'My text field',
-        {
-          delay: 100,
-        }
-      );
+      await userEvent.click(testConnectorTextField);
+      await userEvent.paste('test-connector-text-field');
 
       await userEvent.click(await screen.findByTestId('create-connector-flyout-save-btn'));
       expect(onClose).not.toHaveBeenCalled();
       expect(onConnectorCreated).not.toHaveBeenCalled();
+
       expect(await screen.findByTestId('connector-form-header-error-label')).toBeInTheDocument();
 
-      await userEvent.type(await screen.findByTestId('nameInput'), 'My test', {
-        delay: 100,
-      });
+      await userEvent.click(await screen.findByTestId('nameInput'));
+      await userEvent.paste('My test');
 
       await userEvent.click(await screen.findByTestId('create-connector-flyout-save-btn'));
       expect(onClose).toHaveBeenCalled();
@@ -581,7 +612,7 @@ describe('CreateConnectorFlyout', () => {
         },
       ]);
 
-      const { getByTestId, getByText } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -589,32 +620,30 @@ describe('CreateConnectorFlyout', () => {
           onTestConnector={onTestConnector}
         />
       );
-      await act(() => Promise.resolve());
 
-      await userEvent.click(getByTestId(`${errorActionTypeModel.id}-card`));
-
-      await waitFor(() => {
-        expect(getByTestId('test-connector-error-text-field')).toBeInTheDocument();
-      });
-
-      await userEvent.type(getByTestId('nameInput'), 'My test', {
-        delay: 100,
-      });
-      await userEvent.type(getByTestId('test-connector-error-text-field'), 'My text field', {
-        delay: 100,
-      });
-
-      await userEvent.click(getByTestId('create-connector-flyout-save-btn'));
+      await userEvent.click(await screen.findByTestId(`${errorActionTypeModel.id}-card`));
 
       await waitFor(() => {
-        expect(getByText('Error on pre submit validator')).toBeInTheDocument();
+        expect(screen.getByTestId('test-connector-error-text-field')).toBeInTheDocument();
+      });
+
+      await userEvent.click(await screen.findByTestId('nameInput'));
+      await userEvent.paste('My test');
+
+      await userEvent.click(screen.getByTestId('test-connector-error-text-field'));
+      await userEvent.paste('My text field');
+
+      await userEvent.click(screen.getByTestId('create-connector-flyout-save-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Error on pre submit validator')).toBeInTheDocument();
       });
     });
   });
 
   describe('Testing', () => {
     it('saves and test correctly', async () => {
-      const { getByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -622,22 +651,19 @@ describe('CreateConnectorFlyout', () => {
           onTestConnector={onTestConnector}
         />
       );
-      await act(() => Promise.resolve());
 
-      await userEvent.click(getByTestId(`${actionTypeModel.id}-card`));
+      await userEvent.click(await screen.findByTestId(`${actionTypeModel.id}-card`));
 
       await waitFor(() => {
-        expect(getByTestId('test-connector-text-field')).toBeInTheDocument();
+        expect(screen.getByTestId('test-connector-text-field')).toBeInTheDocument();
       });
 
-      await userEvent.type(getByTestId('nameInput'), 'My test', {
-        delay: 100,
-      });
-      await userEvent.type(getByTestId('test-connector-text-field'), 'My text field', {
-        delay: 100,
-      });
+      await userEvent.click(screen.getByTestId('nameInput'));
+      await userEvent.paste('My test');
+      await userEvent.click(screen.getByTestId('test-connector-text-field'));
+      await userEvent.paste('My text field');
 
-      await userEvent.click(getByTestId('create-connector-flyout-save-test-btn'));
+      await userEvent.click(screen.getByTestId('create-connector-flyout-save-test-btn'));
 
       await waitFor(() => {
         expect(appMockRenderer.coreStart.http.post).toHaveBeenCalledWith('/api/actions/connector', {
@@ -671,7 +697,7 @@ describe('CreateConnectorFlyout', () => {
 
   describe('Footer', () => {
     it('shows the action types when pressing the back button', async () => {
-      const { getByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -679,24 +705,21 @@ describe('CreateConnectorFlyout', () => {
           onTestConnector={onTestConnector}
         />
       );
-      await act(() => Promise.resolve());
 
-      await userEvent.click(getByTestId(`${actionTypeModel.id}-card`));
+      await userEvent.click(await screen.findByTestId(`${actionTypeModel.id}-card`));
 
       await waitFor(() => {
-        expect(getByTestId('create-connector-flyout-back-btn')).toBeInTheDocument();
-        expect(getByTestId('nameInput')).toBeInTheDocument();
+        expect(screen.getByTestId('create-connector-flyout-back-btn')).toBeInTheDocument();
+        expect(screen.getByTestId('nameInput')).toBeInTheDocument();
       });
 
-      await userEvent.click(getByTestId('create-connector-flyout-back-btn'));
+      await userEvent.click(screen.getByTestId('create-connector-flyout-back-btn'));
 
-      await act(() => Promise.resolve());
-
-      expect(getByTestId(`${actionTypeModel.id}-card`)).toBeInTheDocument();
+      expect(screen.getByTestId(`${actionTypeModel.id}-card`)).toBeInTheDocument();
     });
 
     it('closes the flyout when pressing close', async () => {
-      const { getByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
           onClose={onClose}
@@ -704,9 +727,8 @@ describe('CreateConnectorFlyout', () => {
           onTestConnector={onTestConnector}
         />
       );
-      await act(() => Promise.resolve());
 
-      await userEvent.click(getByTestId('create-connector-flyout-close-btn'));
+      await userEvent.click(await screen.findByTestId('create-connector-flyout-close-btn'));
 
       expect(onClose).toHaveBeenCalled();
     });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.tsx
@@ -96,17 +96,22 @@ const CreateConnectorFlyoutComponent: React.FC<CreateConnectorFlyoutProps> = ({
 
   const groupActionTypeModel: Array<ActionTypeModel & { name: string }> =
     actionTypeModel && actionTypeModel.subtype
-      ? (actionTypeModel?.subtype ?? []).map((subtypeAction) => ({
-          ...actionTypeRegistry.get(subtypeAction.id),
-          name: subtypeAction.name,
-        }))
+      ? (actionTypeModel?.subtype ?? [])
+          .filter((item) => allActionTypes && allActionTypes[item.id].enabledInConfig)
+          .map((subtypeAction) => ({
+            ...actionTypeRegistry.get(subtypeAction.id),
+            name: subtypeAction.name,
+          }))
       : [];
 
-  const groupActionButtons = groupActionTypeModel.map((gAction) => ({
-    id: gAction.id,
-    label: gAction.name,
-    'data-test-subj': `${gAction.id}Button`,
-  }));
+  const groupActionButtons =
+    groupActionTypeModel?.length > 1
+      ? groupActionTypeModel.map((gAction) => ({
+          id: gAction.id,
+          label: gAction.name,
+          'data-test-subj': `${gAction.id}Button`,
+        }))
+      : [];
 
   const resetConnectorForm = useRef<ResetForm | undefined>();
 

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/common/connectors.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/common/connectors.ts
@@ -17,7 +17,8 @@ export const getValidConnectors = (
 
   return connectors.filter(
     (connector) =>
-      (allowGroupConnector.includes(connector.actionTypeId) ||
+      ((allowGroupConnector.includes(connector.actionTypeId) &&
+        actionTypesIndex[connector.actionTypeId].enabledInConfig) ||
         connector.actionTypeId === actionItem.actionTypeId) &&
       // include only enabled by config connectors or preconfigured
       (actionType?.enabledInConfig || connector.isPreconfigured)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][Slack] Allow configuring and accessing only slack web api or webhook (#237640)](https://github.com/elastic/kibana/pull/237640)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Janki Salvi","email":"117571355+js-jankisalvi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-09T12:06:30Z","message":"[ResponseOps][Slack] Allow configuring and accessing only slack web api or webhook (#237640)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/233306\nFixes https://github.com/elastic/kibana/issues/233177\n\nThis PR allows to access only slack web api or slack webhook connector\nwhile creating or updating a rule/connector if only one of them is\nconfigured in kibana.yml.\nIf both of them configured, then connector flyout only shows slack\nconnector with webhook and web api sub types.\n\n\n- When `xpack.actions.enabledActionTypes: ['.slack_api'] `\n\n\nhttps://github.com/user-attachments/assets/6dd0aab4-963b-41ba-ba44-81d42338e2fd\n\n- When `xpack.actions.enabledActionTypes: ['.slack'] `\n\n\nhttps://github.com/user-attachments/assets/47b147dc-5d94-4c3e-b0e2-5bc94e987f0f\n\n- When `xpack.actions.enabledActionTypes: ['.slack', '.slack_api'] `\n\n\nhttps://github.com/user-attachments/assets/7d33fda8-b373-43c8-a6e4-656135c2e3cb\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"44e733173851dba16b1f050947d10451c76df2bd","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","Feature:Actions/ConnectorTypes","backport:all-open","v9.3.0"],"title":"[ResponseOps][Slack] Allow configuring and accessing only slack web api or webhook","number":237640,"url":"https://github.com/elastic/kibana/pull/237640","mergeCommit":{"message":"[ResponseOps][Slack] Allow configuring and accessing only slack web api or webhook (#237640)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/233306\nFixes https://github.com/elastic/kibana/issues/233177\n\nThis PR allows to access only slack web api or slack webhook connector\nwhile creating or updating a rule/connector if only one of them is\nconfigured in kibana.yml.\nIf both of them configured, then connector flyout only shows slack\nconnector with webhook and web api sub types.\n\n\n- When `xpack.actions.enabledActionTypes: ['.slack_api'] `\n\n\nhttps://github.com/user-attachments/assets/6dd0aab4-963b-41ba-ba44-81d42338e2fd\n\n- When `xpack.actions.enabledActionTypes: ['.slack'] `\n\n\nhttps://github.com/user-attachments/assets/47b147dc-5d94-4c3e-b0e2-5bc94e987f0f\n\n- When `xpack.actions.enabledActionTypes: ['.slack', '.slack_api'] `\n\n\nhttps://github.com/user-attachments/assets/7d33fda8-b373-43c8-a6e4-656135c2e3cb\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"44e733173851dba16b1f050947d10451c76df2bd"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237640","number":237640,"mergeCommit":{"message":"[ResponseOps][Slack] Allow configuring and accessing only slack web api or webhook (#237640)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/233306\nFixes https://github.com/elastic/kibana/issues/233177\n\nThis PR allows to access only slack web api or slack webhook connector\nwhile creating or updating a rule/connector if only one of them is\nconfigured in kibana.yml.\nIf both of them configured, then connector flyout only shows slack\nconnector with webhook and web api sub types.\n\n\n- When `xpack.actions.enabledActionTypes: ['.slack_api'] `\n\n\nhttps://github.com/user-attachments/assets/6dd0aab4-963b-41ba-ba44-81d42338e2fd\n\n- When `xpack.actions.enabledActionTypes: ['.slack'] `\n\n\nhttps://github.com/user-attachments/assets/47b147dc-5d94-4c3e-b0e2-5bc94e987f0f\n\n- When `xpack.actions.enabledActionTypes: ['.slack', '.slack_api'] `\n\n\nhttps://github.com/user-attachments/assets/7d33fda8-b373-43c8-a6e4-656135c2e3cb\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"44e733173851dba16b1f050947d10451c76df2bd"}},{"url":"https://github.com/elastic/kibana/pull/238245","number":238245,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/238247","number":238247,"branch":"9.1","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/238257","number":238257,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->