### PR TITLE
[Metrics][Discover] Limit wildcard to 'open' datastreams excluding 'hidden'.

### DIFF
--- a/src/platform/plugins/shared/metrics_experience/server/lib/fields/retrieve_fieldcaps.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/lib/fields/retrieve_fieldcaps.ts
@@ -32,7 +32,7 @@ export async function retrieveFieldCaps({
   // First, resolve the index pattern to get data streams
   const resolveResponse = await esClient.indices.resolveIndex({
     name: indexPattern,
-    expand_wildcards: 'all',
+    expand_wildcards: 'open',
   });
 
   // Extract data stream names


### PR DESCRIPTION
## 🍒 Summary

This closes #238875 by only expanding wildcards for "open" datastreams which will exclude "hidden" datastreams. Prior to this PR the display below would include metrics from `remote_cluster:metrics-service_summary.1m.otel-default` and `remote_cluster:metrics-service_summary.30m.otel-default` even though the `30m` summary index was "hidden". 

<img width="2048" height="1005" alt="image" src="https://github.com/user-attachments/assets/51801379-ff8a-4f14-9c3d-152db4d76ea4" />



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->