### PR TITLE
[Background search] Change from body to querystring in esql extend

### DIFF
--- a/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/esql_async_search_strategy.test.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/esql_async_search_strategy.test.ts
@@ -344,7 +344,7 @@ describe('ES|QL async search strategy', () => {
 
       expect(mockApiCaller).toBeCalled();
       const request = mockApiCaller.mock.calls[0][0];
-      expect(request.body).toEqual({ id, keep_alive: keepAlive });
+      expect(request.querystring).toEqual({ id, keep_alive: keepAlive });
     });
 
     it('throws normalized error on ElasticsearchClientError', async () => {

--- a/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/esql_async_search_strategy.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/esql_async_search_strategy.ts
@@ -218,7 +218,11 @@ export const esqlAsyncSearchStrategyProvider = (
       logger.debug(`extend ${id} by ${keepAlive}`);
       try {
         await esClient.asCurrentUser.transport.request(
-          { method: 'GET', path: `/_query/async/${id}`, body: { id, keep_alive: keepAlive } },
+          {
+            method: 'GET',
+            path: `/_query/async/${id}`,
+            querystring: { id, keep_alive: keepAlive },
+          },
           { ...options.transport, signal: options.abortSignal, meta: true }
         );
       } catch (e) {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/238053

We were using a body in a GET request, that was throwing the exception `request [GET /_query/async/<id>] does not support having a body`. Changing to a querystring solves the problem.

---

Before

https://github.com/user-attachments/assets/2bfd3794-4f8d-404b-b314-2b19a3144702

---

After

https://github.com/user-attachments/assets/d8053e4e-ba0b-4a3e-aea3-ed26527c319d

---

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->