### PR TITLE
Make external links open in new tab in nav

### DIFF
--- a/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/navigation_section/navigation_section_ui.tsx
+++ b/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/navigation_section/navigation_section_ui.tsx
@@ -291,6 +291,7 @@ const getEuiProps = (
     ? {
         href,
         external: isExternal,
+        target: isExternal ? '_blank' : undefined,
         'aria-label': navNode.title,
         onClick: (e) => {
           if (href) {
@@ -312,8 +313,10 @@ const getEuiProps = (
           }
 
           if (href) {
-            e.preventDefault();
-            navigateToUrl(href);
+            if (!isExternal) {
+              e.preventDefault();
+              navigateToUrl(href);
+            }
           }
         },
       }
@@ -431,7 +434,12 @@ function nodeToEuiCollapsibleNavProps(
       // NavItemProp declarations are handled by us, rendering is handled by EUI.
       ...(hasVisibleSubItems
         ? { items: subItems, isCollapsible }
-        : { href, ...linkProps, external: isExternalLink }),
+        : {
+            href,
+            ...linkProps,
+            external: isExternalLink,
+            target: isExternalLink ? '_blank' : undefined,
+          }),
     },
   ];
 

--- a/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/navigation_section/navigation_section_ui.tsx
+++ b/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/navigation_section/navigation_section_ui.tsx
@@ -346,8 +346,10 @@ const getEuiProps = (
     }
 
     if (href !== undefined) {
-      e.preventDefault();
-      navigateToUrl(href);
+      if (!isExternal) {
+        e.preventDefault();
+        navigateToUrl(href);
+      }
       closePanel();
       return;
     }


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/9970b8ca-b5de-4922-b26d-f388c33f8535




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release Note:
External links in navigation opens in new tab now

