### PR TITLE
[Discover] Uses BUCKET instead of DATE_TRUNC for the histogram

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/__mocks__/suggestions.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/__mocks__/suggestions.ts
@@ -185,7 +185,7 @@ export const histogramESQLSuggestionMock = {
       '662552df-2cdc-4539-bf3b-73b9f827252c': {
         index: 'e3465e67bdeced2befff9f9dca7ecf9c48504cad68a10efd881f4c7dd5ade28a',
         query: {
-          esql: 'from kibana_sample_data_logs | limit 10 | EVAL timestamp=DATE_TRUNC(30 second, @timestamp) | stats results = count(*) by timestamp',
+          esql: 'from kibana_sample_data_logs | limit 10 | STATS results = COUNT(*) BY timestamp = BUCKET(@timestamp, 30 minute)',
         },
         columns: [
           {

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.attributes.test.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.attributes.test.ts
@@ -682,7 +682,7 @@ describe('LensVisService attributes', () => {
             ],
             "query": Object {
               "esql": "from logstash-* | limit 10
-      | EVAL timestamp=DATE_TRUNC(10 minute, timestamp) | stats results = count(*) by timestamp",
+      | STATS results = COUNT(*) BY timestamp = BUCKET(timestamp, 10 minute)",
             },
             "visualization": Object {
               "gridConfig": Object {
@@ -819,7 +819,7 @@ describe('LensVisService attributes', () => {
   it('should use the correct histogram query when no suggestion passed', async () => {
     const histogramQuery = {
       esql: `from logstash-* | limit 10
-| EVAL timestamp=DATE_TRUNC(10 minute, @timestamp) | stats results = count(*) by timestamp`,
+| STATS results = COUNT(*) BY timestamp = BUCKET(@timestamp, 10 minute)`,
     };
     const lensVis = await getLensVisMock({
       filters,

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.suggestions.test.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.suggestions.test.ts
@@ -125,7 +125,7 @@ describe('LensVisService suggestions', () => {
 
     const histogramQuery = {
       esql: `from the-data-view | limit 100
-| EVAL timestamp=DATE_TRUNC(30 minute, @timestamp) | stats results = count(*) by timestamp`,
+| STATS results = COUNT(*) BY timestamp = BUCKET(@timestamp, 30 minute)`,
     };
 
     expect(lensVis.visContext?.attributes.state.query).toStrictEqual(histogramQuery);
@@ -163,7 +163,7 @@ describe('LensVisService suggestions', () => {
 
     const histogramQuery = {
       esql: `from the-data-view | limit 100
-| EVAL timestamp=DATE_TRUNC(30 minute, @timestamp) | stats results = count(*) by timestamp`,
+| STATS results = COUNT(*) BY timestamp = BUCKET(@timestamp, 30 minute)`,
     };
 
     expect(lensVis.visContext?.attributes.state.query).toStrictEqual(histogramQuery);
@@ -201,7 +201,7 @@ describe('LensVisService suggestions', () => {
 
     const histogramQuery = {
       esql: `FROM metrics*
-| EVAL timestamp=DATE_TRUNC(30 minute, @timestamp) | stats results = count(*) by timestamp`,
+| STATS results = COUNT(*) BY timestamp = BUCKET(@timestamp, 30 minute)`,
     };
 
     expect(lensVis.visContext?.attributes.state.query).toStrictEqual(histogramQuery);
@@ -286,7 +286,7 @@ describe('LensVisService suggestions', () => {
 
     const histogramQuery = {
       esql: `from the-data-view | limit 100
-| EVAL timestamp=DATE_TRUNC(30 minute, @timestamp) | stats results = count(*) by timestamp, \`var0\` | sort \`var0\` asc`,
+| STATS results = COUNT(*) BY timestamp = BUCKET(@timestamp, 30 minute), \`var0\` | sort \`var0\` asc`,
     };
 
     expect(lensVis.visContext?.attributes.state.query).toStrictEqual(histogramQuery);
@@ -367,7 +367,7 @@ describe('LensVisService suggestions', () => {
 
     const histogramQuery = {
       esql: `from the-data-view | limit 100
-| EVAL timestamp=DATE_TRUNC(30 minute, @timestamp) | stats results = count(*) by timestamp, \`coordinates\``,
+| STATS results = COUNT(*) BY timestamp = BUCKET(@timestamp, 30 minute), \`coordinates\``,
     };
 
     expect(lensVis.visContext?.attributes.state.query).toStrictEqual(histogramQuery);

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
@@ -627,9 +627,10 @@ export class LensVisService {
         ? ` | sort \`${breakdownColumn.name}\` asc`
         : '';
 
+    const timeBuckets = `${TIMESTAMP_COLUMN} = BUCKET(${dataView.timeFieldName}, ${queryInterval})`;
     return appendToESQLQuery(
       normalizedQuery,
-      `| EVAL ${TIMESTAMP_COLUMN}=DATE_TRUNC(${queryInterval}, ${dataView.timeFieldName}) | stats results = count(*) by ${TIMESTAMP_COLUMN}${breakdown}${sortBy}`
+      `| STATS results = COUNT(*) BY ${timeBuckets}${breakdown}${sortBy}`
     );
   };
 


### PR DESCRIPTION
## Summary

Uses the BUCKET function instead of DATE_TRUNC to build athe histogram query. This should have no effect in the histogram, it is just a more delightful query

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




