### PR TITLE
[Obs AI Assistant] [deployment Agnostic] skip Serverless GET /kb/status tests

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/knowledge_base/knowledge_base_status.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/knowledge_base/knowledge_base_status.spec.ts
@@ -22,7 +22,9 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
 
   describe('Knowledge base: GET /internal/observability_ai_assistant/kb/status', function () {
-    this.tags(['skipServerless']);
+    // fails/flaky on MKI, see https://github.com/elastic/kibana/issues/232600
+    this.tags(['failsOnMKI']);
+
     it('returns correct status before knowledge base is setup', async () => {
       const res = await observabilityAIAssistantAPIClient.editor({
         endpoint: 'GET /internal/observability_ai_assistant/kb/status',

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/knowledge_base/knowledge_base_status.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/knowledge_base/knowledge_base_status.spec.ts
@@ -22,6 +22,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
 
   describe('Knowledge base: GET /internal/observability_ai_assistant/kb/status', function () {
+    this.tags(['skipServerless']);
     it('returns correct status before knowledge base is setup', async () => {
       const res = await observabilityAIAssistantAPIClient.editor({
         endpoint: 'GET /internal/observability_ai_assistant/kb/status',


### PR DESCRIPTION
[Obs AI Assistant] [deployment Agnostic] skip Serverless GET /kb/status tests

## Summary

This PR skips the Observability AI assistant knowledge base status test suite for MKI runs.
More details about the failures/flakiness in #232600.


