### PR TITLE
[Streams] Disable parsing link from discover when id is not available

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_processing_link.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_processing_link.tsx
@@ -43,6 +43,8 @@ export function DiscoverFlyoutStreamProcessingLink({
     doc,
   });
 
+  if (!doc.raw._id) return null;
+
   if (loading) return <EuiLoadingSpinner size="s" />;
 
   if (!value || error) return null;


### PR DESCRIPTION
## 📓 Summary

Closes #231397

This change hides the link from the Discover flyout to parse the message when the document ID doesn't exist.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->