### PR TITLE
[Security Solution] remove editHighlightedFields feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -178,11 +178,6 @@ export const allowedExperimentalValues = Object.freeze({
   newExpandableFlyoutNavigationDisabled: false,
 
   /**
-   * Enables the ability to edit highlighted fields in the alertflyout
-   */
-  editHighlightedFields: true,
-
-  /**
    * Enables CrowdStrike's RunScript RTR command
    * Release: 8.18/9.0
    */

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.test.tsx
@@ -52,7 +52,7 @@ describe('<HighlightedFields />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useHighlightedFieldsPrivilege as jest.Mock).mockReturnValue({
-      isEditHighlightedFieldsDisabled: false,
+      isDisabled: false,
       tooltipContent: 'tooltip content',
     });
     (useRuleIndexPattern as jest.Mock).mockReturnValue({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.tsx
@@ -127,7 +127,7 @@ export interface HighlightedFieldsProps {
    */
   showCellActions: boolean;
   /**
-   * If true, the edit button will be shown on hover (granted that the editHighlightedFieldsEnabled is also turned on).
+   * If true, the edit button will be shown on hover.
    * This is false by default (for EASE alert summary page) and will be true for the alerts page.
    */
   showEditButton?: boolean;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
@@ -8,7 +8,6 @@
 import React, { memo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useExpandSection } from '../hooks/use_expand_section';
 import { ExpandableSection } from './expandable_section';
 import { HighlightedFields } from './highlighted_fields';
@@ -31,8 +30,6 @@ export const InvestigationSection = memo(() => {
   const ancestorIndex = getField(getFieldsData('signal.ancestors.index')) ?? '';
 
   const expanded = useExpandSection({ title: KEY, defaultValue: true });
-
-  const editHighlightedFieldsEnabled = useIsExperimentalFeatureEnabled('editHighlightedFields');
 
   return (
     <ExpandableSection
@@ -58,7 +55,7 @@ export const InvestigationSection = memo(() => {
         investigationFields={investigationFields}
         scopeId={scopeId}
         showCellActions={true}
-        showEditButton={editHighlightedFieldsEnabled}
+        showEditButton={true}
         ancestorsIndexName={ancestorIndex}
       />
     </ExpandableSection>


### PR DESCRIPTION
## Summary

This PR removes the `editHighlightedFields` feature flag as it's been enabled for a few months now.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
