### PR TITLE
[9.0] [Obs AI Assistant][ES|QL] Add 10s request timeout to ES|QL query execution (#238200)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/query/index.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/query/index.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+import { ChatFunctionClient } from '@kbn/observability-ai-assistant-plugin/server/service/chat_function_client';
+import { registerExecuteQueryFunction } from '.';
+import { EXECUTE_QUERY_FUNCTION_NAME } from '@kbn/observability-ai-assistant-plugin/server';
+
+describe('executeQuery function', () => {
+  const currentUserEsClientMock: DeeplyMockedKeys<ElasticsearchClient> = {
+    search: jest.fn(),
+    fieldCaps: jest.fn(),
+    esql: {
+      query: () => Promise.resolve({ columns: [], values: [] }),
+    },
+  } as any;
+
+  const consoleOrPassThrough = () => {};
+
+  const loggerMock: DeeplyMockedKeys<Logger> = {
+    log: jest.fn().mockImplementation(consoleOrPassThrough),
+    error: jest.fn().mockImplementation(consoleOrPassThrough),
+    debug: jest.fn().mockImplementation(consoleOrPassThrough),
+    trace: jest.fn().mockImplementation(consoleOrPassThrough),
+    isLevelEnabled: jest.fn().mockReturnValue(true),
+  } as any;
+
+  let result: any;
+  const timeoutError = new Error('Request timed out');
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const functionClient = new ChatFunctionClient([]);
+
+    // mock the esql query to throw a timeout error
+    currentUserEsClientMock.esql.query = jest.fn().mockImplementation(() => {
+      const error = timeoutError;
+      error.name = 'TimeoutError';
+      throw error;
+    });
+
+    registerExecuteQueryFunction({
+      functions: functionClient,
+      resources: {
+        context: {
+          // @ts-expect-error Type mismatch is expected in test mocks
+          core: Promise.resolve({
+            elasticsearch: { client: { asCurrentUser: currentUserEsClientMock } },
+          }),
+        },
+      },
+      signal: new AbortController().signal,
+    });
+
+    result = await functionClient.executeFunction({
+      chat: jest.fn(),
+      name: EXECUTE_QUERY_FUNCTION_NAME,
+      args: JSON.stringify({ query: 'FROM logs-* | LIMIT 10' }),
+      messages: [],
+      signal: new AbortController().signal,
+      logger: loggerMock,
+      connectorId: 'foo',
+      simulateFunctionCalling: false,
+    });
+  });
+
+  it('return an error message when the execute_query function throws a timeout', () => {
+    expect(result).toEqual({
+      content: {
+        message: 'The query failed to execute',
+        error: timeoutError,
+        errorMessages: undefined,
+      },
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/query/index.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/query/index.test.ts
@@ -8,8 +8,7 @@
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
 import { ChatFunctionClient } from '@kbn/observability-ai-assistant-plugin/server/service/chat_function_client';
-import { registerExecuteQueryFunction } from '.';
-import { EXECUTE_QUERY_FUNCTION_NAME } from '@kbn/observability-ai-assistant-plugin/server';
+import { registerExecuteQueryFunction, EXECUTE_QUERY_NAME } from '.';
 
 describe('executeQuery function', () => {
   const currentUserEsClientMock: DeeplyMockedKeys<ElasticsearchClient> = {
@@ -58,7 +57,7 @@ describe('executeQuery function', () => {
 
     result = await functionClient.executeFunction({
       chat: jest.fn(),
-      name: EXECUTE_QUERY_FUNCTION_NAME,
+      name: EXECUTE_QUERY_NAME,
       args: JSON.stringify({ query: 'FROM logs-* | LIMIT 10' }),
       messages: [],
       signal: new AbortController().signal,

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/query/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/query/index.ts
@@ -29,27 +29,6 @@ export const registerExecuteQueryFunction = ({
   resources,
   signal,
 }: FunctionRegistrationParameters) => {
-  functions.registerInstruction(({ availableFunctionNames }) => {
-    if (!availableFunctionNames.includes(QUERY_FUNCTION_NAME)) {
-      return;
-    }
-
-    return `You MUST use the "${QUERY_FUNCTION_NAME}" function when the user wants to:
-  - visualize data
-  - run any arbitrary query
-  - breakdown or filter ES|QL queries that are displayed on the current page
-  - convert queries from another language to ES|QL
-  - asks general questions about ES|QL
-
-  DO NOT UNDER ANY CIRCUMSTANCES generate ES|QL queries or explain anything about the ES|QL query language yourself.
-  DO NOT UNDER ANY CIRCUMSTANCES try to correct an ES|QL query yourself - always use the "${QUERY_FUNCTION_NAME}" function for this.
-
-  If the user asks for a query, and one of the dataset info functions was called and returned no results, you should still call the query function to generate an example query.
-
-  Even if the "${QUERY_FUNCTION_NAME}" function was used before that, follow it up with the "${QUERY_FUNCTION_NAME}" function. If a query fails, do not attempt to correct it yourself. Again you should call the "${QUERY_FUNCTION_NAME}" function,
-  even if it has been called before.`;
-  });
-
   functions.registerFunction(
     {
       name: EXECUTE_QUERY_NAME,
@@ -105,7 +84,29 @@ export const registerExecuteQueryFunction = ({
 
 export function registerQueryFunction(params: FunctionRegistrationParameters) {
   const { functions, resources, pluginsStart } = params;
+  functions.registerInstruction(({ availableFunctionNames }) => {
+    if (!availableFunctionNames.includes(QUERY_FUNCTION_NAME)) {
+      return;
+    }
+
+    return `You MUST use the "${QUERY_FUNCTION_NAME}" function when the user wants to:
+  - visualize data
+  - run any arbitrary query
+  - breakdown or filter ES|QL queries that are displayed on the current page
+  - convert queries from another language to ES|QL
+  - asks general questions about ES|QL
+
+  DO NOT UNDER ANY CIRCUMSTANCES generate ES|QL queries or explain anything about the ES|QL query language yourself.
+  DO NOT UNDER ANY CIRCUMSTANCES try to correct an ES|QL query yourself - always use the "${QUERY_FUNCTION_NAME}" function for this.
+
+  If the user asks for a query, and one of the dataset info functions was called and returned no results, you should still call the query function to generate an example query.
+
+  Even if the "${QUERY_FUNCTION_NAME}" function was used before that, follow it up with the "${QUERY_FUNCTION_NAME}" function. If a query fails, do not attempt to correct it yourself. Again you should call the "${QUERY_FUNCTION_NAME}" function,
+  even if it has been called before.`;
+  });
+
   registerExecuteQueryFunction(params);
+
   functions.registerFunction(
     {
       name: QUERY_FUNCTION_NAME,

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/query/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/query/index.ts
@@ -24,12 +24,11 @@ import { runAndValidateEsqlQuery } from './validate_esql_query';
 export const QUERY_FUNCTION_NAME = 'query';
 export const EXECUTE_QUERY_NAME = 'execute_query';
 
-export function registerQueryFunction({
+export const registerExecuteQueryFunction = ({
   functions,
   resources,
-  pluginsStart,
   signal,
-}: FunctionRegistrationParameters) {
+}: FunctionRegistrationParameters) => {
   functions.registerInstruction(({ availableFunctionNames }) => {
     if (!availableFunctionNames.includes(QUERY_FUNCTION_NAME)) {
       return;
@@ -102,6 +101,11 @@ export function registerQueryFunction({
       };
     }
   );
+};
+
+export function registerQueryFunction(params: FunctionRegistrationParameters) {
+  const { functions, resources, pluginsStart } = params;
+  registerExecuteQueryFunction(params);
   functions.registerFunction(
     {
       name: QUERY_FUNCTION_NAME,

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/query/validate_esql_query.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/query/validate_esql_query.ts
@@ -50,7 +50,10 @@ export async function runAndValidateEsqlQuery({
   });
 
   try {
-    const res = await client.esql.query({ query, drop_null_columns: true }, { signal });
+    const res = await client.esql.query(
+      { query, drop_null_columns: true },
+      { signal, requestTimeout: '10s' }
+    );
     const esqlResponse = res as unknown as ESQLSearchResponse;
 
     const columns =

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/tsconfig.json
@@ -85,6 +85,7 @@
     "@kbn/product-doc-base-plugin",
     "@kbn/rule-data-utils",
     "@kbn/utility-types",
+    "@kbn/utility-types-jest",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Obs AI Assistant][ES|QL] Add 10s request timeout to ES|QL query execution (#238200)](https://github.com/elastic/kibana/pull/238200)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Arturo Lidueña","email":"arturo.liduena@elastic.co"},"sourceCommit":{"committedDate":"2025-10-13T10:51:54Z","message":"[Obs AI Assistant][ES|QL] Add 10s request timeout to ES|QL query execution (#238200)\n\nCloses https://github.com/elastic/kibana/issues/234135\n\n## Summary\n\nAdd 10s request timeout to ES|QL query execution\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0f4c777d351118ebb0be2c833b08f87e537a1ef2","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v9.1.0","v9.2.0","v9.3.0"],"title":"[Obs AI Assistant][ES|QL] Add 10s request timeout to ES|QL query execution","number":238200,"url":"https://github.com/elastic/kibana/pull/238200","mergeCommit":{"message":"[Obs AI Assistant][ES|QL] Add 10s request timeout to ES|QL query execution (#238200)\n\nCloses https://github.com/elastic/kibana/issues/234135\n\n## Summary\n\nAdd 10s request timeout to ES|QL query execution\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0f4c777d351118ebb0be2c833b08f87e537a1ef2"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","9.1"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238622","number":238622,"state":"MERGED","mergeCommit":{"sha":"3071e9cc592fa14f9e139d3d1a6d9733a2ecca85","message":"[9.2] [Obs AI Assistant][ES|QL] Add 10s request timeout to ES|QL query execution (#238200) (#238622)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Obs AI Assistant][ES|QL] Add 10s request timeout to ES|QL query\nexecution (#238200)](https://github.com/elastic/kibana/pull/238200)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Arturo Lidueña <arturo.liduena@elastic.co>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238200","number":238200,"mergeCommit":{"message":"[Obs AI Assistant][ES|QL] Add 10s request timeout to ES|QL query execution (#238200)\n\nCloses https://github.com/elastic/kibana/issues/234135\n\n## Summary\n\nAdd 10s request timeout to ES|QL query execution\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0f4c777d351118ebb0be2c833b08f87e537a1ef2"}}]}] BACKPORT-->