### PR TITLE
[Cases] Fix auto extract observables in EASE

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.tsx
@@ -9,6 +9,7 @@ import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiButtonIcon, EuiContextMenu, EuiPopover } from '@elastic/eui';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { i18n } from '@kbn/i18n';
+import { flattenObject } from '@kbn/object-utils';
 import { useAlertTagsActions } from '../../alerts_table/timeline_actions/use_alert_tags_actions';
 import { useAddToCaseActions } from '../../alerts_table/timeline_actions/use_add_to_case_actions';
 
@@ -62,8 +63,17 @@ export const MoreActionsRowControlColumn = memo(
       [togglePopover]
     );
 
+    const nonEcsData = useMemo(() => {
+      const flattened = flattenObject(ecsAlert);
+      return Object.entries(flattened).map(([key, value]) => ({
+        field: key,
+        value: value as string[],
+      }));
+    }, [ecsAlert]);
+
     const { addToCaseActionItems } = useAddToCaseActions({
       ecsData: ecsAlert,
+      nonEcsData,
       onMenuItemClick: closePopover,
       ariaLabel: ADD_TO_CASE_ARIA_LABEL,
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.test.tsx
@@ -43,6 +43,10 @@ const defaultProps = {
       name: ['test-host'],
     },
   },
+  nonEcsData: [
+    { field: 'event.kind', value: ['signal'] },
+    { field: 'host.name', value: ['test-host'] },
+  ],
   refetch,
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
@@ -18,7 +18,7 @@ import type { AlertTableContextMenuItem } from '../types';
 export interface UseAddToCaseActions {
   onMenuItemClick: () => void;
   ariaLabel?: string;
-  ecsData?: Ecs;
+  ecsData: Ecs;
   nonEcsData: TimelineNonEcsData[];
   onSuccess?: () => Promise<void>;
   refetch?: (() => void) | undefined;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
@@ -19,7 +19,7 @@ export interface UseAddToCaseActions {
   onMenuItemClick: () => void;
   ariaLabel?: string;
   ecsData?: Ecs;
-  nonEcsData?: TimelineNonEcsData[];
+  nonEcsData: TimelineNonEcsData[];
   onSuccess?: () => Promise<void>;
   refetch?: (() => void) | undefined;
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/take_action_button.tsx
@@ -8,6 +8,7 @@
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiButton, EuiContextMenu, EuiPopover } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { flattenObject } from '@kbn/object-utils';
 import { useAIForSOCDetailsContext } from '../context';
 import { useAddToCaseActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
 import { useAlertTagsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions';
@@ -59,8 +60,17 @@ export const TakeActionButton = memo(() => {
     [togglePopover]
   );
 
+  const nonEcsData = useMemo(() => {
+    const flattened = flattenObject(dataAsNestedObject);
+    return Object.entries(flattened).map(([key, value]) => ({
+      field: key,
+      value: value as string[],
+    }));
+  }, [dataAsNestedObject]);
+
   const { addToCaseActionItems } = useAddToCaseActions({
     ecsData: dataAsNestedObject,
+    nonEcsData,
     onMenuItemClick: closePopover,
     ariaLabel: ADD_TO_CASE_ARIA_LABEL,
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.tsx
@@ -63,7 +63,7 @@ export interface TakeActionDropdownProps {
   /**
    * The actual raw document object
    */
-  dataAsNestedObject?: Ecs;
+  dataAsNestedObject: Ecs;
   /**
    * Callback called when the popover closes
    */


### PR DESCRIPTION
## Summary

This PR fixes a bug where in Alert summary, enabling auto-extraction does not add observables properly.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->