### PR TITLE
[Security solution] removes automatedProcessActionsEnabled feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -40,11 +40,6 @@ export const allowedExperimentalValues = Object.freeze({
   socTrendsEnabled: false,
 
   /**
-   * Enables Automated Endpoint Process actions
-   */
-  automatedProcessActionsEnabled: true,
-
-  /**
    * Enables use of SentinelOne response actions that complete asynchronously
    *
    * Release: v8.14.0

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/action_type_field.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/action_type_field.tsx
@@ -13,7 +13,6 @@ import { SuperSelectField } from '@kbn/es-ui-shared-plugin/static/forms/componen
 import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiLink } from '@elastic/eui';
-import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { getRbacControl } from '../../../../common/endpoint/service/response_actions/utils';
 import { useKibana } from '../../../common/lib/kibana';
 import { CHOOSE_FROM_THE_LIST, LEARN_MORE } from './translations';
@@ -30,6 +29,11 @@ interface ActionTypeFieldProps {
   readDefaultValueOnForm: boolean;
 }
 
+const enabledActions = [
+  ...ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS,
+  ...['kill-process', 'suspend-process'],
+] as ['isolate', 'kill-process', 'suspend-process'];
+
 const ActionTypeFieldComponent = ({
   basePath,
   disabled,
@@ -44,19 +48,6 @@ const ActionTypeFieldComponent = ({
       },
     },
   } = useKibana().services;
-
-  const automatedProcessActionsEnabled = useIsExperimentalFeatureEnabled(
-    'automatedProcessActionsEnabled'
-  );
-
-  const enabledActions = useMemo(
-    () =>
-      [
-        ...ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS,
-        ...(automatedProcessActionsEnabled ? ['kill-process', 'suspend-process'] : []),
-      ] as ['isolate', 'kill-process', 'suspend-process'],
-    [automatedProcessActionsEnabled]
-  );
 
   const fieldOptions = useMemo(
     () =>
@@ -78,7 +69,7 @@ const ActionTypeFieldComponent = ({
           'data-test-subj': `command-type-${name}`,
         };
       }),
-    [data.responseActions, enabledActions, endpointPrivileges]
+    [data.responseActions, endpointPrivileges]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/automated_response_actions.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/automated_response_actions.cy.ts
@@ -24,15 +24,6 @@ describe(
   'Automated Response Actions',
   {
     tags: ['@ess', '@serverless'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'automatedProcessActionsEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   () => {
     let indexedPolicy: IndexedFleetEndpointPolicyResponse;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/form.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/form.cy.ts
@@ -7,13 +7,13 @@
 
 import {
   addEndpointResponseAction,
+  fillUpNewEsqlRule,
   fillUpNewRule,
   focusAndOpenCommandDropdown,
+  selectIsolateAndSaveWithoutEnabling,
   tryAddingDisabledResponseAction,
   validateAvailableCommands,
   visitRuleActions,
-  selectIsolateAndSaveWithoutEnabling,
-  fillUpNewEsqlRule,
 } from '../../tasks/response_actions';
 import { cleanupRule, generateRandomStringName, loadRule } from '../../tasks/api_fixtures';
 import { ResponseActionTypesEnum } from '../../../../../common/api/detection_engine';
@@ -25,15 +25,6 @@ describe(
   'Form',
   {
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'automatedProcessActionsEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   () => {
     describe('User with no access can not create an endpoint response action', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/response_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/response_actions.ts
@@ -11,6 +11,7 @@ import { loadPage, request } from './common';
 import { resolvePathVariables } from '../../../common/utils/resolve_path_variables';
 import {
   ACTION_DETAILS_ROUTE,
+  CANCEL_ROUTE,
   EXECUTE_ROUTE,
   GET_FILE_ROUTE,
   GET_PROCESSES_ROUTE,
@@ -21,24 +22,17 @@ import {
   SUSPEND_PROCESS_ROUTE,
   UNISOLATE_HOST_ROUTE_V2,
   UPLOAD_ROUTE,
-  CANCEL_ROUTE,
 } from '../../../../common/endpoint/constants';
 import type { ActionDetails, ActionDetailsApiResponse } from '../../../../common/endpoint/types';
 import type { ResponseActionsApiCommandNames } from '../../../../common/endpoint/service/response_actions/constants';
 import { ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS } from '../../../../common/endpoint/service/response_actions/constants';
 
+const enabledActions = [
+  ...ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS,
+  ...['kill-process', 'suspend-process'],
+];
+
 export const validateAvailableCommands = () => {
-  // TODO: TC- use ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS when we go GA with automated process actions
-  const config = Cypress.config();
-  const automatedActionsPAttern = /automatedProcessActionsEnabled/;
-  const automatedProcessActionsEnabled =
-    config.env.ftrConfig.kbnServerArgs[0].match(automatedActionsPAttern);
-
-  const enabledActions = [
-    ...ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS,
-    ...(automatedProcessActionsEnabled ? ['kill-process', 'suspend-process'] : []),
-  ];
-
   cy.get('[data-test-subj^="command-type"]').should('have.length', enabledActions.length);
   enabledActions.forEach((command) => {
     cy.getByTestSubj(`command-type-${command}`);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_response_actions/endpoint_response_action.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_response_actions/endpoint_response_action.ts
@@ -10,8 +10,8 @@ import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import { EndpointError } from '../../../../common/endpoint/errors';
 import { stringify } from '../../../endpoint/utils/stringify';
 import type {
-  RuleResponseEndpointAction,
   ProcessesParams,
+  RuleResponseEndpointAction,
 } from '../../../../common/api/detection_engine';
 import { getErrorProcessAlerts, getIsolateAlerts, getProcessAlerts } from './utils';
 import type { AlertsAction, ResponseActionAlerts } from './types';
@@ -56,9 +56,6 @@ export const endpointResponseAction = async (
     username: 'unknown',
     spaceId,
   });
-
-  const automatedProcessActionsEnabled =
-    endpointAppContextService.experimentalFeatures.automatedProcessActionsEnabled;
 
   const processResponseActionClientError = (err: Error, endpointIds: string[]): Promise<void> => {
     errors.push(
@@ -110,58 +107,55 @@ export const endpointResponseAction = async (
 
     case 'suspend-process':
     case 'kill-process':
-      if (automatedProcessActionsEnabled) {
-        const processesActionRuleConfig: ProcessesParams['config'] = (
-          responseAction.params as ProcessesParams
-        ).config;
+      const processesActionRuleConfig: ProcessesParams['config'] = (
+        responseAction.params as ProcessesParams
+      ).config;
 
-        const createProcessActionFromAlerts = (
-          actionAlerts: Record<string, Record<string, AlertsAction>>
-        ) => {
-          return each(actionAlerts, (actionPerAgent) => {
-            return each(
-              actionPerAgent,
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              ({ endpoint_ids, alert_ids, parameters, error, hosts }: AlertsAction) => {
-                logger.info(
-                  `${logMsgPrefix} [${command}] [${endpoint_ids.length}] agent(s): ${stringify(
-                    endpoint_ids
-                  )}`
-                );
+      const createProcessActionFromAlerts = (
+        actionAlerts: Record<string, Record<string, AlertsAction>>
+      ) => {
+        return each(actionAlerts, (actionPerAgent) => {
+          return each(
+            actionPerAgent,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            ({ endpoint_ids, alert_ids, parameters, error, hosts }: AlertsAction) => {
+              logger.info(
+                `${logMsgPrefix} [${command}] [${endpoint_ids.length}] agent(s): ${stringify(
+                  endpoint_ids
+                )}`
+              );
 
-                return responseActionsClient[
-                  command === 'kill-process' ? 'killProcess' : 'suspendProcess'
-                ](
-                  {
-                    comment,
-                    endpoint_ids,
-                    alert_ids,
-                    parameters: parameters as
-                      | ResponseActionParametersWithPid
-                      | ResponseActionParametersWithEntityId,
-                  },
-                  {
-                    hosts,
-                    ruleId,
-                    ruleName,
-                    error,
-                  }
-                ).catch((err) => {
-                  return processResponseActionClientError(err, endpoint_ids);
-                });
-              }
-            );
-          });
-        };
+              return responseActionsClient[
+                command === 'kill-process' ? 'killProcess' : 'suspendProcess'
+              ](
+                {
+                  comment,
+                  endpoint_ids,
+                  alert_ids,
+                  parameters: parameters as
+                    | ResponseActionParametersWithPid
+                    | ResponseActionParametersWithEntityId,
+                },
+                {
+                  hosts,
+                  ruleId,
+                  ruleName,
+                  error,
+                }
+              ).catch((err) => {
+                return processResponseActionClientError(err, endpoint_ids);
+              });
+            }
+          );
+        });
+      };
 
-        const foundFields = getProcessAlerts(alerts, processesActionRuleConfig);
-        const notFoundField = getErrorProcessAlerts(alerts, processesActionRuleConfig);
-        const processActions = createProcessActionFromAlerts(foundFields);
-        const processActionsWithError = createProcessActionFromAlerts(notFoundField);
+      const foundFields = getProcessAlerts(alerts, processesActionRuleConfig);
+      const notFoundField = getErrorProcessAlerts(alerts, processesActionRuleConfig);
+      const processActions = createProcessActionFromAlerts(foundFields);
+      const processActionsWithError = createProcessActionFromAlerts(notFoundField);
 
-        response.push(Promise.all([processActions, processActionsWithError]));
-      }
-
+      response.push(Promise.all([processActions, processActionsWithError]));
       break;
 
     default:

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_response_actions/schedule_notification_response_actions.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_response_actions/schedule_notification_response_actions.test.ts
@@ -13,6 +13,7 @@ import { createMockEndpointAppContextService } from '../../../endpoint/mocks';
 import { responseActionsClientMock } from '../../../endpoint/services/actions/clients/mocks';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import type { Logger } from '@kbn/logging';
+
 describe('ScheduleNotificationResponseActions', () => {
   const getSignals = () => [
     {
@@ -42,8 +43,6 @@ describe('ScheduleNotificationResponseActions', () => {
   (endpointServiceMock.getInternalResponseActionsClient as jest.Mock).mockImplementation(() => {
     return mockedResponseActionsClient;
   });
-  // @ts-expect-error assignment to readonly property
-  endpointServiceMock.experimentalFeatures.automatedProcessActionsEnabled = true;
 
   const scheduleNotificationResponseActions = getScheduleNotificationResponseActionsService({
     osqueryCreateActionService: osqueryActionMock,


### PR DESCRIPTION
## Summary

This PR removes the `automatedProcessActionsEnabled` feature flag, which has been set to true for over a year now.

> [!NOTE]
> If for some reason we still need this feature flag, feel free to close this PR

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
