### PR TITLE
[ES|QL][Variables] Moves the controls from the Discover histogram last

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/merge_control_group_states.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/merge_control_group_states.test.ts
@@ -70,7 +70,7 @@ describe('mergeControlGroupStates', () => {
         result!.controls.map(
           (c) => controlHasVariableName(c.controlConfig) && c.controlConfig?.variableName
         )
-      ).toEqual(['existingVar1', 'existingVar2', 'newVar1', 'newVar2']);
+      ).toEqual(['newVar1', 'newVar2', 'existingVar1', 'existingVar2']);
     });
 
     it('should not add duplicate controls with same variable names', () => {
@@ -94,7 +94,7 @@ describe('mergeControlGroupStates', () => {
         result!.controls.map(
           (c) => controlHasVariableName(c.controlConfig) && c.controlConfig?.variableName
         )
-      ).toEqual(['sharedVar', 'uniqueVar1', 'uniqueVar2']);
+      ).toEqual(['uniqueVar2', 'sharedVar', 'uniqueVar1']);
     });
 
     it('should handle controls without variable names', () => {
@@ -122,9 +122,9 @@ describe('mergeControlGroupStates', () => {
 
       expect(result!.controls).toHaveLength(3);
       expect(result!.controls.map((c) => c.id)).toEqual([
+        'control-newVar',
         'control-withVar',
         'control-no-var',
-        'control-newVar',
       ]);
     });
   });

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/merge_control_group_states.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/merge_control_group_states.ts
@@ -48,7 +48,7 @@ export function mergeControlGroupStates(
 
     mergedControlGroupState = {
       ...mergedControlGroupState,
-      controls: [...mergedControlGroupState.controls, ...uniqueControls],
+      controls: [...uniqueControls, ...mergedControlGroupState.controls],
     };
   } else if (!mergedControlGroupState && incomingControlGroupState) {
     mergedControlGroupState = incomingControlGroupState as ControlsGroupState;


### PR DESCRIPTION
## Summary

When a user saves the histogram from Discover with controls to a dashboard, these controls should be placed last and not first

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



