### PR TITLE
[One Workflow] Improve YAML editor responsiveness

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list.tsx
@@ -115,7 +115,7 @@ export const WorkflowExecutionList = ({
     content = (
       <EuiFlexGroup direction="column" gutterSize="s">
         {executions.results.map((execution) => (
-          <EuiFlexItem key={execution.id}>
+          <EuiFlexItem key={execution.id} grow={false}>
             <WorkflowExecutionListItem
               status={execution.status}
               startedAt={new Date(execution.startedAt)}

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
@@ -161,10 +161,13 @@ export function WorkflowDetailPage({ id }: { id: string }) {
     setHasChanges(false);
   }, [workflow]);
 
-  const handleChange = (wfString: string = '') => {
-    setWorkflowYaml(wfString);
-    setHasChanges(originalWorkflowYaml !== wfString);
-  };
+  const handleChange = useCallback(
+    (wfString: string = '') => {
+      setWorkflowYaml(wfString);
+      setHasChanges(originalWorkflowYaml !== wfString);
+    },
+    [originalWorkflowYaml]
+  );
 
   if (workflowError) {
     const error = workflowError as Error;

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/yaml_editor/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/yaml_editor/index.tsx
@@ -7,17 +7,38 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { CodeEditorProps } from '@kbn/code-editor';
 import { CodeEditor } from '@kbn/code-editor';
 import { configureMonacoYamlSchema } from '@kbn/monaco';
 import type { MonacoYamlOptions } from 'monaco-yaml';
+import { debounce } from 'lodash';
 
-interface YamlEditorProps extends Omit<CodeEditorProps, 'languageId'> {
+interface YamlEditorProps extends Omit<CodeEditorProps, 'languageId' | 'onChange'> {
+  onChange: (value: string | undefined) => void;
   schemas: MonacoYamlOptions['schemas'] | null;
 }
 
-export function YamlEditor(props: YamlEditorProps) {
+export const YamlEditor = React.memo(({ value, onChange, ...props }: YamlEditorProps) => {
+  const [internalValue, setInternalValue] = useState(value);
+  const onChangeDebounced = useMemo(() => debounce(onChange, 200), [onChange]);
+
+  useEffect(() => {
+    // Update the internal value to the latest value from the props
+    // Most of the time will be the same value, so monaco won't even update, only if some forced modification happened.
+    setInternalValue(value);
+  }, [value]);
+
+  const onChangeInternal = useCallback(
+    (newValue: string) => {
+      // Update internal state quickly so the change is reflected instantly in the editor
+      setInternalValue(newValue);
+      // Debounce the call to onChange to prevent excessive re-renders upstream
+      onChangeDebounced(newValue);
+    },
+    [onChangeDebounced]
+  );
+
   useEffect(() => {
     if (props.schemas) {
       // Configure Monaco YAML with completions and hover disabled
@@ -30,5 +51,7 @@ export function YamlEditor(props: YamlEditorProps) {
     }
   }, [props.schemas]);
 
-  return <CodeEditor languageId="yaml" {...props} />;
-}
+  return (
+    <CodeEditor languageId="yaml" value={internalValue} onChange={onChangeInternal} {...props} />
+  );
+});


### PR DESCRIPTION
## Summary

closes: https://github.com/elastic/security-team/issues/14210

It improves the responsiveness of the Monaco YAML editor by keeping an internal "quick change" state, and debouncing the upstream calls to the `onChange` prop.

before

https://github.com/user-attachments/assets/5ba15888-c986-4d7c-9f45-b2065049cac5


after

https://github.com/user-attachments/assets/13eaf718-e7fa-4d20-894a-ef5cbfd3b5e4





