### PR TITLE
[SideNav] fix `returnFocusId` crash

### DIFF
--- a/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/menu_panel.tsx
+++ b/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/menu_panel.tsx
@@ -29,7 +29,7 @@ export const Panel: FC<PanelProps> = ({ children, id, title }) => {
 
       // If we have a return focus id, we focus the trigger element
       if (returnFocusId && node) {
-        const triggerElement = node.querySelector<HTMLElement>(`#${returnFocusId}`);
+        const triggerElement = node.querySelector<HTMLElement>(`#${CSS.escape(returnFocusId)}`);
         if (triggerElement) return triggerElement.focus();
       }
 


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/9cd33ba4-010c-44db-bb64-83f3b99f9e3c



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->