### PR TITLE
[Presentation] Fix slow FilterItems tests 

### DIFF
--- a/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/customize_panel_editor.test.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/customize_panel_editor.test.tsx
@@ -18,6 +18,11 @@ import { BehaviorSubject } from 'rxjs';
 import type { CustomizePanelActionApi } from './customize_panel_action';
 import { CustomizePanelEditor } from './customize_panel_editor';
 
+// Mock FilterItems to avoid expensive rendering and lazy-loading delays in tests
+jest.mock('@kbn/unified-search-plugin/public', () => ({
+  FilterItems: () => <div data-test-subj="mocked-filter-items">Mocked FilterItems</div>,
+}));
+
 describe('customize panel editor', () => {
   let api: CustomizePanelActionApi;
   let setTitle: (title?: string) => void;

--- a/src/platform/plugins/shared/dashboard/public/dashboard_actions/filters_notification_popover.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_actions/filters_notification_popover.test.tsx
@@ -19,6 +19,11 @@ import type { FiltersNotificationActionApi } from './filters_notification_action
 import { FiltersNotificationPopover } from './filters_notification_popover';
 import type { ViewMode } from '@kbn/presentation-publishing';
 
+// Mock FilterItems to avoid expensive rendering and lazy-loading delays in tests
+jest.mock('@kbn/unified-search-plugin/public', () => ({
+  FilterItems: () => <div data-test-subj="mocked-filter-items">Mocked FilterItems</div>,
+}));
+
 const canEditUnifiedSearch = jest.fn().mockReturnValue(true);
 
 const getMockPhraseFilter = (key: string, value: string): Filter => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/237143
Fixes https://github.com/elastic/kibana/issues/235143

 Fixes slow tests in dashboard and presentation panel components by mocking the `FilterItems` component from `@kbn/unified-search-plugin/public`.

  ## Problem

  Two test we causing timeouts on CI. Locally, they were getting these results:
  - `customize_panel_editor.test.tsx`: "renders local filters, if provided" test took **367ms**
  - `filters_notification_popover.test.tsx`: "renders the filter section when given filters"
  test took **962ms**

  The root cause was that `FilterItems` is a complex component with lazy-loaded dependencies
  that caused:
  - Expensive rendering operations
  - React Suspense delays
  - Unnecessary overhead for tests that only verify component structure

  ## Solution

  Added a mock for `FilterItems` in both test files to replace the heavy component with a
  simple mock implementation. This avoids loading the entire unified search plugin
  infrastructure during tests.

  ## Performance Improvements

  - **customize_panel_editor.test.tsx**: 367ms → 10ms (97% faster)
  - **filters_notification_popover.test.tsx**: 962ms → 68ms (93% faster)

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->