### PR TITLE
[9.0] Fix Host details page doesn't show 'show more' button for ip field (#238239)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/__snapshots__/index.test.tsx.snap
@@ -236,27 +236,48 @@ exports[`IP Overview Component rendering it renders the default IP Overview 1`] 
         <dd
           class="euiDescriptionList__description emotion-euiDescriptionList__description-row-normal"
         >
-          <div
-            data-provider-id="draggableId.content.host-id-renderer-default-draggable-ip-overview-host-id"
-            tabindex="-1"
+          <span
+            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row"
+            data-test-subj="DefaultFieldRendererComponent"
           >
-            <span
-              class="c1"
-              data-test-subj="render-content-host.id"
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
             >
-              <span
-                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                <button
-                  class="euiLink emotion-euiLink-primary"
-                  data-test-subj="host-details-button"
-                  type="button"
+                <div
+                  data-provider-id="draggableId.content.default-field-renderer-default-draggable-host-overview-host_id-b19a781f683541a7a25ee345133aa399"
+                  tabindex="-1"
                 >
-                  b19a781f683541a7a25ee345133aa399
-                </button>
-              </span>
-            </span>
-          </div>
+                  <span
+                    class="c1"
+                    data-test-subj="render-content-host.id"
+                  >
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    >
+                      <button
+                        class="euiLink emotion-euiLink-primary"
+                        data-test-subj="host-details-button"
+                        type="button"
+                      >
+                        b19a781f683541a7a25ee345133aa399
+                      </button>
+                    </span>
+                  </span>
+                </div>
+              </div>
+               
+            </div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
+              />
+            </div>
+          </span>
         </dd>
         <dt
           class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"
@@ -576,27 +597,48 @@ exports[`IP Overview Component rendering it renders the side panel IP overview 1
         <dd
           class="euiDescriptionList__description emotion-euiDescriptionList__description-row-normal"
         >
-          <div
-            data-provider-id="draggableId.content.host-id-renderer-default-draggable-ip-overview-host-id"
-            tabindex="-1"
+          <span
+            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row"
+            data-test-subj="DefaultFieldRendererComponent"
           >
-            <span
-              class="c1"
-              data-test-subj="render-content-host.id"
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
             >
-              <span
-                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                <button
-                  class="euiLink emotion-euiLink-primary"
-                  data-test-subj="host-details-button"
-                  type="button"
+                <div
+                  data-provider-id="draggableId.content.default-field-renderer-default-draggable-host-overview-host_id-b19a781f683541a7a25ee345133aa399"
+                  tabindex="-1"
                 >
-                  b19a781f683541a7a25ee345133aa399
-                </button>
-              </span>
-            </span>
-          </div>
+                  <span
+                    class="c1"
+                    data-test-subj="render-content-host.id"
+                  >
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    >
+                      <button
+                        class="euiLink emotion-euiLink-primary"
+                        data-test-subj="host-details-button"
+                        type="button"
+                      >
+                        b19a781f683541a7a25ee345133aa399
+                      </button>
+                    </span>
+                  </span>
+                </div>
+              </div>
+               
+            </div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
+              />
+            </div>
+          </span>
         </dd>
         <dt
           class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/index.test.tsx
@@ -65,5 +65,14 @@ describe('IP Overview Component', () => {
 
       expect(container.children[0]).toMatchSnapshot();
     });
+
+    test('it renders host id', () => {
+      const { container } = render(
+        <TestProviders>
+          <IpOverview {...mockProps} data={mockData.complete} />
+        </TestProviders>
+      );
+      expect(container).toHaveTextContent('b19a781f683541a7a25ee345133aa399');
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/__snapshots__/index.test.tsx.snap
@@ -80,21 +80,42 @@ exports[`Host Summary Component it renders the default Host Summary 1`] = `
         <dd
           class="euiDescriptionList__description emotion-euiDescriptionList__description-row-normal"
         >
-          <div
-            data-provider-id="draggableId.content.host-id-renderer-default-draggable-ip-overview-host-id"
-            tabindex="-1"
+          <span
+            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row-DefaultFieldRendererComponent"
+            data-test-subj="DefaultFieldRendererComponent"
           >
-            <span
-              class="c1"
-              data-test-subj="render-content-host.id"
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
             >
-              <span
-                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                aa7ca589f1b8220002f2fc61c64cfbf1
-              </span>
-            </span>
-          </div>
+                <div
+                  data-provider-id="draggableId.content.default-field-renderer-default-draggable-host-overview-host_id-aa7ca589f1b8220002f2fc61c64cfbf1"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c1"
+                    data-test-subj="render-content-host.id"
+                  >
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    >
+                      aa7ca589f1b8220002f2fc61c64cfbf1
+                    </span>
+                  </span>
+                </div>
+              </div>
+               
+            </div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
+              />
+            </div>
+          </span>
         </dd>
         <dt
           class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"
@@ -748,21 +769,42 @@ exports[`Host Summary Component it renders the panel view Host Summary 1`] = `
         <dd
           class="euiDescriptionList__description emotion-euiDescriptionList__description-row-normal"
         >
-          <div
-            data-provider-id="draggableId.content.host-id-renderer-default-draggable-ip-overview-host-id"
-            tabindex="-1"
+          <span
+            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row-DefaultFieldRendererComponent"
+            data-test-subj="DefaultFieldRendererComponent"
           >
-            <span
-              class="c1"
-              data-test-subj="render-content-host.id"
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
             >
-              <span
-                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                aa7ca589f1b8220002f2fc61c64cfbf1
-              </span>
-            </span>
-          </div>
+                <div
+                  data-provider-id="draggableId.content.default-field-renderer-default-draggable-host-overview-host_id-aa7ca589f1b8220002f2fc61c64cfbf1"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c1"
+                    data-test-subj="render-content-host.id"
+                  >
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    >
+                      aa7ca589f1b8220002f2fc61c64cfbf1
+                    </span>
+                  </span>
+                </div>
+              </div>
+               
+            </div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiFlexItem emotion-euiFlexItem-growZero"
+              />
+            </div>
+          </span>
         </dd>
         <dt
           class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/__snapshots__/index.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`Host Summary Component it renders the default Host Summary 1`] = `
           class="euiDescriptionList__description emotion-euiDescriptionList__description-row-normal"
         >
           <span
-            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row-DefaultFieldRendererComponent"
+            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row-default_renderer--DefaultFieldRendererComponent"
             data-test-subj="DefaultFieldRendererComponent"
           >
             <div
@@ -770,7 +770,7 @@ exports[`Host Summary Component it renders the panel view Host Summary 1`] = `
           class="euiDescriptionList__description emotion-euiDescriptionList__description-row-normal"
         >
           <span
-            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row-DefaultFieldRendererComponent"
+            class="euiFlexGroup emotion-euiFlexGroup-responsive-none-flexStart-center-row-default_renderer--DefaultFieldRendererComponent"
             data-test-subj="DefaultFieldRendererComponent"
           >
             <div

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/index.test.tsx
@@ -106,4 +106,13 @@ describe('Host Summary Component', () => {
     expect(getByTestId('host-risk-overview')).toHaveTextContent(risk);
     expect(getByTestId('host-risk-overview')).toHaveTextContent(riskScore.toString());
   });
+
+  test('it renders host id', () => {
+    const { container } = render(
+      <TestProviders>
+        <HostOverview {...mockProps} data={mockData.Hosts.edges[0].node} />
+      </TestProviders>
+    );
+    expect(container).toHaveTextContent('aa7ca589f1b8220002f2fc61c64cfbf1');
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.test.tsx
@@ -15,6 +15,7 @@ import {
   locationRenderer,
   whoisRenderer,
   reputationRenderer,
+  hostIdRenderer,
 } from './field_renderers';
 import { mockData } from '../../../explore/network/components/details/mock';
 import type { AutonomousSystem } from '../../../../common/search_strategy';
@@ -134,6 +135,19 @@ describe('Field Renderers', () => {
         <TestProviders>{hostNameRenderer(scopeId, emptyIpHost, FlowTarget.source)}</TestProviders>
       );
       expect(screen.getByText(getEmptyValue())).toBeInTheDocument();
+    });
+
+    test('it renders multiple host ids', () => {
+      render(
+        <TestProviders>
+          {hostIdRenderer({
+            scopeId,
+            host: { ...emptyIdHost, id: ['test1', 'test2'] },
+          })}
+        </TestProviders>
+      );
+      expect(screen.getByText('test1')).toBeInTheDocument();
+      expect(screen.getByText('+1 More')).toBeInTheDocument();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.tsx
@@ -121,11 +121,7 @@ export const hostIdRenderer = ({
           idPrefix={contextID ? `host-overview-${contextID}` : 'host-overview'}
           scopeId={scopeId}
           render={(id) =>
-            noLink ? (
-              <>{id}</>
-            ) : (
-              <HostDetailsLink hostName={hostName}>{id}</HostDetailsLink>
-            )
+            noLink ? <>{id}</> : <HostDetailsLink hostName={hostName}>{id}</HostDetailsLink>
           }
         />
       ) : (

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.tsx
@@ -20,6 +20,7 @@ import { getEmptyTagValue } from '../../../common/components/empty_value';
 import { HostDetailsLink, ReputationLink, WhoIsLink } from '../../../common/components/links';
 import * as i18n from '../../../explore/network/components/details/translations';
 import type { SourcererScopeName } from '../../../sourcerer/store/model';
+import { DefaultFieldRenderer } from './default_renderer';
 
 export const IpOverviewId = 'ip-overview';
 
@@ -108,27 +109,25 @@ export const hostIdRenderer = ({
   ipFilter,
   noLink,
   scopeId,
-}: HostIdRendererTypes): React.ReactElement =>
-  host.id && host.ip && (ipFilter == null || host.ip.includes(ipFilter)) ? (
+}: HostIdRendererTypes): React.ReactElement => {
+  const hostName = host.name && host.name[0];
+  return host.id && host.ip && (ipFilter == null || host.ip.includes(ipFilter)) ? (
     <>
-      {host.name && host.name[0] != null ? (
-        <DefaultDraggable
-          id={`host-id-renderer-default-draggable-${IpOverviewId}-${
-            contextID ? `${contextID}-` : ''
-          }host-id`}
+      {hostName != null ? (
+        <DefaultFieldRenderer
+          rowItems={host.id}
+          attrName={'host.id'}
           isDraggable={isDraggable}
-          field="host.id"
-          value={host.id[0]}
-          isAggregatable={true}
-          fieldType={'keyword'}
+          idPrefix={contextID ? `host-overview-${contextID}` : 'host-overview'}
           scopeId={scopeId}
-        >
-          {noLink ? (
-            <>{host.id}</>
-          ) : (
-            <HostDetailsLink hostName={host.name[0]}>{host.id}</HostDetailsLink>
-          )}
-        </DefaultDraggable>
+          render={(id) =>
+            noLink ? (
+              <>{id}</>
+            ) : (
+              <HostDetailsLink hostName={hostName}>{id}</HostDetailsLink>
+            )
+          }
+        />
       ) : (
         <>{host.id}</>
       )}
@@ -136,6 +135,7 @@ export const hostIdRenderer = ({
   ) : (
     getEmptyTagValue()
   );
+};
 
 export const hostNameRenderer = (
   scopeId: SourcererScopeName,

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helper.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helper.test.ts
@@ -6,120 +6,161 @@
  */
 
 import { Direction } from '../../../../../../common/search_strategy/common';
-import type { AggregationRequest } from '../../../../../../common/search_strategy/security_solution/hosts';
-import { buildFieldsTermAggregation } from './helpers';
+import type {
+  AggregationRequest,
+  HostAggEsItem,
+} from '../../../../../../common/search_strategy/security_solution/hosts';
+import { buildFieldsTermAggregation, formatHostItem } from './helpers';
 
-describe('#buildFieldsTermAggregation', () => {
-  test('it convert fields to aggregation terms', () => {
-    const fields: readonly string[] = [
-      'host.architecture',
-      'host.id',
-      'host.ip',
-      'host.name',
-      'host.os.family',
-      'host.os.name',
-    ];
-    const expected: AggregationRequest = {
-      host_architecture: {
-        terms: {
-          field: 'host.architecture',
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
+describe('#Host details search strategy helpers', () => {
+  describe('#buildFieldsTermAggregation', () => {
+    test('it convert fields to aggregation terms', () => {
+      const fields: readonly string[] = [
+        'host.architecture',
+        'host.id',
+        'host.ip',
+        'host.name',
+        'host.os.family',
+        'host.os.name',
+      ];
+      const expected: AggregationRequest = {
+        host_architecture: {
+          terms: {
+            field: 'host.architecture',
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-      host_id: {
-        terms: {
-          field: 'host.id',
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
+        host_id: {
+          terms: {
+            field: 'host.id',
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-      host_ip: {
-        terms: {
-          script: {
-            source: "doc['host.ip']",
-            lang: 'painless',
+        host_ip: {
+          terms: {
+            script: {
+              source: "doc['host.ip']",
+              lang: 'painless',
+            },
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
-          },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-      host_name: {
-        terms: {
-          field: 'host.name',
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
+        host_name: {
+          terms: {
+            field: 'host.name',
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-      host_os_family: {
-        terms: {
-          field: 'host.os.family',
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
+        host_os_family: {
+          terms: {
+            field: 'host.os.family',
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-      host_os_name: {
-        terms: {
-          field: 'host.os.name',
-          size: 10,
-          order: {
-            timestamp: Direction.desc,
+        host_os_name: {
+          terms: {
+            field: 'host.os.name',
+            size: 10,
+            order: {
+              timestamp: Direction.desc,
+            },
           },
-        },
-        aggs: {
-          timestamp: {
-            max: {
-              field: '@timestamp',
+          aggs: {
+            timestamp: {
+              max: {
+                field: '@timestamp',
+              },
             },
           },
         },
-      },
-    };
-    expect(buildFieldsTermAggregation(fields)).toEqual(expected);
+      };
+      expect(buildFieldsTermAggregation(fields)).toEqual(expected);
+    });
+  });
+
+  const defaultTimestamp = { value: 1, value_as_string: 'timestamp' };
+  describe('#getHostFieldValue', () => {
+    test('it gets the host field value', () => {
+      const bucket: HostAggEsItem = {
+        host_name: {
+          buckets: [{ key: 'host1', doc_count: 1, timestamp: defaultTimestamp }],
+        },
+        host_ip: {
+          buckets: [{ key: 'ip1', doc_count: 1, timestamp: defaultTimestamp }],
+        },
+      };
+      expect(formatHostItem(bucket)).toEqual({
+        _id: 'host1',
+        host: { name: ['host1'], ip: ['ip1'] },
+      });
+    });
+
+    test('it returns multiple values when multiple buckets are present', () => {
+      const bucket: HostAggEsItem = {
+        host_name: {
+          buckets: [{ key: 'host1', doc_count: 1, timestamp: defaultTimestamp }],
+        },
+        host_ip: {
+          buckets: [
+            { key: 'ip1', doc_count: 1, timestamp: defaultTimestamp },
+            { key: 'ip2', doc_count: 1, timestamp: defaultTimestamp },
+          ],
+        },
+      };
+      expect(formatHostItem(bucket)).toEqual({
+        _id: 'host1',
+        host: { name: ['host1'], ip: ['ip1', 'ip2'] },
+      });
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helpers.ts
@@ -19,6 +19,7 @@ import type {
   AggregationRequest,
   EndpointFields,
   HostAggEsItem,
+  HostBucketItem,
   HostBuckets,
   HostItem,
   HostValue,
@@ -132,7 +133,8 @@ const getHostFieldValue = (fieldName: string, bucket: HostAggEsItem): string | s
     : fieldName.replace(/\./g, '_');
 
   if (has(`${aggField}.buckets`, bucket)) {
-    return getFirstItem(get(`${aggField}`, bucket));
+    const buckets = get(`${aggField}.buckets`, bucket);
+    return buckets.length > 0 ? buckets.map((item: HostBucketItem) => item.key) : null;
   } else if (fieldName === 'endpoint.id') {
     return get('endpoint_id.value.buckets[0].key', bucket) || null;
   } else if (has(aggField, bucket)) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Fix Host details page doesn't show 'show more' button for ip field (#238239)](https://github.com/elastic/kibana/pull/238239)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2025-10-10T11:55:13Z","message":"Fix Host details page doesn't show 'show more' button for ip field (#238239)\n\n## Summary\n\nFix Host details page doesn't show the 'show more' button for the IP\nfield.\n\n* It updates the host details endpoint to return multiple values for a\nfield.\n* It updates the host ID renderer in the UI to support multiple values\n\n### What is not included?\n* Refactor host details API; it really needs a refactor, but I am not\ndoing it in this bug fix scope.\n* Network details. Network modal also only displays one value per field,\nbut it is out of the scope.\n\n<img width=\"300\" height=\"682\" alt=\"Screenshot 2025-10-09 at 13 33 33\"\nsrc=\"https://github.com/user-attachments/assets/05f942fd-4bc5-482a-bdf9-23c1d39d3a02\"\n/>\n\n<img width=\"800\" height=\"1002\" alt=\"Screenshot 2025-10-09 at 11 05 09\"\nsrc=\"https://github.com/user-attachments/assets/582e3a6b-868a-4114-ad97-94f0d4654507\"\n/>\n<img width=\"800\" height=\"1066\" alt=\"Screenshot 2025-10-09 at 11 05 04\"\nsrc=\"https://github.com/user-attachments/assets/4b0b69c5-290b-4dbf-b1df-899964a235c3\"\n/>\n\n\n### Checklist\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n### Identify risks","sha":"df167c78d1f3366984b7c0961ac461d888b16e35","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","backport","Team: SecuritySolution","backport:all-open","Theme: entity_analytics","Feature:Entity Analytics","Team:Entity Analytics","v9.3.0"],"title":"Fix Host details page doesn't show 'show more' button for ip field","number":238239,"url":"https://github.com/elastic/kibana/pull/238239","mergeCommit":{"message":"Fix Host details page doesn't show 'show more' button for ip field (#238239)\n\n## Summary\n\nFix Host details page doesn't show the 'show more' button for the IP\nfield.\n\n* It updates the host details endpoint to return multiple values for a\nfield.\n* It updates the host ID renderer in the UI to support multiple values\n\n### What is not included?\n* Refactor host details API; it really needs a refactor, but I am not\ndoing it in this bug fix scope.\n* Network details. Network modal also only displays one value per field,\nbut it is out of the scope.\n\n<img width=\"300\" height=\"682\" alt=\"Screenshot 2025-10-09 at 13 33 33\"\nsrc=\"https://github.com/user-attachments/assets/05f942fd-4bc5-482a-bdf9-23c1d39d3a02\"\n/>\n\n<img width=\"800\" height=\"1002\" alt=\"Screenshot 2025-10-09 at 11 05 09\"\nsrc=\"https://github.com/user-attachments/assets/582e3a6b-868a-4114-ad97-94f0d4654507\"\n/>\n<img width=\"800\" height=\"1066\" alt=\"Screenshot 2025-10-09 at 11 05 04\"\nsrc=\"https://github.com/user-attachments/assets/4b0b69c5-290b-4dbf-b1df-899964a235c3\"\n/>\n\n\n### Checklist\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n### Identify risks","sha":"df167c78d1f3366984b7c0961ac461d888b16e35"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238239","number":238239,"mergeCommit":{"message":"Fix Host details page doesn't show 'show more' button for ip field (#238239)\n\n## Summary\n\nFix Host details page doesn't show the 'show more' button for the IP\nfield.\n\n* It updates the host details endpoint to return multiple values for a\nfield.\n* It updates the host ID renderer in the UI to support multiple values\n\n### What is not included?\n* Refactor host details API; it really needs a refactor, but I am not\ndoing it in this bug fix scope.\n* Network details. Network modal also only displays one value per field,\nbut it is out of the scope.\n\n<img width=\"300\" height=\"682\" alt=\"Screenshot 2025-10-09 at 13 33 33\"\nsrc=\"https://github.com/user-attachments/assets/05f942fd-4bc5-482a-bdf9-23c1d39d3a02\"\n/>\n\n<img width=\"800\" height=\"1002\" alt=\"Screenshot 2025-10-09 at 11 05 09\"\nsrc=\"https://github.com/user-attachments/assets/582e3a6b-868a-4114-ad97-94f0d4654507\"\n/>\n<img width=\"800\" height=\"1066\" alt=\"Screenshot 2025-10-09 at 11 05 04\"\nsrc=\"https://github.com/user-attachments/assets/4b0b69c5-290b-4dbf-b1df-899964a235c3\"\n/>\n\n\n### Checklist\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n### Identify risks","sha":"df167c78d1f3366984b7c0961ac461d888b16e35"}},{"url":"https://github.com/elastic/kibana/pull/238429","number":238429,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/238576","number":238576,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->