### PR TITLE
feat: remove alert rule from Lens context menu

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/lens_wrapper.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/lens_wrapper.tsx
@@ -21,7 +21,7 @@ export type LensWrapperProps = {
   onCopyToDashboard: () => void;
 } & Pick<ChartSectionProps, 'services' | 'onBrushEnd' | 'onFilter' | 'abortController'>;
 
-const DEFAULT_DISABLED_ACTIONS = ['ACTION_CUSTOMIZE_PANEL', 'ACTION_EXPORT_CSV'];
+const DEFAULT_DISABLED_ACTIONS = ['ACTION_CUSTOMIZE_PANEL', 'ACTION_EXPORT_CSV', 'alertRule'];
 
 export function LensWrapper({
   lensProps,


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/236812

## Summary

This PR disables the `Create alert rule` option from metrics experience charts

<img width="1158" height="381" alt="image" src="https://github.com/user-attachments/assets/cf7dfb98-4c81-4a39-b4c5-6b1526149e69" />


## How to test
- Clone https://github.com/simianhacker/simian-forge/tree/main
- Run ` ./forge --dataset hosts --count 25 --interval 30s`
  - For beats metrics, the system integration package MUST be installed (after installing it, make sure to delete all existing metrics data streams)
- Set the following config to `kibana.dev.yml`
```yml
feature_flags.overrides:
  metricsExperienceEnabled: true
 ```
- Navigate to Discover and Switch to ESQL mode
- Validate if the `Create alert rule` is not present in the context menu




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->