### PR TITLE
[Automatic Migration] Retry Migration with resources text shows incorrect count

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/translations.ts
@@ -51,7 +51,8 @@ export const DASHBOARD_MIGRATION_UPLOAD_MISSING_RESOURCES_DESCRIPTION = (
   i18n.translate(
     'xpack.securitySolution.siemMigrations.dashboards.panel.uploadMissingResourcesDescription',
     {
-      defaultMessage: 'Click Upload to continue translating {partialDashboardsCount} dashboards',
+      defaultMessage:
+        'Click Upload to continue translating {partialDashboardsCount, plural, one {# dashboard} other {# dashboards} }',
       values: { partialDashboardsCount },
     }
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/upload_missing_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/upload_missing_panel.test.tsx
@@ -117,7 +117,7 @@ describe('DashboardMigrationsUploadMissingPanel', () => {
     // Description
     expect(getByTestId('uploadMissingPanelDescription')).toBeInTheDocument();
     expect(getByTestId('uploadMissingPanelDescription')).toHaveTextContent(
-      'Click Upload to continue translating 1 dashboards'
+      'Click Upload to continue translating 1 dashboard'
     );
     // Upload button
     expect(getByTestId('uploadMissingPanelButton')).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/upload_missing_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/upload_missing_panel.test.tsx
@@ -117,7 +117,7 @@ describe('DashboardMigrationsUploadMissingPanel', () => {
     // Description
     expect(getByTestId('uploadMissingPanelDescription')).toBeInTheDocument();
     expect(getByTestId('uploadMissingPanelDescription')).toHaveTextContent(
-      'Click Upload to continue translating 3 dashboards'
+      'Click Upload to continue translating 1 dashboards'
     );
     // Upload button
     expect(getByTestId('uploadMissingPanelButton')).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/upload_missing_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/upload_missing_panel.tsx
@@ -70,13 +70,7 @@ const DashboardMigrationsUploadMissingPanelContent =
       const { openFlyout } = useMigrationDataInputContext();
       const { telemetry } = useKibana().services.siemMigrations.dashboards;
       const totalDashboardsToRetry = useMemo(() => {
-        if (!translationStats) return 0;
-
-        return (
-          (translationStats.dashboards.failed ?? 0) +
-          (translationStats.dashboards.success.result.partial ?? 0) +
-          (translationStats.dashboards.success.result.untranslatable ?? 0)
-        );
+        return translationStats?.dashboards.success.result.partial ?? 0;
       }, [translationStats]);
 
       const onOpenFlyout = useCallback(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/translations.ts
@@ -83,7 +83,8 @@ export const RULE_MIGRATION_UPLOAD_MISSING_RESOURCES_DESCRIPTION = (partialRules
   i18n.translate(
     'xpack.securitySolution.siemMigrations.rules.panel.uploadMissingResourcesDescription',
     {
-      defaultMessage: 'Click Upload to continue translating {partialRulesCount} rules',
+      defaultMessage:
+        'Click Upload to continue translating {partialRulesCount, plural, one {# rule} other {# rules}}',
       values: { partialRulesCount },
     }
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/upload_missing_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/upload_missing_panel.test.tsx
@@ -116,7 +116,7 @@ describe('RuleMigrationsUploadMissingPanel', () => {
     // Description
     expect(getByTestId('uploadMissingPanelDescription')).toBeInTheDocument();
     expect(getByTestId('uploadMissingPanelDescription')).toHaveTextContent(
-      'Click Upload to continue translating 3 rules'
+      'Click Upload to continue translating 1 rules'
     );
     // Upload button
     expect(getByTestId('uploadMissingPanelButton')).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/upload_missing_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/upload_missing_panel.test.tsx
@@ -102,6 +102,22 @@ describe('RuleMigrationsUploadMissingPanel', () => {
       </TestProviders>
     );
 
+    mockUseGetMigrationTranslationStats.mockReturnValue({
+      data: {
+        rules: {
+          failed: 1,
+          success: {
+            result: {
+              partial: 2,
+              untranslatable: 1,
+              success: 1,
+            },
+          },
+        },
+      },
+      isLoading: false,
+    });
+
     act(() => {
       setMissingResourcesCallback(missingResourcesMock);
     });
@@ -116,7 +132,7 @@ describe('RuleMigrationsUploadMissingPanel', () => {
     // Description
     expect(getByTestId('uploadMissingPanelDescription')).toBeInTheDocument();
     expect(getByTestId('uploadMissingPanelDescription')).toHaveTextContent(
-      'Click Upload to continue translating 1 rules'
+      'Click Upload to continue translating 2 rules'
     );
     // Upload button
     expect(getByTestId('uploadMissingPanelButton')).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/upload_missing_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/upload_missing_panel.tsx
@@ -77,11 +77,7 @@ const RuleMigrationsUploadMissingPanelContent =
       }, [migrationStats, openFlyout, missingResources, telemetry]);
 
       const totalRulesToRetry = useMemo(() => {
-        return (
-          (translationStats?.rules.failed ?? 0) +
-          (translationStats?.rules.success.result.partial ?? 0) +
-          (translationStats?.rules.success.result.untranslatable ?? 0)
-        );
+        return translationStats?.rules.success.result.partial ?? 0;
       }, [translationStats]);
 
       return (


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/238169

When we retry a migration in case of missing resources, we only process `Partially Translated` or `not_fully_translated` items but the count includes all items except the ones with status `Translated`.

This PR fixes the text so that it matches with the count of items to be retried matches.

### Before
<img width="1083" height="640" alt="image" src="https://github.com/user-attachments/assets/39c34664-82c6-43f3-8ee9-9052c822eb5d" />


### After

<img width="1092" height="647" alt="image" src="https://github.com/user-attachments/assets/1a796676-6590-4705-829a-2dc6cf65f060" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



