### PR TITLE
🌊 Streams: Always validate generic processing errors

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -252,7 +252,7 @@ const prepareSimulationProcessors = (processing: StreamlangDSL): IngestProcessor
               field: '_errors',
               value: {
                 message: '{{{ _ingest.on_failure_message }}}',
-                processor_id: '{{{ _ingest.on_failure_processor_tag }}}',
+                processor_id: Object.values(processor)[0].tag,
                 type: 'generic_processor_failure',
               },
             },

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/validation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/validation_handler.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { errors as esErrors } from '@elastic/elasticsearch';
+import type { IScopedClusterClient } from '@kbn/core/server';
+import type { StreamlangDSL } from '@kbn/streamlang';
+import { transpileIngestPipeline } from '@kbn/streamlang';
+import type { StreamsClient } from '../../../../lib/streams/client';
+
+export interface ProcessingValidationParams {
+  path: {
+    name: string;
+  };
+  body: {
+    processing: StreamlangDSL;
+  };
+}
+
+export interface ValidateProcessingDeps {
+  params: ProcessingValidationParams;
+  scopedClusterClient: IScopedClusterClient;
+  streamsClient: StreamsClient;
+}
+
+export const validateProcessing = async ({
+  params,
+  scopedClusterClient,
+}: ValidateProcessingDeps) => {
+  try {
+    // Transpile the processing configuration to ingest pipeline processors
+    const transpiledPipeline = transpileIngestPipeline(params.body.processing, {
+      ignoreMalformed: true,
+      traceCustomIdentifiers: true,
+    });
+
+    // Attempt pipeline simulation with empty docs array to validate syntax
+    await scopedClusterClient.asCurrentUser.ingest.simulate({
+      docs: [], // Empty docs array - this should trigger the expected error
+      pipeline: {
+        processors: transpiledPipeline.processors,
+        // @ts-expect-error field_access_pattern not supported by typing yet
+        field_access_pattern: 'flexible',
+      },
+      verbose: true,
+    });
+
+    // If we reach here without the expected error, something unexpected happened
+    return {
+      valid: false,
+      error: {
+        type: 'unexpected_success',
+        message: 'Pipeline simulation succeeded unexpectedly with empty documents',
+      },
+    };
+  } catch (error) {
+    if (error instanceof esErrors.ResponseError) {
+      const errorType = error.body?.error?.type;
+      const errorReason = error.body?.error?.reason;
+
+      // This is the expected error when docs array is empty - validation passed
+      if (
+        errorType === 'illegal_argument_exception' &&
+        errorReason === 'must specify at least one document in [docs]'
+      ) {
+        return {
+          valid: true,
+        };
+      }
+
+      // Any other error indicates a problem with the processing configuration
+      return {
+        valid: false,
+        error: {
+          type: errorType || 'unknown_error',
+          message: errorReason || error.message,
+          processor_tag: error.body?.error?.processor_tag,
+        },
+      };
+    }
+
+    // Non-Elasticsearch errors
+    return {
+      valid: false,
+      error: {
+        type: 'validation_error',
+        message: error.message,
+      },
+    };
+  }
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/management_bottom_bar/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/management_bottom_bar/index.tsx
@@ -15,6 +15,7 @@ interface ManagementBottomBarProps {
   disabled?: boolean;
   insufficientPrivileges?: boolean;
   isLoading?: boolean;
+  validationError?: string | null;
   onCancel: () => void;
   onConfirm: () => void;
 }
@@ -24,6 +25,7 @@ export function ManagementBottomBar({
   disabled = false,
   isLoading = false,
   insufficientPrivileges = false,
+  validationError,
   onCancel,
   onConfirm,
 }: ManagementBottomBarProps) {
@@ -58,12 +60,14 @@ export function ManagementBottomBar({
                     defaultMessage: "You don't have sufficient privileges to save changes.",
                   }
                 )
+              : Boolean(validationError)
+              ? String(validationError)
               : undefined
           }
         >
           <EuiButton
             data-test-subj="streamsAppManagementBottomBarButton"
-            disabled={disabled || insufficientPrivileges}
+            disabled={disabled || insufficientPrivileges || Boolean(validationError)}
             color="primary"
             fill
             size="s"

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/stream_enrichment_state_machine.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/stream_enrichment_state_machine.ts
@@ -46,6 +46,10 @@ import {
   simulationMachine,
   createSimulationMachineImplementations,
 } from '../simulation_state_machine';
+import {
+  validationMachine,
+  createValidationMachineImplementations,
+} from '../validation_state_machine/validation_state_machine';
 import { stepMachine } from '../steps_state_machine';
 import {
   collectDescendantIds,
@@ -86,6 +90,7 @@ export const streamEnrichmentMachine = setup({
     setupGrokCollection: getPlaceholderFor(setupGrokCollectionActor),
     stepMachine: getPlaceholderFor(() => stepMachine),
     simulationMachine: getPlaceholderFor(() => simulationMachine),
+    validationMachine: getPlaceholderFor(() => validationMachine),
   },
   actions: {
     notifyUpsertStreamSuccess: getPlaceholderFor(createUpsertStreamSuccessNofitier),
@@ -242,6 +247,11 @@ export const streamEnrichmentMachine = setup({
       { delay: 800, id: 'send-samples-to-simulator' }
     ),
     sendResetEventToSimulator: sendTo('simulator', { type: 'simulation.reset' }),
+    sendStepsToValidator: sendTo('validator', ({ context }) => ({
+      type: 'validation.updateSteps',
+      steps: getStepsForSimulation({ stepRefs: context.stepRefs, includeExistingSteps: true }),
+    })),
+    triggerValidation: sendTo('validator', { type: 'validation.trigger' }),
   },
   guards: {
     hasStagedChanges: ({ context }) => {
@@ -269,7 +279,6 @@ export const streamEnrichmentMachine = setup({
     },
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5RgHYCcCWBjAFgZQBc0wBDAWwDoMUMCMSAbDAL2qkOPIGIBtABgC6iUAAcA9rFoYxKYSAAeiALQB2AIwAWChoAcAZgBMavgY16ArGsMAaEAE9lxgGx8KKlUYCcV85afmNAF9A21RMXA5SSmopRhY2SO4eNSEkEHFJOhk5RQQlJ08nCgNzJyc9FT4+Qo01J1sHPM9PVz01FrUdDQ6XT2DQ9Gx8IiiqGjo41hQoADE0MTIAVTQGLgBXFbHYpmZIflTRCSlstNz8zx0KT18dcza+Sz1yhuUdPkun9Qs+NRLPAz0-XAgwiI3IFFgYAIaxEAHF5gBrADCYgYDDAWCyKC4EBkYDGADcxAj8ZDoXDESi0Risfs5BljrJTsoNFUKDoVHo+Hpak9fHcXnknN0KMY1KUdMYSuZPCogWEholKGSYfDiVT0ZjpNiwGh5mgKCIGCQCAAzMRoZVQ1WU1Ga2mCelHLE5FmeCh8YW1Xx6bwtPQ6QWqSraKyeMwlPgqTxPeUg4acSicCB2LiwMFJjFgDAEvaOtIMl1pRpKO4GbTNDQGcPCyztWy5MNFHnGPRtcUXIIhYHhBOjZN2CEZqgQdFp4fEMl0gvO7WuhBlNSipwcwwqJwGFTmAyB+yINTGcxuC7VTfmHSSjRdga9pUUAdDxMjsfpp8wiAmsDTw6ZOfMvJVkeuilH6ZhOL8grGNcFDlC0fDei4F5xreE6kCmj6jO+JpsDieKEsS+IwpCaAEEqACCmIWt+6SzicoBnIU2hXlWpicmo7gWJBnquCuMoaAUVQxt4yGKqhJDoa+mEiB+dDTFwur6oaxpmhalBEbqpEZhRBBUfmP6MvOmhHhY1ZtEYUYqKuXEqFodQGDubSsg8nQiaCT4PgquBkKgBDrJssB2CgWDUYWf70YgARFJWdRch4mhdIKhgep0K46Bc24yu4rl9uCHnxt5KC+TJJB4GIGxYPiuAkNMX56TRv50QoEUAsU4bXMKnrtNGQZWK4VgGOBhR-Nc2V3nlvYFUVJolWVaAVRQxVIjg1UwCFtFMuFCAaFuVw6KYwqdIUMqaEGXJaEYPI2RdMorqNYnoZ5OCTQtGCwEaJB2AkGBkGsynalwIjzBVsCwBasAUOJEBrQ1G1NXkFR6KKXgcrU+i9PUe7w2YbgPACUZcuY8Fyt2j1jWhg6Pc9ECve9n3THg32-dhMgA0DcCg2g4PEBaEC6tDBn-qWS7mOoGgBDy3Q6INp3Y5U26xQTRN3e55MUJTPkvW9xp0+wjN-SzgNiMDHMUFVNX80Wm3nOWdS+PFNnqNcMuI3LeOcg8Ssk-GZPiRT+Ua9TWsfV9P369ihvGxaEIkLmFthXDSj-CorUxeu-rsWozs4-L+Me9t5jK-2qvq4Vmu0yHTNYmmevMyg95gKak44HHjWNvoMHrr6tzruB3K7iWnQ2+47ybntvxlE4he5cX-ul4H5f0zXWIUASGBgAA7gAItNAAKxCrxv1eh7XK9r1vUI0pAMxrwwECwC3sNnMKiOdOeNmHvZBiCiu2jqBx-jpQeFPTMvs1azwIGXbWFcw6nw3tvAgJA95gAPuvI+ldtSm2WjVJBKDN5G1gNfBgBA+Z1VCq3ZQ-wjyFAeP8bo7g0qnSApKHkbwbi6GvD2USKtQElwgfPKBi9j7L1wbvfeZ9WbILPlSNYZAUDgwAFQP3nKWC4FAAjeHKNyboXIv6Y0Tpca4xgPDnisBeAawD648PAZA4Ogj0EyFgefYhmIr43zvmgmBIiEE4LPkowWwpLguAMD8X4XQ2zrkgk8Nwmh1CSgsiLHkFjxpDCpjTARushEYNwRfFxEBr5gFvrADxJ9TRuIUX4q20Z2SclMFUUofJZSCjFhWbcITDAo09EkmeE0NZkGqiQKAbB4EzXKnAU2DAJCQBxNNUqozwZiBEKgAAsv0mAk0KkJ1oaKK6f8PDlE5E0pKlQWgchFlGH4fQvYoW4Q9axfSUADKGTM2awMKALNQNMhBsy5pjKwBMyEKyHlrJ8hsp+RyLzuFlL6QoG5DnlmOe8LclRKjtC6VYnppd7mPOmMM75rz3nYmKnisZkNQWvA3FcXi4EAxlAloKUoUU2JOEsrUcMaLbkYogViwZOLnlzLeYswlfKfkLQKRfMlQpPQwXDE8KsB4oUaHpeUdkV51znhlFUXQ7K-acooNytge8jbszBs+MArMjUgxNaS0h61lHigPMUbcll1w2VuDGHqMEdwmFqNKEe4EC5XK4UXdFKTemrINWzS1nNTXmsjtG7maBeZoAlUoe1S4SijxdcBd1eiRQbjeKYX4vg-XarAbq-V0xDVxvBlgTgskoCxuNQaWAMdaoHHqgLK28UlzlFKFUdi2a9CRK0CYPaJQUbdDqDoUtvC9XhsrZGjmNa604Qjk2021UKoMBTd2mCFgXA-FdTKIdmNTDlhcL2xFV4NHTsDW5YNHLQ2YvnVAKtTbl2kHrY2qNatqYEB3boHt+7+1HpzY0AmopPTfAnd4YmN4g3TxDV5MNQKI0WqXabFdck10-rNqtG1MM7WAb3X2w9g7ErMpglBwmMH2IzruS+t9UbwaQCkNhxdVqIBQwI52hOmhvAeghSUAdbqT2NG2kUToqq37Xro3enKIDH3Iefahhd6GTWsa-Thk2vN0TEIAwJ94HJhOgbE4gcCS4uhRnHTZSdcHOH3sQ0pp6KHsWvo49GzTq6PPR1jjxy2fHJ2CeM5YUzQZZSeoLT64te1J7yZ9s556Fb3Pqc83+7zqWN1BQKQZpcRnjEiePT1Zp+bvVFpo+YoEKAxC83gGkUmGYnSEcFp0KWbgnUcmZeRvRB5LBuDintKMaU-gWJiBMHYCRGszma1bC47oLD8W+N6AtPUoMensnUaMpROTnlG+MegE3phzAWMsBgTXeNnHUEUASAI0otEA54cLphtB3DbNucU9lowWJVBSdUdoaTxzIY-Fk7cxYHl+L12UF5FV6K26GVkA1mXj0SfF4cUBbTUi1DIGYJAMAMA2GAc7AXcgAi0NuDknIkXin4uYIM7glzeF9NGOyplLnwcc4pxo+lieOH0JcLcmauuiaDMdbOphVyyjKBwhrNzBySXIET+OZxtqI2AgUdoYEIKYxaEedoB49q+BsrKezMuH1y+HBgUchPpsXccGUDuNSzHsV8CUQUzRz3eH4n8AaZhASo9lxhcEWF62K-IXkdo5YzCtfKMyionpaeY1+PZHGLr-CfYKLe9nCnLGJZ8qH4H4foyuAF86oXRXc1tGKLjJ4bQCiVE6f7s3Zan18LSbYjJ9jYZA+UVCylNDTDG4YXogEqu6zcmaIJBb9HdX8PbwzTJDivGILERvfPyipbJ1ZB0SyLg1xmYXJcba7FOQANuEAxvTmdUt5sTrefnfHGbxycQvJZS1+C1r8lA8tL+KdAeN-Q-uyDSZ+m40+1+yWuKLycAb+s2Hg2yVYuyA0CMgoiOFAXIlYJQlk541YoBymXKL6EB-KfykyEA0BCcK4yc-gC21YF4aMmcmMFgiMbw7uXg3qe00u3s90V+uBc6qmUABBPy8ygqpBT8kobgbBJilQ5QAI9K3IxQD23I4u8qcWWeCWXBLmKmbmTGS6whjgV07WguYWw+bYSMbw3IlO7ETwbODm2eyS3ByWWhJqlu6IOh4eBQWgJenWhhA8kWZWvqsW4oOB6heBvBDh0atan6bALhqabh+hpeXh+4SUHI7QBQrSG46ggRSWjGHmLG6W0wURdQ4YsRnh3WjQA0ycFQyRtezKG4AaKhqEoMDAuYEAAASmIGIJpImFEV3OyFYB2DHm0G0KtsKMUHFAED6ANFLMEMEEAA */
   id: 'enrichStream',
   context: ({ input, spawn }) => ({
     definition: input.definition,
@@ -286,8 +295,16 @@ export const streamEnrichmentMachine = setup({
         streamType: getStreamTypeFromDefinition(input.definition.stream),
       },
     }),
+    validatorRef: spawn('validationMachine', {
+      id: 'validator',
+      input: {
+        steps: [],
+        streamName: input.definition.stream.name,
+      },
+    }),
   }),
   initial: 'initializingFromUrl',
+  on: {},
   states: {
     initializingFromUrl: {
       invoke: {
@@ -460,7 +477,10 @@ export const streamEnrichmentMachine = setup({
               initial: 'idle',
               states: {
                 idle: {
-                  entry: [{ type: 'sendStepsEventToSimulator', params: ({ event }) => event }],
+                  entry: [
+                    { type: 'sendStepsEventToSimulator', params: ({ event }) => event },
+                    { type: 'sendStepsToValidator' },
+                  ],
                   on: {
                     'step.edit': {
                       guard: 'hasSimulatePrivileges',
@@ -495,12 +515,16 @@ export const streamEnrichmentMachine = setup({
                 },
                 creating: {
                   id: 'creatingStep',
-                  entry: [{ type: 'sendStepsEventToSimulator', params: ({ event }) => event }],
+                  entry: [
+                    { type: 'sendStepsEventToSimulator', params: ({ event }) => event },
+                    { type: 'sendStepsToValidator' },
+                  ],
                   on: {
                     'step.change': {
                       actions: [
                         { type: 'reassignSteps' },
                         { type: 'sendStepsEventToSimulator', params: ({ event }) => event },
+                        { type: 'sendStepsToValidator' },
                       ],
                     },
                     'step.delete': {
@@ -519,11 +543,15 @@ export const streamEnrichmentMachine = setup({
                 },
                 editing: {
                   id: 'editingStep',
-                  entry: [{ type: 'sendStepsEventToSimulator', params: ({ event }) => event }],
+                  entry: [
+                    { type: 'sendStepsEventToSimulator', params: ({ event }) => event },
+                    { type: 'sendStepsToValidator' },
+                  ],
                   on: {
                     'step.change': {
                       actions: [
                         { type: 'sendStepsEventToSimulator', params: ({ event }) => event },
+                        { type: 'sendStepsToValidator' },
                       ],
                     },
                     'step.cancel': 'idle',
@@ -571,6 +599,12 @@ export const createStreamEnrichmentMachineImplementations = ({
     simulationMachine: simulationMachine.provide(
       createSimulationMachineImplementations({
         data,
+        streamsRepositoryClient,
+        toasts: core.notifications.toasts,
+      })
+    ),
+    validationMachine: validationMachine.provide(
+      createValidationMachineImplementations({
         streamsRepositoryClient,
         toasts: core.notifications.toasts,
       })

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/types.ts
@@ -26,6 +26,7 @@ import type {
 } from '../simulation_state_machine';
 import type { MappedSchemaField } from '../../../schema_editor/types';
 import type { DataSourceActorRef, DataSourceToParentEvent } from '../data_source_state_machine';
+import type { ValidationActorRef } from '../validation_state_machine/validation_state_machine';
 
 export interface StreamEnrichmentServiceDependencies {
   refreshDefinition: () => void;
@@ -47,6 +48,7 @@ export interface StreamEnrichmentContextType {
   stepRefs: StepActorRef[];
   grokCollection: GrokCollection;
   simulatorRef: SimulationActorRef;
+  validatorRef: ValidationActorRef;
   urlState: EnrichmentUrlState;
 }
 
@@ -81,4 +83,5 @@ export type StreamEnrichmentEvent =
     }
   | { type: 'step.reorder'; stepId: string; direction: 'up' | 'down' }
   | { type: 'url.initialized'; urlState: EnrichmentUrlState }
-  | { type: 'url.sync' };
+  | { type: 'url.sync' }
+  | { type: 'validation.trigger' };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/utils.ts
@@ -94,7 +94,13 @@ export function getDataSourcesSamples(
  * - If no processor is being edited: returns all new processors
  * - If a processor is being edited: returns new processors up to and including the one being edited
  */
-export function getStepsForSimulation({ stepRefs }: Pick<StreamEnrichmentContextType, 'stepRefs'>) {
+export function getStepsForSimulation({
+  stepRefs,
+  includeExistingSteps = false,
+}: Pick<StreamEnrichmentContextType, 'stepRefs'> & { includeExistingSteps?: boolean }) {
+  if (includeExistingSteps) {
+    return stepRefs.map((proc) => proc.getSnapshot().context.step);
+  }
   let newStepSnapshots = stepRefs
     .map((procRef) => procRef.getSnapshot())
     .filter((snapshot) => isWhereBlock(snapshot.context.step) || snapshot.context.isNew);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/validation_actor.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/validation_actor.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fromPromise } from 'xstate5';
+import { convertUIStepsToDSL, type StreamlangStepWithUIAttributes } from '@kbn/streamlang';
+import type { IToasts } from '@kbn/core-notifications-browser';
+import type { StreamsRepositoryClient } from '@kbn/streams-plugin/public/api';
+
+export interface ValidationResult {
+  isValid: boolean;
+  errors: string[];
+  warnings: string[];
+  stepCount: number;
+  validatedAt: string;
+}
+
+export interface ValidationInput {
+  steps: StreamlangStepWithUIAttributes[];
+  streamName: string;
+}
+
+export function createValidationActor({
+  streamsRepositoryClient,
+  toasts,
+}: {
+  streamsRepositoryClient: StreamsRepositoryClient;
+  toasts: IToasts;
+}) {
+  return fromPromise<ValidationResult, ValidationInput>(async ({ input, signal }) => {
+    try {
+      const { steps, streamName } = input;
+
+      // Call the actual validation endpoint
+      const result = await streamsRepositoryClient.fetch(
+        `POST /internal/streams/{name}/processing/_validate`,
+        {
+          params: {
+            path: { name: streamName },
+            body: {
+              processing: convertUIStepsToDSL(steps, true),
+            },
+          },
+          signal,
+        }
+      );
+
+      // Transform the API response to match our ValidationResult interface
+      const errors: string[] = [];
+      const warnings: string[] = [];
+
+      if (!result.valid && result.error) {
+        errors.push(result.error.message);
+      }
+
+      return {
+        isValid: result.valid,
+        errors,
+        warnings, // Server doesn't return warnings yet, but keep for future compatibility
+        stepCount: steps.length,
+        validatedAt: new Date().toISOString(),
+      };
+    } catch (error) {
+      // Don't show toast for validation errors - let the parent handle it
+      throw error;
+    }
+  });
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/validation_state_machine/validation_state_machine.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/validation_state_machine/validation_state_machine.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { ActorRefFrom, MachineImplementationsFrom, SnapshotFrom } from 'xstate5';
+import { assign, setup } from 'xstate5';
+import { getPlaceholderFor } from '@kbn/xstate-utils';
+import type { StreamlangStepWithUIAttributes } from '@kbn/streamlang';
+import { createValidationActor } from '../stream_enrichment_state_machine/validation_actor';
+
+export type ValidationActorRef = ActorRefFrom<typeof validationMachine>;
+export type ValidationActorSnapshot = SnapshotFrom<typeof validationMachine>;
+
+export interface ValidationInput {
+  steps: StreamlangStepWithUIAttributes[];
+  streamName: string;
+}
+
+export interface ValidationContext {
+  steps: StreamlangStepWithUIAttributes[];
+  streamName: string;
+  validationResult: any;
+  validationError: string | null;
+}
+
+export interface ValidationEvent {
+  type: 'validation.trigger' | 'validation.updateSteps';
+  steps?: StreamlangStepWithUIAttributes[];
+}
+
+export interface ValidationMachineDeps {
+  streamsRepositoryClient: any;
+  toasts: any;
+}
+
+export const validationMachine = setup({
+  types: {
+    input: {} as ValidationInput,
+    context: {} as ValidationContext,
+    events: {} as ValidationEvent,
+  },
+  actors: {
+    runValidation: getPlaceholderFor(createValidationActor),
+  },
+  actions: {
+    storeSteps: assign((_, params: { steps: StreamlangStepWithUIAttributes[] }) => ({
+      steps: params.steps,
+    })),
+    storeValidationResult: assign((_, params: { result: any }) => ({
+      validationResult: params.result,
+      validationError: null,
+    })),
+    storeValidationError: assign((_, params: { error: string }) => ({
+      validationResult: null,
+      validationError: params.error,
+    })),
+    clearValidation: assign(() => ({
+      validationResult: null,
+      validationError: null,
+    })),
+  },
+  delays: {
+    validationDebounceTime: 500,
+  },
+}).createMachine({
+  id: 'validation',
+  context: ({ input }) => ({
+    steps: input.steps,
+    streamName: input.streamName,
+    validationResult: null,
+    validationError: null,
+  }),
+  initial: 'idle',
+  on: {
+    'validation.updateSteps': {
+      target: '.debouncingChanges',
+      reenter: true,
+      actions: [{ type: 'storeSteps', params: ({ event }) => ({ steps: event.steps || [] }) }],
+    },
+  },
+  states: {
+    idle: {
+      on: {
+        'validation.trigger': 'running',
+      },
+    },
+    debouncingChanges: {
+      after: {
+        validationDebounceTime: 'running',
+      },
+    },
+    running: {
+      invoke: {
+        id: 'validationRunner',
+        src: 'runValidation',
+        input: ({ context }) => ({
+          steps: context.steps,
+          streamName: context.streamName,
+        }),
+        onDone: {
+          target: 'idle',
+          actions: [
+            { type: 'storeValidationResult', params: ({ event }) => ({ result: event.output }) },
+          ],
+        },
+        onError: {
+          target: 'idle',
+          actions: [
+            {
+              type: 'storeValidationError',
+              params: ({ event }) => ({ error: String(event.error) }),
+            },
+          ],
+        },
+      },
+    },
+  },
+});
+
+export const createValidationMachineImplementations = ({
+  streamsRepositoryClient,
+  toasts,
+}: ValidationMachineDeps): MachineImplementationsFrom<typeof validationMachine> => ({
+  actors: {
+    runValidation: createValidationActor({ streamsRepositoryClient, toasts }),
+  },
+});


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/229251

This PR validates whether the processing is even valid in the sense of transpiling to a valid processing pipeline. If not, an error is shown and it blocks saving:
<img width="1168" height="563" alt="Screenshot 2025-10-10 at 13 48 35" src="https://github.com/user-attachments/assets/1fcef538-81da-453b-91a4-2c68334c81d5" />

This works for editing existing processors and if there are no documents to simulate processing, it just validates whether the ingest pipelines is valid.

It does not tie back to the step that caused the issue because we don't have this information, it just shows the error message.

## Technicalities

I introduced a new API and state machine to manage the validation with debouncing and whatnot.

The API is transpiling the processing steps and sending it to pipeline simulate without any docs. This request will never return with 200 OK because Elasticsearch doesn't allow simulating without docs, but we can look for that specific error message and hide it. I didn't find a better way to validate this, maybe it exists.

What comes to mind is trying to write a dummy ingest pipeline with an auto-generated name, but that feels even worse.

I didn't like adding a new endpoint for it, but we can overload it with other stuff going forward regarding ESQL compilation and so on and also return general warnings this way, so maybe it's not bad to have it.