### PR TITLE
[Metrics]Discover] The search bar stays open in case there is a value

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/right_side_actions/search_button.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/right_side_actions/search_button.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import useDebounce from 'react-use/lib/useDebounce';
 import {
   EuiFieldSearch,
@@ -52,6 +52,12 @@ export const SearchButton = ({
   const onShowSearch = useCallback(() => {
     setShowSearchInput(true);
   }, []);
+
+  useEffect(() => {
+    if (searchTerm || value) {
+      onShowSearch();
+    }
+  }, [onShowSearch, searchTerm, value]);
 
   const onClearSearch = useCallback(() => {
     setShowSearchInput(false);


### PR DESCRIPTION
Closes #238938 
## Summary

This PR fixes the search input visibility issue: 
- If there is a value in the search input, it should stay visible
- If the value is cleared, the search input should be hidden

Before: 


https://github.com/user-attachments/assets/cc417519-e9cd-4a03-9b89-4c0a2f382afb



After: 

https://github.com/user-attachments/assets/6fa84f33-6e5e-4236-8cc5-d78383d15a34




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->