### PR TITLE
[streams][retention] subtract failure store size from stream size

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/cards/ingestion_card.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/cards/ingestion_card.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import type { Streams } from '@kbn/streams-schema';
-import { EuiIconTip } from '@elastic/eui';
+import { EuiIconTip, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { BaseMetricCard } from '../../common/base_metric_card';
 import { formatBytes } from '../../helpers/format_bytes';
@@ -18,11 +18,14 @@ export const IngestionCard = ({
   definition,
   stats,
   statsError,
+  failureStoreEnabled,
 }: {
   definition: Streams.ingest.all.GetResponse;
   stats?: DataStreamStats;
   statsError?: Error;
+  failureStoreEnabled: boolean;
 }) => {
+  const inaccurateMetric = failureStoreEnabled && !definition.privileges?.manage_failure_store;
   const title = (
     <FormattedMessage
       id="xpack.streams.streamDetailLifecycle.ingestion.title"
@@ -34,10 +37,25 @@ export const IngestionCard = ({
             title={i18n.translate('xpack.streams.ingestionCard.tooltipTitle', {
               defaultMessage: 'How we calculate ingestion averages',
             })}
-            content={i18n.translate('xpack.streams.ingestionCard.tooltip', {
-              defaultMessage:
-                'Approximate average, calculated by extrapolating the ingestion rate from the documents on the selected time range and the average document size.',
-            })}
+            content={
+              <>
+                {i18n.translate('xpack.streams.ingestionCard.tooltip.description', {
+                  defaultMessage:
+                    'Approximate average, calculated by extrapolating the ingestion rate from the documents on the selected time range and the average document size.',
+                })}
+
+                {inaccurateMetric && (
+                  <>
+                    <EuiSpacer size="xs" />
+
+                    {i18n.translate('xpack.streams.ingestionCard.tooltip.privilegesWarning', {
+                      defaultMessage:
+                        'These averages may not be accurate because you lack sufficient privileges to access all the data.',
+                    })}
+                  </>
+                )}
+              </>
+            }
           />
         ),
       }}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/cards/ingestion_card.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/cards/ingestion_card.tsx
@@ -18,14 +18,14 @@ export const IngestionCard = ({
   definition,
   stats,
   statsError,
-  failureStoreEnabled,
 }: {
   definition: Streams.ingest.all.GetResponse;
   stats?: DataStreamStats;
   statsError?: Error;
-  failureStoreEnabled: boolean;
 }) => {
-  const inaccurateMetric = failureStoreEnabled && !definition.privileges?.manage_failure_store;
+  const inaccurateMetric = Boolean(
+    stats?.hasFailureStore && !definition.privileges?.manage_failure_store
+  );
   const title = (
     <FormattedMessage
       id="xpack.streams.streamDetailLifecycle.ingestion.title"

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/cards/storage_size_card.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/cards/storage_size_card.tsx
@@ -6,9 +6,10 @@
  */
 
 import React from 'react';
-import { formatNumber } from '@elastic/eui';
+import { EuiIconTip, formatNumber } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { Streams } from '@kbn/streams-schema';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { BaseMetricCard } from '../../common/base_metric_card';
 import { formatBytes } from '../../helpers/format_bytes';
 import type { DataStreamStats } from '../../hooks/use_data_stream_stats';
@@ -18,10 +19,12 @@ export const StorageSizeCard = ({
   definition,
   stats,
   statsError,
+  failureStoreEnabled,
 }: {
   definition: Streams.ingest.all.GetResponse;
   stats?: DataStreamStats;
   statsError?: Error;
+  failureStoreEnabled: boolean;
 }) => {
   const hasPrivileges = definition.privileges?.monitor ?? false;
   const metric = [
@@ -45,10 +48,24 @@ export const StorageSizeCard = ({
       'data-test-subj': 'storageSize',
     },
   ];
+  const inaccurateMetric = failureStoreEnabled && !definition.privileges?.manage_failure_store;
 
-  const title = i18n.translate('xpack.streams.streamDetailLifecycle.storageSize.title', {
-    defaultMessage: 'Storage size',
-  });
+  const title = (
+    <FormattedMessage
+      id="xpack.streams.streamDetailLifecycle.storageSize.title"
+      defaultMessage="Storage size {tooltipIcon}"
+      values={{
+        tooltipIcon: inaccurateMetric && (
+          <EuiIconTip
+            type="question"
+            content={i18n.translate('xpack.streams.streamDetailLifecycle.storageSize.tooltip', {
+              defaultMessage: 'The storage size includes the failure store.',
+            })}
+          />
+        ),
+      }}
+    />
+  );
 
   return <BaseMetricCard title={title} metrics={metric} />;
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/cards/storage_size_card.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/cards/storage_size_card.tsx
@@ -19,12 +19,10 @@ export const StorageSizeCard = ({
   definition,
   stats,
   statsError,
-  failureStoreEnabled,
 }: {
   definition: Streams.ingest.all.GetResponse;
   stats?: DataStreamStats;
   statsError?: Error;
-  failureStoreEnabled: boolean;
 }) => {
   const hasPrivileges = definition.privileges?.monitor ?? false;
   const metric = [
@@ -48,7 +46,9 @@ export const StorageSizeCard = ({
       'data-test-subj': 'storageSize',
     },
   ];
-  const inaccurateMetric = failureStoreEnabled && !definition.privileges?.manage_failure_store;
+  const inaccurateMetric = Boolean(
+    stats?.hasFailureStore && !definition.privileges?.manage_failure_store
+  );
 
   const title = (
     <FormattedMessage

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/index.tsx
@@ -25,6 +25,7 @@ import { RetentionCard } from './cards/retention_card';
 import { StorageSizeCard } from './cards/storage_size_card';
 import { IngestionCard } from './cards/ingestion_card';
 import { useAggregations } from '../hooks/use_ingestion_rate';
+import { useFailureStoreStats } from '../hooks/use_failure_store_stats';
 export const StreamDetailGeneralData = ({
   definition,
   refreshDefinition,
@@ -61,6 +62,12 @@ export const StreamDetailGeneralData = ({
     isLoading: isLoadingStats,
     error: statsError,
   } = useDataStreamStats({ definition, timeState, aggregations });
+
+  const { data: failureStore } = useFailureStoreStats({
+    definition,
+    timeState,
+    aggregations,
+  });
 
   const { signal } = useAbortController();
 
@@ -135,10 +142,20 @@ export const StreamDetailGeneralData = ({
           <RetentionCard definition={definition} openEditModal={() => setIsEditModalOpen(true)} />
         </EuiFlexItem>
         <EuiFlexItem>
-          <StorageSizeCard definition={definition} stats={stats} statsError={statsError} />
+          <StorageSizeCard
+            definition={definition}
+            stats={stats}
+            statsError={statsError}
+            failureStoreEnabled={failureStore?.config?.enabled ?? false}
+          />
         </EuiFlexItem>
         <EuiFlexItem>
-          <IngestionCard definition={definition} stats={stats} statsError={statsError} />
+          <IngestionCard
+            definition={definition}
+            stats={stats}
+            statsError={statsError}
+            failureStoreEnabled={failureStore?.config?.enabled ?? false}
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
       {definition.privileges.lifecycle && isIlmLifecycle(definition.effective_lifecycle) ? (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/index.tsx
@@ -63,12 +63,6 @@ export const StreamDetailGeneralData = ({
     error: statsError,
   } = useDataStreamStats({ definition, timeState, aggregations });
 
-  const { data: failureStore } = useFailureStoreStats({
-    definition,
-    timeState,
-    aggregations,
-  });
-
   const { signal } = useAbortController();
 
   const getIlmPolicies = () =>
@@ -142,20 +136,10 @@ export const StreamDetailGeneralData = ({
           <RetentionCard definition={definition} openEditModal={() => setIsEditModalOpen(true)} />
         </EuiFlexItem>
         <EuiFlexItem>
-          <StorageSizeCard
-            definition={definition}
-            stats={stats}
-            statsError={statsError}
-            failureStoreEnabled={failureStore?.config?.enabled ?? false}
-          />
+          <StorageSizeCard definition={definition} stats={stats} statsError={statsError} />
         </EuiFlexItem>
         <EuiFlexItem>
-          <IngestionCard
-            definition={definition}
-            stats={stats}
-            statsError={statsError}
-            failureStoreEnabled={failureStore?.config?.enabled ?? false}
-          />
+          <IngestionCard definition={definition} stats={stats} statsError={statsError} />
         </EuiFlexItem>
       </EuiFlexGroup>
       {definition.privileges.lifecycle && isIlmLifecycle(definition.effective_lifecycle) ? (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/index.tsx
@@ -25,7 +25,6 @@ import { RetentionCard } from './cards/retention_card';
 import { StorageSizeCard } from './cards/storage_size_card';
 import { IngestionCard } from './cards/ingestion_card';
 import { useAggregations } from '../hooks/use_ingestion_rate';
-import { useFailureStoreStats } from '../hooks/use_failure_store_stats';
 export const StreamDetailGeneralData = ({
   definition,
   refreshDefinition,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/hooks/use_data_stream_stats.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/hooks/use_data_stream_stats.tsx
@@ -82,6 +82,7 @@ export const useDataStreamStats = ({
     },
     [
       dataStreamsClient,
+      streamsRepositoryClient,
       definition.stream.name,
       aggregations?.buckets,
       timeState.end,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/hooks/use_data_stream_stats.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/hooks/use_data_stream_stats.tsx
@@ -48,6 +48,7 @@ export const useDataStreamStats = ({
       ] = await Promise.all([
         client.getDataStreamsStats({
           datasetQuery: definition.stream.name,
+          includeCreationDate: true,
         }),
         streamsRepositoryClient.fetch('GET /internal/streams/{name}/failure_store/stats', {
           signal,
@@ -57,7 +58,7 @@ export const useDataStreamStats = ({
         }),
       ]);
 
-      if (!dsStats) {
+      if (!dsStats || !dsStats.creationDate) {
         return;
       }
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/significant_events_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/significant_events_table.tsx
@@ -71,7 +71,7 @@ export function SignificantEventsTable({
     {
       field: 'query',
       name: i18n.translate('xpack.streams.significantEventsTable.feature', {
-        defaultMessage: 'Feauture',
+        defaultMessage: 'Feature',
       }),
       render: (query: StreamQuery) => {
         return (


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/238643

If the failure store is enabled, the reported stream storage size will also include the failure store size. This is problematic because we deduce a document size with `storage size / documents count` and use it to report various metrics.

This change updates the logic around the stream stats to:
- subtract the failure store size from the stream size if the user has permission to read the FS
- or if the user does not have permission, add tooltip informations to the Storage size and Ingestion averages cards to mention the metrics may be skewed because of incomplete privileges

### Testing

**Full permissions**
- ingest documents in a stream and in its failure store
- verify the "Storage size" corresponds to the sum of the regular (`.ds-..`) indices' of the stream
- verify the "Failure storage size" corresponds to the failure store (`.fs-..`) size of the stream

**No failure store permissions**
- create user with no permissions to manage failure store
```
// 1. create role
POST _security/role/streams_no_failure_store
{
  "cluster": [
    "manage_index_templates",
    "manage_ingest_pipelines"
  ],
  "indices": [
    {
      "names": [
        "logs*"
      ],
      "privileges": [
        "view_index_metadata",
        "read",
        "write",
        "monitor"
      ],
      "field_security": {
        "grant": [
          "*"
        ],
        "except": []
      },
      "allow_restricted_indices": false
    }
  ],
  "applications": [
    {
      "application": "kibana-.kibana",
      "privileges": [
        "feature_streams.all"
      ],
      "resources": [
        "*"
      ]
    }
  ],
  "run_as": [],
  "metadata": {},
  "transient_metadata": {
    "enabled": true
  }
}

// 2. create user
POST _security/user/streams_user_no_fs
{
  "password" : "changeme",
  "roles" : [ "streams_no_failure_store" ]
}
```

2. log in as user and visit the stream that contains regular and failure store data
3. verify that "Storage size" is the sum of regular (`.ds-..`) and (`.fs-..`) indices
4. verify that Storage size has a tooltip and Ingestion rate's tooltip mentions that metrics may be inaccurate