### PR TITLE
[Search][Serverless] Update stateless home page promo for iteration 11

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateless_promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateless_promo.tsx
@@ -13,20 +13,21 @@ import { HeaderCTALink } from './cta_link';
 export const StatelessHeaderPromo = () => {
   return (
     <HeaderPromo
-      title={i18n.translate('xpack.searchHomepage.header.statelessPromo.9.title', {
-        defaultMessage: 'Excluding vectors from source',
+      title={i18n.translate('xpack.searchHomepage.header.statelessPromo.title', {
+        defaultMessage: 'GPUs go brrr! GPU-accelerated inference for ELSER',
       })}
-      description={i18n.translate('xpack.searchHomepage.header.statelessPromo.9.description', {
+      description={i18n.translate('xpack.searchHomepage.header.statelessPromo.description', {
         defaultMessage:
-          'Elasticsearch now excludes vectors from source by default, saving space and improving performance while keeping vectors accessible when needed.',
+          'We are thrilled to launch ELSER on ElS -- get state-of-the-art semantic search relevance without having to manage your own machine learning nodes.',
       })}
       cta={
         <HeaderCTALink
-          data-telemetry-id="9-exclude-vectors"
-          href="https://www.elastic.co/search-labs/blog/elasticsearch-exclude-vectors-from-source"
+          // "search-promo-homepage-" is prepended to the telemetry id in HeaderCTALink
+          data-telemetry-id="11-elser-on-eis"
+          href="https://www.elastic.co/docs/explore-analyze/elastic-inference/eis#elser-on-eis"
         >
-          {i18n.translate('xpack.searchHomepage.statelessPromo.9.content', {
-            defaultMessage: 'View on Elasticsearch Labs',
+          {i18n.translate('xpack.searchHomepage.statelessPromo.content', {
+            defaultMessage: 'View docs',
           })}
         </HeaderCTALink>
       }


### PR DESCRIPTION
## Summary

This PR updates the stateless home page promo for iteration 11.

### Screenshots

<img width="1492" height="770" alt="Screenshot 2025-10-14 at 12 56 04" src="https://github.com/user-attachments/assets/909ddae6-3021-4a89-aa53-5283ed0aacaf" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~

