### PR TITLE
Improve maximum shards error detection

### DIFF
--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/es_errors.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/es_errors.ts
@@ -36,7 +36,8 @@ export const isClusterShardLimitExceeded = (errorCause?: ErrorCause): boolean =>
     hasAllKeywordsInOrder(errorCause?.reason, [
       'this action would add',
       'shards, but this cluster currently has',
-      'maximum normal shards open',
+      'maximum',
+      'shards open',
     ])
   );
 };


### PR DESCRIPTION
## Summary
Addresses build failures such as https://buildkite.com/elastic/kibana-elasticsearch-serverless-verify-and-promote/builds/4419/steps/canvas?jid=0199c911-61a6-45da-8dde-5051d866945f

```
illegal_argument_exception: Validation Failed: 1: this action would add [3] shards, but this cluster currently has [56]/[1] maximum index shards open; for more information, see https://www.elastic.co/docs/deploy-manage/production-guidance/optimize-performance/size-shards?version=current#troubleshooting-max-shards-open;]
```

The PR improves the detection to support different error strings
```
# before
this action would add .* shards, but this cluster currently has .* maximum normal shards open

# after
this action would add .* shards, but this cluster currently has .* maximum .* shards open

```