### PR TITLE
[SideNav] Hack: Don't apply blur when focus is moving to `.euiFlyout`

### DIFF
--- a/src/core/packages/chrome/navigation/src/components/popover/index.tsx
+++ b/src/core/packages/chrome/navigation/src/components/popover/index.tsx
@@ -192,7 +192,10 @@ export const SideNavPopover = ({
         nextFocused &&
         (triggerRef.current?.contains(nextFocused) || popoverRef.current?.contains(nextFocused));
 
-      if (!isStayingInComponent) {
+      // TODO: handling specific issue with EuiFlyout and trap focus
+      const isTrappedByFlyout = (nextFocused as HTMLElement)?.classList.contains('euiFlyout');
+
+      if (!isStayingInComponent && !isTrappedByFlyout) {
         handleClose();
       }
     },


### PR DESCRIPTION
## Summary

Same as https://github.com/elastic/kibana/pull/238230, but without flaky test issue

