### PR TITLE
[9.1] [Obs AI Assistant] add snapshot usage telemetry (#237542)

### DIFF
--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
@@ -5699,6 +5699,78 @@
         }
       }
     },
+    "observability_ai_assistant": {
+      "properties": {
+        "knowledge_base": {
+          "properties": {
+            "users_with_global_entries": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of users with global knowledge base entries"
+              }
+            },
+            "users_with_global_entries_user_created": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of users with global knowledge base entries created by user"
+              }
+            },
+            "users_with_global_entries_assistant_created": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of users with global knowledge base entries created by assistant"
+              }
+            },
+            "users_with_private_entries": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of users with private knowledge base entries"
+              }
+            },
+            "users_with_private_entries_user_created": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of users with private knowledge base entries created by user"
+              }
+            },
+            "users_with_private_entries_assistant_created": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of users with private knowledge base entries created by assistant"
+              }
+            },
+            "users_with_user_instructions": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of users who have configured custom user instructions"
+              }
+            }
+          }
+        },
+        "conversations": {
+          "properties": {
+            "users_with_archived_conversations": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of users with archived conversations"
+              }
+            },
+            "users_with_private_conversations": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of users with private conversations"
+              }
+            },
+            "users_with_shared_conversations": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of users with shared conversations"
+              }
+            }
+          }
+        }
+      }
+    },
     "reporting": {
       "properties": {
         "available": {

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/kibana.jsonc
@@ -18,7 +18,7 @@
       "dataViews",
       "inference"
     ],
-    "optionalPlugins": ["cloud", "serverless"],
+    "optionalPlugins": ["cloud", "serverless", "usageCollection"],
     "requiredBundles": ["kibanaReact", "kibanaUtils"],
     "runtimePluginDependencies": ["ml"],
     "extraPublicDirs": []

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/collectors/usage.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/collectors/usage.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  Collector,
+  createUsageCollectionSetupMock,
+} from '@kbn/usage-collection-plugin/server/mocks';
+import { createCollectorFetchContextMock } from '@kbn/usage-collection-plugin/server/mocks';
+import type { CoreSetup } from '@kbn/core/server';
+import { registerUsageCollector } from './usage';
+
+describe('observability_ai_assistant usage collector', () => {
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let collector: Collector<unknown>;
+  let usageCollectionMock: ReturnType<typeof createUsageCollectionSetupMock>;
+  let mockCoreSetup: jest.Mocked<CoreSetup>;
+  let mockEsClient: any;
+  const mockedFetchContext = createCollectorFetchContextMock();
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    usageCollectionMock = createUsageCollectionSetupMock();
+
+    mockEsClient = {
+      search: jest.fn(),
+    };
+
+    mockCoreSetup = {
+      getStartServices: jest.fn().mockResolvedValue([
+        {
+          elasticsearch: {
+            client: {
+              asInternalUser: mockEsClient,
+            },
+          },
+        },
+      ]),
+    } as any;
+
+    usageCollectionMock.makeUsageCollector.mockImplementation((config) => {
+      collector = new Collector(logger, config);
+      return createUsageCollectionSetupMock().makeUsageCollector(config);
+    });
+
+    registerUsageCollector(usageCollectionMock, mockCoreSetup);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers the collector with usageCollection', () => {
+    expect(collector).not.toBeUndefined();
+    expect(collector.type).toBe('observability_ai_assistant');
+    expect(usageCollectionMock.makeUsageCollector).toHaveBeenCalledTimes(1);
+    expect(usageCollectionMock.registerCollector).toHaveBeenCalledTimes(1);
+  });
+
+  describe('isReady', () => {
+    it('returns true', () => {
+      expect(collector.isReady()).toBe(true);
+    });
+  });
+
+  describe('fetch', () => {
+    it('returns usage data with all metrics', async () => {
+      mockEsClient.search.mockResolvedValueOnce({
+        aggregations: {
+          global_entries: { unique_users: { value: 10 } },
+          global_entries_user_created: { unique_users: { value: 8 } },
+          global_entries_assistant_created: { unique_users: { value: 2 } },
+          private_entries: { unique_users: { value: 5 } },
+          private_entries_user_created: { unique_users: { value: 4 } },
+          private_entries_assistant_created: { unique_users: { value: 1 } },
+          user_instructions: { unique_users: { value: 3 } },
+        },
+      });
+
+      mockEsClient.search.mockResolvedValueOnce({
+        aggregations: {
+          archived: { unique_users: { value: 8 } },
+          private: { unique_users: { value: 12 } },
+          shared: { unique_users: { value: 4 } },
+        },
+      });
+
+      const result = await collector.fetch(mockedFetchContext);
+
+      expect(result).toEqual({
+        knowledge_base: {
+          users_with_global_entries: 10,
+          users_with_global_entries_user_created: 8,
+          users_with_global_entries_assistant_created: 2,
+          users_with_private_entries: 5,
+          users_with_private_entries_user_created: 4,
+          users_with_private_entries_assistant_created: 1,
+          users_with_user_instructions: 3,
+        },
+        conversations: {
+          users_with_archived_conversations: 8,
+          users_with_private_conversations: 12,
+          users_with_shared_conversations: 4,
+        },
+      });
+    });
+
+    it('queries both KB and conversations indices', async () => {
+      mockEsClient.search.mockResolvedValue({
+        aggregations: {
+          global_entries: { unique_users: { value: 0 } },
+          global_entries_user_created: { unique_users: { value: 0 } },
+          global_entries_assistant_created: { unique_users: { value: 0 } },
+          private_entries: { unique_users: { value: 0 } },
+          private_entries_user_created: { unique_users: { value: 0 } },
+          private_entries_assistant_created: { unique_users: { value: 0 } },
+          user_instructions: { unique_users: { value: 0 } },
+          archived: { unique_users: { value: 0 } },
+          private: { unique_users: { value: 0 } },
+          shared: { unique_users: { value: 0 } },
+        },
+      });
+
+      await collector.fetch(mockedFetchContext);
+
+      expect(mockEsClient.search).toHaveBeenCalledTimes(2);
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: '.kibana-observability-ai-assistant-kb*',
+        })
+      );
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: '.kibana-observability-ai-assistant-conversations*',
+        })
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/collectors/usage.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/collectors/usage.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
+import type { CoreSetup } from '@kbn/core/server';
+import type { AggregationsCardinalityAggregate } from '@elastic/elasticsearch/lib/api/types';
+import { resourceNames } from '../service';
+
+interface ObservabilityAIAssistantUsage {
+  knowledge_base: {
+    users_with_global_entries: number;
+    users_with_global_entries_user_created: number;
+    users_with_global_entries_assistant_created: number;
+    users_with_private_entries: number;
+    users_with_private_entries_user_created: number;
+    users_with_private_entries_assistant_created: number;
+    users_with_user_instructions: number;
+  };
+  conversations: {
+    users_with_archived_conversations: number;
+    users_with_private_conversations: number;
+    users_with_shared_conversations: number;
+  };
+}
+
+export function registerUsageCollector(
+  usageCollection: UsageCollectionSetup | undefined,
+  core: CoreSetup
+): void {
+  if (!usageCollection) {
+    return;
+  }
+
+  const usageCollector = usageCollection.makeUsageCollector<ObservabilityAIAssistantUsage>({
+    type: 'observability_ai_assistant',
+    isReady: () => true,
+    schema: {
+      knowledge_base: {
+        users_with_global_entries: {
+          type: 'long',
+          _meta: {
+            description: 'Number of users with global knowledge base entries',
+          },
+        },
+        users_with_global_entries_user_created: {
+          type: 'long',
+          _meta: {
+            description: 'Number of users with global knowledge base entries created by user',
+          },
+        },
+        users_with_global_entries_assistant_created: {
+          type: 'long',
+          _meta: {
+            description: 'Number of users with global knowledge base entries created by assistant',
+          },
+        },
+        users_with_private_entries: {
+          type: 'long',
+          _meta: {
+            description: 'Number of users with private knowledge base entries',
+          },
+        },
+        users_with_private_entries_user_created: {
+          type: 'long',
+          _meta: {
+            description: 'Number of users with private knowledge base entries created by user',
+          },
+        },
+        users_with_private_entries_assistant_created: {
+          type: 'long',
+          _meta: {
+            description: 'Number of users with private knowledge base entries created by assistant',
+          },
+        },
+        users_with_user_instructions: {
+          type: 'long',
+          _meta: {
+            description: 'Number of users who have configured custom user instructions',
+          },
+        },
+      },
+      conversations: {
+        users_with_archived_conversations: {
+          type: 'long',
+          _meta: {
+            description: 'Number of users with archived conversations',
+          },
+        },
+        users_with_private_conversations: {
+          type: 'long',
+          _meta: {
+            description: 'Number of users with private conversations',
+          },
+        },
+        users_with_shared_conversations: {
+          type: 'long',
+          _meta: {
+            description: 'Number of users with shared conversations',
+          },
+        },
+      },
+    },
+    fetch: async () => {
+      const [coreStart] = await core.getStartServices();
+      const esClient = coreStart.elasticsearch.client.asInternalUser;
+      const kbIndex = resourceNames.indexPatterns.kb;
+      const conversationsIndex = resourceNames.indexPatterns.conversations;
+
+      const kbResponse = await esClient.search({
+        index: kbIndex,
+        size: 0,
+        query: {
+          bool: {
+            filter: [{ exists: { field: 'user.id' } }],
+          },
+        },
+        aggs: {
+          global_entries: {
+            filter: { term: { public: true } },
+            aggs: {
+              unique_users: {
+                cardinality: { field: 'user.id' },
+              },
+            },
+          },
+          global_entries_user_created: {
+            filter: {
+              bool: {
+                filter: [{ term: { public: true } }, { term: { role: 'user_entry' } }],
+              },
+            },
+            aggs: {
+              unique_users: {
+                cardinality: { field: 'user.id' },
+              },
+            },
+          },
+          global_entries_assistant_created: {
+            filter: {
+              bool: {
+                filter: [{ term: { public: true } }, { term: { role: 'assistant_summarization' } }],
+              },
+            },
+            aggs: {
+              unique_users: {
+                cardinality: { field: 'user.id' },
+              },
+            },
+          },
+          private_entries: {
+            filter: {
+              bool: {
+                filter: [{ term: { public: false } }],
+                must_not: [{ term: { type: 'user_instruction' } }],
+              },
+            },
+            aggs: {
+              unique_users: {
+                cardinality: { field: 'user.id' },
+              },
+            },
+          },
+          private_entries_user_created: {
+            filter: {
+              bool: {
+                filter: [{ term: { public: false } }, { term: { role: 'user_entry' } }],
+                must_not: [{ term: { type: 'user_instruction' } }],
+              },
+            },
+            aggs: {
+              unique_users: {
+                cardinality: { field: 'user.id' },
+              },
+            },
+          },
+          private_entries_assistant_created: {
+            filter: {
+              bool: {
+                filter: [
+                  { term: { public: false } },
+                  { term: { role: 'assistant_summarization' } },
+                ],
+              },
+            },
+            aggs: {
+              unique_users: {
+                cardinality: { field: 'user.id' },
+              },
+            },
+          },
+          user_instructions: {
+            filter: { term: { type: 'user_instruction' } },
+            aggs: {
+              unique_users: {
+                cardinality: { field: 'user.id' },
+              },
+            },
+          },
+        },
+      });
+
+      const conversationsResponse = await esClient.search({
+        index: conversationsIndex,
+        size: 0,
+        query: {
+          bool: {
+            filter: [{ exists: { field: 'user.id' } }],
+          },
+        },
+        aggs: {
+          archived: {
+            filter: { term: { archived: true } },
+            aggs: {
+              unique_users: {
+                cardinality: { field: 'user.id' },
+              },
+            },
+          },
+          private: {
+            filter: { term: { public: false } },
+            aggs: {
+              unique_users: {
+                cardinality: { field: 'user.id' },
+              },
+            },
+          },
+          shared: {
+            filter: { term: { public: true } },
+            aggs: {
+              unique_users: {
+                cardinality: { field: 'user.id' },
+              },
+            },
+          },
+        },
+      });
+
+      return {
+        knowledge_base: {
+          users_with_global_entries: (
+            (kbResponse.aggregations?.global_entries as any)
+              ?.unique_users as AggregationsCardinalityAggregate
+          )?.value,
+          users_with_global_entries_user_created: (
+            (kbResponse.aggregations?.global_entries_user_created as any)
+              ?.unique_users as AggregationsCardinalityAggregate
+          )?.value,
+          users_with_global_entries_assistant_created: (
+            (kbResponse.aggregations?.global_entries_assistant_created as any)
+              ?.unique_users as AggregationsCardinalityAggregate
+          )?.value,
+          users_with_private_entries: (
+            (kbResponse.aggregations?.private_entries as any)
+              ?.unique_users as AggregationsCardinalityAggregate
+          )?.value,
+          users_with_private_entries_user_created: (
+            (kbResponse.aggregations?.private_entries_user_created as any)
+              ?.unique_users as AggregationsCardinalityAggregate
+          )?.value,
+          users_with_private_entries_assistant_created: (
+            (kbResponse.aggregations?.private_entries_assistant_created as any)
+              ?.unique_users as AggregationsCardinalityAggregate
+          )?.value,
+          users_with_user_instructions: (
+            (kbResponse.aggregations?.user_instructions as any)
+              ?.unique_users as AggregationsCardinalityAggregate
+          )?.value,
+        },
+        conversations: {
+          users_with_archived_conversations: (
+            (conversationsResponse.aggregations?.archived as any)
+              ?.unique_users as AggregationsCardinalityAggregate
+          )?.value,
+          users_with_private_conversations: (
+            (conversationsResponse.aggregations?.private as any)
+              ?.unique_users as AggregationsCardinalityAggregate
+          )?.value,
+          users_with_shared_conversations: (
+            (conversationsResponse.aggregations?.shared as any)
+              ?.unique_users as AggregationsCardinalityAggregate
+          )?.value,
+        },
+      };
+    },
+  });
+
+  usageCollection.registerCollector(usageCollector);
+}

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/plugin.ts
@@ -30,6 +30,7 @@ import { registerFunctions } from './functions';
 import { recallRankingEvent } from './analytics/recall_ranking';
 import { aiAssistantCapabilities } from '../common/capabilities';
 import { runStartupMigrations } from './service/startup_migrations/run_startup_migrations';
+import { registerUsageCollector } from './collectors/usage';
 import { toolCallEvent } from './analytics/tool_call';
 import { conversationDeleteEvent } from './analytics/conversation_delete';
 import { conversationDuplicateEvent } from './analytics/conversation_duplicate';
@@ -146,6 +147,8 @@ export class ObservabilityAIAssistantPlugin
       isDev: this.isDev,
     });
 
+    // Register telemetry
+    registerUsageCollector(plugins.usageCollection, core);
     core.analytics.registerEventType(recallRankingEvent);
     core.analytics.registerEventType(toolCallEvent);
     core.analytics.registerEventType(conversationDeleteEvent);

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/index_assets/templates/conversation_component_template.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/index_assets/templates/conversation_component_template.ts
@@ -94,6 +94,9 @@ export const conversationComponentTemplate: ClusterComponentTemplate['component_
         public: {
           type: 'boolean',
         },
+        archived: {
+          type: 'boolean',
+        },
       },
     },
   };

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/index_assets/templates/kb_component_template.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/index_assets/templates/kb_component_template.ts
@@ -74,6 +74,7 @@ export function getComponentTemplate(inferenceId: string) {
         public: {
           type: 'boolean',
         },
+        role: keyword,
       },
     },
   };

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/types.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/types.ts
@@ -24,6 +24,7 @@ import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverle
 import type { RuleRegistryPluginStartContract } from '@kbn/rule-registry-plugin/server';
 import type { AlertingServerSetup, AlertingServerStart } from '@kbn/alerting-plugin/server';
 import type { InferenceServerSetup, InferenceServerStart } from '@kbn/inference-plugin/server';
+import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import type { ObservabilityAIAssistantService } from './service';
 
 export interface ObservabilityAIAssistantServerSetup {
@@ -51,6 +52,7 @@ export interface ObservabilityAIAssistantPluginSetupDependencies {
   serverless?: ServerlessPluginSetup;
   alerting: AlertingServerSetup;
   inference: InferenceServerSetup;
+  usageCollection?: UsageCollectionSetup;
 }
 
 export interface ObservabilityAIAssistantPluginStartDependencies {

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/tsconfig.json
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/tsconfig.json
@@ -58,7 +58,8 @@
     "@kbn/i18n-react",
     "@kbn/inference-tracing",
     "@kbn/core-http-browser",
-    "@kbn/spaces-utils"
+    "@kbn/spaces-utils",
+    "@kbn/usage-collection-plugin"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Obs AI Assistant] add snapshot usage telemetry (#237542)](https://github.com/elastic/kibana/pull/237542)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sandra G","email":"neptunian@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-13T01:41:38Z","message":"[Obs AI Assistant] add snapshot usage telemetry (#237542)\n\n## Summary\n\nImplements snapshot telemetry to check the status of the following:\n\nKnowledge Base:\n- number of users with global entries (no role filtering)\n- number of users with global entries created by the user role (role\nfiltering, no results likely until index rolled over)\n- number of users with global entries created by the assistant role\n(role filtering, no results likely until index rolled over)\n- number of users with private entries\n- number of users with private entries created by the user (role\nfiltering, no results likely until index rolled over)\n- number of users with private entries created by the assistant (role\nfiltering, no results likely until index rolled over)\n- number of users with user instructions (always private and user\ncreated, no role filtering needed)\n\nConversations:\n- Number of unique users with archived conversations\n- Number of unique users  with private conversations\n- Number of unique users with shared conversations\n\n\nAdds `archived` and `role` field mapping. Due to this not being\npreviously mapped, we won't have information for this until users\nrollover the index.\n\n## Testing\n\nYou can manually test by performing the above actions with multiple\nusers and then in dev tools:\n\n`POST kbn:/internal/telemetry/clusters/_stats?apiVersion=2\n{ \"unencrypted\": true, \"refreshCache\": true }`\n\nSearch the hits for \"conversation\" and you should see something like\nthis:\n```\n            \"observability_ai_assistant\": {\n              \"knowledge_base\": {\n                \"users_with_global_entries\": 2,\n                \"users_with_global_entries_user_created\": 2,\n                \"users_with_global_entries_assistant_created\": 2,\n                \"users_with_private_entries\": 1,\n                \"users_with_private_entries_user_created\": 1,\n                \"users_with_private_entries_assistant_created\": 1,\n                \"users_with_user_instructions\": 1\n              },\n              \"conversations\": {\n                \"users_with_archived_conversations\": 1,\n                \"users_with_private_conversations\": 2,\n                \"users_with_shared_conversations\": 1\n              }\n            },\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6f327fbbdfbbb7c125c41ebeba988a21734e4e6a","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0","v9.2.0","v9.3.0"],"title":"[Obs AI Assistant] add snapshot usage telemetry","number":237542,"url":"https://github.com/elastic/kibana/pull/237542","mergeCommit":{"message":"[Obs AI Assistant] add snapshot usage telemetry (#237542)\n\n## Summary\n\nImplements snapshot telemetry to check the status of the following:\n\nKnowledge Base:\n- number of users with global entries (no role filtering)\n- number of users with global entries created by the user role (role\nfiltering, no results likely until index rolled over)\n- number of users with global entries created by the assistant role\n(role filtering, no results likely until index rolled over)\n- number of users with private entries\n- number of users with private entries created by the user (role\nfiltering, no results likely until index rolled over)\n- number of users with private entries created by the assistant (role\nfiltering, no results likely until index rolled over)\n- number of users with user instructions (always private and user\ncreated, no role filtering needed)\n\nConversations:\n- Number of unique users with archived conversations\n- Number of unique users  with private conversations\n- Number of unique users with shared conversations\n\n\nAdds `archived` and `role` field mapping. Due to this not being\npreviously mapped, we won't have information for this until users\nrollover the index.\n\n## Testing\n\nYou can manually test by performing the above actions with multiple\nusers and then in dev tools:\n\n`POST kbn:/internal/telemetry/clusters/_stats?apiVersion=2\n{ \"unencrypted\": true, \"refreshCache\": true }`\n\nSearch the hits for \"conversation\" and you should see something like\nthis:\n```\n            \"observability_ai_assistant\": {\n              \"knowledge_base\": {\n                \"users_with_global_entries\": 2,\n                \"users_with_global_entries_user_created\": 2,\n                \"users_with_global_entries_assistant_created\": 2,\n                \"users_with_private_entries\": 1,\n                \"users_with_private_entries_user_created\": 1,\n                \"users_with_private_entries_assistant_created\": 1,\n                \"users_with_user_instructions\": 1\n              },\n              \"conversations\": {\n                \"users_with_archived_conversations\": 1,\n                \"users_with_private_conversations\": 2,\n                \"users_with_shared_conversations\": 1\n              }\n            },\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6f327fbbdfbbb7c125c41ebeba988a21734e4e6a"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238563","number":238563,"state":"MERGED","mergeCommit":{"sha":"6a86bb2008dd62bc640ed1dc08f9aba0ac366f63","message":"[9.2] [Obs AI Assistant] add snapshot usage telemetry (#237542) (#238563)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Obs AI Assistant] add snapshot usage telemetry\n(#237542)](https://github.com/elastic/kibana/pull/237542)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sandra G <neptunian@users.noreply.github.com>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237542","number":237542,"mergeCommit":{"message":"[Obs AI Assistant] add snapshot usage telemetry (#237542)\n\n## Summary\n\nImplements snapshot telemetry to check the status of the following:\n\nKnowledge Base:\n- number of users with global entries (no role filtering)\n- number of users with global entries created by the user role (role\nfiltering, no results likely until index rolled over)\n- number of users with global entries created by the assistant role\n(role filtering, no results likely until index rolled over)\n- number of users with private entries\n- number of users with private entries created by the user (role\nfiltering, no results likely until index rolled over)\n- number of users with private entries created by the assistant (role\nfiltering, no results likely until index rolled over)\n- number of users with user instructions (always private and user\ncreated, no role filtering needed)\n\nConversations:\n- Number of unique users with archived conversations\n- Number of unique users  with private conversations\n- Number of unique users with shared conversations\n\n\nAdds `archived` and `role` field mapping. Due to this not being\npreviously mapped, we won't have information for this until users\nrollover the index.\n\n## Testing\n\nYou can manually test by performing the above actions with multiple\nusers and then in dev tools:\n\n`POST kbn:/internal/telemetry/clusters/_stats?apiVersion=2\n{ \"unencrypted\": true, \"refreshCache\": true }`\n\nSearch the hits for \"conversation\" and you should see something like\nthis:\n```\n            \"observability_ai_assistant\": {\n              \"knowledge_base\": {\n                \"users_with_global_entries\": 2,\n                \"users_with_global_entries_user_created\": 2,\n                \"users_with_global_entries_assistant_created\": 2,\n                \"users_with_private_entries\": 1,\n                \"users_with_private_entries_user_created\": 1,\n                \"users_with_private_entries_assistant_created\": 1,\n                \"users_with_user_instructions\": 1\n              },\n              \"conversations\": {\n                \"users_with_archived_conversations\": 1,\n                \"users_with_private_conversations\": 2,\n                \"users_with_shared_conversations\": 1\n              }\n            },\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6f327fbbdfbbb7c125c41ebeba988a21734e4e6a"}}]}] BACKPORT-->