### PR TITLE
Fix DistributionBar component left overflow edge case

### DIFF
--- a/x-pack/solutions/security/packages/distribution-bar/src/distribution_bar.stories.tsx
+++ b/x-pack/solutions/security/packages/distribution-bar/src/distribution_bar.stories.tsx
@@ -46,6 +46,68 @@ const mockStatsAlerts = [
   },
 ];
 
+// Edge case: Flip tooltip when the LEFTMOST segment (green/teal) is very small
+const mockStatsEdgeCase = [
+  {
+    key: 'low',
+    count: 220,
+    color: 'green',
+    label: 'Low',
+  },
+  {
+    key: 'medium',
+    count: 2000,
+    color: 'gold',
+    label: 'Medium',
+  },
+  {
+    key: 'high',
+    count: 1500,
+    color: 'orange',
+    label: 'High',
+  },
+  {
+    key: 'critical',
+    count: 1000,
+    color: 'red',
+    label: 'Critical',
+  },
+];
+
+// Edge case: Multiple small segments at the beginning (leftmost)
+const mockStatsMultipleSmall = [
+  {
+    key: 'low1',
+    count: 3,
+    color: 'green',
+    label: 'Low 1',
+  },
+  {
+    key: 'low2',
+    count: 2,
+    color: 'green',
+    label: 'Low 2',
+  },
+  {
+    key: 'medium',
+    count: 3000,
+    color: 'gold',
+    label: 'Medium',
+  },
+  {
+    key: 'high',
+    count: 2000,
+    color: 'orange',
+    label: 'High',
+  },
+  {
+    key: 'critical',
+    count: 1000,
+    color: 'red',
+    label: 'Critical',
+  },
+];
+
 export default {
   title: 'DistributionBar',
   description: 'Distribution Bar',
@@ -83,6 +145,27 @@ export const DistributionBar = () => {
       </EuiTitle>
       <EuiSpacer size={'s'} />
       <DistributionBarComponent stats={[]} />
+    </React.Fragment>,
+  ];
+};
+
+export const EdgeCaseSmallSegments = () => {
+  return [
+    <React.Fragment key={'edge-case-tooltip-overflow'}>
+      <EuiTitle size={'xs'}>
+        <h4>{'Edge Case: Tooltip Change Direction'}</h4>
+      </EuiTitle>
+      <EuiSpacer size={'s'} />
+      <DistributionBarComponent stats={mockStatsEdgeCase} />
+      <EuiSpacer size={'m'} />
+    </React.Fragment>,
+    <React.Fragment key={'edge-case-multiple-small'}>
+      <EuiTitle size={'xs'}>
+        <h4>{'Edge Case: Multiple Small Segments at Beginning'}</h4>
+      </EuiTitle>
+      <EuiSpacer size={'s'} />
+      <DistributionBarComponent stats={mockStatsMultipleSmall} />
+      <EuiSpacer size={'m'} />
     </React.Fragment>,
   ];
 };

--- a/x-pack/solutions/security/packages/distribution-bar/src/distribution_bar.test.tsx
+++ b/x-pack/solutions/security/packages/distribution-bar/src/distribution_bar.test.tsx
@@ -142,4 +142,145 @@ describe('DistributionBar', () => {
   });
 
   // todo: test tooltip visibility logic
+
+  describe('tooltip overflow edge cases', () => {
+    it('should add flipped tooltip attribute for small segments', () => {
+      // Mock getBoundingClientRect to simulate small segment that would overflow
+      const mockGetBoundingClientRect = jest.fn();
+
+      const containerRect = {
+        left: 0,
+        right: 500,
+        width: 500,
+        top: 0,
+        bottom: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      };
+
+      const smallPartRect = {
+        left: 0,
+        right: 50,
+        width: 50,
+        top: 0,
+        bottom: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      };
+
+      const tooltipContentRect = {
+        left: 0,
+        right: 120,
+        width: 120,
+        top: 0,
+        bottom: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      };
+
+      const largePartRect = {
+        left: 250,
+        right: 500,
+        width: 250,
+        top: 0,
+        bottom: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      };
+
+      Element.prototype.getBoundingClientRect = mockGetBoundingClientRect
+        .mockReturnValueOnce(containerRect)
+        .mockReturnValueOnce(smallPartRect)
+        .mockReturnValueOnce(tooltipContentRect)
+        .mockReturnValueOnce(largePartRect)
+        .mockReturnValueOnce(tooltipContentRect);
+
+      const stats = [
+        {
+          key: 'small',
+          count: 1,
+          color: 'green',
+          label: 'Small',
+        },
+        {
+          key: 'large',
+          count: 1000,
+          color: 'red',
+          label: 'Large',
+        },
+      ];
+
+      const { container } = render(<DistributionBar stats={stats} data-test-subj={testSubj} />);
+      expect(container).toBeInTheDocument();
+
+      const parts = container.querySelectorAll(`[data-test-subj="${testSubj}__part"]`);
+      expect(parts.length).toEqual(stats.length);
+
+      expect(parts[0].getAttribute('data-tooltip-flipped')).toBe('true');
+
+      expect(parts[1].getAttribute('data-tooltip-flipped')).toBe('false');
+
+      mockGetBoundingClientRect.mockRestore();
+    });
+
+    it('should not flip tooltip when there is enough space', () => {
+      const mockGetBoundingClientRect = jest.fn();
+
+      const containerRect = {
+        left: 0,
+        right: 500,
+        width: 500,
+        top: 0,
+        bottom: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      };
+      const partRect = {
+        left: 200,
+        right: 500,
+        width: 300,
+        top: 0,
+        bottom: 0,
+        x: 200,
+        y: 0,
+        toJSON: () => ({}),
+      };
+      const tooltipRect = {
+        left: 0,
+        right: 120,
+        width: 120,
+        top: 0,
+        bottom: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      };
+
+      Element.prototype.getBoundingClientRect = mockGetBoundingClientRect
+        .mockReturnValueOnce(containerRect)
+        .mockReturnValueOnce(partRect)
+        .mockReturnValueOnce(tooltipRect);
+
+      const stats = [
+        {
+          key: 'medium',
+          count: 500,
+          color: 'yellow',
+          label: 'Medium',
+        },
+      ];
+
+      const { container } = render(<DistributionBar stats={stats} data-test-subj={testSubj} />);
+
+      const parts = container.querySelectorAll(`[data-test-subj="${testSubj}__part"]`);
+      expect(parts[0].getAttribute('data-tooltip-flipped')).toBe('false');
+
+      mockGetBoundingClientRect.mockRestore();
+    });
+  });
 });

--- a/x-pack/solutions/security/packages/distribution-bar/src/distribution_bar.tsx
+++ b/x-pack/solutions/security/packages/distribution-bar/src/distribution_bar.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useRef, useLayoutEffect } from 'react';
 import { EuiFlexGroup, EuiBadge, useEuiTheme, EuiIcon, EuiFlexItem } from '@elastic/eui';
 import numeral from '@elastic/numeral';
 import { css } from '@emotion/react';
@@ -111,6 +111,14 @@ const useStyles = () => {
         transition: all 0.3s ease;
       }
     `,
+    tooltipFlipped: css`
+      text-align: left;
+      left: 0;
+      right: auto;
+    `,
+    tooltipContent: css`
+      display: inline-block;
+    `,
     tooltipBadgeLeft: css`
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
@@ -154,7 +162,6 @@ const shouldShowTooltip = ({
   return !isHoveringAnyStatsBar && (shouldShowBecauseOfFilter || shouldShowBecauseItIsLast);
 };
 
-// TODO: fix tooltip direction if not enough space;
 /**
  * Security Solution DistributionBar component.
  * Shows visual representation of distribution of stats, such as alerts by criticality or misconfiguration findings by evaluation result.
@@ -166,11 +173,48 @@ export const DistributionBar: React.FC<DistributionBarProps> = React.memo(functi
   const { stats, 'data-test-subj': dataTestSubj, hideLastTooltip } = props;
 
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  const [shouldFlipTooltip, setShouldFlipTooltip] = useState<Record<string, boolean>>({});
+  const barContainerRef = useRef<HTMLDivElement>(null);
+  const partRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const tooltipContentRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const hasCurrentFilter = useMemo(() => stats.some((item) => item.isCurrentFilter), [stats]);
+
+  // Calculate which tooltips need to be flipped to prevent left overflow
+  useLayoutEffect(() => {
+    if (!barContainerRef.current) return;
+
+    const containerRect = barContainerRef.current.getBoundingClientRect();
+    const flippedMap: Record<string, boolean> = {};
+
+    stats.forEach((stat) => {
+      const partElement = partRefs.current[stat.key];
+      const tooltipContentElement = tooltipContentRefs.current[stat.key];
+      if (!partElement || !tooltipContentElement) return;
+
+      const partRect = partElement.getBoundingClientRect();
+      const tooltipContentRect = tooltipContentElement.getBoundingClientRect();
+      const partRightEdge = partRect.right;
+
+      // Get the actual tooltip content width (the badges)
+      const tooltipWidth = tooltipContentRect.width;
+
+      // Check if tooltip would overflow the left edge when right-aligned
+      // The tooltip is positioned right: 0 relative to the part, so it extends left from the part's right edge
+      const tooltipLeftEdge = partRightEdge - tooltipWidth;
+      const containerLeftEdge = containerRect.left;
+
+      if (tooltipLeftEdge < containerLeftEdge) {
+        flippedMap[stat.key] = true;
+      }
+    });
+
+    setShouldFlipTooltip(flippedMap);
+  }, [stats]);
 
   const parts = stats.map((stat, index) => {
     const isLast = index === stats.length - 1;
     const isHovered = hoveredKey === stat.key;
+    const shouldFlip = shouldFlipTooltip[stat.key] ?? false;
 
     // Only show tooltip for segments thats hovered OR Set as Filter OR Last
     const isCurrentFilter = stat.isCurrentFilter ?? false;
@@ -202,8 +246,12 @@ export const DistributionBar: React.FC<DistributionBarProps> = React.memo(functi
     return (
       <div
         key={stat.key}
+        ref={(el) => {
+          partRefs.current[stat.key] = el;
+        }}
         css={partStyle}
         data-test-subj={`${dataTestSubj}__part`}
+        data-tooltip-flipped={shouldFlip ? 'true' : 'false'}
         onClick={stat.filter}
         onMouseEnter={() => setHoveredKey(stat.key)}
         onMouseLeave={() => setHoveredKey(null)}
@@ -215,42 +263,62 @@ export const DistributionBar: React.FC<DistributionBarProps> = React.memo(functi
         tabIndex={0}
         role="button"
       >
-        <div css={[styles.tooltip, showTooltip && styles.part.visibleTooltip]}>
-          <EuiFlexGroup gutterSize="none" justifyContent="flexEnd" wrap={false} responsive={false}>
-            <EuiFlexItem grow={false}>
-              <EuiBadge color="hollow" css={styles.tooltipBadgeLeft}>
-                {prettyNumber}
-              </EuiBadge>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiBadge color="hollow" css={styles.tooltipBadgeRight}>
-                <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-                  <EuiFlexItem grow={false}>
-                    <EuiIcon type="dot" size="s" color={stat.color} />
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>{stat.label ?? stat.key}</EuiFlexItem>
-                  {stat.isCurrentFilter && stat.reset && (
+        <div
+          css={[
+            styles.tooltip,
+            showTooltip && styles.part.visibleTooltip,
+            shouldFlip && styles.tooltipFlipped,
+          ]}
+        >
+          <div
+            ref={(el) => {
+              tooltipContentRefs.current[stat.key] = el;
+            }}
+            css={styles.tooltipContent}
+          >
+            <EuiFlexGroup
+              gutterSize="none"
+              justifyContent={shouldFlip ? 'flexStart' : 'flexEnd'}
+              wrap={false}
+              responsive={false}
+            >
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="hollow" css={styles.tooltipBadgeLeft}>
+                  {prettyNumber}
+                </EuiBadge>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="hollow" css={styles.tooltipBadgeRight}>
+                  <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
                     <EuiFlexItem grow={false}>
-                      <EuiIcon type="cross" size="m" onClick={stat.reset} />
+                      <EuiIcon type="dot" size="s" color={stat.color} />
                     </EuiFlexItem>
-                  )}
-                </EuiFlexGroup>
-              </EuiBadge>
-            </EuiFlexItem>
-          </EuiFlexGroup>
+                    <EuiFlexItem grow={false}>{stat.label ?? stat.key}</EuiFlexItem>
+                    {stat.isCurrentFilter && stat.reset && (
+                      <EuiFlexItem grow={false}>
+                        <EuiIcon type="cross" size="m" onClick={stat.reset} />
+                      </EuiFlexItem>
+                    )}
+                  </EuiFlexGroup>
+                </EuiBadge>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </div>
         </div>
       </div>
     );
   });
 
   return (
-    <EuiFlexGroup
-      alignItems="center"
-      css={styles.bar}
-      data-test-subj={dataTestSubj}
-      responsive={false}
-    >
-      {parts.length ? parts : <EmptyBar data-test-subj={`${dataTestSubj}__emptyBar`} />}
-    </EuiFlexGroup>
+    <div ref={barContainerRef}>
+      <EuiFlexGroup
+        alignItems="center"
+        css={styles.bar}
+        data-test-subj={dataTestSubj}
+        responsive={false}
+      >
+        {parts.length ? parts : <EmptyBar data-test-subj={`${dataTestSubj}__emptyBar`} />}
+      </EuiFlexGroup>
+    </div>
   );
 });


### PR DESCRIPTION
## Summary

Fix the edge case when tooltip overflows to the left

<img width="1421" height="134" alt="Screenshot 2025-10-09 at 18 52 25" src="https://github.com/user-attachments/assets/3c59cb24-0e8d-43b7-a937-960646236ad2" />

Fixes:
- https://github.com/elastic/security-team/issues/10048

to verify run Storybook `yarn storybook security_solution_packages`

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for
 features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


