### PR TITLE
[9.1] [ci] ingest scout test events for internal config (#236263)

### DIFF
--- a/.buildkite/scripts/steps/code_coverage/jest_parallel.sh
+++ b/.buildkite/scripts/steps/code_coverage/jest_parallel.sh
@@ -87,8 +87,7 @@ echo "--- Jest [$TEST_TYPE] configs complete"
 printf "%s\n" "${results[@]}"
 
 # Scout reporter
-echo "--- Upload Scout reporter events to AppEx QA's team cluster"
-node scripts/scout upload-events --dontFailOnError
+source .buildkite/scripts/steps/test/scout_upload_report_events.sh
 
 # Force exit 0 to ensure the next build step starts.
 exit 0

--- a/.buildkite/scripts/steps/test/ftr_configs.sh
+++ b/.buildkite/scripts/steps/test/ftr_configs.sh
@@ -115,7 +115,6 @@ printf "%s\n" "${results[@]}"
 echo ""
 
 # Scout reporter
-echo "--- Upload Scout reporter events to AppEx QA's team cluster"
-node scripts/scout upload-events --dontFailOnError
+source .buildkite/scripts/steps/test/scout_upload_report_events.sh
 
 exit $exitCode

--- a/.buildkite/scripts/steps/test/jest_parallel.sh
+++ b/.buildkite/scripts/steps/test/jest_parallel.sh
@@ -115,7 +115,6 @@ printf "%s\n" "${results[@]}"
 echo ""
 
 # Scout reporter
-echo "--- Upload Scout reporter events to AppEx QA's team cluster"
-node scripts/scout upload-events --dontFailOnError
+source .buildkite/scripts/steps/test/scout_upload_report_events.sh
 
 exit $exitCode

--- a/.buildkite/scripts/steps/test/scout_configs.sh
+++ b/.buildkite/scripts/steps/test/scout_configs.sh
@@ -129,7 +129,6 @@ if [[ ${#failedConfigs[@]} -gt 0 ]]; then
   buildkite-agent meta-data set "$FAILED_CONFIGS_KEY" "$failedConfigs"
 fi
 
-echo "--- Upload Scout reporter events to AppEx QA's team cluster"
-node scripts/scout upload-events --dontFailOnError
+source .buildkite/scripts/steps/test/scout_upload_report_events.sh
 
 exit $FINAL_EXIT_CODE  # Exit with 10 only if there were config failures

--- a/.buildkite/scripts/steps/test/scout_test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout_test_run_builder.sh
@@ -18,5 +18,7 @@ node scripts/scout.js run-tests \
 --config src/platform/packages/shared/kbn-scout/test/scout/playwright.config.ts \
 --kibana-install-dir "$KIBANA_BUILD_LOCATION"
 
+source .buildkite/scripts/steps/test/scout_upload_report_events.sh
+
 echo '--- Producing Scout Test Execution Steps'
 ts-node "$(dirname "${0}")/scout_test_run_builder.ts"

--- a/.buildkite/scripts/steps/test/scout_upload_report_events.sh
+++ b/.buildkite/scripts/steps/test/scout_upload_report_events.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "--- Upload Scout reporter events to AppEx QA's team cluster"
+if [[ "${SCOUT_REPORTER_ENABLED:-}" == "true" ]]; then
+  node scripts/scout upload-events --dontFailOnError
+else
+  echo "⚠️ The SCOUT_REPORTER_ENABLED environment variable is not 'true'. Skipping event upload."
+fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ci] ingest scout test events for internal config (#236263)](https://github.com/elastic/kibana/pull/236263)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-09-26T19:46:15Z","message":"[ci] ingest scout test events for internal config (#236263)\n\n## Summary\n\nThis PR moves `scout upload-events` in its own .sh file, that we can use\nin both entry script (for internal scout tests) and regular scout script\nfor all the external configs.","sha":"82e033459fca94e53b8949e4d0dd290c7db64074","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.2.0","v8.19.5","v9.0.8","v9.1.5"],"title":"[ci] ingest scout test events for internal config","number":236263,"url":"https://github.com/elastic/kibana/pull/236263","mergeCommit":{"message":"[ci] ingest scout test events for internal config (#236263)\n\n## Summary\n\nThis PR moves `scout upload-events` in its own .sh file, that we can use\nin both entry script (for internal scout tests) and regular scout script\nfor all the external configs.","sha":"82e033459fca94e53b8949e4d0dd290c7db64074"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.0","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236263","number":236263,"mergeCommit":{"message":"[ci] ingest scout test events for internal config (#236263)\n\n## Summary\n\nThis PR moves `scout upload-events` in its own .sh file, that we can use\nin both entry script (for internal scout tests) and regular scout script\nfor all the external configs.","sha":"82e033459fca94e53b8949e4d0dd290c7db64074"}},{"branch":"8.19","label":"v8.19.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->