### PR TITLE
[Streams] Improve performance of clustering

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/cluster_logs/cluster_logs.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/cluster_logs/cluster_logs.ts
@@ -169,6 +169,7 @@ export async function clusterLogs({
         hits: response.hits.hits,
         fieldCaps,
         dropUnmapped,
+        valueCardinalityLimit: 100,
       });
 
       return {

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/cluster_logs/cluster_sample_docs.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/cluster_logs/cluster_sample_docs.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { clusterSampleDocs } from './cluster_sample_docs';
+import * as dbscanModule from './dbscan';
 
 // mock ai-tools heavy functions to keep test deterministic and focused
 jest.mock('@kbn/ai-tools', () => {
@@ -25,6 +26,10 @@ jest.mock('@kbn/ai-tools', () => {
 });
 
 describe('clusterSampleDocs', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('returns empty result when no hits', () => {
     const result = clusterSampleDocs({ hits: [], fieldCaps: { fields: {}, indices: [] } });
     expect(result).toEqual({ sampled: 0, noise: [], clusters: [] });
@@ -231,5 +236,56 @@ describe('clusterSampleDocs', () => {
       expect(result.clusters.length).toBe(1);
       expect(result.clusters[0].count).toBe(5);
     });
+  });
+
+  it('skips high-cardinality field values while retaining schema membership', () => {
+    const dbscanSpy = jest
+      .spyOn(dbscanModule, 'dbscan')
+      .mockImplementation(() => ({ clusters: [], noise: [] }));
+
+    const hits = Array.from({ length: 3 }).map((_, i) => ({
+      _id: `hc-${i}`,
+      _index: '',
+      _source: {
+        'service.name': 'checkout',
+        'log.level': 'info',
+        'user.id': `user-${i}`,
+      },
+    }));
+
+    const fieldCaps = {
+      indices: [],
+      fields: {
+        'service.name': { keyword: { type: 'keyword', searchable: true, aggregatable: true } },
+        'log.level': { keyword: { type: 'keyword', searchable: true, aggregatable: true } },
+        'user.id': { keyword: { type: 'keyword', searchable: true, aggregatable: true } },
+      },
+    };
+
+    clusterSampleDocs({
+      hits,
+      fieldCaps,
+      valueCardinalityLimit: 1,
+    });
+
+    expect(dbscanSpy).toHaveBeenCalled();
+    const dataset = dbscanSpy.mock.calls[0][0] as Array<{
+      fieldIds: number[];
+      kvPairIds: number[];
+      kvWeightSum: number;
+    }>;
+
+    expect(dataset).toHaveLength(3);
+    for (const doc of dataset) {
+      expect(doc.fieldIds).toHaveLength(3);
+      expect(doc.kvPairIds.length).toBe(2);
+      expect(doc.kvWeightSum).toBeGreaterThan(0);
+    }
+
+    const uniqueKvIds = new Set<number>();
+    for (const doc of dataset) {
+      doc.kvPairIds.forEach((id) => uniqueKvIds.add(id));
+    }
+    expect(uniqueKvIds.size).toBe(2);
   });
 });

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/cluster_logs/cluster_sample_docs.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/cluster_logs/cluster_sample_docs.ts
@@ -17,6 +17,7 @@ const MIN_POINTS = 5;
 // how much extra weight to give shared keyword values vs schema
 const SCHEMA_WEIGHT = 0.8;
 const VALUE_WEIGHT = 0.2;
+const DEFAULT_VALUE_CARDINALITY_LIMIT = 100;
 
 /**
  * Compute pure Jaccard distance on two sorted int-lists, by
@@ -51,17 +52,20 @@ interface ClusterDocsResponse {
 interface DocPoint {
   id: string;
   fieldIds: number[];
-  kvPairs: string[]; // e.g. "service.name:auth"
+  kvPairIds: number[];
+  kvWeightSum: number;
 }
 
 export function clusterSampleDocs({
   hits,
   fieldCaps,
   dropUnmapped = false,
+  valueCardinalityLimit = DEFAULT_VALUE_CARDINALITY_LIMIT,
 }: {
   hits: SearchHit[];
   fieldCaps: FieldCapsResponse;
   dropUnmapped?: boolean;
+  valueCardinalityLimit?: number;
 }): ClusterDocsResponse {
   if (hits.length === 0) {
     return { sampled: 0, noise: [], clusters: [] };
@@ -71,84 +75,182 @@ export function clusterSampleDocs({
   const fieldToId = new Map<string, number>();
 
   const valueCount = new Map<string, Set<string>>(); // field → distinct string values
+  const fieldWeightById: number[] = [];
+  const fieldCardinalityById: number[] = [];
+  const trackValueForFieldById: boolean[] = [];
+
+  const kvToId = new Map<string, number>();
+  const kvFieldById: number[] = [];
+  const kvWeightById: number[] = [];
 
   const docs: DocPoint[] = [];
 
-  for (const hit of hits) {
-    // flatten object into key-value pairs so it can be converted into integers
-    const src = getFlattenedObject({
-      ...(hit.fields ?? {}),
-      ...(hit._source ?? {}),
-    });
+  function traverseDocs() {
+    for (const hit of hits) {
+      // flatten object into key-value pairs so it can be converted into integers
+      const src = getFlattenedObject({
+        ...(hit.fields ?? {}),
+        ...(hit._source ?? {}),
+      });
 
-    const fields = Object.keys(src);
+      const fields = Object.keys(src);
 
-    const ids: number[] = [];
+      const ids: number[] = [];
 
-    const keyValuePairs: string[] = [];
+      const kvPairIds: number[] = [];
 
-    for (const field of fields) {
-      let fieldId = fieldToId.get(field);
-      // for each unseen field, get the next available int
-      if (fieldId === undefined) {
-        fieldId = fieldToId.size;
-        fieldToId.set(field, fieldId);
-      }
-
-      ids.push(fieldId);
-
-      const value = src[field];
-      if (typeof value === 'string') {
-        // record this field:value occurrence
-        keyValuePairs.push(`${field}:${value}`);
-
-        // record unique values per field
-        if (!valueCount.has(field)) {
-          valueCount.set(field, new Set());
+      for (const field of fields) {
+        let fieldId = fieldToId.get(field);
+        // for each unseen field, get the next available int
+        if (fieldId === undefined) {
+          fieldId = fieldToId.size;
+          fieldToId.set(field, fieldId);
         }
 
-        valueCount.get(field)!.add(value);
+        ids.push(fieldId);
+
+        const value = src[field];
+        if (typeof value === 'string') {
+          // record this field:value occurrence
+          const kvKey = `${field}:${value}`;
+          let kvId = kvToId.get(kvKey);
+          if (kvId === undefined) {
+            kvId = kvToId.size;
+            kvToId.set(kvKey, kvId);
+            kvFieldById[kvId] = fieldId;
+          }
+
+          kvPairIds.push(kvId);
+
+          // record unique values per field
+          if (!valueCount.has(field)) {
+            valueCount.set(field, new Set());
+          }
+
+          valueCount.get(field)!.add(value);
+        }
+      }
+
+      ids.sort((a, b) => a - b);
+
+      kvPairIds.sort((a, b) => a - b);
+
+      docs.push({ id: hit._id as string, fieldIds: ids, kvPairIds, kvWeightSum: 0 });
+    }
+  }
+
+  const fieldWeight = new Map<string, number>();
+
+  function calculateFieldWeights() {
+    // calculate cardinality per field
+    for (const [f, valSet] of valueCount) {
+      const card = valSet.size;
+      // high cardinality fields get less weight
+      fieldWeight.set(f, 1 / Math.log(card + 1));
+      const fieldId = fieldToId.get(f);
+      if (fieldId !== undefined) {
+        fieldCardinalityById[fieldId] = card;
       }
     }
 
-    ids.sort((a, b) => a - b);
-
-    docs.push({ id: hit._id as string, fieldIds: ids, kvPairs: keyValuePairs });
+    for (const [field, id] of fieldToId) {
+      fieldWeightById[id] = fieldWeight.get(field) ?? 0;
+    }
   }
 
-  // calculate cardinality per field
-  const fieldWeight = new Map<string, number>();
-  for (const [f, valSet] of valueCount) {
-    const card = valSet.size;
-    // high cardinality fields get less weight
-    fieldWeight.set(f, 1 / Math.log(card + 1));
+  function determineValueTracking(limit: number) {
+    const effectiveLimit = limit !== undefined && limit > 0 ? limit : Number.POSITIVE_INFINITY;
+    const fieldCount = fieldToId.size;
+    for (let id = 0; id < fieldCount; id++) {
+      const cardinality = fieldCardinalityById[id] ?? 0;
+      trackValueForFieldById[id] = cardinality <= effectiveLimit;
+    }
+  }
+
+  function populateKvWeights() {
+    for (let kvId = 0; kvId < kvFieldById.length; kvId++) {
+      const fieldId = kvFieldById[kvId];
+      kvWeightById[kvId] = trackValueForFieldById[fieldId] ? fieldWeightById[fieldId] ?? 0 : 0;
+    }
+  }
+
+  function finalizeDocs() {
+    for (const doc of docs) {
+      // remove duplicate kv entries after sorting while computing total weight
+      const dedupedKvIds: number[] = [];
+      let prevKv = -1;
+      let weightSum = 0;
+      for (const kvId of doc.kvPairIds) {
+        const weight = kvWeightById[kvId];
+        if (weight === 0) {
+          prevKv = -1; // reset dedupe sentinel when skipping
+          continue;
+        }
+        if (kvId !== prevKv) {
+          dedupedKvIds.push(kvId);
+          weightSum += weight;
+          prevKv = kvId;
+        }
+      }
+
+      doc.kvPairIds = dedupedKvIds;
+      doc.kvWeightSum = weightSum;
+    }
   }
 
   // calculate schema and key-value distances
-  function hybridDistance(a: DocPoint, b: DocPoint): number {
+  function hybridDistance(left: DocPoint, right: DocPoint): number {
     // schema part
-    const schemaDistance = jaccardDistance(a.fieldIds, b.fieldIds);
+    const schemaDistance = jaccardDistance(left.fieldIds, right.fieldIds);
 
-    // weighted-Jaccard on kvPairs
-    const sa = new Set(a.kvPairs);
-    const sb = new Set(b.kvPairs);
+    const minPossible = SCHEMA_WEIGHT * schemaDistance;
+    if (minPossible > EPSILON) {
+      return minPossible;
+    }
 
-    const union = new Set<string>([...sa, ...sb]);
+    const leftKeyValueIds = left.kvPairIds;
+    const rightKeyValueIds = right.kvPairIds;
+
+    // choose smaller array for outer loop to reduce lookups
+    const [small, large] =
+      leftKeyValueIds.length < rightKeyValueIds.length ? [left, right] : [left, right];
 
     let interWeight = 0;
-    let totalWeight = 0;
-    for (const kv of union) {
-      const [f] = kv.split(':');
-      const w = fieldWeight.get(f) ?? 0;
-      totalWeight += w;
-      if (sa.has(kv) && sb.has(kv)) {
-        interWeight += w;
+    let i = 0;
+    let j = 0;
+
+    const smallKvIds = small.kvPairIds;
+    const largeKvIds = large.kvPairIds;
+
+    while (i < smallKvIds.length && j < largeKvIds.length) {
+      const idSmall = smallKvIds[i];
+      const idLarge = largeKvIds[j];
+      if (idSmall === idLarge) {
+        interWeight += kvWeightById[idSmall];
+        i++;
+        j++;
+      } else if (idSmall < idLarge) {
+        i++;
+      } else {
+        j++;
       }
     }
+
+    const totalWeight = small.kvWeightSum + large.kvWeightSum - interWeight;
     const dValues = totalWeight > 0 ? 1 - interWeight / totalWeight : 1;
 
     return SCHEMA_WEIGHT * schemaDistance + VALUE_WEIGHT * dValues;
   }
+
+  traverseDocs();
+
+  calculateFieldWeights();
+
+  determineValueTracking(valueCardinalityLimit);
+
+  populateKvWeights();
+
+  finalizeDocs();
 
   const { clusters, noise } = dbscan(docs, EPSILON, MIN_POINTS, hybridDistance);
 


### PR DESCRIPTION
Currently, our clustering algorithm consumes a lot of CPU on documents with many fields & values. As an example, for serverless logs the dbscan step can take 30s of CPU. This is far too high to be reasonable as it will block the browser or worse, the server for that amount of time. As a mitigation, we ignore fields with a cardinality over a 100, which brings the time down to a more reasonable 250ms. 

Additionally, some minor optimizations were implemented in dbscan (with my friend GPT-5 codex). I've moved the distinct steps before clustering into function calls so they can be more easily timed if needed. 

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->