### PR TITLE
[Discover Tabs] Don't discard new tab label on input blur

### DIFF
--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/edit_tab_label.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/edit_tab_label.tsx
@@ -8,7 +8,7 @@
  */
 
 import type { ChangeEvent } from 'react';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { EuiFieldText, keys, mathWithUnits, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { TabItem } from '../../types';
@@ -26,11 +26,21 @@ export interface EditTabLabelProps {
   onExit: () => void;
 }
 
-export const EditTabLabel: React.FC<EditTabLabelProps> = ({ item, onLabelEdited, onExit }) => {
+export const EditTabLabel: React.FC<EditTabLabelProps> = ({
+  item,
+  onLabelEdited,
+  onExit: onExitOriginal,
+}) => {
   const { euiTheme } = useEuiTheme();
   const [value, setValue] = useState<string>(item.label);
   const [submitState, setSubmitState] = useState<SubmitState>(SubmitState.initial);
   const [inputNode, setInputNode] = useState<HTMLInputElement | null>(null);
+  const isFinishedRef = useRef<boolean>(false);
+
+  const onExit = useCallback(() => {
+    isFinishedRef.current = true;
+    onExitOriginal();
+  }, [onExitOriginal]);
 
   const onChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -40,7 +50,8 @@ export const EditTabLabel: React.FC<EditTabLabelProps> = ({ item, onLabelEdited,
   );
 
   const onSubmit = useCallback(
-    async (newLabel: string) => {
+    async (nextLabel: string) => {
+      const newLabel = nextLabel.trim();
       if (!newLabel || newLabel.length > MAX_TAB_LABEL_LENGTH) {
         return;
       }
@@ -69,11 +80,22 @@ export const EditTabLabel: React.FC<EditTabLabelProps> = ({ item, onLabelEdited,
       }
 
       if (event.key === keys.ENTER) {
-        await onSubmit(value.trim());
+        await onSubmit(value);
       }
     },
     [value, onSubmit, onExit]
   );
+
+  const onBlur = useCallback(async () => {
+    if (isFinishedRef.current) {
+      return;
+    }
+    if (submitState !== SubmitState.initial) {
+      onExit();
+      return;
+    }
+    return onSubmit(value);
+  }, [value, submitState, onSubmit, onExit]);
 
   useEffect(() => {
     if (inputNode) {
@@ -98,7 +120,7 @@ export const EditTabLabel: React.FC<EditTabLabelProps> = ({ item, onLabelEdited,
       }
       onChange={onChange}
       onKeyDown={onKeyDown}
-      onBlur={submitState !== SubmitState.submitting ? onExit : undefined}
+      onBlur={submitState !== SubmitState.submitting ? onBlur : undefined}
     />
   );
 };

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.test.tsx
@@ -179,4 +179,38 @@ describe('Tab', () => {
       expect(onLabelEdited).not.toHaveBeenCalled();
     });
   });
+
+  it('can finish editing of tab label on blur', async () => {
+    const onLabelEdited = jest.fn();
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+
+    render(
+      <Tab
+        tabContentId={tabContentId}
+        tabsSizeConfig={tabsSizeConfig}
+        item={tabItem}
+        isSelected
+        services={servicesMock}
+        getPreviewData={getPreviewDataMock}
+        onLabelEdited={onLabelEdited}
+        onSelect={onSelect}
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.queryByText(tabItem.label)).toBeInTheDocument();
+    await userEvent.dblClick(screen.getByTestId(tabButtonTestSubj));
+    expect(screen.queryByText(tabItem.label)).not.toBeInTheDocument();
+
+    const input = screen.getByRole('textbox');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'label2   ');
+    expect(input).toHaveValue('label2   ');
+    await userEvent.keyboard('{tab}');
+    expect(onLabelEdited).toHaveBeenCalledWith(tabItem, 'label2');
+
+    expect(screen.queryByTestId(tabButtonTestSubj)).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/236931

## Summary

Previously the new tab label would be discard when user presses `Tab` or simply outside of the input. With this PR the new label would be saved in these cases too.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->