### PR TITLE
[ci] Increase FTR timeout

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -565,7 +565,7 @@ export async function pickTestGroupRunOrder() {
                 ({ title, key, queue = defaultQueue }): BuildkiteStep => ({
                   label: title,
                   command: getRequiredEnv('FTR_CONFIGS_SCRIPT'),
-                  timeout_in_minutes: 90,
+                  timeout_in_minutes: 120,
                   agents: expandAgentQueue(queue),
                   env: {
                     SCOUT_TARGET_TYPE: 'local',


### PR DESCRIPTION
Test suites with no tests running are recorded as a short duration, while setup is still adding minutes to runtime.  This is causing a skew in the test groupings, leading to timeouts.

This is a temporary fix until pending tests skip setup.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->