### PR TITLE
[Agent Builder] [PoC] custom renderer registry

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/plugin.tsx
@@ -84,7 +84,6 @@ export class OnechatPlugin
       this.logger.error('Error registering Agent Builder management section', error);
     }
 
-    // Register built-in visualization element
     this.elementRegistry.register({
       tagName: visualizationElement.tagName,
       attributes: visualizationElement.attributes,

--- a/x-pack/platform/plugins/shared/onechat/public/services/element_registry/create_element_parser.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/services/element_registry/create_element_parser.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Parent, Node } from 'unist';
+import type { CustomElementConfig, MarkdownParser } from './types';
+
+type MutableNode = Node & {
+  value?: string;
+  [key: string]: any;
+};
+
+/**
+ * Creates a markdown parser plugin for a custom element
+ * @param config - Element configuration with tag name and attributes
+ * @returns Unified markdown parser plugin
+ */
+export const createElementParser = (config: CustomElementConfig): MarkdownParser => {
+  const { tagName, attributes } = config;
+
+  const extractAttribute = (value: string, attr: string) => {
+    const regex = new RegExp(`${attr}="([^"]*)"`, 'i');
+    return value.match(regex)?.[1];
+  };
+
+  const getElementAttributes = (value: string): Record<string, string | undefined> => {
+    const result: Record<string, string | undefined> = {};
+    for (const [key, attrName] of Object.entries(attributes)) {
+      result[key] = extractAttribute(value, attrName);
+    }
+    return result;
+  };
+
+  const assignElementAttributes = (
+    node: MutableNode,
+    extractedAttributes: Record<string, string | undefined>
+  ) => {
+    node.type = tagName;
+    Object.assign(node, extractedAttributes);
+    delete node.value;
+  };
+
+  const elementTagRegex = new RegExp(`<${tagName}\\b[^>]*\\/?>`, 'gi');
+
+  const createElementNode = (
+    extractedAttributes: Record<string, string | undefined>,
+    position: MutableNode['position']
+  ): MutableNode => ({
+    type: tagName,
+    ...extractedAttributes,
+    position,
+  });
+
+  const visitParent = (parent: Parent) => {
+    for (let index = 0; index < parent.children.length; index++) {
+      const child = parent.children[index] as MutableNode;
+
+      if ('children' in child) {
+        visitParent(child as Parent);
+      }
+
+      if (child.type !== 'html') {
+        continue;
+      }
+
+      const rawValue = child.value;
+      if (!rawValue) {
+        continue;
+      }
+
+      const trimmedValue = rawValue.trim();
+      if (!trimmedValue.toLowerCase().startsWith(`<${tagName}`)) {
+        continue;
+      }
+
+      const matches = Array.from(trimmedValue.matchAll(elementTagRegex));
+      if (matches.length === 0) {
+        continue;
+      }
+
+      const elementAttributes = matches.map((match) => getElementAttributes(match[0]));
+      const leftoverContent = trimmedValue.replace(elementTagRegex, '').trim();
+
+      assignElementAttributes(child, elementAttributes[0]);
+
+      if (elementAttributes.length === 1 || leftoverContent.length > 0) {
+        continue;
+      }
+
+      const additionalNodes = elementAttributes
+        .slice(1)
+        .map((attrs) => createElementNode(attrs, child.position));
+
+      const siblings = parent.children as Node[];
+      siblings.splice(index + 1, 0, ...additionalNodes);
+      index += additionalNodes.length;
+    }
+  };
+
+  return (tree: Node) => {
+    if ('children' in tree) {
+      visitParent(tree as Parent);
+    }
+  };
+};
+

--- a/x-pack/platform/plugins/shared/onechat/public/services/element_registry/element_registry.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/services/element_registry/element_registry.ts
@@ -123,4 +123,3 @@ export class ElementRegistry {
     return /^[a-z][a-z0-9-]*$/.test(attrName);
   }
 }
-

--- a/x-pack/platform/plugins/shared/onechat/public/services/element_registry/element_registry.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/services/element_registry/element_registry.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { CustomElementConfig, MarkdownParser, RendererFactory } from './types';
+import { createElementParser } from './create_element_parser';
+
+/**
+ * Registry for custom markdown elements
+ */
+export class ElementRegistry {
+  private readonly elements = new Map<string, CustomElementConfig>();
+  private readonly parsers = new Map<string, MarkdownParser>();
+  private readonly logger?: Logger;
+
+  constructor(logger?: Logger) {
+    this.logger = logger;
+  }
+
+  /**
+   * Register a custom element
+   * @param config - Element configuration
+   * @throws Error if tag name is invalid or already registered
+   */
+  register(config: CustomElementConfig): void {
+    const { tagName } = config;
+
+    // Validate tag name format (kebab-case)
+    if (!this.isValidTagName(tagName)) {
+      const error = `Invalid tag name: "${tagName}". Tag names must be kebab-case (lowercase letters, numbers, and hyphens).`;
+      this.logger?.error(error);
+      throw new Error(error);
+    }
+
+    // Check for conflicts
+    if (this.elements.has(tagName)) {
+      const warning = `Element with tag name "${tagName}" is already registered. Overwriting previous registration.`;
+      this.logger?.warn(warning);
+    }
+
+    // Validate attribute names
+    for (const attrName of Object.values(config.attributes)) {
+      if (!this.isValidAttributeName(attrName)) {
+        const error = `Invalid attribute name: "${attrName}". Attribute names must be valid HTML attributes.`;
+        this.logger?.error(error);
+        throw new Error(error);
+      }
+    }
+
+    // Store the element config
+    this.elements.set(tagName, config);
+
+    // Generate and store the parser
+    const parser = createElementParser(config);
+    this.parsers.set(tagName, parser);
+
+    this.logger?.debug(`Registered custom element: ${tagName}`);
+  }
+
+  /**
+   * Get parser for a specific tag name
+   */
+  getParser(tagName: string): MarkdownParser | undefined {
+    return this.parsers.get(tagName);
+  }
+
+  /**
+   * Get all registered parsers
+   */
+  getAllParsers(): MarkdownParser[] {
+    return Array.from(this.parsers.values());
+  }
+
+  /**
+   * Get renderer factory for a specific tag name
+   */
+  getRenderer(tagName: string): RendererFactory | undefined {
+    return this.elements.get(tagName)?.rendererFactory;
+  }
+
+  /**
+   * Get all registered renderers as a tag name -> renderer factory map
+   */
+  getAllRenderers(): Record<string, RendererFactory> {
+    const renderers: Record<string, RendererFactory> = {};
+    for (const [tagName, config] of this.elements.entries()) {
+      renderers[tagName] = config.rendererFactory;
+    }
+    return renderers;
+  }
+
+  /**
+   * Check if an element is registered
+   */
+  has(tagName: string): boolean {
+    return this.elements.has(tagName);
+  }
+
+  /**
+   * Get all registered tag names
+   */
+  getTagNames(): string[] {
+    return Array.from(this.elements.keys());
+  }
+
+  /**
+   * Validate tag name format (kebab-case)
+   */
+  private isValidTagName(tagName: string): boolean {
+    // Must be lowercase letters, numbers, and hyphens, starting with a letter
+    return /^[a-z][a-z0-9-]*$/.test(tagName);
+  }
+
+  /**
+   * Validate attribute name format
+   */
+  private isValidAttributeName(attrName: string): boolean {
+    // Must be valid HTML attribute name (letters, numbers, hyphens)
+    return /^[a-z][a-z0-9-]*$/.test(attrName);
+  }
+}
+

--- a/x-pack/platform/plugins/shared/onechat/public/services/element_registry/index.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/services/element_registry/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { ElementRegistry } from './element_registry';
+export type {
+  CustomElementConfig,
+  RendererContext,
+  RendererFactory,
+  ElementAttributes,
+  MarkdownParser,
+} from './types';
+

--- a/x-pack/platform/plugins/shared/onechat/public/services/element_registry/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/services/element_registry/types.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ConversationRoundStep } from '@kbn/onechat-common';
+import type { OnechatStartDependencies } from '../../types';
+
+/**
+ * Configuration for a custom markdown element
+ */
+export interface CustomElementConfig {
+  /**
+   * Tag name for the custom element (e.g., 'visualization', 'custom-widget')
+   * Must be kebab-case and unique
+   */
+  tagName: string;
+
+  /**
+   * Attribute names that should be extracted from the element
+   * Example: { toolResultId: 'tool-result-id', chartType: 'chart-type' }
+   */
+  attributes: Record<string, string>;
+
+  /**
+   * Factory function that creates the renderer component
+   */
+  rendererFactory: RendererFactory;
+}
+
+/**
+ * Context provided to renderer factories
+ */
+export interface RendererContext {
+  /**
+   * Steps from the current conversation round
+   */
+  stepsFromCurrentRound: ConversationRoundStep[];
+
+  /**
+   * Steps from previous conversation rounds
+   */
+  stepsFromPrevRounds: ConversationRoundStep[];
+
+  /**
+   * Start dependencies (lens, dataViews, uiActions, etc.)
+   */
+  startDependencies: OnechatStartDependencies;
+}
+
+/**
+ * Generic element attributes extracted from the markdown
+ */
+export type ElementAttributes = Record<string, string | undefined>;
+
+/**
+ * Factory function that creates a renderer component with access to conversation context
+ */
+export type RendererFactory = (
+  context: RendererContext
+) => (props: ElementAttributes) => React.ReactElement | null;
+
+/**
+ * Markdown parser plugin type (from unified)
+ */
+export type MarkdownParser = (tree: any) => void;
+

--- a/x-pack/platform/plugins/shared/onechat/public/services/element_registry/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/services/element_registry/types.ts
@@ -66,4 +66,3 @@ export type RendererFactory = (
  * Markdown parser plugin type (from unified)
  */
 export type MarkdownParser = (tree: any) => void;
-

--- a/x-pack/platform/plugins/shared/onechat/public/services/index.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/services/index.ts
@@ -9,4 +9,6 @@ export { AgentService } from './agents';
 export { ChatService } from './chat';
 export { ConversationsService } from './conversations';
 export { ToolsService } from './tools';
+export { ElementRegistry } from './element_registry';
 export type { OnechatInternalService } from './types';
+export type { CustomElementConfig, RendererContext, RendererFactory } from './element_registry';

--- a/x-pack/platform/plugins/shared/onechat/public/services/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/services/types.ts
@@ -10,11 +10,13 @@ import type { AgentService } from './agents';
 import type { ChatService } from './chat';
 import type { ConversationsService } from './conversations';
 import type { ToolsService } from './tools';
+import type { ElementRegistry } from './element_registry';
 
 export interface OnechatInternalService {
   agentService: AgentService;
   chatService: ChatService;
   conversationsService: ConversationsService;
   toolsService: ToolsService;
+  elementRegistry: ElementRegistry;
   startDependencies: OnechatStartDependencies;
 }

--- a/x-pack/platform/plugins/shared/onechat/public/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/types.ts
@@ -15,6 +15,7 @@ import type { ManagementSetup } from '@kbn/management-plugin/public';
 import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import type { ToolServiceStartContract } from '@kbn/onechat-browser';
 import type { UiActionsSetup, UiActionsStart } from '@kbn/ui-actions-plugin/public';
+import type { CustomElementConfig } from './services/element_registry';
 
 /* eslint-disable @typescript-eslint/no-empty-interface*/
 
@@ -36,7 +37,18 @@ export interface OnechatStartDependencies {
   uiActions: UiActionsStart;
 }
 
-export interface OnechatPluginSetup {}
+export interface OnechatPluginSetup {
+  /**
+   * Element registry for custom markdown elements
+   */
+  elementRegistry: {
+    /**
+     * Register a custom markdown element that can be rendered in AI responses
+     * @param config - Element configuration including tag name, attributes, and renderer
+     */
+    registerCustomElement: (config: CustomElementConfig) => void;
+  };
+}
 
 /**
  * Public start contract for the browser-side onechat plugin.

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/agents_service.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/agents_service.ts
@@ -17,6 +17,7 @@ import type { Runner } from '@kbn/onechat-server';
 import { getCurrentSpaceId } from '../../utils/spaces';
 import type { AgentsServiceSetup, AgentsServiceStart } from './types';
 import type { ToolsServiceStart } from '../tools';
+import type { ElementRegistry } from '../element_registry';
 import {
   createBuiltinAgentRegistry,
   createBuiltinProviderFn,
@@ -25,9 +26,11 @@ import {
 } from './builtin';
 import { createPersistedProviderFn } from './persisted';
 import { createAgentRegistry } from './agent_registry';
+import { setElementRegistry } from './modes/default/prompts';
 
 export interface AgentsServiceSetupDeps {
   logger: Logger;
+  elementRegistry: ElementRegistry;
 }
 
 export interface AgentsServiceStartDeps {
@@ -42,6 +45,7 @@ export class AgentsService {
   private builtinRegistry: BuiltinAgentRegistry;
 
   private setupDeps?: AgentsServiceSetupDeps;
+  private elementRegistry?: ElementRegistry;
 
   constructor() {
     this.builtinRegistry = createBuiltinAgentRegistry();
@@ -49,6 +53,10 @@ export class AgentsService {
 
   setup(setupDeps: AgentsServiceSetupDeps): AgentsServiceSetup {
     this.setupDeps = setupDeps;
+    this.elementRegistry = setupDeps.elementRegistry;
+
+    // Make element registry available to prompt generation
+    setElementRegistry(this.elementRegistry);
 
     registerBuiltinAgents({ registry: this.builtinRegistry });
 

--- a/x-pack/platform/plugins/shared/onechat/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/create_services.ts
@@ -28,7 +28,11 @@ export class ServiceManager {
   public internalSetup?: InternalSetupServices;
   public internalStart?: InternalStartServices;
 
-  setupServices({ logger, workflowsManagement }: ServiceSetupDeps): InternalSetupServices {
+  setupServices({
+    logger,
+    workflowsManagement,
+    elementRegistry,
+  }: ServiceSetupDeps): InternalSetupServices {
     this.services = {
       tools: new ToolsService(),
       agents: new AgentsService(),
@@ -36,7 +40,7 @@ export class ServiceManager {
 
     this.internalSetup = {
       tools: this.services.tools.setup({ logger, workflowsManagement }),
-      agents: this.services.agents.setup({ logger }),
+      agents: this.services.agents.setup({ logger, elementRegistry }),
     };
 
     return this.internalSetup;

--- a/x-pack/platform/plugins/shared/onechat/server/services/element_registry/element_registry.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/element_registry/element_registry.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { CustomElementConfig, ElementRegistry as IElementRegistry } from './types';
+
+const STANDARD_TOOL_RESULT_ID_ATTR = 'tool-result-id';
+
+export class ElementRegistry implements IElementRegistry {
+  private elements = new Map<string, CustomElementConfig>();
+
+  constructor(private logger: Logger) {}
+
+  register(config: CustomElementConfig): void {
+    const { tagName } = config;
+
+    if (this.elements.has(tagName)) {
+      this.logger.warn(`Element with tag name '${tagName}' is already registered. Overwriting.`);
+    }
+
+    this.elements.set(tagName, config);
+    this.logger.debug(`Registered element: ${tagName}`);
+  }
+
+  generateAIInstructions(): string {
+    if (this.elements.size === 0) {
+      return '';
+    }
+
+    const instructions = Array.from(this.elements.values())
+      .map((element) => this.generateElementPrompt(element))
+      .join('\n\n');
+
+    return instructions;
+  }
+
+  private generateElementPrompt(config: CustomElementConfig): string {
+    const { tagName, toolResultType, additionalAttributes } = config;
+
+    // Auto-generate description from tag name and tool result type
+    const description = this.generateDescription(tagName, toolResultType);
+
+    // All elements have the standard tool-result-id attribute
+    const allAttributes = {
+      toolResultId: STANDARD_TOOL_RESULT_ID_ATTR,
+      ...additionalAttributes,
+    };
+
+    // Build attribute list
+    const attributeDocs = Object.entries(allAttributes).map(([propName, htmlAttr]) => {
+      const isToolResultId = htmlAttr === STANDARD_TOOL_RESULT_ID_ATTR;
+      const required = isToolResultId ? ' (required)' : ' (optional)';
+      const desc = isToolResultId
+        ? ' - The tool_result_id from the tool response'
+        : ` - Additional parameter for ${propName}`;
+      return `  * \`${htmlAttr}\`${required}${desc}`;
+    });
+
+    // Build example usage - only include required attributes
+    const exampleAttrs = `${STANDARD_TOOL_RESULT_ID_ATTR}="..."`;
+
+    return `#### Rendering with the <${tagName}> Element
+
+${description}
+
+**When to use:**
+This element should be used when a tool call returns a result of type "${toolResultType}".
+
+**Syntax:**
+\`\`\`
+<${tagName} ${exampleAttrs} />
+\`\`\`
+
+**Attributes:**
+${attributeDocs.join('\n')}
+
+**Rules:**
+* Only use this element with tool results of type \`${toolResultType}\`
+* The \`${STANDARD_TOOL_RESULT_ID_ATTR}\` must exactly match the \`tool_result_id\` from the tool response
+* Do not invent or modify attribute values
+* The element must be self-closing (end with \`/>\`)`;
+  }
+
+  private generateDescription(tagName: string, toolResultType: string): string {
+    // Convert kebab-case to Title Case for display
+    const displayName = tagName
+      .split('-')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+
+    // Generate description based on tool result type
+    const typeDescriptions: Record<string, string> = {
+      tabular_data: 'Renders visualizations from tabular data results.',
+      resource: 'Displays resource information from retrieved documents.',
+      query: 'Shows query details and structure.',
+      other: 'Renders custom output from tool results.',
+      error: 'Displays error information from failed tool executions.',
+    };
+
+    const baseDescription =
+      typeDescriptions[toolResultType] || `Renders ${toolResultType} results.`;
+
+    return `${displayName}: ${baseDescription}`;
+  }
+}
+

--- a/x-pack/platform/plugins/shared/onechat/server/services/element_registry/index.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/element_registry/index.ts
@@ -6,10 +6,5 @@
  */
 
 export { ElementRegistry } from './element_registry';
-export type {
-  CustomElementConfig,
-  RendererContext,
-  RendererFactory,
-  ElementAttributes,
-  MarkdownParser,
-} from './types';
+export type { CustomElementConfig, ElementRegistry as IElementRegistry } from './types';
+

--- a/x-pack/platform/plugins/shared/onechat/server/services/element_registry/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/element_registry/types.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ToolResultType } from '@kbn/onechat-common/tools/tool_result';
+
+/**
+ * Configuration for registering a custom rendering element.
+ * The prompt, description, and standard attributes will be auto-generated.
+ */
+export interface CustomElementConfig {
+  /** The HTML tag name for this element (e.g., 'visualization') */
+  tagName: string;
+  /** The tool result type this element renders (e.g., ToolResultType.tabularData) */
+  toolResultType: ToolResultType;
+  /**
+   * Optional: Additional custom attributes beyond the standard 'tool-result-id'.
+   * Format: { propName: 'html-attribute-name' }
+   */
+  additionalAttributes?: Record<string, string>;
+}
+
+/**
+ * Public interface for the element registry
+ */
+export interface ElementRegistry {
+  /**
+   * Register a custom element. All prompts and instructions will be auto-generated.
+   */
+  register(config: CustomElementConfig): void;
+
+  /**
+   * Generate combined AI instructions for all registered elements
+   */
+  generateAIInstructions(): string;
+}
+

--- a/x-pack/platform/plugins/shared/onechat/server/services/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/types.ts
@@ -18,6 +18,7 @@ import type { RunnerFactory } from './runner';
 import type { AgentsServiceSetup, AgentsServiceStart } from './agents';
 import type { ConversationService } from './conversation';
 import type { ChatService } from './chat';
+import type { ElementRegistry } from './element_registry';
 
 export interface InternalSetupServices {
   tools: ToolsServiceSetup;
@@ -35,6 +36,7 @@ export interface InternalStartServices {
 export interface ServiceSetupDeps {
   logger: Logger;
   workflowsManagement?: WorkflowsPluginSetup;
+  elementRegistry: ElementRegistry;
 }
 
 export interface ServicesStartDeps {

--- a/x-pack/platform/plugins/shared/onechat/server/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/types.ts
@@ -15,6 +15,7 @@ import type { InferenceServerSetup, InferenceServerStart } from '@kbn/inference-
 import type { WorkflowsPluginSetup } from '@kbn/workflows-management-plugin/server';
 import type { BuiltInAgentDefinition } from '@kbn/onechat-server/agents';
 import type { ToolsServiceSetup, ToolRegistry } from './services/tools';
+import type { CustomElementConfig } from './services/element_registry';
 
 export interface OnechatSetupDependencies {
   cloud?: CloudSetup;
@@ -62,6 +63,13 @@ export interface AgentsSetup {
   register: (definition: BuiltInAgentDefinition) => void;
 }
 
+export interface ElementRegistrySetup {
+  /**
+   * Register a custom rendering element with prompt generation
+   */
+  registerCustomElement: (config: CustomElementConfig) => void;
+}
+
 /**
  * Setup contract of the onechat plugin.
  */
@@ -74,6 +82,10 @@ export interface OnechatPluginSetup {
    * Tools setup contract, can be used to register built-in tools.
    */
   tools: ToolsSetup;
+  /**
+   * Element registry setup contract, can be used to register custom rendering elements.
+   */
+  elementRegistry: ElementRegistrySetup;
 }
 
 /**


### PR DESCRIPTION
## Summary

adds custom renderer registry to the contract. 
- allows solutions to provide custom ways to render results of their tools
- registers internal visualizeESQL renderer to the registry to serve as an example
