### PR TITLE
[Cases] Disable case events in management section

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -167,7 +167,7 @@ export const DEFAULT_FEATURES: CasesFeaturesAllRequired = Object.freeze({
   alerts: { sync: true, enabled: true, isExperimental: false },
   metrics: [],
   observables: { enabled: true, autoExtract: false },
-  events: { enabled: true },
+  events: { enabled: false },
 });
 
 /**

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_tabs.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_tabs.test.tsx
@@ -80,7 +80,7 @@ describe('CaseViewTabs', () => {
   it('should render CaseViewTabs', async () => {
     const props = { activeTab: CASE_VIEW_PAGE_TABS.ACTIVITY, caseData };
     renderWithTestingProviders(<CaseViewTabs {...props} />, {
-      wrapperProps: { license: basicLicense },
+      wrapperProps: { license: basicLicense, features: { events: { enabled: true } } },
     });
 
     expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
@@ -132,7 +132,7 @@ describe('CaseViewTabs', () => {
     renderWithTestingProviders(
       <CaseViewTabs {...caseProps} activeTab={CASE_VIEW_PAGE_TABS.EVENTS} />,
       {
-        wrapperProps: { license: basicLicense },
+        wrapperProps: { license: basicLicense, features: { events: { enabled: true } } },
       }
     );
 
@@ -245,7 +245,7 @@ describe('CaseViewTabs', () => {
   it('navigates to the events tab when the events tab is clicked', async () => {
     const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
     renderWithTestingProviders(<CaseViewTabs {...caseProps} />, {
-      wrapperProps: { license: basicLicense },
+      wrapperProps: { license: basicLicense, features: { events: { enabled: true } } },
     });
 
     await userEvent.click(await screen.findByTestId('case-view-tab-title-events'));


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/238689 by disabling the section entirely (no events table defined for cases outside of security context)





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->