### PR TITLE
[One Workflow] Auto-run when no input needed

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -52,7 +52,7 @@ export function WorkflowExecuteModal({
   onClose,
   onSubmit,
 }: {
-  definition: WorkflowYaml | null;
+  definition: WorkflowYaml;
   onClose: () => void;
   onSubmit: (data: Record<string, any>) => void;
 }) {
@@ -79,23 +79,34 @@ export function WorkflowExecuteModal({
     [setExecutionInput, setSelectedTrigger]
   );
 
+  const shouldAutoRun = useMemo(() => {
+    if (definition.triggers?.some((trigger) => trigger.type === 'alert') || definition.inputs) {
+      return false;
+    }
+    return true;
+  }, [definition]);
+
   useEffect(() => {
-    if (!definition) {
+    if (shouldAutoRun) {
+      onSubmit({});
+      onClose();
       return;
     }
+    // Default trigger selection
     if (definition.triggers?.some((trigger) => trigger.type === 'alert')) {
       setSelectedTrigger('alert');
       return;
     }
-    if (!definition.inputs) {
-      // no inputs, and no alert trigger, we can run the workflow right away and close
-      onSubmit({});
-      onClose();
-      return;
-    } else {
+    if (definition.inputs) {
       setSelectedTrigger('manual');
+      return;
     }
-  }, [definition, onClose, onSubmit]);
+  }, [shouldAutoRun, onSubmit, onClose, definition]);
+
+  if (shouldAutoRun) {
+    // Not rendered if the workflow should auto run, will close the modal automatically
+    return null;
+  }
 
   return (
     <>

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list.tsx
@@ -449,7 +449,7 @@ export function WorkflowList({ search, setSearch, onCreateWorkflow }: WorkflowLi
           pageIndex: search.page - 1,
         }}
       />
-      {executeWorkflow && (
+      {executeWorkflow?.definition && (
         <WorkflowExecuteModal
           definition={executeWorkflow.definition}
           onClose={() => setExecuteWorkflow(null)}

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
@@ -243,7 +243,7 @@ export function WorkflowDetailPage({ id }: { id: string }) {
           />
         </EuiFlexItem>
 
-        {workflowExecuteModalOpen && workflow && (
+        {workflowExecuteModalOpen && definitionFromCurrentYaml && (
           <WorkflowExecuteModal
             definition={definitionFromCurrentYaml}
             onClose={closeModal}

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
@@ -48,6 +48,11 @@ export function WorkflowDetailPage({ id }: { id: string }) {
   const [hasChanges, setHasChanges] = useState(false);
   const [highlightDiff, setHighlightDiff] = useState(false);
 
+  const [workflowExecuteModalOpen, setWorkflowExecuteModalOpen] = useState(false);
+  const closeModal = useCallback(() => {
+    setWorkflowExecuteModalOpen(false);
+  }, []);
+
   const yamlValue = selectedExecutionId && execution ? execution.yaml : workflowYaml;
 
   const { updateWorkflow, testWorkflow } = useWorkflowActions();
@@ -77,8 +82,6 @@ export function WorkflowDetailPage({ id }: { id: string }) {
     },
     [id, workflowYaml, updateWorkflow, notifications?.toasts]
   );
-
-  const [workflowExecuteModalOpen, setWorkflowExecuteModalOpen] = useState(false);
 
   const definitionFromCurrentYaml: WorkflowYaml | null = useMemo(() => {
     const parsingResult = parseWorkflowYamlToJSON(workflowYaml, getWorkflowZodSchemaLoose());
@@ -243,7 +246,7 @@ export function WorkflowDetailPage({ id }: { id: string }) {
         {workflowExecuteModalOpen && workflow && (
           <WorkflowExecuteModal
             definition={definitionFromCurrentYaml}
-            onClose={() => setWorkflowExecuteModalOpen(false)}
+            onClose={closeModal}
             onSubmit={handleRunWorkflow}
           />
         )}


### PR DESCRIPTION
## Summary

The workflow is auto-run when there's no `input` defined and the trigger type is not `alert`, otherwise open the modal

Also added entry type pre-selection:

- When the `input` entry is defined: `Manual` type is selected by default
- When no `input` entry: `Alert` type is selected by default

<img width="1361" height="806" alt="Captura de pantalla 2025-10-10 a les 17 33 51" src="https://github.com/user-attachments/assets/1d71a37a-3d08-4c13-9916-ec529951a703" />

### Demo

https://github.com/user-attachments/assets/ed1ad59f-02fd-4145-b2d9-123932310301



