### PR TITLE
[9.0] [Security Solution] Fix naming inconsistency for telemetry events (#238088)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/index.ts
@@ -18,7 +18,7 @@ export const ruleUpgradeFlyoutButtonClickEvent: RuleUpgradeTelemetryEvent = {
         optional: false,
       },
     },
-    hasMissingBaseVersion: {
+    hasBaseVersion: {
       type: 'boolean',
       _meta: {
         description: 'Indicates if the rule has a missing base version',
@@ -44,7 +44,7 @@ export const ruleUpgradeSingleButtonClickEvent: RuleUpgradeTelemetryEvent = {
 export const ruleUpgradeOpenFlyoutEvent: RuleUpgradeTelemetryEvent = {
   eventType: RuleUpgradeEventTypes.RuleUpgradeFlyoutOpen,
   schema: {
-    hasMissingBaseVersion: {
+    hasBaseVersion: {
       type: 'boolean',
       _meta: {
         description: 'Indicates if the rule has a missing base version',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/types.ts
@@ -7,13 +7,13 @@
 import type { RootSchema } from '@kbn/core/public';
 
 export enum RuleUpgradeEventTypes {
-  RuleUpgradeFlyoutButtonClick = 'Click Rule Upgrade Flyout Button',
+  RuleUpgradeFlyoutButtonClick = 'Click Rule Upgrade Flyout Button v2',
   RuleUpgradeSingleButtonClick = 'Click Rule Upgrade Single Button',
-  RuleUpgradeFlyoutOpen = 'Open Rule Upgrade Flyout',
+  RuleUpgradeFlyoutOpen = 'Open Rule Upgrade Flyout v2',
 }
 interface ReportRuleUpgradeFlyoutButtonClickParams {
   type: 'update' | 'dismiss';
-  hasMissingBaseVersion: boolean;
+  hasBaseVersion: boolean;
 }
 
 interface ReportRuleUpgradeSingleButtonClickParams {
@@ -21,7 +21,7 @@ interface ReportRuleUpgradeSingleButtonClickParams {
 }
 
 interface ReportRuleUpgradeFlyoutOpenParams {
-  hasMissingBaseVersion: boolean;
+  hasBaseVersion: boolean;
 }
 
 export interface RuleUpgradeTelemetryEventsMap {

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
@@ -353,16 +353,16 @@ export function usePrebuiltRulesUpgrade({
   );
   const closeRulePreviewAction = (rule: RuleResponse, reason: RulePreviewFlyoutCloseReason) => {
     const ruleUpgradeState = rulesUpgradeState[rule.rule_id];
-    const hasMissingBaseVersion = ruleUpgradeState.has_base_version === false;
+    const hasBaseVersion = ruleUpgradeState.has_base_version === true;
     if (reason === 'dismiss') {
       telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick, {
         type: 'dismiss',
-        hasMissingBaseVersion,
+        hasBaseVersion,
       });
     } else {
       telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick, {
         type: 'update',
-        hasMissingBaseVersion,
+        hasBaseVersion,
       });
     }
   };
@@ -382,9 +382,9 @@ export function usePrebuiltRulesUpgrade({
     (ruleId: string) => {
       openRulePreviewDefault(ruleId);
       const ruleUpgradeState = rulesUpgradeState[ruleId];
-      const hasMissingBaseVersion = ruleUpgradeState.has_base_version === false;
+      const hasBaseVersion = ruleUpgradeState.has_base_version === true;
       telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutOpen, {
-        hasMissingBaseVersion,
+        hasBaseVersion,
       });
     },
     [openRulePreviewDefault, rulesUpgradeState, telemetry]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Fix naming inconsistency for telemetry events (#238088)](https://github.com/elastic/kibana/pull/238088)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jacek Kolezynski","email":"jacek.kolezynski@elastic.co"},"sourceCommit":{"committedDate":"2025-10-09T11:46:27Z","message":"[Security Solution] Fix naming inconsistency for telemetry events (#238088)\n\n**Partially resolves: #140369**\n\n## Summary\n\nThis PR fixes naming inconsistency that creeped in my previous PRs. We\nshould use always 'hasBaseVersion' (currently there is a mixture of\nhasBaseVersion and hasMissingBaseVersion).\nIn order to be sure that the visualizations (which need to be updated)\nuse only the event with the new shape, I am adding 'v2' to the name.","sha":"207cb36c89755f4199c87fe86a4197246c534ba4","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:version","v9.2.0","v9.3.0","v9.1.6","v8.18.9","v8.19.6","v9.0.9"],"title":"[Security Solution] Fix naming inconsistency for telemetry events","number":238088,"url":"https://github.com/elastic/kibana/pull/238088","mergeCommit":{"message":"[Security Solution] Fix naming inconsistency for telemetry events (#238088)\n\n**Partially resolves: #140369**\n\n## Summary\n\nThis PR fixes naming inconsistency that creeped in my previous PRs. We\nshould use always 'hasBaseVersion' (currently there is a mixture of\nhasBaseVersion and hasMissingBaseVersion).\nIn order to be sure that the visualizations (which need to be updated)\nuse only the event with the new shape, I am adding 'v2' to the name.","sha":"207cb36c89755f4199c87fe86a4197246c534ba4"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238235","number":238235,"state":"MERGED","mergeCommit":{"sha":"84f0c2db8835564bbbbdb020b607dadd93c48c7d","message":"[9.2] [Security Solution] Fix naming inconsistency for telemetry events (#238088) (#238235)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Security Solution] Fix naming inconsistency for telemetry events\n(#238088)](https://github.com/elastic/kibana/pull/238088)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jacek Kolezynski <jacek.kolezynski@elastic.co>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238088","number":238088,"mergeCommit":{"message":"[Security Solution] Fix naming inconsistency for telemetry events (#238088)\n\n**Partially resolves: #140369**\n\n## Summary\n\nThis PR fixes naming inconsistency that creeped in my previous PRs. We\nshould use always 'hasBaseVersion' (currently there is a mixture of\nhasBaseVersion and hasMissingBaseVersion).\nIn order to be sure that the visualizations (which need to be updated)\nuse only the event with the new shape, I am adding 'v2' to the name.","sha":"207cb36c89755f4199c87fe86a4197246c534ba4"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238234","number":238234,"state":"MERGED","mergeCommit":{"sha":"658de645074f80e77a051ecdf73ee3685aae7942","message":"[9.1] [Security Solution] Fix naming inconsistency for telemetry events (#238088) (#238234)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution] Fix naming inconsistency for telemetry events\n(#238088)](https://github.com/elastic/kibana/pull/238088)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jacek Kolezynski <jacek.kolezynski@elastic.co>"}},{"branch":"8.18","label":"v8.18.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238232","number":238232,"state":"MERGED","mergeCommit":{"sha":"93d8c9d12db72d83f448203ff10832bb5eefd641","message":"[8.18] [Security Solution] Fix naming inconsistency for telemetry events (#238088) (#238232)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Security Solution] Fix naming inconsistency for telemetry events\n(#238088)](https://github.com/elastic/kibana/pull/238088)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jacek Kolezynski <jacek.kolezynski@elastic.co>"}},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238233","number":238233,"state":"MERGED","mergeCommit":{"sha":"0f1f889c3c685806cb68dbf997b408a6197a8400","message":"[8.19] [Security Solution] Fix naming inconsistency for telemetry events (#238088) (#238233)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Security Solution] Fix naming inconsistency for telemetry events\n(#238088)](https://github.com/elastic/kibana/pull/238088)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jacek Kolezynski <jacek.kolezynski@elastic.co>"}},{"branch":"9.0","label":"v9.0.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->