### PR TITLE
[Discover BGS] Prevent new searches when histogram state is toggled

### DIFF
--- a/src/platform/plugins/shared/discover/common/app_locator.ts
+++ b/src/platform/plugins/shared/discover/common/app_locator.ts
@@ -110,6 +110,14 @@ export interface DiscoverAppLocatorParams extends SerializableRecord {
    */
   breakdownField?: string;
   /**
+   * Used to force the chart to be hidden or visible
+   */
+  hideChart?: boolean;
+  /**
+   * Number of rows to sample for Discover grid
+   */
+  sampleSize?: number;
+  /**
    * Used when navigating to particular alert results
    */
   isAlertResults?: boolean;

--- a/src/platform/plugins/shared/discover/common/app_locator_get_location.ts
+++ b/src/platform/plugins/shared/discover/common/app_locator_get_location.ts
@@ -86,6 +86,8 @@ export const parseAppLocatorParams = (params: DiscoverAppLocatorParams) => {
     viewMode,
     hideAggregatedPreview,
     breakdownField,
+    hideChart,
+    sampleSize,
     isAlertResults,
   } = params;
 
@@ -109,6 +111,8 @@ export const parseAppLocatorParams = (params: DiscoverAppLocatorParams) => {
   if (viewMode) appState.viewMode = viewMode;
   if (hideAggregatedPreview) appState.hideAggregatedPreview = hideAggregatedPreview;
   if (breakdownField) appState.breakdownField = breakdownField;
+  if (typeof hideChart === 'boolean') appState.hideChart = hideChart;
+  if (typeof sampleSize === 'number' && sampleSize > 0) appState.sampleSize = sampleSize;
 
   const state: MainHistoryLocationState = {};
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
@@ -728,5 +728,11 @@ function createUrlGeneratorState({
     hideAggregatedPreview: appState.hideAggregatedPreview,
     breakdownField: appState.breakdownField,
     dataViewSpec: !dataView?.isPersisted() ? dataView?.toMinimalSpec() : undefined,
+    ...(shouldRestoreSearchSession
+      ? {
+          hideChart: appState.hideChart ?? false,
+          sampleSize: appState.sampleSize,
+        }
+      : {}),
   };
 }


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/237219

## Summary

This PR adds `hideChart` and `sampleSize` to the restorable state of a search session.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->