### PR TITLE
[Security Solution] Improve versioning of EBT events

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/types.ts
@@ -7,13 +7,14 @@
 import type { RootSchema } from '@kbn/core/public';
 
 export enum RuleUpgradeEventTypes {
-  RuleUpgradeFlyoutButtonClick = 'Click Rule Upgrade Flyout Button v2',
+  RuleUpgradeFlyoutButtonClick = 'Click Rule Upgrade Flyout Button',
   RuleUpgradeSingleButtonClick = 'Click Rule Upgrade Single Button',
-  RuleUpgradeFlyoutOpen = 'Open Rule Upgrade Flyout v2',
+  RuleUpgradeFlyoutOpen = 'Open Rule Upgrade Flyout',
 }
 interface ReportRuleUpgradeFlyoutButtonClickParams {
   type: 'update' | 'dismiss';
   hasBaseVersion: boolean;
+  eventVersion: number;
 }
 
 interface ReportRuleUpgradeSingleButtonClickParams {
@@ -22,6 +23,7 @@ interface ReportRuleUpgradeSingleButtonClickParams {
 
 interface ReportRuleUpgradeFlyoutOpenParams {
   hasBaseVersion: boolean;
+  eventVersion: number;
 }
 
 export interface RuleUpgradeTelemetryEventsMap {

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
@@ -48,6 +48,8 @@ import { useKibana } from '../../../common/lib/kibana';
 import { TabContentPadding } from '../components/rule_details/rule_details_flyout';
 
 const REVIEW_PREBUILT_RULES_UPGRADE_REFRESH_INTERVAL = 5 * 60 * 1000;
+const RULE_UPGRADE_FLYOUT_BUTTON_EVENT_VERSION = 2;
+const RULE_UPGRADE_FLYOUT_OPEN_EVENT_VERSION = 2;
 
 export const PREBUILT_RULE_UPDATE_FLYOUT_ANCHOR = 'updatePrebuiltRulePreview';
 
@@ -369,11 +371,13 @@ export function usePrebuiltRulesUpgrade({
       telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick, {
         type: 'dismiss',
         hasBaseVersion,
+        eventVersion: RULE_UPGRADE_FLYOUT_BUTTON_EVENT_VERSION,
       });
     } else {
       telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick, {
         type: 'update',
         hasBaseVersion,
+        eventVersion: RULE_UPGRADE_FLYOUT_BUTTON_EVENT_VERSION,
       });
     }
   };
@@ -394,8 +398,10 @@ export function usePrebuiltRulesUpgrade({
       openRulePreviewDefault(ruleId);
       const ruleUpgradeState = rulesUpgradeState[ruleId];
       const hasBaseVersion = ruleUpgradeState.has_base_version === true;
+
       telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutOpen, {
         hasBaseVersion,
+        eventVersion: RULE_UPGRADE_FLYOUT_OPEN_EVENT_VERSION,
       });
     },
     [openRulePreviewDefault, rulesUpgradeState, telemetry]


### PR DESCRIPTION
**Partially resolves: #140369**

## Summary

This PR improves versioning of two EBT events introduced in #238088. Instead of adding a postfix to the name, we will have a proper version number.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.1","9.2"]} ONMERGE-->