### PR TITLE
[Navigation] [Observability] Link to correct rules page in v2 left nav

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
@@ -500,7 +500,7 @@ function createNavTree({ streamsAvailable }: { streamsAvailable?: boolean }) {
                 spaceBefore: null,
                 children: [
                   {
-                    link: 'observability-overview:rules',
+                    link: 'management:triggersActions',
                   },
                   {
                     link: 'management:triggersActionsConnectors',


### PR DESCRIPTION
## Summary

Related to #232456.

In the recent work on the o11y solution left nav, we put in a link to the Observability rules page instead of the Management one. This was likely a mistake on our part, this corrects it.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->