### PR TITLE
[Search][Accessibility] Show error text when fields are invalid

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/public/components/edit_context/context_fields_select.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/edit_context/context_fields_select.tsx
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback, useState, useRef } from 'react';
 
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
-import { EuiCallOut, EuiComboBox } from '@elastic/eui';
+import { EuiCallOut, EuiComboBox, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import type { QuerySourceFields } from '../../types';
@@ -26,6 +26,24 @@ export const ContextFieldsSelect = ({
   selectedContextFields,
   updateSelectedContextFields,
 }: ContextFieldsSelectProps) => {
+  const searchValue = useRef('');
+  const [hasError, setHasError] = useState(false);
+
+  const handleSearchChange = (value: string) => {
+    searchValue.current = value;
+    setHasError(false);
+  };
+
+  const handleBlur = () => {
+    if (searchValue.current.trim() === '') return;
+
+    const hasExactMatch = selectOptions.some(
+      (opt) => opt.label.toLowerCase() === searchValue.current.toLowerCase()
+    );
+
+    setHasError(!hasExactMatch);
+  };
+
   const { options: selectOptions, selectedOptions } = useMemo(() => {
     if (!indexFields.source_fields?.length) return { options: [], selectedOptions: [] };
 
@@ -75,13 +93,34 @@ export const ContextFieldsSelect = ({
   }
 
   return (
-    <EuiComboBox
-      data-test-subj={`contextFieldsSelectable-${indexName}`}
-      options={selectOptions}
-      selectedOptions={selectedOptions}
-      onChange={onSelectFields}
-      isClearable={false}
+    <EuiFormRow
       fullWidth
-    />
+      isInvalid={hasError}
+      error={
+        hasError
+          ? `"${searchValue.current}" ${i18n.translate(
+              'xpack.searchPlayground.editContext.noSourceFieldWarning',
+              {
+                defaultMessage: 'does not match any options',
+              }
+            )}`
+          : undefined
+      }
+    >
+      <EuiComboBox
+        data-test-subj={`contextFieldsSelectable-${indexName}`}
+        options={selectOptions}
+        selectedOptions={selectedOptions}
+        onChange={onSelectFields}
+        isClearable={false}
+        fullWidth
+        aria-label={i18n.translate('xpack.searchPlayground.editContext.', {
+          defaultMessage: 'Select context field options',
+        })}
+        onSearchChange={handleSearchChange}
+        onBlur={handleBlur}
+        isInvalid={hasError}
+      />
+    </EuiFormRow>
   );
 };

--- a/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
@@ -53,6 +53,14 @@ export const InstructionsField: React.FC<InstructionsFieldProps> = ({ value, onC
         </span>
       }
       fullWidth
+      isInvalid={isEmpty(value)}
+      error={
+        isEmpty(value)
+          ? i18n.translate('xpack.searchPlayground.sidebar.instructionsField.errorMessage', {
+              defaultMessage: 'Instructions cannot be empty',
+            })
+          : undefined
+      }
     >
       <EuiTextArea
         data-test-subj="instructionsPrompt"


### PR DESCRIPTION
## Summary

This PR ensures that when a field in the RAG Playground is in an error state, the corresponding error text is displayed below the field. Previously, only the red error styling was applied without any accompanying message, which did not meet accessibility requirements.

<img width="600" height="686" alt="Screenshot 2025-10-09 at 16 10 06" src="https://github.com/user-attachments/assets/ef980bcb-cae0-4c5c-a330-c4e20bbbfd61" />

### Testing

1. Navigate to Search → Build → RAG Playground.
2. In the Instructions field, delete all text and press Tab.
3. Confirm that an error message appears below the field (e.g., “Instructions cannot be empty”).
4. In the Context fields input, enter any text (e.g., test), then press Tab.
5. Confirm that invalid entries display a red border and an error message below the field.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release note

Fixes an issue in the RAG Playground where invalid fields displayed red styling but no error message. Error text is now shown to help users identify and correct form issues.



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->