### PR TITLE
[Attack discovery] Enable the Attack discovery and Attack discovery schedules public API feature flag by default

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -9479,8 +9479,9 @@ paths:
           example: 50
           in: query
           name: size
-          required: true
+          required: false
           schema:
+            default: 50
             minimum: 1
             type: number
         - description: Start of the time range for filtering generations. Accepts absolute timestamps (ISO 8601) or relative date math (e.g. "now-7d").

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/attack_discovery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/attack_discovery_api_2023_10_31.bundled.schema.yaml
@@ -1428,8 +1428,9 @@ paths:
           example: 50
           in: query
           name: size
-          required: true
+          required: false
           schema:
+            default: 50
             minimum: 1
             type: number
         - description: >-

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/attack_discovery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/attack_discovery_api_2023_10_31.bundled.schema.yaml
@@ -1428,8 +1428,9 @@ paths:
           example: 50
           in: query
           name: size
-          required: true
+          required: false
           schema:
+            default: 50
             minimum: 1
             type: number
         - description: >-

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/get_attack_discovery_generations_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/get_attack_discovery_generations_route.gen.ts
@@ -29,7 +29,7 @@ export const GetAttackDiscoveryGenerationsRequestQuery = z.object({
   /**
    * The maximum number of generations to retrieve
    */
-  size: z.coerce.number().min(1),
+  size: z.coerce.number().min(1).optional().default(50),
   /**
    * Start of the time range for filtering generations. Accepts absolute timestamps (ISO 8601) or relative date math (e.g. "now-7d").
    */

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/get_attack_discovery_generations_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/get_attack_discovery_generations_route.schema.yaml
@@ -28,10 +28,11 @@ paths:
           example: "now"
         - name: size
           in: query
-          required: true
+          required: false
           schema:
             type: number
             minimum: 1
+            default: 50
           description: The maximum number of generations to retrieve
           example: 50
         - name: start

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/get_kibana_feature_flags.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/get_kibana_feature_flags.ts
@@ -20,7 +20,7 @@ export const getKibanaFeatureFlags = async (
 
   const attackDiscoveryPublicApiEnabled = await featureFlags.getBooleanValue(
     ATTACK_DISCOVERY_PUBLIC_API_ENABLED_FEATURE_FLAG,
-    false
+    true
   );
 
   return {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_selection_query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_selection_query/index.tsx
@@ -203,6 +203,7 @@ const AlertSelectionQueryComponent: React.FC<Props> = ({
       >
         <EuiSuperDatePicker
           commonlyUsedRanges={commonlyUsedRanges}
+          compressed={true}
           data-test-subj="alertSelectionDatePicker"
           end={settings.end}
           isDisabled={false}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_kibana_feature_flags/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_kibana_feature_flags/index.test.tsx
@@ -74,7 +74,7 @@ describe('useKibanaFeatureFlags', () => {
     });
   });
 
-  it('calls getBooleanValue with the expected default value (false)', async () => {
+  it('calls getBooleanValue with the expected default value (true)', async () => {
     mockGetBooleanValueFn.mockReturnValue(false);
 
     renderHook(() => useKibanaFeatureFlags(), {
@@ -84,7 +84,7 @@ describe('useKibanaFeatureFlags', () => {
     await waitFor(() => {
       expect(mockGetBooleanValueFn).toHaveBeenCalledWith(
         ATTACK_DISCOVERY_PUBLIC_API_ENABLED_FEATURE_FLAG,
-        false // <-- expected default when the feature flag is not configured
+        true // <-- expected default when the feature flag is not configured
       );
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_kibana_feature_flags/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_kibana_feature_flags/index.tsx
@@ -19,7 +19,7 @@ export const useKibanaFeatureFlags = (): UseKibanaFeatureFlags => {
   } = useKibana();
 
   const attackDiscoveryPublicApiEnabled = useMemo(
-    () => featureFlags.getBooleanValue(ATTACK_DISCOVERY_PUBLIC_API_ENABLED_FEATURE_FLAG, false),
+    () => featureFlags.getBooleanValue(ATTACK_DISCOVERY_PUBLIC_API_ENABLED_FEATURE_FLAG, true),
     [featureFlags]
   );
 


### PR DESCRIPTION
## [Attack discovery] Enable the Attack discovery and Attack discovery schedules public API feature flag by default

This PR enables the feature flag for the [Attack discovery and Attack discovery schedules public APIs](https://github.com/elastic/kibana/pull/236736) by default.

- The `securitySolution.attackDiscoveryPublicApiEnabled`, feature flag now defaults to `true`; it may be overridden in `config/kibana.yml`:

```yaml
feature_flags.overrides:
  securitySolution.attackDiscoveryPublicApiEnabled: true
```

In addition to the above:

- The `compressed={true}` style is applied to the `EuiSuperDatePicker` in the `Attack discovery settings` and `Create new schedule` flyout
- The `GET` `/api/attack_discovery/generations` route now includes a default for the size parameter

### Desk testing

1) _Remove_ any references to the `securitySolution.attackDiscoveryPublicApiEnabled` in the `feature_flags.overrides` in section of your local `config/kibana.dev.yml` or `config/kibana.yml`.

**Expected result**

- The feature flag is **NOT** present in `config/kibana.dev.yml` or `config/kibana.yml`

2) Navigate to Security > Attack discovery

3) Open the browser's dev tools, and click the Network tab

4) Filter the network tab by `_generate`

5) In the header of the Attack discovery page, click the `Run` button

**Expected result**

- A `POST` request is made to the public API route: `/api/attack_discovery/_generate`

6) In the header of the Attack discovery page, click the `Settings` button

**Expected results**

- The `Attack discovery settings` flyout appears
- The `Custom query` KQL bar and date picker appear to have the same height, as illustrated by the following screenshot:

![date_picker_after](https://github.com/user-attachments/assets/cd42cc51-b36f-43c2-ac93-cd680969bb12)

7) Click `Cancel` to close the `Attack discovery settings` flyout

8) In the header of the Attack discovery page, click the `Schedule` button

9) Click the `Create new schedule` button

**Expected results**

- The `Create new schedule` flyout appears
- The `Custom query` KQL bar and date picker appear to have the same height

10) Navigate to the Dev Tools > Console page

11) Execute the following query:

```sh
GET kbn:/api/attack_discovery/generations
```

**Expected result**

- The API returns previous generation results
- The API does NOT return an error

12) Disable the `securitySolution.attackDiscoveryPublicApiEnabled` feature flag in your local `config/kibana.dev.yml` or `config/kibana.yml`, like the following example:

```yaml
feature_flags.overrides:
  securitySolution.attackDiscoveryPublicApiEnabled: false
```

13) **After Kibana server finishes restarting**, do a full page refresh of your browser

14) Navigate to Security > Attack discovery

15) Once again, in the header of the Attack discovery page, click the `Run` button

**Expected result**

- In the browsers dev tools, the network tab is still filtered by `_generate`
- A `POST` request is NOT made to the public API route: `/api/attack_discovery/_generate`

16) In the browsers dev tools, filter the network tab by `/internal/elastic_assistant/attack_discovery`

**Expected result**

- A `POST` request was made to `/internal/elastic_assistant/attack_discovery`

17) Once again, Navigate to the Dev Tools > Console page

18) Execute the following query:

```sh
GET kbn:/api/attack_discovery/generations
```

**Expected result**

- The API returns results an error indicating the public API is disabled

```json
{
  "message": "Attack discovery public API is disabled",
  "status_code": 403
}
```


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->