### PR TITLE
[Automatic Migrations] Update copies for SIEM dashboards migration (#14168)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/start_migration_modal/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/start_migration_modal/index.tsx
@@ -141,7 +141,7 @@ export const StartMigrationModal: FC<StartMigrationModalProps> = React.memo(
                 helpText={
                   <FormattedMessage
                     id="xpack.securitySolution.siemMigrations.reprocessFailedDialog.connectorHelpText"
-                    defaultMessage={'To setup other LLM connectors, visit {link}.'}
+                    defaultMessage={'To set up other LLM connectors, visit {link}.'}
                     values={{
                       link: (
                         /* eslint-disable-next-line @elastic/eui/href-or-on-click */
@@ -170,6 +170,7 @@ export const StartMigrationModal: FC<StartMigrationModalProps> = React.memo(
               <EuiFlexGroup justifyContent="flexEnd">
                 <EuiFlexItem grow={false}>
                   <EuiButtonEmpty
+                    aria-label={i18n.START_MIGRATION_MODAL_CANCEL}
                     onClick={closeModal}
                     data-test-subj={`${DATA_TEST_SUBJ_PREFIX}-Cancel`}
                   >

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/actions.tsx
@@ -82,8 +82,8 @@ export const createActionsColumn = ({
           <FormattedMessage
             id="xpack.securitySolution.siemMigrations.dashboards.tableColumn.actionsTooltip"
             defaultMessage="{title}
-            {view} - go to the installed Dashboard. {lineBreak}
-            {install} - install Dashboard to view and edit it. {lineBreak}"
+            {view} - go to the installed dashboard.{lineBreak}
+            {install} - install dashboard to view and edit it."
             values={{
               lineBreak: <br />,
               title: (

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/status.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/status.tsx
@@ -29,10 +29,10 @@ export const createStatusColumn = (): TableColumn => {
           <FormattedMessage
             id="xpack.securitySolution.siemMigrations.dashboards.tableColumn.statusTooltip"
             defaultMessage={`{title}
-            {installed} - already added to Elastic SIEM. Click "View" to manage and enable it.{lineBreak}
+            {installed} - already added to Dashboards with a tag of “Migrated from Splunk”.{lineBreak}
             {translated} - ready to install. This dashboard was translated by AI.{lineBreak}
-            {partiallyTranslated} - part of the query could not be translated. Upload any missing macros or lookups and check your syntax.{lineBreak}
-            {notTranslated} - none of the original query could be translated.`}
+            {partiallyTranslated} - part of the dashboard could not be translated.{lineBreak}
+            {notTranslated} - none of the original dashboard could be translated.`}
             values={{
               lineBreak: <br />,
               title: (

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/tags.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/tags.tsx
@@ -21,7 +21,7 @@ export const createTagsColumn = (): TableColumn => {
       <TableHeader
         id={SIEM_DASHBOARDS_MIGRATIONS_TAGS_HEADER_ID}
         title={i18n.COLUMN_TAGS}
-        tooltipContent={i18n.COLUMN_TAGS}
+        tooltipContent={i18n.TAGS_COLUMN_TOOLTIP}
       />
     ),
     render: (value: DashboardMigrationDashboard['original_dashboard']['splunk_properties']) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/translations.ts
@@ -76,3 +76,18 @@ export const VIEW_DASHBOARD_TRANSLATION_SUMMARY_TOOLTIP = i18n.translate(
     defaultMessage: 'View dashboard translation summary',
   }
 );
+
+export const UPDATE_COLUMN_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.siemMigrations.dashboards.updateColumnTooltip',
+  {
+    defaultMessage:
+      'This column references the date in the dashboard when last modified in the source platform.',
+  }
+);
+
+export const TAGS_COLUMN_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.siemMigrations.dashboards.tagsColumnTooltip',
+  {
+    defaultMessage: 'Tags reference the app the dashboard originated from.',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/updated.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table_columns/updated.tsx
@@ -21,7 +21,7 @@ export const createUpdatedColumn = (): TableColumn => {
       <TableHeader
         id={SIEM_DASHBOARDS_MIGRATIONS_UPDATED_HEADER_ID}
         title={i18n.COLUMN_UPDATED}
-        tooltipContent={i18n.COLUMN_UPDATED}
+        tooltipContent={i18n.UPDATE_COLUMN_TOOLTIP}
       />
     ),
     render: (value: DashboardMigrationDashboard['original_dashboard']['last_updated']) => (

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/hooks/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/hooks/translations.ts
@@ -10,15 +10,14 @@ import { i18n } from '@kbn/i18n';
 export const START_DASHBOARDS_MIGRATION_DIALOG_TITLE = i18n.translate(
   'xpack.securitySolution.siemMigrations.dashboards.startMigrationDialog.title',
   {
-    defaultMessage: 'Start dashboards migration',
+    defaultMessage: 'Migrate dashboards',
   }
 );
 
 export const START_DASHBOARDS_MIGRATION_DIALOG_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.siemMigrations.dashboards.startMigrationDialog.description',
   {
-    defaultMessage:
-      'You are about to start dashboards migration and this will incur additional tokens. You have option to choose a different LLM. This option applies only to the current execution.',
+    defaultMessage: 'You are about to start a migration. Select which AI connector to use.',
   }
 );
 
@@ -33,7 +32,7 @@ export const RETRY_DASHBOARDS_MIGRATION_DIALOG_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.siemMigrations.dashboards.retryMigrationDialog.description',
   {
     defaultMessage:
-      'You are about to retry dashboards migration and this will incur additional tokens. You have option to choose a different LLM. This option applies only to the current execution.',
+      'You are about to retry a migration, which will use additional tokens. Select which AI connector to use.',
   }
 );
 
@@ -47,6 +46,6 @@ export const REPROCESS_DASHBOARDS_MIGRATION_DIALOG_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.siemMigrations.dashboards.reprocessDialog.description',
   {
     defaultMessage:
-      'You are about to reprocess selected dashboards and this will incur additional tokens. You have option to choose a different LLM. This option applies only to the current execution.',
+      'You are about to reprocess a migration, which will use additional tokens. Select which AI connector to use.',
   }
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/hooks/use_start_dashboard_migration_modal.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/hooks/use_start_dashboard_migration_modal.test.tsx
@@ -69,7 +69,7 @@ describe('useStartDashboardsMigrationModal', () => {
 
     rerender();
 
-    expect(result.current.modal?.props.title).toEqual('Start dashboards migration');
+    expect(result.current.modal?.props.title).toEqual('Migrate dashboards');
   });
 
   it('should have correct title for "retry" type', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/links.ts
@@ -25,8 +25,7 @@ const subLinks: LinkItem[] = [
       defaultMessage: 'Translated rules',
     }),
     description: i18n.translate('xpack.securitySolution.appLinks.siemMigrationsRules.description', {
-      defaultMessage:
-        'Our generative AI powered Automatic migration tool automates some of the most time consuming migrations tasks and processes.',
+      defaultMessage: 'Migrate your SIEM rules to Elastic using AI powered Automatic migration.',
     }),
     landingIcon: IconRules,
     path: SIEM_MIGRATIONS_RULES_PATH,
@@ -43,8 +42,7 @@ const subLinks: LinkItem[] = [
     description: i18n.translate(
       'xpack.securitySolution.appLinks.siemMigrationsDashboards.description',
       {
-        defaultMessage:
-          'Our generative AI powered Automatic migration tool automates some of the most time consuming migrations tasks and processes.',
+        defaultMessage: 'Migrate your dashboards to Elastic using AI powered Automatic migration.',
       }
     ),
     landingIcon: IconDashboards,

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/hooks/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/hooks/translations.ts
@@ -10,15 +10,14 @@ import { i18n } from '@kbn/i18n';
 export const START_RULES_MIGRATION_DIALOG_TITLE = i18n.translate(
   'xpack.securitySolution.siemMigrations.rules.startMigrationDialog.title',
   {
-    defaultMessage: 'Start rules migration',
+    defaultMessage: 'Migrate rules',
   }
 );
 
 export const START_RULES_MIGRATION_DIALOG_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.siemMigrations.rules.startMigrationDialog.description',
   {
-    defaultMessage:
-      "You are about to start rules migration and this will incur additional tokens. You have option to choose a different LLM and to switch off mapping to Elastic's prebuilt rules. These options apply only to the current execution.",
+    defaultMessage: 'You are about to start a migration. Select which AI connector to use.',
   }
 );
 
@@ -33,7 +32,7 @@ export const RETRY_RULES_MIGRATION_DIALOG_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.siemMigrations.rules.retryMigrationDialog.description',
   {
     defaultMessage:
-      "You are about to retry rules migration and this will incur additional tokens. You have option to choose a different LLM and to switch off mapping to Elastic's prebuilt rules. These options apply only to the current execution.",
+      'You are about to retry a migration, which will use additional tokens. Select which AI connector to use.',
   }
 );
 
@@ -47,7 +46,7 @@ export const REPROCESS_RULES_MIGRATION_DIALOG_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.siemMigrations.rules.reprocessDialog.description',
   {
     defaultMessage:
-      "You are about to reprocess selected rules and this will incur additional tokens. You have option to choose a different LLM and to switch off mapping to Elastic's prebuilt rules. These options apply only to the current execution.",
+      'You are about to reprocess all failed rules, which will use additional tokens. Select which AI connector to use. Optionally, you have the ability to not match prebuilt rules.',
   }
 );
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/security-team/issues/14168

These changes update copies across SIEM Migrations feature according to this [internal doc](https://docs.google.com/document/d/1LqNTWmpEWEYMJvl7aoBV36tZWlUpgNXQrr-19FrBZOE/edit?tab=t.0#heading=h.zfoy3ewov28b).

### Migrations landing page

<img width="1714" height="1378" alt="Screenshot 2025-10-14 at 10 56 10" src="https://github.com/user-attachments/assets/24f04802-7bfb-4eca-bc0a-edbdf9b77963" />

### Translated dashboards - Updated column header tooltip

<img width="1714" height="1378" alt="Screenshot 2025-10-14 at 10 56 23" src="https://github.com/user-attachments/assets/92c5215c-db79-49f1-8a89-ca56ef9fbb6a" />

### Translated dashboards - Status column header tooltip

<img width="1714" height="1378" alt="Screenshot 2025-10-14 at 10 56 33" src="https://github.com/user-attachments/assets/0aa833fa-2503-4340-b37c-c6e700cdb9bf" />

### Translated dashboards - Tags column header tooltip

<img width="1714" height="1378" alt="Screenshot 2025-10-14 at 10 56 38" src="https://github.com/user-attachments/assets/56000f35-57eb-4aee-8ba8-111408e0bc6a" />

### Translated dashboards - Actions column header tooltip

<img width="1714" height="1378" alt="Screenshot 2025-10-14 at 10 56 41" src="https://github.com/user-attachments/assets/808824c3-e845-4c33-8309-b4c8d9c2cba3" />

### Dashboards start modal

<img width="1714" height="1378" alt="Screenshot 2025-10-14 at 10 57 18" src="https://github.com/user-attachments/assets/bc6d43e9-ade3-4a8f-a36b-7baf6f04ac63" />

### Dashboards retry modal

<img width="1714" height="1378" alt="Screenshot 2025-10-14 at 10 57 09" src="https://github.com/user-attachments/assets/29ee5784-891c-45ef-9187-37c47d36a196" />

### Dashboards reprocess modal

<img width="1714" height="1378" alt="Screenshot 2025-10-14 at 10 57 04" src="https://github.com/user-attachments/assets/e061a582-f502-4bcb-ae9d-f3c41320bcf7" />

### Rules start modal

<img width="1714" height="1378" alt="Screenshot 2025-10-14 at 10 57 24" src="https://github.com/user-attachments/assets/05c47377-a382-493b-9612-982a195c8440" />

### Rules retry modal

<img width="1714" height="1378" alt="Screenshot 2025-10-14 at 10 57 37" src="https://github.com/user-attachments/assets/46a2b964-c464-46b9-b14d-2b60e8b9a513" />

### Rules reprocess modal

<img width="1714" height="1378" alt="Screenshot 2025-10-14 at 10 57 30" src="https://github.com/user-attachments/assets/69628831-eacd-4f92-b8ae-998c37dce70e" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->