### PR TITLE
[Security Solution] add feature flag to hide all the attacks/alerts alignment work

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -294,6 +294,10 @@ export const allowedExperimentalValues = Object.freeze({
    * Release: 9.2.0
    */
   microsoftDefenderEndpointCancelEnabled: true,
+  /**
+   * Protects all the work related to the attacks and alert alignment effort
+   */
+  attacksAlertAlignment: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;


### PR DESCRIPTION
## Summary

We're about to start working on the attacks and alerts alignment effort (see [this Epic ticket](https://github.com/elastic/kibana/issues/232341)). All this work will not be release until late in the `9.3` release cycle.
This PR adds a feature flag so we can safely work without deploying any changes.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/232574