### PR TITLE
migrate Dashboard from content management client to REST API

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/delete_dashboards.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/delete_dashboards.ts
@@ -7,18 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DeleteIn, DeleteResult } from '@kbn/content-management-plugin/common';
 import { DASHBOARD_CONTENT_ID } from '../../../utils/telemetry_constants';
 import { getDashboardContentManagementCache } from '..';
-import { contentManagementService } from '../../kibana_services';
+import { coreServices } from '../../kibana_services';
 
 export const deleteDashboards = async (ids: string[]) => {
-  const deletePromises = ids.map((id) => {
+  const deletePromises = ids.map(async (id) => {
     getDashboardContentManagementCache().deleteDashboard(id);
-    return contentManagementService.client.delete<DeleteIn, DeleteResult>({
-      contentTypeId: DASHBOARD_CONTENT_ID,
-      id,
-    });
+    await coreServices.http.delete(`/api/dashboards/dashboard/${id}`);
   });
 
   await Promise.all(deletePromises);

--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
@@ -14,7 +14,7 @@ import type {
   DashboardUpdateOut,
 } from '../../../../server/content_management';
 import { findDashboardsByIds } from './find_dashboards';
-import { contentManagementService, savedObjectsTaggingService } from '../../kibana_services';
+import { contentManagementService, savedObjectsTaggingService, coreServices } from '../../kibana_services';
 import { getDashboardContentManagementCache } from '..';
 
 export interface UpdateDashboardMetaProps {
@@ -41,11 +41,10 @@ export const updateDashboardMeta = async ({
       ? savedObjectsTaggingApi.ui.updateTagsReferences(dashboard.references, tags)
       : dashboard.references;
 
-  await contentManagementService.client.update<DashboardUpdateIn, DashboardUpdateOut>({
-    contentTypeId: DASHBOARD_CONTENT_ID,
-    id,
-    data: { title, description },
-    options: { references },
+  await coreServices.http.put(`/api/dashboards/dashboard/${id}`, {
+    title,
+    description,
+    references,
   });
 
   getDashboardContentManagementCache().deleteDashboard(id);


### PR DESCRIPTION
fixes: #238500

### Summary
**Migrate Dashboard from content management client to REST API**

- Updated Dashboard service to use direct HTTP calls (`/api/dashboards/dashboard/*`) instead of content management RPC client for CRUD operations. Maintains existing behavior and interfaces.

### Checklist
- [x] Follows EUI writing guidelines and i18n support
- [x] No breaking HTTP API changes
- [x] Includes release notes label