### PR TITLE
[9.0] [Search][Accessibility] Show error text when fields are invalid (#238284)

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
@@ -53,6 +53,14 @@ export const InstructionsField: React.FC<InstructionsFieldProps> = ({ value, onC
         </span>
       }
       fullWidth
+      isInvalid={isEmpty(value)}
+      error={
+        isEmpty(value)
+          ? i18n.translate('xpack.searchPlayground.sidebar.instructionsField.errorMessage', {
+              defaultMessage: 'Instructions cannot be empty',
+            })
+          : undefined
+      }
     >
       <EuiTextArea
         data-test-subj="instructionsPrompt"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Search][Accessibility] Show error text when fields are invalid (#238284)](https://github.com/elastic/kibana/pull/238284)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brittany","email":"seialkali@gmail.com"},"sourceCommit":{"committedDate":"2025-10-10T14:12:08Z","message":"[Search][Accessibility] Show error text when fields are invalid (#238284)\n\n## Summary\n\nThis PR ensures that when a field in the RAG Playground is in an error\nstate, the corresponding error text is displayed below the field.\nPreviously, only the red error styling was applied without any\naccompanying message, which did not meet accessibility requirements.\n\n<img width=\"600\" height=\"686\" alt=\"Screenshot 2025-10-09 at 16 10 06\"\nsrc=\"https://github.com/user-attachments/assets/ef980bcb-cae0-4c5c-a330-c4e20bbbfd61\"\n/>\n\n### Testing\n\n1. Navigate to Search → Build → RAG Playground.\n2. In the Instructions field, delete all text and press Tab.\n3. Confirm that an error message appears below the field (e.g.,\n“Instructions cannot be empty”).\n4. In the Context fields input, enter any text (e.g., test), then press\nTab.\n5. Confirm that invalid entries display a red border and an error\nmessage below the field.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes an issue in the RAG Playground where invalid fields displayed red\nstyling but no error message. Error text is now shown to help users\nidentify and correct form issues.","sha":"3a56deb3f6b5187c60f9a38ac416c9322f76bd31","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Search","backport:version","v9.2.0","v9.3.0","v9.1.6","v8.18.9","v8.19.6","v9.0.9"],"title":"[Search][Accessibility] Show error text when fields are invalid","number":238284,"url":"https://github.com/elastic/kibana/pull/238284","mergeCommit":{"message":"[Search][Accessibility] Show error text when fields are invalid (#238284)\n\n## Summary\n\nThis PR ensures that when a field in the RAG Playground is in an error\nstate, the corresponding error text is displayed below the field.\nPreviously, only the red error styling was applied without any\naccompanying message, which did not meet accessibility requirements.\n\n<img width=\"600\" height=\"686\" alt=\"Screenshot 2025-10-09 at 16 10 06\"\nsrc=\"https://github.com/user-attachments/assets/ef980bcb-cae0-4c5c-a330-c4e20bbbfd61\"\n/>\n\n### Testing\n\n1. Navigate to Search → Build → RAG Playground.\n2. In the Instructions field, delete all text and press Tab.\n3. Confirm that an error message appears below the field (e.g.,\n“Instructions cannot be empty”).\n4. In the Context fields input, enter any text (e.g., test), then press\nTab.\n5. Confirm that invalid entries display a red border and an error\nmessage below the field.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes an issue in the RAG Playground where invalid fields displayed red\nstyling but no error message. Error text is now shown to help users\nidentify and correct form issues.","sha":"3a56deb3f6b5187c60f9a38ac416c9322f76bd31"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.18","8.19","9.0"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238465","number":238465,"state":"OPEN"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238284","number":238284,"mergeCommit":{"message":"[Search][Accessibility] Show error text when fields are invalid (#238284)\n\n## Summary\n\nThis PR ensures that when a field in the RAG Playground is in an error\nstate, the corresponding error text is displayed below the field.\nPreviously, only the red error styling was applied without any\naccompanying message, which did not meet accessibility requirements.\n\n<img width=\"600\" height=\"686\" alt=\"Screenshot 2025-10-09 at 16 10 06\"\nsrc=\"https://github.com/user-attachments/assets/ef980bcb-cae0-4c5c-a330-c4e20bbbfd61\"\n/>\n\n### Testing\n\n1. Navigate to Search → Build → RAG Playground.\n2. In the Instructions field, delete all text and press Tab.\n3. Confirm that an error message appears below the field (e.g.,\n“Instructions cannot be empty”).\n4. In the Context fields input, enter any text (e.g., test), then press\nTab.\n5. Confirm that invalid entries display a red border and an error\nmessage below the field.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes an issue in the RAG Playground where invalid fields displayed red\nstyling but no error message. Error text is now shown to help users\nidentify and correct form issues.","sha":"3a56deb3f6b5187c60f9a38ac416c9322f76bd31"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->