### PR TITLE
Fix SO checks CI step

### DIFF
--- a/packages/kbn-check-saved-objects-cli/src/util/servers.ts
+++ b/packages/kbn-check-saved-objects-cli/src/util/servers.ts
@@ -49,7 +49,11 @@ export async function startServers(): Promise<ServerHandles> {
         [ENABLE_ALL_PLUGINS_CONFIG_PATH]: true,
       },
     },
-    { oss: false }
+    {
+      oss: false,
+      // running in 'dev' mode prevents cloud-experiments plugin to fail due to missing config
+      dev: true,
+    }
   );
   await kibanaRoot.preboot();
   await kibanaRoot.setup();


### PR DESCRIPTION
## Summary
At the moment the check is systematically failing whenever SO types change.

This is due to the fact that we are starting ALL Kibana plugins, and that one of them (_cloud-experiments_) requires certain configuration in order to work.

The PR circumvents the problem by running the Kibana instance in dev mode for the SO snapshot extraction.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->