### PR TITLE
[ML] Anomaly Explorer: Fixes the display of `No Jobs Selected` screen

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/explorer.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/explorer.tsx
@@ -470,7 +470,7 @@ export const Explorer: FC<ExplorerUIProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(selectedJobIds)]);
 
-  if (noJobsSelected && !isDataLoading) {
+  if (noJobsSelected) {
     return (
       <ExplorerPage dataViews={dataViews} jobSelectorProps={jobSelectorProps}>
         <ExplorerNoJobsSelected />


### PR DESCRIPTION
After recent changes in https://github.com/elastic/kibana/pull/237423 I modified the logic of the `isDataLoading` variable, which caused the `No Jobs Selected` screen to never appear. I think it's sufficient to check whether any jobs are selected, without needing to check `isDataLoading`.

Before:

https://github.com/user-attachments/assets/e5b0643a-1837-4068-b252-c99bd194a6e0

After:

https://github.com/user-attachments/assets/4c0af682-d9fa-4db2-a776-f5a7ec2c2b67


