### PR TITLE
[dashboard] fix Adhoc dataviews from ES|QL charts are being filtered out in the KQL search bar

### DIFF
--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_data_views.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_data_views.ts
@@ -11,8 +11,7 @@ import type { DataView } from '@kbn/data-views-plugin/common';
 import type { PublishingSubject } from '../publishing_subject';
 
 /**
- * This API publishes a list of data views that it uses. Note that this should not contain any
- * ad-hoc data views.
+ * This API publishes a list of data views that it uses.
  */
 export interface PublishesDataViews {
   dataViews$: PublishingSubject<DataView[] | undefined>;

--- a/src/platform/plugins/shared/controls/public/control_group/get_control_group_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/control_group/get_control_group_factory.tsx
@@ -104,7 +104,7 @@ export const getControlGroupEmbeddableFactory = () => {
         isEditingEnabled: () => true,
         openAddDataControlFlyout: (settings) => {
           const parentDataViewId = apiPublishesDataViews(parentApi)
-            ? parentApi.dataViews$.value?.[0]?.id
+            ? parentApi.dataViews$.value?.find((dataView) => dataView.isPersisted())?.id
             : undefined;
           const newControlState = controlsManager.getNewControlState();
 

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/data_views_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/data_views_manager.ts
@@ -40,9 +40,7 @@ export function initializeDataViewsManager(
   const dataViewsSubscription = combineLatest([controlGroupDataViewsPipe, childDataViewsPipe])
     .pipe(
       switchMap(async ([controlGroupDataViews, childDataViews]) => {
-        const allDataViews = [...(controlGroupDataViews ?? []), ...childDataViews].filter(
-          (dataView) => dataView.isPersisted()
-        );
+        const allDataViews = [...(controlGroupDataViews ?? []), ...childDataViews];
 
         if (allDataViews.length === 0) {
           try {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/236288

### Background
https://github.com/elastic/kibana/pull/225705 fixed an issue where controls where getting created with adhoc data views. This fix cause regression https://github.com/elastic/kibana/issues/236288. Instead of filtering out adhoc data views from dashboard.dataViews$, the fix should occur in the control group level and ignore adhoc data views when suggesting the data view when creating a control.

### Test instructions
* install sample web logs and wait until its install - web logs is expected to be default data view
* install sample flights data set
* create new dashboard
* add ESQL panel with statement `FROM kibana_sample_data_flights | LIMIT 10`
* click into unified search query bar. Verify typeahead is populated from `flights` data view.
* Add new control to dashboard. Ensure suggested data view is `Kibana Sample Data Logs` - meaning the control suggested the default data view and not the adhoc flights data view from the lens panel.

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1","9.2"]} ONMERGE-->