### PR TITLE
[Fleet] Fix "package not found" error when skipping cloud onboarding for a prerelease package

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/index.tsx
@@ -104,6 +104,7 @@ export const CreatePackagePolicyMultiPage: CreatePackagePolicyParams = ({
     useMultiPageLayout: false,
     ...(integration ? { integration } : {}),
     ...(agentPolicyId ? { agentPolicyId } : {}),
+    ...(prerelease ? { prerelease: 'true' } : {}),
   });
 
   if (onSplash || !packageInfo) {


### PR DESCRIPTION
## Summary

Closes #236750

When installing an integration for the first time on cloud we use the guided onboarding experience, if the package was pre-release clicking "Add integration only (skip agent installation)" did not correctly add the `prerelease` query paramater causing "package not found" to occur.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->