### PR TITLE
[CI] Disable moon cache for build

### DIFF
--- a/kbn_pm/src/commands/build_shared_packages.mjs
+++ b/kbn_pm/src/commands/build_shared_packages.mjs
@@ -37,7 +37,7 @@ export const command = {
         pipe: !quiet,
         env: {
           ...process.env,
-          ...(!cache || dist ? { MOON_CACHE: 'off' } : {}),
+          ...(!cache ? { MOON_CACHE: 'off' } : {}),
         },
       }
     );

--- a/kbn_pm/src/commands/build_shared_packages.mjs
+++ b/kbn_pm/src/commands/build_shared_packages.mjs
@@ -9,7 +9,7 @@
 
 import { run } from '../lib/spawn.mjs';
 
-/** @type {import("../lib/command").Command} */
+/** @type {import('../lib/command').Command} */
 export const command = {
   name: 'build-shared',
   intro: 'Builds shared packages with webpack',
@@ -35,6 +35,10 @@ export const command = {
       [':build-webpack'].concat(!cache ? ['-u'] : []).concat(dist ? ['--', '--dist'] : []),
       {
         pipe: !quiet,
+        env: {
+          ...process.env,
+          ...(!cache || dist ? { MOON_CACHE: 'off' } : {}),
+        },
       }
     );
 

--- a/src/dev/build/tasks/build_packages_task.ts
+++ b/src/dev/build/tasks/build_packages_task.ts
@@ -323,8 +323,20 @@ export const BuildPackages: Task = {
   },
 };
 
-export async function buildWebpackBundles({ quiet, dist }: { quiet: boolean; dist: boolean }) {
-  const options = [quiet ? ['--quiet'] : [], dist ? ['--dist'] : []].flat();
+export async function buildWebpackBundles({
+  quiet,
+  dist,
+  noCache,
+}: {
+  quiet: boolean;
+  dist: boolean;
+  noCache?: boolean;
+}) {
+  const options = [
+    quiet ? ['--quiet'] : [],
+    dist ? ['--dist'] : [],
+    noCache ? ['--no-cache'] : [],
+  ].flat();
   const stdio: StdioOption[] = quiet
     ? ['ignore', 'pipe', 'pipe']
     : ['inherit', 'inherit', 'inherit'];

--- a/src/dev/build/tasks/build_packages_task.ts
+++ b/src/dev/build/tasks/build_packages_task.ts
@@ -113,6 +113,7 @@ export const BuildPackages: Task = {
     await buildWebpackBundles({
       quiet: false,
       dist: true,
+      noCache: true,
     });
 
     const transformConfig: TransformConfig = {


### PR DESCRIPTION
## Summary
Kibana's build seems to be breaking on a `yarn` command, it's not quite clear how/why, but this attempts to disable cache for that step, to get it working.


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->