### PR TITLE
[Security Solution] update the name of the Security solution default and Security solution alerts data views when needed

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/create_sourcerer_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/create_sourcerer_data_view.test.ts
@@ -1,0 +1,312 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createSourcererDataView } from './create_sourcerer_data_view';
+import { DEFAULT_TIME_FIELD } from '../../../common/constants';
+import {
+  DEFAULT_SECURITY_ALERT_DATA_VIEW,
+  DEFAULT_SECURITY_DATA_VIEW,
+} from '../../data_view_manager/components/data_view_picker/translations';
+import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public/types';
+
+describe('createSourcererDataView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return null if dataViewId is null', async () => {
+    const result = await createSourcererDataView({
+      body: { patternList: [] },
+      dataViewService: {} as unknown as jest.Mocked<DataViewsServicePublic>,
+      dataViewId: null,
+    });
+
+    expect(result).toEqual(undefined);
+  });
+
+  describe('default data view', () => {
+    it('should create new default data view if it does not exist', async () => {
+      const patternList = ['index1', 'index2'];
+
+      const mockCreateAndSave = jest.fn();
+      const dataViewService = {
+        getIdsWithTitle: jest.fn().mockReturnValue([]),
+        createAndSave: mockCreateAndSave.mockReturnValue({
+          id: 'siemDataViewId',
+          title: 'index1,index2',
+        }),
+        getExistingIndices: jest.fn().mockReturnValue(['index3', 'index4']),
+      } as unknown as jest.Mocked<DataViewsServicePublic>;
+
+      const result = await createSourcererDataView({
+        body: { patternList },
+        dataViewService,
+        dataViewId: 'dataViewId',
+      });
+
+      expect(mockCreateAndSave).toHaveBeenCalledWith(
+        {
+          allowNoIndex: true,
+          id: 'dataViewId',
+          title: patternList.join(),
+          timeFieldName: DEFAULT_TIME_FIELD,
+          name: DEFAULT_SECURITY_DATA_VIEW,
+        },
+        true
+      );
+      expect(result).toEqual({
+        defaultDataView: {
+          id: 'siemDataViewId',
+          patternList: ['index3', 'index4'],
+          title: 'index1,index2',
+        },
+        kibanaDataViews: [
+          {
+            id: 'siemDataViewId',
+            patternList: ['index1', 'index2'],
+            title: 'index1,index2',
+          },
+        ],
+        alertDataView: {
+          id: '',
+          patternList: [],
+          title: '',
+        },
+      });
+    });
+
+    it('should update default data view if patterns are different', async () => {
+      const patternList = ['index1', 'index2'];
+
+      const mockUpdateSavedObject = jest.fn();
+      const dataViewService = {
+        getIdsWithTitle: jest.fn().mockReturnValue([
+          {
+            id: 'dataViewId',
+            title: 'dataViewTitle',
+            name: 'Security solution default',
+          },
+        ]),
+        updateSavedObject: mockUpdateSavedObject,
+        getExistingIndices: jest.fn().mockReturnValue(['index3', 'index4']),
+        get: jest.fn().mockReturnValue({
+          id: 'dataViewId',
+          title: 'dataViewTitle',
+        }),
+      } as unknown as jest.Mocked<DataViewsServicePublic>;
+
+      const result = await createSourcererDataView({
+        body: { patternList },
+        dataViewService,
+        dataViewId: 'dataViewId',
+      });
+
+      expect(mockUpdateSavedObject).toHaveBeenCalledWith({
+        id: 'dataViewId',
+        title: 'index1,index2',
+      });
+      expect(result).toEqual({
+        defaultDataView: {
+          id: 'dataViewId',
+          patternList: ['index3', 'index4'],
+          title: 'index1,index2',
+        },
+        kibanaDataViews: [
+          {
+            id: 'dataViewId',
+            patternList: ['index3', 'index4'],
+            title: 'index1,index2',
+          },
+        ],
+        alertDataView: {
+          id: '',
+          patternList: [],
+          title: '',
+        },
+      });
+    });
+
+    it('should update default data view if name is not Security solution default', async () => {
+      const patternList = ['index1', 'index2'];
+
+      const mockUpdateSavedObject = jest.fn();
+      const dataViewService = {
+        getIdsWithTitle: jest.fn().mockReturnValue([
+          {
+            id: 'dataViewId',
+            title: 'index1,index2',
+            name: 'old name',
+          },
+        ]),
+        updateSavedObject: mockUpdateSavedObject,
+        getExistingIndices: jest.fn().mockReturnValue(['index3', 'index4']),
+        get: jest.fn().mockReturnValue({
+          id: 'dataViewId',
+          title: 'dataViewTitle',
+        }),
+      } as unknown as jest.Mocked<DataViewsServicePublic>;
+
+      const result = await createSourcererDataView({
+        body: { patternList },
+        dataViewService,
+        dataViewId: 'dataViewId',
+      });
+
+      expect(mockUpdateSavedObject).toHaveBeenCalledWith({
+        id: 'dataViewId',
+        name: 'Security solution default',
+        title: 'dataViewTitle',
+      });
+      expect(result).toEqual({
+        defaultDataView: {
+          id: 'dataViewId',
+          patternList: ['index3', 'index4'],
+          title: 'index1,index2',
+        },
+        kibanaDataViews: [
+          {
+            id: 'dataViewId',
+            patternList: ['index3', 'index4'],
+            title: 'index1,index2',
+          },
+        ],
+        alertDataView: {
+          id: '',
+          patternList: [],
+          title: '',
+        },
+      });
+    });
+  });
+
+  describe('alerts data view', () => {
+    it('should create new alerts data view if it does not exist', async () => {
+      const patternList = ['index1', 'index2'];
+
+      const mockCreateAndSave = jest.fn();
+      const dataViewService = {
+        getIdsWithTitle: jest.fn().mockReturnValue([
+          {
+            id: 'dataViewId',
+            title: 'dataViewTitle',
+          },
+        ]),
+        createAndSave: mockCreateAndSave.mockReturnValue({
+          id: 'alertsDataViewId',
+          title: 'index1,index2',
+        }),
+        getExistingIndices: jest.fn(),
+        get: jest.fn().mockReturnValue({
+          id: 'dataViewId',
+          title: 'dataViewTitle',
+        }),
+        updateSavedObject: jest.fn(),
+      } as unknown as jest.Mocked<DataViewsServicePublic>;
+
+      const result = await createSourcererDataView({
+        body: { patternList },
+        dataViewService,
+        dataViewId: 'dataViewId',
+        alertDataViewId: 'alertDataViewId',
+        signalIndexName: 'signalIndexName',
+      });
+
+      expect(mockCreateAndSave).toHaveBeenCalledWith(
+        {
+          allowNoIndex: true,
+          id: 'alertDataViewId',
+          title: 'signalIndexName',
+          timeFieldName: DEFAULT_TIME_FIELD,
+          name: DEFAULT_SECURITY_ALERT_DATA_VIEW,
+          managed: true,
+        },
+        true
+      );
+      expect(result).toEqual({
+        defaultDataView: {
+          id: 'dataViewId',
+          patternList: undefined,
+          title: 'index1,index2',
+        },
+        kibanaDataViews: [
+          {
+            id: 'dataViewId',
+            patternList: undefined,
+            title: 'index1,index2',
+          },
+        ],
+        alertDataView: {
+          id: 'alertsDataViewId',
+          patternList: ['index1', 'index2'],
+          title: 'index1,index2',
+        },
+      });
+    });
+
+    it('should update alerts data view if name is not Security solution alerts', async () => {
+      const patternList = ['index1', 'index2'];
+
+      const mockUpdateSavedObject = jest.fn();
+      const dataViewService = {
+        getIdsWithTitle: jest.fn().mockReturnValue([
+          {
+            id: 'dataViewId',
+            title: 'index1,index2',
+          },
+          {
+            id: 'alertsDataViewId',
+            title: 'index1,index2',
+            name: 'old name',
+          },
+        ]),
+        updateSavedObject: mockUpdateSavedObject,
+        getExistingIndices: jest.fn(),
+        get: jest.fn().mockReturnValue({
+          id: 'alertsDataViewId',
+          title: 'alertsDataViewTitle',
+        }),
+      } as unknown as jest.Mocked<DataViewsServicePublic>;
+
+      const result = await createSourcererDataView({
+        body: { patternList },
+        dataViewService,
+        dataViewId: 'dataViewId',
+        alertDataViewId: 'alertsDataViewId',
+      });
+
+      expect(mockUpdateSavedObject).toHaveBeenCalledWith({
+        id: 'alertsDataViewId',
+        name: 'Security solution alerts',
+        title: 'alertsDataViewTitle',
+      });
+      expect(result).toEqual({
+        defaultDataView: {
+          id: 'dataViewId',
+          patternList: undefined,
+          title: 'index1,index2',
+        },
+        kibanaDataViews: [
+          {
+            id: 'dataViewId',
+            patternList: undefined,
+            title: 'index1,index2',
+          },
+          {
+            id: 'alertsDataViewId',
+            patternList: ['index1', 'index2'],
+            title: 'index1,index2',
+          },
+        ],
+        alertDataView: {
+          id: 'alertsDataViewId',
+          patternList: [],
+          title: '',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR aims at fixing a UI issue related to the data view picker changes we made recently in Security Solution. After enabling the `dataViewPickerEnabled` feature flag (see [this PR](https://github.com/elastic/kibana/pull/234101)) we realized that the `Security solution default` and `Security solution alerts` aren't displayed properly.
This is only visible within an environment that had those data view existing before turning on the feature flag.

Instead of showing `Security solution default` we show this
<img width="562" height="366" alt="Screenshot 2025-10-09 at 4 10 40 PM" src="https://github.com/user-attachments/assets/3b59501e-f1ae-460d-b26c-b46f876ea772" />

And instead of showing `Security solution alerts` we show this
<img width="558" height="404" alt="Screenshot 2025-10-09 at 4 10 18 PM" src="https://github.com/user-attachments/assets/f50a0eb7-a5f2-41e0-8018-28d9ddf92ee6" />

Looking at the Data Views screen under Stack Management, we indeed see that the names are matching what we see in the data view picker
<img width="734" height="655" alt="Screenshot 2025-10-09 at 4 11 46 PM" src="https://github.com/user-attachments/assets/ebc743e8-91d9-4ac1-8992-85290db59f10" />

For the `Security solution default` data view, we added the name in [this PR](https://github.com/elastic/kibana/pull/224333).
For the `Security solution alerts` data view, we created the alert index and the corresponding data view in [this PR](https://github.com/elastic/kibana/pull/224144).
But we changed both names in [this PR](https://github.com/elastic/kibana/pull/231374) (from `Default security data view` to `Security solution default` and from `Security alert data view` to `Security solution alerts` respectively).

This means that if one of these data views was created either without a name or with an old name, that name would persist and be visible within the new data view picker.

## The fix

This PR makes a simple fix: if the names of the saved object differ from what we expect (only for the `default` and `alerts` data views), we update the saved object.

Here's en example of the data view being updated after a refresh

https://github.com/user-attachments/assets/4ef8c623-3e45-4a57-93bb-0464c3189f67

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->