### PR TITLE
[Security solution] removes old unused feature flags

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -12,7 +12,6 @@ export type ExperimentalFeatures = { [K in keyof typeof allowedExperimentalValue
  * This object is then used to validate and parse the value entered.
  */
 export const allowedExperimentalValues = Object.freeze({
-  kubernetesEnabled: false,
   donutChartEmbeddablesEnabled: false, // Depends on https://github.com/elastic/kibana/issues/136409 item 2 - 6
 
   /**
@@ -131,25 +130,6 @@ export const allowedExperimentalValues = Object.freeze({
   protectionUpdatesEnabled: true,
 
   /**
-   * Disables the timeline save tour.
-   * This flag is used to disable the tour in cypress tests.
-   */
-  disableTimelineSaveTour: false,
-
-  /**
-   * Enables the risk engine privileges route
-   * and associated callout in the UI
-   */
-  riskEnginePrivilegesRouteEnabled: true,
-
-  /**
-   * Enables SentinelOne manual host isolation response actions directly through the connector
-   * sub-actions framework.
-   * v8.12.0
-   */
-  sentinelOneManualHostActionsEnabled: true,
-
-  /**
    * Enables Response actions telemetry collection
    * Should be enabled in 8.17.0
    */
@@ -201,22 +181,10 @@ export const allowedExperimentalValues = Object.freeze({
   doesNotMatchForIndicatorMatchRuleEnabled: true,
 
   /**
-   * Enables the new data ingestion hub
-   */
-  dataIngestionHubEnabled: false,
-
-  /**
    * Disables Security's Entity Store engine routes. The Entity Store feature is available by default, but
    * can be disabled if necessary in a given environment.
    */
   entityStoreDisabled: false,
-
-  /**
-   * Enables the Service Entity Store. The Entity Store feature will install the service engine by default.
-   */
-  serviceEntityStoreEnabled: true,
-  /**
-
 
   /**
    * Disables the siem migrations feature

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/policy/policy_details.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/policy/policy_details.cy.ts
@@ -25,15 +25,6 @@ describe(
       // skipped on MKI since feature flags are not supported there
       '@skipInServerlessMKI',
     ],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'sentinelOneManualHostActionsEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   () => {
     const getAutomaticUpdatesToggle = () => cy.getByTestSubj('protection-updates-manifest-switch');

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/sentinelone/isolate.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/sentinelone/isolate.cy.ts
@@ -10,7 +10,7 @@ import { openAlertDetailsView } from '../../screens/alerts';
 import { closeAllToasts } from '../../tasks/toasts';
 import { toggleRuleOffAndOn, visitRuleAlerts } from '../../tasks/isolate';
 import { cleanupRule, loadRule } from '../../tasks/api_fixtures';
-import { ROLE, login } from '../../tasks/login';
+import { login, ROLE } from '../../tasks/login';
 import { waitForAlertsToPopulate } from '../../tasks/alerts';
 
 describe.skip(
@@ -20,9 +20,6 @@ describe.skip(
     env: {
       ftrConfig: {
         kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'sentinelOneManualHostActionsEnabled',
-          ])}`,
           `--xpack.stack_connectors.enableExperimental=${JSON.stringify([
             'sentinelOneConnectorOn',
           ])}`,


### PR DESCRIPTION
## Summary

This PR removes 4 unused feature flags:
- `kubernetesEnabled`, last modified in 2024, is nowhere in the codebase
- `disableTimelineSaveTour`, `riskEnginePrivilegesRouteEnabled`, both last modified in 2023, are also nowhere in the codebase
- `sentinelOneManualHostActionsEnabled`, last modified in 2024, is only in 2 Cypress tests (but is already set to `true` by default)

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
