### PR TITLE
[Fleet] Fix upgrade limited package new inputs

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -6753,7 +6753,7 @@ describe('Package policy service', () => {
     });
 
     describe('when updating a limited package', () => {
-      it('should no add new inputs', () => {
+      it('should not add new inputs', () => {
         const basePackagePolicy: NewPackagePolicy = {
           name: 'base-package-policy',
           description: 'Base Package Policy',

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -6751,6 +6751,80 @@ describe('Package policy service', () => {
         expect(result.inputs[0]?.policy_template).toBe('template_1');
       });
     });
+
+    describe('when updating a limited package', () => {
+      it('should no add new inputs', () => {
+        const basePackagePolicy: NewPackagePolicy = {
+          name: 'base-package-policy',
+          description: 'Base Package Policy',
+          namespace: 'default',
+          enabled: true,
+          policy_id: 'xxxx',
+          policy_ids: ['xxxx'],
+          package: {
+            name: 'test-package',
+            title: 'Test Package',
+            version: '0.0.1',
+          },
+          inputs: [
+            {
+              enabled: true,
+              type: 'connectors-py',
+              policy_template: 'github',
+              streams: [],
+            },
+          ],
+        };
+        const packageInfo: PackageInfo = {
+          name: 'test-package',
+          description: 'Test Package',
+          title: 'Test Package',
+          version: '0.0.1',
+          latestVersion: '0.0.1',
+          release: 'experimental',
+          format_version: '1.0.0',
+          owner: { github: 'elastic/fleet' },
+          policy_templates: [
+            {
+              multiple: false,
+              name: 'github',
+              description: 'test',
+              title: 'github',
+              template_path: 'agent.yml.hbs',
+              type: 'connectors-py',
+              input: 'connectors-py',
+            },
+            {
+              multiple: false,
+              type: 'connectors-py',
+              name: 'gmail',
+              description: 'test',
+              title: 'gmail',
+              template_path: 'agent.yml.hbs',
+              input: 'connectors-py',
+            },
+          ],
+        } as any;
+
+        const inputsOverride: NewPackagePolicyInput[] = packageToPackagePolicyInputs(packageInfo);
+        const result = updatePackageInputs(
+          basePackagePolicy,
+          packageInfo,
+          inputsOverride as InputsOverride[],
+          false
+        );
+
+        expect(result.inputs.length).toBe(2);
+        const enabledInputs = result.inputs.filter((input) => input.enabled);
+        const disabledInputs = result.inputs.filter((input) => !input.enabled);
+        expect(enabledInputs.length).toBe(1);
+        expect(disabledInputs.length).toBe(1);
+        expect(enabledInputs[0]?.type).toBe('connectors-py');
+        expect(enabledInputs[0]?.policy_template).toBe('github');
+        expect(disabledInputs[0]?.type).toBe('connectors-py');
+        expect(disabledInputs[0]?.policy_template).toBe('gmail');
+      });
+    });
   });
 
   describe('enrich package policy on create', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -3517,7 +3517,7 @@ export function updatePackageInputs(
     // take the override value from the new package as-is. This case typically
     // occurs when inputs or package policy templates are added/removed between versions.
     if (originalInput === undefined) {
-      // Do not new inputs for limited packages
+      // Do not enable new inputs for limited packages
       if (limitedPackage) {
         update.enabled = false;
       }

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -3463,6 +3463,7 @@ export function updatePackageInputs(
   if (!inputsUpdated) return basePackagePolicy;
 
   const availablePolicyTemplates = packageInfo.policy_templates ?? [];
+  const limitedPackage = isPackageLimited(packageInfo);
 
   const inputs = [
     ...basePackagePolicy.inputs.filter((input) => {
@@ -3516,6 +3517,10 @@ export function updatePackageInputs(
     // take the override value from the new package as-is. This case typically
     // occurs when inputs or package policy templates are added/removed between versions.
     if (originalInput === undefined) {
+      // Do not new inputs for limited packages
+      if (limitedPackage) {
+        update.enabled = false;
+      }
       inputs.push(update as NewPackagePolicyInput);
       continue;
     }
@@ -3523,7 +3528,7 @@ export function updatePackageInputs(
     // For flags like this, we only want to override the original value if it was set
     // as `undefined` in the original object. An explicit true/false value should be
     // persisted from the original object to the result after the override process is complete.
-    if (originalInput.enabled === undefined && update.enabled !== undefined) {
+    if (!limitedPackage && originalInput.enabled === undefined && update.enabled !== undefined) {
       originalInput.enabled = update.enabled;
     }
 


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/238741

Fix upgrading limited packages, those package do not work with multiple input enabled, creating id collisions. 
There was a bug on upgrade where we enable new inputs, that PR fix that.

## Tests

I added unit test to cover that 

You can manually test this by upgrading from upgrading to `elastic_connectors@1.0.1` to  `elastic_connectors@1.0.3` where a new `sandfly` input has been added. After the upgrade there should be mn 


<!--ONMERGE {"backportTargets":["8.19","9.2"]} ONMERGE-->