### PR TITLE
[Security Solution] Assign auto-generated API clients to teams in CODEOWERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2466,6 +2466,8 @@ x-pack/solutions/security/test/security_solution_api_integration/test_suites/sou
 /x-pack/solutions/security/test/fixtures/es_archives/signals @elastic/security-detections-response
 /x-pack/solutions/security/test/fixtures/es_archives/rule_keyword_family @elastic/security-detections-response
 
+/x-pack/solutions/security/packages/test-api-clients/supertest/detections.gen.ts @elastic/security-detections-response
+
 # Security Solution sub teams
 
 ## Security Solution sub teams - security-engineering-productivity
@@ -2608,6 +2610,8 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigations @elastic/security-threat-hunting-investigations
 
 /x-pack/solutions/security/test/serverless/functional/configs/config.context_awareness.ts @elastic/security-threat-hunting-investigations
+
+/x-pack/solutions/security/packages/test-api-clients/supertest/timelines.gen.ts @elastic/security-threat-hunting-investigations
 
 ## Security Solution Threat Hunting areas - Kibana Cases
 
@@ -2758,6 +2762,10 @@ x-pack/platform/plugins/shared/actions/server/lib/token_tracking @elastic/securi
 /x-pack/solutions/security/plugins/security_solution/server/usage/exceptions @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/server/usage/value_lists @elastic/security-detection-engine
 
+/x-pack/solutions/security/packages/test-api-clients/supertest/endpoint_exceptions.gen.ts @elastic/security-detection-engine
+/x-pack/solutions/security/packages/test-api-clients/supertest/exceptions.gen.ts @elastic/security-detection-engine
+/x-pack/solutions/security/packages/test-api-clients/supertest/lists.gen.ts @elastic/security-detection-engine
+
 ## Security Threat Intelligence - Under Security Platform
 /x-pack/solutions/security/plugins/security_solution/public/common/components/threat_match @elastic/security-detection-engine
 
@@ -2795,6 +2803,8 @@ x-pack/solutions/security/plugins/elastic_assistant/server/knowledge_base/defend
 x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/public/common/components/response_actions @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution_serverless/public/upselling/pages/osquery_automated_response_actions.tsx @elastic/security-defend-workflows
+/x-pack/solutions/security/packages/test-api-clients/supertest/endpoint_management.gen.ts @elastic/security-defend-workflows
+/x-pack/solutions/security/packages/test-api-clients/supertest/osquery.gen.ts @elastic/security-defend-workflows
 
 ## Security Solution sub teams - security-telemetry (Data Engineering)
 x-pack/solutions/security/plugins/security_solution/server/usage/ @elastic/security-data-analytics
@@ -2837,6 +2847,8 @@ x-pack/platform/test/fixtures/es_archives/auditbeat/uncommon_processes @elastic/
 x-pack/platform/test/fixtures/es_archives/auditbeat/users @elastic/security-entity-analytics
 x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics @elastic/security-entity-analytics
 x-pack/solutions/security/test/security_solution_api_integration/test_suites/explore @elastic/security-entity-analytics
+
+/x-pack/solutions/security/packages/test-api-clients/supertest/entity_analytics.gen.ts @elastic/security-entity-analytics
 
 ## Security Solution sub teams - GenAI
 x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai @elastic/security-generative-ai


### PR DESCRIPTION
**Partially addresses: https://github.com/elastic/kibana/issues/234642**

## Summary

Follow-up to https://github.com/elastic/kibana/pull/235221. The previous PR introduced the `@kbn/security-solution-test-api-clients` package, which contains all auto-generated API clients used in FTR tests. This PR adds more granular team ownership for this package.

## Changes

- Updated the CODEOWNERS file to assign each team to their respective generated API client files.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->