### PR TITLE
[Security solution][Cases] Clear alert's closing reason from cases

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/services/alerts/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/alerts/index.test.ts
@@ -128,7 +128,8 @@ describe('updateAlertsStatus', () => {
                     }
                     if (ctx._source.signal != null && ctx._source.signal.status != null) {
                       ctx._source.signal.status = 'acknowledged'
-                    }",
+                    }
+                    ctx._source.remove('kibana.alert.workflow_reason')",
             },
           },
         ]
@@ -194,7 +195,8 @@ describe('updateAlertsStatus', () => {
                     }
                     if (ctx._source.signal != null && ctx._source.signal.status != null) {
                       ctx._source.signal.status = 'open'
-                    }",
+                    }
+                    ctx._source.remove('kibana.alert.workflow_reason')",
             },
           },
         ]
@@ -260,7 +262,8 @@ describe('updateAlertsStatus', () => {
                     }
                     if (ctx._source.signal != null && ctx._source.signal.status != null) {
                       ctx._source.signal.status = 'open'
-                    }",
+                    }
+                    ctx._source.remove('kibana.alert.workflow_reason')",
             },
           },
         ]

--- a/x-pack/platform/plugins/shared/cases/server/services/alerts/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/alerts/index.ts
@@ -11,6 +11,7 @@ import { isEmpty } from 'lodash';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { STATUS_VALUES } from '@kbn/rule-registry-plugin/common/technical_rule_data_field_names';
 import {
+  ALERT_WORKFLOW_REASON,
   ALERT_WORKFLOW_STATUS,
   ALERT_WORKFLOW_STATUS_UPDATED_AT,
 } from '@kbn/rule-registry-plugin/common/technical_rule_data_field_names';
@@ -176,6 +177,11 @@ export class AlertService {
             }
             if (ctx._source.signal != null && ctx._source.signal.status != null) {
               ctx._source.signal.status = '${status}'
+            }${
+              status !== 'closed'
+                ? `
+            ctx._source.remove('${ALERT_WORKFLOW_REASON}')`
+                : ''
             }`,
             lang: 'painless',
           },


### PR DESCRIPTION
## Summary

Closes #237813 

## 🛑 Problem

When re-opening a case synced with its alerts, the closed alerts will correctly re-open, but their closing reason wouldn't be removed.

<details>
<summary>Screen-recording of the bug 🎬  </summary>


https://github.com/user-attachments/assets/f081fc50-caff-45e1-b373-ad35ab2d23b2


</details>

## 💡 Solution

As the sync is made on server-side, I missed the spot while developing this feature. I just had to update the query used for updating the alerts.

<details>
<summary>Screen-recording of the working functionality 🎬 </summary>

https://github.com/user-attachments/assets/65be482b-8998-4d09-8b66-0df23b66116f
</details>





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->