### PR TITLE
[API DOCS] Fix malformed Content-Type in package upload API curl examples

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -25588,13 +25588,26 @@
         ],
         "requestBody": {
           "content": {
+            "application/gzip": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            },
             "application/gzip; application/zip": {
               "schema": {
                 "format": "binary",
                 "type": "string"
               }
+            },
+            "application/zip": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -25588,13 +25588,26 @@
         ],
         "requestBody": {
           "content": {
+            "application/gzip": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            },
             "application/gzip; application/zip": {
               "schema": {
                 "format": "binary",
                 "type": "string"
               }
+            },
+            "application/zip": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -28954,10 +28954,19 @@ paths:
             type: boolean
       requestBody:
         content:
+          application/gzip:
+            schema:
+              format: binary
+              type: string
           application/gzip; application/zip:
             schema:
               format: binary
               type: string
+          application/zip:
+            schema:
+              format: binary
+              type: string
+        required: true
       responses:
         '200':
           content:

--- a/x-pack/platform/plugins/shared/fleet/server/routes/epm/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/epm/index.ts
@@ -772,6 +772,27 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        options: {
+          oasOperationObject: () => ({
+            requestBody: {
+              required: true,
+              content: {
+                'application/gzip': {
+                  schema: {
+                    type: 'string',
+                    format: 'binary',
+                  },
+                },
+                'application/zip': {
+                  schema: {
+                    type: 'string',
+                    format: 'binary',
+                  },
+                },
+              },
+            },
+          }),
+        },
         validate: {
           request: InstallPackageByUploadRequestSchema,
           response: {


### PR DESCRIPTION
# `WIP`

Add explicit OAS requestBody definition to properly separate application/gzip and application/zip content types instead of concatenating them.

## https://elastic.slack.com/archives/C0JF80CJZ/p1760357362364139


## Problem
[Current example](https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-fleet-epm-packages) in the docs concatenates the two accepted content types so the curl command is invalid:

```bash
curl \
 --request POST 'https://localhost:5601/api/fleet/epm/packages' \
 --header "Authorization: $API_KEY" \
 --header "Content-Type: application/gzip; application/zip" \
 --header "kbn-xsrf: true" \
 --data-binary '@file'
```

## Solution

First example is valid

```bash
curl \
 --request POST 'https://localhost:5601/api/fleet/epm/packages' \
 --header "Authorization: $API_KEY" \
 --header "Content-Type: application/gzip" \
 --header "kbn-xsrf: true" \
 --data-binary '@file'
```

## Remaining issue

The invalid example is still available in dropdown

<img width="541" height="215" alt="Screenshot 2025-10-13 at 15 37 58" src="https://github.com/user-attachments/assets/0e8bbd64-e6a9-417e-adbd-a05b031bd67f" />




