### PR TITLE
[9.2] [Cases] Enable auto-extraction by default and add user actions for observable actions (#236524)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/action/v1.ts
@@ -26,6 +26,7 @@ export const UserActionTypes = {
   delete_case: 'delete_case',
   category: 'category',
   customFields: 'customFields',
+  observables: 'observables',
 } as const;
 
 type UserActionActionTypeKeys = keyof typeof UserActionTypes;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/observables/latest.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/observables/latest.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './v1';

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/observables/v1.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/observables/v1.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { UserActionTypes } from '../action/v1';
+import { ObservablesUserActionPayloadRt, ObservablesUserActionRt } from './v1';
+
+describe('Observables', () => {
+  describe('ObservablesUserActionPayloadRt', () => {
+    const defaultRequest = {
+      observables: {
+        count: 1,
+        actionType: 'add',
+      },
+    };
+
+    it('has expected attributes in request', () => {
+      const query = ObservablesUserActionPayloadRt.decode(defaultRequest);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('removes foo:bar attributes from request', () => {
+      const query = ObservablesUserActionPayloadRt.decode({ ...defaultRequest, foo: 'bar' });
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('removes foo:bar attributes from observables', () => {
+      const query = ObservablesUserActionPayloadRt.decode({
+        observables: { ...defaultRequest.observables, foo: 'bar' },
+      });
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+  });
+  describe('ObservablesUserActionRt', () => {
+    const defaultRequest = {
+      type: UserActionTypes.observables,
+      payload: {
+        observables: {
+          count: 1,
+          actionType: 'add',
+        },
+      },
+    };
+
+    it('has expected attributes in request', () => {
+      const query = ObservablesUserActionRt.decode(defaultRequest);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('removes foo:bar attributes from request', () => {
+      const query = ObservablesUserActionRt.decode({ ...defaultRequest, foo: 'bar' });
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('removes foo:bar attributes from payload', () => {
+      const query = ObservablesUserActionRt.decode({
+        ...defaultRequest,
+        payload: { ...defaultRequest.payload, foo: 'bar' },
+      });
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/observables/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/observables/v1.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as rt from 'io-ts';
+import { UserActionTypes } from '../action/v1';
+
+const ObservablesActionTypeRt = rt.union([
+  rt.literal('add'),
+  rt.literal('delete'),
+  rt.literal('update'),
+]);
+
+export const ObservablePayloadRt = rt.strict({
+  count: rt.number,
+  actionType: ObservablesActionTypeRt,
+});
+
+export const ObservablesUserActionPayloadRt = rt.strict({ observables: ObservablePayloadRt });
+
+export const ObservablesUserActionRt = rt.strict({
+  type: rt.literal(UserActionTypes.observables),
+  payload: ObservablesUserActionPayloadRt,
+});
+
+export type ObservablesActionType = rt.TypeOf<typeof ObservablesActionTypeRt>;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/v1.ts
@@ -23,7 +23,7 @@ import { StatusUserActionRt } from './status/v1';
 import { TagsUserActionRt } from './tags/v1';
 import { TitleUserActionRt } from './title/v1';
 import { CustomFieldsUserActionRt } from './custom_fields/v1';
-
+import { ObservablesUserActionRt } from './observables/v1';
 export { UserActionTypes, UserActionActions } from './action/v1';
 export { StatusUserActionRt } from './status/v1';
 
@@ -61,6 +61,7 @@ const BasicUserActionsRt = rt.union([
   DeleteCaseUserActionRt,
   CategoryUserActionRt,
   CustomFieldsUserActionRt,
+  ObservablesUserActionRt,
 ]);
 
 const CommonUserActionsWithIdsRt = rt.union([BasicUserActionsRt, CommentUserActionRt]);
@@ -154,3 +155,4 @@ export type CreateCaseUserActionWithoutConnectorId = UserActionWithAttributes<
   rt.TypeOf<typeof CreateCaseUserActionWithoutConnectorIdRt>
 >;
 export type CustomFieldsUserAction = UserAction<rt.TypeOf<typeof CustomFieldsUserActionRt>>;
+export type ObservablesUserAction = UserAction<rt.TypeOf<typeof ObservablesUserActionRt>>;

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/translations.ts
@@ -247,3 +247,24 @@ export const TOTAL_USERS_ASSIGNED = (total: number) =>
     defaultMessage: '{total} assigned',
     values: { total },
   });
+
+export const ADDED_OBSERVABLES = (totalObservables: number): string =>
+  i18n.translate('xpack.cases.caseView.observables.addedObservables', {
+    values: { totalObservables },
+    defaultMessage:
+      'added {totalObservables, plural, =1 {an} other {{totalObservables}}} {totalObservables, plural, =1 {observable} other {observables}}',
+  });
+
+export const DELETED_OBSERVABLES = (totalObservables: number): string =>
+  i18n.translate('xpack.cases.caseView.observables.deletedObservables', {
+    values: { totalObservables },
+    defaultMessage:
+      'deleted {totalObservables, plural, =1 {an} other {{totalObservables}}} {totalObservables, plural, =1 {observable} other {observables}}',
+  });
+
+export const UPDATED_OBSERVABLES = (totalObservables: number): string =>
+  i18n.translate('xpack.cases.caseView.observables.updatedObservables', {
+    values: { totalObservables },
+    defaultMessage:
+      'updated {totalObservables, plural, =1 {an} other {{totalObservables}}} {totalObservables, plural, =1 {observable} other {observables}}',
+  });

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/builder.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/builder.tsx
@@ -19,6 +19,7 @@ import { createCaseUserActionBuilder } from './create_case';
 import type { UserActionBuilderMap } from './types';
 import { createCategoryUserActionBuilder } from './category';
 import { createCustomFieldsUserActionBuilder } from './custom_fields/custom_fields';
+import { createObservablesUserActionBuilder } from './observables';
 
 export const builderMap: UserActionBuilderMap = {
   create_case: createCaseUserActionBuilder,
@@ -34,4 +35,5 @@ export const builderMap: UserActionBuilderMap = {
   assignees: createAssigneesUserActionBuilder,
   category: createCategoryUserActionBuilder,
   customFields: createCustomFieldsUserActionBuilder,
+  observables: createObservablesUserActionBuilder,
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/observables.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/observables.test.tsx
@@ -13,30 +13,33 @@ import { UserActionActions } from '../../../common/types/domain';
 import { renderWithTestingProviders } from '../../common/mock';
 import { getUserAction } from '../../containers/mock';
 import { getMockBuilderArgs } from './mock';
-import { createSettingsUserActionBuilder } from './settings';
+import { createObservablesUserActionBuilder } from './observables';
+import type { ObservablesActionType } from '../../../common/types/domain/user_action/observables/v1';
 
 jest.mock('../../common/lib/kibana');
 jest.mock('../../common/navigation/hooks');
 
-describe('createSettingsUserActionBuilder ', () => {
+describe('createObservablesUserActionBuilder ', () => {
   const builderArgs = getMockBuilderArgs();
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  const tests = [
-    [false, 'disabled'],
-    [true, 'enabled'],
+  const tests: [number, ObservablesActionType, string][] = [
+    [1, 'add', 'added an observable'],
+    [1, 'delete', 'deleted an observable'],
+    [1, 'update', 'updated an observable'],
+    [10, 'add', 'added 10 observables'],
   ];
 
   it.each(tests)(
-    'renders correctly when changed setting sync-alerts to %s',
-    async (syncAlerts, label) => {
-      const userAction = getUserAction('settings', UserActionActions.update, {
-        payload: { settings: { syncAlerts, extractObservables: true } },
+    'renders correctly when changed observables to %s',
+    async (count, actionType, label) => {
+      const userAction = getUserAction('observables', UserActionActions.update, {
+        payload: { observables: { count, actionType } },
       });
-      const builder = createSettingsUserActionBuilder({
+      const builder = createObservablesUserActionBuilder({
         ...builderArgs,
         userAction,
       });
@@ -44,8 +47,7 @@ describe('createSettingsUserActionBuilder ', () => {
       const createdUserAction = builder.build();
       renderWithTestingProviders(<EuiCommentList comments={createdUserAction} />);
 
-      expect(screen.getByTestId('settings-update-action-settings-update')).toBeTruthy();
-      expect(screen.getByText(`${label} sync alerts and enabled extract observables`)).toBeTruthy();
+      expect(screen.getByTestId(`observables-${actionType}-action`)).toHaveTextContent(label);
     }
   );
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/observables.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/observables.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { type ReactNode } from 'react';
+import { EuiText } from '@elastic/eui';
+import type { SnakeToCamelCase } from '../../../common/types';
+import type { ObservablesUserAction } from '../../../common/types/domain';
+import type { UserActionBuilder } from './types';
+
+import { createCommonUpdateUserActionBuilder } from './common';
+import { ADDED_OBSERVABLES, DELETED_OBSERVABLES, UPDATED_OBSERVABLES } from './translations';
+import type { ObservablesActionType } from '../../../common/types/domain/user_action/observables/v1';
+
+const getLabel: (actionType: ObservablesActionType, count: number) => ReactNode = (
+  actionType,
+  count
+) => {
+  let label = '';
+  switch (actionType) {
+    case 'add':
+      label = ADDED_OBSERVABLES(count);
+      break;
+    case 'delete':
+      label = DELETED_OBSERVABLES(count);
+      break;
+    case 'update':
+      label = UPDATED_OBSERVABLES(count);
+      break;
+  }
+  return (
+    <EuiText size="s" data-test-subj={`observables-${actionType}-action`}>
+      {label}
+    </EuiText>
+  );
+};
+export const createObservablesUserActionBuilder: UserActionBuilder = ({
+  userAction,
+  userProfiles,
+  handleOutlineComment,
+}) => ({
+  build: () => {
+    const action = userAction as SnakeToCamelCase<ObservablesUserAction>;
+    const { count, actionType } = action?.payload?.observables;
+    const label = getLabel(actionType, count);
+
+    if (count > 0) {
+      const commonBuilder = createCommonUpdateUserActionBuilder({
+        userProfiles,
+        userAction,
+        handleOutlineComment,
+        label,
+        icon: 'dot',
+      });
+
+      return commonBuilder.build();
+    }
+    return [];
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/translations.ts
@@ -151,6 +151,10 @@ export const CUSTOM_FIELDS = i18n.translate('xpack.cases.caseView.userActions.cu
   defaultMessage: 'Custom Fields',
 });
 
+export const OBSERVABLES = i18n.translate('xpack.cases.caseView.userActions.observables', {
+  defaultMessage: 'Observables',
+});
+
 export const USER_ACTION_EDITED = (type: string) =>
   i18n.translate('xpack.cases.caseView.userActions.edited', {
     values: { type },

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/user_actions_aria_labels.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/user_actions_aria_labels.tsx
@@ -24,6 +24,7 @@ export const getUserActionAriaLabel = (type: keyof typeof UserActionTypes) => {
     delete_case: i18n.CASE_DELETED,
     category: i18n.CATEGORY,
     customFields: i18n.CUSTOM_FIELDS,
+    observables: i18n.OBSERVABLES,
   };
 
   switch (type) {

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/builder_factory.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/builder_factory.test.ts
@@ -777,6 +777,43 @@ describe('UserActionBuilder', () => {
         }
       `);
     });
+
+    it('builds an add observables user action correctly', () => {
+      const builder = builderFactory.getBuilder(UserActionTypes.observables)!;
+      const userAction = builder.build({
+        payload: { observables: { count: 1, actionType: 'add' } },
+        ...commonArgs,
+      });
+
+      expect(userAction!.parameters).toMatchInlineSnapshot(`
+        Object {
+          "attributes": Object {
+            "action": "create",
+            "created_at": "2022-01-09T22:00:00.000Z",
+            "created_by": Object {
+              "email": "elastic@elastic.co",
+              "full_name": "Elastic User",
+              "username": "elastic",
+            },
+            "owner": "securitySolution",
+            "payload": Object {
+              "observables": Object {
+                "actionType": "add",
+                "count": 1,
+              },
+            },
+            "type": "observables",
+          },
+          "references": Array [
+            Object {
+              "id": "123",
+              "name": "associated-cases",
+              "type": "cases",
+            },
+          ],
+        }
+      `);
+    });
   });
 
   describe('eventDetails', () => {
@@ -1237,6 +1274,27 @@ describe('UserActionBuilder', () => {
       `);
       expect(userAction!.eventDetails.getMessage('123')).toMatchInlineSnapshot(
         `"User updated the category for case id: 123 - user action id: 123"`
+      );
+    });
+
+    it('builds an update observables user action correctly', () => {
+      const builder = builderFactory.getBuilder(UserActionTypes.observables)!;
+      const userAction = builder.build({
+        payload: { observables: { count: 1, actionType: 'update' } },
+        ...commonArgs,
+      });
+
+      expect(userAction!.eventDetails).toMatchInlineSnapshot(`
+        Object {
+          "action": "create",
+          "descriptiveAction": "case_user_action_observables",
+          "getMessage": [Function],
+          "savedObjectId": "123",
+          "savedObjectType": "cases",
+        }
+      `);
+      expect(userAction!.eventDetails.getMessage('123')).toMatchInlineSnapshot(
+        `"User added observables to case id: 123 - user action id: 123"`
       );
     });
   });

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/builder_factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/builder_factory.ts
@@ -23,6 +23,7 @@ import { AssigneesUserActionBuilder } from './builders/assignees';
 import { NoopUserActionBuilder } from './builders/noop';
 import { CategoryUserActionBuilder } from './builders/category';
 import { CustomFieldsUserActionBuilder } from './builders/custom_fields';
+import { ObservablesUserActionBuilder } from './builders/observables';
 
 const builderMap = {
   assignees: AssigneesUserActionBuilder,
@@ -39,6 +40,7 @@ const builderMap = {
   settings: SettingsUserActionBuilder,
   delete_case: NoopUserActionBuilder,
   customFields: CustomFieldsUserActionBuilder,
+  observables: ObservablesUserActionBuilder,
 };
 
 export class BuilderFactory {

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/builders/observables.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/builders/observables.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { UserActionActions, UserActionTypes } from '../../../../common/types/domain';
+import { CASE_SAVED_OBJECT } from '../../../../common/constants';
+import { UserActionBuilder } from '../abstract_builder';
+import type { EventDetails, UserActionParameters, UserActionEvent } from '../types';
+
+export class ObservablesUserActionBuilder extends UserActionBuilder {
+  build(args: UserActionParameters<'observables'>): UserActionEvent {
+    const { caseId } = args;
+    const action = UserActionActions.create;
+
+    const parameters = this.buildCommonUserAction({
+      ...args,
+      action,
+      valueKey: 'observables',
+      value: args.payload.observables,
+      type: UserActionTypes.observables,
+    });
+
+    const getMessage = (id?: string) =>
+      `User added observables to case id: ${caseId} - user action id: ${id}`;
+
+    const eventDetails: EventDetails = {
+      getMessage,
+      action,
+      descriptiveAction: 'case_user_action_observables',
+      savedObjectId: caseId,
+      savedObjectType: CASE_SAVED_OBJECT,
+    };
+
+    return {
+      parameters,
+      eventDetails,
+    };
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
@@ -40,6 +40,7 @@ import type {
   CasePostRequest,
   UserActionFindRequest,
 } from '../../../common/types/api';
+import type { ObservablesActionType } from '../../../common/types/domain/user_action/observables/v1';
 
 export interface BuilderParameters {
   title: {
@@ -95,6 +96,13 @@ export interface BuilderParameters {
   };
   customFields: {
     parameters: { payload: { customFields: CaseCustomFields } };
+  };
+  observables: {
+    parameters: {
+      payload: {
+        observables: { actionType: ObservablesActionType; count: number };
+      };
+    };
   };
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/index.ts
@@ -11,7 +11,7 @@ import { routes } from './routes';
 export const CASES_FEATURES = {
   observables: {
     enabled: true,
-    autoExtract: false,
+    autoExtract: true,
   },
 } as const;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -144,7 +144,7 @@ const casesConfiguration = {
   featureId: CASES_FEATURE_ID,
   owner: [APP_ID],
   syncAlerts: true,
-  extractObservables: false,
+  extractObservables: true,
 };
 const emptyInputFilters: Filter[] = [];
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Cases] Enable auto-extraction by default and add user actions for observable actions (#236524)](https://github.com/elastic/kibana/pull/236524)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"christineweng","email":"18648970+christineweng@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-06T18:50:20Z","message":"[Cases] Enable auto-extraction by default and add user actions for observable actions (#236524)\n\n## Summary\n\nRef: https://github.com/elastic/kibana/issues/234007\n\nThis PR enables auto-extraction in alerts and adds activity entry for\nobservable actions (manually add/update/delete 1 observable, bulk add\nfrom auto-extraction).\n\nBefore\nObservable actions are not reflected in the activity tab\n\nAfter\n\n<img width=\"513\" height=\"263\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/28bf5e20-ed80-40b0-9100-24e5132902a9\"\n/>\n\n\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Michael Olorunnisola <michael.olorunnisola@elastic.co>","sha":"435b22513d15851e695ca3f1dedfff21609c4d9e","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:skip","Team:Cases","v9.2.0","v9.3.0"],"title":"[Cases] Enable auto-extraction by default and add user actions for observable actions","number":236524,"url":"https://github.com/elastic/kibana/pull/236524","mergeCommit":{"message":"[Cases] Enable auto-extraction by default and add user actions for observable actions (#236524)\n\n## Summary\n\nRef: https://github.com/elastic/kibana/issues/234007\n\nThis PR enables auto-extraction in alerts and adds activity entry for\nobservable actions (manually add/update/delete 1 observable, bulk add\nfrom auto-extraction).\n\nBefore\nObservable actions are not reflected in the activity tab\n\nAfter\n\n<img width=\"513\" height=\"263\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/28bf5e20-ed80-40b0-9100-24e5132902a9\"\n/>\n\n\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Michael Olorunnisola <michael.olorunnisola@elastic.co>","sha":"435b22513d15851e695ca3f1dedfff21609c4d9e"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236524","number":236524,"mergeCommit":{"message":"[Cases] Enable auto-extraction by default and add user actions for observable actions (#236524)\n\n## Summary\n\nRef: https://github.com/elastic/kibana/issues/234007\n\nThis PR enables auto-extraction in alerts and adds activity entry for\nobservable actions (manually add/update/delete 1 observable, bulk add\nfrom auto-extraction).\n\nBefore\nObservable actions are not reflected in the activity tab\n\nAfter\n\n<img width=\"513\" height=\"263\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/28bf5e20-ed80-40b0-9100-24e5132902a9\"\n/>\n\n\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Michael Olorunnisola <michael.olorunnisola@elastic.co>","sha":"435b22513d15851e695ca3f1dedfff21609c4d9e"}}]}] BACKPORT-->