### PR TITLE
[Docs] Edit search sessions settings page

### DIFF
--- a/docs/reference/configuration-reference/search-sessions-settings.md
+++ b/docs/reference/configuration-reference/search-sessions-settings.md
@@ -11,8 +11,7 @@ applies_to:
 
 :::{important} - Background search replaces Search sessions
 
-% [Background search](docs-content://explore-analyze/discover/background-search.md) is a feature introduced in version 9.2. It replaces the **Search sessions** feature, deprecated in version 8.15.
-Background search is a feature introduced in version 9.2. It replaces the **Search sessions** feature, deprecated in version 8.15.
+[Background search](docs-content://explore-analyze/discover/background-search.md) is a feature introduced in version 9.2. It replaces the **Search sessions** feature, deprecated in version 8.15.
 :::
 
 :::{note}

--- a/docs/reference/configuration-reference/search-sessions-settings.md
+++ b/docs/reference/configuration-reference/search-sessions-settings.md
@@ -27,6 +27,9 @@ If a setting is applicable to {{ech}} environments, its name is followed by this
 `data.search.sessions.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   `false` by default. Set to `true` to enable background searches.
 
+`data.search.sessions.maxUpdateRetries` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
+:   How many retries {{kib}} can perform while attempting to send a search to the background. The default is `10`.
+
 `data.search.sessions.defaultExpiration` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   How long background search results are stored before they expire and are deleted. When users extend the validity period of the background search, this setting also determines by how long. The default is `7d`.
 ::::

--- a/docs/reference/configuration-reference/search-sessions-settings.md
+++ b/docs/reference/configuration-reference/search-sessions-settings.md
@@ -47,7 +47,3 @@ If a setting is applicable to {{ech}} environments, its name is followed by this
 ::::
 
 :::::
-
-
-
-

--- a/docs/reference/configuration-reference/search-sessions-settings.md
+++ b/docs/reference/configuration-reference/search-sessions-settings.md
@@ -1,20 +1,37 @@
 ---
-navigation_title: "Search sessions settings"
+navigation_title: "Background search settings"
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/search-session-settings-kb.html
 applies_to:
-  stack: deprecated 8.15.0
-  deployment:
-    ess: all
-    self: all
+  stack: preview 9.2
+  serverless: unavailable
 ---
 
-# Search sessions settings in {{kib}} [search-session-settings-kb]
+# Background search and search sessions settings in {{kib}} [search-session-settings-kb]
+
+:::{important} - Background search replaces Search sessions
+
+[Background search](docs-content://explore-analyze/discover/background-search.md) is a feature introduced in version 9.2. It replaces the **Search sessions** feature, deprecated in version 8.15.
+:::
 
 :::{note}
 If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :::
 
+:::::{tab-set}
+:group: background search
+
+::::{tab-item} 9.2 and later
+:sync: 92
+`data.search.sessions.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
+:   `false` by default. Set to `true` to enable background searches.
+
+`data.search.sessions.defaultExpiration` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
+:   How long background search results are stored before they are deleted. Extending the validity period of the background search  the expiration by the same value. The default is `7d`.
+::::
+
+::::{tab-item} 9.1 and earlier
+:sync: 91
 `data.search.sessions.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Deprecated in 8.15.0. `false` by default. Set to `true` to enable search sessions.
 
@@ -26,4 +43,11 @@ If a setting is applicable to {{ech}} environments, its name is followed by this
 
 `data.search.sessions.defaultExpiration` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Deprecated in 8.15.0. How long search session results are stored before they are deleted. Extending a search session resets the expiration by the same value. The default is `7d`.
+
+::::
+
+:::::
+
+
+
 

--- a/docs/reference/configuration-reference/search-sessions-settings.md
+++ b/docs/reference/configuration-reference/search-sessions-settings.md
@@ -27,7 +27,7 @@ If a setting is applicable to {{ech}} environments, its name is followed by this
 :   `false` by default. Set to `true` to enable background searches.
 
 `data.search.sessions.defaultExpiration` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
-:   How long background search results are stored before they are deleted. Extending the validity period of the background search  the expiration by the same value. The default is `7d`.
+:   How long background search results are stored before they expire and are deleted. When users extend the validity period of the background search, this setting also determines by how long. The default is `7d`.
 ::::
 
 ::::{tab-item} 9.1 and earlier

--- a/docs/reference/configuration-reference/search-sessions-settings.md
+++ b/docs/reference/configuration-reference/search-sessions-settings.md
@@ -11,7 +11,8 @@ applies_to:
 
 :::{important} - Background search replaces Search sessions
 
-[Background search](docs-content://explore-analyze/discover/background-search.md) is a feature introduced in version 9.2. It replaces the **Search sessions** feature, deprecated in version 8.15.
+% [Background search](docs-content://explore-analyze/discover/background-search.md) is a feature introduced in version 9.2. It replaces the **Search sessions** feature, deprecated in version 8.15.
+Background search is a feature introduced in version 9.2. It replaces the **Search sessions** feature, deprecated in version 8.15.
 :::
 
 :::{note}


### PR DESCRIPTION
This PR edits the search sessions/background search settings page.

**Must merge the following PR first to re-add a link to a new page here:**

Relates to: https://github.com/elastic/docs-content/pull/3455

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->