### PR TITLE
[Cases] Reduce amount of sync tasks by a factor of 4

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/constants.ts
@@ -87,11 +87,6 @@ export const getCAIActivityBackfillTaskId = (spaceId: string, owner: Owner): str
   return `${CAI_ACTIVITY_BACKFILL_TASK_ID}-${spaceId}-${owner}`;
 };
 
-const CAI_ACTIVITY_SYNCHRONIZATION_TASK_ID = 'cai_cases_activity_synchronization_task';
-export const getCAIActivitySynchronizationTaskId = (spaceId: string, owner: Owner): string => {
-  return `${CAI_ACTIVITY_SYNCHRONIZATION_TASK_ID}-${spaceId}-${owner}`;
-};
-
 export const getActivitySynchronizationSourceQuery = (
   lastSyncAt: Date,
   spaceId: string,

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/index.ts
@@ -15,13 +15,10 @@ import {
   CAI_ACTIVITY_INDEX_VERSION,
   CAI_ACTIVITY_SOURCE_INDEX,
   getActivitySourceQuery,
-  getCAIActivitySynchronizationTaskId,
   getCAIActivityBackfillTaskId,
-  CAI_ACTIVITY_SYNC_TYPE,
 } from './constants';
 import { CAI_ACTIVITY_INDEX_MAPPINGS } from './mappings';
 import { CAI_ACTIVITY_INDEX_SCRIPT, CAI_ACTIVITY_INDEX_SCRIPT_ID } from './painless_scripts';
-import { scheduleCAISynchronizationTask } from '../tasks/synchronization_task';
 
 export const createActivityAnalyticsIndex = ({
   esClient,
@@ -53,29 +50,3 @@ export const createActivityAnalyticsIndex = ({
     sourceIndex: CAI_ACTIVITY_SOURCE_INDEX,
     sourceQuery: getActivitySourceQuery(spaceId, owner),
   });
-
-export const scheduleActivityAnalyticsSyncTask = ({
-  taskManager,
-  logger,
-  spaceId,
-  owner,
-}: {
-  taskManager: TaskManagerStartContract;
-  logger: Logger;
-  spaceId: string;
-  owner: Owner;
-}) => {
-  const taskId = getCAIActivitySynchronizationTaskId(spaceId, owner);
-  scheduleCAISynchronizationTask({
-    taskId,
-    sourceIndex: CAI_ACTIVITY_SOURCE_INDEX,
-    destIndex: getActivityDestinationIndexName(spaceId, owner),
-    spaceId,
-    owner,
-    syncType: CAI_ACTIVITY_SYNC_TYPE,
-    taskManager,
-    logger,
-  }).catch((e) => {
-    logger.error(`Error scheduling ${taskId} task, received ${e.message}`);
-  });
-};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/constants.ts
@@ -72,11 +72,6 @@ export const getCAIAttachmentsBackfillTaskId = (spaceId: string, owner: Owner): 
   return `${CAI_ATTACHMENTS_BACKFILL_TASK_ID}-${spaceId}-${owner}`;
 };
 
-const CAI_ATTACHMENTS_SYNCHRONIZATION_TASK_ID = 'cai_cases_attachments_synchronization_task';
-export const getCAIAttachmentsSynchronizationTaskId = (spaceId: string, owner: Owner): string => {
-  return `${CAI_ATTACHMENTS_SYNCHRONIZATION_TASK_ID}-${spaceId}-${owner}`;
-};
-
 export const getAttachmentsSynchronizationSourceQuery = (
   lastSyncAt: Date,
   spaceId: string,

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/index.ts
@@ -16,12 +16,9 @@ import {
   CAI_ATTACHMENTS_SOURCE_INDEX,
   getAttachmentsSourceQuery,
   getCAIAttachmentsBackfillTaskId,
-  getCAIAttachmentsSynchronizationTaskId,
-  CAI_ATTACHMENTS_SYNC_TYPE,
 } from './constants';
 import { CAI_ATTACHMENTS_INDEX_MAPPINGS } from './mappings';
 import { CAI_ATTACHMENTS_INDEX_SCRIPT, CAI_ATTACHMENTS_INDEX_SCRIPT_ID } from './painless_scripts';
-import { scheduleCAISynchronizationTask } from '../tasks/synchronization_task';
 
 export const createAttachmentsAnalyticsIndex = ({
   esClient,
@@ -53,29 +50,3 @@ export const createAttachmentsAnalyticsIndex = ({
     sourceIndex: CAI_ATTACHMENTS_SOURCE_INDEX,
     sourceQuery: getAttachmentsSourceQuery(spaceId, owner),
   });
-
-export const scheduleAttachmentsAnalyticsSyncTask = ({
-  taskManager,
-  logger,
-  spaceId,
-  owner,
-}: {
-  taskManager: TaskManagerStartContract;
-  logger: Logger;
-  spaceId: string;
-  owner: Owner;
-}) => {
-  const taskId = getCAIAttachmentsSynchronizationTaskId(spaceId, owner);
-  scheduleCAISynchronizationTask({
-    taskId,
-    sourceIndex: CAI_ATTACHMENTS_SOURCE_INDEX,
-    destIndex: getAttachmentsDestinationIndexName(spaceId, owner),
-    taskManager,
-    spaceId,
-    owner,
-    syncType: CAI_ATTACHMENTS_SYNC_TYPE,
-    logger,
-  }).catch((e) => {
-    logger.error(`Error scheduling ${taskId} task, received ${e.message}`);
-  });
-};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/constants.ts
@@ -53,10 +53,6 @@ export const getCAICasesBackfillTaskId = (spaceId: string, owner: Owner): string
   return `${CAI_CASES_BACKFILL_TASK_ID}-${spaceId}-${owner}`;
 };
 
-const CAI_CASES_SYNCHRONIZATION_TASK_ID_BASE = 'cai_cases_synchronization_task';
-export const getCAICasesSynchronizationTaskId = (spaceId: string, owner: Owner) =>
-  `${CAI_CASES_SYNCHRONIZATION_TASK_ID_BASE}-${spaceId}-${owner}`;
-
 export const getCasesSynchronizationSourceQuery = (
   lastSyncAt: Date,
   spaceId: string,

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/index.ts
@@ -16,12 +16,9 @@ import {
   CAI_CASES_SOURCE_INDEX,
   getCasesSourceQuery,
   getCAICasesBackfillTaskId,
-  getCAICasesSynchronizationTaskId,
-  CAI_CASES_SYNC_TYPE,
 } from './constants';
 import { CAI_CASES_INDEX_MAPPINGS } from './mappings';
 import { CAI_CASES_INDEX_SCRIPT_ID, CAI_CASES_INDEX_SCRIPT } from './painless_scripts';
-import { scheduleCAISynchronizationTask } from '../tasks/synchronization_task';
 
 export const createCasesAnalyticsIndex = ({
   esClient,
@@ -53,29 +50,3 @@ export const createCasesAnalyticsIndex = ({
     sourceIndex: CAI_CASES_SOURCE_INDEX,
     sourceQuery: getCasesSourceQuery(spaceId, owner),
   });
-
-export const scheduleCasesAnalyticsSyncTask = ({
-  taskManager,
-  logger,
-  spaceId,
-  owner,
-}: {
-  taskManager: TaskManagerStartContract;
-  logger: Logger;
-  spaceId: string;
-  owner: Owner;
-}) => {
-  const taskId = getCAICasesSynchronizationTaskId(spaceId, owner);
-  scheduleCAISynchronizationTask({
-    taskId,
-    sourceIndex: CAI_CASES_SOURCE_INDEX,
-    destIndex: getCasesDestinationIndexName(spaceId, owner),
-    spaceId,
-    owner,
-    syncType: CAI_CASES_SYNC_TYPE,
-    taskManager,
-    logger,
-  }).catch((e) => {
-    logger.error(`Error scheduling ${taskId} task, received ${e.message}`);
-  });
-};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/constants.ts
@@ -58,11 +58,6 @@ export const getCAICommentsBackfillTaskId = (spaceId: string, owner: Owner): str
   return `${CAI_COMMENTS_BACKFILL_TASK_ID}-${spaceId}-${owner}`;
 };
 
-const CAI_COMMENTS_SYNCHRONIZATION_TASK_ID = 'cai_cases_comments_synchronization_task';
-export const getCAICommentsSynchronizationTaskId = (spaceId: string, owner: Owner): string => {
-  return `${CAI_COMMENTS_SYNCHRONIZATION_TASK_ID}-${spaceId}-${owner}`;
-};
-
 export const getCommentsSynchronizationSourceQuery = (
   lastSyncAt: Date,
   spaceId: string,

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/index.ts
@@ -16,12 +16,9 @@ import {
   CAI_COMMENTS_SOURCE_INDEX,
   getCommentsSourceQuery,
   getCAICommentsBackfillTaskId,
-  getCAICommentsSynchronizationTaskId,
-  CAI_COMMENTS_SYNC_TYPE,
 } from './constants';
 import { CAI_COMMENTS_INDEX_MAPPINGS } from './mappings';
 import { CAI_COMMENTS_INDEX_SCRIPT, CAI_COMMENTS_INDEX_SCRIPT_ID } from './painless_scripts';
-import { scheduleCAISynchronizationTask } from '../tasks/synchronization_task';
 
 export const createCommentsAnalyticsIndex = ({
   esClient,
@@ -53,29 +50,3 @@ export const createCommentsAnalyticsIndex = ({
     sourceIndex: CAI_COMMENTS_SOURCE_INDEX,
     sourceQuery: getCommentsSourceQuery(spaceId, owner),
   });
-
-export const scheduleCommentsAnalyticsSyncTask = ({
-  taskManager,
-  logger,
-  spaceId,
-  owner,
-}: {
-  taskManager: TaskManagerStartContract;
-  logger: Logger;
-  spaceId: string;
-  owner: Owner;
-}) => {
-  const taskId = getCAICommentsSynchronizationTaskId(spaceId, owner);
-  scheduleCAISynchronizationTask({
-    taskId,
-    sourceIndex: CAI_COMMENTS_SOURCE_INDEX,
-    destIndex: getCommentsDestinationIndexName(spaceId, owner),
-    taskManager,
-    owner,
-    spaceId,
-    syncType: CAI_COMMENTS_SYNC_TYPE,
-    logger,
-  }).catch((e) => {
-    logger.error(`Error scheduling ${taskId} task, received ${e.message}`);
-  });
-};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/constants.ts
@@ -9,16 +9,27 @@ import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/type
 
 import type { Owner } from '../../common/constants/types';
 import {
+  CAI_ATTACHMENTS_SOURCE_INDEX,
   CAI_ATTACHMENTS_SYNC_TYPE,
+  getAttachmentsDestinationIndexName,
   getAttachmentsSynchronizationSourceQuery,
 } from './attachments_index/constants';
-import { CAI_CASES_SYNC_TYPE, getCasesSynchronizationSourceQuery } from './cases_index/constants';
 import {
+  CAI_CASES_SOURCE_INDEX,
+  CAI_CASES_SYNC_TYPE,
+  getCasesDestinationIndexName,
+  getCasesSynchronizationSourceQuery,
+} from './cases_index/constants';
+import {
+  CAI_COMMENTS_SOURCE_INDEX,
   CAI_COMMENTS_SYNC_TYPE,
+  getCommentsDestinationIndexName,
   getCommentsSynchronizationSourceQuery,
 } from './comments_index/constants';
 import {
+  CAI_ACTIVITY_SOURCE_INDEX,
   CAI_ACTIVITY_SYNC_TYPE,
+  getActivityDestinationIndexName,
   getActivitySynchronizationSourceQuery,
 } from './activity_index/constants';
 
@@ -45,6 +56,13 @@ export type CAISyncType =
   | typeof CAI_ATTACHMENTS_SYNC_TYPE
   | typeof CAI_ACTIVITY_SYNC_TYPE;
 
+export const CAISyncTypes = [
+  CAI_CASES_SYNC_TYPE,
+  CAI_COMMENTS_SYNC_TYPE,
+  CAI_ATTACHMENTS_SYNC_TYPE,
+  CAI_ACTIVITY_SYNC_TYPE,
+] as const;
+
 export const SYNCHRONIZATION_QUERIES_DICTIONARY: Record<
   string,
   (lastSyncAt: Date, spaceId: string, owner: Owner) => QueryDslQueryContainer
@@ -53,4 +71,38 @@ export const SYNCHRONIZATION_QUERIES_DICTIONARY: Record<
   [CAI_COMMENTS_SYNC_TYPE]: getCommentsSynchronizationSourceQuery,
   [CAI_ATTACHMENTS_SYNC_TYPE]: getAttachmentsSynchronizationSourceQuery,
   [CAI_ACTIVITY_SYNC_TYPE]: getActivitySynchronizationSourceQuery,
+};
+
+export const sourceIndexBySyncType = (syncType: CAISyncType): string => {
+  switch (syncType) {
+    case CAI_CASES_SYNC_TYPE:
+      return CAI_CASES_SOURCE_INDEX;
+    case CAI_COMMENTS_SYNC_TYPE:
+      return CAI_COMMENTS_SOURCE_INDEX;
+    case CAI_ATTACHMENTS_SYNC_TYPE:
+      return CAI_ATTACHMENTS_SOURCE_INDEX;
+    case CAI_ACTIVITY_SYNC_TYPE:
+      return CAI_ACTIVITY_SOURCE_INDEX;
+    default:
+      throw new Error(`[sourceIndexBySyncType]: Unknown sync type: ${syncType}`);
+  }
+};
+
+export const destinationIndexBySyncType = (
+  syncType: CAISyncType,
+  spaceId: string,
+  owner: Owner
+): string => {
+  switch (syncType) {
+    case CAI_CASES_SYNC_TYPE:
+      return getCasesDestinationIndexName(spaceId, owner);
+    case CAI_COMMENTS_SYNC_TYPE:
+      return getCommentsDestinationIndexName(spaceId, owner);
+    case CAI_ATTACHMENTS_SYNC_TYPE:
+      return getAttachmentsDestinationIndexName(spaceId, owner);
+    case CAI_ACTIVITY_SYNC_TYPE:
+      return getActivityDestinationIndexName(spaceId, owner);
+    default:
+      throw new Error(`[destinationIndexBySyncType]: Unknown sync type: ${syncType}`);
+  }
 };

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/index.ts
@@ -18,14 +18,14 @@ import type {
 import { OWNERS } from '../../common/constants';
 import type { CasesServerStartDependencies } from '../types';
 import { registerCAIBackfillTask } from './tasks/backfill_task';
-import { registerCAISynchronizationTask } from './tasks/synchronization_task';
 import {
-  createAttachmentsAnalyticsIndex,
-  scheduleAttachmentsAnalyticsSyncTask,
-} from './attachments_index';
-import { createCasesAnalyticsIndex, scheduleCasesAnalyticsSyncTask } from './cases_index';
-import { createCommentsAnalyticsIndex, scheduleCommentsAnalyticsSyncTask } from './comments_index';
-import { createActivityAnalyticsIndex, scheduleActivityAnalyticsSyncTask } from './activity_index';
+  registerCAISynchronizationTask,
+  scheduleCAISynchronizationTask,
+} from './tasks/synchronization_task';
+import { createAttachmentsAnalyticsIndex } from './attachments_index';
+import { createCasesAnalyticsIndex } from './cases_index';
+import { createCommentsAnalyticsIndex } from './comments_index';
+import { createActivityAnalyticsIndex } from './activity_index';
 import type { ConfigType } from '../config';
 import { getAllSpacesWithCases } from './utils';
 import { registerCAISchedulerTask } from './tasks/scheduler_task';
@@ -147,10 +147,7 @@ export const scheduleCasesAnalyticsSyncTasks = ({
   spaceId: string;
 }) => {
   for (const owner of OWNERS) {
-    scheduleActivityAnalyticsSyncTask({ taskManager, logger, spaceId, owner });
-    scheduleCasesAnalyticsSyncTask({ taskManager, logger, spaceId, owner });
-    scheduleCommentsAnalyticsSyncTask({ taskManager, logger, spaceId, owner });
-    scheduleAttachmentsAnalyticsSyncTask({ taskManager, logger, spaceId, owner });
+    scheduleCAISynchronizationTask({ taskManager, logger, spaceId, owner });
   }
 };
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/index.ts
@@ -147,7 +147,7 @@ export const scheduleCasesAnalyticsSyncTasks = ({
   spaceId: string;
 }) => {
   for (const owner of OWNERS) {
-    scheduleCAISynchronizationTask({ taskManager, logger, spaceId, owner });
+    void scheduleCAISynchronizationTask({ taskManager, logger, spaceId, owner });
   }
 };
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/index.ts
@@ -18,7 +18,6 @@ import { ANALYTICS_SYNCHRONIZATION_TASK_TYPE } from '../../../../common/constant
 import type { Owner } from '../../../../common/constants/types';
 import type { CasesServerStartDependencies } from '../../../types';
 import { AnalyticsIndexSynchronizationTaskFactory } from './synchronization_task_factory';
-import type { CAISyncType } from '../../constants';
 
 const SCHEDULE: IntervalSchedule = { interval: '5m' };
 
@@ -52,30 +51,27 @@ export function registerCAISynchronizationTask({
   });
 }
 
+export function getSynchronizationTaskId(spaceId: string, owner: Owner): string {
+  return `cai_cases_analytics_sync_${spaceId}_${owner}`;
+}
+
 export async function scheduleCAISynchronizationTask({
-  taskId,
-  sourceIndex,
-  destIndex,
   taskManager,
   logger,
   spaceId,
   owner,
-  syncType,
 }: {
-  taskId: string;
-  sourceIndex: string;
-  destIndex: string;
   taskManager: TaskManagerStartContract;
   logger: Logger;
   spaceId: string;
   owner: Owner;
-  syncType: CAISyncType;
 }) {
+  const taskId = getSynchronizationTaskId(spaceId, owner);
   try {
     await taskManager.ensureScheduled({
       id: taskId,
       taskType: ANALYTICS_SYNCHRONIZATION_TASK_TYPE,
-      params: { sourceIndex, destIndex, owner, spaceId, syncType },
+      params: { owner, spaceId },
       schedule: SCHEDULE, // every 5 minutes
       state: {},
     });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_sub_task.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_sub_task.ts
@@ -1,0 +1,324 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import {
+  TaskErrorSource,
+  createTaskRunError,
+  throwRetryableError,
+  throwUnrecoverableError,
+} from '@kbn/task-manager-plugin/server';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type {
+  IndicesGetMappingResponse,
+  QueryDslQueryContainer,
+} from '@elastic/elasticsearch/lib/api/types';
+import type { Owner } from '../../../../common/constants/types';
+import { isRetryableEsClientError } from '../../utils';
+import { type CAISyncType, SYNCHRONIZATION_QUERIES_DICTIONARY } from '../../constants';
+
+const LOOKBACK_WINDOW = 5 * 60 * 1000;
+
+interface SynchronizationTaskState {
+  lastSyncSuccess?: Date | undefined;
+  lastSyncAttempt?: Date | undefined;
+  esReindexTaskId?: TaskId | undefined;
+  syncType?: CAISyncType;
+}
+
+enum ReindexStatus {
+  RUNNING = 'running',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  MISSING_TASK_ID = 'missing_task_id',
+}
+
+export class SynchronizationSubTaskRunner {
+  private readonly sourceIndex: string;
+  private readonly destIndex: string;
+  private readonly owner: Owner;
+  private readonly spaceId: string;
+  private readonly syncType: CAISyncType;
+  private readonly esClient: ElasticsearchClient;
+  private readonly logger: Logger;
+  private readonly errorSource = TaskErrorSource.FRAMEWORK;
+  private readonly esReindexTaskId: TaskId | undefined;
+  private lastSyncSuccess: Date | undefined;
+  private lastSyncAttempt: Date | undefined;
+
+  constructor({
+    esReindexTaskId,
+    lastSyncSuccess,
+    lastSyncAttempt,
+    sourceIndex,
+    destIndex,
+    owner,
+    spaceId,
+    syncType,
+    esClient,
+    logger,
+  }: {
+    esReindexTaskId?: TaskId;
+    lastSyncSuccess?: string;
+    lastSyncAttempt?: string;
+    sourceIndex: string;
+    destIndex: string;
+    owner: Owner;
+    spaceId: string;
+    syncType: CAISyncType;
+    esClient: ElasticsearchClient;
+    logger: Logger;
+  }) {
+    if (lastSyncSuccess) this.lastSyncSuccess = new Date(lastSyncSuccess);
+    if (lastSyncAttempt) this.lastSyncAttempt = new Date(lastSyncAttempt);
+    this.esReindexTaskId = esReindexTaskId;
+    this.sourceIndex = sourceIndex;
+    this.destIndex = destIndex;
+    this.owner = owner;
+    this.spaceId = spaceId;
+    this.syncType = syncType;
+    this.esClient = esClient;
+    this.logger = logger;
+  }
+
+  public async run(): Promise<SynchronizationTaskState | undefined> {
+    const esClient = this.esClient;
+
+    try {
+      // Parent task
+      const destIndexExists = await esClient.indices.exists({ index: this.destIndex });
+
+      if (!destIndexExists) {
+        this.logDebug('Destination index does not exist, skipping synchronization task.');
+        return;
+      }
+
+      const previousReindexStatus = await this.getPreviousReindexStatus(esClient);
+      this.logDebug(`Previous synchronization task status: "${previousReindexStatus}".`);
+      // Break down previousReindexStatus into status for each sub task. Broken down by syncType.
+      // </Parent task>
+
+      // Sub task
+      if (previousReindexStatus === ReindexStatus.RUNNING) {
+        /*
+         * If the reindex task is still running we return the
+         * same state and the next run will cover any missing
+         * updates.
+         **/
+        return this.getSyncState() as Record<string, unknown>;
+      }
+
+      if (previousReindexStatus === ReindexStatus.COMPLETED) {
+        /*
+         * If the previous reindex task is completed we reindex
+         * with a new time window.
+         **/
+        await this.isIndexAvailable(esClient);
+
+        this.updateLastSyncTimes({ updateSuccessTime: true });
+
+        const esReindexTaskId = await this.synchronizeIndex({ esClient });
+
+        return {
+          lastSyncSuccess: this.lastSyncSuccess,
+          lastSyncAttempt: this.lastSyncAttempt,
+          syncType: this.syncType,
+          esReindexTaskId,
+        };
+      }
+
+      if (
+        /*
+         * A missing task id can only happen if this is
+         * the first task execution.
+         **/
+        previousReindexStatus === ReindexStatus.MISSING_TASK_ID ||
+        previousReindexStatus === ReindexStatus.FAILED
+      ) {
+        await this.isIndexAvailable(esClient);
+
+        /*
+         * There are two possible scenarios here:
+         * 1. If the previous task failed (ReindexStatus.FAILED)
+         * 2. If the state is missing
+         *
+         * In both cases we try to reindex without updating lastSyncSuccess.
+         * This will ensure the reindex query is built with the correct value.
+         **/
+        this.updateLastSyncTimes({ updateSuccessTime: false });
+
+        const esReindexTaskId = await this.synchronizeIndex({ esClient });
+
+        return {
+          lastSyncSuccess: this.lastSyncSuccess,
+          lastSyncAttempt: this.lastSyncAttempt,
+          syncType: this.syncType,
+          esReindexTaskId,
+        };
+      }
+
+      throw new Error('Invalid task state.');
+    } catch (e) {
+      if (isRetryableEsClientError(e)) {
+        throwRetryableError(
+          createTaskRunError(new Error(this.handleErrorMessage(e.message)), this.errorSource),
+          true
+        );
+      }
+
+      this.handleErrorMessage(e.message);
+      throwUnrecoverableError(createTaskRunError(e, this.errorSource));
+    }
+  }
+
+  private updateLastSyncTimes({ updateSuccessTime }: { updateSuccessTime?: boolean }) {
+    this.logDebug('Updating lastSyncAttempt and lastSyncSuccess before synchronization.');
+
+    if (updateSuccessTime) {
+      this.lastSyncSuccess = this.lastSyncAttempt;
+    }
+    this.lastSyncAttempt = new Date();
+  }
+
+  /**
+   * This method does a call to elasticsearch that reindexes from this.destIndex
+   * to this.sourceIndex. The query used takes into account the lastSyncSuccess
+   * and lastSyncAttempt values in the class.
+   *
+   * @returns {SynchronizationTaskState} The updated task state
+   */
+  private async synchronizeIndex({
+    esClient,
+  }: {
+    esClient: ElasticsearchClient;
+  }): Promise<TaskId | undefined> {
+    const painlessScript = await this.getPainlessScript(esClient);
+
+    if (painlessScript.found) {
+      this.logDebug(`Synchronizing with ${this.sourceIndex}.`);
+
+      const reindexResponse = await esClient.reindex({
+        source: {
+          index: this.sourceIndex,
+          query: this.buildSourceQuery(),
+        },
+        dest: { index: this.destIndex },
+        script: {
+          id: painlessScript._id,
+        },
+        /** If `true`, the request refreshes affected shards to make this operation visible to search. */
+        refresh: true,
+        /** We do not wait for the es reindex operation to be completed. */
+        wait_for_completion: false,
+      });
+
+      return reindexResponse.task;
+    } else {
+      throw createTaskRunError(
+        new Error(this.handleErrorMessage('Painless script not found.')),
+        this.errorSource
+      );
+    }
+  }
+
+  private async getPreviousReindexStatus(esClient: ElasticsearchClient): Promise<ReindexStatus> {
+    this.logDebug('Checking previous synchronization task status.');
+
+    if (!this.esReindexTaskId) {
+      return ReindexStatus.MISSING_TASK_ID;
+    }
+
+    const taskResponse = await esClient.tasks.get({ task_id: this.esReindexTaskId.toString() });
+
+    if (!taskResponse.completed) {
+      return ReindexStatus.RUNNING;
+    }
+
+    if (taskResponse.response?.failures?.length || taskResponse?.error) {
+      return ReindexStatus.FAILED;
+    }
+
+    return ReindexStatus.COMPLETED;
+  }
+
+  private buildSourceQuery(): QueryDslQueryContainer {
+    return SYNCHRONIZATION_QUERIES_DICTIONARY[this.syncType](
+      new Date(this.lastSyncSuccess ? this.lastSyncSuccess : Date.now() - LOOKBACK_WINDOW),
+      this.spaceId,
+      this.owner
+    );
+  }
+
+  private getSyncState(): SynchronizationTaskState {
+    return {
+      lastSyncSuccess: this.lastSyncSuccess,
+      lastSyncAttempt: this.lastSyncAttempt,
+      esReindexTaskId: this.esReindexTaskId,
+      syncType: this.syncType,
+    };
+  }
+
+  private async getMapping(esClient: ElasticsearchClient): Promise<IndicesGetMappingResponse> {
+    this.logDebug('Getting index mapping.');
+
+    return esClient.indices.getMapping({
+      index: this.destIndex,
+    });
+  }
+
+  private async getPainlessScript(esClient: ElasticsearchClient) {
+    const painlessScriptId = await this.getPainlessScriptId(esClient);
+
+    this.logDebug(`Getting painless script with id: "${painlessScriptId}".`);
+
+    return esClient.getScript({
+      id: painlessScriptId,
+    });
+  }
+
+  private async getPainlessScriptId(esClient: ElasticsearchClient): Promise<string> {
+    const mapping = await this.getMapping(esClient);
+    const painlessScriptId = mapping[this.destIndex].mappings._meta?.painless_script_id;
+
+    if (!painlessScriptId) {
+      throw createTaskRunError(
+        new Error(this.handleErrorMessage('Painless script id missing from mapping.')),
+        this.errorSource
+      );
+    }
+
+    return painlessScriptId;
+  }
+
+  private async isIndexAvailable(esClient: ElasticsearchClient) {
+    this.logDebug('Checking index availability.');
+
+    return esClient.cluster.health({
+      index: this.destIndex,
+      wait_for_status: 'green',
+      timeout: '30s',
+    });
+  }
+
+  public logDebug(message: string) {
+    this.logger.debug(`[${this.destIndex}] ${message}`, {
+      tags: ['cai-synchronization', this.destIndex],
+    });
+  }
+
+  public handleErrorMessage(message: string) {
+    const errorMessage = `[${this.destIndex}] Synchronization reindex failed. Error: ${message}`;
+
+    this.logger.error(errorMessage, {
+      tags: ['cai-synchronization', 'cai-synchronization-error', this.destIndex],
+    });
+
+    return errorMessage;
+  }
+
+  public async cancel() {}
+}

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
@@ -6,19 +6,22 @@
  */
 
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
-import type { TasksTaskInfo } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  IndicesGetMappingResponse,
+  TasksTaskInfo,
+} from '@elastic/elasticsearch/lib/api/types';
 import { errors as esErrors } from '@elastic/elasticsearch';
 
 import { SynchronizationTaskRunner } from './synchronization_task_runner';
 import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import { isRetryableError } from '@kbn/task-manager-plugin/server/task_running';
-import { getCasesDestinationIndexName, CAI_CASES_SYNC_TYPE } from '../../cases_index/constants';
+import { getCasesDestinationIndexName } from '../../cases_index/constants';
+import { CAISyncTypes, destinationIndexBySyncType } from '../../constants';
 
 describe('SynchronizationTaskRunner', () => {
   const logger = loggingSystemMock.createLogger();
   const esClient = elasticsearchServiceMock.createElasticsearchClient();
 
-  const sourceIndex = '.source-index';
   const destIndex = getCasesDestinationIndexName('default', 'securitySolution');
 
   const painlessScriptId = 'painlessScriptId';
@@ -35,17 +38,18 @@ describe('SynchronizationTaskRunner', () => {
 
   const taskInstance = {
     params: {
-      sourceIndex,
-      destIndex,
       owner: 'securitySolution',
       spaceId: 'default',
-      syncType: CAI_CASES_SYNC_TYPE,
     },
-    state: {
-      lastSyncSuccess,
-      lastSyncAttempt,
-      esReindexTaskId,
-    },
+    state: CAISyncTypes.reduce((acc, syncType) => {
+      acc[syncType] = {
+        lastSyncSuccess,
+        lastSyncAttempt,
+        esReindexTaskId,
+        syncType,
+      };
+      return acc;
+    }, {} as Record<string, unknown>),
   } as unknown as ConcreteTaskInstance;
 
   let taskRunner: SynchronizationTaskRunner;
@@ -60,13 +64,16 @@ describe('SynchronizationTaskRunner', () => {
     jest.clearAllMocks();
     jest.useFakeTimers().setSystemTime(newAttemptTime);
     esClient.indices.getMapping.mockResolvedValue({
-      [destIndex]: {
-        mappings: {
-          _meta: {
-            painless_script_id: painlessScriptId,
+      ...(CAISyncTypes.reduce((acc, syncType) => {
+        acc[destinationIndexBySyncType(syncType, 'default', 'securitySolution')] = {
+          mappings: {
+            _meta: {
+              painless_script_id: painlessScriptId,
+            },
           },
-        },
-      },
+        };
+        return acc;
+      }, {} as Record<string, unknown>) as IndicesGetMappingResponse),
     });
 
     esClient.getScript.mockResolvedValue({
@@ -113,7 +120,7 @@ describe('SynchronizationTaskRunner', () => {
     expect(esClient.getScript).toBeCalledWith({ id: painlessScriptId });
     expect(esClient.reindex).toBeCalledWith({
       source: {
-        index: sourceIndex,
+        index: '.kibana_alerting_cases',
         /*
          * The previous attempt was successful so we will reindex with
          * a new time.
@@ -172,14 +179,13 @@ describe('SynchronizationTaskRunner', () => {
       wait_for_completion: false,
     });
 
-    expect(result).toEqual({
-      state: {
-        // because the previous sync task was completed lastSyncSuccess is now lastSyncAttempt
-        lastSyncSuccess: lastSyncAttempt,
-        // we set a new value for lastSyncAttempt
-        lastSyncAttempt: newAttemptTime,
-        esReindexTaskId,
-      },
+    expect(result?.state.cai_cases_sync).toEqual({
+      // because the previous sync task was completed lastSyncSuccess is now lastSyncAttempt
+      lastSyncSuccess: lastSyncAttempt,
+      // we set a new value for lastSyncAttempt
+      lastSyncAttempt: newAttemptTime,
+      esReindexTaskId,
+      syncType: 'cai_cases_sync',
     });
   });
 
@@ -206,7 +212,7 @@ describe('SynchronizationTaskRunner', () => {
 
     expect(esClient.reindex).toBeCalledWith({
       source: {
-        index: sourceIndex,
+        index: '.kibana_alerting_cases',
         /*
          * The previous attempt was successful so we will reindex with
          * a new time.
@@ -265,12 +271,11 @@ describe('SynchronizationTaskRunner', () => {
       wait_for_completion: false,
     });
 
-    expect(result).toEqual({
-      state: {
-        lastSyncSuccess: undefined,
-        lastSyncAttempt: newAttemptTime,
-        esReindexTaskId,
-      },
+    expect(result?.state.cai_cases_sync).toEqual({
+      lastSyncSuccess: undefined,
+      lastSyncAttempt: newAttemptTime,
+      esReindexTaskId,
+      syncType: 'cai_cases_sync',
     });
   });
 
@@ -294,7 +299,7 @@ describe('SynchronizationTaskRunner', () => {
 
     expect(esClient.reindex).toBeCalledWith({
       source: {
-        index: sourceIndex,
+        index: '.kibana_alerting_cases',
         /*
          * The previous attempt was unsuccessful so we will reindex with
          * the old lastSyncSuccess. And updated the attempt time.
@@ -353,14 +358,13 @@ describe('SynchronizationTaskRunner', () => {
       wait_for_completion: false,
     });
 
-    expect(result).toEqual({
-      state: {
-        // because the previous sync task failed we do not update this value
-        lastSyncSuccess,
-        // we set a new value for lastSyncAttempt
-        lastSyncAttempt: newAttemptTime,
-        esReindexTaskId,
-      },
+    expect(result?.state.cai_cases_sync).toEqual({
+      // because the previous sync task failed we do not update this value
+      lastSyncSuccess,
+      // we set a new value for lastSyncAttempt
+      lastSyncAttempt: newAttemptTime,
+      esReindexTaskId,
+      syncType: 'cai_cases_sync',
     });
   });
 
@@ -399,11 +403,10 @@ describe('SynchronizationTaskRunner', () => {
       analyticsConfig,
     });
 
-    const result = await taskRunner.run();
+    await taskRunner.run();
 
     expect(esClient.cluster.health).not.toBeCalled();
     expect(esClient.reindex).not.toBeCalled();
-    expect(result).toBe(undefined);
 
     expect(logger.error).not.toBeCalled();
     expect(logger.debug).toBeCalledWith(

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.ts
@@ -6,23 +6,18 @@
  */
 
 import type { Logger } from '@kbn/logging';
-import {
-  createTaskRunError,
-  TaskErrorSource,
-  throwRetryableError,
-  throwUnrecoverableError,
-  type ConcreteTaskInstance,
-} from '@kbn/task-manager-plugin/server';
+import { type ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { CancellableTask } from '@kbn/task-manager-plugin/server/task';
-import type {
-  IndicesGetMappingResponse,
-  QueryDslQueryContainer,
-} from '@elastic/elasticsearch/lib/api/types';
 import type { Owner } from '../../../../common/constants/types';
 import type { ConfigType } from '../../../config';
-import { isRetryableEsClientError } from '../../utils';
-import { type CAISyncType, SYNCHRONIZATION_QUERIES_DICTIONARY } from '../../constants';
+import {
+  type CAISyncType,
+  CAISyncTypes,
+  sourceIndexBySyncType,
+  destinationIndexBySyncType,
+} from '../../constants';
+import { SynchronizationSubTaskRunner } from './synchronization_sub_task';
 
 interface SynchronizationTaskRunnerFactoryConstructorParams {
   taskInstance: ConcreteTaskInstance;
@@ -31,34 +26,22 @@ interface SynchronizationTaskRunnerFactoryConstructorParams {
   analyticsConfig: ConfigType['analytics'];
 }
 
+type SynchronizationTaskStateBySyncType = Record<CAISyncType, SynchronizationTaskState>;
+
 interface SynchronizationTaskState {
-  lastSyncSuccess?: Date | undefined;
-  lastSyncAttempt?: Date | undefined;
-  esReindexTaskId?: TaskId | undefined;
+  lastSyncSuccess?: string;
+  lastSyncAttempt?: string;
+  esReindexTaskId?: TaskId;
 }
-
-enum ReindexStatus {
-  RUNNING = 'running',
-  COMPLETED = 'completed',
-  FAILED = 'failed',
-  MISSING_TASK_ID = 'missing_task_id',
-}
-
-const LOOKBACK_WINDOW = 5 * 60 * 1000;
 
 export class SynchronizationTaskRunner implements CancellableTask {
-  private readonly sourceIndex: string;
-  private readonly destIndex: string;
   private readonly owner: Owner;
   private readonly spaceId: string;
-  private readonly syncType: CAISyncType;
   private readonly getESClient: () => Promise<ElasticsearchClient>;
+  private readonly previousTaskState?: SynchronizationTaskStateBySyncType;
   private readonly logger: Logger;
-  private readonly errorSource = TaskErrorSource.FRAMEWORK;
-  private readonly esReindexTaskId: TaskId | undefined;
+
   private readonly analyticsConfig: ConfigType['analytics'];
-  private lastSyncSuccess: Date | undefined;
-  private lastSyncAttempt: Date | undefined;
 
   constructor({
     taskInstance,
@@ -66,16 +49,10 @@ export class SynchronizationTaskRunner implements CancellableTask {
     logger,
     analyticsConfig,
   }: SynchronizationTaskRunnerFactoryConstructorParams) {
-    if (taskInstance.state.lastSyncSuccess)
-      this.lastSyncSuccess = new Date(taskInstance.state.lastSyncSuccess);
-    if (taskInstance.state.lastSyncAttempt)
-      this.lastSyncAttempt = new Date(taskInstance.state.lastSyncAttempt);
-    this.esReindexTaskId = taskInstance.state.esReindexTaskId;
-    this.sourceIndex = taskInstance.params.sourceIndex;
-    this.destIndex = taskInstance.params.destIndex;
+    this.previousTaskState =
+      (taskInstance.state as SynchronizationTaskStateBySyncType) || undefined;
     this.owner = taskInstance.params.owner;
     this.spaceId = taskInstance.params.spaceId;
-    this.syncType = taskInstance.params.syncType;
     this.getESClient = getESClient;
     this.logger = logger;
     this.analyticsConfig = analyticsConfig;
@@ -88,236 +65,49 @@ export class SynchronizationTaskRunner implements CancellableTask {
     }
 
     const esClient = await this.getESClient();
+    const runners = CAISyncTypes.map((syncType) => {
+      const stateForSyncType = this.previousTaskState
+        ? this.previousTaskState[syncType]
+        : undefined;
 
-    try {
-      const destIndexExists = await esClient.indices.exists({ index: this.destIndex });
+      return new SynchronizationSubTaskRunner({
+        esReindexTaskId: stateForSyncType?.esReindexTaskId,
+        lastSyncSuccess: stateForSyncType?.lastSyncSuccess,
+        lastSyncAttempt: stateForSyncType?.lastSyncAttempt,
+        sourceIndex: sourceIndexBySyncType(syncType),
+        destIndex: destinationIndexBySyncType(syncType, this.spaceId, this.owner),
+        owner: this.owner,
+        spaceId: this.spaceId,
+        syncType,
+        esClient,
+        logger: this.logger,
+      }).run();
+    });
 
-      if (!destIndexExists) {
-        this.logDebug('Destination index does not exist, skipping synchronization task.');
-        return;
-      }
-
-      const previousReindexStatus = await this.getPreviousReindexStatus(esClient);
-      this.logDebug(`Previous synchronization task status: "${previousReindexStatus}".`);
-
-      if (previousReindexStatus === ReindexStatus.RUNNING) {
-        /*
-         * If the reindex task is still running we return the
-         * same state and the next run will cover any missing
-         * updates.
-         **/
-        return {
-          state: this.getSyncState() as Record<string, unknown>,
-        };
-      }
-
-      if (previousReindexStatus === ReindexStatus.COMPLETED) {
-        /*
-         * If the previous reindex task is completed we reindex
-         * with a new time window.
-         **/
-        await this.isIndexAvailable(esClient);
-
-        this.updateLastSyncTimes({ updateSuccessTime: true });
-
-        const esReindexTaskId = await this.synchronizeIndex({ esClient });
-
-        return {
-          state: {
-            lastSyncSuccess: this.lastSyncSuccess,
-            lastSyncAttempt: this.lastSyncAttempt,
-            esReindexTaskId,
-          } as Record<string, unknown>,
-        };
-      }
-
-      if (
-        /*
-         * A missing task id can only happen if this is
-         * the first task execution.
-         **/
-        previousReindexStatus === ReindexStatus.MISSING_TASK_ID ||
-        previousReindexStatus === ReindexStatus.FAILED
-      ) {
-        await this.isIndexAvailable(esClient);
-
-        /*
-         * There are two possible scenarios here:
-         * 1. If the previous task failed (ReindexStatus.FAILED)
-         * 2. If the state is missing
-         *
-         * In both cases we try to reindex without updating lastSyncSuccess.
-         * This will ensure the reindex query is built with the correct value.
-         **/
-        this.updateLastSyncTimes({ updateSuccessTime: false });
-
-        const esReindexTaskId = await this.synchronizeIndex({ esClient });
-
-        return {
-          state: {
-            lastSyncSuccess: this.lastSyncSuccess,
-            lastSyncAttempt: this.lastSyncAttempt,
-            esReindexTaskId,
-          } as Record<string, unknown>,
-        };
-      }
-
-      throw new Error('Invalid task state.');
-    } catch (e) {
-      if (isRetryableEsClientError(e)) {
-        throwRetryableError(
-          createTaskRunError(new Error(this.handleErrorMessage(e.message)), this.errorSource),
-          true
-        );
-      }
-
-      this.handleErrorMessage(e.message);
-      throwUnrecoverableError(createTaskRunError(e, this.errorSource));
-    }
-  }
-
-  private updateLastSyncTimes({ updateSuccessTime }: { updateSuccessTime?: boolean }) {
-    this.logDebug('Updating lastSyncAttempt and lastSyncSuccess before synchronization.');
-
-    if (updateSuccessTime) {
-      this.lastSyncSuccess = this.lastSyncAttempt;
-    }
-    this.lastSyncAttempt = new Date();
-  }
-
-  /**
-   * This method does a call to elasticsearch that reindexes from this.destIndex
-   * to this.sourceIndex. The query used takes into account the lastSyncSuccess
-   * and lastSyncAttempt values in the class.
-   *
-   * @returns {SynchronizationTaskState} The updated task state
-   */
-  private async synchronizeIndex({
-    esClient,
-  }: {
-    esClient: ElasticsearchClient;
-  }): Promise<TaskId | undefined> {
-    const painlessScript = await this.getPainlessScript(esClient);
-
-    if (painlessScript.found) {
-      this.logDebug(`Synchronizing with ${this.sourceIndex}.`);
-
-      const reindexResponse = await esClient.reindex({
-        source: {
-          index: this.sourceIndex,
-          query: this.buildSourceQuery(),
-        },
-        dest: { index: this.destIndex },
-        script: {
-          id: painlessScript._id,
-        },
-        /** If `true`, the request refreshes affected shards to make this operation visible to search. */
-        refresh: true,
-        /** We do not wait for the es reindex operation to be completed. */
-        wait_for_completion: false,
-      });
-
-      return reindexResponse.task;
-    } else {
-      throw createTaskRunError(
-        new Error(this.handleErrorMessage('Painless script not found.')),
-        this.errorSource
-      );
-    }
-  }
-
-  private async getPreviousReindexStatus(esClient: ElasticsearchClient): Promise<ReindexStatus> {
-    this.logDebug('Checking previous synchronization task status.');
-
-    if (!this.esReindexTaskId) {
-      return ReindexStatus.MISSING_TASK_ID;
-    }
-
-    const taskResponse = await esClient.tasks.get({ task_id: this.esReindexTaskId.toString() });
-
-    if (!taskResponse.completed) {
-      return ReindexStatus.RUNNING;
-    }
-
-    if (taskResponse.response?.failures?.length || taskResponse?.error) {
-      return ReindexStatus.FAILED;
-    }
-
-    return ReindexStatus.COMPLETED;
-  }
-
-  private buildSourceQuery(): QueryDslQueryContainer {
-    return SYNCHRONIZATION_QUERIES_DICTIONARY[this.syncType](
-      new Date(this.lastSyncSuccess ? this.lastSyncSuccess : Date.now() - LOOKBACK_WINDOW),
-      this.spaceId,
-      this.owner
+    const results = await Promise.all(runners);
+    const newTaskState = results.reduce<Partial<SynchronizationTaskStateBySyncType>>(
+      (acc, result) => {
+        if (result?.syncType) {
+          acc[result.syncType] = result as SynchronizationTaskState;
+          return acc;
+        }
+        return acc;
+      },
+      {}
     );
-  }
 
-  private getSyncState(): SynchronizationTaskState {
     return {
-      lastSyncSuccess: this.lastSyncSuccess,
-      lastSyncAttempt: this.lastSyncAttempt,
-      esReindexTaskId: this.esReindexTaskId,
+      state: {
+        ...this.previousTaskState,
+        ...newTaskState,
+      },
     };
   }
 
-  private async getMapping(esClient: ElasticsearchClient): Promise<IndicesGetMappingResponse> {
-    this.logDebug('Getting index mapping.');
-
-    return esClient.indices.getMapping({
-      index: this.destIndex,
-    });
-  }
-
-  private async getPainlessScript(esClient: ElasticsearchClient) {
-    const painlessScriptId = await this.getPainlessScriptId(esClient);
-
-    this.logDebug(`Getting painless script with id: "${painlessScriptId}".`);
-
-    return esClient.getScript({
-      id: painlessScriptId,
-    });
-  }
-
-  private async getPainlessScriptId(esClient: ElasticsearchClient): Promise<string> {
-    const mapping = await this.getMapping(esClient);
-    const painlessScriptId = mapping[this.destIndex].mappings._meta?.painless_script_id;
-
-    if (!painlessScriptId) {
-      throw createTaskRunError(
-        new Error(this.handleErrorMessage('Painless script id missing from mapping.')),
-        this.errorSource
-      );
-    }
-
-    return painlessScriptId;
-  }
-
-  private async isIndexAvailable(esClient: ElasticsearchClient) {
-    this.logDebug('Checking index availability.');
-
-    return esClient.cluster.health({
-      index: this.destIndex,
-      wait_for_status: 'green',
-      timeout: '30s',
-    });
-  }
-
   public logDebug(message: string) {
-    this.logger.debug(`[${this.destIndex}] ${message}`, {
-      tags: ['cai-synchronization', this.destIndex],
+    this.logger.debug(`[synchronization-task-runner] ${message}`, {
+      tags: ['cai-synchronization', 'synchronization-task-runner'],
     });
-  }
-
-  public handleErrorMessage(message: string) {
-    const errorMessage = `[${this.destIndex}] Synchronization reindex failed. Error: ${message}`;
-
-    this.logger.error(errorMessage, {
-      tags: ['cai-synchronization', 'cai-synchronization-error', this.destIndex],
-    });
-
-    return errorMessage;
   }
 
   public async cancel() {}

--- a/x-pack/platform/test/cases_api_integration/common/lib/api/analytics.ts
+++ b/x-pack/platform/test/cases_api_integration/common/lib/api/analytics.ts
@@ -9,32 +9,29 @@ import type SuperTest from 'supertest';
 
 import {
   getCAIActivityBackfillTaskId,
-  getCAIActivitySynchronizationTaskId,
   CAI_ACTIVITY_SOURCE_INDEX,
   getActivityDestinationIndexName,
   getActivitySourceQuery,
 } from '@kbn/cases-plugin/server/cases_analytics/activity_index/constants';
 import {
   getCAIAttachmentsBackfillTaskId,
-  getCAIAttachmentsSynchronizationTaskId,
   CAI_ATTACHMENTS_SOURCE_INDEX,
   getAttachmentsDestinationIndexName,
   getAttachmentsSourceQuery,
 } from '@kbn/cases-plugin/server/cases_analytics/attachments_index/constants';
 import {
   getCAICasesBackfillTaskId,
-  getCAICasesSynchronizationTaskId,
   CAI_CASES_SOURCE_INDEX,
   getCasesDestinationIndexName,
   getCasesSourceQuery,
 } from '@kbn/cases-plugin/server/cases_analytics/cases_index/constants';
 import {
   getCAICommentsBackfillTaskId,
-  getCAICommentsSynchronizationTaskId,
   CAI_COMMENTS_SOURCE_INDEX,
   getCommentsDestinationIndexName,
   getCommentsSourceQuery,
 } from '@kbn/cases-plugin/server/cases_analytics/comments_index/constants';
+import { getSynchronizationTaskId } from '@kbn/cases-plugin/server/cases_analytics/tasks/synchronization_task';
 
 export const runCasesBackfillTask = async (supertest: SuperTest.Agent) => {
   await supertest
@@ -53,7 +50,7 @@ export const runCasesSynchronizationTask = async (supertest: SuperTest.Agent) =>
   await supertest
     .post('/api/analytics_index/synchronization/run_soon')
     .set('kbn-xsrf', 'xxx')
-    .send({ taskId: getCAICasesSynchronizationTaskId('default', 'securitySolution') })
+    .send({ taskId: getSynchronizationTaskId('default', 'securitySolution') })
     .expect(200);
 };
 
@@ -82,7 +79,7 @@ export const runAttachmentsSynchronizationTask = async (supertest: SuperTest.Age
   await supertest
     .post('/api/analytics_index/synchronization/run_soon')
     .set('kbn-xsrf', 'xxx')
-    .send({ taskId: getCAIAttachmentsSynchronizationTaskId('default', 'securitySolution') })
+    .send({ taskId: getSynchronizationTaskId('default', 'securitySolution') })
     .expect(200);
 };
 
@@ -103,7 +100,7 @@ export const runCommentsSynchronizationTask = async (supertest: SuperTest.Agent)
   await supertest
     .post('/api/analytics_index/synchronization/run_soon')
     .set('kbn-xsrf', 'xxx')
-    .send({ taskId: getCAICommentsSynchronizationTaskId('default', 'securitySolution') })
+    .send({ taskId: getSynchronizationTaskId('default', 'securitySolution') })
     .expect(200);
 };
 
@@ -124,6 +121,6 @@ export const runActivitySynchronizationTask = async (supertest: SuperTest.Agent)
   await supertest
     .post('/api/analytics_index/synchronization/run_soon')
     .set('kbn-xsrf', 'xxx')
-    .send({ taskId: getCAIActivitySynchronizationTaskId('default', 'securitySolution') })
+    .send({ taskId: getSynchronizationTaskId('default', 'securitySolution') })
     .expect(200);
 };

--- a/x-pack/platform/test/cases_api_integration/common/lib/api/analytics.ts
+++ b/x-pack/platform/test/cases_api_integration/common/lib/api/analytics.ts
@@ -46,7 +46,7 @@ export const runCasesBackfillTask = async (supertest: SuperTest.Agent) => {
     .expect(200);
 };
 
-export const runCasesSynchronizationTask = async (supertest: SuperTest.Agent) => {
+export const runCAISynchronizationTask = async (supertest: SuperTest.Agent) => {
   await supertest
     .post('/api/analytics_index/synchronization/run_soon')
     .set('kbn-xsrf', 'xxx')
@@ -75,14 +75,6 @@ export const runSchedulerTask = async (supertest: SuperTest.Agent) => {
     .expect(200);
 };
 
-export const runAttachmentsSynchronizationTask = async (supertest: SuperTest.Agent) => {
-  await supertest
-    .post('/api/analytics_index/synchronization/run_soon')
-    .set('kbn-xsrf', 'xxx')
-    .send({ taskId: getSynchronizationTaskId('default', 'securitySolution') })
-    .expect(200);
-};
-
 export const runCommentsBackfillTask = async (supertest: SuperTest.Agent) => {
   await supertest
     .post('/api/analytics_index/backfill/run_soon')
@@ -96,14 +88,6 @@ export const runCommentsBackfillTask = async (supertest: SuperTest.Agent) => {
     .expect(200);
 };
 
-export const runCommentsSynchronizationTask = async (supertest: SuperTest.Agent) => {
-  await supertest
-    .post('/api/analytics_index/synchronization/run_soon')
-    .set('kbn-xsrf', 'xxx')
-    .send({ taskId: getSynchronizationTaskId('default', 'securitySolution') })
-    .expect(200);
-};
-
 export const runActivityBackfillTask = async (supertest: SuperTest.Agent) => {
   await supertest
     .post('/api/analytics_index/backfill/run_soon')
@@ -114,13 +98,5 @@ export const runActivityBackfillTask = async (supertest: SuperTest.Agent) => {
       destIndex: getActivityDestinationIndexName('default', 'securitySolution'),
       sourceQuery: JSON.stringify(getActivitySourceQuery('default', 'securitySolution')),
     })
-    .expect(200);
-};
-
-export const runActivitySynchronizationTask = async (supertest: SuperTest.Agent) => {
-  await supertest
-    .post('/api/analytics_index/synchronization/run_soon')
-    .set('kbn-xsrf', 'xxx')
-    .send({ taskId: getSynchronizationTaskId('default', 'securitySolution') })
     .expect(200);
 };

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/synchronization.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/synchronization.ts
@@ -13,10 +13,7 @@ import {
 } from '@kbn/cases-plugin/common/types/domain';
 import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common';
 import {
-  runActivitySynchronizationTask,
-  runAttachmentsSynchronizationTask,
-  runCasesSynchronizationTask,
-  runCommentsSynchronizationTask,
+  runCAISynchronizationTask,
   runSchedulerTask,
 } from '../../../../../common/lib/api/analytics';
 import {
@@ -101,7 +98,7 @@ export default ({ getService }: FtrProviderContext): void => {
         200
       );
 
-      await runCasesSynchronizationTask(supertest);
+      await runCAISynchronizationTask(supertest);
 
       await retry.tryForTime(300000, async () => {
         const caseAnalytics = await esClient.get({
@@ -188,7 +185,7 @@ export default ({ getService }: FtrProviderContext): void => {
         auth: authSpace1,
       });
 
-      await runAttachmentsSynchronizationTask(supertest);
+      await runCAISynchronizationTask(supertest);
 
       await retry.tryForTime(300000, async () => {
         const firstAttachmentAnalytics = await esClient.get({
@@ -219,7 +216,7 @@ export default ({ getService }: FtrProviderContext): void => {
         params: { ...postCommentUserReq, owner: SECURITY_SOLUTION_OWNER },
       });
 
-      await runCommentsSynchronizationTask(supertest);
+      await runCAISynchronizationTask(supertest);
 
       await retry.try(async () => {
         const commentAnalytics = await esClient.get({
@@ -278,7 +275,7 @@ export default ({ getService }: FtrProviderContext): void => {
         },
       });
 
-      await runActivitySynchronizationTask(supertest);
+      await runCAISynchronizationTask(supertest);
 
       let activityArray: any[] = [];
       await retry.try(async () => {


### PR DESCRIPTION
## Summary

This PR reduces the effective amount of tasks used for synchronizing the cases analytics index from 12 per space to 3 per space. In larger Kibana deployments, this should result in a lot less stress on the Task Manager.

Instead of scheduling a task for each combination of space/owner/sync type, we only schedule a task per space/owner. This is done by moving the different sync types into a single task which then starts "sub tasks" per sync type. These are not real tasks, just ephemeral asynchronous functions.

```mermaid
flowchart TD
    A(Synchronization Task)
    B(Synchronization Task)
    D(Synchronization Task)
    E(Synchronization Task)
    C("(Observability)")
    A1("Scheduler Task")
    
    subgraph v1
        A1-->C
        A1-->C2
        A1-->C3
        EC@{ shape: braces, label: "state passed:
        sourceIndex
        destIndex
        owner
        spaceId
        syncType" }
        C-->A
        C-->B
        C-->D
        C-->E
        C2-->A2(...)
        C2-->B2(...)
        C2-->D2(...)
        C2-->E2(...)
        C3-->A3(...)
        C3-->B3(...)
        C3-->D3(...)
        C3-->E3(...)
        C2("(Security)")
        C3("(Stack)")
    end

    subgraph v2
        X("Scheduler Task")
        Y("(Observability)")
        Y2("(Security)")
        Y3("(Stack)")
        Z("Synchronization Task")
        Z2("Synchronization Task")
        Z3("Synchronization Task")

        X-->Y
        X-->Y2
        X-->Y3

        Y-->Z
        Y2-->Z2
        Y3-->Z3
        EC2@{ shape: braces, label: "state passed:
        owner
        spaceId" }
    end
```

### Testing

See `Testing` section in original PR: https://github.com/elastic/kibana/pull/234125

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->