### PR TITLE
[Cases] Change order in CAI index name

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/constants.ts
@@ -12,12 +12,12 @@ import type { Owner } from '../../../common/constants/types';
 
 const CAI_ACTIVITY_INDEX_NAME_BASE = '.internal.cases-activity';
 export function getActivityDestinationIndexName(spaceId: string, owner: Owner) {
-  return `${CAI_ACTIVITY_INDEX_NAME_BASE}.${spaceId}-${owner}`.toLowerCase();
+  return `${CAI_ACTIVITY_INDEX_NAME_BASE}.${owner}-${spaceId}`.toLowerCase();
 }
 
 const CAI_ACTIVITY_INDEX_ALIAS_BASE = '.cases-activity';
 export function getActivityDestinationIndexAlias(spaceId: string, owner: Owner) {
-  return `${CAI_ACTIVITY_INDEX_ALIAS_BASE}.${spaceId}-${owner}`.toLowerCase();
+  return `${CAI_ACTIVITY_INDEX_ALIAS_BASE}.${owner}-${spaceId}`.toLowerCase();
 }
 
 export const CAI_ACTIVITY_INDEX_VERSION = 1;
@@ -84,7 +84,7 @@ export const CAI_ACTIVITY_SOURCE_INDEX = ALERTING_CASES_SAVED_OBJECT_INDEX;
 
 const CAI_ACTIVITY_BACKFILL_TASK_ID = 'cai_activity_backfill_task';
 export const getCAIActivityBackfillTaskId = (spaceId: string, owner: Owner): string => {
-  return `${CAI_ACTIVITY_BACKFILL_TASK_ID}-${spaceId}-${owner}`;
+  return `${CAI_ACTIVITY_BACKFILL_TASK_ID}-${owner}-${spaceId}`;
 };
 
 export const getActivitySynchronizationSourceQuery = (

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/constants.ts
@@ -12,12 +12,12 @@ import type { Owner } from '../../../common/constants/types';
 
 const CAI_ATTACHMENTS_INDEX_NAME_BASE = '.internal.cases-attachments';
 export function getAttachmentsDestinationIndexName(spaceId: string, owner: Owner) {
-  return `${CAI_ATTACHMENTS_INDEX_NAME_BASE}.${spaceId}-${owner}`.toLowerCase();
+  return `${CAI_ATTACHMENTS_INDEX_NAME_BASE}.${owner}-${spaceId}`.toLowerCase();
 }
 
 const CAI_ATTACHMENTS_INDEX_ALIAS_BASE = '.cases-attachments';
 export function getAttachmentsDestinationIndexAlias(spaceId: string, owner: Owner) {
-  return `${CAI_ATTACHMENTS_INDEX_ALIAS_BASE}.${spaceId}-${owner}`.toLowerCase();
+  return `${CAI_ATTACHMENTS_INDEX_ALIAS_BASE}.${owner}-${spaceId}`.toLowerCase();
 }
 
 export const CAI_ATTACHMENTS_INDEX_VERSION = 1;
@@ -69,7 +69,7 @@ export const CAI_ATTACHMENTS_SOURCE_INDEX = ALERTING_CASES_SAVED_OBJECT_INDEX;
 
 const CAI_ATTACHMENTS_BACKFILL_TASK_ID = 'cai_attachments_backfill_task';
 export const getCAIAttachmentsBackfillTaskId = (spaceId: string, owner: Owner): string => {
-  return `${CAI_ATTACHMENTS_BACKFILL_TASK_ID}-${spaceId}-${owner}`;
+  return `${CAI_ATTACHMENTS_BACKFILL_TASK_ID}-${owner}-${spaceId}`;
 };
 
 export const getAttachmentsSynchronizationSourceQuery = (

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/constants.ts
@@ -12,12 +12,12 @@ import type { Owner } from '../../../common/constants/types';
 
 const CAI_CASES_INDEX_NAME_BASE = '.internal.cases';
 export function getCasesDestinationIndexName(spaceId: string, owner: Owner) {
-  return `${CAI_CASES_INDEX_NAME_BASE}.${spaceId}-${owner}`.toLowerCase();
+  return `${CAI_CASES_INDEX_NAME_BASE}.${owner}-${spaceId}`.toLowerCase();
 }
 
 const CAI_CASES_INDEX_ALIAS_BASE = '.cases';
 export function getCasesDestinationIndexAlias(spaceId: string, owner: Owner) {
-  return `${CAI_CASES_INDEX_ALIAS_BASE}.${spaceId}-${owner}`.toLowerCase();
+  return `${CAI_CASES_INDEX_ALIAS_BASE}.${owner}-${spaceId}`.toLowerCase();
 }
 
 export const CAI_CASES_INDEX_VERSION = 1;
@@ -50,7 +50,7 @@ export const CAI_CASES_SOURCE_INDEX = ALERTING_CASES_SAVED_OBJECT_INDEX;
 
 const CAI_CASES_BACKFILL_TASK_ID = 'cai_cases_backfill_task';
 export const getCAICasesBackfillTaskId = (spaceId: string, owner: Owner): string => {
-  return `${CAI_CASES_BACKFILL_TASK_ID}-${spaceId}-${owner}`;
+  return `${CAI_CASES_BACKFILL_TASK_ID}-${owner}-${spaceId}`;
 };
 
 export const getCasesSynchronizationSourceQuery = (

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/constants.ts
@@ -12,12 +12,12 @@ import type { Owner } from '../../../common/constants/types';
 
 export const CAI_COMMENTS_INDEX_NAME_BASE = '.internal.cases-comments';
 export function getCommentsDestinationIndexName(spaceId: string, owner: Owner) {
-  return `${CAI_COMMENTS_INDEX_NAME_BASE}.${spaceId}-${owner}`.toLowerCase();
+  return `${CAI_COMMENTS_INDEX_NAME_BASE}.${owner}-${spaceId}`.toLowerCase();
 }
 
 export const CAI_COMMENTS_INDEX_ALIAS_BASE = '.cases-comments';
 export function getCommentsDestinationIndexAlias(spaceId: string, owner: Owner) {
-  return `${CAI_COMMENTS_INDEX_ALIAS_BASE}.${spaceId}-${owner}`.toLowerCase();
+  return `${CAI_COMMENTS_INDEX_ALIAS_BASE}.${owner}-${spaceId}`.toLowerCase();
 }
 
 export const CAI_COMMENTS_INDEX_VERSION = 1;
@@ -55,7 +55,7 @@ export const CAI_COMMENTS_SOURCE_INDEX = ALERTING_CASES_SAVED_OBJECT_INDEX;
 
 const CAI_COMMENTS_BACKFILL_TASK_ID = 'cai_comments_backfill_task';
 export const getCAICommentsBackfillTaskId = (spaceId: string, owner: Owner): string => {
-  return `${CAI_COMMENTS_BACKFILL_TASK_ID}-${spaceId}-${owner}`;
+  return `${CAI_COMMENTS_BACKFILL_TASK_ID}-${owner}-${spaceId}`;
 };
 
 export const getCommentsSynchronizationSourceQuery = (

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
@@ -410,8 +410,8 @@ describe('SynchronizationTaskRunner', () => {
 
     expect(logger.error).not.toBeCalled();
     expect(logger.debug).toBeCalledWith(
-      '[.internal.cases.default-securitysolution] Destination index does not exist, skipping synchronization task.',
-      { tags: ['cai-synchronization', '.internal.cases.default-securitysolution'] }
+      '[.internal.cases.securitysolution-default] Destination index does not exist, skipping synchronization task.',
+      { tags: ['cai-synchronization', '.internal.cases.securitysolution-default'] }
     );
   });
 
@@ -435,12 +435,12 @@ describe('SynchronizationTaskRunner', () => {
       }
 
       expect(logger.error).toBeCalledWith(
-        '[.internal.cases.default-securitysolution] Synchronization reindex failed. Error: My retryable error',
+        '[.internal.cases.securitysolution-default] Synchronization reindex failed. Error: My retryable error',
         {
           tags: [
             'cai-synchronization',
             'cai-synchronization-error',
-            '.internal.cases.default-securitysolution',
+            '.internal.cases.securitysolution-default',
           ],
         }
       );
@@ -465,12 +465,12 @@ describe('SynchronizationTaskRunner', () => {
       }
 
       expect(logger.error).toBeCalledWith(
-        '[.internal.cases.default-securitysolution] Synchronization reindex failed. Error: My unrecoverable error',
+        '[.internal.cases.securitysolution-default] Synchronization reindex failed. Error: My unrecoverable error',
         {
           tags: [
             'cai-synchronization',
             'cai-synchronization-error',
-            '.internal.cases.default-securitysolution',
+            '.internal.cases.securitysolution-default',
           ],
         }
       );

--- a/x-pack/platform/test/cases_api_integration/common/lib/api/index.ts
+++ b/x-pack/platform/test/cases_api_integration/common/lib/api/index.ts
@@ -920,7 +920,7 @@ export const deleteAllCaseAnalyticsItems = async (es: Client) => {
 
 export const deleteCasesAnalytics = async (es: Client): Promise<void> => {
   await es.deleteByQuery({
-    index: ['.internal.cases.default-securitysolution', '.internal.cases.space1-securitysolution'],
+    index: ['.internal.cases.securitysolution-default', '.internal.cases.securitysolution-space1'],
     query: { match_all: {} },
     wait_for_completion: true,
     refresh: true,
@@ -931,8 +931,8 @@ export const deleteCasesAnalytics = async (es: Client): Promise<void> => {
 export const deleteAttachmentsAnalytics = async (es: Client): Promise<void> => {
   await es.deleteByQuery({
     index: [
-      '.internal.cases-attachments.default-securitysolution',
-      '.internal.cases-attachments.space1-securitysolution',
+      '.internal.cases-attachments.securitysolution-default',
+      '.internal.cases-attachments.securitysolution-space1',
     ],
     query: { match_all: {} },
     wait_for_completion: true,
@@ -944,8 +944,8 @@ export const deleteAttachmentsAnalytics = async (es: Client): Promise<void> => {
 export const deleteCommentsAnalytics = async (es: Client): Promise<void> => {
   await es.deleteByQuery({
     index: [
-      '.internal.cases-comments.default-securitysolution',
-      '.internal.cases-comments.space1-securitysolution',
+      '.internal.cases-comments.securitysolution-default',
+      '.internal.cases-comments.securitysolution-space1',
     ],
     query: { match_all: {} },
     wait_for_completion: true,
@@ -957,8 +957,8 @@ export const deleteCommentsAnalytics = async (es: Client): Promise<void> => {
 export const deleteActivityAnalytics = async (es: Client): Promise<void> => {
   await es.deleteByQuery({
     index: [
-      '.internal.cases-activity.default-securitysolution',
-      '.internal.cases-activity.space1-securitysolution',
+      '.internal.cases-activity.securitysolution-default',
+      '.internal.cases-activity.securitysolution-space1',
     ],
     query: { match_all: {} },
     wait_for_completion: true,

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/backfill.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/backfill.ts
@@ -193,14 +193,14 @@ export default ({ getService }: FtrProviderContext): void => {
 
       await retry.tryForTime(300000, async () => {
         const firstAttachmentAnalytics = await esClient.get({
-          index: '.internal.cases-attachments.space1-securitysolution',
+          index: '.internal.cases-attachments.securitysolution-space1',
           id: `cases-comments:${postedCaseWithAttachments.comments![0].id}`,
         });
 
         expect(firstAttachmentAnalytics.found).to.be(true);
 
         const secondAttachmentAnalytics = await esClient.get({
-          index: '.internal.cases-attachments.space1-securitysolution',
+          index: '.internal.cases-attachments.securitysolution-space1',
           id: `cases-comments:${postedCaseWithAttachments.comments![1].id}`,
         });
 

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/backfill.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/backfill.ts
@@ -104,7 +104,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
       await retry.tryForTime(300000, async () => {
         const caseAnalytics = await esClient.get({
-          index: '.internal.cases.default-securitysolution',
+          index: '.internal.cases.securitysolution-default',
           id: `cases:${caseToBackfill.id}`,
         });
 
@@ -227,7 +227,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
       await retry.try(async () => {
         const commentAnalytics = await esClient.get({
-          index: '.internal.cases-comments.default-securitysolution',
+          index: '.internal.cases-comments.securitysolution-default',
           id: `cases-comments:${patchedCase.comments![0].id}`,
         });
 
@@ -293,7 +293,7 @@ export default ({ getService }: FtrProviderContext): void => {
       await retry.try(async () => {
         await runActivityBackfillTask(supertest);
         const activityAnalytics = await esClient.search({
-          index: '.internal.cases-activity.default-securitysolution',
+          index: '.internal.cases-activity.securitysolution-default',
         });
 
         // @ts-ignore

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/creation.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/creation.ts
@@ -48,7 +48,7 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     it('cases index should be created with the correct mappings and scripts on startup', async () => {
-      const indexName = '.internal.cases.default-securitysolution';
+      const indexName = '.internal.cases.securitysolution-default';
       const painlessScriptId = 'cai_cases_script_1';
       const version = indexVersion;
 
@@ -75,7 +75,7 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     it('activity index should be created with the correct mappings and scripts on startup', async () => {
-      const indexName = '.internal.cases-activity.default-securitysolution';
+      const indexName = '.internal.cases-activity.securitysolution-default';
       const painlessScriptId = 'cai_activity_script_1';
       const version = indexVersion;
 
@@ -102,7 +102,7 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     it('attachments index should be created with the correct mappings and scripts on startup', async () => {
-      const indexName = '.internal.cases-attachments.default-securitysolution';
+      const indexName = '.internal.cases-attachments.securitysolution-default';
       const painlessScriptId = 'cai_attachments_script_1';
       const version = indexVersion;
 
@@ -129,7 +129,7 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     it('comments index should be created with the correct mappings and scripts on startup', async () => {
-      const indexName = '.internal.cases-comments.default-securitysolution';
+      const indexName = '.internal.cases-comments.securitysolution-default';
       const painlessScriptId = 'cai_comments_script_1';
       const version = indexVersion;
 

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/synchronization.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/synchronization.ts
@@ -189,14 +189,14 @@ export default ({ getService }: FtrProviderContext): void => {
 
       await retry.tryForTime(300000, async () => {
         const firstAttachmentAnalytics = await esClient.get({
-          index: '.internal.cases-attachments.space1-securitysolution',
+          index: '.internal.cases-attachments.securitysolution-space1',
           id: `cases-comments:${postedCaseWithAttachments.comments![0].id}`,
         });
 
         expect(firstAttachmentAnalytics.found).to.be(true);
 
         const secondAttachmentAnalytics = await esClient.get({
-          index: '.internal.cases-attachments.space1-securitysolution',
+          index: '.internal.cases-attachments.securitysolution-space1',
           id: `cases-comments:${postedCaseWithAttachments.comments![1].id}`,
         });
 

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/synchronization.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/synchronization.ts
@@ -102,7 +102,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
       await retry.tryForTime(300000, async () => {
         const caseAnalytics = await esClient.get({
-          index: '.internal.cases.default-securitysolution',
+          index: '.internal.cases.securitysolution-default',
           id: `cases:${caseToBackfill.id}`,
         });
 
@@ -220,7 +220,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
       await retry.try(async () => {
         const commentAnalytics = await esClient.get({
-          index: '.internal.cases-comments.default-securitysolution',
+          index: '.internal.cases-comments.securitysolution-default',
           id: `cases-comments:${patchedCase.comments![0].id}`,
         });
 
@@ -280,7 +280,7 @@ export default ({ getService }: FtrProviderContext): void => {
       let activityArray: any[] = [];
       await retry.try(async () => {
         const activityAnalytics = await esClient.search({
-          index: '.internal.cases-activity.default-securitysolution',
+          index: '.internal.cases-activity.securitysolution-default',
         });
 
         // @ts-ignore


### PR DESCRIPTION
## Summary

Instead of `.{entity}.{spaceId}-{owner}`, the new index name order is `.{entity}.{owner}-{spaceId}`, e.g. `.cases.securitysolution-default`.


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->