### PR TITLE
[Agent Builder] hide `workflow` tools when workflow UI is disabled

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tool_type_info.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tool_type_info.ts
@@ -5,17 +5,34 @@
  * 2.0.
  */
 
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { ToolType } from '@kbn/onechat-common';
 import { queryKeys } from '../../query_keys';
 import { useOnechatServices } from '../use_onechat_service';
+import { useKibana } from '../use_kibana';
 
 export const useToolTypes = () => {
   const { toolsService } = useOnechatServices();
+  const {
+    services: { settings },
+  } = useKibana();
 
-  const { data: toolTypes, isLoading } = useQuery({
+  const { data: serverToolTypes = [], isLoading } = useQuery({
     queryKey: queryKeys.tools.typeInfo,
     queryFn: () => toolsService.getToolTypes(),
   });
+
+  const workflowsEnabled = useMemo(
+    () => settings.client.get('workflows:ui:enabled', false),
+    [settings]
+  );
+
+  const toolTypes = useMemo(() => {
+    return serverToolTypes.filter(
+      (toolType) => workflowsEnabled || !(toolType.type === ToolType.workflow)
+    );
+  }, [serverToolTypes, workflowsEnabled]);
 
   return { toolTypes, isLoading };
 };


### PR DESCRIPTION
## Summary

We were checking if the plugin was enabled, but since https://github.com/elastic/kibana/pull/236884 the plugin is now enabled by default and the feature gated behind a feature flag instead.

We can't easily have the back-end implementation check that flag (tool type registration is static atm, changing that would be a bit too much work for a fix), so we just check the setting in the UI, it will be good enough for now given this tool type isn't documented anywhere atm.