### PR TITLE
Fix CPU profiler to mimic Node.js behavior

### DIFF
--- a/src/cli/profiler/profiler.js
+++ b/src/cli/profiler/profiler.js
@@ -13,6 +13,7 @@ import { join } from 'path';
 import { Session } from 'node:inspector';
 import { threadId } from 'node:worker_threads';
 import { promisify } from 'util';
+import { chain } from 'lodash';
 import { Logger } from '../logger';
 
 class Profiler {
@@ -24,7 +25,10 @@ class Profiler {
   constructor(logger) {
     const execOpts = getopts(process.execArgv);
     const envOpts = getopts(process.env.NODE_OPTIONS ? process.env.NODE_OPTIONS.split(/\s+/) : []);
-    this.#path = execOpts['diagnostic-dir'] || envOpts['diagnostic-dir'] || process.cwd();
+    this.#path = chain(execOpts['diagnostic-dir'] || envOpts['diagnostic-dir'] || process.cwd())
+      .castArray()
+      .last()
+      .value();
     this.#logger = logger;
   }
 


### PR DESCRIPTION
## Summary

When passing a few `--diagnostic-dir` options, the CPU profiler fails with an error.
The expected behavior would be to take the last one, similar to what Node.js does when capturing heap snapshots.


