### PR TITLE
[9.1] Fix broken documentation links in API Key creation page (#237964)

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -720,6 +720,13 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       createApiKey: isServerless
         ? `${ELASTICSEARCH_SERVERLESS_APIS}operation/operation-security-create-api-key`
         : `${ELASTICSEARCH_APIS}operation/operation-security-create-api-key`,
+      createApiKeyMetadata: isServerless
+        ? `${ELASTICSEARCH_SERVERLESS_APIS}operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json`
+        : `${ELASTICSEARCH_APIS}operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json`,
+      createApiKeyRoleDescriptors: isServerless
+        ? `${ELASTICSEARCH_SERVERLESS_APIS}operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json-role_descriptors`
+        : `${ELASTICSEARCH_APIS}operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json-role_descriptors`,
+      createCrossClusterApiKey: `${ELASTICSEARCH_APIS}operation/operation-security-create-cross-cluster-api-key`,
       createPipeline: isServerless
         ? `${ELASTICSEARCH_SERVERLESS_APIS}operation/operation-ingest-put-pipeline`
         : `${ELASTICSEARCH_APIS}operation/operation-ingest-put-pipeline`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -380,6 +380,9 @@ export interface DocLinks {
     createRoleMappingTemplates: string;
     createRollupJobsRequest: string;
     createApiKey: string;
+    createApiKeyMetadata: string;
+    createApiKeyRoleDescriptors: string;
+    createCrossClusterApiKey: string;
     createPipeline: string;
     createTransformRequest: string;
     cronExpressions: string;

--- a/x-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx
+++ b/x-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx
@@ -21,6 +21,7 @@ import {
   EuiFormRow,
   EuiHorizontalRule,
   EuiIcon,
+  EuiLink,
   EuiPanel,
   EuiSkeletonText,
   EuiSpacer,
@@ -57,7 +58,7 @@ import type {
   UpdateAPIKeyParams,
   UpdateAPIKeyResult,
 } from './api_keys_api_client';
-import { DocLink } from './doc_link';
+import { useDocLinks } from './doc_link';
 
 const TypeLabel = () => (
   <FormattedMessage
@@ -188,6 +189,7 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
   const {
     services: { http },
   } = useKibana();
+  const [docLinks] = useDocLinks();
   const [responseError, setResponseError] = useState<KibanaServerError | undefined>(undefined);
   const [{ value: roles, loading: isLoadingRoles }, getRoles] = useAsyncFn(() => {
     if (http) {
@@ -700,15 +702,16 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                       />
                     }
                     helpText={
-                      <DocLink
-                        app="elasticsearch"
-                        doc="security-api-create-cross-cluster-api-key.html#security-api-create-cross-cluster-api-key-request-body"
+                      <EuiLink
+                        href={docLinks.apis.createCrossClusterApiKey}
+                        target="_blank"
+                        external
                       >
                         <FormattedMessage
                           id="xpack.security.accountManagement.apiKeyFlyout.accessHelpText"
                           defaultMessage="Learn how to structure access permissions."
                         />
-                      </DocLink>
+                      </EuiLink>
                     }
                     fullWidth
                   >
@@ -835,15 +838,16 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                       </EuiPanel>
                       <FormRow
                         helpText={
-                          <DocLink
-                            app="elasticsearch"
-                            doc="security-api-create-api-key.html#security-api-create-api-key-request-body"
+                          <EuiLink
+                            href={docLinks.apis.createApiKeyRoleDescriptors}
+                            target="_blank"
+                            external
                           >
                             <FormattedMessage
                               id="xpack.security.accountManagement.apiKeyFlyout.roleDescriptorsHelpText"
                               defaultMessage="Learn how to structure role descriptors."
                             />
-                          </DocLink>
+                          </EuiLink>
                         }
                         fullWidth
                         data-test-subj="apiKeysRoleDescriptorsCodeEditor"
@@ -921,15 +925,12 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                     <FormRow
                       data-test-subj="apiKeysMetadataCodeEditor"
                       helpText={
-                        <DocLink
-                          app="elasticsearch"
-                          doc="security-api-create-api-key.html#security-api-create-api-key-request-body"
-                        >
+                        <EuiLink href={docLinks.apis.createApiKeyMetadata} target="_blank" external>
                           <FormattedMessage
                             id="xpack.security.accountManagement.apiKeyFlyout.metadataHelpText"
                             defaultMessage="Learn how to structure metadata."
                           />
-                        </DocLink>
+                        </EuiLink>
                       }
                       fullWidth
                     >


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix broken documentation links in API Key creation page (#237964)](https://github.com/elastic/kibana/pull/237964)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-09T13:40:12Z","message":"Fix broken documentation links in API Key creation page (#237964)\n\n## Summary\n\nFixes three broken documentation links in the \"Create API Key\" page\n(Stack Management → Security → API Keys → Create API Key) that were\nreturning 404 errors.\n\nResolves https://github.com/elastic/kibana/issues/237255\n\n## Problem\n\nUsers clicking on documentation links in the API Key creation flyout\nwere encountering 404 errors. The affected links were:\n- \"Learn how to structure access permissions\" (for cross-cluster API\nkeys)\n- \"Learn how to structure metadata\"\n- \"Learn how to structure role descriptors\"\n\nThese links were using the old documentation URL pattern\n(`https://www.elastic.co/guide/en/elasticsearch/reference/9.1/...`)\nwhich has been replaced with the new API docs pattern\n(`https://www.elastic.co/docs/api/doc/elasticsearch/...`).\n\n## Changes\n\n### Migrated to centralized doc links service\n\nThe component was previously using hardcoded URLs via a custom `DocLink`\ncomponent. This PR updates it to use the centralized doc links service\n(`kbn-doc-links` package), which:\n- Manages all documentation URLs in one place\n- Automatically handles serverless vs non-serverless environments\n- Ensures consistency across the Kibana codebase\n\n### Added three new doc link entries:\n- `createCrossClusterApiKey` - Cross-cluster API key access permissions\ndocumentation\n- `createApiKeyMetadata` - API key metadata structure documentation  \n- `createApiKeyRoleDescriptors` - API key role descriptors structure\ndocumentation\n\n### Updated component implementation:\n- Replaced `DocLink` component with `useDocLinks()` hook and `EuiLink`\n- All three help text links now use the centralized doc links\n\n## New URLs\n\n| Link | Non-serverless URL |\n|------|-------------------|\n| Cross-cluster access |\n`https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key`\n|\n| Metadata |\n`https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json`\n|\n| Role descriptors |\n`https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json-role_descriptors`\n|\n\n_Note: Serverless deployments use the `/elasticsearch-serverless/` path\nvariant automatically._\n\n## Testing\n\n- ✅ ESLint checks passing\n- ✅ Code follows existing patterns in `kbn-doc-links` package\n- ✅ Maintains backward compatibility with existing doc link\ninfrastructure\n\n## Screenshots\n\n**Before:** Links returned 404 errors\n\n![404 error\nscreenshot](https://github.com/user-attachments/assets/affe9d5b-efc1-4d6e-9a85-87b1458877da)\n\n**After:** Links correctly point to the new API documentation\n\nCo-authored-by: florent-leborgne\n<10208282+florent-leborgne@users.noreply.github.com>\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v22.17.1/bin/node\n--no-experimental-require-module scripts/kbn bootstrap --quiet` (dns\nblock)\n> - Triggering command: `node scripts/eslint.js\nsrc/platform/packages/shared/kbn-doc-links/src/types.ts\nsrc/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx`\n(dns block)\n> - Triggering command: `node scripts/eslint.js --fix\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx`\n(dns block)\n> - `download.cypress.io`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v22.17.1/bin/node index.js --exec\ninstall` (dns block)\n> - `googlechromelabs.github.io`\n> - `iojs.org`\n> - Triggering command: `curl -q --fail --compressed -L -s REDACTED -o\n-` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n\n\n\n\n<details>\n\n<summary>Original prompt</summary>\n\n> \n> ----\n> \n> *This section details on the original issue you should resolve*\n> \n> <issue_title>[404] Broken links in create api key page</issue_title>\n> <issue_description>**Kibana version:** 9.1.4\n> \n> **Elasticsearch version:** 9.1.4\n> \n> **Server OS version:**\n> \n> **Browser version:**\n> \n> **Browser OS version:**\n> \n> **Original install method (e.g. download page, yum, from source,\netc.):**\n> ECH cluster\n> \n> **Describe the bug:**\n> Hyperlinks part of the \"Create API Key\" page redirect to 404 page not\nfound.\n> All the hyperlinks end to 404 which could most likely mean the pages\nhave been either moved or removed.\n> \n> List of links:\n> - [Learn how to structure access\npermissions.](https://www.elastic.co/guide/en/elasticsearch/reference/9.1/security-api-create-cross-cluster-api-key.html#security-api-create-cross-cluster-api-key-request-body)\n> - [Learn how to structure\nmetadata.](https://www.elastic.co/guide/en/elasticsearch/reference/9.1/security-api-create-api-key.html#security-api-create-api-key-request-body)\n> - [Learn how to structure role\ndescriptors.](https://www.elastic.co/guide/en/elasticsearch/reference/9.1/security-api-create-api-key.html#security-api-create-api-key-request-body)\n> \n> \n> **Steps to reproduce:**\n> 1. Login to Kibana\n> 2. Navigate to Stack Management -> Security -> API Keys -> Create API\nKey\n> 3. Select Cross-cluster API Key and under access permissions, Click on\nthe hyperlink \"Learn how to structure access permissions.\"\n> \n> **Expected behavior:**\n> \n> **Screenshots (if relevant):**\n> \n> <img width=\"1736\" height=\"465\" alt=\"Image\"\nsrc=\"https://github.com/user-attachments/assets/affe9d5b-efc1-4d6e-9a85-87b1458877da\"\n/>\n> \n> **Errors in browser console (if relevant):**\n> \n> **Provide logs and/or server output (if relevant):**\n> \n> **Any additional context:**\n> </issue_description>\n> \n> <agent_instructions>The\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx\ncontains incorrect links listed in the issue description.\n> Update these links to their correct URL, specified in a comment of the\nissue, and make sure that it uses the doc links service so links can be\nmanaged centrally. The doc links service relies mainly on these two\nfiles:\nhttps://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts\nand\nhttps://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-doc-links/src/types.ts</agent_instructions>\n> \n> ## Comments on the Issue (you are @copilot in this section)\n> \n> <comments>\n> <comment_new><author>@elasticmachine</author><body>\n> Pinging @elastic/experience-docs (Team:Docs)</body></comment_new>\n> <comment_new><author>@florent-leborgne</author><body>\n> The URL structure looks incorrect and doesn't correspond to doc URLs\nsince 9.0. The correct URLs are respectively:\n> \n> -\nhttps://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key\n> -\nhttps://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json\n> -\nhttps://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json-role_descriptors</body></comment_new>\n> <comment_new><author>@florent-leborgne</author><body>\n> These links are also not using the central doc links service\nhttps://github.com/elastic/kibana/tree/main/src/platform/packages/shared/kbn-doc-links/src</body></comment_new>\n> <comment_new><author>@florent-leborgne</author><body>\n> The file containing the incorrect links is\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx</body></comment_new>\n> </comments>\n> \n\n\n</details>\nFixes elastic/kibana#237255\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: florent-leborgne <10208282+florent-leborgne@users.noreply.github.com>\nCo-authored-by: florent-leborgne <florent.leborgne@elastic.co>","sha":"15047411f0d95171d8516be4a993496ca3f038bb","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","Team:Security","release_note:skip","💝community","backport:version","v9.2.0","v9.3.0","v9.1.6","v9.0.9"],"title":"Fix broken documentation links in API Key creation page","number":237964,"url":"https://github.com/elastic/kibana/pull/237964","mergeCommit":{"message":"Fix broken documentation links in API Key creation page (#237964)\n\n## Summary\n\nFixes three broken documentation links in the \"Create API Key\" page\n(Stack Management → Security → API Keys → Create API Key) that were\nreturning 404 errors.\n\nResolves https://github.com/elastic/kibana/issues/237255\n\n## Problem\n\nUsers clicking on documentation links in the API Key creation flyout\nwere encountering 404 errors. The affected links were:\n- \"Learn how to structure access permissions\" (for cross-cluster API\nkeys)\n- \"Learn how to structure metadata\"\n- \"Learn how to structure role descriptors\"\n\nThese links were using the old documentation URL pattern\n(`https://www.elastic.co/guide/en/elasticsearch/reference/9.1/...`)\nwhich has been replaced with the new API docs pattern\n(`https://www.elastic.co/docs/api/doc/elasticsearch/...`).\n\n## Changes\n\n### Migrated to centralized doc links service\n\nThe component was previously using hardcoded URLs via a custom `DocLink`\ncomponent. This PR updates it to use the centralized doc links service\n(`kbn-doc-links` package), which:\n- Manages all documentation URLs in one place\n- Automatically handles serverless vs non-serverless environments\n- Ensures consistency across the Kibana codebase\n\n### Added three new doc link entries:\n- `createCrossClusterApiKey` - Cross-cluster API key access permissions\ndocumentation\n- `createApiKeyMetadata` - API key metadata structure documentation  \n- `createApiKeyRoleDescriptors` - API key role descriptors structure\ndocumentation\n\n### Updated component implementation:\n- Replaced `DocLink` component with `useDocLinks()` hook and `EuiLink`\n- All three help text links now use the centralized doc links\n\n## New URLs\n\n| Link | Non-serverless URL |\n|------|-------------------|\n| Cross-cluster access |\n`https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key`\n|\n| Metadata |\n`https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json`\n|\n| Role descriptors |\n`https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json-role_descriptors`\n|\n\n_Note: Serverless deployments use the `/elasticsearch-serverless/` path\nvariant automatically._\n\n## Testing\n\n- ✅ ESLint checks passing\n- ✅ Code follows existing patterns in `kbn-doc-links` package\n- ✅ Maintains backward compatibility with existing doc link\ninfrastructure\n\n## Screenshots\n\n**Before:** Links returned 404 errors\n\n![404 error\nscreenshot](https://github.com/user-attachments/assets/affe9d5b-efc1-4d6e-9a85-87b1458877da)\n\n**After:** Links correctly point to the new API documentation\n\nCo-authored-by: florent-leborgne\n<10208282+florent-leborgne@users.noreply.github.com>\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v22.17.1/bin/node\n--no-experimental-require-module scripts/kbn bootstrap --quiet` (dns\nblock)\n> - Triggering command: `node scripts/eslint.js\nsrc/platform/packages/shared/kbn-doc-links/src/types.ts\nsrc/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx`\n(dns block)\n> - Triggering command: `node scripts/eslint.js --fix\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx`\n(dns block)\n> - `download.cypress.io`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v22.17.1/bin/node index.js --exec\ninstall` (dns block)\n> - `googlechromelabs.github.io`\n> - `iojs.org`\n> - Triggering command: `curl -q --fail --compressed -L -s REDACTED -o\n-` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n\n\n\n\n<details>\n\n<summary>Original prompt</summary>\n\n> \n> ----\n> \n> *This section details on the original issue you should resolve*\n> \n> <issue_title>[404] Broken links in create api key page</issue_title>\n> <issue_description>**Kibana version:** 9.1.4\n> \n> **Elasticsearch version:** 9.1.4\n> \n> **Server OS version:**\n> \n> **Browser version:**\n> \n> **Browser OS version:**\n> \n> **Original install method (e.g. download page, yum, from source,\netc.):**\n> ECH cluster\n> \n> **Describe the bug:**\n> Hyperlinks part of the \"Create API Key\" page redirect to 404 page not\nfound.\n> All the hyperlinks end to 404 which could most likely mean the pages\nhave been either moved or removed.\n> \n> List of links:\n> - [Learn how to structure access\npermissions.](https://www.elastic.co/guide/en/elasticsearch/reference/9.1/security-api-create-cross-cluster-api-key.html#security-api-create-cross-cluster-api-key-request-body)\n> - [Learn how to structure\nmetadata.](https://www.elastic.co/guide/en/elasticsearch/reference/9.1/security-api-create-api-key.html#security-api-create-api-key-request-body)\n> - [Learn how to structure role\ndescriptors.](https://www.elastic.co/guide/en/elasticsearch/reference/9.1/security-api-create-api-key.html#security-api-create-api-key-request-body)\n> \n> \n> **Steps to reproduce:**\n> 1. Login to Kibana\n> 2. Navigate to Stack Management -> Security -> API Keys -> Create API\nKey\n> 3. Select Cross-cluster API Key and under access permissions, Click on\nthe hyperlink \"Learn how to structure access permissions.\"\n> \n> **Expected behavior:**\n> \n> **Screenshots (if relevant):**\n> \n> <img width=\"1736\" height=\"465\" alt=\"Image\"\nsrc=\"https://github.com/user-attachments/assets/affe9d5b-efc1-4d6e-9a85-87b1458877da\"\n/>\n> \n> **Errors in browser console (if relevant):**\n> \n> **Provide logs and/or server output (if relevant):**\n> \n> **Any additional context:**\n> </issue_description>\n> \n> <agent_instructions>The\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx\ncontains incorrect links listed in the issue description.\n> Update these links to their correct URL, specified in a comment of the\nissue, and make sure that it uses the doc links service so links can be\nmanaged centrally. The doc links service relies mainly on these two\nfiles:\nhttps://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts\nand\nhttps://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-doc-links/src/types.ts</agent_instructions>\n> \n> ## Comments on the Issue (you are @copilot in this section)\n> \n> <comments>\n> <comment_new><author>@elasticmachine</author><body>\n> Pinging @elastic/experience-docs (Team:Docs)</body></comment_new>\n> <comment_new><author>@florent-leborgne</author><body>\n> The URL structure looks incorrect and doesn't correspond to doc URLs\nsince 9.0. The correct URLs are respectively:\n> \n> -\nhttps://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key\n> -\nhttps://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json\n> -\nhttps://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json-role_descriptors</body></comment_new>\n> <comment_new><author>@florent-leborgne</author><body>\n> These links are also not using the central doc links service\nhttps://github.com/elastic/kibana/tree/main/src/platform/packages/shared/kbn-doc-links/src</body></comment_new>\n> <comment_new><author>@florent-leborgne</author><body>\n> The file containing the incorrect links is\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx</body></comment_new>\n> </comments>\n> \n\n\n</details>\nFixes elastic/kibana#237255\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: florent-leborgne <10208282+florent-leborgne@users.noreply.github.com>\nCo-authored-by: florent-leborgne <florent.leborgne@elastic.co>","sha":"15047411f0d95171d8516be4a993496ca3f038bb"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.1"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237964","number":237964,"mergeCommit":{"message":"Fix broken documentation links in API Key creation page (#237964)\n\n## Summary\n\nFixes three broken documentation links in the \"Create API Key\" page\n(Stack Management → Security → API Keys → Create API Key) that were\nreturning 404 errors.\n\nResolves https://github.com/elastic/kibana/issues/237255\n\n## Problem\n\nUsers clicking on documentation links in the API Key creation flyout\nwere encountering 404 errors. The affected links were:\n- \"Learn how to structure access permissions\" (for cross-cluster API\nkeys)\n- \"Learn how to structure metadata\"\n- \"Learn how to structure role descriptors\"\n\nThese links were using the old documentation URL pattern\n(`https://www.elastic.co/guide/en/elasticsearch/reference/9.1/...`)\nwhich has been replaced with the new API docs pattern\n(`https://www.elastic.co/docs/api/doc/elasticsearch/...`).\n\n## Changes\n\n### Migrated to centralized doc links service\n\nThe component was previously using hardcoded URLs via a custom `DocLink`\ncomponent. This PR updates it to use the centralized doc links service\n(`kbn-doc-links` package), which:\n- Manages all documentation URLs in one place\n- Automatically handles serverless vs non-serverless environments\n- Ensures consistency across the Kibana codebase\n\n### Added three new doc link entries:\n- `createCrossClusterApiKey` - Cross-cluster API key access permissions\ndocumentation\n- `createApiKeyMetadata` - API key metadata structure documentation  \n- `createApiKeyRoleDescriptors` - API key role descriptors structure\ndocumentation\n\n### Updated component implementation:\n- Replaced `DocLink` component with `useDocLinks()` hook and `EuiLink`\n- All three help text links now use the centralized doc links\n\n## New URLs\n\n| Link | Non-serverless URL |\n|------|-------------------|\n| Cross-cluster access |\n`https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key`\n|\n| Metadata |\n`https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json`\n|\n| Role descriptors |\n`https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json-role_descriptors`\n|\n\n_Note: Serverless deployments use the `/elasticsearch-serverless/` path\nvariant automatically._\n\n## Testing\n\n- ✅ ESLint checks passing\n- ✅ Code follows existing patterns in `kbn-doc-links` package\n- ✅ Maintains backward compatibility with existing doc link\ninfrastructure\n\n## Screenshots\n\n**Before:** Links returned 404 errors\n\n![404 error\nscreenshot](https://github.com/user-attachments/assets/affe9d5b-efc1-4d6e-9a85-87b1458877da)\n\n**After:** Links correctly point to the new API documentation\n\nCo-authored-by: florent-leborgne\n<10208282+florent-leborgne@users.noreply.github.com>\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v22.17.1/bin/node\n--no-experimental-require-module scripts/kbn bootstrap --quiet` (dns\nblock)\n> - Triggering command: `node scripts/eslint.js\nsrc/platform/packages/shared/kbn-doc-links/src/types.ts\nsrc/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx`\n(dns block)\n> - Triggering command: `node scripts/eslint.js --fix\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx`\n(dns block)\n> - `download.cypress.io`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v22.17.1/bin/node index.js --exec\ninstall` (dns block)\n> - `googlechromelabs.github.io`\n> - `iojs.org`\n> - Triggering command: `curl -q --fail --compressed -L -s REDACTED -o\n-` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n\n\n\n\n<details>\n\n<summary>Original prompt</summary>\n\n> \n> ----\n> \n> *This section details on the original issue you should resolve*\n> \n> <issue_title>[404] Broken links in create api key page</issue_title>\n> <issue_description>**Kibana version:** 9.1.4\n> \n> **Elasticsearch version:** 9.1.4\n> \n> **Server OS version:**\n> \n> **Browser version:**\n> \n> **Browser OS version:**\n> \n> **Original install method (e.g. download page, yum, from source,\netc.):**\n> ECH cluster\n> \n> **Describe the bug:**\n> Hyperlinks part of the \"Create API Key\" page redirect to 404 page not\nfound.\n> All the hyperlinks end to 404 which could most likely mean the pages\nhave been either moved or removed.\n> \n> List of links:\n> - [Learn how to structure access\npermissions.](https://www.elastic.co/guide/en/elasticsearch/reference/9.1/security-api-create-cross-cluster-api-key.html#security-api-create-cross-cluster-api-key-request-body)\n> - [Learn how to structure\nmetadata.](https://www.elastic.co/guide/en/elasticsearch/reference/9.1/security-api-create-api-key.html#security-api-create-api-key-request-body)\n> - [Learn how to structure role\ndescriptors.](https://www.elastic.co/guide/en/elasticsearch/reference/9.1/security-api-create-api-key.html#security-api-create-api-key-request-body)\n> \n> \n> **Steps to reproduce:**\n> 1. Login to Kibana\n> 2. Navigate to Stack Management -> Security -> API Keys -> Create API\nKey\n> 3. Select Cross-cluster API Key and under access permissions, Click on\nthe hyperlink \"Learn how to structure access permissions.\"\n> \n> **Expected behavior:**\n> \n> **Screenshots (if relevant):**\n> \n> <img width=\"1736\" height=\"465\" alt=\"Image\"\nsrc=\"https://github.com/user-attachments/assets/affe9d5b-efc1-4d6e-9a85-87b1458877da\"\n/>\n> \n> **Errors in browser console (if relevant):**\n> \n> **Provide logs and/or server output (if relevant):**\n> \n> **Any additional context:**\n> </issue_description>\n> \n> <agent_instructions>The\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx\ncontains incorrect links listed in the issue description.\n> Update these links to their correct URL, specified in a comment of the\nissue, and make sure that it uses the doc links service so links can be\nmanaged centrally. The doc links service relies mainly on these two\nfiles:\nhttps://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts\nand\nhttps://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-doc-links/src/types.ts</agent_instructions>\n> \n> ## Comments on the Issue (you are @copilot in this section)\n> \n> <comments>\n> <comment_new><author>@elasticmachine</author><body>\n> Pinging @elastic/experience-docs (Team:Docs)</body></comment_new>\n> <comment_new><author>@florent-leborgne</author><body>\n> The URL structure looks incorrect and doesn't correspond to doc URLs\nsince 9.0. The correct URLs are respectively:\n> \n> -\nhttps://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key\n> -\nhttps://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json\n> -\nhttps://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key#operation-security-create-api-key-body-application-json-role_descriptors</body></comment_new>\n> <comment_new><author>@florent-leborgne</author><body>\n> These links are also not using the central doc links service\nhttps://github.com/elastic/kibana/tree/main/src/platform/packages/shared/kbn-doc-links/src</body></comment_new>\n> <comment_new><author>@florent-leborgne</author><body>\n> The file containing the incorrect links is\nx-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx</body></comment_new>\n> </comments>\n> \n\n\n</details>\nFixes elastic/kibana#237255\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: florent-leborgne <10208282+florent-leborgne@users.noreply.github.com>\nCo-authored-by: florent-leborgne <florent.leborgne@elastic.co>","sha":"15047411f0d95171d8516be4a993496ca3f038bb"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238261","number":238261,"state":"OPEN"}]}] BACKPORT-->