### PR TITLE
[8.18] [Obs AI Assistant] Unskip API test: “Knowledge base: when upgrading from 8.10 to 8.18" (#238117)

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/reindex_knowledge_base.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/reindex_knowledge_base.ts
@@ -101,7 +101,7 @@ export function isKnowledgeBaseIndexWriteBlocked(error: any) {
 
 export function isSemanticTextUnsupportedError(error: Error) {
   const semanticTextUnsupportedError =
-    'The [sparse_vector] field type is not supported on indices created on versions 8.0 to 8.10';
+    '[semantic_text] is available on indices created with 8.11 or higher. Please create a new index to use [semantic_text]';
 
   const isSemanticTextUnspported =
     error instanceof EsErrors.ResponseError &&

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_reindex.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_reindex.spec.ts
@@ -26,8 +26,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const retry = getService('retry');
   const log = getService('log');
 
-  // Failing: See https://github.com/elastic/kibana/issues/233242
-  describe.skip('when the knowledge base index was created before 8.11', function () {
+  describe('when the knowledge base index was created before 8.11', function () {
     // Intentionally skipped in all serverless environnments (local and MKI)
     // because the migration scenario being tested is not relevant to MKI and Serverless.
     this.tags(['skipServerless']);


### PR DESCRIPTION
Closes: https://github.com/elastic/kibana/issues/233242

# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Obs AI Assistant] Unskip API test: “Knowledge base: when upgrading from 8.10 to 8.18" (#238117)](https://github.com/elastic/kibana/pull/238117)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Søren Louv-Jansen","email":"soren.louv@elastic.co"},"sourceCommit":{"committedDate":"2025-10-09T07:38:08Z","message":"[Obs AI Assistant] Unskip API test: “Knowledge base: when upgrading from 8.10 to 8.18\" (#238117)\n\nCloses https://github.com/elastic/kibana/issues/233043\nThis test broke due to an Elasticsearch change:\nhttps://github.com/elastic/elasticsearch/pull/135845\n\nRelated:\n\n- https://github.com/elastic/kibana/issues/233242\n- https://github.com/elastic/kibana/issues/233043\n-","sha":"7fc4c393f189a4c9a17d142a7c89a49474b6e551","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v8.18.0","v9.1.0","v8.19.0","v9.3.0","v9.1.6"],"title":"[Obs AI Assistant] Unskip API test: “Knowledge base: when upgrading from 8.10 to 8.18\"","number":238117,"url":"https://github.com/elastic/kibana/pull/238117","mergeCommit":{"message":"[Obs AI Assistant] Unskip API test: “Knowledge base: when upgrading from 8.10 to 8.18\" (#238117)\n\nCloses https://github.com/elastic/kibana/issues/233043\nThis test broke due to an Elasticsearch change:\nhttps://github.com/elastic/elasticsearch/pull/135845\n\nRelated:\n\n- https://github.com/elastic/kibana/issues/233242\n- https://github.com/elastic/kibana/issues/233043\n-","sha":"7fc4c393f189a4c9a17d142a7c89a49474b6e551"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18","8.19"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238172","number":238172,"state":"MERGED","mergeCommit":{"sha":"2bd22d437fda2194120f449a47add20ad4ec1300","message":"[9.1] [Obs AI Assistant] Unskip API test: “Knowledge base: when upgrading from 8.10 to 8.18\" (#238117) (#238172)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Obs AI Assistant] Unskip API test: “Knowledge base: when upgrading\nfrom 8.10 to 8.18\"\n(#238117)](https://github.com/elastic/kibana/pull/238117)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Søren Louv-Jansen <soren.louv@elastic.co>"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238117","number":238117,"mergeCommit":{"message":"[Obs AI Assistant] Unskip API test: “Knowledge base: when upgrading from 8.10 to 8.18\" (#238117)\n\nCloses https://github.com/elastic/kibana/issues/233043\nThis test broke due to an Elasticsearch change:\nhttps://github.com/elastic/elasticsearch/pull/135845\n\nRelated:\n\n- https://github.com/elastic/kibana/issues/233242\n- https://github.com/elastic/kibana/issues/233043\n-","sha":"7fc4c393f189a4c9a17d142a7c89a49474b6e551"}}]}] BACKPORT-->