### PR TITLE
[Evals] Optimize tracing for Phoenix

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/index.ts
@@ -11,4 +11,4 @@ export { createPlaywrightEvalsConfig } from './src/config/create_playwright_eval
 export type { KibanaPhoenixClient } from './src/kibana_phoenix_client/client';
 export { createQuantitativeCorrectnessEvaluators } from './src/evaluators/correctness';
 export { createQuantitativeGroundednessEvaluator } from './src/evaluators/groundedness';
-export type { EvaluationDataset } from './src/types';
+export type { EvaluationDataset, EvaluationWorkerFixtures } from './src/types';

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluate.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluate.ts
@@ -6,22 +6,15 @@
  */
 
 import type { InferenceConnectorType, InferenceConnector, Model } from '@kbn/inference-common';
-import {
-  getConnectorModel,
-  type BoundInferenceClient,
-  getConnectorFamily,
-  getConnectorProvider,
-} from '@kbn/inference-common';
+import { getConnectorModel, getConnectorFamily, getConnectorProvider } from '@kbn/inference-common';
 import { createRestClient } from '@kbn/inference-plugin/common';
 import { test as base } from '@kbn/scout';
-import type { HttpHandler } from '@kbn/core/public';
-import type { AvailableConnectorWithId } from '@kbn/gen-ai-functional-testing';
 import { getPhoenixConfig } from './utils/get_phoenix_config';
 import { KibanaPhoenixClient } from './kibana_phoenix_client/client';
 import type { EvaluationTestOptions } from './config/create_playwright_eval_config';
 import { httpHandlerFromKbnClient } from './utils/http_handler_from_kbn_client';
 import { createCriteriaEvaluator } from './evaluators/criteria';
-import type { DefaultEvaluators } from './types';
+import type { DefaultEvaluators, EvaluationSpecificWorkerFixtures } from './types';
 import { reportModelScore } from './utils/report_model_score';
 import { createConnectorFixture } from './utils/create_connector_fixture';
 import { createCorrectnessAnalysisEvaluator } from './evaluators/correctness';
@@ -33,19 +26,7 @@ import { createGroundednessAnalysisEvaluator } from './evaluators/groundedness';
  * Test type for evaluations. Loads an inference client and a
  * (Kibana-flavored) Phoenix client.
  */
-export const evaluate = base.extend<
-  {},
-  {
-    inferenceClient: BoundInferenceClient;
-    phoenixClient: KibanaPhoenixClient;
-    evaluators: DefaultEvaluators;
-    fetch: HttpHandler;
-    connector: AvailableConnectorWithId;
-    evaluationConnector: AvailableConnectorWithId;
-    repetitions: number;
-    evaluationAnalysisService: EvaluationAnalysisService;
-  }
->({
+export const evaluate = base.extend<{}, EvaluationSpecificWorkerFixtures>({
   fetch: [
     async ({ kbnClient, log }, use) => {
       // add a HttpHandler as a fixture, so consumers can use

--- a/x-pack/platform/packages/shared/kbn-evals/src/kibana_phoenix_client/diff_examples.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/kibana_phoenix_client/diff_examples.ts
@@ -7,13 +7,14 @@
 
 import type { Example } from '@arizeai/phoenix-client/dist/esm/types/datasets';
 import objectHash from 'object-hash';
+import { isEmpty, omitBy } from 'lodash';
 import type { ExampleWithId } from '../types';
 
 function normaliseExample(example: Example | ExampleWithId) {
   return {
     input: example.input,
     output: example.output,
-    metadata: example.metadata,
+    metadata: omitBy(example.metadata, isEmpty),
   };
 }
 

--- a/x-pack/platform/packages/shared/kbn-evals/src/types.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/types.ts
@@ -7,11 +7,17 @@
 
 import type { Example } from '@arizeai/phoenix-client/dist/esm/types/datasets';
 import type {
-  EvaluationResult,
+  EvaluationResult as PhoenixEvaluationResult,
   Evaluator as PhoenixEvaluator,
   TaskOutput,
 } from '@arizeai/phoenix-client/dist/esm/types/experiments';
+import type { BoundInferenceClient } from '@kbn/inference-common';
+import type { HttpHandler } from '@kbn/core/public';
+import type { AvailableConnectorWithId } from '@kbn/gen-ai-functional-testing';
+import type { ScoutWorkerFixtures } from '@kbn/scout';
+import type { KibanaPhoenixClient } from './kibana_phoenix_client/client';
 import type { EvaluationCriterion } from './evaluators/criteria';
+import type { EvaluationAnalysisService } from './utils/analysis';
 
 export interface EvaluationDataset {
   name: string;
@@ -29,6 +35,11 @@ export interface EvaluatorParams<TExample extends Example, TTaskOutput extends T
   output: TTaskOutput;
   expected: TExample['output'];
   metadata: TExample['metadata'];
+  weight?: number;
+}
+
+interface EvaluationResult extends PhoenixEvaluationResult {
+  weight?: number;
 }
 
 type EvaluatorCallback<TExample extends Example, TTaskOutput extends TaskOutput> = (
@@ -54,3 +65,25 @@ export type ExperimentTask<TExample extends Example, TTaskOutput extends TaskOut
 
 // simple version of Phoenix's ExampleWithId
 export type ExampleWithId = Example & { id: string };
+
+export interface EvaluationSpecificWorkerFixtures {
+  inferenceClient: BoundInferenceClient;
+  phoenixClient: KibanaPhoenixClient;
+  evaluators: DefaultEvaluators;
+  fetch: HttpHandler;
+  connector: AvailableConnectorWithId;
+  evaluationConnector: AvailableConnectorWithId;
+  repetitions: number;
+  evaluationAnalysisService: EvaluationAnalysisService;
+}
+
+export interface EvaluationWorkerFixtures extends ScoutWorkerFixtures {
+  inferenceClient: BoundInferenceClient;
+  phoenixClient: KibanaPhoenixClient;
+  evaluators: DefaultEvaluators;
+  fetch: HttpHandler;
+  connector: AvailableConnectorWithId;
+  evaluationConnector: AvailableConnectorWithId;
+  repetitions: number;
+  evaluationAnalysisService: EvaluationAnalysisService;
+}

--- a/x-pack/platform/packages/shared/kbn-evals/src/types.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/types.ts
@@ -35,12 +35,9 @@ export interface EvaluatorParams<TExample extends Example, TTaskOutput extends T
   output: TTaskOutput;
   expected: TExample['output'];
   metadata: TExample['metadata'];
-  weight?: number;
 }
 
-interface EvaluationResult extends PhoenixEvaluationResult {
-  weight?: number;
-}
+export type EvaluationResult = PhoenixEvaluationResult;
 
 type EvaluatorCallback<TExample extends Example, TTaskOutput extends TaskOutput> = (
   params: EvaluatorParams<TExample, TTaskOutput>

--- a/x-pack/platform/packages/shared/kbn-evals/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-evals/tsconfig.json
@@ -29,5 +29,6 @@
     "@kbn/repo-info",
     "@kbn/std",
     "@kbn/test",
+    "@kbn/inference-prompt-utils",
   ]
 }

--- a/x-pack/platform/packages/shared/kbn-inference-prompt-utils/index.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-prompt-utils/index.ts
@@ -10,3 +10,5 @@ export type {
   ReasoningPromptResponse,
   ReasoningPromptResponseOf,
 } from './src/flows/reasoning/types';
+
+export { executeUntilValid } from './src/flows/until_valid/execute_until_valid';

--- a/x-pack/platform/packages/shared/kbn-inference-prompt-utils/src/flows/until_valid/execute_until_valid.test.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-prompt-utils/src/flows/until_valid/execute_until_valid.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BoundInferenceClient } from '@kbn/inference-common';
+import { MessageRole, type Prompt, type ToolCall, type ToolMessage } from '@kbn/inference-common';
+import { executeUntilValid } from './execute_until_valid';
+import { trace as otelTrace } from '@opentelemetry/api';
+
+const trace = otelTrace as jest.Mocked<typeof otelTrace>;
+
+jest.mock('@opentelemetry/api', () => {
+  const recordException = jest.fn();
+
+  const getActiveSpan = jest.fn(() => ({ recordException }));
+
+  return {
+    trace: {
+      getActiveSpan,
+    },
+  };
+});
+
+jest.mock('@kbn/inference-tracing', () => ({
+  ElasticGenAIAttributes: {
+    InferenceSpanKind: 'CHAIN',
+  },
+  withActiveInferenceSpan: jest.fn(async (_name: string, _options: unknown, fn: () => unknown) =>
+    fn()
+  ),
+  withExecuteToolSpan: jest.fn(
+    async (_toolName: string, _attributes: unknown, fn: () => Promise<unknown>) => fn()
+  ),
+}));
+
+describe('executeUntilValid', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves with the first prompt response when no tool errors occur', async () => {
+    const mockContent = [{ text: 'complete' }];
+
+    const promptSpy = jest.fn().mockResolvedValue({
+      content: mockContent,
+      toolCalls: [],
+      tokens: { completion: 10 },
+    });
+
+    const result = await executeUntilValid({
+      finalToolChoice: { function: 'noop' } as any,
+      inferenceClient: { prompt: promptSpy } as unknown as BoundInferenceClient,
+      maxRetries: 3,
+      prompt: {} as unknown as Prompt,
+      toolCallbacks: {},
+      input: {},
+    });
+
+    expect(result.content).toBe(mockContent);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.input).toEqual<MessageRole[]>([] as unknown as MessageRole[]);
+    expect(promptSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when a tool callback throws and passes error details back to the prompt', async () => {
+    const failingToolCall = {
+      function: { name: 'repair', arguments: '{}' },
+      toolCallId: 'call-1',
+    } as unknown as ToolCall;
+
+    const firstPromptResponse = {
+      content: [],
+      toolCalls: [failingToolCall],
+      tokens: { completion: 1 },
+    };
+
+    const successfulPromptResponse = {
+      content: [{ text: 'fixed' }],
+      toolCalls: [],
+      tokens: { completion: 2 },
+    };
+
+    const promptSpy = jest
+      .fn()
+      .mockResolvedValueOnce(firstPromptResponse)
+      .mockResolvedValueOnce(successfulPromptResponse);
+
+    const toolCallbackError = new Error('tool failure');
+
+    const toolCallback = jest.fn().mockRejectedValueOnce(toolCallbackError);
+
+    const result = await executeUntilValid({
+      finalToolChoice: { function: 'repair' } as any,
+      inferenceClient: { prompt: promptSpy } as unknown as BoundInferenceClient,
+      maxRetries: 2,
+      prompt: {} as unknown as Prompt,
+      toolCallbacks: { repair: toolCallback },
+      input: {},
+    });
+
+    expect(promptSpy).toHaveBeenCalledTimes(2);
+
+    const secondCallOptions = promptSpy.mock.calls[1][0];
+
+    expect(secondCallOptions.prevMessages).toHaveLength(1);
+    expect(secondCallOptions.prevMessages[0]).toEqual<ToolMessage>(
+      expect.objectContaining({
+        name: 'repair',
+        role: MessageRole.Tool,
+        toolCallId: 'call-1',
+        response: expect.objectContaining({
+          error: toolCallbackError,
+          stepsLeft: 3,
+        }),
+      })
+    );
+
+    expect(result.content).toBe(successfulPromptResponse.content);
+    expect(trace.getActiveSpan()?.recordException).toHaveBeenCalledWith(toolCallbackError);
+  });
+
+  it('throws an AggregateError when retries are exhausted', async () => {
+    const persistentToolCall = {
+      function: { name: 'retry', arguments: '{}' },
+      toolCallId: 'call-1',
+    } as unknown as ToolCall;
+
+    const promptSpy = jest.fn().mockResolvedValue({
+      content: [],
+      toolCalls: [persistentToolCall],
+      tokens: { completion: 1 },
+    });
+
+    const persistentError = new Error('still failing');
+
+    const options = {
+      finalToolChoice: { function: 'retry' },
+      inferenceClient: { prompt: promptSpy } as unknown as BoundInferenceClient,
+      maxRetries: 0,
+      prompt: {} as unknown as Prompt,
+      toolCallbacks: { retry: jest.fn().mockRejectedValue(persistentError) },
+      input: {},
+    } as unknown as Parameters<typeof executeUntilValid>[0];
+
+    const execution = executeUntilValid(options);
+
+    await expect(execution).rejects.toThrow(
+      'LLM could not complete task successfully in 1 attempts'
+    );
+
+    await execution.catch((error) => {
+      const aggregateError = error as AggregateError;
+      expect(aggregateError).toBeInstanceOf(AggregateError);
+      expect(aggregateError.errors).toEqual([persistentError]);
+    });
+
+    expect(promptSpy).toHaveBeenCalledTimes(2);
+    expect(trace.getActiveSpan()?.recordException).toHaveBeenCalledTimes(2);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-inference-prompt-utils/src/flows/until_valid/execute_until_valid.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-prompt-utils/src/flows/until_valid/execute_until_valid.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Message } from '@kbn/inference-common';
+import {
+  MessageRole,
+  type Prompt,
+  type PromptOptions,
+  type ToolCall,
+  type ToolCallback,
+  type ToolCallbackResult,
+  type ToolCallbacksOfToolOptions,
+  type ToolChoice,
+  type ToolMessage,
+  type ToolNamesOf,
+  type ToolOptionsOfPrompt,
+  type UnboundPromptOptions,
+} from '@kbn/inference-common';
+import { trace } from '@opentelemetry/api';
+import {
+  ElasticGenAIAttributes,
+  withActiveInferenceSpan,
+  withExecuteToolSpan,
+} from '@kbn/inference-tracing';
+import { omit } from 'lodash';
+import type {
+  UntilValidPromptOptions,
+  UntilValidPromptResponse,
+  UntilValidPromptResponseOf,
+} from './types';
+
+export function executeUntilValid<
+  TPrompt extends Prompt,
+  TPromptOptions extends PromptOptions<TPrompt>,
+  TToolCallbacks extends ToolCallbacksOfToolOptions<ToolOptionsOfPrompt<TPrompt>>,
+  TFinalToolChoice extends ToolChoice<ToolNamesOf<ToolOptionsOfPrompt<TPrompt>>> | undefined =
+    | ToolChoice<ToolNamesOf<ToolOptionsOfPrompt<TPrompt>>>
+    | undefined
+>(
+  options: UnboundPromptOptions<TPrompt> &
+    UntilValidPromptOptions & { prompt: TPrompt } & {
+      toolCallbacks: TToolCallbacks;
+      finalToolChoice: TFinalToolChoice;
+    }
+): Promise<
+  UntilValidPromptResponseOf<
+    TPrompt,
+    TPromptOptions & { toolChoice: TFinalToolChoice },
+    TToolCallbacks
+  >
+>;
+
+/**
+ * Executes a prompt, forcing a specific tool call, until the tool call does not return
+ * an error. If an error occurs, the LLM receives the error and is asked to retry.
+ */
+export async function executeUntilValid(
+  options: UnboundPromptOptions &
+    UntilValidPromptOptions & {
+      toolCallbacks: Record<string, ToolCallback>;
+      finalToolChoice: ToolChoice;
+    }
+): Promise<UntilValidPromptResponse> {
+  const { inferenceClient, finalToolChoice, maxRetries = 3, toolCallbacks } = options;
+
+  async function callTools(toolCalls: ToolCall[]): Promise<ToolMessage[]> {
+    return await Promise.all(
+      toolCalls.map(async (toolCall): Promise<ToolMessage> => {
+        const callback = toolCallbacks[toolCall.function.name];
+
+        const response = await withExecuteToolSpan(
+          toolCall.function.name,
+          {
+            tool: {
+              input: 'arguments' in toolCall.function ? toolCall.function.arguments : undefined,
+              toolCallId: toolCall.toolCallId,
+            },
+          },
+          () => callback(toolCall)
+        ).catch((error): ToolCallbackResult => {
+          trace.getActiveSpan()?.recordException(error);
+          return {
+            response: { error, data: undefined },
+          };
+        });
+
+        return {
+          response: response.response,
+          data: response.data,
+          name: toolCall.function.name,
+          toolCallId: toolCall.toolCallId,
+          role: MessageRole.Tool,
+        };
+      })
+    );
+  }
+
+  async function innerCallPromptUntil({
+    messages: prevMessages,
+    stepsLeft,
+    temperature,
+  }: {
+    messages: Message[];
+    stepsLeft: number;
+    temperature?: number;
+  }): Promise<UntilValidPromptResponse> {
+    const nextPrompt = options.prompt;
+
+    const promptOptions = {
+      ...omit(options, 'finalToolChoice'),
+      prompt: nextPrompt,
+    };
+
+    const response = await inferenceClient.prompt({
+      ...promptOptions,
+      stream: false,
+      temperature,
+      toolChoice: finalToolChoice,
+      prevMessages,
+    });
+
+    const toolMessages = response.toolCalls.length
+      ? (await callTools(response.toolCalls)).map((toolMessage) => {
+          return {
+            ...toolMessage,
+            response: {
+              ...(typeof toolMessage.response === 'string'
+                ? { content: toolMessage.response }
+                : toolMessage.response),
+              stepsLeft,
+            },
+          };
+        })
+      : [];
+
+    const errors = toolMessages.flatMap((toolMessage) =>
+      'error' in toolMessage.response ? [toolMessage.response.error] : []
+    );
+
+    if (errors.length) {
+      if (stepsLeft === 0) {
+        throw new AggregateError(
+          errors,
+          `LLM could not complete task successfully in ${maxRetries + 1} attempts`
+        );
+      }
+
+      return innerCallPromptUntil({
+        messages: prevMessages.concat(...toolMessages),
+        stepsLeft: stepsLeft - 1,
+      });
+    }
+
+    const content = response.content;
+
+    return {
+      content,
+      toolCalls: response.toolCalls,
+      tokens: response.tokens,
+      input: prevMessages,
+    };
+  }
+
+  return await withActiveInferenceSpan(
+    'UntilValid',
+    {
+      attributes: {
+        [ElasticGenAIAttributes.InferenceSpanKind]: 'CHAIN',
+      },
+    },
+    () =>
+      innerCallPromptUntil({
+        messages: [],
+        stepsLeft: maxRetries + 1,
+      })
+  );
+}

--- a/x-pack/platform/packages/shared/kbn-inference-prompt-utils/src/flows/until_valid/types.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-prompt-utils/src/flows/until_valid/types.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  BoundInferenceClient,
+  Message,
+  MessageOf,
+  Prompt,
+  PromptOptions,
+  PromptResponse,
+  ToolCallbacksOfToolOptions,
+  ToolOptionsOfPrompt,
+} from '@kbn/inference-common';
+
+export interface UntilValidPromptOptions {
+  inferenceClient: BoundInferenceClient;
+  maxRetries?: number;
+  prevMessages?: undefined;
+}
+
+export type UntilValidPromptResponseOf<
+  TPrompt extends Prompt = Prompt,
+  TPromptOptions extends PromptOptions<TPrompt> = PromptOptions<TPrompt>,
+  TToolCallbacks extends ToolCallbacksOfToolOptions<
+    ToolOptionsOfPrompt<TPrompt>
+  > = ToolCallbacksOfToolOptions<ToolOptionsOfPrompt<TPrompt>>
+> = PromptResponse<TPromptOptions> & {
+  input: Array<
+    MessageOf<
+      ToolOptionsOfPrompt<TPrompt>,
+      {
+        [key in keyof TToolCallbacks]: Awaited<ReturnType<TToolCallbacks[key]>>;
+      }
+    >
+  >;
+};
+
+export type UntilValidPromptResponse = PromptResponse & { input: Message[] };

--- a/x-pack/platform/packages/shared/kbn-inference-tracing/index.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-tracing/index.ts
@@ -7,6 +7,7 @@
 export { withChatCompleteSpan } from './src/with_chat_complete_span';
 export { withExecuteToolSpan } from './src/with_execute_tool_span';
 export { withActiveInferenceSpan } from './src/with_active_inference_span';
+export { withInferenceContext } from './src/with_inference_context';
 export { GenAISemanticConventions, ElasticGenAIAttributes } from './src/types';
 
 export { LangfuseSpanProcessor } from './src/langfuse/langfuse_span_processor';

--- a/x-pack/platform/packages/shared/kbn-inference-tracing/src/base_inference_span_processor.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-tracing/src/base_inference_span_processor.ts
@@ -38,7 +38,7 @@ export abstract class BaseInferenceSpanProcessor implements tracing.SpanProcesso
       delete span.attributes._should_track;
 
       // if this is the "root" inference span, but has a parent,
-      // drop the parent context and Langfuse only shows root spans
+      // drop the parent context as Phoenix only shows root spans
       if (span.attributes[IS_ROOT_INFERENCE_SPAN_ATTRIBUTE_NAME] && span.parentSpanContext) {
         span = {
           ...span,
@@ -50,6 +50,12 @@ export abstract class BaseInferenceSpanProcessor implements tracing.SpanProcesso
       delete span.attributes[IS_ROOT_INFERENCE_SPAN_ATTRIBUTE_NAME];
 
       span = this.processInferenceSpan(span);
+
+      // Phoenix does not show resource attributes, so we move them under `attributes.resource.*`
+      Object.entries(span.resource.attributes).forEach(([name, value]) => {
+        span.attributes[`resource.${name}`] = value;
+      });
+
       this.delegate.onEnd(span);
     }
   }

--- a/x-pack/platform/packages/shared/kbn-inference-tracing/src/create_inference_context.test.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-tracing/src/create_inference_context.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { context, propagation, trace, TraceFlags } from '@opentelemetry/api';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { BAGGAGE_TRACKING_BEACON_KEY, BAGGAGE_TRACKING_BEACON_VALUE } from './baggage';
+import { createInferenceContext } from './create_inference_context';
+
+const TEST_SPAN_CONTEXT = {
+  isRemote: false,
+  spanId: '1234567890abcdef',
+  traceFlags: TraceFlags.SAMPLED,
+  traceId: '1234567890abcdef1234567890abcdef',
+} as const;
+
+describe('createInferenceContext', () => {
+  let contextManager: AsyncHooksContextManager;
+
+  beforeEach(() => {
+    contextManager = new AsyncHooksContextManager();
+    context.setGlobalContextManager(contextManager);
+    contextManager.enable();
+  });
+
+  afterEach(() => {
+    contextManager.disable();
+  });
+
+  it('marks requests without tracking baggage as root and clears span context', () => {
+    const contextWithSpan = trace.setSpanContext(context.active(), TEST_SPAN_CONTEXT);
+
+    const inferenceContext = context.with(contextWithSpan, () => createInferenceContext());
+
+    expect(inferenceContext.isRoot).toBe(true);
+
+    const spanContext = trace.getSpanContext(inferenceContext.context);
+    expect(spanContext).toBeUndefined();
+
+    const baggageEntry = propagation
+      .getBaggage(inferenceContext.context)
+      ?.getEntry(BAGGAGE_TRACKING_BEACON_KEY);
+    expect(baggageEntry?.value).toBe(BAGGAGE_TRACKING_BEACON_VALUE);
+  });
+
+  it('preserves span context when tracking baggage exists', () => {
+    const nextBaggage = propagation.createBaggage({
+      [BAGGAGE_TRACKING_BEACON_KEY]: { value: BAGGAGE_TRACKING_BEACON_VALUE },
+    });
+
+    const parentContext = trace.setSpanContext(context.active(), TEST_SPAN_CONTEXT);
+
+    const nextContext = propagation.setBaggage(parentContext, nextBaggage);
+
+    const inferenceContext = context.with(nextContext, () => createInferenceContext());
+
+    expect(inferenceContext.isRoot).toBe(false);
+
+    const spanContext = trace.getSpanContext(inferenceContext.context);
+    expect(spanContext).toMatchObject(TEST_SPAN_CONTEXT);
+  });
+
+  it('resets span context when tracking beacon needs to be refreshed', () => {
+    const baggage = propagation.createBaggage({
+      [BAGGAGE_TRACKING_BEACON_KEY]: { value: 'some-other-value' },
+    });
+    const contextWithOutdatedBaggage = propagation.setBaggage(
+      trace.setSpanContext(context.active(), TEST_SPAN_CONTEXT),
+      baggage
+    );
+
+    const inferenceContext = context.with(contextWithOutdatedBaggage, () =>
+      createInferenceContext()
+    );
+
+    expect(inferenceContext.isRoot).toBe(true);
+
+    const spanContext = trace.getSpanContext(inferenceContext.context);
+    expect(spanContext).toBeUndefined();
+
+    const baggageEntry = propagation
+      .getBaggage(inferenceContext.context)
+      ?.getEntry(BAGGAGE_TRACKING_BEACON_KEY);
+    expect(baggageEntry?.value).toBe(BAGGAGE_TRACKING_BEACON_VALUE);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-inference-tracing/src/create_inference_context.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-tracing/src/create_inference_context.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { context, propagation, trace } from '@opentelemetry/api';
+import { BAGGAGE_TRACKING_BEACON_KEY, BAGGAGE_TRACKING_BEACON_VALUE } from './baggage';
+
+export function createInferenceContext() {
+  const ctx = context.active();
+  let baggage = propagation.getBaggage(ctx);
+
+  let isRoot = false;
+
+  if (!baggage) {
+    isRoot = true;
+    baggage = propagation.createBaggage({
+      [BAGGAGE_TRACKING_BEACON_KEY]: {
+        value: BAGGAGE_TRACKING_BEACON_VALUE,
+      },
+    });
+  } else if (
+    baggage.getEntry(BAGGAGE_TRACKING_BEACON_KEY)?.value !== BAGGAGE_TRACKING_BEACON_VALUE
+  ) {
+    isRoot = true;
+    baggage = baggage.setEntry(BAGGAGE_TRACKING_BEACON_KEY, {
+      value: BAGGAGE_TRACKING_BEACON_VALUE,
+    });
+  }
+
+  // create a new context with the updated baggage
+  let parentContext = propagation.setBaggage(ctx, baggage);
+
+  if (isRoot) {
+    // Remove any pre-existing span context so new work starts a fresh trace
+    parentContext = trace.deleteSpan(parentContext);
+  }
+  return { context: parentContext, baggage, isRoot };
+}

--- a/x-pack/platform/packages/shared/kbn-inference-tracing/src/with_inference_context.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-tracing/src/with_inference_context.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { context } from '@opentelemetry/api';
+import { createInferenceContext } from './create_inference_context';
+
+/**
+ * Creates an active "inference"-scoped context. Every span created in this
+ * context will be exported via the inference exporters. This allows us to export
+ * a subset of spans to external systems like Phoenix.
+ */
+export const withInferenceContext = <T>(fn: () => T): T => {
+  const { context: parentContext } = createInferenceContext();
+
+  return context.with(parentContext, fn);
+};


### PR DESCRIPTION
## What

Optimizes inference instrumentation for use in Phoenix, by no longer requiring a single root trace. Additionally, retry on missing scores in the criteria evaluator.

## Why

We previously required a single root trace for its events to be exported. This was done to not have to ingest all unrelated HTTP requests that do not have any value for what we use Phoenix for: debugging LLM-based workflows. The change we are making here is that we use context to flag events as inference-related, instead of requiring it to be a span. We don't need a single `RunExperiment` span anymore for this reason, which messes up the token metrics in Phoenix for evaluations.

I also added retries around scoring - in some cases the LLM did not score all criteria. To that end, I've added `executeUntilValid` which will ask the LLM to keep calling a tool until it no longer encounters errors.

Some other minor changes:
- experiments can now contain metadata
- export types for `@kbn/evals` worker fixtures

I've targeted this at 9.2.0 as it is a dev-only change (mostly) and I want to limit the chance of conflicts.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->