### PR TITLE
[Background search] Add telemetry

### DIFF
--- a/src/platform/plugins/private/vis_types/timelion/public/helpers/timelion_request_handler.ts
+++ b/src/platform/plugins/private/vis_types/timelion/public/helpers/timelion_request_handler.ts
@@ -151,10 +151,14 @@ export function getTimelionRequestHandler({
       const searchSessionOptions = dataSearch.session.getSearchOptions(searchSessionId);
       const visData = await doSearch(searchSessionOptions);
 
-      searchTracker?.complete();
+      searchTracker?.complete({
+        runtimeMs: 0,
+        resultsBytesSize: 0,
+        resultsCount: 0,
+      });
       return visData;
     } catch (e) {
-      searchTracker?.error();
+      searchTracker?.error(e);
 
       if (e && e.body) {
         const err = new Error(

--- a/src/platform/plugins/private/vis_types/timelion/public/helpers/timelion_request_handler.ts
+++ b/src/platform/plugins/private/vis_types/timelion/public/helpers/timelion_request_handler.ts
@@ -154,7 +154,7 @@ export function getTimelionRequestHandler({
       searchTracker?.complete();
       return visData;
     } catch (e) {
-      searchTracker?.error(e);
+      searchTracker?.error();
 
       if (e && e.body) {
         const err = new Error(

--- a/src/platform/plugins/private/vis_types/timelion/public/helpers/timelion_request_handler.ts
+++ b/src/platform/plugins/private/vis_types/timelion/public/helpers/timelion_request_handler.ts
@@ -151,11 +151,7 @@ export function getTimelionRequestHandler({
       const searchSessionOptions = dataSearch.session.getSearchOptions(searchSessionId);
       const visData = await doSearch(searchSessionOptions);
 
-      searchTracker?.complete({
-        runtimeMs: 0,
-        resultsBytesSize: 0,
-        resultsCount: 0,
-      });
+      searchTracker?.complete();
       return visData;
     } catch (e) {
       searchTracker?.error(e);

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -218,7 +218,8 @@ export const useDashboardMenuItems = ({
         testId: 'openBackgroundSearchFlyoutButton',
         run: () =>
           dataService.search.showSearchSessionsFlyout({
-            appId,
+            appId: appId!,
+            trackingProps: { entryPoint: 'background search button' },
           }),
       } as TopNavMenuData,
 

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -219,7 +219,7 @@ export const useDashboardMenuItems = ({
         run: () =>
           dataService.search.showSearchSessionsFlyout({
             appId: appId!,
-            trackingProps: { entryPoint: 'background search button' },
+            trackingProps: { openedFrom: 'background search button' },
           }),
       } as TopNavMenuData,
 

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -386,11 +386,7 @@ export class SearchInterceptor {
         id = response.id;
 
         if (!isRunningResponse(response)) {
-          searchTracker?.complete({
-            runtimeMs: response.rawResponse.took,
-            resultsCount: response.rawResponse.values_loaded,
-            resultsBytesSize: Buffer.byteLength(JSON.stringify(response.rawResponse)),
-          });
+          searchTracker?.complete(response);
         }
       }),
       map((response) => {

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -386,7 +386,11 @@ export class SearchInterceptor {
         id = response.id;
 
         if (!isRunningResponse(response)) {
-          searchTracker?.complete(response);
+          searchTracker?.complete({
+            runtimeMs: response.rawResponse.took,
+            resultsCount: response.rawResponse.values_loaded,
+            resultsBytesSize: Buffer.byteLength(JSON.stringify(response.rawResponse)),
+          });
         }
       }),
       map((response) => {

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -386,7 +386,7 @@ export class SearchInterceptor {
         id = response.id;
 
         if (!isRunningResponse(response)) {
-          searchTracker?.complete();
+          searchTracker?.complete(response);
         }
       }),
       map((response) => {
@@ -420,7 +420,7 @@ export class SearchInterceptor {
         } else {
           // Don't error out the search or cancel if it is being saved to the background
           if (!isSavedToBackground) {
-            searchTracker?.error();
+            searchTracker?.error(e);
             cancel();
           }
           return throwError(e);

--- a/src/platform/plugins/shared/data/public/search/search_service.ts
+++ b/src/platform/plugins/shared/data/public/search/search_service.ts
@@ -69,7 +69,7 @@ import { createUsageCollector } from './collectors';
 import { getEql, getEsaggs, getEsdsl, getEssql, getEsql } from './expressions';
 import type { ISearchInterceptor } from './search_interceptor';
 import { SearchInterceptor } from './search_interceptor';
-import type { ISessionsClient, ISessionService } from './session';
+import type { ISearchSessionEBTManager, ISessionsClient, ISessionService } from './session';
 import {
   SessionsClient,
   SessionService,
@@ -104,7 +104,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
   private usageCollector?: SearchUsageCollector;
   private sessionService!: ISessionService;
   private sessionsClient!: ISessionsClient;
-  private searchSessionEBTManager!: SearchSessionEBTManager;
+  private searchSessionEBTManager!: ISearchSessionEBTManager;
 
   constructor(private initializerContext: PluginInitializerContext<ConfigSchema>) {}
 

--- a/src/platform/plugins/shared/data/public/search/search_service.ts
+++ b/src/platform/plugins/shared/data/public/search/search_service.ts
@@ -70,10 +70,15 @@ import { getEql, getEsaggs, getEsdsl, getEssql, getEsql } from './expressions';
 import type { ISearchInterceptor } from './search_interceptor';
 import { SearchInterceptor } from './search_interceptor';
 import type { ISessionsClient, ISessionService } from './session';
-import { SessionsClient, SessionService } from './session';
-import { registerSearchSessionsMgmt } from './session/sessions_mgmt';
+import {
+  SessionsClient,
+  SessionService,
+  SearchSessionEBTManager,
+  registerSearchSessionEBTManagerAnalytics,
+} from './session';
+import { registerSearchSessionsMgmt, openSearchSessionsFlyout } from './session/sessions_mgmt';
 import type { ISearchSetup, ISearchStart } from './types';
-import { openSearchSessionsFlyout } from './session/sessions_mgmt';
+
 /** @internal */
 export interface SearchServiceSetupDependencies {
   expressions: ExpressionsSetup;
@@ -99,6 +104,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
   private usageCollector?: SearchUsageCollector;
   private sessionService!: ISessionService;
   private sessionsClient!: ISessionsClient;
+  private searchSessionEBTManager!: SearchSessionEBTManager;
 
   constructor(private initializerContext: PluginInitializerContext<ConfigSchema>) {}
 
@@ -110,9 +116,14 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
     this.usageCollector = createUsageCollector(getStartServices, usageCollection);
 
     this.sessionsClient = new SessionsClient({ http });
+
+    registerSearchSessionEBTManagerAnalytics(core);
+    this.searchSessionEBTManager = new SearchSessionEBTManager({ core });
+
     this.sessionService = new SessionService(
       this.initializerContext,
       getStartServices,
+      this.searchSessionEBTManager,
       this.sessionsClient,
       nowProvider,
       this.usageCollector
@@ -203,6 +214,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
           management,
           searchUsageCollector: this.usageCollector!,
           sessionsClient: this.sessionsClient,
+          searchSessionEBTManager: this.searchSessionEBTManager,
         },
         sessionsConfig,
         this.initializerContext.env.packageInfo.version
@@ -297,6 +309,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
         usageCollector: this.usageCollector!,
         config: config.search.sessions,
         sessionsClient: this.sessionsClient,
+        ebtManager: this.searchSessionEBTManager,
         share,
       }),
       showWarnings: (adapter, callback) => {

--- a/src/platform/plugins/shared/data/public/search/search_service.ts
+++ b/src/platform/plugins/shared/data/public/search/search_service.ts
@@ -118,7 +118,10 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
     this.sessionsClient = new SessionsClient({ http });
 
     registerSearchSessionEBTManagerAnalytics(core);
-    this.searchSessionEBTManager = new SearchSessionEBTManager({ core });
+    this.searchSessionEBTManager = new SearchSessionEBTManager({
+      core,
+      initializerContext: this.initializerContext,
+    });
 
     this.sessionService = new SessionService(
       this.initializerContext,

--- a/src/platform/plugins/shared/data/public/search/search_service.ts
+++ b/src/platform/plugins/shared/data/public/search/search_service.ts
@@ -120,7 +120,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
     registerSearchSessionEBTManagerAnalytics(core);
     this.searchSessionEBTManager = new SearchSessionEBTManager({
       core,
-      initializerContext: this.initializerContext,
+      logger: this.initializerContext.logger.get(),
     });
 
     this.sessionService = new SessionService(

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/constants.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/constants.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const BG_SEARCH_START = 'bg_search_start';
+export const BG_SEARCH_COMPLETE = 'bg_search_complete';
+export const BG_SEARCH_ERROR = 'bg_search_error';
+export const BG_SEARCH_CANCEL = 'bg_search_cancel';
+export const BG_SEARCH_OPEN = 'bg_search_open';
+export const BG_SEARCH_LIST_VIEW = 'bg_search_list_view';

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/index.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/index.ts
@@ -7,5 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+export type { ISearchSessionEBTManager } from './search_session_ebt_manager';
 export { SearchSessionEBTManager } from './search_session_ebt_manager';
 export { registerSearchSessionEBTManagerAnalytics } from './search_session_ebt_manager_registrations';

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/index.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { SearchSessionEBTManager } from './search_session_ebt_manager';
+export { registerSearchSessionEBTManagerAnalytics } from './search_session_ebt_manager_registrations';

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
@@ -112,12 +112,13 @@ export class SearchSessionEBTManager {
     });
   }
 
-  public trackBgsOpened({ session }: { session: UISession }) {
+  public trackBgsOpened({ session, resumeSource }: { session: UISession; resumeSource: string }) {
     this.reportEvent(BG_SEARCH_OPEN, {
       query_lang: this.getQueryLanguage(
         session.restoreState?.query as Query | AggregateQuery | undefined
       ),
       session_id: session.id,
+      resume_source: resumeSource || '',
       status: session.status,
     });
   }

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
@@ -81,7 +81,7 @@ export class SearchSessionEBTManager {
   }
 
   public trackBgsError({ session, error }: { session: SearchSessionSavedObject; error: Error }) {
-    const errorType = 'attributes' in error ? (error as any).attributes.error?.type : undefined;
+    const errorType = 'attributes' in error ? (error as any).attributes.error?.type : '';
     const httpStatus = 'attributes' in error ? (error as any).attributes.rawResponse?.status : -1;
 
     this.reportEvent(BG_SEARCH_ERROR, {

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
@@ -8,7 +8,7 @@
  */
 
 import type { CoreSetup } from '@kbn/core/public';
-import type { AggregateQuery, Query } from '@kbn/es-query';
+import { isOfAggregateQueryType, type AggregateQuery, type Query } from '@kbn/es-query';
 import type { PublicContract } from '@kbn/utility-types';
 import type { SearchSessionSavedObject } from '../sessions_client';
 import {
@@ -122,15 +122,15 @@ export class SearchSessionEBTManager {
 
   private getQueryLanguage(query: Query | AggregateQuery | undefined) {
     if (!query) return '';
-    if ('language' in query) return query.language;
-    return 'esql';
+    if (isOfAggregateQueryType(query)) return 'esql';
+    return query.language;
   }
 
   private getQueryString(query: Query | AggregateQuery | undefined) {
     if (!query) return '';
-    if ('query' in query && typeof query.query === 'string') return query.query;
-    if ('esql' in query) return query.esql;
-    return '';
+    if (isOfAggregateQueryType(query)) return query.esql;
+    if (typeof query.query === 'string') return query.query;
+    return Object.values(query.query).join('');
   }
 
   private getQueryStringCharCount(queryString: string) {

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
@@ -34,11 +34,18 @@ export class SearchSessionEBTManager {
     this.reportEventCore(...args);
   }
 
-  public trackBgsStarted({ session }: { session: SearchSessionSavedObject }) {
+  public trackBgsStarted({
+    entryPoint,
+    session,
+  }: {
+    entryPoint: string;
+    session: SearchSessionSavedObject;
+  }) {
     const query = session.attributes.restoreState?.query as Query | AggregateQuery | undefined;
     const queryString = this.getQueryString(query);
 
     this.reportEvent(BG_SEARCH_START, {
+      entry_point: entryPoint,
       query_lang: this.getQueryLanguage(query),
       session_id: session.attributes.sessionId,
       query_chars_bucket: this.getQueryStringCharCount(queryString),

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
@@ -7,12 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { CoreSetup, PluginInitializerContext } from '@kbn/core/public';
+import type { CoreSetup } from '@kbn/core/public';
 import { isOfAggregateQueryType, type AggregateQuery, type Query } from '@kbn/es-query';
 import type { PublicContract } from '@kbn/utility-types';
 import type { IKibanaSearchResponse } from '@kbn/search-types';
 import type { Logger } from '@kbn/logging';
-import type { ConfigSchema } from '../../../../server/config';
 import type { SearchSessionSavedObject } from '../sessions_client';
 import {
   BG_SEARCH_CANCEL,
@@ -30,15 +29,9 @@ export class SearchSessionEBTManager {
   private reportEventCore: CoreSetup['analytics']['reportEvent'];
   private logger: Logger;
 
-  constructor({
-    core,
-    initializerContext,
-  }: {
-    core: CoreSetup;
-    initializerContext: PluginInitializerContext<ConfigSchema>;
-  }) {
+  constructor({ core, logger }: { core: CoreSetup; logger: Logger }) {
     this.reportEventCore = core.analytics.reportEvent;
-    this.logger = initializerContext.logger.get();
+    this.logger = logger;
   }
 
   private reportEvent(...args: Parameters<CoreSetup['analytics']['reportEvent']>) {

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
@@ -9,7 +9,6 @@
 
 import type { CoreSetup } from '@kbn/core/public';
 import type { AggregateQuery, Query } from '@kbn/es-query';
-import type { IKibanaSearchResponse } from '@kbn/search-types';
 import type { PublicContract } from '@kbn/utility-types';
 import type { SearchSessionSavedObject } from '../sessions_client';
 import {
@@ -48,10 +47,14 @@ export class SearchSessionEBTManager {
   }
 
   public trackBgsCompleted({
-    response,
+    trackingData,
     session,
   }: {
-    response: IKibanaSearchResponse;
+    trackingData: {
+      runtimeMs: number;
+      resultsCount: number;
+      resultsBytesSize: number;
+    };
     session: SearchSessionSavedObject;
   }) {
     this.reportEvent(BG_SEARCH_COMPLETE, {
@@ -59,9 +62,9 @@ export class SearchSessionEBTManager {
         session.attributes.restoreState?.query as Query | AggregateQuery | undefined
       ),
       session_id: session.id,
-      runtime_ms: response.rawResponse.took,
-      result_rows_bucket: response.rawResponse.values_loaded,
-      result_bytes_bucket: Buffer.byteLength(JSON.stringify(response.rawResponse)),
+      runtime_ms: trackingData.runtimeMs,
+      result_rows_bucket: trackingData.resultsCount,
+      result_bytes_bucket: trackingData.resultsBytesSize,
     });
   }
 

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
@@ -19,6 +19,7 @@ import {
   BG_SEARCH_OPEN,
   BG_SEARCH_START,
 } from './constants';
+import type { UISession } from '../sessions_mgmt/types';
 
 export type ISearchSessionEBTManager = PublicContract<SearchSessionEBTManager>;
 
@@ -105,10 +106,10 @@ export class SearchSessionEBTManager {
     });
   }
 
-  public trackBgsOpened({ session }: { session: SearchSessionSavedObject }) {
+  public trackBgsOpened({ session }: { session: UISession }) {
     this.reportEvent(BG_SEARCH_OPEN, {
       query_lang: this.getQueryLanguage(
-        session.attributes.restoreState?.query as Query | AggregateQuery | undefined
+        session.restoreState?.query as Query | AggregateQuery | undefined
       ),
       session_id: session.id,
     });

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
@@ -118,6 +118,7 @@ export class SearchSessionEBTManager {
         session.restoreState?.query as Query | AggregateQuery | undefined
       ),
       session_id: session.id,
+      status: session.status,
     });
   }
 

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CoreSetup } from '@kbn/core/public';
+import type { AggregateQuery, Query } from '@kbn/es-query';
+import type { IKibanaSearchResponse } from '@kbn/search-types';
+import type { SearchSessionSavedObject } from '../sessions_client';
+import {
+  BG_SEARCH_CANCEL,
+  BG_SEARCH_COMPLETE,
+  BG_SEARCH_ERROR,
+  BG_SEARCH_LIST_VIEW,
+  BG_SEARCH_OPEN,
+  BG_SEARCH_START,
+} from './constants';
+
+export class SearchSessionEBTManager {
+  private reportEventCore: CoreSetup['analytics']['reportEvent'];
+
+  constructor({ core }: { core: CoreSetup }) {
+    this.reportEventCore = core.analytics.reportEvent;
+  }
+
+  private reportEvent(...args: Parameters<CoreSetup['analytics']['reportEvent']>) {
+    if (!this.reportEventCore) return;
+    this.reportEventCore(...args);
+  }
+
+  public trackBgsStarted({ session }: { session: SearchSessionSavedObject }) {
+    const query = session.attributes.restoreState?.query as Query | AggregateQuery | undefined;
+    const queryString = this.getQueryString(query);
+
+    this.reportEvent(BG_SEARCH_START, {
+      query_lang: this.getQueryLanguage(query),
+      session_id: session.attributes.sessionId,
+      query_chars_bucket: this.getQueryStringCharCount(queryString),
+      query_lines_bucket: this.getQueryStringLineCount(queryString),
+    });
+  }
+
+  public trackBgsCompleted({
+    response,
+    session,
+  }: {
+    response: IKibanaSearchResponse;
+    session: SearchSessionSavedObject;
+  }) {
+    this.reportEvent(BG_SEARCH_COMPLETE, {
+      query_lang: this.getQueryLanguage(
+        session.attributes.restoreState?.query as Query | AggregateQuery | undefined
+      ),
+      session_id: session.id,
+      runtime_ms: response.rawResponse.took,
+      result_rows_bucket: response.rawResponse.values_loaded,
+      result_bytes_bucket: Buffer.byteLength(JSON.stringify(response.rawResponse)),
+    });
+  }
+
+  public trackBgsError({ session, error }: { session: SearchSessionSavedObject; error: Error }) {
+    const errorType = 'attributes' in error ? (error as any).attributes.error?.type : undefined;
+    const httpStatus = 'attributes' in error ? (error as any).attributes.rawResponse?.status : -1;
+
+    this.reportEvent(BG_SEARCH_ERROR, {
+      query_lang: this.getQueryLanguage(
+        session.attributes.restoreState?.query as Query | AggregateQuery | undefined
+      ),
+      session_id: session.id,
+      error_type: errorType,
+      http_status: httpStatus,
+    });
+  }
+
+  public trackBgsCancelled({
+    session,
+    cancelSource,
+  }: {
+    session: SearchSessionSavedObject;
+    cancelSource: string;
+  }) {
+    this.reportEvent(BG_SEARCH_CANCEL, {
+      query_lang: this.getQueryLanguage(
+        session.attributes.restoreState?.query as Query | AggregateQuery | undefined
+      ),
+      session_id: session.id,
+      cancel_source: cancelSource,
+    });
+  }
+
+  public trackBgsOpened({ session }: { session: SearchSessionSavedObject }) {
+    this.reportEvent(BG_SEARCH_OPEN, {
+      query_lang: this.getQueryLanguage(
+        session.attributes.restoreState?.query as Query | AggregateQuery | undefined
+      ),
+      session_id: session.id,
+    });
+  }
+
+  public trackBgsListView({ entryPoint }: { entryPoint: string }) {
+    this.reportEvent(BG_SEARCH_LIST_VIEW, {
+      entry_point: entryPoint,
+    });
+  }
+
+  private getQueryLanguage(query: Query | AggregateQuery | undefined) {
+    if (!query) return '';
+    if ('language' in query) return query.language;
+    return 'esql';
+  }
+
+  private getQueryString(query: Query | AggregateQuery | undefined) {
+    if (!query) return '';
+    if ('query' in query && typeof query.query === 'string') return query.query;
+    if ('esql' in query) return query.esql;
+    return '';
+  }
+
+  private getQueryStringCharCount(queryString: string) {
+    return queryString.replace(/\n/g, '').length;
+  }
+
+  private getQueryStringLineCount(queryString: string) {
+    return queryString.split('\n').length;
+  }
+}

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager.ts
@@ -10,6 +10,7 @@
 import type { CoreSetup } from '@kbn/core/public';
 import type { AggregateQuery, Query } from '@kbn/es-query';
 import type { IKibanaSearchResponse } from '@kbn/search-types';
+import type { PublicContract } from '@kbn/utility-types';
 import type { SearchSessionSavedObject } from '../sessions_client';
 import {
   BG_SEARCH_CANCEL,
@@ -19,6 +20,8 @@ import {
   BG_SEARCH_OPEN,
   BG_SEARCH_START,
 } from './constants';
+
+export type ISearchSessionEBTManager = PublicContract<SearchSessionEBTManager>;
 
 export class SearchSessionEBTManager {
   private reportEventCore: CoreSetup['analytics']['reportEvent'];

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager_registrations.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager_registrations.ts
@@ -120,6 +120,10 @@ export const registerSearchSessionEBTManagerAnalytics = (core: CoreSetup) => {
     schema: {
       query_lang: COMMON_SCHEMA.query_lang,
       session_id: COMMON_SCHEMA.session_id,
+      status: {
+        type: 'keyword',
+        _meta: { description: 'The current status of the search session.' },
+      },
     },
   });
 

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager_registrations.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager_registrations.ts
@@ -34,6 +34,10 @@ export const registerSearchSessionEBTManagerAnalytics = (core: CoreSetup) => {
     schema: {
       query_lang: COMMON_SCHEMA.query_lang,
       session_id: COMMON_SCHEMA.session_id,
+      entry_point: {
+        type: 'keyword',
+        _meta: { description: 'The entry point used to start the background search.' },
+      },
       query_chars_bucket: {
         type: 'integer',
         _meta: {

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager_registrations.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager_registrations.ts
@@ -124,6 +124,12 @@ export const registerSearchSessionEBTManagerAnalytics = (core: CoreSetup) => {
         type: 'keyword',
         _meta: { description: 'The current status of the search session.' },
       },
+      resume_source: {
+        type: 'keyword',
+        _meta: {
+          description: 'The source from which the background search session was resumed.',
+        },
+      },
     },
   });
 

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager_registrations.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager_registrations.ts
@@ -100,12 +100,6 @@ export const registerSearchSessionEBTManagerAnalytics = (core: CoreSetup) => {
           description: 'The HTTP status code returned by the search request.',
         },
       },
-      error_code: {
-        type: 'keyword',
-        _meta: {
-          description: 'The type of error that occurred during the background search.',
-        },
-      },
     },
   });
 

--- a/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager_registrations.ts
+++ b/src/platform/plugins/shared/data/public/search/session/ebt_manager/search_session_ebt_manager_registrations.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CoreSetup, SchemaValue } from '@kbn/core/public';
+import {
+  BG_SEARCH_CANCEL,
+  BG_SEARCH_COMPLETE,
+  BG_SEARCH_ERROR,
+  BG_SEARCH_LIST_VIEW,
+  BG_SEARCH_OPEN,
+  BG_SEARCH_START,
+} from './constants';
+
+const COMMON_SCHEMA: Record<string, SchemaValue<unknown>> = {
+  query_lang: {
+    type: 'keyword',
+    _meta: { description: 'The query language used in the search (e.g., KQL, Lucene, DSL).' },
+  },
+  session_id: {
+    type: 'keyword',
+    _meta: { description: 'The unique identifier for the search session.' },
+  },
+};
+
+export const registerSearchSessionEBTManagerAnalytics = (core: CoreSetup) => {
+  core.analytics.registerEventType({
+    eventType: BG_SEARCH_START,
+    schema: {
+      query_lang: COMMON_SCHEMA.query_lang,
+      session_id: COMMON_SCHEMA.session_id,
+      query_chars_bucket: {
+        type: 'integer',
+        _meta: {
+          description:
+            'A bucketed representation of the number of characters in the search query (e.g., 0-50, 51-100).',
+        },
+      },
+      query_lines_bucket: {
+        type: 'integer',
+        _meta: {
+          description:
+            'A bucketed representation of the number of lines in the search query (e.g., 1, 2-5, 6-10).',
+        },
+      },
+    },
+  });
+
+  core.analytics.registerEventType({
+    eventType: BG_SEARCH_COMPLETE,
+    schema: {
+      query_lang: COMMON_SCHEMA.query_lang,
+      session_id: COMMON_SCHEMA.session_id,
+      runtime_ms: {
+        type: 'integer',
+        _meta: {
+          description: 'The total time taken to complete the background search in milliseconds.',
+        },
+      },
+      result_rows_bucket: {
+        type: 'integer',
+        _meta: {
+          description:
+            'A bucketed representation of the number of rows returned by the search (e.g., 0-100, 101-500).',
+        },
+      },
+      result_bytes_bucket: {
+        type: 'integer',
+        _meta: {
+          description:
+            'A bucketed representation of the size of the search results in bytes (e.g., 0-1KB, 1KB-10KB).',
+        },
+      },
+    },
+  });
+
+  core.analytics.registerEventType({
+    eventType: BG_SEARCH_ERROR,
+    schema: {
+      query_lang: COMMON_SCHEMA.query_lang,
+      session_id: COMMON_SCHEMA.session_id,
+      error_type: {
+        type: 'keyword',
+        _meta: {
+          description: 'The type of error that occurred during the background search.',
+        },
+      },
+      http_status: {
+        type: 'integer',
+        _meta: {
+          description: 'The HTTP status code returned by the search request.',
+        },
+      },
+      error_code: {
+        type: 'keyword',
+        _meta: {
+          description: 'The type of error that occurred during the background search.',
+        },
+      },
+    },
+  });
+
+  core.analytics.registerEventType({
+    eventType: BG_SEARCH_CANCEL,
+    schema: {
+      query_lang: COMMON_SCHEMA.query_lang,
+      session_id: COMMON_SCHEMA.session_id,
+      cancel_source: {
+        type: 'keyword',
+        _meta: { description: 'The source that initiated the cancellation (e.g., user, system).' },
+      },
+    },
+  });
+
+  core.analytics.registerEventType({
+    eventType: BG_SEARCH_OPEN,
+    schema: {
+      query_lang: COMMON_SCHEMA.query_lang,
+      session_id: COMMON_SCHEMA.session_id,
+    },
+  });
+
+  core.analytics.registerEventType({
+    eventType: BG_SEARCH_LIST_VIEW,
+    schema: {
+      entry_point: {
+        type: 'keyword',
+        _meta: { description: 'The entry point used to access the background search list view.' },
+      },
+    },
+  });
+};

--- a/src/platform/plugins/shared/data/public/search/session/index.ts
+++ b/src/platform/plugins/shared/data/public/search/session/index.ts
@@ -16,3 +16,4 @@ export { noSearchSessionStorageCapabilityMessage } from './i18n';
 export { SEARCH_SESSIONS_MANAGEMENT_ID } from './constants';
 export type { WaitUntilNextSessionCompletesOptions } from './session_helpers';
 export { waitUntilNextSessionCompletes$ } from './session_helpers';
+export * from './ebt_manager';

--- a/src/platform/plugins/shared/data/public/search/session/mocks.ts
+++ b/src/platform/plugins/shared/data/public/search/session/mocks.ts
@@ -13,6 +13,7 @@ import type { ISessionService } from './session_service';
 import { SearchSessionState } from './search_session_state';
 import type { SessionMeta } from './search_session_state';
 import type { PersistedSearchSessionSavedObjectAttributes } from './sessions_mgmt/types';
+import type { ISearchSessionEBTManager } from './ebt_manager';
 
 export function getSessionsClientMock(): jest.Mocked<ISessionsClient> {
   return {
@@ -84,3 +85,14 @@ export const getPersistedSearchSessionSavedObjectAttributesMock = (
     ...overrides,
   };
 };
+
+export function getSearchSessionEBTManagerMock(): jest.Mocked<ISearchSessionEBTManager> {
+  return {
+    trackBgsStarted: jest.fn(),
+    trackBgsCompleted: jest.fn(),
+    trackBgsError: jest.fn(),
+    trackBgsCancelled: jest.fn(),
+    trackBgsOpened: jest.fn(),
+    trackBgsListView: jest.fn(),
+  };
+}

--- a/src/platform/plugins/shared/data/public/search/session/session_helpers.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_helpers.test.ts
@@ -17,7 +17,7 @@ import type { NowProviderInternalContract } from '../../now_provider';
 import { coreMock } from '@kbn/core/public/mocks';
 import { createNowProviderMock } from '../../now_provider/mocks';
 import { SEARCH_SESSIONS_MANAGEMENT_ID } from './constants';
-import { getSessionsClientMock } from './mocks';
+import { getSearchSessionEBTManagerMock, getSessionsClientMock } from './mocks';
 
 let sessionService: ISessionService;
 let state$: BehaviorSubject<SearchSessionState>;
@@ -56,6 +56,7 @@ beforeEach(() => {
         },
         ...rest,
       ]),
+    getSearchSessionEBTManagerMock(),
     getSessionsClientMock(),
     nowProvider,
     undefined,
@@ -82,7 +83,7 @@ describe('waitUntilNextSessionCompletes$', () => {
         poll: async () => {},
       });
 
-      completeSearch();
+      completeSearch({ rawResponse: {} });
 
       const next = jest.fn();
       const complete = jest.fn();
@@ -97,7 +98,7 @@ describe('waitUntilNextSessionCompletes$', () => {
         poll: async () => {},
       }).complete;
 
-      completeSearch();
+      completeSearch({ rawResponse: {} });
 
       expect(next).not.toBeCalled();
       advance(500);

--- a/src/platform/plugins/shared/data/public/search/session/session_helpers.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_helpers.test.ts
@@ -83,7 +83,7 @@ describe('waitUntilNextSessionCompletes$', () => {
         poll: async () => {},
       });
 
-      completeSearch({ rawResponse: {} });
+      completeSearch({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
 
       const next = jest.fn();
       const complete = jest.fn();
@@ -98,7 +98,7 @@ describe('waitUntilNextSessionCompletes$', () => {
         poll: async () => {},
       }).complete;
 
-      completeSearch({ rawResponse: {} });
+      completeSearch({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
 
       expect(next).not.toBeCalled();
       advance(500);

--- a/src/platform/plugins/shared/data/public/search/session/session_helpers.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_helpers.test.ts
@@ -83,7 +83,7 @@ describe('waitUntilNextSessionCompletes$', () => {
         poll: async () => {},
       });
 
-      completeSearch({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
+      completeSearch();
 
       const next = jest.fn();
       const complete = jest.fn();
@@ -98,7 +98,7 @@ describe('waitUntilNextSessionCompletes$', () => {
         poll: async () => {},
       }).complete;
 
-      completeSearch({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
+      completeSearch();
 
       expect(next).not.toBeCalled();
       advance(500);

--- a/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
@@ -159,9 +159,9 @@ describe('Session service', () => {
       }).complete;
 
       expect(state$.getValue()).toBe(SearchSessionState.Loading);
-      complete1({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
+      complete1();
       expect(state$.getValue()).toBe(SearchSessionState.Loading);
-      complete2({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
+      complete2();
       expect(state$.getValue()).toBe(SearchSessionState.Completed);
     });
 
@@ -174,7 +174,7 @@ describe('Session service', () => {
       sessionService.trackSearch({ abort, poll });
       sessionService.trackSearch({ abort, poll });
       const complete = sessionService.trackSearch({ abort, poll }).complete;
-      complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
+      complete();
 
       await sessionService.cancel({ source: 'test' });
 
@@ -213,7 +213,7 @@ describe('Session service', () => {
         sessionService.start();
 
         const searchTracker = sessionService.trackSearch({ abort, poll });
-        searchTracker.complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
+        searchTracker.complete();
 
         expect(poll).toHaveBeenCalledTimes(0);
 
@@ -427,7 +427,7 @@ describe('Session service', () => {
     const poll = jest.fn(() => Promise.resolve());
 
     const search1 = sessionService.trackSearch({ poll, abort });
-    search1.complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
+    search1.complete();
 
     const search2 = sessionService.trackSearch({ poll, abort });
     search2.error(new Error());
@@ -554,7 +554,7 @@ describe('Session service', () => {
         poll: async () => {},
       }).complete;
 
-      complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
+      complete();
 
       expect(emitResult).toEqual([false]);
 
@@ -584,7 +584,7 @@ describe('Session service', () => {
         poll: async () => {},
       }).complete;
 
-      complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
+      complete();
 
       expect(emitResult).toEqual([false]);
 
@@ -614,7 +614,7 @@ describe('Session service', () => {
 
       expect(usageCollector.trackSessionIndicatorSaveDisabled).toHaveBeenCalledTimes(0);
 
-      complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
+      complete();
 
       jest.advanceTimersByTime(5 * 60 * 1000); // 5 minutes
 
@@ -673,7 +673,7 @@ describe('Session service', () => {
         sessionService.start();
 
         // When
-        complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
+        complete();
 
         // Then
         expect(sessionService.isCurrentSession(firstSessionId)).toBe(false);

--- a/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
@@ -314,7 +314,7 @@ describe('Session service', () => {
         restoreState: {},
       }),
     });
-    await sessionService.save();
+    await sessionService.save({ entryPoint: 'test' });
 
     expect(sessionService.getSearchOptions(someOtherId)).toEqual({
       isStored: false,
@@ -354,9 +354,9 @@ describe('Session service', () => {
 
   test('enableStorage() enables storage capabilities', async () => {
     sessionService.start();
-    await expect(() => sessionService.save()).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"No info provider for current session"`
-    );
+    await expect(() =>
+      sessionService.save({ entryPoint: 'test' })
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"No info provider for current session"`);
 
     expect(sessionService.isSessionStorageReady()).toBe(false);
 
@@ -371,7 +371,7 @@ describe('Session service', () => {
 
     expect(sessionService.isSessionStorageReady()).toBe(true);
 
-    await expect(() => sessionService.save()).resolves;
+    await expect(() => sessionService.save({ entryPoint: 'test' })).resolves;
 
     sessionService.clear();
     expect(sessionService.isSessionStorageReady()).toBe(false);
@@ -407,7 +407,9 @@ describe('Session service', () => {
       },
     });
     sessionService.start();
-    await expect(() => sessionService.save()).rejects.toMatchInlineSnapshot(`[Error: Haha]`);
+    await expect(() => sessionService.save({ entryPoint: 'test' })).rejects.toMatchInlineSnapshot(
+      `[Error: Haha]`
+    );
   });
 
   test('save() triggers search polling to extend searches', async () => {
@@ -434,7 +436,7 @@ describe('Session service', () => {
 
     expect(poll).toHaveBeenCalledTimes(0);
 
-    await sessionService.save();
+    await sessionService.save({ entryPoint: 'test' });
 
     expect(poll).toHaveBeenCalledTimes(2); // for completed and in-progress
   });
@@ -458,7 +460,7 @@ describe('Session service', () => {
 
     expect(onSavingSession).toHaveBeenCalledTimes(0);
 
-    await sessionService.save();
+    await sessionService.save({ entryPoint: 'test' });
 
     expect(onSavingSession).toHaveBeenCalledTimes(1);
   });
@@ -484,7 +486,7 @@ describe('Session service', () => {
 
     expect(onSavingSession).toHaveBeenCalledTimes(0);
 
-    const searchSession = await sessionService.save();
+    const searchSession = await sessionService.save({ entryPoint: 'test' });
 
     expect(searchSession.attributes.name).toBe(mockSavedObject.attributes.name);
   });
@@ -504,9 +506,9 @@ describe('Session service', () => {
 
     test('save() throws', async () => {
       sessionService.start();
-      await expect(() => sessionService.save()).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"No access to search sessions"`
-      );
+      await expect(() =>
+        sessionService.save({ entryPoint: 'test' })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"No access to search sessions"`);
     });
   });
 
@@ -522,7 +524,7 @@ describe('Session service', () => {
       }),
     });
     sessionService.start();
-    await sessionService.save();
+    await sessionService.save({ entryPoint: 'test' });
     await expect(sessionService.renameCurrentSession('New name')).resolves.toBeUndefined();
     expect(toastService.addError).toHaveBeenCalledWith(
       renameError,
@@ -661,7 +663,7 @@ describe('Session service', () => {
 
         const firstSessionId = sessionService.start();
         // We need to store the search so poll gets called when the search is completed and we can assert on it
-        await sessionService.save();
+        await sessionService.save({ entryPoint: 'test' });
 
         const poll = jest.fn().mockResolvedValue(undefined);
         const { complete } = sessionService.trackSearch({

--- a/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
@@ -159,9 +159,9 @@ describe('Session service', () => {
       }).complete;
 
       expect(state$.getValue()).toBe(SearchSessionState.Loading);
-      complete1({ rawResponse: {} });
+      complete1({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
       expect(state$.getValue()).toBe(SearchSessionState.Loading);
-      complete2({ rawResponse: {} });
+      complete2({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
       expect(state$.getValue()).toBe(SearchSessionState.Completed);
     });
 
@@ -174,7 +174,7 @@ describe('Session service', () => {
       sessionService.trackSearch({ abort, poll });
       sessionService.trackSearch({ abort, poll });
       const complete = sessionService.trackSearch({ abort, poll }).complete;
-      complete({ rawResponse: {} });
+      complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
 
       await sessionService.cancel({ source: 'test' });
 
@@ -213,7 +213,7 @@ describe('Session service', () => {
         sessionService.start();
 
         const searchTracker = sessionService.trackSearch({ abort, poll });
-        searchTracker.complete({ rawResponse: {} });
+        searchTracker.complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
 
         expect(poll).toHaveBeenCalledTimes(0);
 
@@ -425,7 +425,7 @@ describe('Session service', () => {
     const poll = jest.fn(() => Promise.resolve());
 
     const search1 = sessionService.trackSearch({ poll, abort });
-    search1.complete({ rawResponse: {} });
+    search1.complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
 
     const search2 = sessionService.trackSearch({ poll, abort });
     search2.error(new Error());
@@ -552,7 +552,7 @@ describe('Session service', () => {
         poll: async () => {},
       }).complete;
 
-      complete({ rawResponse: {} });
+      complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
 
       expect(emitResult).toEqual([false]);
 
@@ -582,7 +582,7 @@ describe('Session service', () => {
         poll: async () => {},
       }).complete;
 
-      complete({ rawResponse: {} });
+      complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
 
       expect(emitResult).toEqual([false]);
 
@@ -612,7 +612,7 @@ describe('Session service', () => {
 
       expect(usageCollector.trackSessionIndicatorSaveDisabled).toHaveBeenCalledTimes(0);
 
-      complete({ rawResponse: {} });
+      complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
 
       jest.advanceTimersByTime(5 * 60 * 1000); // 5 minutes
 
@@ -671,7 +671,7 @@ describe('Session service', () => {
         sessionService.start();
 
         // When
-        complete({ rawResponse: {} });
+        complete({ resultsBytesSize: 0, resultsCount: 0, runtimeMs: 0 });
 
         // Then
         expect(sessionService.isCurrentSession(firstSessionId)).toBe(false);

--- a/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.test.ts
@@ -11,7 +11,7 @@ import type { ISessionService } from './session_service';
 import { SessionService } from './session_service';
 import { coreMock } from '@kbn/core/public/mocks';
 import { first, take, toArray } from 'rxjs';
-import { getSessionsClientMock } from './mocks';
+import { getSearchSessionEBTManagerMock, getSessionsClientMock } from './mocks';
 import { BehaviorSubject } from 'rxjs';
 import { SearchSessionState } from './search_session_state';
 import { createNowProviderMock } from '../../now_provider/mocks';
@@ -89,6 +89,7 @@ describe('Session service', () => {
           },
           ...rest,
         ]),
+      getSearchSessionEBTManagerMock(),
       sessionsClient,
       nowProvider,
       usageCollector,
@@ -158,9 +159,9 @@ describe('Session service', () => {
       }).complete;
 
       expect(state$.getValue()).toBe(SearchSessionState.Loading);
-      complete1();
+      complete1({ rawResponse: {} });
       expect(state$.getValue()).toBe(SearchSessionState.Loading);
-      complete2();
+      complete2({ rawResponse: {} });
       expect(state$.getValue()).toBe(SearchSessionState.Completed);
     });
 
@@ -173,9 +174,9 @@ describe('Session service', () => {
       sessionService.trackSearch({ abort, poll });
       sessionService.trackSearch({ abort, poll });
       const complete = sessionService.trackSearch({ abort, poll }).complete;
-      complete();
+      complete({ rawResponse: {} });
 
-      await sessionService.cancel();
+      await sessionService.cancel({ source: 'test' });
 
       expect(abort).toBeCalledTimes(3);
     });
@@ -212,7 +213,7 @@ describe('Session service', () => {
         sessionService.start();
 
         const searchTracker = sessionService.trackSearch({ abort, poll });
-        searchTracker.complete();
+        searchTracker.complete({ rawResponse: {} });
 
         expect(poll).toHaveBeenCalledTimes(0);
 
@@ -424,10 +425,10 @@ describe('Session service', () => {
     const poll = jest.fn(() => Promise.resolve());
 
     const search1 = sessionService.trackSearch({ poll, abort });
-    search1.complete();
+    search1.complete({ rawResponse: {} });
 
     const search2 = sessionService.trackSearch({ poll, abort });
-    search2.error();
+    search2.error(new Error());
 
     sessionService.trackSearch({ poll, abort });
 
@@ -551,7 +552,7 @@ describe('Session service', () => {
         poll: async () => {},
       }).complete;
 
-      complete();
+      complete({ rawResponse: {} });
 
       expect(emitResult).toEqual([false]);
 
@@ -581,7 +582,7 @@ describe('Session service', () => {
         poll: async () => {},
       }).complete;
 
-      complete();
+      complete({ rawResponse: {} });
 
       expect(emitResult).toEqual([false]);
 
@@ -611,7 +612,7 @@ describe('Session service', () => {
 
       expect(usageCollector.trackSessionIndicatorSaveDisabled).toHaveBeenCalledTimes(0);
 
-      complete();
+      complete({ rawResponse: {} });
 
       jest.advanceTimersByTime(5 * 60 * 1000); // 5 minutes
 
@@ -670,7 +671,7 @@ describe('Session service', () => {
         sessionService.start();
 
         // When
-        complete();
+        complete({ rawResponse: {} });
 
         // Then
         expect(sessionService.isCurrentSession(firstSessionId)).toBe(false);

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -110,7 +110,7 @@ interface TrackSearchHandler {
   /**
    * Transition search into "error" status
    */
-  error(error: Error): void;
+  error(error?: Error): void;
 
   /**
    * Call to notify when search is about to be polled to get current search state to build `searchOptions` from (mainly isSearchStored),
@@ -413,7 +413,7 @@ export class SessionService {
         }
 
         const searchSessionSavedObject = state.get().searchSessionSavedObject;
-        if (searchSessionSavedObject) {
+        if (searchSessionSavedObject && error) {
           this.searchSessionEBTManager?.trackBgsError({
             session: searchSessionSavedObject,
             error,

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -369,7 +369,7 @@ export class SessionService {
     });
 
     return {
-      complete: (response) => {
+      complete: () => {
         const state = this.isCurrentSession(sessionId)
           ? this.state
           : this.sessionSnapshots.get(sessionId!);
@@ -385,13 +385,6 @@ export class SessionService {
         // when search completes and session has just been saved,
         // trigger polling once again to save search into a session and extend its keep_alive
         if (this.isStored(state)) {
-          const searchSessionSavedObject = state.get().searchSessionSavedObject;
-          if (searchSessionSavedObject && response) {
-            this.searchSessionEBTManager?.trackBgsCompleted({
-              response,
-              session: searchSessionSavedObject,
-            });
-          }
           const search = state.selectors.getSearch(searchDescriptor);
           if (search && !search.searchMeta.isStored) {
             search.searchDescriptor.poll().catch((e) => {
@@ -401,7 +394,7 @@ export class SessionService {
           }
         }
       },
-      error: (error) => {
+      error: () => {
         const state = this.isCurrentSession(sessionId)
           ? this.state
           : this.sessionSnapshots.get(sessionId!);
@@ -410,14 +403,6 @@ export class SessionService {
             `SearchSessionService trackSearch error: sessionId not found: "${sessionId}"`
           );
           return;
-        }
-
-        const searchSessionSavedObject = state.get().searchSessionSavedObject;
-        if (searchSessionSavedObject && error) {
-          this.searchSessionEBTManager?.trackBgsError({
-            session: searchSessionSavedObject,
-            error,
-          });
         }
 
         state.transitions.errorSearch(searchDescriptor);

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -629,7 +629,7 @@ export class SessionService {
    * Save current session as SO to get back to results later
    * (Send to background)
    */
-  public async save() {
+  public async save(trackingProps: { entryPoint: string }) {
     const sessionId = this.getSessionId();
     if (!sessionId) throw new Error('No current session');
     const currentSessionApp = this.state.get().appName;
@@ -659,7 +659,10 @@ export class SessionService {
       sessionId,
     });
 
-    this.searchSessionEBTManager?.trackBgsStarted({ session: searchSessionSavedObject });
+    this.searchSessionEBTManager?.trackBgsStarted({
+      session: searchSessionSavedObject,
+      ...trackingProps,
+    });
 
     // if we are still interested in this result
     if (this.isCurrentSession(sessionId)) {

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -29,7 +29,7 @@ import type {
 } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
-import type { IKibanaSearchResponse, ISearchOptions } from '@kbn/search-types';
+import type { ISearchOptions } from '@kbn/search-types';
 import { LRUCache } from 'lru-cache';
 import type { Logger } from '@kbn/logging';
 import type { SearchUsageCollector } from '../..';
@@ -105,7 +105,11 @@ interface TrackSearchHandler {
   /**
    * Transition search into "complete" status
    */
-  complete(response: IKibanaSearchResponse): void;
+  complete(trackingData: {
+    runtimeMs: number;
+    resultsCount: number;
+    resultsBytesSize: number;
+  }): void;
 
   /**
    * Transition search into "error" status
@@ -369,7 +373,7 @@ export class SessionService {
     });
 
     return {
-      complete: (response) => {
+      complete: (trackingData) => {
         const state = this.isCurrentSession(sessionId)
           ? this.state
           : this.sessionSnapshots.get(sessionId!);
@@ -388,7 +392,7 @@ export class SessionService {
           const searchSessionSavedObject = state.get().searchSessionSavedObject;
           if (searchSessionSavedObject) {
             this.searchSessionEBTManager?.trackBgsCompleted({
-              response,
+              trackingData,
               session: searchSessionSavedObject,
             });
           }

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -44,7 +44,7 @@ import type { ISessionsClient } from './sessions_client';
 import type { NowProviderInternalContract } from '../../now_provider';
 import { SEARCH_SESSIONS_MANAGEMENT_ID } from './constants';
 import { formatSessionName } from './lib/session_name_formatter';
-import type { SearchSessionEBTManager } from './ebt_manager';
+import type { ISearchSessionEBTManager } from './ebt_manager';
 
 /**
  * Polling interval for keeping completed searches alive
@@ -196,7 +196,7 @@ export class SessionService {
   private hasAccessToSearchSessions: boolean = false;
 
   private toastService?: ToastService;
-  private searchSessionEBTManager?: SearchSessionEBTManager;
+  private searchSessionEBTManager?: ISearchSessionEBTManager;
 
   private sessionSnapshots: LRUCache<string, SessionSnapshot>;
   private logger: Logger;
@@ -204,7 +204,7 @@ export class SessionService {
   constructor(
     initializerContext: PluginInitializerContext<ConfigSchema>,
     getStartServices: StartServicesAccessor,
-    searchSessionEBTManager: SearchSessionEBTManager,
+    searchSessionEBTManager: ISearchSessionEBTManager,
     private readonly sessionsClient: ISessionsClient,
     private readonly nowProvider: NowProviderInternalContract,
     private readonly usageCollector?: SearchUsageCollector,

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -29,7 +29,7 @@ import type {
 } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
-import type { ISearchOptions } from '@kbn/search-types';
+import type { IKibanaSearchResponse, ISearchOptions } from '@kbn/search-types';
 import { LRUCache } from 'lru-cache';
 import type { Logger } from '@kbn/logging';
 import type { SearchUsageCollector } from '../..';
@@ -105,11 +105,7 @@ interface TrackSearchHandler {
   /**
    * Transition search into "complete" status
    */
-  complete(trackingData?: {
-    runtimeMs: number;
-    resultsCount: number;
-    resultsBytesSize: number;
-  }): void;
+  complete(response?: IKibanaSearchResponse): void;
 
   /**
    * Transition search into "error" status
@@ -373,7 +369,7 @@ export class SessionService {
     });
 
     return {
-      complete: (trackingData) => {
+      complete: (response) => {
         const state = this.isCurrentSession(sessionId)
           ? this.state
           : this.sessionSnapshots.get(sessionId!);
@@ -390,9 +386,9 @@ export class SessionService {
         // trigger polling once again to save search into a session and extend its keep_alive
         if (this.isStored(state)) {
           const searchSessionSavedObject = state.get().searchSessionSavedObject;
-          if (searchSessionSavedObject && trackingData) {
+          if (searchSessionSavedObject && response) {
             this.searchSessionEBTManager?.trackBgsCompleted({
-              trackingData,
+              response,
               session: searchSessionSavedObject,
             });
           }

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -105,7 +105,7 @@ interface TrackSearchHandler {
   /**
    * Transition search into "complete" status
    */
-  complete(trackingData: {
+  complete(trackingData?: {
     runtimeMs: number;
     resultsCount: number;
     resultsBytesSize: number;
@@ -390,7 +390,7 @@ export class SessionService {
         // trigger polling once again to save search into a session and extend its keep_alive
         if (this.isStored(state)) {
           const searchSessionSavedObject = state.get().searchSessionSavedObject;
-          if (searchSessionSavedObject) {
+          if (searchSessionSavedObject && trackingData) {
             this.searchSessionEBTManager?.trackBgsCompleted({
               trackingData,
               session: searchSessionSavedObject,
@@ -520,13 +520,7 @@ export class SessionService {
   public async restore(sessionId: string) {
     this.storeSessionSnapshot();
     this.state.transitions.restore(sessionId);
-    const savedObject = await this.refreshSearchSessionSavedObject();
-
-    if (savedObject) {
-      this.searchSessionEBTManager?.trackBgsOpened({
-        session: savedObject,
-      });
-    }
+    await this.refreshSearchSessionSavedObject();
   }
 
   /**

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/application/index.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/application/index.tsx
@@ -61,6 +61,7 @@ export class SearchSessionsMgmtApp {
       share: pluginsStart.share,
       kibanaVersion: this.kibanaVersion,
       searchUsageCollector: setupDeps.searchUsageCollector,
+      searchSessionEBTManager: setupDeps.searchSessionEBTManager,
     };
 
     const { element } = params;

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/main.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/main.test.tsx
@@ -17,6 +17,7 @@ import { LocaleWrapper } from '../__mocks__';
 import { SearchSessionsMgmtMain } from './main';
 import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
 import { createSearchUsageCollectorMock } from '../../../collectors/mocks';
+import { getSearchSessionEBTManagerMock } from '../../mocks';
 const setup = async () => {
   const mockCoreSetup = coreMock.createSetup();
   mockCoreSetup.uiSettings.get.mockImplementation((key: string) => {
@@ -57,6 +58,7 @@ const setup = async () => {
           kibanaVersion={'8.0.0'}
           searchUsageCollector={mockSearchUsageCollector}
           share={mockShareStart}
+          searchSessionEBTManager={getSearchSessionEBTManagerMock()}
         />
       </LocaleWrapper>
     );

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/main.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/main.tsx
@@ -16,7 +16,7 @@ import type { SearchSessionsMgmtAPI } from '../lib/api';
 import { SearchSessionsMgmtTable } from './table';
 import type { SearchSessionsConfigSchema } from '../../../../../server/config';
 import type { SearchUsageCollector } from '../../../collectors';
-import type { SearchSessionEBTManager } from '../../ebt_manager';
+import type { ISearchSessionEBTManager } from '../../ebt_manager';
 
 interface Props {
   core: CoreStart;
@@ -27,7 +27,7 @@ interface Props {
   kibanaVersion: string;
   share: SharePluginStart;
   searchUsageCollector: SearchUsageCollector;
-  searchSessionEBTManager: SearchSessionEBTManager;
+  searchSessionEBTManager: ISearchSessionEBTManager;
 }
 
 export function SearchSessionsMgmtMain({ share, ...tableProps }: Props) {

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/main.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/main.tsx
@@ -16,6 +16,7 @@ import type { SearchSessionsMgmtAPI } from '../lib/api';
 import { SearchSessionsMgmtTable } from './table';
 import type { SearchSessionsConfigSchema } from '../../../../../server/config';
 import type { SearchUsageCollector } from '../../../collectors';
+import type { SearchSessionEBTManager } from '../../ebt_manager';
 
 interface Props {
   core: CoreStart;
@@ -26,6 +27,7 @@ interface Props {
   kibanaVersion: string;
   share: SharePluginStart;
   searchUsageCollector: SearchUsageCollector;
+  searchSessionEBTManager: SearchSessionEBTManager;
 }
 
 export function SearchSessionsMgmtMain({ share, ...tableProps }: Props) {
@@ -51,6 +53,7 @@ export function SearchSessionsMgmtMain({ share, ...tableProps }: Props) {
       <SearchSessionsMgmtTable
         data-test-subj="search-sessions-mgmt-table"
         locators={share.url.locators}
+        from="management"
         {...tableProps}
       />
     </>

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/main.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/main.tsx
@@ -53,7 +53,7 @@ export function SearchSessionsMgmtMain({ share, ...tableProps }: Props) {
       <SearchSessionsMgmtTable
         data-test-subj="search-sessions-mgmt-table"
         locators={share.url.locators}
-        from="management"
+        trackingProps={{ renderedIn: 'management', openedFrom: 'management' }}
         {...tableProps}
       />
     </>

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
@@ -49,7 +49,10 @@ const Component = ({
   const sessionsClient = new SessionsClient({
     http: mockCoreSetup.http,
   });
-  const ebtManager = new SearchSessionEBTManager({ core: mockCoreSetup });
+  const ebtManager = new SearchSessionEBTManager({
+    core: mockCoreSetup,
+    logger: coreMock.createPluginInitializerContext().logger.get(),
+  });
 
   const mockConfig = {
     defaultExpiration: moment.duration('7d'),

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
@@ -23,6 +23,7 @@ import type { SearchSessionSavedObject } from '../../types';
 import { ACTION } from '../../types';
 import { getPersistedSearchSessionSavedObjectAttributesMock } from '../../../mocks';
 import { columns } from '.';
+import { SearchSessionEBTManager } from '../../../ebt_manager';
 
 export default {
   title: 'components/SearchSessionsMgmtTable',
@@ -48,6 +49,7 @@ const Component = ({
   const sessionsClient = new SessionsClient({
     http: mockCoreSetup.http,
   });
+  const ebtManager = new SearchSessionEBTManager({ core: mockCoreSetup });
 
   const mockConfig = {
     defaultExpiration: moment.duration('7d'),
@@ -83,6 +85,8 @@ const Component = ({
         kibanaVersion="8.0.0"
         locators={mockShareStart.url.locators}
         searchUsageCollector={mockSearchUsageCollector}
+        from=""
+        searchSessionEBTManager={ebtManager}
         {...props}
       />
     </IntlProvider>

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.stories.tsx
@@ -85,7 +85,7 @@ const Component = ({
         kibanaVersion="8.0.0"
         locators={mockShareStart.url.locators}
         searchUsageCollector={mockSearchUsageCollector}
-        from=""
+        trackingProps={{ renderedIn: 'storybook', openedFrom: 'storybook' }}
         searchSessionEBTManager={ebtManager}
         {...props}
       />

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.test.tsx
@@ -78,7 +78,7 @@ const setup = async ({
           locators={mockShareStart.url.locators}
           searchUsageCollector={mockSearchUsageCollector}
           searchSessionEBTManager={getSearchSessionEBTManagerMock()}
-          from="test"
+          trackingProps={{ renderedIn: 'test', openedFrom: 'test' }}
           {...props}
         />
       </LocaleWrapper>

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.test.tsx
@@ -22,6 +22,7 @@ import { SearchSessionsMgmtTable } from './table';
 import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
 import { createSearchUsageCollectorMock } from '../../../../collectors/mocks';
 import type { UISession } from '../../types';
+import { getSearchSessionEBTManagerMock } from '../../../mocks';
 
 const setup = async ({
   mockSessionsFindResponse = {
@@ -76,6 +77,8 @@ const setup = async ({
           kibanaVersion="8.0.0"
           locators={mockShareStart.url.locators}
           searchUsageCollector={mockSearchUsageCollector}
+          searchSessionEBTManager={getSearchSessionEBTManagerMock()}
+          from="test"
           {...props}
         />
       </LocaleWrapper>

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
@@ -26,11 +26,13 @@ import { getStatusFilter } from './utils/get_status_filter';
 import type { SearchUsageCollector } from '../../../../collectors';
 import type { SearchSessionsConfigSchema } from '../../../../../../server/config';
 import { mapToUISession } from './utils/map_to_ui_session';
+import type { SearchSessionEBTManager } from '../../../ebt_manager/search_session_ebt_manager';
 
 interface Props {
   core: CoreStart;
   locators: LocatorsStart;
   api: SearchSessionsMgmtAPI;
+  searchSessionEBTManager: SearchSessionEBTManager;
   timezone: string;
   config: SearchSessionsConfigSchema;
   kibanaVersion: string;
@@ -48,6 +50,7 @@ interface Props {
     onActionComplete: OnActionComplete;
     onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
   }) => Array<EuiBasicTableColumn<UISession>>;
+  from: string;
 }
 
 export type GetColumnsFn = Props['getColumns'];
@@ -58,12 +61,14 @@ export function SearchSessionsMgmtTable({
   api,
   timezone,
   config,
+  searchSessionEBTManager,
   kibanaVersion,
   searchUsageCollector,
   hideRefreshButton = false,
   getColumns = getDefaultColumns,
   appId,
   onBackgroundSearchOpened,
+  from,
   ...props
 }: Props) {
   const [tableData, setTableData] = useState<UISession[]>([]);
@@ -96,6 +101,10 @@ export function SearchSessionsMgmtTable({
     250,
     [isLoading]
   );
+
+  useEffect(() => {
+    searchSessionEBTManager.trackBgsListView({ entryPoint: from });
+  }, [searchSessionEBTManager, from]);
 
   // refresh behavior
   const doRefresh = useCallback(async () => {

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
@@ -50,7 +50,7 @@ interface Props {
     onActionComplete: OnActionComplete;
     onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
   }) => Array<EuiBasicTableColumn<UISession>>;
-  from: string;
+  trackingProps: { openedFrom: string; renderedIn: string };
 }
 
 export type GetColumnsFn = Props['getColumns'];
@@ -68,7 +68,7 @@ export function SearchSessionsMgmtTable({
   getColumns = getDefaultColumns,
   appId,
   onBackgroundSearchOpened,
-  from,
+  trackingProps,
   ...props
 }: Props) {
   const [tableData, setTableData] = useState<UISession[]>([]);
@@ -103,8 +103,8 @@ export function SearchSessionsMgmtTable({
   );
 
   useEffect(() => {
-    searchSessionEBTManager.trackBgsListView({ entryPoint: from });
-  }, [searchSessionEBTManager, from]);
+    searchSessionEBTManager.trackBgsListView({ entryPoint: trackingProps.openedFrom });
+  }, [searchSessionEBTManager, trackingProps.openedFrom]);
 
   // refresh behavior
   const doRefresh = useCallback(async () => {
@@ -166,7 +166,10 @@ export function SearchSessionsMgmtTable({
     onActionComplete,
     kibanaVersion,
     searchUsageCollector,
-    onBackgroundSearchOpened,
+    onBackgroundSearchOpened: (attrs) => {
+      searchSessionEBTManager.trackBgsOpened({ session: attrs.session });
+      onBackgroundSearchOpened?.(attrs);
+    },
   });
 
   const filters = useMemo(() => {

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
@@ -167,7 +167,10 @@ export function SearchSessionsMgmtTable({
     kibanaVersion,
     searchUsageCollector,
     onBackgroundSearchOpened: (attrs) => {
-      searchSessionEBTManager.trackBgsOpened({ session: attrs.session });
+      searchSessionEBTManager.trackBgsOpened({
+        session: attrs.session,
+        resumeSource: trackingProps.renderedIn,
+      });
       onBackgroundSearchOpened?.(attrs);
     },
   });

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/table.tsx
@@ -26,13 +26,13 @@ import { getStatusFilter } from './utils/get_status_filter';
 import type { SearchUsageCollector } from '../../../../collectors';
 import type { SearchSessionsConfigSchema } from '../../../../../../server/config';
 import { mapToUISession } from './utils/map_to_ui_session';
-import type { SearchSessionEBTManager } from '../../../ebt_manager/search_session_ebt_manager';
+import type { ISearchSessionEBTManager } from '../../../ebt_manager';
 
 interface Props {
   core: CoreStart;
   locators: LocatorsStart;
   api: SearchSessionsMgmtAPI;
-  searchSessionEBTManager: SearchSessionEBTManager;
+  searchSessionEBTManager: ISearchSessionEBTManager;
   timezone: string;
   config: SearchSessionsConfigSchema;
   kibanaVersion: string;

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.test.tsx
@@ -18,6 +18,7 @@ import { SearchSessionsMgmtAPI } from '../lib/api';
 import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
 import { SessionsClient } from '../../sessions_client';
 import { userEvent } from '@testing-library/user-event';
+import { getSearchSessionEBTManagerMock } from '../../mocks';
 
 const setup = () => {
   const mockCoreSetup = coreMock.createSetup();
@@ -58,6 +59,7 @@ const setup = () => {
         kibanaVersion={kibanaVersion}
         locators={mockShareStart.url.locators}
         usageCollector={mockSearchUsageCollector}
+        ebtManager={getSearchSessionEBTManagerMock()}
       />
     </IntlProvider>
   );

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.test.tsx
@@ -60,7 +60,7 @@ const setup = () => {
         locators={mockShareStart.url.locators}
         usageCollector={mockSearchUsageCollector}
         ebtManager={getSearchSessionEBTManagerMock()}
-        entryPoint="test"
+        trackingProps={{ openedFrom: 'test' }}
       />
     </IntlProvider>
   );

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.test.tsx
@@ -60,6 +60,7 @@ const setup = () => {
         locators={mockShareStart.url.locators}
         usageCollector={mockSearchUsageCollector}
         ebtManager={getSearchSessionEBTManagerMock()}
+        entryPoint="test"
       />
     </IntlProvider>
   );

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
@@ -41,6 +41,7 @@ export const Flyout = ({
   kibanaVersion,
   locators,
   appId,
+  entryPoint,
   onBackgroundSearchOpened,
 }: {
   onClose: () => void;
@@ -52,6 +53,7 @@ export const Flyout = ({
   kibanaVersion: string;
   locators: LocatorsStart;
   appId?: string;
+  entryPoint: string;
   onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
 }) => {
   const flyoutId = useGeneratedHtmlId();
@@ -88,7 +90,7 @@ export const Flyout = ({
           appId={appId}
           onBackgroundSearchOpened={onBackgroundSearchOpened}
           searchSessionEBTManager={ebtManager}
-          from="flyout"
+          from={entryPoint}
         />
       </EuiFlyoutBody>
       <EuiFlyoutFooter>

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
@@ -29,12 +29,14 @@ import type { SearchUsageCollector } from '../../../collectors';
 import type { BackgroundSearchOpenedHandler, LocatorsStart } from '../types';
 import { getColumns } from './get_columns';
 import { FLYOUT_WIDTH } from './constants';
+import type { SearchSessionEBTManager } from '../../ebt_manager';
 
 export const Flyout = ({
   onClose,
   api,
   coreStart,
   usageCollector,
+  ebtManager,
   config,
   kibanaVersion,
   locators,
@@ -45,6 +47,7 @@ export const Flyout = ({
   api: SearchSessionsMgmtAPI;
   coreStart: CoreStart;
   usageCollector: SearchUsageCollector;
+  ebtManager: SearchSessionEBTManager;
   config: SearchSessionsConfigSchema;
   kibanaVersion: string;
   locators: LocatorsStart;
@@ -84,6 +87,8 @@ export const Flyout = ({
           getColumns={getColumns}
           appId={appId}
           onBackgroundSearchOpened={onBackgroundSearchOpened}
+          searchSessionEBTManager={ebtManager}
+          from="flyout"
         />
       </EuiFlyoutBody>
       <EuiFlyoutFooter>

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
@@ -29,7 +29,7 @@ import type { SearchUsageCollector } from '../../../collectors';
 import type { BackgroundSearchOpenedHandler, LocatorsStart } from '../types';
 import { getColumns } from './get_columns';
 import { FLYOUT_WIDTH } from './constants';
-import type { SearchSessionEBTManager } from '../../ebt_manager';
+import type { ISearchSessionEBTManager } from '../../ebt_manager';
 
 export const Flyout = ({
   onClose,
@@ -47,7 +47,7 @@ export const Flyout = ({
   api: SearchSessionsMgmtAPI;
   coreStart: CoreStart;
   usageCollector: SearchUsageCollector;
-  ebtManager: SearchSessionEBTManager;
+  ebtManager: ISearchSessionEBTManager;
   config: SearchSessionsConfigSchema;
   kibanaVersion: string;
   locators: LocatorsStart;

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
@@ -41,7 +41,7 @@ export const Flyout = ({
   kibanaVersion,
   locators,
   appId,
-  entryPoint,
+  trackingProps,
   onBackgroundSearchOpened,
 }: {
   onClose: () => void;
@@ -53,7 +53,7 @@ export const Flyout = ({
   kibanaVersion: string;
   locators: LocatorsStart;
   appId?: string;
-  entryPoint: string;
+  trackingProps: { openedFrom: string };
   onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
 }) => {
   const flyoutId = useGeneratedHtmlId();
@@ -90,7 +90,7 @@ export const Flyout = ({
           appId={appId}
           onBackgroundSearchOpened={onBackgroundSearchOpened}
           searchSessionEBTManager={ebtManager}
-          from={entryPoint}
+          trackingProps={{ openedFrom: trackingProps.openedFrom, renderedIn: 'flyout' }}
         />
       </EuiFlyoutBody>
       <EuiFlyoutFooter>

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
@@ -40,7 +40,7 @@ export function openSearchSessionsFlyout({
 }) {
   return (attrs: {
     appId: string;
-    trackingProps: { entryPoint: string };
+    trackingProps: { openedFrom: string };
     onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
   }) => {
     const api = new SearchSessionsMgmtAPI(sessionsClient, config, {
@@ -69,7 +69,7 @@ export function openSearchSessionsFlyout({
               config={config}
               kibanaVersion={kibanaVersion}
               locators={share.url.locators}
-              entryPoint={attrs.trackingProps.entryPoint}
+              trackingProps={{ openedFrom: attrs.trackingProps.openedFrom }}
             />
           </KibanaReactContextProvider>
         ),

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
@@ -19,7 +19,7 @@ import type { SearchSessionsConfigSchema } from '../../../../../server/config';
 import { Flyout } from './flyout';
 import type { BackgroundSearchOpenedHandler } from '../types';
 import { FLYOUT_WIDTH } from './constants';
-import type { SearchSessionEBTManager } from '../../ebt_manager';
+import type { ISearchSessionEBTManager } from '../../ebt_manager';
 
 export function openSearchSessionsFlyout({
   coreStart,
@@ -33,7 +33,7 @@ export function openSearchSessionsFlyout({
   coreStart: CoreStart;
   kibanaVersion: string;
   usageCollector: SearchUsageCollector;
-  ebtManager: SearchSessionEBTManager;
+  ebtManager: ISearchSessionEBTManager;
   config: SearchSessionsConfigSchema;
   sessionsClient: ISessionsClient;
   share: SharePluginStart;

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
@@ -19,11 +19,13 @@ import type { SearchSessionsConfigSchema } from '../../../../../server/config';
 import { Flyout } from './flyout';
 import type { BackgroundSearchOpenedHandler } from '../types';
 import { FLYOUT_WIDTH } from './constants';
+import type { SearchSessionEBTManager } from '../../ebt_manager';
 
 export function openSearchSessionsFlyout({
   coreStart,
   kibanaVersion,
   usageCollector,
+  ebtManager,
   config,
   sessionsClient,
   share,
@@ -31,6 +33,7 @@ export function openSearchSessionsFlyout({
   coreStart: CoreStart;
   kibanaVersion: string;
   usageCollector: SearchUsageCollector;
+  ebtManager: SearchSessionEBTManager;
   config: SearchSessionsConfigSchema;
   sessionsClient: ISessionsClient;
   share: SharePluginStart;
@@ -60,6 +63,7 @@ export function openSearchSessionsFlyout({
               api={api}
               coreStart={coreStart}
               usageCollector={usageCollector}
+              ebtManager={ebtManager}
               config={config}
               kibanaVersion={kibanaVersion}
               locators={share.url.locators}

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/get_flyout.tsx
@@ -38,9 +38,11 @@ export function openSearchSessionsFlyout({
   sessionsClient: ISessionsClient;
   share: SharePluginStart;
 }) {
-  return (
-    attrs: { appId?: string; onBackgroundSearchOpened?: BackgroundSearchOpenedHandler } = {}
-  ) => {
+  return (attrs: {
+    appId: string;
+    trackingProps: { entryPoint: string };
+    onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
+  }) => {
     const api = new SearchSessionsMgmtAPI(sessionsClient, config, {
       notifications: coreStart.notifications,
       application: coreStart.application,
@@ -67,6 +69,7 @@ export function openSearchSessionsFlyout({
               config={config}
               kibanaVersion={kibanaVersion}
               locators={share.url.locators}
+              entryPoint={attrs.trackingProps.entryPoint}
             />
           </KibanaReactContextProvider>
         ),

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/index.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/index.ts
@@ -16,6 +16,7 @@ import type { ISessionsClient, SearchUsageCollector } from '../../..';
 import { SEARCH_SESSIONS_MANAGEMENT_ID } from '../constants';
 import type { SearchSessionsMgmtAPI } from './lib/api';
 import type { SearchSessionsConfigSchema } from '../../../../server/config';
+import type { SearchSessionEBTManager } from '../ebt_manager';
 
 export { openSearchSessionsFlyout } from './flyout/get_flyout';
 export type { BackgroundSearchOpenedHandler } from './types';
@@ -24,6 +25,7 @@ export interface IManagementSectionsPluginsSetup {
   management: ManagementSetup;
   searchUsageCollector: SearchUsageCollector;
   sessionsClient: ISessionsClient;
+  searchSessionEBTManager: SearchSessionEBTManager;
 }
 
 export interface IManagementSectionsPluginsStart {
@@ -40,6 +42,7 @@ export interface AppDependencies {
   config: SearchSessionsConfigSchema;
   kibanaVersion: string;
   searchUsageCollector: SearchUsageCollector;
+  searchSessionEBTManager: SearchSessionEBTManager;
 }
 
 export const APP = {

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/index.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/index.ts
@@ -16,7 +16,7 @@ import type { ISessionsClient, SearchUsageCollector } from '../../..';
 import { SEARCH_SESSIONS_MANAGEMENT_ID } from '../constants';
 import type { SearchSessionsMgmtAPI } from './lib/api';
 import type { SearchSessionsConfigSchema } from '../../../../server/config';
-import type { SearchSessionEBTManager } from '../ebt_manager';
+import type { ISearchSessionEBTManager } from '../ebt_manager';
 
 export { openSearchSessionsFlyout } from './flyout/get_flyout';
 export type { BackgroundSearchOpenedHandler } from './types';
@@ -25,7 +25,7 @@ export interface IManagementSectionsPluginsSetup {
   management: ManagementSetup;
   searchUsageCollector: SearchUsageCollector;
   sessionsClient: ISessionsClient;
-  searchSessionEBTManager: SearchSessionEBTManager;
+  searchSessionEBTManager: ISearchSessionEBTManager;
 }
 
 export interface IManagementSectionsPluginsStart {
@@ -42,7 +42,7 @@ export interface AppDependencies {
   config: SearchSessionsConfigSchema;
   kibanaVersion: string;
   searchUsageCollector: SearchUsageCollector;
-  searchSessionEBTManager: SearchSessionEBTManager;
+  searchSessionEBTManager: ISearchSessionEBTManager;
 }
 
 export const APP = {

--- a/src/platform/plugins/shared/data/public/search/types.ts
+++ b/src/platform/plugins/shared/data/public/search/types.ts
@@ -71,8 +71,9 @@ export interface ISearchStart {
   /**
    * Shows a flyout with a table to manage search sessions.
    */
-  showSearchSessionsFlyout: (attrs?: {
-    appId?: string;
+  showSearchSessionsFlyout: (attrs: {
+    appId: string;
+    trackingProps: { entryPoint: string };
     onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
   }) => void;
   /**

--- a/src/platform/plugins/shared/data/public/search/types.ts
+++ b/src/platform/plugins/shared/data/public/search/types.ts
@@ -73,7 +73,7 @@ export interface ISearchStart {
    */
   showSearchSessionsFlyout: (attrs: {
     appId: string;
-    trackingProps: { entryPoint: string };
+    trackingProps: { openedFrom: string };
     onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
   }) => void;
   /**

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -143,6 +143,7 @@ export const useTopNavLinks = ({
           onClick: () => {
             services.data.search.showSearchSessionsFlyout({
               appId,
+              trackingProps: { entryPoint: 'background search button' },
               onBackgroundSearchOpened: services.discoverFeatureFlags.getTabsEnabled()
                 ? ({ session, event }) => {
                     event?.preventDefault();

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -143,7 +143,7 @@ export const useTopNavLinks = ({
           onClick: () => {
             services.data.search.showSearchSessionsFlyout({
               appId,
-              trackingProps: { entryPoint: 'background search button' },
+              trackingProps: { openedFrom: 'background search button' },
               onBackgroundSearchOpened: services.discoverFeatureFlags.getTabsEnabled()
                 ? ({ session, event }) => {
                     event?.preventDefault();

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -556,7 +556,7 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
                   this.services.notifications.toasts.remove(toast);
                   this.services.data.search.showSearchSessionsFlyout({
                     appId: this.services.appName,
-                    trackingProps: { entryPoint: 'toast' },
+                    trackingProps: { openedFrom: 'toast' },
                   });
                 }}
               >

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -556,6 +556,7 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
                   this.services.notifications.toasts.remove(toast);
                   this.services.data.search.showSearchSessionsFlyout({
                     appId: this.services.appName,
+                    trackingProps: { entryPoint: 'toast' },
                   });
                 }}
               >
@@ -574,7 +575,9 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
     query?: QT | Query | undefined;
   }) => {
     if (!this.isDirty()) {
-      const searchSession = await this.services.data.search.session.save();
+      const searchSession = await this.services.data.search.session.save({
+        entryPoint: 'main button',
+      });
       this.showBackgroundSearchCreatedToast(searchSession.attributes.name);
       return;
     }
@@ -586,7 +589,9 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
       .subscribe(async (newSessionId) => {
         if (currentSessionId === newSessionId) return;
         subscription.unsubscribe();
-        const searchSession = await this.services.data.search.session.save();
+        const searchSession = await this.services.data.search.session.save({
+          entryPoint: 'main button',
+        });
         this.showBackgroundSearchCreatedToast(searchSession.attributes.name);
       });
 

--- a/src/platform/plugins/shared/vis_types/timeseries/public/request_handler.ts
+++ b/src/platform/plugins/shared/vis_types/timeseries/public/request_handler.ts
@@ -101,16 +101,7 @@ export const metricsRequestHandler = async ({
             .ok({ time: query.time, json: { rawResponse: query.response } });
         });
 
-        const maxTime = Object.values(visData.trackedEsSearches || {}).reduce(
-          (max, search) => Math.max(max, search.time || 0),
-          0
-        );
-
-        searchTracker?.complete({
-          runtimeMs: maxTime,
-          resultsCount: 0,
-          resultsBytesSize: 0,
-        });
+        searchTracker?.complete();
 
         return visData;
       } catch (e) {

--- a/src/platform/plugins/shared/vis_types/timeseries/public/request_handler.ts
+++ b/src/platform/plugins/shared/vis_types/timeseries/public/request_handler.ts
@@ -101,11 +101,20 @@ export const metricsRequestHandler = async ({
             .ok({ time: query.time, json: { rawResponse: query.response } });
         });
 
-        searchTracker?.complete();
+        const maxTime = Object.values(visData.trackedEsSearches || {}).reduce(
+          (max, search) => Math.max(max, search.time || 0),
+          0
+        );
+
+        searchTracker?.complete({
+          runtimeMs: maxTime,
+          resultsCount: 0,
+          resultsBytesSize: 0,
+        });
 
         return visData;
       } catch (e) {
-        searchTracker?.error();
+        searchTracker?.error(e);
         throw e;
       } finally {
         expressionAbortSignal.removeEventListener('abort', expressionAbortHandler);

--- a/src/platform/plugins/shared/vis_types/timeseries/public/request_handler.ts
+++ b/src/platform/plugins/shared/vis_types/timeseries/public/request_handler.ts
@@ -105,7 +105,7 @@ export const metricsRequestHandler = async ({
 
         return visData;
       } catch (e) {
-        searchTracker?.error(e);
+        searchTracker?.error();
         throw e;
       } finally {
         expressionAbortSignal.removeEventListener('abort', expressionAbortHandler);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/235482

With this PR telemetry for background search is added in multiple places, we have the following evets:
- `bg_search_start` when a background search saved object is created.
- `bg_search_cancel` when a search session is cancelled - right now this isn't used anywhere
- `bg_search_open` when a search session is restored
- `bg_search_list_view` when the management table is showed

There are some limitations/difficulties in this so not all the props are implemented:
- When doing `bg_search_complete` we have 2 legacy sources, TSVB and Timelion which don't provide all the information regarding runtime and results size or is more complex to get.
  - Timelion doesn't provide the information
  - TSVB can have multiple data sources so we can measure many things here
- When doing `bg_search_open` we just follow a URL so it's kind of tricky to get from where it was opened.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



