### PR TITLE
[Automatic Migrations] Remove toasts when navigating to different pages

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/service/migrations_service_base.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/service/migrations_service_base.ts
@@ -7,7 +7,7 @@
 
 import { isEqual } from 'lodash';
 import { BehaviorSubject, distinctUntilChanged, type Observable } from 'rxjs';
-import type { CoreStart } from '@kbn/core/public';
+import type { CoreStart, Toast } from '@kbn/core/public';
 import type { TraceOptions } from '@kbn/elastic-assistant/impl/assistant/types';
 import {
   DEFAULT_ASSISTANT_NAMESPACE,
@@ -43,6 +43,7 @@ export abstract class SiemMigrationsServiceBase<T extends MigrationTaskStats> {
   private isPolling = false;
   public connectorIdStorage: MigrationsStorage<string>;
   public traceOptionsStorage: MigrationsStorage<TraceOptions>;
+  public toasts: Toast[] = [];
 
   constructor(
     protected readonly core: CoreStart,
@@ -202,5 +203,14 @@ export abstract class SiemMigrationsServiceBase<T extends MigrationTaskStats> {
         await this.sleep(TASK_STATS_POLLING_SLEEP_SECONDS);
       }
     } while (pendingMigrationIds.length > 0);
+  }
+
+  public removeFinishedMigrationsNotification() {
+    if (this.toasts.length > 0) {
+      this.toasts.forEach((toast) => {
+        this.core.notifications.toasts.remove(toast);
+      });
+      this.toasts = [];
+    }
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/pages/index.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { EuiSkeletonLoading, EuiSkeletonText, EuiSkeletonTitle, EuiSpacer } from '@elastic/eui';
 import type { RouteComponentProps } from 'react-router-dom';
 import { SiemMigrationTaskStatus } from '../../../../common/siem_migrations/constants';
-import { useNavigation } from '../../../common/lib/kibana';
+import { useKibana, useNavigation } from '../../../common/lib/kibana';
 import { HeaderPage } from '../../../common/components/header_page';
 import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
 import { SecurityPageName } from '../../../app/types';
@@ -53,6 +53,14 @@ export const MigrationDashboardsPage: React.FC<MigrationDashboardsPageProps> = R
         });
       }
     }, [isLoading, migrationId, navigateTo, dashboardMigrationsStats]);
+
+    const { removeFinishedMigrationsNotification } = useKibana().services.siemMigrations.dashboards;
+
+    useEffect(() => {
+      return () => {
+        removeFinishedMigrationsNotification();
+      };
+    }, [removeFinishedMigrationsNotification]);
 
     const onMigrationIdChange = (selectedId?: string) => {
       navigateTo({ deepLinkId: SecurityPageName.siemMigrationsDashboards, path: selectedId });

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/service/dashboard_migrations_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/service/dashboard_migrations_service.ts
@@ -221,7 +221,9 @@ export class SiemDashboardMigrationsService extends SiemMigrationsServiceBase<Da
   }
 
   protected sendFinishedMigrationNotification(taskStats: DashboardMigrationStats) {
-    this.core.notifications.toasts.addSuccess(getSuccessToast(taskStats, this.core));
+    this.toasts.push(
+      this.core.notifications.toasts.addSuccess(getSuccessToast(taskStats, this.core))
+    );
   }
 
   /** Deletes a dashboard migration by its ID, refreshing the stats to remove it from the list */

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/landing.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/landing.tsx
@@ -4,12 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiSpacer } from '@elastic/eui';
 import { LandingLinksIconsCategories } from '@kbn/security-solution-navigation/landing_links';
 import { SecurityPageName } from '../../common';
 import { SecuritySolutionPageWrapper } from '../common/components/page_wrapper';
+import { useKibana } from '../common/lib/kibana';
 import { Title } from '../common/components/header_page/title';
 import { useRootNavLink } from '../common/links/nav_links';
 import { useGlobalQueryString } from '../common/utils/global_query_string';
@@ -26,6 +27,13 @@ export const MigrationsLandingPage = () => {
   const { links = [], categories = [] } =
     useRootNavLink(SecurityPageName.siemMigrationsLanding) ?? {};
   const urlState = useGlobalQueryString();
+  const { removeFinishedMigrationsNotification } = useKibana().services.siemMigrations.dashboards;
+
+  useEffect(() => {
+    return () => {
+      removeFinishedMigrationsNotification();
+    };
+  }, [removeFinishedMigrationsNotification]);
 
   return (
     <SecuritySolutionPageWrapper>

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/pages/index.tsx
@@ -11,7 +11,7 @@ import { EuiSkeletonLoading, EuiSkeletonText, EuiSkeletonTitle, EuiSpacer } from
 import type { RouteComponentProps } from 'react-router-dom';
 import type { RelatedIntegration } from '../../../../common/api/detection_engine';
 import { SiemMigrationTaskStatus } from '../../../../common/siem_migrations/constants';
-import { useNavigation } from '../../../common/lib/kibana';
+import { useKibana, useNavigation } from '../../../common/lib/kibana';
 import { HeaderPage } from '../../../common/components/header_page';
 import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
 import { SecurityPageName } from '../../../app/types';
@@ -67,6 +67,14 @@ export const MigrationRulesPage: React.FC<MigrationRulesPageProps> = React.memo(
         });
       }
     }, [isLoading, migrationId, navigateTo, ruleMigrationsStats]);
+
+    const { removeFinishedMigrationsNotification } = useKibana().services.siemMigrations.dashboards;
+
+    useEffect(() => {
+      return () => {
+        removeFinishedMigrationsNotification();
+      };
+    }, [removeFinishedMigrationsNotification]);
 
     const onMigrationIdChange = (selectedId?: string) => {
       navigateTo({ deepLinkId: SecurityPageName.siemMigrationsRules, path: selectedId });

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/service/rule_migrations_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/service/rule_migrations_service.ts
@@ -238,6 +238,8 @@ export class SiemRulesMigrationsService extends SiemMigrationsServiceBase<RuleMi
   }
 
   protected sendFinishedMigrationNotification(taskStats: RuleMigrationStats) {
-    this.core.notifications.toasts.addSuccess(getSuccessToast(taskStats, this.core));
+    this.toasts.push(
+      this.core.notifications.toasts.addSuccess(getSuccessToast(taskStats, this.core))
+    );
   }
 }


### PR DESCRIPTION
## Summary

Issue: https://github.com/elastic/kibana/issues/237466

This pr fixes an issue where toasts persisted across kibana for migration status messages even when changing pages. Fixes the issue by storing toasts in the base service class, and calling remove on each when navigating away from a migrations page.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



