### PR TITLE
[9.2] [Synthetics] Use runWithCache for fleet bulk operations !! (#238326)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/mocks/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/mocks/index.ts
@@ -381,6 +381,7 @@ export const createFleetStartContractMock = (): DeeplyMockedKeys<FleetStartContr
     createFleetActionsClient: jest.fn((_) => fleetActionsClient),
     getPackageSpecTagId: jest.fn(getPackageSpecTagId),
     createOutputClient: jest.fn(async (_) => createOutputClientMock()),
+    runWithCache: (async (cb: any) => await cb()) as any,
   };
 
   return startContract;

--- a/x-pack/platform/plugins/shared/fleet/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/plugin.ts
@@ -69,6 +69,8 @@ import {
   LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
 } from '../common/constants';
 
+import { runWithCache } from './services/epm/packages/cache';
+
 import { getFilesClientFactory } from './services/files/get_files_client_factory';
 
 import type { MessageSigningServiceInterface } from './services/security';
@@ -256,6 +258,7 @@ export interface FleetStartContract {
    * Services for Fleet's package policies
    */
   packagePolicyService: typeof packagePolicyService;
+  runWithCache: typeof runWithCache;
   agentPolicyService: AgentPolicyServiceInterface;
   cloudConnectorService: CloudConnectorServiceInterface;
   /**
@@ -925,6 +928,7 @@ export class FleetPlugin
         return new OutputClient(soClient, authz);
       },
       cloudConnectorService,
+      runWithCache,
     };
   }
 

--- a/x-pack/solutions/observability/packages/synthetics-test-data/src/e2e/tasks/read_kibana_config.ts
+++ b/x-pack/solutions/observability/packages/synthetics-test-data/src/e2e/tasks/read_kibana_config.ts
@@ -19,5 +19,5 @@ export const readKibanaConfig = () => {
 
   return (yaml.load(
     fs.readFileSync(fs.existsSync(kibanaDevConfig) ? kibanaDevConfig : kibanaConfig, 'utf8')
-  ) || {}) as Record<string, string>;
+  ) || {}) as Record<string, any>;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.test.ts
@@ -67,6 +67,7 @@ describe('SyntheticsPrivateLocation', () => {
         bulkCreate: jest.fn(),
         getByIDs: jest.fn(),
       },
+      runWithCache: async (cb: any) => await cb(),
     },
     spaces: {
       spacesService: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -148,73 +148,74 @@ export class SyntheticsPrivateLocation {
     if (configs.length === 0) {
       return { created: [], failed: [] };
     }
+    return this.runWithCache(async () => {
+      const newPolicies: NewPackagePolicyWithId[] = [];
+      const newPolicyTemplate = await this.buildNewPolicy();
 
-    const newPolicies: NewPackagePolicyWithId[] = [];
-    const newPolicyTemplate = await this.buildNewPolicy();
+      for (const { config, globalParams } of configs) {
+        try {
+          const { locations } = config;
+          const fleetManagedLocations = locations.filter((loc) => !loc.isServiceManaged);
 
-    for (const { config, globalParams } of configs) {
-      try {
-        const { locations } = config;
-        const fleetManagedLocations = locations.filter((loc) => !loc.isServiceManaged);
+          for (const privateLocation of fleetManagedLocations) {
+            const location = privateLocations?.find((loc) => loc.id === privateLocation.id)!;
+            if (!location) {
+              throw new Error(
+                `Unable to find Synthetics private location for agentId ${privateLocation.id}`
+              );
+            }
 
-        for (const privateLocation of fleetManagedLocations) {
-          const location = privateLocations?.find((loc) => loc.id === privateLocation.id)!;
-          if (!location) {
-            throw new Error(
-              `Unable to find Synthetics private location for agentId ${privateLocation.id}`
+            const newPolicy = await this.generateNewPolicy(
+              config,
+              location,
+              newPolicyTemplate,
+              spaceId,
+              globalParams,
+              maintenanceWindows,
+              testRunId,
+              runOnce
             );
-          }
 
-          const newPolicy = await this.generateNewPolicy(
-            config,
-            location,
-            newPolicyTemplate,
-            spaceId,
-            globalParams,
-            maintenanceWindows,
-            testRunId,
-            runOnce
-          );
-
-          if (!newPolicy) {
-            throw new Error(
-              `Unable to create Synthetics package policy for monitor ${
-                config[ConfigKey.NAME]
-              } with private location ${location.label}`
-            );
-          }
-          if (newPolicy) {
-            if (testRunId) {
-              newPolicies.push(newPolicy as NewPackagePolicyWithId);
-            } else {
-              newPolicies.push({
-                ...newPolicy,
-                id: this.getPolicyId(config, location.id, spaceId),
-              });
+            if (!newPolicy) {
+              throw new Error(
+                `Unable to create Synthetics package policy for monitor ${
+                  config[ConfigKey.NAME]
+                } with private location ${location.label}`
+              );
+            }
+            if (newPolicy) {
+              if (testRunId) {
+                newPolicies.push(newPolicy as NewPackagePolicyWithId);
+              } else {
+                newPolicies.push({
+                  ...newPolicy,
+                  id: this.getPolicyId(config, location.id, spaceId),
+                });
+              }
             }
           }
+        } catch (e) {
+          this.server.logger.error(e);
+          throw e;
         }
+      }
+
+      if (newPolicies.length === 0) {
+        throw new Error('Failed to build package policies for all monitors');
+      }
+
+      try {
+        const result = await this.createPolicyBulk(newPolicies);
+        if (result?.created && result?.created?.length > 0 && testRunId) {
+          // ignore await here, we don't want to wait for this to finish
+          void scheduleCleanUpTask(this.server);
+        }
+        return result;
       } catch (e) {
         this.server.logger.error(e);
         throw e;
       }
-    }
-
-    if (newPolicies.length === 0) {
-      throw new Error('Failed to build package policies for all monitors');
-    }
-
-    try {
-      const result = await this.createPolicyBulk(newPolicies);
-      if (result?.created && result?.created?.length > 0 && testRunId) {
-        // ignore await here, we don't want to wait for this to finish
-        void scheduleCleanUpTask(this.server);
-      }
-      return result;
-    } catch (e) {
-      this.server.logger.error(e);
-      throw e;
-    }
+    });
   }
 
   async inspectPackagePolicy({
@@ -270,91 +271,95 @@ export class SyntheticsPrivateLocation {
     maintenanceWindows: MaintenanceWindow[]
   ) {
     if (configs.length === 0) {
-      return {};
+      return {
+        failedUpdates: [],
+      };
     }
 
-    const [newPolicyTemplate, existingPolicies] = await Promise.all([
-      this.buildNewPolicy(),
-      this.getExistingPolicies(
-        configs.map(({ config }) => config),
-        allPrivateLocations,
-        spaceId
-      ),
-    ]);
+    return this.runWithCache(async () => {
+      const [newPolicyTemplate, existingPolicies] = await Promise.all([
+        this.buildNewPolicy(),
+        this.getExistingPolicies(
+          configs.map(({ config }) => config),
+          allPrivateLocations,
+          spaceId
+        ),
+      ]);
 
-    const policiesToUpdate: NewPackagePolicyWithId[] = [];
-    const policiesToCreate: NewPackagePolicyWithId[] = [];
-    const policiesToDelete: string[] = [];
+      const policiesToUpdate: NewPackagePolicyWithId[] = [];
+      const policiesToCreate: NewPackagePolicyWithId[] = [];
+      const policiesToDelete: string[] = [];
 
-    for (const { config, globalParams } of configs) {
-      const { locations } = config;
-
-      const monitorPrivateLocations = locations.filter((loc) => !loc.isServiceManaged);
-
-      for (const privateLocation of allPrivateLocations) {
-        const hasLocation = monitorPrivateLocations?.some((loc) => loc.id === privateLocation.id);
-        const currId = this.getPolicyId(config, privateLocation.id, spaceId);
-        const hasPolicy = existingPolicies?.some((policy) => policy.id === currId);
-        try {
-          if (hasLocation) {
-            const newPolicy = await this.generateNewPolicy(
-              config,
-              privateLocation,
-              newPolicyTemplate,
-              spaceId,
-              globalParams,
-              maintenanceWindows
-            );
-
-            if (!newPolicy) {
-              throwAddEditError(hasPolicy, privateLocation.label);
-            }
-
-            if (hasPolicy) {
-              policiesToUpdate.push({ ...newPolicy, id: currId } as NewPackagePolicyWithId);
-            } else {
-              policiesToCreate.push({ ...newPolicy, id: currId } as NewPackagePolicyWithId);
-            }
-          } else if (hasPolicy) {
-            policiesToDelete.push(currId);
-          }
-        } catch (e) {
-          this.server.logger.error(e);
-          throwAddEditError(hasPolicy, privateLocation.label, config[ConfigKey.NAME]);
-        }
-      }
-    }
-
-    this.server.logger.debug(
-      `[editingMonitors] Creating ${policiesToCreate.length} policies, updating ${policiesToUpdate.length} policies, and deleting ${policiesToDelete.length} policies`
-    );
-
-    const [_createResponse, failedUpdatesRes, _deleteResponse] = await Promise.all([
-      this.createPolicyBulk(policiesToCreate),
-      this.updatePolicyBulk(policiesToUpdate),
-      this.deletePolicyBulk(policiesToDelete),
-    ]);
-
-    const failedUpdates = failedUpdatesRes?.map(({ packagePolicy, error }) => {
-      const policyConfig = configs.find(({ config }) => {
+      for (const { config, globalParams } of configs) {
         const { locations } = config;
 
         const monitorPrivateLocations = locations.filter((loc) => !loc.isServiceManaged);
-        for (const privateLocation of monitorPrivateLocations) {
+
+        for (const privateLocation of allPrivateLocations) {
+          const hasLocation = monitorPrivateLocations?.some((loc) => loc.id === privateLocation.id);
           const currId = this.getPolicyId(config, privateLocation.id, spaceId);
-          return currId === packagePolicy.id;
+          const hasPolicy = existingPolicies?.some((policy) => policy.id === currId);
+          try {
+            if (hasLocation) {
+              const newPolicy = await this.generateNewPolicy(
+                config,
+                privateLocation,
+                newPolicyTemplate,
+                spaceId,
+                globalParams,
+                maintenanceWindows
+              );
+
+              if (!newPolicy) {
+                throwAddEditError(hasPolicy, privateLocation.label);
+              }
+
+              if (hasPolicy) {
+                policiesToUpdate.push({ ...newPolicy, id: currId } as NewPackagePolicyWithId);
+              } else {
+                policiesToCreate.push({ ...newPolicy, id: currId } as NewPackagePolicyWithId);
+              }
+            } else if (hasPolicy) {
+              policiesToDelete.push(currId);
+            }
+          } catch (e) {
+            this.server.logger.error(e);
+            throwAddEditError(hasPolicy, privateLocation.label, config[ConfigKey.NAME]);
+          }
         }
+      }
+
+      this.server.logger.debug(
+        `[editingMonitors] Creating ${policiesToCreate.length} policies, updating ${policiesToUpdate.length} policies, and deleting ${policiesToDelete.length} policies`
+      );
+
+      const [_createResponse, failedUpdatesRes, _deleteResponse] = await Promise.all([
+        this.createPolicyBulk(policiesToCreate),
+        this.updatePolicyBulk(policiesToUpdate),
+        this.deletePolicyBulk(policiesToDelete),
+      ]);
+
+      const failedUpdates = failedUpdatesRes?.map(({ packagePolicy, error }) => {
+        const policyConfig = configs.find(({ config }) => {
+          const { locations } = config;
+
+          const monitorPrivateLocations = locations.filter((loc) => !loc.isServiceManaged);
+          for (const privateLocation of monitorPrivateLocations) {
+            const currId = this.getPolicyId(config, privateLocation.id, spaceId);
+            return currId === packagePolicy.id;
+          }
+        });
+        return {
+          error,
+          packagePolicy,
+          config: policyConfig?.config,
+        };
       });
+
       return {
-        error,
-        packagePolicy,
-        config: policyConfig?.config,
+        failedUpdates,
       };
     });
-
-    return {
-      failedUpdates,
-    };
   }
 
   async getExistingPolicies(
@@ -431,37 +436,39 @@ export class SyntheticsPrivateLocation {
   }
 
   async deleteMonitors(configs: HeartbeatConfig[], spaceId: string) {
-    const soClient = this.server.coreStart.savedObjects.createInternalRepository();
-    const esClient = this.server.coreStart.elasticsearch.client.asInternalUser;
+    return this.runWithCache(async () => {
+      const soClient = this.server.coreStart.savedObjects.createInternalRepository();
+      const esClient = this.server.coreStart.elasticsearch.client.asInternalUser;
 
-    const policyIdsToDelete = [];
-    for (const config of configs) {
-      const { locations } = config;
+      const policyIdsToDelete = [];
+      for (const config of configs) {
+        const { locations } = config;
 
-      const monitorPrivateLocations = locations.filter((loc) => !loc.isServiceManaged);
+        const monitorPrivateLocations = locations.filter((loc) => !loc.isServiceManaged);
 
-      for (const privateLocation of monitorPrivateLocations) {
-        policyIdsToDelete.push(this.getPolicyId(config, privateLocation.id, spaceId));
-      }
-    }
-    if (policyIdsToDelete.length > 0) {
-      const result = await this.server.fleet.packagePolicyService.delete(
-        soClient,
-        esClient,
-        policyIdsToDelete,
-        {
-          force: true,
-          asyncDeploy: true,
+        for (const privateLocation of monitorPrivateLocations) {
+          policyIdsToDelete.push(this.getPolicyId(config, privateLocation.id, spaceId));
         }
-      );
-      const failedPolicies = result?.filter((policy) => {
-        return !policy.success && policy?.statusCode !== 404;
-      });
-      if (failedPolicies?.length === policyIdsToDelete.length) {
-        throw new Error(deletePolicyError(configs[0][ConfigKey.NAME]));
       }
-      return result;
-    }
+      if (policyIdsToDelete.length > 0) {
+        const result = await this.server.fleet.packagePolicyService.delete(
+          soClient,
+          esClient,
+          policyIdsToDelete,
+          {
+            force: true,
+            asyncDeploy: true,
+          }
+        );
+        const failedPolicies = result?.filter((policy) => {
+          return !policy.success && policy?.statusCode !== 404;
+        });
+        if (failedPolicies?.length === policyIdsToDelete.length) {
+          throw new Error(deletePolicyError(configs[0][ConfigKey.NAME]));
+        }
+        return result;
+      }
+    });
   }
 
   async getAgentPolicies() {
@@ -473,6 +480,10 @@ export class SyntheticsPrivateLocation {
       return configNamespace;
     }
     return undefined;
+  }
+
+  async runWithCache<T>(fn: () => Promise<T>): Promise<T> {
+    return await this.server.fleet.runWithCache(fn);
   }
 }
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.test.ts
@@ -118,6 +118,7 @@ describe('ProjectMonitorFormatter', () => {
     coreStart: {
       savedObjects: savedObjectsServiceMock.createStartContract(),
     },
+    fleet: { runWithCache: async (cb: any) => await cb() },
   } as unknown as SyntheticsServerSetup;
 
   const syntheticsService = new SyntheticsService(serverMock);
@@ -253,7 +254,7 @@ describe('ProjectMonitorFormatter', () => {
       updatedMonitors: [],
       failedMonitors: [
         {
-          details: "Cannot read properties of undefined (reading 'packagePolicyService')",
+          details: "Cannot read properties of undefined (reading 'buildPackagePolicyFromPackage')",
           payload: payloadData,
           reason: 'Failed to create 2 monitors',
         },
@@ -284,7 +285,7 @@ describe('ProjectMonitorFormatter', () => {
       updatedMonitors: [],
       failedMonitors: [
         {
-          details: "Cannot read properties of undefined (reading 'packagePolicyService')",
+          details: "Cannot read properties of undefined (reading 'buildPackagePolicyFromPackage')",
           payload: payloadData,
           reason: 'Failed to create 2 monitors',
         },
@@ -315,7 +316,7 @@ describe('ProjectMonitorFormatter', () => {
       updatedMonitors: [],
       failedMonitors: [
         {
-          details: "Cannot read properties of undefined (reading 'packagePolicyService')",
+          details: "Cannot read properties of undefined (reading 'buildPackagePolicyFromPackage')",
           reason: 'Failed to create 2 monitors',
           payload: payloadData,
         },

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
@@ -52,6 +52,7 @@ const mockServerSetup: jest.Mocked<SyntheticsServerSetup> = {
   } as any,
   encryptedSavedObjects: mockEncryptedSoClient as any,
   logger: mockLogger,
+  fleet: mockFleet,
 } as any;
 
 const getMockTaskInstance = (state: Record<string, any> = {}): CustomTaskInstance => {

--- a/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
@@ -119,7 +119,8 @@
     "@kbn/field-formats-plugin",
     "@kbn/core-ui-settings-browser",
     "@kbn/content-management-plugin",
-    "@kbn/licensing-types"
+    "@kbn/licensing-types",
+    "@kbn/observability-synthetics-test-data"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Synthetics] Use runWithCache for fleet bulk operations !! (#238326)](https://github.com/elastic/kibana/pull/238326)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2025-10-13T18:38:53Z","message":"[Synthetics] Use runWithCache for fleet bulk operations !! (#238326)\n\n## Summary\n\nUse runWithCache for fleet bulk operations !!\n\nThis was causing too many extra operations being called unecessarily\nwith bulk operations, for example having to update 1000 update monitors\n, it was causing 1000s of epr requests for package info for synthetics\nintegration,\n\n\n### Testing\n\nCreating/updating private location monitors should work as expected and\nalso injecting global params via task.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8ef3800a1fef551fdf9b1226cfabffc54afad6c1","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","Team:obs-ux-management","backport:version","v9.2.0","v9.3.0","v9.1.6","v8.19.6"],"title":"[Synthetics] Use runWithCache for fleet bulk operations !!","number":238326,"url":"https://github.com/elastic/kibana/pull/238326","mergeCommit":{"message":"[Synthetics] Use runWithCache for fleet bulk operations !! (#238326)\n\n## Summary\n\nUse runWithCache for fleet bulk operations !!\n\nThis was causing too many extra operations being called unecessarily\nwith bulk operations, for example having to update 1000 update monitors\n, it was causing 1000s of epr requests for package info for synthetics\nintegration,\n\n\n### Testing\n\nCreating/updating private location monitors should work as expected and\nalso injecting global params via task.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8ef3800a1fef551fdf9b1226cfabffc54afad6c1"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","8.19"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238326","number":238326,"mergeCommit":{"message":"[Synthetics] Use runWithCache for fleet bulk operations !! (#238326)\n\n## Summary\n\nUse runWithCache for fleet bulk operations !!\n\nThis was causing too many extra operations being called unecessarily\nwith bulk operations, for example having to update 1000 update monitors\n, it was causing 1000s of epr requests for package info for synthetics\nintegration,\n\n\n### Testing\n\nCreating/updating private location monitors should work as expected and\nalso injecting global params via task.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8ef3800a1fef551fdf9b1226cfabffc54afad6c1"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238726","number":238726,"state":"OPEN"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->