### PR TITLE
[CI] Fix "Store Cache" step for on-merge

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -25,6 +25,9 @@ steps:
     depends_on:
       - terrazzo-initial-pipeline-upload
     agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
       machineType: n2-standard-2
       diskSizeGb: 95
 


### PR DESCRIPTION
## Summary
The issue was that the step was tested and copied over from `base.yml` where there's some processing adding the missing fields, we don't have that in the on-merge pipeline, but the steps are as is in the .yml. This PR adds missing `image` / `imageProject` / `provider` for the `on_merge.yml` pipeline.
