### PR TITLE
[Automatic Migratins] Prevents Dashboards migration graph cancellation because of timeout and rate limit errors.

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/task/siem_migrations_task_runner.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/task/siem_migrations_task_runner.ts
@@ -26,7 +26,7 @@ import type { SiemMigrationTelemetryClient } from './siem_migrations_telemetry_c
 /** Number of items loaded in memory to be translated in the pool */
 const TASK_BATCH_SIZE = 100 as const;
 /** The timeout of each individual agent invocation in minutes */
-const AGENT_INVOKE_TIMEOUT_MIN = 3 as const;
+const AGENT_INVOKE_TIMEOUT_MIN = 20 as const;
 
 /** Exponential backoff configuration to handle rate limit errors */
 const RETRY_CONFIG = {


### PR DESCRIPTION
## Summary

This PR increases the timeout for Dashboard Graph from 3m to 20m. But it also affects Rules. We might have to separate the two timeouts later but i do not see any downside of having a higher timeout for Rules as well. Below i explain why dashboard graph needs a higher timeout.

### Explanation

In Dashboards, each node has a retry policy if it encounters rate limit errors. Retry policy has max retries of 8 which means when a node is retried multiple times, the whole graph has to wait for that node to be completed, this increase the overall execution time of the graph.

If `timeout` is reached before the graph is completed, an `Abort` signal is promptly raised cancelling the execution. See below trace where 3 dashboards reach the timeout of 180s ( 3m ) and got automatically Aborted. 

### Comparison

#### Trace with 3m timeout
- [Trace](https://smith.langchain.com/o/a9ce6102-b198-4b3d-9190-95bedc24ca4f/projects/p/66aedda3-8cfd-4eee-950d-7ba2f93a317e?timeModel=%7B%22duration%22%3A%227d%22%7D&searchModel=%7B%22filter%22%3A%22and%28eq%28is_root%2C+true%29%2C+and%28eq%28metadata_key%2C+%5C%22migrationId%5C%22%29%2C+eq%28metadata_value%2C+%5C%222560172a-f952-46eb-96eb-e1a1615f3f35%5C%22%29%29%29%22%2C%22searchFilter%22%3A%22eq%28is_root%2C+true%29%22%7D) 
- 2 dashboards Failed because of timeout of 3m (180s)
- <img width="959" height="580" alt="image" src="https://github.com/user-attachments/assets/4108887f-119c-4299-9aef-6bf7bbaa1c41" />
- <img width="1087" height="585" alt="image" src="https://github.com/user-attachments/assets/40dc8e1a-6ca0-47ec-bb0c-698f747002d6" />


#### Trace with 20m timeout and 7 dashboards 
- [Trace for migration with 7 dashboards](https://smith.langchain.com/o/a9ce6102-b198-4b3d-9190-95bedc24ca4f/projects/p/66aedda3-8cfd-4eee-950d-7ba2f93a317e?timeModel=%7B%22duration%22%3A%227d%22%7D&searchModel=%7B%22filter%22%3A%22and%28eq%28is_root%2C+true%29%2C+and%28eq%28metadata_key%2C+%5C%22migrationId%5C%22%29%2C+eq%28metadata_value%2C+%5C%226de7ecba-c183-4e55-a488-515e32967f7a%5C%22%29%29%29%22%2C%22searchFilter%22%3A%22eq%28is_root%2C+true%29%22%7D)
- 0 failed dashboards and 0 errors.
- Previously Failed dashboard completed successfully with total time of ~492s.
- <img width="1006" height="724" alt="image" src="https://github.com/user-attachments/assets/43faf572-3a80-47e6-9cf7-f81eecf5c991" />

- <img width="1091" height="582" alt="image" src="https://github.com/user-attachments/assets/7e5d278d-b2fa-4d0a-9d30-5be39ee1b95f" />


#### Trace with 20m timeout and 40 dashboards 
- [Trace for migration with 40 Dashboards](https://smith.langchain.com/o/a9ce6102-b198-4b3d-9190-95bedc24ca4f/projects/p/66aedda3-8cfd-4eee-950d-7ba2f93a317e?timeModel=%7B%22duration%22%3A%227d%22%7D&searchModel=%7B%22filter%22%3A%22and%28eq%28is_root%2C+true%29%2C+and%28eq%28metadata_key%2C+%5C%22migrationId%5C%22%29%2C+eq%28metadata_value%2C+%5C%22cda99b66-b842-419d-ada4-0b6f15a394a6%5C%22%29%29%29%22%2C%22searchFilter%22%3A%22eq%28is_root%2C+true%29%22%7D)
- 0 Errors
- 99th Percentile time Processing time for a single graph/dashboard : 556.41s ( ~ 10m )
- <img width="1098" height="591" alt="image" src="https://github.com/user-attachments/assets/0ea2268b-4d96-4d8b-9728-dfba4e62dffb" />



Since, the actual number of dashboards will be much higher than the above tests ( 40 ), i think a higher timeout is necessary and 20m might to be a good number. 

If still some dashboards fail, user will be able reprocess them without any issues.





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->