### PR TITLE
[Metrics][Discover] Enable Metrics experience by default

### DIFF
--- a/src/platform/plugins/shared/metrics_experience/public/plugin.tsx
+++ b/src/platform/plugins/shared/metrics_experience/public/plugin.tsx
@@ -18,10 +18,7 @@ export class MetricsExperiencePlugin implements MetricsExperiencePluginClass {
   }
 
   public start(_core: CoreStart) {
-    const isEnabled = _core.featureFlags.getBooleanValue(
-      METRICS_EXPERIENCE_FEATURE_FLAG_KEY,
-      false
-    );
+    const isEnabled = _core.featureFlags.getBooleanValue(METRICS_EXPERIENCE_FEATURE_FLAG_KEY, true);
 
     return {
       metricsExperienceClient: isEnabled ? createMetricsExperienceClient(_core) : undefined,

--- a/src/platform/plugins/shared/metrics_experience/server/lib/utils/index.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/lib/utils/index.ts
@@ -13,7 +13,7 @@ import { METRICS_EXPERIENCE_FEATURE_FLAG_KEY } from '../../../common/constants';
 export const throwNotFoundIfMetricsExperienceDisabled = async (
   featureFlag: FeatureFlagsRequestHandlerContext
 ) => {
-  const isEnabled = await featureFlag.getBooleanValue(METRICS_EXPERIENCE_FEATURE_FLAG_KEY, false);
+  const isEnabled = await featureFlag.getBooleanValue(METRICS_EXPERIENCE_FEATURE_FLAG_KEY, true);
 
   if (!isEnabled) {
     throw notFound();

--- a/src/platform/plugins/shared/metrics_experience/server/plugin.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/plugin.ts
@@ -56,7 +56,7 @@ export class MetricsExperiencePlugin
       });
 
       this.metricExperienceEnabled$ = coreStart.featureFlags
-        .getBooleanValue$(METRICS_EXPERIENCE_FEATURE_FLAG_KEY, false)
+        .getBooleanValue$(METRICS_EXPERIENCE_FEATURE_FLAG_KEY, true)
         .pipe(takeUntil(this.pluginStop$))
         .subscribe((isMetricsExperienceEnabled) => {
           if (isMetricsExperienceEnabled) {

--- a/src/platform/test/api_integration/apis/metrics_experience/dimensions.ts
+++ b/src/platform/test/api_integration/apis/metrics_experience/dimensions.ts
@@ -33,6 +33,7 @@ export default function ({ getService }: FtrProviderContext) {
       await esArchiver.unload(
         'src/platform/test/api_integration/fixtures/es_archiver/metrics_experience'
       );
+      await toggleMetricsExperienceFeature(supertest, true);
     });
 
     it('should return dimension values for a single dimension', async () => {

--- a/src/platform/test/api_integration/apis/metrics_experience/dimensions.ts
+++ b/src/platform/test/api_integration/apis/metrics_experience/dimensions.ts
@@ -24,7 +24,6 @@ export default function ({ getService }: FtrProviderContext) {
 
   describe('GET /internal/metrics_experience/dimensions', () => {
     before(async () => {
-      await toggleMetricsExperienceFeature(supertest, true);
       await esArchiver.load(
         'src/platform/test/api_integration/fixtures/es_archiver/metrics_experience'
       );

--- a/src/platform/test/api_integration/apis/metrics_experience/fields.ts
+++ b/src/platform/test/api_integration/apis/metrics_experience/fields.ts
@@ -24,7 +24,6 @@ export default function ({ getService }: FtrProviderContext) {
 
   describe('GET /internal/metrics_experience/fields', () => {
     before(async () => {
-      await toggleMetricsExperienceFeature(supertest, true);
       await esArchiver.load(
         'src/platform/test/api_integration/fixtures/es_archiver/metrics_experience'
       );

--- a/src/platform/test/api_integration/apis/metrics_experience/fields.ts
+++ b/src/platform/test/api_integration/apis/metrics_experience/fields.ts
@@ -33,6 +33,7 @@ export default function ({ getService }: FtrProviderContext) {
       await esArchiver.unload(
         'src/platform/test/api_integration/fixtures/es_archiver/metrics_experience'
       );
+      await toggleMetricsExperienceFeature(supertest, true);
     });
 
     it('should return a list of fields', async () => {

--- a/src/platform/test/api_integration/apis/metrics_experience/index_pattern.ts
+++ b/src/platform/test/api_integration/apis/metrics_experience/index_pattern.ts
@@ -25,7 +25,6 @@ export default function ({ getService }: FtrProviderContext) {
 
   describe('GET /internal/metrics_experience/index_pattern_metadata/:indexPattern', () => {
     before(async () => {
-      await toggleMetricsExperienceFeature(supertest, true);
       await esArchiver.load(
         'src/platform/test/api_integration/fixtures/es_archiver/metrics_experience'
       );

--- a/src/platform/test/api_integration/apis/metrics_experience/index_pattern.ts
+++ b/src/platform/test/api_integration/apis/metrics_experience/index_pattern.ts
@@ -34,6 +34,7 @@ export default function ({ getService }: FtrProviderContext) {
       await esArchiver.unload(
         'src/platform/test/api_integration/fixtures/es_archiver/metrics_experience'
       );
+      await toggleMetricsExperienceFeature(supertest, true);
     });
 
     it('should return 200 when the metrics experience feature flag is enabled', async () => {


### PR DESCRIPTION
## Summary

Part of #237849

Enable [Metrics Experience feature flag](https://github.com/elastic/kibana/pull/233326) by default for on-premise. It won't affect feature availability in cloud offerings.

## How to test
- Clone https://github.com/simianhacker/simian-forge/tree/main
- Run ` ./forge --dataset hosts --count 25 --interval 30s`
- Navigate to Discover, switch to ESQL mode and select `metrics*` index => **Metrics experience is visible**
- Set the following config to `kibana.dev.yml`
```yml
feature_flags.overrides:
  metricsExperienceEnabled: false
 ```
 - Navigate to Discover, switch to ESQL mode and select `metrics*` index => **Metrics experience is not visible**





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->