### PR TITLE
[Fleet] Add latest executed state to telemetry

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
@@ -43,6 +43,7 @@ import type {
   KibanaAssetType,
   PackageVerificationResult,
   InstallResultStatus,
+  InstallLatestExecutedState,
 } from '../../../types';
 import {
   AUTO_UPGRADE_POLICIES_PACKAGES,
@@ -460,6 +461,25 @@ function sendEvent(telemetryEvent: PackageUpdateEvent) {
   );
 }
 
+function sendEventWithLatestState(
+  telemetryEvent: PackageUpdateEvent,
+  errorMessage: string,
+  latestExecutedState?: InstallLatestExecutedState
+) {
+  sendEvent({
+    ...telemetryEvent,
+    errorMessage,
+    ...(latestExecutedState
+      ? {
+          latestExecutedState: {
+            name: latestExecutedState.name,
+            error: latestExecutedState.error,
+          },
+        }
+      : {}),
+  });
+}
+
 async function installPackageFromRegistry({
   savedObjectsClient,
   pkgkey,
@@ -487,11 +507,12 @@ async function installPackageFromRegistry({
   let installType: InstallType = 'unknown';
   const installSource = 'registry';
   const telemetryEvent: PackageUpdateEvent = getTelemetryEvent(pkgName, pkgVersion);
+  let installedPkg: SavedObject<Installation> | undefined;
 
   try {
     // get the currently installed package
 
-    const installedPkg = await getInstallationObject({ savedObjectsClient, pkgName });
+    installedPkg = await getInstallationObject({ savedObjectsClient, pkgName });
     installType = getInstallType({ pkgVersion, installedPkg });
 
     telemetryEvent.installType = installType;
@@ -583,10 +604,11 @@ async function installPackageFromRegistry({
       automaticInstall,
     });
   } catch (e) {
-    sendEvent({
-      ...telemetryEvent,
-      errorMessage: e.message,
-    });
+    sendEventWithLatestState(
+      telemetryEvent,
+      e.message,
+      installedPkg?.attributes.latest_executed_state
+    );
     return {
       error: e,
       installType,
@@ -804,17 +826,19 @@ export async function installPackageWithStateMachine(options: {
           authorizationHeader,
           keepFailedInstallation,
         });
-        sendEvent({
-          ...telemetryEvent!,
-          errorMessage: err.message,
-        });
+        sendEventWithLatestState(
+          telemetryEvent,
+          err.message,
+          installedPkg?.attributes.latest_executed_state
+        );
         return { error: err, installType, installSource, pkgName };
       });
   } catch (e) {
-    sendEvent({
-      ...telemetryEvent,
-      errorMessage: e.message,
-    });
+    sendEventWithLatestState(
+      telemetryEvent,
+      e.message,
+      installedPkg?.attributes.latest_executed_state
+    );
     return {
       error: e,
       installType,

--- a/x-pack/platform/plugins/shared/fleet/server/services/upgrade_sender.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/upgrade_sender.ts
@@ -25,6 +25,10 @@ export interface PackageUpdateEvent {
   packageType?: string;
   discoveryDatasets?: DiscoveryDataset[];
   automaticInstall?: boolean;
+  latestExecutedState?: {
+    name: string;
+    error?: string;
+  };
 }
 
 export enum UpdateEventType {


### PR DESCRIPTION
## Summary

Relates https://github.com/elastic/kibana/issues/189350

Add latest executed state name and error to telemetry to keep track of which step has frequent errors.

```
Sending telemetry event {
  "packageName": "apm",
  "currentVersion": "9.1.0-preview-1747764883",
  "newVersion": "9.1.0-preview-1747764883",
  "status": "failure",
  "dryRun": false,
  "eventType": "package-install",
  "installType": "reinstall",
  "packageType": "integration",
  "automaticInstall": false,
  "errorMessage": "simulated error",
  "latestExecutedState": {
    "name": "create_restart_installation",
    "error": "Error during execution of state \"install_kibana_assets\" with status \"failed\": simulated error"
  }
}
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




