### PR TITLE
[Security solution] create attack dataview

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -39,6 +39,7 @@ export const DEFAULT_INDEX_KEY = 'securitySolution:defaultIndex' as const;
 export const DEFAULT_NUMBER_FORMAT = 'format:number:defaultPattern' as const;
 export const DEFAULT_DATA_VIEW_ID = 'security-solution' as const;
 export const DEFAULT_ALERT_DATA_VIEW_ID = 'security-solution-alert' as const;
+export const DEFAULT_ATTACK_DATA_VIEW_ID = 'security-solution-attack' as const;
 export const DEFAULT_TIME_FIELD = '@timestamp' as const;
 export const DEFAULT_TIME_RANGE = 'timepicker:timeDefaults' as const;
 export const DEFAULT_REFRESH_RATE_INTERVAL = 'timepicker:refreshIntervalDefaults' as const;

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -187,9 +187,9 @@ export const allowedExperimentalValues = Object.freeze({
    */
   microsoftDefenderEndpointCancelEnabled: true,
   /**
-   * Protects all the work related to the attacks and alert alignment effort
+   * Protects all the work related to the attacks and alerts alignment effort
    */
-  attacksAlertAlignment: false,
+  attacksAlertsAlignment: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/translations.ts
@@ -25,6 +25,13 @@ export const DEFAULT_SECURITY_ALERT_DATA_VIEW = i18n.translate(
   }
 );
 
+export const DEFAULT_SECURITY_ATTACK_DATA_VIEW = i18n.translate(
+  'xpack.securitySolution.dataViewManager.defaultSecurityAttackDataView',
+  {
+    defaultMessage: 'Security solution attacks',
+  }
+);
+
 export const SECURITY_SOLUTION_EXPLORE_DATA_VIEW = i18n.translate(
   'xpack.securitySolution.dataViewManager.securitySolutionExploreDataView',
   {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
@@ -42,7 +42,7 @@ export const useInitDataViewManager = () => {
   const dispatch = useDispatch();
   const services = useKibana().services;
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const attacksAlertAlignment = useIsExperimentalFeatureEnabled('attacksAlertAlignment');
+  const attacksAlertsAlignmentEnabled = useIsExperimentalFeatureEnabled('attacksAlertsAlignment');
 
   const {
     loading: loadingSignalIndex,
@@ -89,7 +89,7 @@ export const useInitDataViewManager = () => {
         application: services.application,
         spaces: services.spaces,
       },
-      attacksAlertAlignment
+      attacksAlertsAlignmentEnabled
     );
 
     dispatch(addListener(dataViewsLoadingListener));
@@ -121,7 +121,7 @@ export const useInitDataViewManager = () => {
       });
     };
   }, [
-    attacksAlertAlignment,
+    attacksAlertsAlignmentEnabled,
     dispatch,
     newDataViewPickerEnabled,
     services.application,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
@@ -42,6 +42,7 @@ export const useInitDataViewManager = () => {
   const dispatch = useDispatch();
   const services = useKibana().services;
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
+  const attacksAlertAlignment = useIsExperimentalFeatureEnabled('attacksAlertAlignment');
 
   const {
     loading: loadingSignalIndex,
@@ -80,13 +81,16 @@ export const useInitDataViewManager = () => {
     }
 
     // NOTE: init listener contains logic that preloads default security solution data view
-    const dataViewsLoadingListener = createInitListener({
-      dataViews: services.dataViews,
-      http: services.http,
-      uiSettings: services.uiSettings,
-      application: services.application,
-      spaces: services.spaces,
-    });
+    const dataViewsLoadingListener = createInitListener(
+      {
+        dataViews: services.dataViews,
+        http: services.http,
+        uiSettings: services.uiSettings,
+        application: services.application,
+        spaces: services.spaces,
+      },
+      attacksAlertAlignment
+    );
 
     dispatch(addListener(dataViewsLoadingListener));
 
@@ -117,6 +121,7 @@ export const useInitDataViewManager = () => {
       });
     };
   }, [
+    attacksAlertAlignment,
     dispatch,
     newDataViewPickerEnabled,
     services.application,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -11,7 +11,7 @@ import { createInitListener } from './init_listener';
 import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public';
 import type { RootState } from '../reducer';
 import { sharedDataViewManagerSlice } from '../slices';
-import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, DataViewManagerScopeName } from '../../constants';
+import { DataViewManagerScopeName, DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID } from '../../constants';
 import { DEFAULT_ALERT_DATA_VIEW_ID } from '../../../../common/constants';
 import { selectDataViewAsync } from '../actions';
 import type { CoreStart } from '@kbn/core/public';
@@ -67,13 +67,16 @@ describe('createInitListener', () => {
       kibanaDataViews: [],
     } as unknown as Awaited<ReturnType<typeof createDefaultDataView>>);
 
-    listener = createInitListener({
-      dataViews: mockDataViewsService,
-      http,
-      application,
-      uiSettings,
-      spaces,
-    });
+    listener = createInitListener(
+      {
+        dataViews: mockDataViewsService,
+        http,
+        application,
+        uiSettings,
+        spaces,
+      },
+      false
+    );
   });
 
   it('should load the data views and dispatch further actions', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
@@ -31,7 +31,7 @@ import { createExploreDataView } from '../../utils/create_explore_data_view';
  * and that state is not reset for slices that already have selections.
  *
  * @param dependencies - Core and plugin services required for data view creation and retrieval.
- * @param attacksAlertAlignment - Prevent attacks dataview creation if feature flag is not enabled.
+ * @param attacksAlertsAlignmentEnabled - Prevent attacks dataview creation if feature flag is not enabled.
  * @returns An object with the actionCreator and effect for Redux listener middleware.
  */
 export const createInitListener = (
@@ -42,7 +42,7 @@ export const createInitListener = (
     dataViews: DataViewsServicePublic;
     spaces: SpacesPluginStart;
   },
-  attacksAlertAlignment: boolean
+  attacksAlertsAlignmentEnabled: boolean
 ) => {
   return {
     actionCreator: sharedDataViewManagerSlice.actions.init,
@@ -58,7 +58,7 @@ export const createInitListener = (
           spaces: dependencies.spaces,
           application: dependencies.application,
           http: dependencies.http,
-          attacksAlertAlignment,
+          attacksAlertsAlignmentEnabled,
         });
 
         const exploreDataView = await createExploreDataView(

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
@@ -31,15 +31,19 @@ import { createExploreDataView } from '../../utils/create_explore_data_view';
  * and that state is not reset for slices that already have selections.
  *
  * @param dependencies - Core and plugin services required for data view creation and retrieval.
+ * @param attacksAlertAlignment - Prevent attacks dataview creation if feature flag is not enabled.
  * @returns An object with the actionCreator and effect for Redux listener middleware.
  */
-export const createInitListener = (dependencies: {
-  http: CoreStart['http'];
-  application: CoreStart['application'];
-  uiSettings: CoreStart['uiSettings'];
-  dataViews: DataViewsServicePublic;
-  spaces: SpacesPluginStart;
-}) => {
+export const createInitListener = (
+  dependencies: {
+    http: CoreStart['http'];
+    application: CoreStart['application'];
+    uiSettings: CoreStart['uiSettings'];
+    dataViews: DataViewsServicePublic;
+    spaces: SpacesPluginStart;
+  },
+  attacksAlertAlignment: boolean
+) => {
   return {
     actionCreator: sharedDataViewManagerSlice.actions.init,
     effect: async (
@@ -54,6 +58,7 @@ export const createInitListener = (dependencies: {
           spaces: dependencies.spaces,
           application: dependencies.application,
           http: dependencies.http,
+          attacksAlertAlignment,
         });
 
         const exploreDataView = await createExploreDataView(

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_default_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_default_data_view.test.ts
@@ -6,17 +6,13 @@
  */
 
 import {
-  type CreateDefaultDataViewDependencies,
   createDefaultDataView,
+  type CreateDefaultDataViewDependencies,
 } from './create_default_data_view';
 import { initDataView } from '../../sourcerer/store/model';
 import * as helpersAccess from '../../helpers_access';
 import * as createSourcererDataViewModule from '../../sourcerer/containers/create_sourcerer_data_view';
-import {
-  DEFAULT_ALERT_DATA_VIEW_ID,
-  DEFAULT_DATA_VIEW_ID,
-  DETECTION_ENGINE_INDEX_URL,
-} from '../../../common/constants';
+import { DETECTION_ENGINE_INDEX_URL } from '../../../common/constants';
 
 jest.mock('../../helpers_access');
 jest.mock('../../sourcerer/containers/create_sourcerer_data_view');
@@ -76,11 +72,12 @@ describe('createDefaultDataView', () => {
     expect(mockHttp.fetch).toHaveBeenCalledWith(DETECTION_ENGINE_INDEX_URL, expect.any(Object));
     expect(createSourcererDataViewModule.createSourcererDataView).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: { patternList: ['pattern-*', 'signal-index'] },
-        dataViewService: mockDataViewService,
-        dataViewId: `${DEFAULT_DATA_VIEW_ID}-space1`,
-        alertDataViewId: `${DEFAULT_ALERT_DATA_VIEW_ID}-space1`,
-        signalIndexName: 'signal-index',
+        alertDetails: { dataViewId: 'security-solution-alert-space1', indexName: 'signal-index' },
+        dataViewService: {},
+        defaultDetails: {
+          dataViewId: 'security-solution-space1',
+          patternList: ['pattern-*', 'signal-index'],
+        },
       })
     );
     expect(result.defaultDataView).toMatchObject({ id: 'dv1', title: 'title1' });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_default_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_default_data_view.ts
@@ -31,7 +31,7 @@ export interface CreateDefaultDataViewDependencies {
   /**
    * If true, will create the attack data view along with the default and alert data views.
    */
-  attacksAlertAlignment?: boolean;
+  attacksAlertsAlignmentEnabled?: boolean;
 }
 
 export const createDefaultDataView = async ({
@@ -41,7 +41,7 @@ export const createDefaultDataView = async ({
   skip = false,
   http,
   application,
-  attacksAlertAlignment = false,
+  attacksAlertsAlignmentEnabled = false,
 }: CreateDefaultDataViewDependencies) => {
   const configPatternList = uiSettings.get(DEFAULT_INDEX_KEY);
   let defaultDataView: SourcererModel['defaultDataView'];
@@ -85,7 +85,7 @@ export const createDefaultDataView = async ({
         dataViewId: `${DEFAULT_ALERT_DATA_VIEW_ID}-${currentSpaceId}`,
         indexName: signal.name ?? undefined,
       },
-      ...(attacksAlertAlignment && {
+      ...(attacksAlertsAlignmentEnabled && {
         attackDetails: {
           dataViewId: `${DEFAULT_ATTACK_DATA_VIEW_ID}-${currentSpaceId}`,
           patternList: [

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_default_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_default_data_view.ts
@@ -8,12 +8,14 @@
 import type { CoreStart } from '@kbn/core/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public/types';
+import { ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX } from '@kbn/elastic-assistant-common';
 import type { KibanaDataView, SourcererModel } from '../../sourcerer/store/model';
 import { initDataView } from '../../sourcerer/store/model';
 import { createSourcererDataView } from '../../sourcerer/containers/create_sourcerer_data_view';
 import {
-  DEFAULT_DATA_VIEW_ID,
   DEFAULT_ALERT_DATA_VIEW_ID,
+  DEFAULT_ATTACK_DATA_VIEW_ID,
+  DEFAULT_DATA_VIEW_ID,
   DEFAULT_INDEX_KEY,
   DETECTION_ENGINE_INDEX_URL,
 } from '../../../common/constants';
@@ -26,19 +28,25 @@ export interface CreateDefaultDataViewDependencies {
   dataViewService: DataViewsServicePublic;
   spaces: SpacesPluginStart;
   skip?: boolean;
+  /**
+   * If true, will create the attack data view along with the default and alert data views.
+   */
+  attacksAlertAlignment?: boolean;
 }
 
 export const createDefaultDataView = async ({
   uiSettings,
   dataViewService,
   spaces,
-  skip,
+  skip = false,
   http,
   application,
+  attacksAlertAlignment = false,
 }: CreateDefaultDataViewDependencies) => {
   const configPatternList = uiSettings.get(DEFAULT_INDEX_KEY);
   let defaultDataView: SourcererModel['defaultDataView'];
   let alertDataView: SourcererModel['alertDataView'];
+  let attackDataView: SourcererModel['attackDataView'];
   let kibanaDataViews: SourcererModel['kibanaDataViews'];
 
   let signal: { name: string | null; index_mapping_outdated: null | boolean } = {
@@ -51,6 +59,7 @@ export const createDefaultDataView = async ({
       kibanaDataViews: [],
       defaultDataView: { ...initDataView },
       alertDataView: { ...initDataView },
+      attackDataView: { ...initDataView },
       signal,
     };
   }
@@ -63,15 +72,28 @@ export const createDefaultDataView = async ({
       });
     }
 
+    const currentSpaceId = (await spaces?.getActiveSpace())?.id;
+
     // check for/generate default Security Solution Kibana data view
     const sourcererDataView = await createSourcererDataView({
-      body: {
+      dataViewService,
+      defaultDetails: {
+        dataViewId: `${DEFAULT_DATA_VIEW_ID}-${currentSpaceId}`,
         patternList: [...configPatternList, ...(signal.name != null ? [signal.name] : [])],
       },
-      dataViewService,
-      dataViewId: `${DEFAULT_DATA_VIEW_ID}-${(await spaces?.getActiveSpace())?.id}`,
-      alertDataViewId: `${DEFAULT_ALERT_DATA_VIEW_ID}-${(await spaces?.getActiveSpace())?.id}`,
-      signalIndexName: signal.name ?? undefined,
+      alertDetails: {
+        dataViewId: `${DEFAULT_ALERT_DATA_VIEW_ID}-${currentSpaceId}`,
+        indexName: signal.name ?? undefined,
+      },
+      ...(attacksAlertAlignment && {
+        attackDetails: {
+          dataViewId: `${DEFAULT_ATTACK_DATA_VIEW_ID}-${currentSpaceId}`,
+          patternList: [
+            `${ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX}-${currentSpaceId}`,
+            ...(signal.name != null ? [signal.name] : []),
+          ],
+        },
+      }),
     });
 
     if (sourcererDataView === undefined) {
@@ -79,6 +101,7 @@ export const createDefaultDataView = async ({
     }
     defaultDataView = { ...initDataView, ...sourcererDataView.defaultDataView };
     alertDataView = { ...initDataView, ...sourcererDataView.alertDataView };
+    attackDataView = { ...initDataView, ...sourcererDataView.attackDataView };
     kibanaDataViews = sourcererDataView.kibanaDataViews.map((dataView: KibanaDataView) => ({
       ...initDataView,
       ...dataView,
@@ -86,8 +109,9 @@ export const createDefaultDataView = async ({
   } catch (error) {
     defaultDataView = { ...initDataView, error };
     alertDataView = { ...initDataView, error };
+    attackDataView = { ...initDataView, error };
     kibanaDataViews = [];
   }
 
-  return { kibanaDataViews, defaultDataView, alertDataView, signal };
+  return { kibanaDataViews, defaultDataView, alertDataView, attackDataView, signal };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/create_sourcerer_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/create_sourcerer_data_view.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { DataView as DataViewType, DataViewListItem } from '@kbn/data-views-plugin/common';
+import type { DataView, DataViewListItem } from '@kbn/data-views-plugin/common';
 import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public/types';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { ensurePatternFormat } from '../../../common/utils/sourcerer';
@@ -13,49 +13,35 @@ import type { KibanaDataView } from '../store/model';
 import { DEFAULT_TIME_FIELD } from '../../../common/constants';
 import {
   DEFAULT_SECURITY_ALERT_DATA_VIEW,
+  DEFAULT_SECURITY_ATTACK_DATA_VIEW,
   DEFAULT_SECURITY_DATA_VIEW,
 } from '../../data_view_manager/components/data_view_picker/translations';
 
-export interface GetSourcererDataView {
-  signal?: AbortSignal;
-  body: {
-    patternList: string[];
-  };
-  dataViewService: DataViewsServicePublic;
-  dataViewId: string | null;
-  alertDataViewId?: string;
-  signalIndexName?: string;
-}
-
-export interface SecurityDataView {
-  defaultDataView: KibanaDataView;
-  alertDataView: KibanaDataView;
-  kibanaDataViews: Array<Omit<KibanaDataView, 'fields'>>;
-}
-
-// eslint-disable-next-line complexity
-export const createSourcererDataView = async ({
-  body,
+/**
+ * Creates the default data view used by security solution.
+ * If the data view already exists, it will update the pattern list if it is different
+ * or the name if it is incorrect.
+ */
+const getDefaultDataView = async ({
   dataViewService,
+  allDataViews,
   dataViewId,
-  alertDataViewId,
-  signalIndexName,
-}: GetSourcererDataView): Promise<SecurityDataView | undefined> => {
-  if (dataViewId === null) {
-    return;
-  }
-  let allDataViews: DataViewListItem[] = await dataViewService.getIdsWithTitle();
-  const siemDataViewExist = allDataViews.find((dv) => dv.id === dataViewId);
-  const alertDataViewExist = allDataViews.find((dv) => dv.id === alertDataViewId);
-
-  const { patternList } = body;
-  const patternListFormatted = ensurePatternFormat(patternList);
-  const patternListAsTitle = patternListFormatted.join();
-  let siemDataView: DataViewType;
+  patternListFormatted,
+  patternListAsTitle,
+}: {
+  dataViewService: DataViewsServicePublic;
+  allDataViews: DataViewListItem[];
+  dataViewId: string;
+  patternListFormatted: string[];
+  patternListAsTitle: string;
+}): Promise<KibanaDataView> => {
   let defaultDataView: KibanaDataView;
+  let dataView: DataView;
+
+  const siemDataViewExist = allDataViews.find((dv) => dv.id === dataViewId);
   if (siemDataViewExist === undefined) {
     try {
-      siemDataView = await dataViewService.createAndSave(
+      dataView = await dataViewService.createAndSave(
         {
           allowNoIndex: true,
           id: dataViewId,
@@ -70,15 +56,15 @@ export const createSourcererDataView = async ({
     } catch (err) {
       const error = transformError(err);
       if (err.name === 'DuplicateDataViewError' || error.statusCode === 409) {
-        siemDataView = await dataViewService.get(dataViewId);
+        dataView = await dataViewService.get(dataViewId);
       } else {
         throw error;
       }
     }
     defaultDataView = {
-      id: siemDataView.id ?? dataViewId,
-      patternList: siemDataView.title.split(','),
-      title: siemDataView.title,
+      id: dataView.id ?? dataViewId,
+      patternList: dataView.title.split(','),
+      title: dataView.title,
     };
   } else {
     let patterns = ensurePatternFormat(siemDataViewExist.title.split(','));
@@ -88,18 +74,18 @@ export const createSourcererDataView = async ({
 
     // Update the saved object if the pattern list is different or the name is incorrect
     if (arePatternsDifferent || !isDefaultDataViewName) {
-      siemDataView = await dataViewService.get(dataViewId);
+      dataView = await dataViewService.get(dataViewId);
 
       if (arePatternsDifferent) {
         patterns = patternListFormatted;
-        siemDataView.title = patternListAsTitle;
+        dataView.title = patternListAsTitle;
       }
 
       if (!isDefaultDataViewName) {
-        siemDataView.name = DEFAULT_SECURITY_DATA_VIEW;
+        dataView.name = DEFAULT_SECURITY_DATA_VIEW;
       }
 
-      await dataViewService.updateSavedObject(siemDataView);
+      await dataViewService.updateSavedObject(dataView);
     }
 
     defaultDataView = {
@@ -109,15 +95,42 @@ export const createSourcererDataView = async ({
     };
   }
 
-  let alertOnlyDataView: DataViewType;
+  const existingPatternList = await dataViewService.getExistingIndices(defaultDataView.patternList);
+  defaultDataView = {
+    ...defaultDataView,
+    patternList: existingPatternList,
+  };
+
+  return defaultDataView;
+};
+
+/**
+ * Creates the alert data view used by security solution.
+ * If the data view already exists, it will update the name if it is incorrect.
+ */
+const getAlertDataView = async ({
+  dataViewService,
+  allDataViews,
+  alertDetails: { dataViewId, indexName },
+}: {
+  dataViewService: DataViewsServicePublic;
+  allDataViews: DataViewListItem[];
+  alertDetails: {
+    dataViewId?: string;
+    indexName?: string;
+  };
+}): Promise<KibanaDataView> => {
   let alertDataView: KibanaDataView;
-  if (signalIndexName && alertDataViewId && alertDataViewExist === undefined) {
+  let dataView: DataView;
+
+  const dataViewExist = allDataViews.find((dv) => dv.id === dataViewId);
+  if (indexName && dataViewId && dataViewExist === undefined) {
     try {
-      alertOnlyDataView = await dataViewService.createAndSave(
+      dataView = await dataViewService.createAndSave(
         {
           allowNoIndex: true,
-          id: alertDataViewId,
-          title: signalIndexName,
+          id: dataViewId,
+          title: indexName,
           timeFieldName: DEFAULT_TIME_FIELD,
           name: DEFAULT_SECURITY_ALERT_DATA_VIEW,
           managed: true,
@@ -129,29 +142,151 @@ export const createSourcererDataView = async ({
     } catch (err) {
       const error = transformError(err);
       if (err.name === 'DuplicateDataViewError' || error.statusCode === 409) {
-        alertOnlyDataView = await dataViewService.get(alertDataViewId);
+        dataView = await dataViewService.get(dataViewId);
       } else {
         throw error;
       }
     }
     alertDataView = {
-      id: alertOnlyDataView.id ?? alertDataViewId,
-      patternList: alertOnlyDataView.title.split(','),
-      title: alertOnlyDataView.title,
+      id: dataView.id ?? dataViewId,
+      patternList: dataView.title.split(','),
+      title: dataView.title,
     };
   } else {
     // Update the saved object if the name is incorrect
-    if (alertDataViewId && alertDataViewExist?.name !== DEFAULT_SECURITY_ALERT_DATA_VIEW) {
-      siemDataView = await dataViewService.get(alertDataViewId);
-      siemDataView.name = DEFAULT_SECURITY_ALERT_DATA_VIEW;
-      await dataViewService.updateSavedObject(siemDataView);
+    if (dataViewId && dataViewExist?.name !== DEFAULT_SECURITY_ALERT_DATA_VIEW) {
+      const dv = await dataViewService.get(dataViewId);
+      dv.name = DEFAULT_SECURITY_ALERT_DATA_VIEW;
+      await dataViewService.updateSavedObject(dv);
     }
 
     alertDataView = {
-      id: alertDataViewId ?? '',
-      patternList: signalIndexName ? [signalIndexName] : [],
-      title: signalIndexName ?? '',
+      id: dataViewId ?? '',
+      patternList: indexName ? [indexName] : [],
+      title: indexName ?? '',
     };
+  }
+
+  return alertDataView;
+};
+
+/**
+ * Creates the attack data view used by security solution.
+ */
+const getAttackDataView = async ({
+  dataViewService,
+  allDataViews,
+  attackDetails: { dataViewId, patternList },
+}: {
+  dataViewService: DataViewsServicePublic;
+  allDataViews: DataViewListItem[];
+  attackDetails: {
+    dataViewId?: string;
+    patternList?: string[];
+  };
+}): Promise<KibanaDataView> => {
+  let attackDataView: KibanaDataView;
+  let dataView: DataView;
+
+  const dataViewExist = allDataViews.find((dv) => dv.id === dataViewId);
+  if (patternList && dataViewId && dataViewExist === undefined) {
+    const patternListFormatted = ensurePatternFormat(patternList);
+    const patternListAsTitle = patternListFormatted.join();
+
+    try {
+      dataView = await dataViewService.createAndSave(
+        {
+          allowNoIndex: true,
+          id: dataViewId,
+          title: patternListAsTitle,
+          timeFieldName: DEFAULT_TIME_FIELD,
+          name: DEFAULT_SECURITY_ATTACK_DATA_VIEW,
+          managed: true,
+        },
+        // Override property - if a data view exists with the security solution pattern
+        // delete it and replace it with our data view
+        true
+      );
+    } catch (err) {
+      const error = transformError(err);
+      if (err.name === 'DuplicateDataViewError' || error.statusCode === 409) {
+        dataView = await dataViewService.get(dataViewId);
+      } else {
+        throw error;
+      }
+    }
+    attackDataView = {
+      id: dataView.id ?? dataViewId,
+      patternList: dataView.title.split(','),
+      title: dataView.title,
+    };
+  } else {
+    attackDataView = {
+      id: dataViewId ?? '',
+      patternList: patternList ? patternList : [],
+      title: patternList ? patternList.join() : '',
+    };
+  }
+
+  return attackDataView;
+};
+
+export interface SecurityDataView {
+  defaultDataView: KibanaDataView;
+  alertDataView: KibanaDataView;
+  attackDataView?: KibanaDataView; // TODO remove optional when we remove the attacksAlertAlignment feature flag
+  kibanaDataViews: Array<Omit<KibanaDataView, 'fields'>>;
+}
+
+/**
+ * Returns sourcerer data view used by security solution.
+ * Creates the default, alert, and attack data views if they do not exist.
+ */
+export const createSourcererDataView = async ({
+  dataViewService,
+  defaultDetails: { dataViewId, patternList },
+  alertDetails,
+  attackDetails,
+}: {
+  dataViewService: DataViewsServicePublic;
+  defaultDetails: {
+    dataViewId: string | null;
+    patternList: string[];
+  };
+  alertDetails: {
+    dataViewId?: string;
+    indexName?: string;
+  };
+  attackDetails?: {
+    dataViewId?: string;
+    patternList?: string[];
+  };
+}): Promise<SecurityDataView | undefined> => {
+  if (dataViewId === null) {
+    return;
+  }
+  let allDataViews: DataViewListItem[] = await dataViewService.getIdsWithTitle();
+
+  const patternListFormatted = ensurePatternFormat(patternList);
+  const patternListAsTitle = patternListFormatted.join();
+
+  const defaultDataView = await getDefaultDataView({
+    dataViewService,
+    allDataViews,
+    dataViewId,
+    patternListFormatted,
+    patternListAsTitle,
+  });
+
+  const alertDataView = await getAlertDataView({
+    dataViewService,
+    allDataViews,
+    alertDetails,
+  });
+
+  let attackDataView: KibanaDataView | undefined;
+  if (attackDetails) {
+    attackDataView = await getAttackDataView({ dataViewService, allDataViews, attackDetails });
   }
 
   if (allDataViews.some((dv) => dv.id === dataViewId)) {
@@ -161,12 +296,6 @@ export const createSourcererDataView = async ({
   } else if (defaultDataView !== null) {
     allDataViews.push({ id: defaultDataView.id ?? dataViewId, title: defaultDataView?.title });
   }
-
-  const existingPatternList = await dataViewService.getExistingIndices(defaultDataView.patternList);
-  defaultDataView = {
-    ...defaultDataView,
-    patternList: existingPatternList,
-  };
 
   return {
     defaultDataView,
@@ -180,5 +309,6 @@ export const createSourcererDataView = async ({
           }
     ),
     alertDataView,
+    ...(attackDataView && { attackDataView }),
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/create_sourcerer_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/create_sourcerer_data_view.ts
@@ -234,7 +234,7 @@ const getAttackDataView = async ({
 export interface SecurityDataView {
   defaultDataView: KibanaDataView;
   alertDataView: KibanaDataView;
-  attackDataView?: KibanaDataView; // TODO remove optional when we remove the attacksAlertAlignment feature flag
+  attackDataView?: KibanaDataView; // TODO remove optional when we remove the attacksAlertsAlignment feature flag
   kibanaDataViews: Array<Omit<KibanaDataView, 'fields'>>;
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx
@@ -237,10 +237,12 @@ export const useInitSourcerer = (
 
         try {
           const response = await createSourcererDataView({
-            body: { patternList: newPatternList },
-            signal: abortCtrl.current.signal,
             dataViewService: dataViews,
-            dataViewId,
+            defaultDetails: {
+              dataViewId,
+              patternList: newPatternList,
+            },
+            alertDetails: {},
           });
 
           if (response?.defaultDataView.patternList.includes(newSignalsIndex)) {

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_signal_helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_signal_helpers.tsx
@@ -8,7 +8,7 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 import { useDispatch, useSelector } from 'react-redux';
-import { sourcererSelectors, sourcererActions } from '../store';
+import { sourcererActions, sourcererSelectors } from '../store';
 import { useSourcererDataView } from '.';
 import { SourcererScopeName } from '../store/model';
 import { useDataView as useOldDataView } from '../../common/containers/source/use_data_view';
@@ -77,10 +77,12 @@ export const useSignalHelpers = (): {
       abortCtrl.current = new AbortController();
       try {
         const sourcererDataView = await createSourcererDataView({
-          body: { patternList: defaultDataViewPattern.split(',') },
-          signal: abortCtrl.current.signal,
-          dataViewId,
           dataViewService: dataViews,
+          defaultDetails: {
+            dataViewId,
+            patternList: defaultDataViewPattern.split(','),
+          },
+          alertDetails: {},
         });
 
         if (

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/model.ts
@@ -109,6 +109,8 @@ export interface SourcererModel {
   defaultDataView: SourcererDataView & { id: string; error?: unknown };
   /** default security-solution alert data view */
   alertDataView: SourcererDataView & { id: string; error?: unknown };
+  /** default security-solution attack data view */
+  attackDataView: SourcererDataView & { id: string; error?: unknown };
   /** all Kibana data views, including security-solution */
   kibanaDataViews: SourcererDataView[];
   /** security solution signals index name */
@@ -146,6 +148,7 @@ export const initDataView: SourcererDataView & { id: string; error?: unknown } =
 export const initialSourcererState: SourcererModel = {
   defaultDataView: initDataView,
   alertDataView: initDataView,
+  attackDataView: initDataView,
   kibanaDataViews: [],
   signalIndexName: null,
   signalIndexMappingOutdated: null,


### PR DESCRIPTION
## Summary

This PR adds a new managed dataview for the Attacks screen. The dataview must have the following indices:
- the alert index for the current space (`.alerts-security.alerts-myCurrentIndex`)
- the attack index for the current space (`.alerts-security.attack.discovery.alerts-myCurrentIndex`)

<img width="773" height="541" alt="Screenshot 2025-10-13 at 6 01 36 PM" src="https://github.com/user-attachments/assets/e2b70b21-f285-47e2-b8e1-608b684c74f0" />

The attack view creation is protected behind the `attacksAlertAlignment` feature flag.

With flag off, no data view is created

https://github.com/user-attachments/assets/84103279-0f6b-4c11-b49d-fd8397ab1dbd

With the flag on, we create the attack data view

https://github.com/user-attachments/assets/5b089890-5eac-42e2-a82f-e1a568fb1b91


The PR also takes the opportunity to clean up and improve some of the code related to the dataview creation:
- split the `createSourcererDataView` function into 3 blocks to make the code easier to read
- change the props of the `createSourcererDataView` to group things together for default, alerts and attacks dataviews

## How to test

- turn the `attacksAlertAlignment` feature flag on
- navigate to any Security Solution page
- verify that the attack data view has been created

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/232589