### PR TITLE
[Discover] Hide tabs and background search in Timeline ES|QL

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -241,6 +241,7 @@ export const DiscoverTopNav = ({
       <DiscoverTopNavMenu topNavBadges={topNavBadges} topNavMenu={topNavMenu} />
       <SearchBar
         useBackgroundSearchButton={
+          stateContainer.customizationContext.displayMode !== 'embedded' &&
           services.data.search.isBackgroundSearchEnabled &&
           !!services.capabilities.discover_v2.storeSearchSession
         }

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
@@ -252,7 +252,11 @@ const DiscoverMainRouteContent = (props: SingleTabViewProps) => {
     <rootProfileState.AppWrapper>
       <ChartPortalsRenderer runtimeStateManager={runtimeStateManager}>
         <DiscoverTopNavMenuProvider>
-          {tabsEnabled ? <TabsView {...props} /> : <SingleTabView {...props} />}
+          {tabsEnabled && customizationContext.displayMode !== 'embedded' ? (
+            <TabsView {...props} />
+          ) : (
+            <SingleTabView {...props} />
+          )}
         </DiscoverTopNavMenuProvider>
       </ChartPortalsRenderer>
     </rootProfileState.AppWrapper>


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/238289

## Summary

This PR adds checks for `customizationContext` value and hides tabs and the background search split button when Discover is embedded in Timeline.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->