### PR TITLE
[Security Solution] remove newExpandableFlyoutNavigationDisabled feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -142,11 +142,6 @@ export const allowedExperimentalValues = Object.freeze({
   endpointExceptionsMovedUnderManagement: false,
 
   /**
-   * Disables flyout history and new preview navigation
-   */
-  newExpandableFlyoutNavigationDisabled: false,
-
-  /**
    * Enables CrowdStrike's RunScript RTR command
    * Release: 8.18/9.0
    */

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/alerts/alerts_preview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/alerts/alerts_preview.test.tsx
@@ -54,7 +54,7 @@ describe('AlertsPreview', () => {
       <TestProviders>
         <AlertsPreview
           alertsData={mockAlertsData}
-          isLinkEnabled={true}
+          isPreviewMode={false}
           openDetailsPanel={mockOpenLeftPanel}
         />
       </TestProviders>
@@ -68,7 +68,7 @@ describe('AlertsPreview', () => {
       <TestProviders>
         <AlertsPreview
           alertsData={mockAlertsData}
-          isLinkEnabled={true}
+          isPreviewMode={false}
           openDetailsPanel={mockOpenLeftPanel}
         />
       </TestProviders>
@@ -82,7 +82,7 @@ describe('AlertsPreview', () => {
       <TestProviders>
         <AlertsPreview
           alertsData={mockAlertsData}
-          isLinkEnabled={true}
+          isPreviewMode={false}
           openDetailsPanel={mockOpenLeftPanel}
         />
       </TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/alerts/alerts_preview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/alerts/alerts_preview.tsx
@@ -64,12 +64,10 @@ export const AlertsPreview = ({
   alertsData,
   isPreviewMode,
   openDetailsPanel,
-  isLinkEnabled,
 }: {
   alertsData: ParsedAlertsData;
-  isPreviewMode?: boolean;
+  isPreviewMode: boolean;
   openDetailsPanel: (path: EntityDetailsPath) => void;
-  isLinkEnabled: boolean;
 }) => {
   const { euiTheme } = useEuiTheme();
 
@@ -101,27 +99,26 @@ export const AlertsPreview = ({
 
   const hasNonClosedAlerts = totalAlertsCount > 0;
 
-  const goToEntityInsightTab = useCallback(() => {
-    openDetailsPanel({
-      tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
-      subTab: CspInsightLeftPanelSubTab.ALERTS,
-    });
-  }, [openDetailsPanel]);
+  const goToEntityInsightTab = useCallback(
+    () =>
+      openDetailsPanel({
+        tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
+        subTab: CspInsightLeftPanelSubTab.ALERTS,
+      }),
+    [openDetailsPanel]
+  );
 
   const link = useMemo(
-    () =>
-      isLinkEnabled
-        ? {
-            callback: goToEntityInsightTab,
-            tooltip: (
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.right.insights.alerts.alertsTooltip"
-                defaultMessage="Show all alerts"
-              />
-            ),
-          }
-        : undefined,
-    [isLinkEnabled, goToEntityInsightTab]
+    () => ({
+      callback: goToEntityInsightTab,
+      tooltip: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.right.insights.alerts.alertsTooltip"
+          defaultMessage="Show all alerts"
+        />
+      ),
+    }),
+    [goToEntityInsightTab]
   );
   return (
     <ExpandablePanel

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
@@ -33,13 +33,11 @@ export const EntityInsight = <T,>({
   value,
   field,
   isPreviewMode,
-  isLinkEnabled,
   openDetailsPanel,
 }: {
   value: string;
   field: CloudPostureEntityIdentifier;
-  isPreviewMode?: boolean;
-  isLinkEnabled: boolean;
+  isPreviewMode: boolean;
   openDetailsPanel: (path: EntityDetailsPath) => void;
 }) => {
   const { euiTheme } = useEuiTheme();
@@ -70,7 +68,6 @@ export const EntityInsight = <T,>({
         <AlertsPreview
           alertsData={filteredAlertsData}
           isPreviewMode={isPreviewMode}
-          isLinkEnabled={isLinkEnabled}
           openDetailsPanel={openDetailsPanel}
         />
         <EuiSpacer size="s" />
@@ -85,7 +82,6 @@ export const EntityInsight = <T,>({
           value={value}
           field={field}
           isPreviewMode={isPreviewMode}
-          isLinkEnabled={isLinkEnabled}
           openDetailsPanel={openDetailsPanel}
         />
         <EuiSpacer size="s" />
@@ -98,7 +94,6 @@ export const EntityInsight = <T,>({
           value={value}
           field={field}
           isPreviewMode={isPreviewMode}
-          isLinkEnabled={isLinkEnabled}
           openDetailsPanel={openDetailsPanel}
         />
         <EuiSpacer size="s" />

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/misconfiguration/misconfiguration_preview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/misconfiguration/misconfiguration_preview.test.tsx
@@ -35,7 +35,7 @@ describe('MisconfigurationsPreview', () => {
         <MisconfigurationsPreview
           value="host1"
           field={EntityIdentifierFields.hostName}
-          isLinkEnabled={true}
+          isPreviewMode={false}
           openDetailsPanel={mockOpenLeftPanel}
         />
       </TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/misconfiguration/misconfiguration_preview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/misconfiguration/misconfiguration_preview.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { css } from '@emotion/react';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, useEuiTheme, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle, useEuiTheme } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { DistributionBar } from '@kbn/security-solution-distribution-bar';
 import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations';
@@ -108,13 +108,11 @@ export const MisconfigurationsPreview = ({
   value,
   field,
   isPreviewMode,
-  isLinkEnabled,
   openDetailsPanel,
 }: {
   value: string;
   field: CloudPostureEntityIdentifier;
-  isPreviewMode?: boolean;
-  isLinkEnabled: boolean;
+  isPreviewMode: boolean;
   openDetailsPanel: (path: EntityDetailsPath) => void;
 }) => {
   const { hasMisconfigurationFindings, passedFindings, failedFindings } = useHasMisconfigurations(
@@ -128,27 +126,26 @@ export const MisconfigurationsPreview = ({
   }, []);
   const { euiTheme } = useEuiTheme();
 
-  const goToEntityInsightTab = useCallback(() => {
-    openDetailsPanel({
-      tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
-      subTab: CspInsightLeftPanelSubTab.MISCONFIGURATIONS,
-    });
-  }, [openDetailsPanel]);
+  const goToEntityInsightTab = useCallback(
+    () =>
+      openDetailsPanel({
+        tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
+        subTab: CspInsightLeftPanelSubTab.MISCONFIGURATIONS,
+      }),
+    [openDetailsPanel]
+  );
 
   const link = useMemo(
-    () =>
-      isLinkEnabled
-        ? {
-            callback: goToEntityInsightTab,
-            tooltip: (
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.right.insights.misconfiguration.misconfigurationTooltip"
-                defaultMessage="Show all misconfiguration findings"
-              />
-            ),
-          }
-        : undefined,
-    [isLinkEnabled, goToEntityInsightTab]
+    () => ({
+      callback: goToEntityInsightTab,
+      tooltip: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.right.insights.misconfiguration.misconfigurationTooltip"
+          defaultMessage="Show all misconfiguration findings"
+        />
+      ),
+    }),
+    [goToEntityInsightTab]
   );
   return (
     <ExpandablePanel

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/vulnerabilities/vulnerabilities_preview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/vulnerabilities/vulnerabilities_preview.test.tsx
@@ -35,7 +35,7 @@ describe('VulnerabilitiesPreview', () => {
         <VulnerabilitiesPreview
           value="host1"
           field={EntityIdentifierFields.hostName}
-          isLinkEnabled={true}
+          isPreviewMode={false}
           openDetailsPanel={mockOpenLeftPanel}
         />
       </TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/vulnerabilities/vulnerabilities_preview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/vulnerabilities/vulnerabilities_preview.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { css } from '@emotion/react';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, useEuiTheme, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle, useEuiTheme } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { DistributionBar } from '@kbn/security-solution-distribution-bar';
 import { useVulnerabilitiesPreview } from '@kbn/cloud-security-posture/src/hooks/use_vulnerabilities_preview';
@@ -67,13 +67,11 @@ export const VulnerabilitiesPreview = ({
   value,
   field,
   isPreviewMode,
-  isLinkEnabled,
   openDetailsPanel,
 }: {
   value: string;
   field: CloudPostureEntityIdentifier;
-  isPreviewMode?: boolean;
-  isLinkEnabled: boolean;
+  isPreviewMode: boolean;
   openDetailsPanel: (path: EntityDetailsPath) => void;
 }) => {
   useEffect(() => {
@@ -102,27 +100,26 @@ export const VulnerabilitiesPreview = ({
   const { euiTheme } = useEuiTheme();
   const { getSeverityStatusColor } = useGetSeverityStatusColor();
 
-  const goToEntityInsightTab = useCallback(() => {
-    openDetailsPanel({
-      tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
-      subTab: CspInsightLeftPanelSubTab.VULNERABILITIES,
-    });
-  }, [openDetailsPanel]);
+  const goToEntityInsightTab = useCallback(
+    () =>
+      openDetailsPanel({
+        tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
+        subTab: CspInsightLeftPanelSubTab.VULNERABILITIES,
+      }),
+    [openDetailsPanel]
+  );
 
   const link = useMemo(
-    () =>
-      isLinkEnabled
-        ? {
-            callback: goToEntityInsightTab,
-            tooltip: (
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.right.insights.vulnerabilities.vulnerabilitiesTooltip"
-                defaultMessage="Show all vulnerabilities findings"
-              />
-            ),
-          }
-        : undefined,
-    [isLinkEnabled, goToEntityInsightTab]
+    () => ({
+      callback: goToEntityInsightTab,
+      tooltip: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.right.insights.vulnerabilities.vulnerabilitiesTooltip"
+          defaultMessage="Show all vulnerabilities findings"
+        />
+      ),
+    }),
+    [goToEntityInsightTab]
   );
 
   const vulnerabilityStats = getVulnerabilityStats(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.stories.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.stories.tsx
@@ -28,7 +28,7 @@ export const Default: StoryFn = () => {
             riskScoreData={{ ...mockRiskScoreState, data: [] }}
             queryId={'testQuery'}
             recalculatingScore={false}
-            isLinkEnabled
+            isPreviewMode={false}
             entityType={EntityType.user}
           />
         </div>
@@ -37,7 +37,7 @@ export const Default: StoryFn = () => {
   );
 };
 
-export const LinkEnabledInPreviewMode: StoryFn = () => {
+export const InPreviewMode: StoryFn = () => {
   return (
     <StorybookProviders>
       <TestProvider>
@@ -47,27 +47,7 @@ export const LinkEnabledInPreviewMode: StoryFn = () => {
             queryId={'testQuery'}
             recalculatingScore={false}
             openDetailsPanel={() => {}}
-            isLinkEnabled
             isPreviewMode
-            entityType={EntityType.user}
-          />
-        </div>
-      </TestProvider>
-    </StorybookProviders>
-  );
-};
-
-export const LinkDisabled: StoryFn = () => {
-  return (
-    <StorybookProviders>
-      <TestProvider>
-        <div css={{ maxWidth: '300px' }}>
-          <FlyoutRiskSummary
-            riskScoreData={{ ...mockRiskScoreState, data: [] }}
-            queryId={'testQuery'}
-            recalculatingScore={false}
-            openDetailsPanel={() => {}}
-            isLinkEnabled={false}
             entityType={EntityType.user}
           />
         </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.test.tsx
@@ -42,7 +42,7 @@ describe('FlyoutRiskSummary', () => {
           queryId={'testQuery'}
           openDetailsPanel={() => {}}
           recalculatingScore={false}
-          isLinkEnabled
+          isPreviewMode={false}
           entityType={EntityType.host}
         />
       </TestProviders>
@@ -79,7 +79,6 @@ describe('FlyoutRiskSummary', () => {
           queryId={'testQuery'}
           openDetailsPanel={() => {}}
           recalculatingScore={false}
-          isLinkEnabled
           isPreviewMode
           entityType={EntityType.host}
         />
@@ -99,7 +98,7 @@ describe('FlyoutRiskSummary', () => {
           queryId={'testQuery'}
           openDetailsPanel={() => {}}
           recalculatingScore={false}
-          isLinkEnabled
+          isPreviewMode={false}
           entityType={EntityType.host}
         />
       </TestProviders>
@@ -115,25 +114,7 @@ describe('FlyoutRiskSummary', () => {
           queryId={'testQuery'}
           openDetailsPanel={() => {}}
           recalculatingScore={false}
-          isLinkEnabled
-          entityType={EntityType.host}
-        />
-      </TestProviders>
-    );
-
-    expect(queryByTestId('riskInputsTitleLink')).not.toBeInTheDocument();
-  });
-
-  it('risk summary header does not render link when link is not enabled', () => {
-    const { queryByTestId } = render(
-      <TestProviders>
-        <FlyoutRiskSummary
-          riskScoreData={{ ...mockHostRiskScoreState, data: undefined, loading: true }}
-          queryId={'testQuery'}
-          openDetailsPanel={() => {}}
-          recalculatingScore={false}
-          isLinkEnabled={false}
-          isPreviewMode
+          isPreviewMode={false}
           entityType={EntityType.host}
         />
       </TestProviders>
@@ -150,7 +131,7 @@ describe('FlyoutRiskSummary', () => {
           queryId={'testQuery'}
           openDetailsPanel={() => {}}
           recalculatingScore={false}
-          isLinkEnabled
+          isPreviewMode={false}
           entityType={EntityType.host}
         />
       </TestProviders>
@@ -167,7 +148,7 @@ describe('FlyoutRiskSummary', () => {
           queryId={'testQuery'}
           openDetailsPanel={() => {}}
           recalculatingScore={false}
-          isLinkEnabled
+          isPreviewMode={false}
           entityType={EntityType.host}
         />
       </TestProviders>
@@ -184,7 +165,7 @@ describe('FlyoutRiskSummary', () => {
           queryId={'testQuery'}
           openDetailsPanel={() => {}}
           recalculatingScore={false}
-          isLinkEnabled
+          isPreviewMode={false}
           entityType={EntityType.host}
         />
       </TestProviders>
@@ -213,7 +194,7 @@ describe('FlyoutRiskSummary', () => {
           queryId={'testQuery'}
           openDetailsPanel={() => {}}
           recalculatingScore={false}
-          isLinkEnabled
+          isPreviewMode={false}
           entityType={EntityType.host}
         />
       </TestProviders>
@@ -237,7 +218,7 @@ describe('FlyoutRiskSummary', () => {
           queryId={'testQuery'}
           openDetailsPanel={() => {}}
           recalculatingScore={false}
-          isLinkEnabled
+          isPreviewMode={false}
           entityType={EntityType.user}
         />
       </TestProviders>
@@ -261,7 +242,7 @@ describe('FlyoutRiskSummary', () => {
           queryId={'testQuery'}
           openDetailsPanel={() => {}}
           recalculatingScore={false}
-          isLinkEnabled
+          isPreviewMode={false}
           entityType={EntityType.user}
         />
       </TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.tsx
@@ -6,16 +6,15 @@
  */
 
 import React, { useCallback, useMemo } from 'react';
-
 import {
-  useEuiTheme,
   EuiAccordion,
-  EuiTitle,
-  EuiSpacer,
   EuiBasicTable,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiSpacer,
+  EuiTitle,
   useEuiFontSize,
+  useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -53,8 +52,7 @@ export interface RiskSummaryProps<T extends EntityType> {
   recalculatingScore: boolean;
   queryId: string;
   openDetailsPanel: (path: EntityDetailsPath) => void;
-  isLinkEnabled: boolean;
-  isPreviewMode?: boolean;
+  isPreviewMode: boolean;
 }
 
 const FlyoutRiskSummaryComponent = <T extends EntityType>({
@@ -63,7 +61,6 @@ const FlyoutRiskSummaryComponent = <T extends EntityType>({
   recalculatingScore,
   queryId,
   openDetailsPanel,
-  isLinkEnabled,
   isPreviewMode,
 }: RiskSummaryProps<T>) => {
   const { telemetry } = useKibana().services;
@@ -120,6 +117,24 @@ const FlyoutRiskSummaryComponent = <T extends EntityType>({
     return { from, to };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [riskDataTimestamp]); // Update the timerange whenever the risk score timestamp changes to include new entries
+
+  const goToEntityInsightsTab = useCallback(
+    () => openDetailsPanel({ tab: EntityDetailsLeftPanelTab.RISK_INPUTS }),
+    [openDetailsPanel]
+  );
+
+  const link = useMemo(
+    () => ({
+      callback: goToEntityInsightsTab,
+      tooltip: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.entityDetails.showAllRiskInputs"
+          defaultMessage="Show all risk inputs"
+        />
+      ),
+    }),
+    [goToEntityInsightsTab]
+  );
 
   return (
     <EuiAccordion
@@ -178,19 +193,7 @@ const FlyoutRiskSummaryComponent = <T extends EntityType>({
               defaultMessage="View risk contributions"
             />
           ),
-          link: riskScoreData.loading
-            ? undefined
-            : {
-                callback: isLinkEnabled
-                  ? () => openDetailsPanel({ tab: EntityDetailsLeftPanelTab.RISK_INPUTS })
-                  : undefined,
-                tooltip: (
-                  <FormattedMessage
-                    id="xpack.securitySolution.flyout.entityDetails.showAllRiskInputs"
-                    defaultMessage="Show all risk inputs"
-                  />
-                ),
-              },
+          link: riskScoreData.loading ? undefined : link,
           iconType: !isPreviewMode ? 'arrowStart' : undefined,
         }}
         expand={{

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.tsx
@@ -36,6 +36,7 @@ import { useNonClosedAlerts } from '../../../../cloud_security_posture/hooks/use
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import type { RelatedUser } from '../../../../../common/search_strategy/security_solution/related_entities/related_users';
 import type { RiskSeverity } from '../../../../../common/search_strategy';
+import { buildHostNamesFilter } from '../../../../../common/search_strategy';
 import { HostOverview } from '../../../../overview/components/host_overview';
 import { AnomalyTableProvider } from '../../../../common/components/ml/anomaly/anomaly_table_provider';
 import { InspectButton, InspectButtonContainer } from '../../../../common/components/inspect';
@@ -80,7 +81,6 @@ import { AlertCountInsight } from '../../shared/components/alert_count_insight';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
 import { useNavigateToHostDetails } from '../../../entity_details/host_right/hooks/use_navigate_to_host_details';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
-import { buildHostNamesFilter } from '../../../../../common/search_strategy';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 
 const HOST_DETAILS_ID = 'entities-hosts-details';
@@ -199,7 +199,7 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, s
   const { hasMisconfigurationFindings } = useHasMisconfigurations('host.name', hostName);
   const { hasVulnerabilitiesFindings } = useHasVulnerabilities('host.name', hostName);
 
-  const { openDetailsPanel } = useNavigateToHostDetails({
+  const openDetailsPanel = useNavigateToHostDetails({
     hostName,
     scopeId,
     isRiskScoreExist,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.tsx
@@ -15,12 +15,12 @@ import {
   EuiFlexItem,
   EuiHorizontalRule,
   EuiIcon,
+  EuiIconTip,
   EuiInMemoryTable,
   EuiPanel,
   EuiSpacer,
   EuiText,
   EuiTitle,
-  EuiIconTip,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -32,6 +32,7 @@ import { useNonClosedAlerts } from '../../../../cloud_security_posture/hooks/use
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import type { RelatedHost } from '../../../../../common/search_strategy/security_solution/related_entities/related_hosts';
 import type { RiskSeverity } from '../../../../../common/search_strategy';
+import { buildUserNamesFilter } from '../../../../../common/search_strategy';
 import { UserOverview } from '../../../../overview/components/user_overview';
 import { AnomalyTableProvider } from '../../../../common/components/ml/anomaly/anomaly_table_provider';
 import { InspectButton, InspectButtonContainer } from '../../../../common/components/inspect';
@@ -74,7 +75,6 @@ import { AlertCountInsight } from '../../shared/components/alert_count_insight';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
 import { useNavigateToUserDetails } from '../../../entity_details/user_right/hooks/use_navigate_to_user_details';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
-import { buildUserNamesFilter } from '../../../../../common/search_strategy';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 
 const USER_DETAILS_ID = 'entities-users-details';
@@ -186,7 +186,7 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, s
     queryId: USER_DETAILS_INSIGHTS_ID,
   });
 
-  const { openDetailsPanel } = useNavigateToUserDetails({
+  const openDetailsPanel = useNavigateToUserDetails({
     userName,
     scopeId,
     isRiskScoreExist,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { TestProviders } from '../../../../common/mock';
 import React from 'react';
 import { DocumentDetailsContext } from '../../shared/context';
@@ -15,14 +15,7 @@ import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/
 import { ANALYZER_PREVIEW_TEST_ID } from './test_ids';
 import { useAlertPrevalenceFromProcessTree } from '../../shared/hooks/use_alert_prevalence_from_process_tree';
 import * as mock from '../mocks/mock_analyzer_data';
-import {
-  EXPANDABLE_PANEL_CONTENT_TEST_ID,
-  EXPANDABLE_PANEL_HEADER_TITLE_ICON_TEST_ID,
-  EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID,
-  EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID,
-  EXPANDABLE_PANEL_TOGGLE_ICON_TEST_ID,
-} from '../../../shared/components/test_ids';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import { EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID } from '../../../shared/components/test_ids';
 import { useInvestigateInTimeline } from '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
 
 jest.mock(
@@ -32,7 +25,6 @@ jest.mock('../../shared/hooks/use_alert_prevalence_from_process_tree');
 jest.mock(
   '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
 );
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockNavigateToAnalyzer = jest.fn();
 jest.mock('../../shared/hooks/use_navigate_to_analyzer', () => {
@@ -52,9 +44,6 @@ jest.mock('react-redux', () => {
   };
 });
 
-const NO_ANALYZER_MESSAGE =
-  'You can only visualize events triggered by hosts configured with the Elastic Defend integration or any sysmon data from winlogbeat. Refer to Visual event analyzer(external, opens in a new tab or window) for more information.';
-
 const renderAnalyzerPreview = (context = mockContextValue) =>
   render(
     <TestProviders>
@@ -65,161 +54,39 @@ const renderAnalyzerPreview = (context = mockContextValue) =>
   );
 
 describe('AnalyzerPreviewContainer', () => {
-  describe('when newExpandableFlyoutNavigationDisabled is true', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+  beforeEach(() => {
+    (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
+    (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      alertIds: ['alertid'],
+      statsNodes: mock.mockStatsNodes,
     });
-
-    it('should render component and link in header', () => {
-      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-      (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
-        loading: false,
-        error: false,
-        alertIds: ['alertid'],
-        statsNodes: mock.mockStatsNodes,
-      });
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
-
-      const { getByTestId } = renderAnalyzerPreview();
-
-      expect(getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByTestId(EXPANDABLE_PANEL_TOGGLE_ICON_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
-      ).not.toBeInTheDocument();
-      expect(
-        screen.getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_ICON_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
-      ).not.toBeInTheDocument();
-      expect(
-        screen.getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
-      ).not.toHaveTextContent(NO_ANALYZER_MESSAGE);
-    });
-
-    it('should render error message and text in header', () => {
-      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(false);
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
-
-      const { getByTestId } = renderAnalyzerPreview();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
-      ).toHaveTextContent(NO_ANALYZER_MESSAGE);
-    });
-
-    it('should open left flyout visualization tab when clicking on title', () => {
-      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-      (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
-        loading: false,
-        error: false,
-        alertIds: ['alertid'],
-        statsNodes: mock.mockStatsNodes,
-      });
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
-
-      const { getByTestId } = renderAnalyzerPreview();
-
-      getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID)).click();
-      expect(mockNavigateToAnalyzer).toHaveBeenCalled();
-    });
-
-    it('should disable link when in rule preview', () => {
-      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-      (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
-        loading: false,
-        error: false,
-        alertIds: ['alertid'],
-        statsNodes: mock.mockStatsNodes,
-      });
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
-
-      const { queryByTestId } = renderAnalyzerPreview({
-        ...mockContextValue,
-        isRulePreview: true,
-      });
-      expect(
-        queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
-      ).not.toBeInTheDocument();
-    });
-
-    it('should disable link when in preview mode', () => {
-      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-      (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
-        loading: false,
-        error: false,
-        alertIds: ['alertid'],
-        statsNodes: mock.mockStatsNodes,
-      });
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
-
-      const { queryByTestId } = renderAnalyzerPreview({
-        ...mockContextValue,
-        isPreviewMode: true,
-      });
-      expect(
-        queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
-      ).not.toBeInTheDocument();
+    (useInvestigateInTimeline as jest.Mock).mockReturnValue({
+      investigateInTimelineAlertClick: jest.fn(),
     });
   });
+  it('should open left flyout visualization tab when clicking on title', () => {
+    const { getByTestId } = renderAnalyzerPreview();
 
-  describe('when newExpandableFlyoutNavigationDisabled is false', () => {
-    beforeEach(() => {
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
-    });
-    beforeEach(() => {
-      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-      (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
-        loading: false,
-        error: false,
-        alertIds: ['alertid'],
-        statsNodes: mock.mockStatsNodes,
-      });
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
-    });
-    it('should open left flyout visualization tab when clicking on title', () => {
-      const { getByTestId } = renderAnalyzerPreview();
+    getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID)).click();
+    expect(mockNavigateToAnalyzer).toHaveBeenCalled();
+  });
 
-      getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID)).click();
-      expect(mockNavigateToAnalyzer).toHaveBeenCalled();
+  it('should disable link when in rule preview', () => {
+    const { queryByTestId } = renderAnalyzerPreview({
+      ...mockContextValue,
+      isRulePreview: true,
     });
+    expect(
+      queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
+    ).not.toBeInTheDocument();
+  });
 
-    it('should disable link when in rule preview', () => {
-      const { queryByTestId } = renderAnalyzerPreview({
-        ...mockContextValue,
-        isRulePreview: true,
-      });
-      expect(
-        queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
-      ).not.toBeInTheDocument();
-    });
+  it('should render link when in preview mode', () => {
+    const { getByTestId } = renderAnalyzerPreview({ ...mockContextValue, isPreviewMode: true });
 
-    it('should render link when in preview mode', () => {
-      const { getByTestId } = renderAnalyzerPreview({ ...mockContextValue, isPreviewMode: true });
-
-      getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID)).click();
-      expect(mockNavigateToAnalyzer).toHaveBeenCalled();
-    });
+    getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID)).click();
+    expect(mockNavigateToAnalyzer).toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.tsx
@@ -14,7 +14,6 @@ import { AnalyzerPreview } from './analyzer_preview';
 import { ANALYZER_PREVIEW_TEST_ID } from './test_ids';
 import { useNavigateToAnalyzer } from '../../shared/hooks/use_navigate_to_analyzer';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 /**
  * Analyzer preview under Overview, Visualizations. It shows a tree representation of analyzer.
@@ -23,9 +22,6 @@ export const AnalyzerPreviewContainer: React.FC = () => {
   const { dataAsNestedObject, isRulePreview, eventId, indexName, scopeId, isPreviewMode } =
     useDocumentDetailsContext();
 
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
   // decide whether to show the analyzer preview or not
   const isEnabled = useIsInvestigateInResolverActionEnabled(dataAsNestedObject);
 
@@ -39,18 +35,11 @@ export const AnalyzerPreviewContainer: React.FC = () => {
 
   const iconType = useMemo(() => (!isPreviewMode ? 'arrowStart' : undefined), [isPreviewMode]);
 
-  const isNavigationEnabled = useMemo(() => {
-    // if the analyzer is not enabled or in rule preview mode, the navigation is not enabled
-    if (!isEnabled || isRulePreview) {
-      return false;
-    }
-    // if the new navigation is enabled, the navigation is enabled (flyout or timeline)
-    if (isNewNavigationEnabled) {
-      return true;
-    }
-    // if the new navigation is not enabled, the navigation is enabled if the flyout is not in preview mode
-    return !isPreviewMode;
-  }, [isNewNavigationEnabled, isPreviewMode, isEnabled, isRulePreview]);
+  // if the analyzer is not enabled or in rule preview mode, the navigation is not enabled
+  const isNavigationEnabled = useMemo(
+    () => !(!isEnabled || isRulePreview),
+    [isEnabled, isRulePreview]
+  );
 
   return (
     <ExpandablePanel

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/correlations_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/correlations_overview.test.tsx
@@ -121,10 +121,7 @@ describe('<CorrelationsOverview />', () => {
     (useSecurityDefaultPatterns as jest.Mock).mockReturnValue({
       indexPatterns: ['index'],
     });
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
   });
 
   it('should render wrapper component', () => {
@@ -141,18 +138,6 @@ describe('<CorrelationsOverview />', () => {
     );
     expect(getByTestId(TITLE_LINK_TEST_ID)).toBeInTheDocument();
     expect(queryByTestId(TITLE_ICON_TEST_ID)).not.toBeInTheDocument();
-  });
-
-  it('should not render link when navigation is disabled', () => {
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: false,
-    });
-
-    const { getByTestId, queryByTestId } = render(renderCorrelationsOverview(panelContextValue));
-    expect(queryByTestId(TOGGLE_ICON_TEST_ID)).not.toBeInTheDocument();
-    expect(queryByTestId(TITLE_LINK_TEST_ID)).not.toBeInTheDocument();
-    expect(getByTestId(TITLE_TEXT_TEST_ID)).toBeInTheDocument();
   });
 
   it('should show component with all rows in expandable panel', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/correlations_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/correlations_overview.tsx
@@ -49,11 +49,10 @@ export const CorrelationsOverview: React.FC = () => {
     ? experimentalSecurityDefaultIndexPatterns
     : oldSecurityDefaultPatterns;
 
-  const { navigateToLeftPanel: goToCorrelationsTab, isEnabled: isLinkEnabled } =
-    useNavigateToLeftPanel({
-      tab: LeftPanelInsightsTab,
-      subTab: CORRELATIONS_TAB_ID,
-    });
+  const goToCorrelationsTab = useNavigateToLeftPanel({
+    tab: LeftPanelInsightsTab,
+    subTab: CORRELATIONS_TAB_ID,
+  });
 
   const { show: showAlertsByAncestry, documentId } = useShowRelatedAlertsByAncestry({
     getFieldsData,
@@ -81,19 +80,16 @@ export const CorrelationsOverview: React.FC = () => {
   const ruleType = get(dataAsNestedObject, ALERT_RULE_TYPE)?.[0] as Type | undefined;
 
   const link = useMemo(
-    () =>
-      isLinkEnabled
-        ? {
-            callback: goToCorrelationsTab,
-            tooltip: (
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.right.insights.correlations.overviewTooltip"
-                defaultMessage="Show all correlations"
-              />
-            ),
-          }
-        : undefined,
-    [goToCorrelationsTab, isLinkEnabled]
+    () => ({
+      callback: goToCorrelationsTab,
+      tooltip: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.right.insights.correlations.overviewTooltip"
+          defaultMessage="Show all correlations"
+        />
+      ),
+    }),
+    [goToCorrelationsTab]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/entities_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/entities_overview.test.tsx
@@ -84,10 +84,7 @@ describe('<EntitiesOverview />', () => {
     mockUseRiskScore.mockReturnValue({ data: null, isAuthorized: false });
     mockUseHostDetails.mockReturnValue([false, { hostDetails: null }]);
     mockUseFirstLastSeen.mockReturnValue([false, { lastSeen: null }]);
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
   });
   it('should render wrapper component', () => {
     const { getByTestId, queryByTestId } = renderEntitiesOverview(mockContextValue);
@@ -108,17 +105,6 @@ describe('<EntitiesOverview />', () => {
     expect(getByTestId(TITLE_LINK_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(TITLE_LINK_TEST_ID)).toHaveTextContent('Entities');
     expect(queryByTestId(TITLE_ICON_TEST_ID)).not.toBeInTheDocument();
-  });
-
-  it('should not render link if navigation is disabled', () => {
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: false,
-    });
-    const { getByTestId, queryByTestId } = renderEntitiesOverview(mockContextValue);
-
-    expect(queryByTestId(TITLE_LINK_TEST_ID)).not.toBeInTheDocument();
-    expect(getByTestId(TITLE_TEXT_TEST_ID)).toBeInTheDocument();
   });
 
   it('should render user and host', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/entities_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/entities_overview.tsx
@@ -26,25 +26,22 @@ export const EntitiesOverview: React.FC = () => {
   const hostName = getField(getFieldsData('host.name'));
   const userName = getField(getFieldsData('user.name'));
 
-  const { navigateToLeftPanel, isEnabled: isLinkEnabled } = useNavigateToLeftPanel({
+  const navigateToLeftPanel = useNavigateToLeftPanel({
     tab: LeftPanelInsightsTab,
     subTab: ENTITIES_TAB_ID,
   });
 
   const link = useMemo(
-    () =>
-      isLinkEnabled
-        ? {
-            callback: navigateToLeftPanel,
-            tooltip: (
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.right.insights.entities.entitiesTooltip"
-                defaultMessage="Show all entities"
-              />
-            ),
-          }
-        : undefined,
-    [navigateToLeftPanel, isLinkEnabled]
+    () => ({
+      callback: navigateToLeftPanel,
+      tooltip: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.right.insights.entities.entitiesTooltip"
+          defaultMessage="Show all entities"
+        />
+      ),
+    }),
+    [navigateToLeftPanel]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
@@ -9,11 +9,11 @@ import React, { useMemo } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiText,
   EuiIcon,
-  useEuiTheme,
-  useEuiFontSize,
   EuiSkeletonText,
+  EuiText,
+  useEuiFontSize,
+  useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { getOr } from 'lodash/fp';
@@ -47,18 +47,18 @@ import { getField } from '../../shared/utils';
 import { CellActions } from '../../shared/components/cell_actions';
 import {
   FAMILY,
-  LAST_SEEN,
   HOST_RISK_LEVEL,
+  LAST_SEEN,
 } from '../../../../overview/components/host_overview/translations';
 import {
-  ENTITIES_HOST_OVERVIEW_TEST_ID,
-  ENTITIES_HOST_OVERVIEW_OS_FAMILY_TEST_ID,
+  ENTITIES_HOST_OVERVIEW_ALERT_COUNT_TEST_ID,
   ENTITIES_HOST_OVERVIEW_LAST_SEEN_TEST_ID,
-  ENTITIES_HOST_OVERVIEW_RISK_LEVEL_TEST_ID,
   ENTITIES_HOST_OVERVIEW_LINK_TEST_ID,
   ENTITIES_HOST_OVERVIEW_LOADING_TEST_ID,
-  ENTITIES_HOST_OVERVIEW_ALERT_COUNT_TEST_ID,
   ENTITIES_HOST_OVERVIEW_MISCONFIGURATIONS_TEST_ID,
+  ENTITIES_HOST_OVERVIEW_OS_FAMILY_TEST_ID,
+  ENTITIES_HOST_OVERVIEW_RISK_LEVEL_TEST_ID,
+  ENTITIES_HOST_OVERVIEW_TEST_ID,
   ENTITIES_HOST_OVERVIEW_VULNERABILITIES_TEST_ID,
 } from './test_ids';
 import { RiskScoreDocTooltip } from '../../../../overview/components/common';
@@ -210,7 +210,7 @@ export const HostEntityOverview: React.FC<HostEntityOverviewProps> = ({ hostName
   const { hasMisconfigurationFindings } = useHasMisconfigurations('host.name', hostName);
   const { hasVulnerabilitiesFindings } = useHasVulnerabilities('host.name', hostName);
 
-  const { openDetailsPanel } = useNavigateToHostDetails({
+  const openDetailsPanel = useNavigateToHostDetails({
     hostName,
     scopeId,
     isRiskScoreExist,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/insights_summary_row.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/insights_summary_row.test.tsx
@@ -24,10 +24,7 @@ describe('<InsightsSummaryRow />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
   });
 
   it('should render loading skeleton if loading is true', () => {
@@ -103,29 +100,5 @@ describe('<InsightsSummaryRow />', () => {
     getByTestId(buttonTestId).click();
 
     expect(mockNavigateToLeftPanel).toHaveBeenCalled();
-  });
-
-  it('should disabled the click when navigation is disabled', () => {
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: undefined,
-      isEnabled: false,
-    });
-
-    const { getByTestId } = render(
-      <IntlProvider locale="en">
-        <InsightsSummaryRow
-          text={'this is a test for red'}
-          value={2}
-          expandedSubTab={'subTab'}
-          data-test-subj={testId}
-        />
-      </IntlProvider>
-    );
-    const button = getByTestId(buttonTestId);
-
-    expect(button).toHaveAttribute('disabled');
-
-    button.click();
-    expect(mockNavigateToLeftPanel).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/insights_summary_row.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/insights_summary_row.tsx
@@ -64,7 +64,7 @@ export const InsightsSummaryRow: VFC<InsightsSummaryRowProps> = ({
   expandedSubTab,
   'data-test-subj': dataTestSubj,
 }) => {
-  const { navigateToLeftPanel: onClick, isEnabled: isLinkEnabled } = useNavigateToLeftPanel({
+  const onClick = useNavigateToLeftPanel({
     tab: LeftPanelInsightsTab,
     subTab: expandedSubTab,
   });
@@ -85,7 +85,6 @@ export const InsightsSummaryRow: VFC<InsightsSummaryRowProps> = ({
               onClick={onClick}
               flush={'both'}
               size="xs"
-              disabled={!isLinkEnabled}
               data-test-subj={buttonDataTestSubj}
             >
               <FormattedCount count={value} />
@@ -96,7 +95,7 @@ export const InsightsSummaryRow: VFC<InsightsSummaryRowProps> = ({
         )}
       </>
     );
-  }, [dataTestSubj, onClick, value, isLinkEnabled]);
+  }, [dataTestSubj, onClick, value]);
 
   if (loading) {
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_guide.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_guide.test.tsx
@@ -26,8 +26,6 @@ const mockNavigateToLeftPanel = jest.fn();
 
 const NO_DATA_MESSAGE = "Investigation guideThere's no investigation guide for this rule.";
 const PREVIEW_MESSAGE = 'Investigation guide is not available in alert preview.';
-const OPEN_FLYOUT_MESSAGE =
-  'Investigation guide availableOpen alert details to access investigation guides.';
 
 const renderInvestigationGuide = () =>
   render(
@@ -40,10 +38,7 @@ const renderInvestigationGuide = () =>
 
 describe('<InvestigationGuide />', () => {
   beforeEach(() => {
-    jest.mocked(useNavigateToLeftPanel).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    jest.mocked(useNavigateToLeftPanel).mockReturnValue(mockNavigateToLeftPanel);
   });
 
   it('should render investigation guide button correctly', () => {
@@ -122,23 +117,6 @@ describe('<InvestigationGuide />', () => {
 
     expect(queryByTestId(INVESTIGATION_GUIDE_BUTTON_TEST_ID)).not.toBeInTheDocument();
     expect(getByTestId(INVESTIGATION_GUIDE_TEST_ID)).toHaveTextContent(PREVIEW_MESSAGE);
-  });
-
-  it('should render open flyout message if navigation is disabled', () => {
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: undefined,
-      isEnabled: false,
-    });
-    const { queryByTestId, getByTestId } = render(
-      <IntlProvider locale="en">
-        <DocumentDetailsContext.Provider value={mockContextValue}>
-          <InvestigationGuide />
-        </DocumentDetailsContext.Provider>
-      </IntlProvider>
-    );
-
-    expect(queryByTestId(INVESTIGATION_GUIDE_BUTTON_TEST_ID)).not.toBeInTheDocument();
-    expect(getByTestId(INVESTIGATION_GUIDE_TEST_ID)).toHaveTextContent(OPEN_FLYOUT_MESSAGE);
   });
 
   it('should navigate to investigation guide when clicking on button', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_guide.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_guide.tsx
@@ -4,8 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import React, { useMemo } from 'react';
-import { EuiButton, EuiSkeletonText, EuiCallOut } from '@elastic/eui';
+import { EuiButton, EuiCallOut, EuiSkeletonText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { useInvestigationGuide } from '../../shared/hooks/use_investigation_guide';
@@ -29,10 +30,9 @@ export const InvestigationGuide: React.FC = () => {
     dataFormattedForFieldBrowser,
   });
 
-  const { navigateToLeftPanel: goToInvestigationsTab, isEnabled: isLinkEnabled } =
-    useNavigateToLeftPanel({
-      tab: LeftPanelInvestigationTab,
-    });
+  const goToInvestigationsTab = useNavigateToLeftPanel({
+    tab: LeftPanelInvestigationTab,
+  });
 
   const hasInvestigationGuide = useMemo(
     () => !error && basicAlertData && basicAlertData.ruleId && ruleNote,
@@ -43,6 +43,7 @@ export const InvestigationGuide: React.FC = () => {
     if (isRulePreview) {
       return (
         <EuiCallOut
+          announceOnMount
           iconType="documentation"
           size="s"
           title={
@@ -73,30 +74,6 @@ export const InvestigationGuide: React.FC = () => {
             { defaultMessage: 'investigation guide' }
           )}
         />
-      );
-    }
-
-    if (hasInvestigationGuide && !isLinkEnabled) {
-      return (
-        <EuiCallOut
-          iconType="documentation"
-          size="s"
-          title={
-            <FormattedMessage
-              id="xpack.securitySolution.flyout.right.investigation.investigationGuide.openFlyoutTitle"
-              defaultMessage="Investigation guide available"
-            />
-          }
-          aria-label={i18n.translate(
-            'xpack.securitySolution.flyout.right.investigation.investigationGuide.openFlyoutAriaLabel',
-            { defaultMessage: 'Investigation guide available' }
-          )}
-        >
-          <FormattedMessage
-            id="xpack.securitySolution.flyout.right.investigation.investigationGuide.openFlyoutMessage"
-            defaultMessage="Open alert details to access investigation guides."
-          />
-        </EuiCallOut>
       );
     }
 
@@ -142,7 +119,7 @@ export const InvestigationGuide: React.FC = () => {
         />
       </EuiCallOut>
     );
-  }, [isRulePreview, loading, hasInvestigationGuide, isLinkEnabled, goToInvestigationsTab]);
+  }, [isRulePreview, loading, hasInvestigationGuide, goToInvestigationsTab]);
 
   return <div data-test-subj={INVESTIGATION_GUIDE_TEST_ID}>{content}</div>;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/notes.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/notes.test.tsx
@@ -52,10 +52,7 @@ describe('<Notes />', () => {
     (useUserPrivileges as jest.Mock).mockReturnValue({
       notesPrivileges: { crud: true, read: true },
     });
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
   });
 
   it('should render loading spinner', () => {
@@ -101,30 +98,6 @@ describe('<Notes />', () => {
     expect(mockNavigateToLeftPanel).toHaveBeenCalled();
   });
 
-  it('should disabled the Add note button if in preview mode', () => {
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: undefined,
-      isEnabled: false,
-    });
-    const { getByTestId } = render(
-      <TestProviders>
-        <DocumentDetailsContext.Provider value={mockContextValue}>
-          <Notes />
-        </DocumentDetailsContext.Provider>
-      </TestProviders>
-    );
-
-    expect(mockDispatch).not.toHaveBeenCalled();
-
-    const button = getByTestId(NOTES_ADD_NOTE_BUTTON_TEST_ID);
-    expect(button).toBeInTheDocument();
-    expect(button).toBeDisabled();
-
-    button.click();
-
-    expect(mockNavigateToLeftPanel).not.toHaveBeenCalled();
-  });
-
   it('should render number of notes and plus button', () => {
     const contextValue = {
       ...mockContextValue,
@@ -148,38 +121,6 @@ describe('<Notes />', () => {
     button.click();
 
     expect(mockNavigateToLeftPanel).toHaveBeenCalled();
-  });
-
-  it('should disable the plus button if navigation is disabled', () => {
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: undefined,
-      isEnabled: false,
-    });
-    const contextValue = {
-      ...mockContextValue,
-      eventId: '1',
-    };
-
-    const { getByTestId } = render(
-      <TestProviders>
-        <DocumentDetailsContext.Provider value={contextValue}>
-          <Notes />
-        </DocumentDetailsContext.Provider>
-      </TestProviders>
-    );
-
-    expect(getByTestId(NOTES_COUNT_TEST_ID)).toBeInTheDocument();
-    expect(getByTestId(NOTES_COUNT_TEST_ID)).toHaveTextContent('1');
-
-    expect(mockDispatch).not.toHaveBeenCalled();
-
-    const button = getByTestId(NOTES_ADD_NOTE_ICON_BUTTON_TEST_ID);
-
-    expect(button).toBeInTheDocument();
-    button.click();
-    expect(button).toBeDisabled();
-
-    expect(mockNavigateToLeftPanel).not.toHaveBeenCalled();
   });
 
   it('should render number of notes in scientific notation for big numbers', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/notes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/notes.tsx
@@ -73,14 +73,12 @@ export const Notes = memo(() => {
   const { addError: addErrorToast } = useAppToasts();
   const { notesPrivileges } = useUserPrivileges();
 
-  const { navigateToLeftPanel: openExpandedFlyoutNotesTab, isEnabled: isLinkEnabled } =
-    useNavigateToLeftPanel({
-      tab: LeftPanelNotesTab,
-    });
+  const openExpandedFlyoutNotesTab = useNavigateToLeftPanel({
+    tab: LeftPanelNotesTab,
+  });
 
-  const isNotesDisabled = !isLinkEnabled || isRulePreview;
-  const cannotAddNotes = isNotesDisabled || !notesPrivileges.crud;
-  const cannotReadNotes = isNotesDisabled || !notesPrivileges.read;
+  const cannotAddNotes = isRulePreview || !notesPrivileges.crud;
+  const cannotReadNotes = isRulePreview || !notesPrivileges.read;
 
   useEffect(() => {
     // fetch notes only if we are not in a preview panel, or not in a rule preview workflow, and if the user has the correct privileges

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.test.tsx
@@ -54,10 +54,7 @@ describe('<PrevalenceOverview />', () => {
       error: false,
       data: [],
     });
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
   });
 
   it('should render wrapper component', () => {
@@ -76,17 +73,6 @@ describe('<PrevalenceOverview />', () => {
     });
     expect(getByTestId(TITLE_LINK_TEST_ID)).toBeInTheDocument();
     expect(queryByTestId(TITLE_ICON_TEST_ID)).not.toBeInTheDocument();
-  });
-
-  it('should not render link if navigation is disabled', () => {
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: false,
-    });
-
-    const { getByTestId, queryByTestId } = renderPrevalenceOverview(mockContextValue);
-    expect(queryByTestId(TITLE_LINK_TEST_ID)).not.toBeInTheDocument();
-    expect(getByTestId(TITLE_TEXT_TEST_ID)).toBeInTheDocument();
   });
 
   it('should render loading', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.tsx
@@ -37,11 +37,10 @@ export const PrevalenceOverview: FC = () => {
   const { dataFormattedForFieldBrowser, investigationFields, isPreviewMode } =
     useDocumentDetailsContext();
 
-  const { navigateToLeftPanel: goToPrevalenceTab, isEnabled: isLinkEnabled } =
-    useNavigateToLeftPanel({
-      tab: LeftPanelInsightsTab,
-      subTab: PREVALENCE_TAB_ID,
-    });
+  const goToPrevalenceTab = useNavigateToLeftPanel({
+    tab: LeftPanelInsightsTab,
+    subTab: PREVALENCE_TAB_ID,
+  });
 
   const { loading, error, data } = usePrevalence({
     dataFormattedForFieldBrowser,
@@ -64,19 +63,16 @@ export const PrevalenceOverview: FC = () => {
     [data]
   );
   const link = useMemo(
-    () =>
-      isLinkEnabled
-        ? {
-            callback: goToPrevalenceTab,
-            tooltip: (
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.right.insights.prevalence.prevalenceTooltip"
-                defaultMessage="Show all prevalence"
-              />
-            ),
-          }
-        : undefined,
-    [goToPrevalenceTab, isLinkEnabled]
+    () => ({
+      callback: goToPrevalenceTab,
+      tooltip: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.right.insights.prevalence.prevalenceTooltip"
+          defaultMessage="Show all prevalence"
+        />
+      ),
+    }),
+    [goToPrevalenceTab]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_ancestry.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_ancestry.test.tsx
@@ -9,10 +9,10 @@ import React from 'react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
 import {
-  SUMMARY_ROW_TEXT_TEST_ID,
-  SUMMARY_ROW_LOADING_TEST_ID,
   CORRELATIONS_RELATED_ALERTS_BY_ANCESTRY_TEST_ID,
   SUMMARY_ROW_BUTTON_TEST_ID,
+  SUMMARY_ROW_LOADING_TEST_ID,
+  SUMMARY_ROW_TEXT_TEST_ID,
 } from './test_ids';
 import { RelatedAlertsByAncestry } from './related_alerts_by_ancestry';
 import { useFetchRelatedAlertsByAncestry } from '../../shared/hooks/use_fetch_related_alerts_by_ancestry';
@@ -43,10 +43,7 @@ const renderRelatedAlertsByAncestry = () =>
 describe('<RelatedAlertsByAncestry />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
   });
 
   it('should render single related alert correctly', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_same_source_event.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_same_source_event.test.tsx
@@ -9,10 +9,10 @@ import React from 'react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
 import {
-  SUMMARY_ROW_TEXT_TEST_ID,
-  SUMMARY_ROW_LOADING_TEST_ID,
   CORRELATIONS_RELATED_ALERTS_BY_SAME_SOURCE_EVENT_TEST_ID,
   SUMMARY_ROW_BUTTON_TEST_ID,
+  SUMMARY_ROW_LOADING_TEST_ID,
+  SUMMARY_ROW_TEXT_TEST_ID,
 } from './test_ids';
 import { useFetchRelatedAlertsBySameSourceEvent } from '../../shared/hooks/use_fetch_related_alerts_by_same_source_event';
 import { RelatedAlertsBySameSourceEvent } from './related_alerts_by_same_source_event';
@@ -47,10 +47,7 @@ describe('<RelatedAlertsBySameSourceEvent />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
   });
 
   it('should render single related alert correctly', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_session.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_session.test.tsx
@@ -9,10 +9,10 @@ import React from 'react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
 import {
-  SUMMARY_ROW_TEXT_TEST_ID,
-  SUMMARY_ROW_LOADING_TEST_ID,
   CORRELATIONS_RELATED_ALERTS_BY_SESSION_TEST_ID,
   SUMMARY_ROW_BUTTON_TEST_ID,
+  SUMMARY_ROW_LOADING_TEST_ID,
+  SUMMARY_ROW_TEXT_TEST_ID,
 } from './test_ids';
 import { RelatedAlertsBySession } from './related_alerts_by_session';
 import { useFetchRelatedAlertsBySession } from '../../shared/hooks/use_fetch_related_alerts_by_session';
@@ -41,10 +41,7 @@ describe('<RelatedAlertsBySession />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
   });
 
   it('should render single related alerts correctly', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_cases.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_cases.test.tsx
@@ -10,9 +10,9 @@ import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
 import {
   CORRELATIONS_RELATED_CASES_TEST_ID,
-  SUMMARY_ROW_TEXT_TEST_ID,
-  SUMMARY_ROW_LOADING_TEST_ID,
   SUMMARY_ROW_BUTTON_TEST_ID,
+  SUMMARY_ROW_LOADING_TEST_ID,
+  SUMMARY_ROW_TEXT_TEST_ID,
 } from './test_ids';
 import { RelatedCases } from './related_cases';
 import { useFetchRelatedCases } from '../../shared/hooks/use_fetch_related_cases';
@@ -40,10 +40,7 @@ describe('<RelatedCases />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
   });
 
   it('should render single related case correctly', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_button.test.tsx
@@ -14,9 +14,6 @@ import { mockContextValue } from '../../shared/mocks/mock_context';
 import { ResponseButton } from './response_button';
 import type { SearchHit } from '../../../../../common/search_strategy';
 import { TestProvider } from '@kbn/expandable-flyout/src/test/provider';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockValidSearchHit = {
   fields: {
@@ -43,9 +40,9 @@ const renderResponseButton = (panelContextValue: DocumentDetailsContext = mockCo
       </TestProvider>
     </IntlProvider>
   );
+
 describe('<ResponseButton />', () => {
   it('should render response button correctly', () => {
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
     const panelContextValue = { ...mockContextValue, searchHit: mockValidSearchHit };
     const { getByTestId, queryByTestId } = renderResponseButton(panelContextValue);
     expect(getByTestId(RESPONSE_BUTTON_TEST_ID)).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_button.tsx
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import React from 'react';
 import { EuiButton } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -15,7 +16,7 @@ import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_
  * Response button that opens Response section in the left panel
  */
 export const ResponseButton: React.FC = () => {
-  const { navigateToLeftPanel: goToResponseTab } = useNavigateToLeftPanel({
+  const goToResponseTab = useNavigateToLeftPanel({
     tab: LeftPanelResponseTab,
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.test.tsx
@@ -18,21 +18,16 @@ import { mockContextValue } from '../../shared/mocks/mock_context';
 import { ResponseSection } from './response_section';
 import { TestProvider } from '@kbn/expandable-flyout/src/test/provider';
 import { useExpandSection } from '../hooks/use_expand_section';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useKibana as mockUseKibana } from '../../../../common/lib/kibana/__mocks__';
 import { useKibana } from '../../../../common/lib/kibana';
 
 jest.mock('../hooks/use_expand_section');
 jest.mock('../../../../common/lib/kibana');
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockedUseKibana = mockUseKibana();
 (useKibana as jest.Mock).mockReturnValue(mockedUseKibana);
 
-const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
-
 const PREVIEW_MESSAGE = 'Response is not available in alert preview.';
-const OPEN_FLYOUT_MESSAGE = 'Open alert details to access response actions.';
 
 const renderResponseSection = () =>
   render(
@@ -46,10 +41,6 @@ const renderResponseSection = () =>
   );
 
 describe('<ResponseSection />', () => {
-  beforeEach(() => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
-  });
-
   it('should render response component', () => {
     const { getByTestId } = renderResponseSection();
 
@@ -114,21 +105,6 @@ describe('<ResponseSection />', () => {
     expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).toHaveTextContent(PREVIEW_MESSAGE);
   });
 
-  it('should render open details flyout message if flyout is in preview mode', () => {
-    (useExpandSection as jest.Mock).mockReturnValue(true);
-
-    const { getByTestId } = render(
-      <IntlProvider locale="en">
-        <TestProvider>
-          <DocumentDetailsContext.Provider value={{ ...mockContextValue, isPreviewMode: true }}>
-            <ResponseSection />
-          </DocumentDetailsContext.Provider>
-        </TestProvider>
-      </IntlProvider>
-    );
-    expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).toHaveTextContent(OPEN_FLYOUT_MESSAGE);
-  });
-
   it('should render empty component if document is not signal', () => {
     (useExpandSection as jest.Mock).mockReturnValue(true);
 
@@ -155,24 +131,18 @@ describe('<ResponseSection />', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  describe('newExpandableFlyoutNavigationDisabled is false', () => {
-    beforeEach(() => {
-      mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
-    });
-
-    it('should render if isPreviewMode is true', () => {
-      const { getByTestId } = render(
-        <IntlProvider locale="en">
-          <TestProvider>
-            <DocumentDetailsContext.Provider value={{ ...mockContextValue, isPreviewMode: true }}>
-              <ResponseSection />
-            </DocumentDetailsContext.Provider>
-          </TestProvider>
-        </IntlProvider>
-      );
-      expect(getByTestId(RESPONSE_SECTION_HEADER_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(RESPONSE_SECTION_HEADER_TEST_ID)).toHaveTextContent('Response');
-      expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).toBeInTheDocument();
-    });
+  it('should render if isPreviewMode is true', () => {
+    const { getByTestId } = render(
+      <IntlProvider locale="en">
+        <TestProvider>
+          <DocumentDetailsContext.Provider value={{ ...mockContextValue, isPreviewMode: true }}>
+            <ResponseSection />
+          </DocumentDetailsContext.Provider>
+        </TestProvider>
+      </IntlProvider>
+    );
+    expect(getByTestId(RESPONSE_SECTION_HEADER_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(RESPONSE_SECTION_HEADER_TEST_ID)).toHaveTextContent('Response');
+    expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
@@ -16,7 +16,6 @@ import { useDocumentDetailsContext } from '../../shared/context';
 import { getField } from '../../shared/utils';
 import { EventKind } from '../../shared/constants/event_kinds';
 import { RESPONSE_SECTION_TEST_ID } from './test_ids';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 const KEY = 'response';
 
@@ -24,19 +23,16 @@ const KEY = 'response';
  * Most bottom section of the overview tab. It contains a summary of the response tab.
  */
 export const ResponseSection = memo(() => {
-  const { isRulePreview, getFieldsData, isPreviewMode } = useDocumentDetailsContext();
+  const { isRulePreview, getFieldsData } = useDocumentDetailsContext();
 
   const expanded = useExpandSection({ title: KEY, defaultValue: false });
   const eventKind = getField(getFieldsData('event.kind'));
-
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
 
   const content = useMemo(() => {
     if (isRulePreview) {
       return (
         <EuiCallOut
+          announceOnMount
           iconType="documentation"
           size="s"
           title={
@@ -58,32 +54,8 @@ export const ResponseSection = memo(() => {
       );
     }
 
-    if (!isNewNavigationEnabled && isPreviewMode) {
-      return (
-        <EuiCallOut
-          iconType="documentation"
-          size="s"
-          title={
-            <FormattedMessage
-              id="xpack.securitySolution.flyout.right.response.openFlyoutTitle"
-              defaultMessage="Response actions"
-            />
-          }
-          aria-label={i18n.translate(
-            'xpack.securitySolution.flyout.right.response.openFlyoutAriaLabel',
-            { defaultMessage: 'Response actions' }
-          )}
-        >
-          <FormattedMessage
-            id="xpack.securitySolution.flyout.right.response.openFlyoutMessage"
-            defaultMessage="Open alert details to access response actions."
-          />
-        </EuiCallOut>
-      );
-    }
-
     return <ResponseButton />;
-  }, [isRulePreview, isPreviewMode, isNewNavigationEnabled]);
+  }, [isRulePreview]);
 
   if (eventKind !== EventKind.signal) {
     return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { TestProviders } from '../../../../common/mock';
 import React from 'react';
 import { DocumentDetailsContext } from '../../shared/context';
@@ -14,19 +14,13 @@ import { useSessionViewConfig } from '../../shared/hooks/use_session_view_config
 import { useLicense } from '../../../../common/hooks/use_license';
 import { SESSION_PREVIEW_TEST_ID } from './test_ids';
 import {
-  EXPANDABLE_PANEL_CONTENT_TEST_ID,
-  EXPANDABLE_PANEL_HEADER_TITLE_ICON_TEST_ID,
   EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID,
   EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID,
-  EXPANDABLE_PANEL_TOGGLE_ICON_TEST_ID,
 } from '../../../shared/components/test_ids';
 import { mockContextValue } from '../../shared/mocks/mock_context';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-import { useInvestigateInTimeline } from '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
 
 jest.mock('../../shared/hooks/use_session_view_config');
 jest.mock('../../../../common/hooks/use_license');
-jest.mock('../../../../common/hooks/use_experimental_features');
 jest.mock(
   '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
 );
@@ -45,11 +39,6 @@ jest.mock('react-redux', () => {
   };
 });
 
-const NO_DATA_MESSAGE =
-  'You can only view Linux session details if you’ve enabled the Include session data setting in your Elastic Defend integration policy. Refer to Enable Session View data(external, opens in a new tab or window) for more information.';
-
-const UPSELL_TEXT = 'This feature requires an Enterprise subscription';
-
 const sessionViewConfig = {
   index: {},
   sessionEntityId: 'sessionEntityId',
@@ -66,189 +55,50 @@ const renderSessionPreview = (context = mockContextValue) =>
   );
 
 describe('SessionPreviewContainer', () => {
-  describe('when newExpandableFlyoutNavigationDisabled is true', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
-    });
-
-    it('should render component and link in header', () => {
-      (useSessionViewConfig as jest.Mock).mockReturnValue(sessionViewConfig);
-      (useLicense as jest.Mock).mockReturnValue({ isEnterprise: () => true });
-
-      const { getByTestId } = renderSessionPreview();
-
-      expect(getByTestId(SESSION_PREVIEW_TEST_ID)).toBeInTheDocument();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-
-      expect(
-        screen.queryByTestId(EXPANDABLE_PANEL_TOGGLE_ICON_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).not.toBeInTheDocument();
-      expect(
-        screen.getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_ICON_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).not.toHaveTextContent(NO_DATA_MESSAGE);
-      expect(
-        screen.queryByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).not.toHaveTextContent(UPSELL_TEXT);
-    });
-
-    it('should render error message and text in header if no sessionConfig', () => {
-      (useSessionViewConfig as jest.Mock).mockReturnValue(null);
-      (useLicense as jest.Mock).mockReturnValue({ isEnterprise: () => true });
-
-      const { getByTestId, queryByTestId } = renderSessionPreview();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toHaveTextContent(NO_DATA_MESSAGE);
-
-      expect(
-        screen.queryByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).not.toHaveTextContent(UPSELL_TEXT);
-      expect(queryByTestId(SESSION_PREVIEW_TEST_ID)).not.toBeInTheDocument();
-    });
-
-    it('should render upsell message in header if no correct license', () => {
-      (useSessionViewConfig as jest.Mock).mockReturnValue(sessionViewConfig);
-      (useLicense as jest.Mock).mockReturnValue({ isEnterprise: () => false });
-
-      const { getByTestId, queryByTestId } = renderSessionPreview();
-
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toHaveTextContent(UPSELL_TEXT);
-
-      expect(
-        screen.queryByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).not.toHaveTextContent(NO_DATA_MESSAGE);
-      expect(queryByTestId(SESSION_PREVIEW_TEST_ID)).not.toBeInTheDocument();
-    });
-
-    it('should not render link to session viewer if flyout is open in rule preview', () => {
-      (useSessionViewConfig as jest.Mock).mockReturnValue(sessionViewConfig);
-      (useLicense as jest.Mock).mockReturnValue({ isEnterprise: () => true });
-
-      const { getByTestId, queryByTestId } = renderSessionPreview({
-        ...mockContextValue,
-        isRulePreview: true,
-      });
-
-      expect(getByTestId(SESSION_PREVIEW_TEST_ID)).toBeInTheDocument();
-      expect(
-        queryByTestId(EXPANDABLE_PANEL_TOGGLE_ICON_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).not.toBeInTheDocument();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_ICON_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).not.toBeInTheDocument();
-    });
-
-    it('should not render link to session viewer if flyout is open in preview mode', () => {
-      (useSessionViewConfig as jest.Mock).mockReturnValue(sessionViewConfig);
-      (useLicense as jest.Mock).mockReturnValue({ isEnterprise: () => true });
-
-      const { getByTestId, queryByTestId } = renderSessionPreview({
-        ...mockContextValue,
-        isPreviewMode: true,
-      });
-
-      expect(getByTestId(SESSION_PREVIEW_TEST_ID)).toBeInTheDocument();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).not.toBeInTheDocument();
-    });
-
-    it('should open left panel visualization tab when visualization in flyout flag is on', () => {
-      (useSessionViewConfig as jest.Mock).mockReturnValue(sessionViewConfig);
-      (useLicense as jest.Mock).mockReturnValue({ isEnterprise: () => true });
-
-      const { getByTestId } = renderSessionPreview();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID)).click();
-
-      expect(mockNavigateToSessionView).toHaveBeenCalled();
-    });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSessionViewConfig as jest.Mock).mockReturnValue(sessionViewConfig);
+    (useLicense as jest.Mock).mockReturnValue({ isEnterprise: () => true });
   });
 
-  describe('when newExpandableFlyoutNavigationDisabled is false', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      (useSessionViewConfig as jest.Mock).mockReturnValue(sessionViewConfig);
-      (useLicense as jest.Mock).mockReturnValue({ isEnterprise: () => true });
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
+  it('should open left panel visualization tab when visualization in flyout flag is on', () => {
+    const { getByTestId } = renderSessionPreview();
+
+    expect(
+      getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
+    ).toBeInTheDocument();
+    getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID)).click();
+
+    expect(mockNavigateToSessionView).toHaveBeenCalled();
+  });
+
+  it('should not render link to session viewer if flyout is open in rule preview', () => {
+    const { getByTestId, queryByTestId } = renderSessionPreview({
+      ...mockContextValue,
+      isRulePreview: true,
     });
 
-    it('should open left panel visualization tab when visualization in flyout flag is on', () => {
-      const { getByTestId } = renderSessionPreview();
+    expect(getByTestId(SESSION_PREVIEW_TEST_ID)).toBeInTheDocument();
+    expect(
+      getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(SESSION_PREVIEW_TEST_ID))
+    ).toBeInTheDocument();
+    expect(
+      queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
+    ).not.toBeInTheDocument();
+  });
 
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID)).click();
-
-      expect(mockNavigateToSessionView).toHaveBeenCalled();
+  it('should render link to session viewer if flyout is open in preview mode', () => {
+    const { getByTestId } = renderSessionPreview({
+      ...mockContextValue,
+      isPreviewMode: true,
     });
 
-    it('should not render link to session viewer if flyout is open in rule preview', () => {
-      const { getByTestId, queryByTestId } = renderSessionPreview({
-        ...mockContextValue,
-        isRulePreview: true,
-      });
+    expect(getByTestId(SESSION_PREVIEW_TEST_ID)).toBeInTheDocument();
+    expect(
+      getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
+    ).toBeInTheDocument();
 
-      expect(getByTestId(SESSION_PREVIEW_TEST_ID)).toBeInTheDocument();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-      expect(
-        queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).not.toBeInTheDocument();
-    });
-
-    it('should render link to session viewer if flyout is open in preview mode', () => {
-      const { getByTestId } = renderSessionPreview({
-        ...mockContextValue,
-        isPreviewMode: true,
-      });
-
-      expect(getByTestId(SESSION_PREVIEW_TEST_ID)).toBeInTheDocument();
-      expect(
-        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
-      ).toBeInTheDocument();
-
-      getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID)).click();
-      expect(mockNavigateToSessionView).toHaveBeenCalled();
-    });
+    getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID)).click();
+    expect(mockNavigateToSessionView).toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.tsx
@@ -15,7 +15,6 @@ import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import { SESSION_PREVIEW_TEST_ID } from './test_ids';
 import { useNavigateToSessionView } from '../../shared/hooks/use_navigate_to_session_view';
 import { SessionViewNoDataMessage } from '../../shared/components/session_view_no_data_message';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 /**
  * Checks if the SessionView component is available, if so render it or else render an error message
@@ -36,10 +35,6 @@ export const SessionPreviewContainer: FC = () => {
   const isEnterprisePlus = useLicense().isEnterprise();
   const isEnabled = sessionViewConfig && isEnterprisePlus;
 
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
-
   const { navigateToSessionView } = useNavigateToSessionView({
     eventId,
     indexName,
@@ -50,18 +45,11 @@ export const SessionPreviewContainer: FC = () => {
 
   const iconType = useMemo(() => (!isPreviewMode ? 'arrowStart' : undefined), [isPreviewMode]);
 
-  const isNavigationEnabled = useMemo(() => {
-    // if the session view is not enabled or in rule preview mode, the navigation is not enabled
-    if (!isEnabled || isRulePreview) {
-      return false;
-    }
-    // if the new navigation is enabled, the navigation is enabled (flyout or timeline)
-    if (isNewNavigationEnabled) {
-      return true;
-    }
-    // if the new navigation is not enabled, the navigation is enabled if the flyout is not in preview mode
-    return !isPreviewMode;
-  }, [isNewNavigationEnabled, isPreviewMode, isEnabled, isRulePreview]);
+  // if the session view is not enabled or in rule preview mode, the navigation is not enabled
+  const isNavigationEnabled = useMemo(
+    () => !(!isEnabled || isRulePreview),
+    [isEnabled, isRulePreview]
+  );
 
   return (
     <ExpandablePanel

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/suppressed_alerts.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/suppressed_alerts.test.tsx
@@ -9,10 +9,10 @@ import React from 'react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
 import {
-  SUMMARY_ROW_TEXT_TEST_ID,
-  CORRELATIONS_SUPPRESSED_ALERTS_TEST_ID,
   CORRELATIONS_SUPPRESSED_ALERTS_TECHNICAL_PREVIEW_TEST_ID,
+  CORRELATIONS_SUPPRESSED_ALERTS_TEST_ID,
   SUMMARY_ROW_BUTTON_TEST_ID,
+  SUMMARY_ROW_TEXT_TEST_ID,
 } from './test_ids';
 import { SuppressedAlerts } from './suppressed_alerts';
 import { isSuppressionRuleInGA } from '../../../../../common/detection_engine/utils';
@@ -42,10 +42,7 @@ describe('<SuppressedAlerts />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
   });
 
   it('should render single suppressed alert correctly', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.test.tsx
@@ -78,10 +78,7 @@ describe('<ThreatIntelligenceOverview />', () => {
     (useFetchThreatIntelligence as jest.Mock).mockReturnValue({
       loading: false,
     });
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
   });
 
   it('should render wrapper component', () => {
@@ -98,25 +95,10 @@ describe('<ThreatIntelligenceOverview />', () => {
       dataFormattedForFieldBrowser,
       isPreviewMode: true,
     });
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: true,
-    });
+
     const { getByTestId, queryByTestId } = renderThreatIntelligenceOverview();
     expect(queryByTestId(TITLE_ICON_TEST_ID)).not.toBeInTheDocument();
     expect(getByTestId(TITLE_LINK_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('should not render link if navigation is not enabled', () => {
-    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
-      navigateToLeftPanel: mockNavigateToLeftPanel,
-      isEnabled: false,
-    });
-
-    const { getByTestId, queryByTestId } = renderThreatIntelligenceOverview();
-
-    expect(queryByTestId(TITLE_LINK_TEST_ID)).not.toBeInTheDocument();
-    expect(getByTestId(TITLE_TEXT_TEST_ID)).toBeInTheDocument();
   });
 
   it('should render 1 match detected and 1 field enriched', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
@@ -43,25 +43,21 @@ const TOOLTIP = (
 export const ThreatIntelligenceOverview: FC = () => {
   const { dataFormattedForFieldBrowser, isPreviewMode } = useDocumentDetailsContext();
 
-  const { navigateToLeftPanel: goToThreatIntelligenceTab, isEnabled: isLinkEnabled } =
-    useNavigateToLeftPanel({
-      tab: LeftPanelInsightsTab,
-      subTab: THREAT_INTELLIGENCE_TAB_ID,
-    });
+  const goToThreatIntelligenceTab = useNavigateToLeftPanel({
+    tab: LeftPanelInsightsTab,
+    subTab: THREAT_INTELLIGENCE_TAB_ID,
+  });
 
   const { loading, threatMatchesCount, threatEnrichmentsCount } = useFetchThreatIntelligence({
     dataFormattedForFieldBrowser,
   });
 
   const link = useMemo(
-    () =>
-      isLinkEnabled
-        ? {
-            callback: goToThreatIntelligenceTab,
-            tooltip: TOOLTIP,
-          }
-        : undefined,
-    [goToThreatIntelligenceTab, isLinkEnabled]
+    () => ({
+      callback: goToThreatIntelligenceTab,
+      tooltip: TOOLTIP,
+    }),
+    [goToThreatIntelligenceTab]
   );
 
   const threatMatchCountText = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.test.tsx
@@ -4,20 +4,21 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import React from 'react';
 import { render } from '@testing-library/react';
 import { TestProviders } from '../../../../common/mock';
 import { useMisconfigurationPreview } from '@kbn/cloud-security-posture/src/hooks/use_misconfiguration_preview';
-import { UserEntityOverview, USER_PREVIEW_BANNER } from './user_entity_overview';
+import { USER_PREVIEW_BANNER, UserEntityOverview } from './user_entity_overview';
 import { useFirstLastSeen } from '../../../../common/containers/use_first_last_seen';
 import {
+  ENTITIES_USER_OVERVIEW_ALERT_COUNT_TEST_ID,
   ENTITIES_USER_OVERVIEW_DOMAIN_TEST_ID,
   ENTITIES_USER_OVERVIEW_LAST_SEEN_TEST_ID,
   ENTITIES_USER_OVERVIEW_LINK_TEST_ID,
-  ENTITIES_USER_OVERVIEW_RISK_LEVEL_TEST_ID,
   ENTITIES_USER_OVERVIEW_LOADING_TEST_ID,
   ENTITIES_USER_OVERVIEW_MISCONFIGURATIONS_TEST_ID,
-  ENTITIES_USER_OVERVIEW_ALERT_COUNT_TEST_ID,
+  ENTITIES_USER_OVERVIEW_RISK_LEVEL_TEST_ID,
 } from './test_ids';
 import { useObservedUserDetails } from '../../../../explore/users/containers/users/observed_details';
 import { mockContextValue } from '../../shared/mocks/mock_context';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
@@ -10,10 +10,10 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
-  EuiText,
-  useEuiTheme,
-  useEuiFontSize,
   EuiSkeletonText,
+  EuiText,
+  useEuiFontSize,
+  useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { getOr } from 'lodash/fp';
@@ -41,19 +41,19 @@ import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import {
-  USER_DOMAIN,
   LAST_SEEN,
+  USER_DOMAIN,
   USER_RISK_LEVEL,
 } from '../../../../overview/components/user_overview/translations';
 import {
-  ENTITIES_USER_OVERVIEW_TEST_ID,
+  ENTITIES_USER_OVERVIEW_ALERT_COUNT_TEST_ID,
   ENTITIES_USER_OVERVIEW_DOMAIN_TEST_ID,
   ENTITIES_USER_OVERVIEW_LAST_SEEN_TEST_ID,
-  ENTITIES_USER_OVERVIEW_RISK_LEVEL_TEST_ID,
   ENTITIES_USER_OVERVIEW_LINK_TEST_ID,
   ENTITIES_USER_OVERVIEW_LOADING_TEST_ID,
   ENTITIES_USER_OVERVIEW_MISCONFIGURATIONS_TEST_ID,
-  ENTITIES_USER_OVERVIEW_ALERT_COUNT_TEST_ID,
+  ENTITIES_USER_OVERVIEW_RISK_LEVEL_TEST_ID,
+  ENTITIES_USER_OVERVIEW_TEST_ID,
 } from './test_ids';
 import { useObservedUserDetails } from '../../../../explore/users/containers/users/observed_details';
 import { RiskScoreDocTooltip } from '../../../../overview/components/common';
@@ -139,7 +139,7 @@ export const UserEntityOverview: React.FC<UserEntityOverviewProps> = ({ userName
     queryId: USER_ENTITY_OVERVIEW_ID,
   });
 
-  const { openDetailsPanel } = useNavigateToUserDetails({
+  const openDetailsPanel = useNavigateToUserDetails({
     userName,
     scopeId,
     isRiskScoreExist,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.test.tsx
@@ -13,18 +13,13 @@ import { useAlertsByStatus } from '../../../../overview/components/detection_res
 import type { ParsedAlertsData } from '../../../../overview/components/detection_response/alerts_by_status/types';
 import { useEuiTheme } from '@elastic/eui';
 import {
-  INSIGHTS_ALERTS_COUNT_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID,
-  INSIGHTS_ALERTS_COUNT_TEXT_TEST_ID,
   INSIGHTS_ALERTS_COUNT_NAVIGATION_BUTTON_TEST_ID,
+  INSIGHTS_ALERTS_COUNT_TEXT_TEST_ID,
 } from './test_ids';
-import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useSignalIndex } from '../../../../detections/containers/detection_engine/alerts/use_signal_index';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../../../../detections/containers/detection_engine/alerts/use_signal_index');
-jest.mock('../../../../common/components/user_privileges');
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -86,8 +81,6 @@ const renderAlertCountInsight = () => {
 describe('AlertCountInsight', () => {
   beforeEach(() => {
     (useSignalIndex as jest.Mock).mockReturnValue({ signalIndexName: '' });
-    (useUserPrivileges as jest.Mock).mockReturnValue({ timelinePrivileges: { read: true } });
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
   });
 
   it('renders', () => {
@@ -101,14 +94,10 @@ describe('AlertCountInsight', () => {
     expect(getByTestId(testId)).toBeInTheDocument();
     expect(getByTestId(`${testId}-distribution-bar`)).toBeInTheDocument();
     expect(getByTestId(`${testId}-count`)).toHaveTextContent('8');
-    expect(
-      getByTestId(INSIGHTS_ALERTS_COUNT_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID)
-    ).toBeInTheDocument();
     expect(queryByTestId(INSIGHTS_ALERTS_COUNT_TEXT_TEST_ID)).not.toBeInTheDocument();
   });
 
-  it('open entity details panel when clicking on the count if newExpandableFlyoutNavigationDisabled is false', () => {
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
+  it('open entity details panel when clicking on the count', () => {
     (useAlertsByStatus as jest.Mock).mockReturnValue({
       isLoading: false,
       items: mockAlertData,
@@ -116,22 +105,6 @@ describe('AlertCountInsight', () => {
     const { getByTestId } = renderAlertCountInsight();
     getByTestId(INSIGHTS_ALERTS_COUNT_NAVIGATION_BUTTON_TEST_ID).click();
     expect(openDetailsPanel).toHaveBeenCalled();
-  });
-
-  it('renders the count as text instead of button', () => {
-    (useUserPrivileges as jest.Mock).mockReturnValue({ timelinePrivileges: { read: false } });
-    (useAlertsByStatus as jest.Mock).mockReturnValue({
-      isLoading: false,
-      items: mockAlertData,
-    });
-
-    const { getByTestId, queryByTestId } = renderAlertCountInsight();
-
-    expect(getByTestId(`${testId}-count`)).toHaveTextContent('8');
-    expect(getByTestId(INSIGHTS_ALERTS_COUNT_TEXT_TEST_ID)).toBeInTheDocument();
-    expect(
-      queryByTestId(INSIGHTS_ALERTS_COUNT_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID)
-    ).not.toBeInTheDocument();
   });
 
   it('renders loading spinner if data is being fetched', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.tsx
@@ -8,41 +8,29 @@
 import React, { useMemo } from 'react';
 import { capitalize } from 'lodash';
 import {
-  EuiLoadingSpinner,
-  EuiFlexItem,
-  EuiText,
   type EuiFlexGroupProps,
-  type EuiThemeComputed,
-  useEuiTheme,
+  EuiFlexItem,
   EuiLink,
+  EuiLoadingSpinner,
+  type EuiThemeComputed,
   EuiToolTip,
+  useEuiTheme,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { InsightDistributionBar } from './insight_distribution_bar';
 import { getSeverityColor } from '../../../../detections/components/alerts_kpis/severity_level_panel/helpers';
 import { FormattedCount } from '../../../../common/components/formatted_number';
-import { InvestigateInTimelineButton } from '../../../../common/components/event_details/investigate_in_timeline_button';
-import {
-  getDataProvider,
-  getDataProviderAnd,
-} from '../../../../common/components/event_details/use_action_cell_data_provider';
-import { FILTER_CLOSED, IS_OPERATOR } from '../../../../../common/types';
+import { FILTER_CLOSED } from '../../../../../common/types';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { useAlertsByStatus } from '../../../../overview/components/detection_response/alerts_by_status/use_alerts_by_status';
 import { useSignalIndex } from '../../../../detections/containers/detection_engine/alerts/use_signal_index';
-import { DETECTION_RESPONSE_ALERTS_BY_STATUS_ID } from '../../../../overview/components/detection_response/alerts_by_status/types';
 import type {
   AlertsByStatus,
   ParsedAlertsData,
 } from '../../../../overview/components/detection_response/alerts_by_status/types';
-import { useUserPrivileges } from '../../../../common/components/user_privileges';
-import {
-  INSIGHTS_ALERTS_COUNT_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID,
-  INSIGHTS_ALERTS_COUNT_TEXT_TEST_ID,
-  INSIGHTS_ALERTS_COUNT_NAVIGATION_BUTTON_TEST_ID,
-} from './test_ids';
+import { DETECTION_RESPONSE_ALERTS_BY_STATUS_ID } from '../../../../overview/components/detection_response/alerts_by_status/types';
+import { INSIGHTS_ALERTS_COUNT_NAVIGATION_BUTTON_TEST_ID } from './test_ids';
 import type { EntityDetailsPath } from '../../../entity_details/shared/components/left_panel/left_panel_header';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import {
   CspInsightLeftPanelSubTab,
   EntityDetailsLeftPanelTab,
@@ -119,13 +107,6 @@ export const AlertCountInsight: React.FC<AlertCountInsightProps> = ({
   'data-test-subj': dataTestSubj,
 }) => {
   const { euiTheme } = useEuiTheme();
-  const {
-    timelinePrivileges: { read: canUseTimeline },
-  } = useUserPrivileges();
-
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
   const entityFilter = useMemo(() => ({ field: fieldName, value: name }), [fieldName, name]);
   const { to, from } = useGlobalTime();
   const { signalIndexName } = useSignalIndex();
@@ -145,72 +126,34 @@ export const AlertCountInsight: React.FC<AlertCountInsightProps> = ({
     [alertStats]
   );
 
-  const dataProviders = useMemo(
-    () => [
-      {
-        ...getDataProvider(fieldName, `timeline-indicator-${fieldName}-${name}`, name),
-        and: [
-          getDataProviderAnd(
-            'kibana.alert.workflow_status',
-            `timeline-indicator-kibana.alert.workflow_status-not-closed}`,
-            FILTER_CLOSED,
-            IS_OPERATOR,
-            true
-          ),
-        ],
-      },
-    ],
-    [fieldName, name]
-  );
-
   // renders either a button to go to host alert details, open timeline or just plain text depending on the user's timeline privileges
   const alertCount = useMemo(() => {
     const formattedAlertCount = <FormattedCount count={totalAlertCount} />;
 
-    if (isNewNavigationEnabled) {
-      return (
-        <EuiToolTip
-          content={
-            <FormattedMessage
-              id="xpack.securitySolution.flyout.insights.alert.alertCountTooltip"
-              defaultMessage="Opens {count, plural, one {this alert} other {these alerts}} in a new flyout"
-              values={{ count: totalAlertCount }}
-            />
+    return (
+      <EuiToolTip
+        content={
+          <FormattedMessage
+            id="xpack.securitySolution.flyout.insights.alert.alertCountTooltip"
+            defaultMessage="Opens {count, plural, one {this alert} other {these alerts}} in a new flyout"
+            values={{ count: totalAlertCount }}
+          />
+        }
+      >
+        <EuiLink
+          data-test-subj={INSIGHTS_ALERTS_COUNT_NAVIGATION_BUTTON_TEST_ID}
+          onClick={() =>
+            openDetailsPanel({
+              tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
+              subTab: CspInsightLeftPanelSubTab.ALERTS,
+            })
           }
         >
-          <EuiLink
-            data-test-subj={INSIGHTS_ALERTS_COUNT_NAVIGATION_BUTTON_TEST_ID}
-            onClick={() =>
-              openDetailsPanel({
-                tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
-                subTab: CspInsightLeftPanelSubTab.ALERTS,
-              })
-            }
-          >
-            {formattedAlertCount}
-          </EuiLink>
-        </EuiToolTip>
-      );
-    }
-
-    if (!canUseTimeline) {
-      return (
-        <EuiText size="xs" data-test-subj={INSIGHTS_ALERTS_COUNT_TEXT_TEST_ID}>
           {formattedAlertCount}
-        </EuiText>
-      );
-    }
-    return (
-      <InvestigateInTimelineButton
-        asEmptyButton
-        dataProviders={dataProviders}
-        flush={'both'}
-        data-test-subj={INSIGHTS_ALERTS_COUNT_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID}
-      >
-        {formattedAlertCount}
-      </InvestigateInTimelineButton>
+        </EuiLink>
+      </EuiToolTip>
     );
-  }, [canUseTimeline, dataProviders, totalAlertCount, isNewNavigationEnabled, openDetailsPanel]);
+  }, [totalAlertCount, openDetailsPanel]);
 
   if (!isLoading && totalAlertCount === 0) return null;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.tsx
@@ -126,7 +126,6 @@ export const AlertCountInsight: React.FC<AlertCountInsightProps> = ({
     [alertStats]
   );
 
-  // renders either a button to go to host alert details, open timeline or just plain text depending on the user's timeline privileges
   const alertCount = useMemo(() => {
     const formattedAlertCount = <FormattedCount count={totalAlertCount} />;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/misconfiguration_insight.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/misconfiguration_insight.test.tsx
@@ -11,21 +11,11 @@ import { TestProviders } from '../../../../common/mock';
 import { MisconfigurationsInsight } from './misconfiguration_insight';
 import { useMisconfigurationPreview } from '@kbn/cloud-security-posture/src/hooks/use_misconfiguration_preview';
 import { DocumentDetailsContext } from '../context';
-import { mockFlyoutApi } from '../mocks/mock_flyout_context';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { mockContextValue } from '../mocks/mock_context';
-import { HostPreviewPanelKey } from '../../../entity_details/host_right';
-import { HOST_PREVIEW_BANNER } from '../../right/components/host_entity_overview';
-import { UserPreviewPanelKey } from '../../../entity_details/user_right';
-import { USER_PREVIEW_BANNER } from '../../right/components/user_entity_overview';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
-jest.mock('@kbn/expandable-flyout');
 jest.mock('@kbn/cloud-security-posture/src/hooks/use_misconfiguration_preview');
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 const hostName = 'test host';
-const userName = 'test user';
 const testId = 'test';
 
 const openDetailsPanel = jest.fn();
@@ -46,11 +36,6 @@ const renderMisconfigurationsInsight = (fieldName: 'host.name' | 'user.name', va
 };
 
 describe('MisconfigurationsInsight', () => {
-  beforeEach(() => {
-    jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-  });
-
   it('renders', () => {
     (useMisconfigurationPreview as jest.Mock).mockReturnValue({
       data: { count: { passed: 1, failed: 2 } },
@@ -60,8 +45,7 @@ describe('MisconfigurationsInsight', () => {
     expect(getByTestId(`${testId}-distribution-bar`)).toBeInTheDocument();
   });
 
-  it('open entity details panel when clicking on the count if newExpandableFlyoutNavigationDisabled is false', () => {
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
+  it('open entity details panel when clicking on the count', () => {
     (useMisconfigurationPreview as jest.Mock).mockReturnValue({
       data: { count: { passed: 1, failed: 2 } },
     });
@@ -74,43 +58,5 @@ describe('MisconfigurationsInsight', () => {
     (useMisconfigurationPreview as jest.Mock).mockReturnValue({});
     const { container } = renderMisconfigurationsInsight('host.name', hostName);
     expect(container).toBeEmptyDOMElement();
-  });
-
-  describe('should open entity flyout when clicking on badge', () => {
-    it('should open host entity flyout when clicking on host badge', () => {
-      (useMisconfigurationPreview as jest.Mock).mockReturnValue({
-        data: { count: { passed: 1, failed: 2 } },
-      });
-      const { getByTestId } = renderMisconfigurationsInsight('host.name', hostName);
-      expect(getByTestId(`${testId}-count`)).toHaveTextContent('3');
-
-      getByTestId(`${testId}-count`).click();
-      expect(mockFlyoutApi.openPreviewPanel).toHaveBeenCalledWith({
-        id: HostPreviewPanelKey,
-        params: {
-          hostName,
-          banner: HOST_PREVIEW_BANNER,
-          scopeId: mockContextValue.scopeId,
-        },
-      });
-    });
-
-    it('should open user entity flyout when clicking on user badge', () => {
-      (useMisconfigurationPreview as jest.Mock).mockReturnValue({
-        data: { count: { passed: 2, failed: 3 } },
-      });
-      const { getByTestId } = renderMisconfigurationsInsight('user.name', userName);
-      expect(getByTestId(`${testId}-count`)).toHaveTextContent('5');
-
-      getByTestId(`${testId}-count`).click();
-      expect(mockFlyoutApi.openPreviewPanel).toHaveBeenCalledWith({
-        id: UserPreviewPanelKey,
-        params: {
-          userName,
-          banner: USER_PREVIEW_BANNER,
-          scopeId: mockContextValue.scopeId,
-        },
-      });
-    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/misconfiguration_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/misconfiguration_insight.tsx
@@ -7,29 +7,26 @@
 
 import React, { useEffect, useMemo } from 'react';
 import {
-  EuiFlexItem,
   type EuiFlexGroupProps,
-  useEuiTheme,
-  useGeneratedHtmlId,
+  EuiFlexItem,
   EuiLink,
   EuiToolTip,
+  useEuiTheme,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import { useMisconfigurationPreview } from '@kbn/cloud-security-posture/src/hooks/use_misconfiguration_preview';
 import { buildGenericEntityFlyoutPreviewQuery } from '@kbn/cloud-security-posture-common';
 import {
-  uiMetricService,
   type CloudSecurityUiCounters,
+  uiMetricService,
 } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { InsightDistributionBar } from './insight_distribution_bar';
 import { useGetFindingsStats } from '../../../../cloud_security_posture/components/misconfiguration/misconfiguration_preview';
 import { FormattedCount } from '../../../../common/components/formatted_number';
-import { PreviewLink } from '../../../shared/components/preview_link';
-import { useDocumentDetailsContext } from '../context';
 import type { EntityDetailsPath } from '../../../entity_details/shared/components/left_panel/left_panel_header';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import {
   CspInsightLeftPanelSubTab,
   EntityDetailsLeftPanelTab,
@@ -74,7 +71,6 @@ export const MisconfigurationsInsight: React.FC<MisconfigurationsInsightProps> =
   openDetailsPanel,
 }) => {
   const renderingId = useGeneratedHtmlId();
-  const { scopeId } = useDocumentDetailsContext();
   const { euiTheme } = useEuiTheme();
   const { data } = useMisconfigurationPreview({
     query: buildGenericEntityFlyoutPreviewQuery(fieldName, name),
@@ -82,10 +78,6 @@ export const MisconfigurationsInsight: React.FC<MisconfigurationsInsightProps> =
     enabled: true,
     pageSize: 1,
   });
-
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
 
   const passedFindings = data?.count.passed || 0;
   const failedFindings = data?.count.failed || 0;
@@ -111,50 +103,30 @@ export const MisconfigurationsInsight: React.FC<MisconfigurationsInsightProps> =
           margin-bottom: ${euiTheme.size.xs};
         `}
       >
-        {isNewNavigationEnabled ? (
-          <EuiToolTip
-            content={
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.insights.misconfiguration.misconfigurationCountTooltip"
-                defaultMessage="Opens {count, plural, one {this misconfiguration} other {these misconfigurations}} in a new flyout"
-                values={{ count: totalFindings }}
-              />
+        <EuiToolTip
+          content={
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.insights.misconfiguration.misconfigurationCountTooltip"
+              defaultMessage="Opens {count, plural, one {this misconfiguration} other {these misconfigurations}} in a new flyout"
+              values={{ count: totalFindings }}
+            />
+          }
+        >
+          <EuiLink
+            data-test-subj={`${dataTestSubj}-count`}
+            onClick={() =>
+              openDetailsPanel({
+                tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
+                subTab: CspInsightLeftPanelSubTab.MISCONFIGURATIONS,
+              })
             }
           >
-            <EuiLink
-              data-test-subj={`${dataTestSubj}-count`}
-              onClick={() =>
-                openDetailsPanel({
-                  tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
-                  subTab: CspInsightLeftPanelSubTab.MISCONFIGURATIONS,
-                })
-              }
-            >
-              <FormattedCount count={totalFindings} />
-            </EuiLink>
-          </EuiToolTip>
-        ) : (
-          <PreviewLink
-            field={fieldName}
-            value={name}
-            scopeId={scopeId}
-            data-test-subj={`${dataTestSubj}-count`}
-          >
             <FormattedCount count={totalFindings} />
-          </PreviewLink>
-        )}
+          </EuiLink>
+        </EuiToolTip>
       </div>
     ),
-    [
-      totalFindings,
-      fieldName,
-      name,
-      scopeId,
-      dataTestSubj,
-      euiTheme.size,
-      isNewNavigationEnabled,
-      openDetailsPanel,
-    ]
+    [totalFindings, dataTestSubj, euiTheme.size, openDetailsPanel]
   );
 
   if (!shouldRender) return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/vulnerabilities_insight.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/vulnerabilities_insight.test.tsx
@@ -11,16 +11,9 @@ import React from 'react';
 import { VulnerabilitiesInsight } from './vulnerabilities_insight';
 import { useVulnerabilitiesPreview } from '@kbn/cloud-security-posture/src/hooks/use_vulnerabilities_preview';
 import { DocumentDetailsContext } from '../context';
-import { mockFlyoutApi } from '../mocks/mock_flyout_context';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { mockContextValue } from '../mocks/mock_context';
-import { HostPreviewPanelKey } from '../../../entity_details/host_right';
-import { HOST_PREVIEW_BANNER } from '../../right/components/host_entity_overview';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
-jest.mock('@kbn/expandable-flyout');
 jest.mock('@kbn/cloud-security-posture/src/hooks/use_vulnerabilities_preview');
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 const hostName = 'test host';
 const testId = 'test';
@@ -41,11 +34,6 @@ const renderVulnerabilitiesInsight = () => {
 };
 
 describe('VulnerabilitiesInsight', () => {
-  beforeEach(() => {
-    jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-  });
-
   it('renders', () => {
     (useVulnerabilitiesPreview as jest.Mock).mockReturnValue({
       data: { count: { CRITICAL: 0, HIGH: 1, MEDIUM: 1, LOW: 0, NONE: 0 } },
@@ -56,26 +44,7 @@ describe('VulnerabilitiesInsight', () => {
     expect(getByTestId(`${testId}-distribution-bar`)).toBeInTheDocument();
   });
 
-  it('opens host preview when click on count badge if new navigation is disabled', () => {
-    (useVulnerabilitiesPreview as jest.Mock).mockReturnValue({
-      data: { count: { CRITICAL: 1, HIGH: 2, MEDIUM: 1, LOW: 2, NONE: 2 } },
-    });
-    const { getByTestId } = renderVulnerabilitiesInsight();
-    expect(getByTestId(`${testId}-count`)).toHaveTextContent('8');
-
-    getByTestId(`${testId}-count`).click();
-    expect(mockFlyoutApi.openPreviewPanel).toHaveBeenCalledWith({
-      id: HostPreviewPanelKey,
-      params: {
-        hostName,
-        banner: HOST_PREVIEW_BANNER,
-        scopeId: mockContextValue.scopeId,
-      },
-    });
-  });
-
-  it('open entity details panel when clicking on the count if newExpandableFlyoutNavigationDisabled is false', () => {
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
+  it('open entity details panel when clicking on the count', () => {
     (useVulnerabilitiesPreview as jest.Mock).mockReturnValue({
       data: { count: { CRITICAL: 1, HIGH: 2, MEDIUM: 1, LOW: 2, NONE: 2 } },
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/vulnerabilities_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/vulnerabilities_insight.tsx
@@ -7,12 +7,12 @@
 
 import React, { useEffect, useMemo } from 'react';
 import {
-  EuiFlexItem,
   type EuiFlexGroupProps,
-  useEuiTheme,
-  useGeneratedHtmlId,
+  EuiFlexItem,
   EuiLink,
   EuiToolTip,
+  useEuiTheme,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
@@ -21,20 +21,17 @@ import { useGetSeverityStatusColor } from '@kbn/cloud-security-posture/src/hooks
 import { buildGenericEntityFlyoutPreviewQuery } from '@kbn/cloud-security-posture-common';
 import { getVulnerabilityStats, hasVulnerabilitiesData } from '@kbn/cloud-security-posture';
 import {
-  uiMetricService,
   type CloudSecurityUiCounters,
+  uiMetricService,
 } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { InsightDistributionBar } from './insight_distribution_bar';
 import { FormattedCount } from '../../../../common/components/formatted_number';
-import { PreviewLink } from '../../../shared/components/preview_link';
-import { useDocumentDetailsContext } from '../context';
-import {
-  EntityDetailsLeftPanelTab,
-  CspInsightLeftPanelSubTab,
-} from '../../../entity_details/shared/components/left_panel/left_panel_header';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import type { EntityDetailsPath } from '../../../entity_details/shared/components/left_panel/left_panel_header';
+import {
+  CspInsightLeftPanelSubTab,
+  EntityDetailsLeftPanelTab,
+} from '../../../entity_details/shared/components/left_panel/left_panel_header';
 
 interface VulnerabilitiesInsightProps {
   /**
@@ -70,7 +67,6 @@ export const VulnerabilitiesInsight: React.FC<VulnerabilitiesInsightProps> = ({
   openDetailsPanel,
 }) => {
   const renderingId = useGeneratedHtmlId();
-  const { scopeId } = useDocumentDetailsContext();
   const { euiTheme } = useEuiTheme();
   const { getSeverityStatusColor } = useGetSeverityStatusColor();
   const { data } = useVulnerabilitiesPreview({
@@ -79,10 +75,6 @@ export const VulnerabilitiesInsight: React.FC<VulnerabilitiesInsightProps> = ({
     enabled: true,
     pageSize: 1,
   });
-
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
 
   const { CRITICAL = 0, HIGH = 0, MEDIUM = 0, LOW = 0, NONE = 0 } = data?.count || {};
   const totalVulnerabilities = useMemo(
@@ -132,49 +124,30 @@ export const VulnerabilitiesInsight: React.FC<VulnerabilitiesInsightProps> = ({
           margin-bottom: ${euiTheme.size.xs};
         `}
       >
-        {isNewNavigationEnabled ? (
-          <EuiToolTip
-            content={
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.insights.vulnerabilities.vulnerabilitiesCountTooltip"
-                defaultMessage="Opens {count, plural, one {this vulnerability} other {these vulnerabilities}} in a new flyout"
-                values={{ count: totalVulnerabilities }}
-              />
+        <EuiToolTip
+          content={
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.insights.vulnerabilities.vulnerabilitiesCountTooltip"
+              defaultMessage="Opens {count, plural, one {this vulnerability} other {these vulnerabilities}} in a new flyout"
+              values={{ count: totalVulnerabilities }}
+            />
+          }
+        >
+          <EuiLink
+            data-test-subj={`${dataTestSubj}-count`}
+            onClick={() =>
+              openDetailsPanel({
+                tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
+                subTab: CspInsightLeftPanelSubTab.VULNERABILITIES,
+              })
             }
           >
-            <EuiLink
-              data-test-subj={`${dataTestSubj}-count`}
-              onClick={() =>
-                openDetailsPanel({
-                  tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
-                  subTab: CspInsightLeftPanelSubTab.VULNERABILITIES,
-                })
-              }
-            >
-              <FormattedCount count={totalVulnerabilities} />
-            </EuiLink>
-          </EuiToolTip>
-        ) : (
-          <PreviewLink
-            field={'host.name'}
-            value={hostName}
-            scopeId={scopeId}
-            data-test-subj={`${dataTestSubj}-count`}
-          >
             <FormattedCount count={totalVulnerabilities} />
-          </PreviewLink>
-        )}
+          </EuiLink>
+        </EuiToolTip>
       </div>
     ),
-    [
-      totalVulnerabilities,
-      hostName,
-      scopeId,
-      dataTestSubj,
-      euiTheme.size,
-      isNewNavigationEnabled,
-      openDetailsPanel,
-    ]
+    [totalVulnerabilities, dataTestSubj, euiTheme.size, openDetailsPanel]
   );
 
   if (!shouldRender) return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_analyzer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_analyzer.tsx
@@ -14,7 +14,6 @@ import { useKibana } from '../../../../common/lib/kibana';
 import { ANALYZE_GRAPH_ID } from '../../left/components/analyze_graph';
 import { DocumentDetailsLeftPanelKey, DocumentDetailsRightPanelKey } from '../constants/panel_keys';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 export interface UseNavigateToAnalyzerParams {
   /**
@@ -60,10 +59,6 @@ export const useNavigateToAnalyzer = ({
   const { telemetry } = useKibana().services;
   const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
 
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
-
   const right: FlyoutPanelProps = useMemo(
     () => ({
       id: DocumentDetailsRightPanelKey,
@@ -104,7 +99,7 @@ export const useNavigateToAnalyzer = ({
     }
     // if flyout is not currently open, open flyout with right, left and preview panel
     // if new navigation is enabled and in preview mode, open flyout with right, left and preview panel
-    else if (!isFlyoutOpen || (isNewNavigationEnabled && isPreviewMode)) {
+    else {
       openFlyout({
         right,
         left,
@@ -114,17 +109,7 @@ export const useNavigateToAnalyzer = ({
         panel: 'left',
       });
     }
-  }, [
-    openFlyout,
-    openLeftPanel,
-    right,
-    left,
-    scopeId,
-    telemetry,
-    isFlyoutOpen,
-    isNewNavigationEnabled,
-    isPreviewMode,
-  ]);
+  }, [openFlyout, openLeftPanel, right, left, scopeId, telemetry, isFlyoutOpen, isPreviewMode]);
 
   return useMemo(() => ({ navigateToAnalyzer }), [navigateToAnalyzer]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.test.tsx
@@ -6,17 +6,13 @@
  */
 
 import { useNavigateToLeftPanel } from './use_navigate_to_left_panel';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { renderHook } from '@testing-library/react';
 import { useDocumentDetailsContext } from '../context';
 import { mockFlyoutApi } from '../mocks/mock_flyout_context';
-import { DocumentDetailsRightPanelKey, DocumentDetailsLeftPanelKey } from '../constants/panel_keys';
+import { DocumentDetailsLeftPanelKey, DocumentDetailsRightPanelKey } from '../constants/panel_keys';
 import { useKibana as mockUseKibana } from '../../../../common/lib/kibana/__mocks__';
 import { useKibana } from '../../../../common/lib/kibana';
-
-const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 jest.mock('../../../../common/lib/kibana');
 
@@ -31,77 +27,61 @@ const indexName = 'indexName';
 const scopeId = 'scopeId';
 
 describe('useNavigateToLeftPanel', () => {
-  describe('newExpandableFlyoutNavigationDisabled is true', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
-      jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
-    });
-
-    it('should enable navigation if isPreviewMode is false', () => {
-      (useDocumentDetailsContext as jest.Mock).mockReturnValue({
-        eventId,
-        indexName,
-        scopeId,
-        isPreviewMode: false,
-      });
-      const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
-      expect(hookResult.result.current.isEnabled).toEqual(true);
-
-      hookResult.result.current.navigateToLeftPanel();
-
-      expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
-        id: DocumentDetailsLeftPanelKey,
-        path: {
-          tab: 'tab',
-          subTab: 'subTab',
-        },
-        params: {
-          id: eventId,
-          indexName,
-          scopeId,
-        },
-      });
-      expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
-    });
-
-    it('should disable navigation if isPreviewMode is true', () => {
-      (useDocumentDetailsContext as jest.Mock).mockReturnValue({
-        eventId,
-        indexName,
-        scopeId,
-        isPreviewMode: true,
-      });
-
-      const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
-      expect(hookResult.result.current.isEnabled).toEqual(false);
-
-      hookResult.result.current.navigateToLeftPanel();
-
-      expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
-      expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
-    });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
   });
 
-  describe('newExpandableFlyoutNavigationDisabled is false', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  it('should enable navigation if isPreviewMode is false', () => {
+    (useDocumentDetailsContext as jest.Mock).mockReturnValue({
+      eventId,
+      indexName,
+      scopeId,
+      isPreviewMode: false,
     });
+    const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
+    expect(hookResult.result.current.isEnabled).toEqual(true);
 
-    it('should enable navigation if isPreviewMode is false', () => {
-      (useDocumentDetailsContext as jest.Mock).mockReturnValue({
-        eventId,
+    hookResult.result.current.navigateToLeftPanel();
+
+    expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
+      id: DocumentDetailsLeftPanelKey,
+      path: {
+        tab: 'tab',
+        subTab: 'subTab',
+      },
+      params: {
+        id: eventId,
         indexName,
         scopeId,
-        isPreviewMode: false,
-      });
-      const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
-      expect(hookResult.result.current.isEnabled).toEqual(true);
+      },
+    });
+    expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
+  });
 
-      hookResult.result.current.navigateToLeftPanel();
+  it('should open new flyout if isPreviewMode is true', () => {
+    (useDocumentDetailsContext as jest.Mock).mockReturnValue({
+      eventId,
+      indexName,
+      scopeId,
+      isPreviewMode: true,
+    });
+    const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
+    expect(hookResult.result.current.isEnabled).toEqual(true);
 
-      expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
+    hookResult.result.current.navigateToLeftPanel();
+
+    expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
+    expect(mockFlyoutApi.openFlyout).toHaveBeenCalledWith({
+      right: {
+        id: DocumentDetailsRightPanelKey,
+        params: {
+          id: eventId,
+          indexName,
+          scopeId,
+        },
+      },
+      left: {
         id: DocumentDetailsLeftPanelKey,
         path: {
           tab: 'tab',
@@ -112,45 +92,7 @@ describe('useNavigateToLeftPanel', () => {
           indexName,
           scopeId,
         },
-      });
-      expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
-    });
-
-    it('should open new flyout if isPreviewMode is true', () => {
-      (useDocumentDetailsContext as jest.Mock).mockReturnValue({
-        eventId,
-        indexName,
-        scopeId,
-        isPreviewMode: true,
-      });
-      const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
-      expect(hookResult.result.current.isEnabled).toEqual(true);
-
-      hookResult.result.current.navigateToLeftPanel();
-
-      expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
-      expect(mockFlyoutApi.openFlyout).toHaveBeenCalledWith({
-        right: {
-          id: DocumentDetailsRightPanelKey,
-          params: {
-            id: eventId,
-            indexName,
-            scopeId,
-          },
-        },
-        left: {
-          id: DocumentDetailsLeftPanelKey,
-          path: {
-            tab: 'tab',
-            subTab: 'subTab',
-          },
-          params: {
-            id: eventId,
-            indexName,
-            scopeId,
-          },
-        },
-      });
+      },
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.test.tsx
@@ -40,9 +40,8 @@ describe('useNavigateToLeftPanel', () => {
       isPreviewMode: false,
     });
     const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
-    expect(hookResult.result.current.isEnabled).toEqual(true);
 
-    hookResult.result.current.navigateToLeftPanel();
+    hookResult.result.current();
 
     expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
       id: DocumentDetailsLeftPanelKey,
@@ -67,9 +66,8 @@ describe('useNavigateToLeftPanel', () => {
       isPreviewMode: true,
     });
     const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
-    expect(hookResult.result.current.isEnabled).toEqual(true);
 
-    hookResult.result.current.navigateToLeftPanel();
+    hookResult.result.current();
 
     expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
     expect(mockFlyoutApi.openFlyout).toHaveBeenCalledWith({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.tsx
@@ -24,24 +24,13 @@ export interface UseNavigateToLeftPanelParams {
   subTab?: string;
 }
 
-export interface UseNavigateToLeftPanelResult {
-  /**
-   * Callback to open analyzer in visualize tab
-   */
-  navigateToLeftPanel: () => void;
-  /**
-   * Whether the button should be disabled
-   */
-  isEnabled: boolean;
-}
-
 /**
  * Hook that returns a callback to navigate to the analyzer in the flyout
  */
 export const useNavigateToLeftPanel = ({
   tab,
   subTab,
-}: UseNavigateToLeftPanelParams): UseNavigateToLeftPanelResult => {
+}: UseNavigateToLeftPanelParams): (() => void) => {
   const { telemetry } = useKibana().services;
   const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
   const { eventId, indexName, scopeId, isPreviewMode } = useDocumentDetailsContext();
@@ -74,7 +63,7 @@ export const useNavigateToLeftPanel = ({
     [eventId, indexName, scopeId, tab, subTab]
   );
 
-  const navigateToLeftPanel = useCallback(() => {
+  return useCallback(() => {
     if (!isPreviewMode) {
       openLeftPanel(left);
       telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutTabClicked, {
@@ -93,6 +82,4 @@ export const useNavigateToLeftPanel = ({
       });
     }
   }, [openFlyout, openLeftPanel, right, left, scopeId, telemetry, isPreviewMode, tab]);
-
-  return useMemo(() => ({ navigateToLeftPanel, isEnabled: true }), [navigateToLeftPanel]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.tsx
@@ -12,7 +12,7 @@ import { DocumentEventTypes } from '../../../../common/lib/telemetry/types';
 import { useKibana } from '../../../../common/lib/kibana';
 import { DocumentDetailsLeftPanelKey, DocumentDetailsRightPanelKey } from '../constants/panel_keys';
 import { useDocumentDetailsContext } from '../context';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+
 export interface UseNavigateToLeftPanelParams {
   /**
    * The tab to navigate to
@@ -36,7 +36,7 @@ export interface UseNavigateToLeftPanelResult {
 }
 
 /**
- * Hook that returns the a callback to navigate to the analyzer in the flyout
+ * Hook that returns a callback to navigate to the analyzer in the flyout
  */
 export const useNavigateToLeftPanel = ({
   tab,
@@ -45,12 +45,6 @@ export const useNavigateToLeftPanel = ({
   const { telemetry } = useKibana().services;
   const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
   const { eventId, indexName, scopeId, isPreviewMode } = useDocumentDetailsContext();
-
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
-
-  const isEnabled = isNewNavigationEnabled || (!isNewNavigationEnabled && !isPreviewMode);
 
   const right: FlyoutPanelProps = useMemo(
     () => ({
@@ -88,7 +82,7 @@ export const useNavigateToLeftPanel = ({
         panel: 'left',
         tabId: tab,
       });
-    } else if (isNewNavigationEnabled && isPreviewMode) {
+    } else {
       openFlyout({
         right,
         left,
@@ -98,17 +92,7 @@ export const useNavigateToLeftPanel = ({
         panel: 'left',
       });
     }
-  }, [
-    openFlyout,
-    openLeftPanel,
-    right,
-    left,
-    scopeId,
-    telemetry,
-    isPreviewMode,
-    tab,
-    isNewNavigationEnabled,
-  ]);
+  }, [openFlyout, openLeftPanel, right, left, scopeId, telemetry, isPreviewMode, tab]);
 
-  return useMemo(() => ({ navigateToLeftPanel, isEnabled }), [navigateToLeftPanel, isEnabled]);
+  return useMemo(() => ({ navigateToLeftPanel, isEnabled: true }), [navigateToLeftPanel]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_session_view.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_session_view.test.tsx
@@ -11,13 +11,11 @@ import { useNavigateToSessionView } from './use_navigate_to_session_view';
 import { mockFlyoutApi } from '../mocks/mock_flyout_context';
 import { useKibana as mockUseKibana } from '../../../../common/lib/kibana/__mocks__';
 import { useKibana } from '../../../../common/lib/kibana';
-import { DocumentDetailsRightPanelKey, DocumentDetailsLeftPanelKey } from '../constants/panel_keys';
+import { DocumentDetailsLeftPanelKey, DocumentDetailsRightPanelKey } from '../constants/panel_keys';
 import { SESSION_VIEW_ID } from '../../left/components/session_view';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 jest.mock('@kbn/expandable-flyout');
 jest.mock('../../../../common/lib/kibana');
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockedUseKibana = mockUseKibana();
 (useKibana as jest.Mock).mockReturnValue(mockedUseKibana);
@@ -30,7 +28,6 @@ describe('useNavigateToSessionView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
   });
 
   it('when isFlyoutOpen is true, should return callback that opens left panel', () => {
@@ -53,7 +50,7 @@ describe('useNavigateToSessionView', () => {
     });
   });
 
-  it('when isFlyoutOpen is true and in preview mode, navigation is disabled', () => {
+  it('when isFlyoutOpen is true and in preview mode, should return callback that opens a new flyout', () => {
     const hookResult = renderHook(() =>
       useNavigateToSessionView({
         isFlyoutOpen: true,
@@ -66,7 +63,28 @@ describe('useNavigateToSessionView', () => {
     hookResult.result.current.navigateToSessionView();
 
     expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
-    expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
+    expect(mockFlyoutApi.openFlyout).toHaveBeenCalledWith({
+      right: {
+        id: DocumentDetailsRightPanelKey,
+        params: {
+          id: eventId,
+          indexName,
+          scopeId,
+        },
+      },
+      left: {
+        id: DocumentDetailsLeftPanelKey,
+        path: {
+          tab: 'visualize',
+          subTab: SESSION_VIEW_ID,
+        },
+        params: {
+          id: eventId,
+          indexName,
+          scopeId,
+        },
+      },
+    });
   });
 
   it('when isFlyoutOpen is false, should return callback that opens a new flyout', () => {
@@ -96,98 +114,6 @@ describe('useNavigateToSessionView', () => {
           scopeId,
         },
       },
-    });
-  });
-
-  describe('when newExpandableFlyoutNavigationDisabled is false', () => {
-    beforeEach(() => {
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
-    });
-    it('when isFlyoutOpen is true, should return callback that opens left panel', () => {
-      const hookResult = renderHook(() =>
-        useNavigateToSessionView({ isFlyoutOpen: true, eventId, indexName, scopeId })
-      );
-      hookResult.result.current.navigateToSessionView();
-      expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
-      expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
-        id: DocumentDetailsLeftPanelKey,
-        path: {
-          tab: 'visualize',
-          subTab: SESSION_VIEW_ID,
-        },
-        params: {
-          id: eventId,
-          indexName,
-          scopeId,
-        },
-      });
-    });
-
-    it('when isFlyoutOpen is true and in preview mode, should return callback that opens a new flyout', () => {
-      const hookResult = renderHook(() =>
-        useNavigateToSessionView({
-          isFlyoutOpen: true,
-          eventId,
-          indexName,
-          scopeId,
-          isPreviewMode: true,
-        })
-      );
-      hookResult.result.current.navigateToSessionView();
-
-      expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
-      expect(mockFlyoutApi.openFlyout).toHaveBeenCalledWith({
-        right: {
-          id: DocumentDetailsRightPanelKey,
-          params: {
-            id: eventId,
-            indexName,
-            scopeId,
-          },
-        },
-        left: {
-          id: DocumentDetailsLeftPanelKey,
-          path: {
-            tab: 'visualize',
-            subTab: SESSION_VIEW_ID,
-          },
-          params: {
-            id: eventId,
-            indexName,
-            scopeId,
-          },
-        },
-      });
-    });
-
-    it('when isFlyoutOpen is false, should return callback that opens a new flyout', () => {
-      const hookResult = renderHook(() =>
-        useNavigateToSessionView({ isFlyoutOpen: false, eventId, indexName, scopeId })
-      );
-      hookResult.result.current.navigateToSessionView();
-      expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
-      expect(mockFlyoutApi.openFlyout).toHaveBeenCalledWith({
-        right: {
-          id: DocumentDetailsRightPanelKey,
-          params: {
-            id: eventId,
-            indexName,
-            scopeId,
-          },
-        },
-        left: {
-          id: DocumentDetailsLeftPanelKey,
-          path: {
-            tab: 'visualize',
-            subTab: SESSION_VIEW_ID,
-          },
-          params: {
-            id: eventId,
-            indexName,
-            scopeId,
-          },
-        },
-      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_session_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_session_view.tsx
@@ -14,7 +14,6 @@ import { useKibana } from '../../../../common/lib/kibana';
 import { SESSION_VIEW_ID } from '../../left/components/session_view';
 import { DocumentDetailsLeftPanelKey, DocumentDetailsRightPanelKey } from '../constants/panel_keys';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 export interface UseNavigateToSessionViewParams {
   /**
@@ -60,10 +59,6 @@ export const useNavigateToSessionView = ({
   const { telemetry } = useKibana().services;
   const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
 
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
-
   const right: FlyoutPanelProps = useMemo(
     () => ({
       id: DocumentDetailsRightPanelKey,
@@ -104,7 +99,7 @@ export const useNavigateToSessionView = ({
     }
     // if flyout is not currently open, open flyout with right and left panels
     // if new navigation is enabled and in preview mode, open flyout with right and left panels
-    else if (!isFlyoutOpen || (isNewNavigationEnabled && isPreviewMode)) {
+    else {
       openFlyout({
         right,
         left,
@@ -114,17 +109,7 @@ export const useNavigateToSessionView = ({
         panel: 'left',
       });
     }
-  }, [
-    openFlyout,
-    openLeftPanel,
-    right,
-    left,
-    scopeId,
-    telemetry,
-    isFlyoutOpen,
-    isNewNavigationEnabled,
-    isPreviewMode,
-  ]);
+  }, [openFlyout, openLeftPanel, right, left, scopeId, telemetry, isFlyoutOpen, isPreviewMode]);
 
   return useMemo(() => ({ navigateToSessionView }), [navigateToSessionView]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/content.tsx
@@ -7,9 +7,9 @@
 
 import React, { useMemo } from 'react';
 import {
+  ASSET_INVENTORY_APP_NAME,
   ASSET_INVENTORY_CRITICALITY_ASSIGNED_MANUAL,
   uiMetricService,
-  ASSET_INVENTORY_APP_NAME,
 } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiTitle, useEuiTheme } from '@elastic/eui';
@@ -106,7 +106,6 @@ export const GenericEntityFlyoutContent = ({
         field={insightsField}
         value={insightsValue}
         isPreviewMode={false}
-        isLinkEnabled={true}
         openDetailsPanel={openGenericEntityDetailsPanelByPath}
       />
       <ExpandableSection

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.stories.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.stories.tsx
@@ -43,7 +43,7 @@ export const Default = {
       hostName={'test-host-name'}
       onAssetCriticalityChange={() => {}}
       recalculatingScore={false}
-      isLinkEnabled={true}
+      isPreviewMode={false}
     />
   ),
 
@@ -73,7 +73,7 @@ export const NoObservedData = {
       hostName={'test-host-name'}
       onAssetCriticalityChange={() => {}}
       recalculatingScore={false}
-      isLinkEnabled={true}
+      isPreviewMode={false}
     />
   ),
 
@@ -103,7 +103,7 @@ export const Loading = {
       hostName={'test-host-name'}
       onAssetCriticalityChange={() => {}}
       recalculatingScore={false}
-      isLinkEnabled={true}
+      isPreviewMode={false}
     />
   ),
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
@@ -31,8 +31,7 @@ interface HostPanelContentProps {
   hostName: string;
   onAssetCriticalityChange: () => void;
   recalculatingScore: boolean;
-  isPreviewMode?: boolean;
-  isLinkEnabled: boolean;
+  isPreviewMode: boolean;
 }
 
 export const HostPanelContent = ({
@@ -45,7 +44,6 @@ export const HostPanelContent = ({
   openDetailsPanel,
   onAssetCriticalityChange,
   isPreviewMode,
-  isLinkEnabled,
 }: HostPanelContentProps) => {
   const observedFields = useObservedHostFields(observedHost);
 
@@ -67,7 +65,6 @@ export const HostPanelContent = ({
             queryId={HOST_PANEL_RISK_SCORE_QUERY_ID}
             openDetailsPanel={openDetailsPanel}
             isPreviewMode={isPreviewMode}
-            isLinkEnabled={isLinkEnabled}
           />
           <EuiHorizontalRule />
         </>
@@ -81,7 +78,6 @@ export const HostPanelContent = ({
         field={EntityIdentifierFields.hostName}
         isPreviewMode={isPreviewMode}
         openDetailsPanel={openDetailsPanel}
-        isLinkEnabled={isLinkEnabled}
       />
       <ObservedEntity
         observedData={observedHost}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.test.ts
@@ -7,7 +7,6 @@
 
 import { renderHook } from '@testing-library/react';
 import { useNavigateToHostDetails } from './use_navigate_to_host_details';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import {
   CspInsightLeftPanelSubTab,
@@ -18,7 +17,6 @@ import { createTelemetryServiceMock } from '../../../../common/lib/telemetry/tel
 import { HostPanelKey } from '../../shared/constants';
 
 jest.mock('@kbn/expandable-flyout');
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockedTelemetry = createTelemetryServiceMock();
 jest.mock('../../../../common/lib/kibana', () => {
@@ -53,88 +51,53 @@ const mockOpenLeftPanel = jest.fn();
 const mockOpenFlyout = jest.fn();
 
 describe('useNavigateToHostDetails', () => {
-  describe('when newExpandableFlyoutNavigationDisabled is false', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
-      (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
-        openLeftPanel: mockOpenLeftPanel,
-        openFlyout: mockOpenFlyout,
-      });
-    });
-
-    it('returns callback that opens details panel when not in preview mode', () => {
-      const { result } = renderHook(() => useNavigateToHostDetails(mockProps));
-
-      expect(result.current.isLinkEnabled).toBe(true);
-      result.current.openDetailsPanel({ tab, subTab });
-
-      expect(mockOpenLeftPanel).toHaveBeenCalledWith({
-        id: HostDetailsPanelKey,
-        params: {
-          name: mockProps.hostName,
-          scopeId: mockProps.scopeId,
-          isRiskScoreExist: mockProps.isRiskScoreExist,
-          path: { tab, subTab },
-          hasMisconfigurationFindings: mockProps.hasMisconfigurationFindings,
-          hasVulnerabilitiesFindings: mockProps.hasVulnerabilitiesFindings,
-          hasNonClosedAlerts: mockProps.hasNonClosedAlerts,
-        },
-      });
-      expect(mockOpenFlyout).not.toHaveBeenCalled();
-    });
-
-    it('returns callback that opens flyout when in preview mode', () => {
-      const { result } = renderHook(() =>
-        useNavigateToHostDetails({ ...mockProps, isPreviewMode: true })
-      );
-
-      expect(result.current.isLinkEnabled).toBe(true);
-      result.current.openDetailsPanel({ tab, subTab });
-
-      expect(mockOpenFlyout).toHaveBeenCalledWith({
-        right: {
-          id: HostPanelKey,
-          params: {
-            contextID: mockProps.contextID,
-            scopeId: mockProps.scopeId,
-            hostName: mockProps.hostName,
-          },
-        },
-        left: {
-          id: HostDetailsPanelKey,
-          params: {
-            name: mockProps.hostName,
-            scopeId: mockProps.scopeId,
-            isRiskScoreExist: mockProps.isRiskScoreExist,
-            path: { tab, subTab },
-            hasMisconfigurationFindings: mockProps.hasMisconfigurationFindings,
-            hasVulnerabilitiesFindings: mockProps.hasVulnerabilitiesFindings,
-            hasNonClosedAlerts: mockProps.hasNonClosedAlerts,
-          },
-        },
-      });
-      expect(mockOpenLeftPanel).not.toHaveBeenCalled();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
+      openLeftPanel: mockOpenLeftPanel,
+      openFlyout: mockOpenFlyout,
     });
   });
 
-  describe('when newExpandableFlyoutNavigationDisabled is true', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-      (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
-        openLeftPanel: mockOpenLeftPanel,
-        openFlyout: mockOpenFlyout,
-      });
+  it('returns callback that opens details panel when not in preview mode', () => {
+    const { result } = renderHook(() => useNavigateToHostDetails(mockProps));
+
+    expect(result.current.isLinkEnabled).toBe(true);
+    result.current.openDetailsPanel({ tab, subTab });
+
+    expect(mockOpenLeftPanel).toHaveBeenCalledWith({
+      id: HostDetailsPanelKey,
+      params: {
+        name: mockProps.hostName,
+        scopeId: mockProps.scopeId,
+        isRiskScoreExist: mockProps.isRiskScoreExist,
+        path: { tab, subTab },
+        hasMisconfigurationFindings: mockProps.hasMisconfigurationFindings,
+        hasVulnerabilitiesFindings: mockProps.hasVulnerabilitiesFindings,
+        hasNonClosedAlerts: mockProps.hasNonClosedAlerts,
+      },
     });
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+  });
 
-    it('returns callback that opens details panel when not in preview mode', () => {
-      const { result } = renderHook(() => useNavigateToHostDetails(mockProps));
+  it('returns callback that opens flyout when in preview mode', () => {
+    const { result } = renderHook(() =>
+      useNavigateToHostDetails({ ...mockProps, isPreviewMode: true })
+    );
 
-      expect(result.current.isLinkEnabled).toBe(true);
-      result.current.openDetailsPanel({ tab, subTab });
+    expect(result.current.isLinkEnabled).toBe(true);
+    result.current.openDetailsPanel({ tab, subTab });
 
-      expect(mockOpenLeftPanel).toHaveBeenCalledWith({
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: HostPanelKey,
+        params: {
+          contextID: mockProps.contextID,
+          scopeId: mockProps.scopeId,
+          hostName: mockProps.hostName,
+        },
+      },
+      left: {
         id: HostDetailsPanelKey,
         params: {
           name: mockProps.hostName,
@@ -145,20 +108,8 @@ describe('useNavigateToHostDetails', () => {
           hasVulnerabilitiesFindings: mockProps.hasVulnerabilitiesFindings,
           hasNonClosedAlerts: mockProps.hasNonClosedAlerts,
         },
-      });
-      expect(mockOpenFlyout).not.toHaveBeenCalled();
+      },
     });
-
-    it('returns empty callback and isLinkEnabled is false when in preview mode', () => {
-      const { result } = renderHook(() =>
-        useNavigateToHostDetails({ ...mockProps, isPreviewMode: true })
-      );
-
-      expect(result.current.isLinkEnabled).toBe(false);
-      result.current.openDetailsPanel({ tab, subTab });
-
-      expect(mockOpenLeftPanel).not.toHaveBeenCalled();
-      expect(mockOpenFlyout).not.toHaveBeenCalled();
-    });
+    expect(mockOpenLeftPanel).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.test.ts
@@ -62,8 +62,7 @@ describe('useNavigateToHostDetails', () => {
   it('returns callback that opens details panel when not in preview mode', () => {
     const { result } = renderHook(() => useNavigateToHostDetails(mockProps));
 
-    expect(result.current.isLinkEnabled).toBe(true);
-    result.current.openDetailsPanel({ tab, subTab });
+    result.current({ tab, subTab });
 
     expect(mockOpenLeftPanel).toHaveBeenCalledWith({
       id: HostDetailsPanelKey,
@@ -85,8 +84,7 @@ describe('useNavigateToHostDetails', () => {
       useNavigateToHostDetails({ ...mockProps, isPreviewMode: true })
     );
 
-    expect(result.current.isLinkEnabled).toBe(true);
-    result.current.openDetailsPanel({ tab, subTab });
+    result.current({ tab, subTab });
 
     expect(mockOpenFlyout).toHaveBeenCalledWith({
       right: {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.ts
@@ -12,7 +12,6 @@ import { useKibana } from '../../../../common/lib/kibana';
 import { HostDetailsPanelKey } from '../../host_details_left';
 import type { EntityDetailsPath } from '../../shared/components/left_panel/left_panel_header';
 import { EntityEventTypes } from '../../../../common/lib/telemetry';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { HostPanelKey } from '../../shared/constants';
 
 interface UseNavigateToHostDetailsParams {
@@ -43,17 +42,12 @@ export const useNavigateToHostDetails = ({
 }: UseNavigateToHostDetailsParams): UseNavigateToHostDetailsResult => {
   const { telemetry } = useKibana().services;
   const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
 
   telemetry.reportEvent(EntityEventTypes.RiskInputsExpandedFlyoutOpened, {
     entity: EntityType.host,
   });
 
-  const isLinkEnabled = useMemo(() => {
-    return !isPreviewMode || (isNewNavigationEnabled && isPreviewMode);
-  }, [isNewNavigationEnabled, isPreviewMode]);
+  const isLinkEnabled = useMemo(() => !isPreviewMode || isPreviewMode, [isPreviewMode]);
 
   const openDetailsPanel = useCallback(
     (path?: EntityDetailsPath) => {
@@ -80,16 +74,15 @@ export const useNavigateToHostDetails = ({
       };
 
       // When new navigation is enabled, nevigation in preview is enabled and open a new flyout
-      if (isNewNavigationEnabled && isPreviewMode) {
+      if (isPreviewMode) {
         openFlyout({ right, left });
       }
       // When not in preview mode, open left panel as usual
-      else if (!isPreviewMode) {
+      else {
         openLeftPanel(left);
       }
     },
     [
-      isNewNavigationEnabled,
       isPreviewMode,
       openFlyout,
       openLeftPanel,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { EntityType } from '../../../../../common/search_strategy';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -21,13 +21,8 @@ interface UseNavigateToHostDetailsParams {
   hasMisconfigurationFindings: boolean;
   hasVulnerabilitiesFindings: boolean;
   hasNonClosedAlerts: boolean;
-  isPreviewMode?: boolean;
+  isPreviewMode: boolean;
   contextID: string;
-}
-
-interface UseNavigateToHostDetailsResult {
-  openDetailsPanel: (path: EntityDetailsPath) => void;
-  isLinkEnabled: boolean;
 }
 
 export const useNavigateToHostDetails = ({
@@ -39,7 +34,7 @@ export const useNavigateToHostDetails = ({
   hasNonClosedAlerts,
   isPreviewMode,
   contextID,
-}: UseNavigateToHostDetailsParams): UseNavigateToHostDetailsResult => {
+}: UseNavigateToHostDetailsParams): ((path: EntityDetailsPath) => void) => {
   const { telemetry } = useKibana().services;
   const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
 
@@ -47,9 +42,7 @@ export const useNavigateToHostDetails = ({
     entity: EntityType.host,
   });
 
-  const isLinkEnabled = useMemo(() => !isPreviewMode || isPreviewMode, [isPreviewMode]);
-
-  const openDetailsPanel = useCallback(
+  return useCallback(
     (path?: EntityDetailsPath) => {
       const left = {
         id: HostDetailsPanelKey,
@@ -73,12 +66,9 @@ export const useNavigateToHostDetails = ({
         },
       };
 
-      // When new navigation is enabled, nevigation in preview is enabled and open a new flyout
       if (isPreviewMode) {
         openFlyout({ right, left });
-      }
-      // When not in preview mode, open left panel as usual
-      else {
+      } else {
         openLeftPanel(left);
       }
     },
@@ -95,6 +85,4 @@ export const useNavigateToHostDetails = ({
       contextID,
     ]
   );
-
-  return { openDetailsPanel, isLinkEnabled };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -7,7 +7,6 @@
 
 import React, { useCallback, useMemo } from 'react';
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
-
 import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations';
 import { useHasVulnerabilities } from '@kbn/cloud-security-posture/src/hooks/use_has_vulnerabilities';
 import { TableId } from '@kbn/securitysolution-data-table';
@@ -42,7 +41,7 @@ export interface HostPanelProps extends Record<string, unknown> {
   contextID: string;
   scopeId: string;
   hostName: string;
-  isPreviewMode?: boolean;
+  isPreviewMode: boolean;
 }
 
 export interface HostPanelExpandableFlyoutProps extends FlyoutPanelProps {
@@ -59,7 +58,12 @@ const FIRST_RECORD_PAGINATION = {
   querySize: 1,
 };
 
-export const HostPanel = ({ contextID, scopeId, hostName, isPreviewMode }: HostPanelProps) => {
+export const HostPanel = ({
+  contextID,
+  scopeId,
+  hostName,
+  isPreviewMode = false,
+}: HostPanelProps) => {
   const { uiSettings } = useKibana().services;
   const assetInventoryEnabled = uiSettings.get(ENABLE_ASSET_INVENTORY_SETTING, true);
 
@@ -113,7 +117,7 @@ export const HostPanel = ({ contextID, scopeId, hostName, isPreviewMode }: HostP
     setQuery,
   });
 
-  const { openDetailsPanel, isLinkEnabled } = useNavigateToHostDetails({
+  const openDetailsPanel = useNavigateToHostDetails({
     hostName,
     scopeId,
     isRiskScoreExist,
@@ -178,7 +182,6 @@ export const HostPanel = ({ contextID, scopeId, hostName, isPreviewMode }: HostP
               contextID={contextID}
               scopeId={scopeId}
               openDetailsPanel={openDetailsPanel}
-              isLinkEnabled={isLinkEnabled}
               recalculatingScore={recalculatingScore}
               onAssetCriticalityChange={calculateEntityRiskScore}
               isPreviewMode={isPreviewMode}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.tsx
@@ -6,7 +6,6 @@
  */
 
 import { EuiHorizontalRule } from '@elastic/eui';
-
 import React from 'react';
 import type { ServiceItem } from '../../../../common/search_strategy';
 import { AssetCriticalityAccordion } from '../../../entity_analytics/components/asset_criticality/asset_criticality_selector';
@@ -31,8 +30,6 @@ interface ServicePanelContentProps {
   scopeId: string;
   onAssetCriticalityChange: () => void;
   openDetailsPanel: (path: EntityDetailsPath) => void;
-  isPreviewMode?: boolean;
-  isLinkEnabled: boolean;
 }
 
 export const ServicePanelContent = ({
@@ -44,8 +41,6 @@ export const ServicePanelContent = ({
   scopeId,
   openDetailsPanel,
   onAssetCriticalityChange,
-  isPreviewMode,
-  isLinkEnabled,
 }: ServicePanelContentProps) => {
   const observedFields = useObservedServiceItems(observedService);
 
@@ -58,8 +53,7 @@ export const ServicePanelContent = ({
             recalculatingScore={recalculatingScore}
             queryId={SERVICE_PANEL_RISK_SCORE_QUERY_ID}
             openDetailsPanel={openDetailsPanel}
-            isPreviewMode={isPreviewMode}
-            isLinkEnabled={isLinkEnabled}
+            isPreviewMode={false}
             entityType={EntityType.service}
           />
           <EuiHorizontalRule />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/use_navigate_to_service_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/use_navigate_to_service_details.test.ts
@@ -7,7 +7,6 @@
 
 import { renderHook } from '@testing-library/react';
 import { useNavigateToServiceDetails } from './use_navigate_to_service_details';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import {
   CspInsightLeftPanelSubTab,
@@ -18,7 +17,6 @@ import { createTelemetryServiceMock } from '../../../../common/lib/telemetry/tel
 import { ServicePanelKey } from '../../shared/constants';
 
 jest.mock('@kbn/expandable-flyout');
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockedTelemetry = createTelemetryServiceMock();
 jest.mock('../../../../common/lib/kibana', () => {
@@ -53,88 +51,54 @@ const mockOpenLeftPanel = jest.fn();
 const mockOpenFlyout = jest.fn();
 
 describe('useNavigateToServiceDetails', () => {
-  describe('when newExpandableFlyoutNavigationDisabled is false', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
-      (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
-        openLeftPanel: mockOpenLeftPanel,
-        openFlyout: mockOpenFlyout,
-      });
-    });
-
-    it('returns callback that opens details panel when not in preview mode', () => {
-      const { result } = renderHook(() => useNavigateToServiceDetails(mockProps));
-
-      expect(result.current.isLinkEnabled).toBe(true);
-      result.current.openDetailsPanel({ tab, subTab });
-
-      expect(result.current.isLinkEnabled).toBe(true);
-      result.current.openDetailsPanel({ tab, subTab });
-
-      expect(mockOpenLeftPanel).toHaveBeenCalledWith({
-        id: ServiceDetailsPanelKey,
-        params: {
-          service: {
-            name: mockProps.serviceName,
-          },
-          scopeId: mockProps.scopeId,
-          isRiskScoreExist: mockProps.isRiskScoreExist,
-          path: { tab, subTab },
-        },
-      });
-    });
-
-    it('returns callback that opens flyout when in preview mode', () => {
-      const { result } = renderHook(() =>
-        useNavigateToServiceDetails({ ...mockProps, isPreviewMode: true })
-      );
-
-      expect(result.current.isLinkEnabled).toBe(true);
-      result.current.openDetailsPanel({ tab, subTab });
-
-      expect(mockOpenFlyout).toHaveBeenCalledWith({
-        right: {
-          id: ServicePanelKey,
-          params: {
-            contextID: mockProps.contextID,
-            scopeId: mockProps.scopeId,
-            serviceName: mockProps.serviceName,
-          },
-        },
-        left: {
-          id: ServiceDetailsPanelKey,
-          params: {
-            service: {
-              name: mockProps.serviceName,
-            },
-            scopeId: mockProps.scopeId,
-            isRiskScoreExist: mockProps.isRiskScoreExist,
-            path: { tab, subTab },
-          },
-        },
-      });
-      expect(mockOpenLeftPanel).not.toHaveBeenCalled();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
+      openLeftPanel: mockOpenLeftPanel,
+      openFlyout: mockOpenFlyout,
     });
   });
 
-  describe('when newExpandableFlyoutNavigationDisabled is true', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-      (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
-        openLeftPanel: mockOpenLeftPanel,
-        openFlyout: mockOpenFlyout,
-      });
+  it('returns callback that opens details panel when not in preview mode', () => {
+    const { result } = renderHook(() => useNavigateToServiceDetails(mockProps));
+
+    expect(result.current.isLinkEnabled).toBe(true);
+    result.current.openDetailsPanel({ tab, subTab });
+
+    expect(result.current.isLinkEnabled).toBe(true);
+    result.current.openDetailsPanel({ tab, subTab });
+
+    expect(mockOpenLeftPanel).toHaveBeenCalledWith({
+      id: ServiceDetailsPanelKey,
+      params: {
+        service: {
+          name: mockProps.serviceName,
+        },
+        scopeId: mockProps.scopeId,
+        isRiskScoreExist: mockProps.isRiskScoreExist,
+        path: { tab, subTab },
+      },
     });
+  });
 
-    it('returns callback that opens details panel when not in preview mode', () => {
-      const { result } = renderHook(() => useNavigateToServiceDetails(mockProps));
+  it('returns callback that opens flyout when in preview mode', () => {
+    const { result } = renderHook(() =>
+      useNavigateToServiceDetails({ ...mockProps, isPreviewMode: true })
+    );
 
-      expect(result.current.isLinkEnabled).toBe(true);
-      result.current.openDetailsPanel({ tab, subTab });
+    expect(result.current.isLinkEnabled).toBe(true);
+    result.current.openDetailsPanel({ tab, subTab });
 
-      expect(mockOpenLeftPanel).toHaveBeenCalledWith({
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: ServicePanelKey,
+        params: {
+          contextID: mockProps.contextID,
+          scopeId: mockProps.scopeId,
+          serviceName: mockProps.serviceName,
+        },
+      },
+      left: {
         id: ServiceDetailsPanelKey,
         params: {
           service: {
@@ -144,20 +108,8 @@ describe('useNavigateToServiceDetails', () => {
           isRiskScoreExist: mockProps.isRiskScoreExist,
           path: { tab, subTab },
         },
-      });
-      expect(mockOpenFlyout).not.toHaveBeenCalled();
+      },
     });
-
-    it('returns empty callback and isLinkEnabled is false when in preview mode', () => {
-      const { result } = renderHook(() =>
-        useNavigateToServiceDetails({ ...mockProps, isPreviewMode: true })
-      );
-
-      expect(result.current.isLinkEnabled).toBe(false);
-      result.current.openDetailsPanel({ tab, subTab });
-
-      expect(mockOpenLeftPanel).not.toHaveBeenCalled();
-      expect(mockOpenFlyout).not.toHaveBeenCalled();
-    });
+    expect(mockOpenLeftPanel).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/use_navigate_to_service_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/use_navigate_to_service_details.test.ts
@@ -14,7 +14,6 @@ import {
 } from '../../shared/components/left_panel/left_panel_header';
 import { ServiceDetailsPanelKey } from '../../service_details_left';
 import { createTelemetryServiceMock } from '../../../../common/lib/telemetry/telemetry_service.mock';
-import { ServicePanelKey } from '../../shared/constants';
 
 jest.mock('@kbn/expandable-flyout');
 
@@ -37,11 +36,6 @@ const mockProps = {
   serviceName: 'testService',
   scopeId: 'testScopeId',
   isRiskScoreExist: false,
-  hasMisconfigurationFindings: false,
-  hasNonClosedAlerts: false,
-  contextID: 'testContextID',
-  isPreviewMode: false,
-  email: ['test@test.com'],
 };
 
 const tab = EntityDetailsLeftPanelTab.RISK_INPUTS;
@@ -59,14 +53,10 @@ describe('useNavigateToServiceDetails', () => {
     });
   });
 
-  it('returns callback that opens details panel when not in preview mode', () => {
+  it('returns callback that opens details panel', () => {
     const { result } = renderHook(() => useNavigateToServiceDetails(mockProps));
 
-    expect(result.current.isLinkEnabled).toBe(true);
-    result.current.openDetailsPanel({ tab, subTab });
-
-    expect(result.current.isLinkEnabled).toBe(true);
-    result.current.openDetailsPanel({ tab, subTab });
+    result.current({ tab, subTab });
 
     expect(mockOpenLeftPanel).toHaveBeenCalledWith({
       id: ServiceDetailsPanelKey,
@@ -79,37 +69,5 @@ describe('useNavigateToServiceDetails', () => {
         path: { tab, subTab },
       },
     });
-  });
-
-  it('returns callback that opens flyout when in preview mode', () => {
-    const { result } = renderHook(() =>
-      useNavigateToServiceDetails({ ...mockProps, isPreviewMode: true })
-    );
-
-    expect(result.current.isLinkEnabled).toBe(true);
-    result.current.openDetailsPanel({ tab, subTab });
-
-    expect(mockOpenFlyout).toHaveBeenCalledWith({
-      right: {
-        id: ServicePanelKey,
-        params: {
-          contextID: mockProps.contextID,
-          scopeId: mockProps.scopeId,
-          serviceName: mockProps.serviceName,
-        },
-      },
-      left: {
-        id: ServiceDetailsPanelKey,
-        params: {
-          service: {
-            name: mockProps.serviceName,
-          },
-          scopeId: mockProps.scopeId,
-          isRiskScoreExist: mockProps.isRiskScoreExist,
-          path: { tab, subTab },
-        },
-      },
-    });
-    expect(mockOpenLeftPanel).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/use_navigate_to_service_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/use_navigate_to_service_details.ts
@@ -11,7 +11,6 @@ import type { EntityDetailsPath } from '../../shared/components/left_panel/left_
 import { useKibana } from '../../../../common/lib/kibana';
 import { EntityEventTypes } from '../../../../common/lib/telemetry';
 import { ServiceDetailsPanelKey } from '../../service_details_left';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { ServicePanelKey } from '../../shared/constants';
 
 interface UseNavigateToServiceDetailsParams {
@@ -43,11 +42,6 @@ export const useNavigateToServiceDetails = ({
 }: UseNavigateToServiceDetailsParams): UseNavigateToServiceDetailsResult => {
   const { telemetry } = useKibana().services;
   const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
-
-  const isLinkEnabled = !isPreviewMode || (isNewNavigationEnabled && isPreviewMode);
 
   const openDetailsPanel = useCallback(
     (path: EntityDetailsPath) => {
@@ -77,16 +71,15 @@ export const useNavigateToServiceDetails = ({
       };
 
       // When new navigation is enabled, navigation in preview is enabled and open a new flyout
-      if (isNewNavigationEnabled && isPreviewMode) {
+      if (isPreviewMode) {
         openFlyout({ right, left });
-      } else if (!isPreviewMode) {
+      } else {
         // When not in preview mode, open left panel as usual
         openLeftPanel(left);
       }
     },
     [
       contextID,
-      isNewNavigationEnabled,
       isPreviewMode,
       isRiskScoreExist,
       openFlyout,
@@ -97,5 +90,5 @@ export const useNavigateToServiceDetails = ({
     ]
   );
 
-  return { openDetailsPanel, isLinkEnabled };
+  return { openDetailsPanel, isLinkEnabled: true };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/use_navigate_to_service_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/use_navigate_to_service_details.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useCallback } from 'react';
 import { EntityType } from '../../../../../common/search_strategy';
@@ -11,45 +12,28 @@ import type { EntityDetailsPath } from '../../shared/components/left_panel/left_
 import { useKibana } from '../../../../common/lib/kibana';
 import { EntityEventTypes } from '../../../../common/lib/telemetry';
 import { ServiceDetailsPanelKey } from '../../service_details_left';
-import { ServicePanelKey } from '../../shared/constants';
 
 interface UseNavigateToServiceDetailsParams {
   serviceName: string;
-  email?: string[];
   scopeId: string;
-  contextID: string;
   isRiskScoreExist: boolean;
-  isPreviewMode?: boolean;
-}
-
-interface UseNavigateToServiceDetailsResult {
-  /**
-   * Opens the service details panel
-   */
-  openDetailsPanel: (path: EntityDetailsPath) => void;
-  /**
-   * Whether the link is enabled
-   */
-  isLinkEnabled: boolean;
 }
 
 export const useNavigateToServiceDetails = ({
   serviceName,
   scopeId,
-  contextID,
   isRiskScoreExist,
-  isPreviewMode,
-}: UseNavigateToServiceDetailsParams): UseNavigateToServiceDetailsResult => {
+}: UseNavigateToServiceDetailsParams): ((path: EntityDetailsPath) => void) => {
   const { telemetry } = useKibana().services;
-  const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
+  const { openLeftPanel } = useExpandableFlyoutApi();
 
-  const openDetailsPanel = useCallback(
+  return useCallback(
     (path: EntityDetailsPath) => {
       telemetry.reportEvent(EntityEventTypes.RiskInputsExpandedFlyoutOpened, {
         entity: EntityType.service,
       });
 
-      const left = {
+      openLeftPanel({
         id: ServiceDetailsPanelKey,
         params: {
           isRiskScoreExist,
@@ -59,36 +43,8 @@ export const useNavigateToServiceDetails = ({
           },
           path,
         },
-      };
-
-      const right = {
-        id: ServicePanelKey,
-        params: {
-          contextID,
-          serviceName,
-          scopeId,
-        },
-      };
-
-      // When new navigation is enabled, navigation in preview is enabled and open a new flyout
-      if (isPreviewMode) {
-        openFlyout({ right, left });
-      } else {
-        // When not in preview mode, open left panel as usual
-        openLeftPanel(left);
-      }
+      });
     },
-    [
-      contextID,
-      isPreviewMode,
-      isRiskScoreExist,
-      openFlyout,
-      openLeftPanel,
-      scopeId,
-      serviceName,
-      telemetry,
-    ]
+    [isRiskScoreExist, openLeftPanel, scopeId, serviceName, telemetry]
   );
-
-  return { openDetailsPanel, isLinkEnabled: true };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
@@ -84,10 +84,9 @@ export const ServicePanel = ({ contextID, scopeId, serviceName }: ServicePanelPr
     setQuery,
   });
 
-  const { openDetailsPanel, isLinkEnabled } = useNavigateToServiceDetails({
+  const openDetailsPanel = useNavigateToServiceDetails({
     serviceName,
     scopeId,
-    contextID,
     isRiskScoreExist,
   });
 
@@ -120,7 +119,6 @@ export const ServicePanel = ({ contextID, scopeId, serviceName }: ServicePanelPr
         contextID={contextID}
         scopeId={scopeId}
         openDetailsPanel={openDetailsPanel}
-        isLinkEnabled={isLinkEnabled}
       />
     </>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/components/managed_user_accordion.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/components/managed_user_accordion.test.tsx
@@ -21,7 +21,7 @@ describe('ManagedUserAccordion', () => {
           managedUser={mockEntraUserFields}
           tableType={UserAssetTableType.assetEntra}
           openDetailsPanel={() => {}}
-          isLinkEnabled
+          isPreviewMode={false}
         >
           <div data-test-subj="test-children" />
         </ManagedUserAccordion>
@@ -41,7 +41,6 @@ describe('ManagedUserAccordion', () => {
           managedUser={mockEntraUserFields}
           tableType={UserAssetTableType.assetEntra}
           openDetailsPanel={() => {}}
-          isLinkEnabled
           isPreviewMode
         >
           <div data-test-subj="test-children" />
@@ -51,23 +50,5 @@ describe('ManagedUserAccordion', () => {
 
     expect(getByTestId('managed-user-accordion-userAssetEntraTitleLink')).toBeInTheDocument();
     expect(queryByTestId('managed-user-accordion-userAssetEntraTitleIcon')).not.toBeInTheDocument();
-  });
-
-  it('does not render link when link is not enabled', () => {
-    const { queryByTestId } = render(
-      <TestProviders>
-        <ManagedUserAccordion
-          title="test title"
-          managedUser={mockEntraUserFields}
-          tableType={UserAssetTableType.assetEntra}
-          openDetailsPanel={() => {}}
-          isLinkEnabled={false}
-        >
-          <div data-test-subj="test-children" />
-        </ManagedUserAccordion>
-      </TestProviders>
-    );
-
-    expect(queryByTestId('managed-user-accordion-userAssetEntraTitleLink')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/components/managed_user_accordion.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/components/managed_user_accordion.tsx
@@ -6,8 +6,7 @@
  */
 
 import { useEuiFontSize } from '@elastic/eui';
-
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { get } from 'lodash/fp';
@@ -15,18 +14,17 @@ import type { EntityDetailsPath } from '../../shared/components/left_panel/left_
 import { EntityDetailsLeftPanelTab } from '../../shared/components/left_panel/left_panel_header';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import type { ManagedUserFields } from '../../../../../common/search_strategy/security_solution/users/managed_details';
-
 import { FormattedRelativePreferenceDate } from '../../../../common/components/formatted_date';
 import { ONE_WEEK_IN_HOURS } from '../../shared/constants';
 import { UserAssetTableType } from '../../../../explore/users/store/model';
+
 interface ManagedUserAccordionProps {
   children: React.ReactNode;
   title: string;
   managedUser: ManagedUserFields;
   tableType: UserAssetTableType;
   openDetailsPanel: (path: EntityDetailsPath) => void;
-  isLinkEnabled: boolean;
-  isPreviewMode?: boolean;
+  isPreviewMode: boolean;
 }
 
 export const ManagedUserAccordion: React.FC<ManagedUserAccordionProps> = ({
@@ -35,11 +33,34 @@ export const ManagedUserAccordion: React.FC<ManagedUserAccordionProps> = ({
   managedUser,
   tableType,
   openDetailsPanel,
-  isLinkEnabled,
   isPreviewMode,
 }) => {
   const xsFontSize = useEuiFontSize('xxs').fontSize;
   const timestamp = get('@timestamp[0]', managedUser) as unknown as string | undefined;
+
+  const goToEntityInsightTab = useCallback(
+    () =>
+      openDetailsPanel({
+        tab:
+          tableType === UserAssetTableType.assetOkta
+            ? EntityDetailsLeftPanelTab.OKTA
+            : EntityDetailsLeftPanelTab.ENTRA,
+      }),
+    [openDetailsPanel, tableType]
+  );
+
+  const link = useMemo(
+    () => ({
+      callback: goToEntityInsightTab,
+      tooltip: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.entityDetails.showAssetDocument"
+          defaultMessage="Show asset details"
+        />
+      ),
+    }),
+    [goToEntityInsightTab]
+  );
 
   return (
     <ExpandablePanel
@@ -68,23 +89,7 @@ export const ManagedUserAccordion: React.FC<ManagedUserAccordionProps> = ({
             />
           </span>
         ),
-        link: {
-          callback: isLinkEnabled
-            ? () =>
-                openDetailsPanel({
-                  tab:
-                    tableType === UserAssetTableType.assetOkta
-                      ? EntityDetailsLeftPanelTab.OKTA
-                      : EntityDetailsLeftPanelTab.ENTRA,
-                })
-            : undefined,
-          tooltip: (
-            <FormattedMessage
-              id="xpack.securitySolution.flyout.entityDetails.showAssetDocument"
-              defaultMessage="Show asset details"
-            />
-          ),
-        },
+        link,
       }}
       expand={{ expandable: false }}
     >

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.stories.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.stories.tsx
@@ -43,7 +43,7 @@ export const Default = {
       userName={'test-user-name'}
       onAssetCriticalityChange={() => {}}
       recalculatingScore={false}
-      isLinkEnabled={true}
+      isPreviewMode={false}
     />
   ),
 
@@ -61,7 +61,7 @@ export const IntegrationDisabled = {
       userName={'test-user-name'}
       onAssetCriticalityChange={() => {}}
       recalculatingScore={false}
-      isLinkEnabled={true}
+      isPreviewMode={false}
     />
   ),
 
@@ -79,7 +79,7 @@ export const NoManagedData = {
       userName={'test-user-name'}
       onAssetCriticalityChange={() => {}}
       recalculatingScore={false}
-      isLinkEnabled={true}
+      isPreviewMode={false}
     />
   ),
 
@@ -121,7 +121,7 @@ export const NoObservedData = {
       userName={'test-user-name'}
       onAssetCriticalityChange={() => {}}
       recalculatingScore={false}
-      isLinkEnabled={true}
+      isPreviewMode={false}
     />
   ),
 
@@ -163,7 +163,7 @@ export const Loading = {
       userName={'test-user-name'}
       onAssetCriticalityChange={() => {}}
       recalculatingScore={false}
-      isLinkEnabled={true}
+      isPreviewMode={false}
     />
   ),
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
@@ -31,8 +31,7 @@ interface UserPanelContentProps {
   scopeId: string;
   onAssetCriticalityChange: () => void;
   openDetailsPanel: (path: EntityDetailsPath) => void;
-  isPreviewMode?: boolean;
-  isLinkEnabled: boolean;
+  isPreviewMode: boolean;
 }
 
 export const UserPanelContent = ({
@@ -45,7 +44,6 @@ export const UserPanelContent = ({
   openDetailsPanel,
   onAssetCriticalityChange,
   isPreviewMode,
-  isLinkEnabled,
 }: UserPanelContentProps) => {
   const observedFields = useObservedUserItems(observedUser);
 
@@ -60,7 +58,6 @@ export const UserPanelContent = ({
             queryId={USER_PANEL_RISK_SCORE_QUERY_ID}
             openDetailsPanel={openDetailsPanel}
             isPreviewMode={isPreviewMode}
-            isLinkEnabled={isLinkEnabled}
             entityType={EntityType.user}
           />
           <EuiHorizontalRule />
@@ -74,7 +71,6 @@ export const UserPanelContent = ({
         value={userName}
         field={EntityIdentifierFields.userName}
         isPreviewMode={isPreviewMode}
-        isLinkEnabled={isLinkEnabled}
         openDetailsPanel={openDetailsPanel}
       />
       <ObservedEntity

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.test.ts
@@ -62,11 +62,7 @@ describe('useNavigateToUserDetails', () => {
   it('returns callback that opens details panel when not in preview mode', () => {
     const { result } = renderHook(() => useNavigateToUserDetails(mockProps));
 
-    expect(result.current.isLinkEnabled).toBe(true);
-    result.current.openDetailsPanel({ tab, subTab });
-
-    expect(result.current.isLinkEnabled).toBe(true);
-    result.current.openDetailsPanel({ tab, subTab });
+    result.current({ tab, subTab });
 
     expect(mockOpenLeftPanel).toHaveBeenCalledWith({
       id: UserDetailsPanelKey,
@@ -89,8 +85,7 @@ describe('useNavigateToUserDetails', () => {
       useNavigateToUserDetails({ ...mockProps, isPreviewMode: true })
     );
 
-    expect(result.current.isLinkEnabled).toBe(true);
-    result.current.openDetailsPanel({ tab, subTab });
+    result.current({ tab, subTab });
 
     expect(mockOpenFlyout).toHaveBeenCalledWith({
       right: {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.test.ts
@@ -7,7 +7,6 @@
 
 import { renderHook } from '@testing-library/react';
 import { useNavigateToUserDetails } from './use_navigate_to_user_details';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import {
   CspInsightLeftPanelSubTab,
@@ -18,7 +17,6 @@ import { createTelemetryServiceMock } from '../../../../common/lib/telemetry/tel
 import { UserPanelKey } from '../../shared/constants';
 
 jest.mock('@kbn/expandable-flyout');
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockedTelemetry = createTelemetryServiceMock();
 jest.mock('../../../../common/lib/kibana', () => {
@@ -53,94 +51,57 @@ const mockOpenLeftPanel = jest.fn();
 const mockOpenFlyout = jest.fn();
 
 describe('useNavigateToUserDetails', () => {
-  describe('when newExpandableFlyoutNavigationDisabled is false', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
-      (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
-        openLeftPanel: mockOpenLeftPanel,
-        openFlyout: mockOpenFlyout,
-      });
-    });
-
-    it('returns callback that opens details panel when not in preview mode', () => {
-      const { result } = renderHook(() => useNavigateToUserDetails(mockProps));
-
-      expect(result.current.isLinkEnabled).toBe(true);
-      result.current.openDetailsPanel({ tab, subTab });
-
-      expect(result.current.isLinkEnabled).toBe(true);
-      result.current.openDetailsPanel({ tab, subTab });
-
-      expect(mockOpenLeftPanel).toHaveBeenCalledWith({
-        id: UserDetailsPanelKey,
-        params: {
-          user: {
-            name: mockProps.userName,
-            email: mockProps.email,
-          },
-          scopeId: mockProps.scopeId,
-          isRiskScoreExist: mockProps.isRiskScoreExist,
-          path: { tab, subTab },
-          hasMisconfigurationFindings: mockProps.hasMisconfigurationFindings,
-          hasNonClosedAlerts: mockProps.hasNonClosedAlerts,
-        },
-      });
-    });
-
-    it('returns callback that opens flyout when in preview mode', () => {
-      const { result } = renderHook(() =>
-        useNavigateToUserDetails({ ...mockProps, isPreviewMode: true })
-      );
-
-      expect(result.current.isLinkEnabled).toBe(true);
-      result.current.openDetailsPanel({ tab, subTab });
-
-      expect(mockOpenFlyout).toHaveBeenCalledWith({
-        right: {
-          id: UserPanelKey,
-          params: {
-            contextID: mockProps.contextID,
-            scopeId: mockProps.scopeId,
-            userName: mockProps.userName,
-          },
-        },
-        left: {
-          id: UserDetailsPanelKey,
-          params: {
-            user: {
-              name: mockProps.userName,
-              email: mockProps.email,
-            },
-            scopeId: mockProps.scopeId,
-            isRiskScoreExist: mockProps.isRiskScoreExist,
-            path: { tab, subTab },
-            hasMisconfigurationFindings: mockProps.hasMisconfigurationFindings,
-            hasNonClosedAlerts: mockProps.hasNonClosedAlerts,
-          },
-        },
-      });
-      expect(mockOpenLeftPanel).not.toHaveBeenCalled();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
+      openLeftPanel: mockOpenLeftPanel,
+      openFlyout: mockOpenFlyout,
     });
   });
 
-  describe('when newExpandableFlyoutNavigationDisabled is true', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-      (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
-        openLeftPanel: mockOpenLeftPanel,
-        openFlyout: mockOpenFlyout,
-      });
+  it('returns callback that opens details panel when not in preview mode', () => {
+    const { result } = renderHook(() => useNavigateToUserDetails(mockProps));
+
+    expect(result.current.isLinkEnabled).toBe(true);
+    result.current.openDetailsPanel({ tab, subTab });
+
+    expect(result.current.isLinkEnabled).toBe(true);
+    result.current.openDetailsPanel({ tab, subTab });
+
+    expect(mockOpenLeftPanel).toHaveBeenCalledWith({
+      id: UserDetailsPanelKey,
+      params: {
+        user: {
+          name: mockProps.userName,
+          email: mockProps.email,
+        },
+        scopeId: mockProps.scopeId,
+        isRiskScoreExist: mockProps.isRiskScoreExist,
+        path: { tab, subTab },
+        hasMisconfigurationFindings: mockProps.hasMisconfigurationFindings,
+        hasNonClosedAlerts: mockProps.hasNonClosedAlerts,
+      },
     });
+  });
 
-    it('returns callback that opens details panel when not in preview mode', () => {
-      const { result } = renderHook(() => useNavigateToUserDetails(mockProps));
+  it('returns callback that opens flyout when in preview mode', () => {
+    const { result } = renderHook(() =>
+      useNavigateToUserDetails({ ...mockProps, isPreviewMode: true })
+    );
 
-      expect(result.current.isLinkEnabled).toBe(true);
-      result.current.openDetailsPanel({ tab, subTab });
+    expect(result.current.isLinkEnabled).toBe(true);
+    result.current.openDetailsPanel({ tab, subTab });
 
-      expect(mockOpenLeftPanel).toHaveBeenCalledWith({
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: UserPanelKey,
+        params: {
+          contextID: mockProps.contextID,
+          scopeId: mockProps.scopeId,
+          userName: mockProps.userName,
+        },
+      },
+      left: {
         id: UserDetailsPanelKey,
         params: {
           user: {
@@ -153,20 +114,8 @@ describe('useNavigateToUserDetails', () => {
           hasMisconfigurationFindings: mockProps.hasMisconfigurationFindings,
           hasNonClosedAlerts: mockProps.hasNonClosedAlerts,
         },
-      });
-      expect(mockOpenFlyout).not.toHaveBeenCalled();
+      },
     });
-
-    it('returns empty callback and isLinkEnabled is false when in preview mode', () => {
-      const { result } = renderHook(() =>
-        useNavigateToUserDetails({ ...mockProps, isPreviewMode: true })
-      );
-
-      expect(result.current.isLinkEnabled).toBe(false);
-      result.current.openDetailsPanel({ tab, subTab });
-
-      expect(mockOpenLeftPanel).not.toHaveBeenCalled();
-      expect(mockOpenFlyout).not.toHaveBeenCalled();
-    });
+    expect(mockOpenLeftPanel).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.ts
@@ -11,7 +11,6 @@ import type { EntityDetailsPath } from '../../shared/components/left_panel/left_
 import { useKibana } from '../../../../common/lib/kibana';
 import { EntityEventTypes } from '../../../../common/lib/telemetry';
 import { UserDetailsPanelKey } from '../../user_details_left';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { UserPanelKey } from '../../shared/constants';
 
 interface UseNavigateToUserDetailsParams {
@@ -48,11 +47,6 @@ export const useNavigateToUserDetails = ({
 }: UseNavigateToUserDetailsParams): UseNavigateToUserDetailsResult => {
   const { telemetry } = useKibana().services;
   const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
-  const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-    'newExpandableFlyoutNavigationDisabled'
-  );
-
-  const isLinkEnabled = !isPreviewMode || (isNewNavigationEnabled && isPreviewMode);
 
   const openDetailsPanel = useCallback(
     (path: EntityDetailsPath) => {
@@ -85,11 +79,11 @@ export const useNavigateToUserDetails = ({
       };
 
       // When new navigation is enabled, nevigation in preview is enabled and open a new flyout
-      if (isNewNavigationEnabled && isPreviewMode) {
+      if (isPreviewMode) {
         openFlyout({ right, left });
       }
       // When not in preview mode, open left panel as usual
-      else if (!isPreviewMode) {
+      else {
         openLeftPanel(left);
       }
     },
@@ -102,12 +96,11 @@ export const useNavigateToUserDetails = ({
       email,
       hasMisconfigurationFindings,
       hasNonClosedAlerts,
-      isNewNavigationEnabled,
       isPreviewMode,
       openFlyout,
       contextID,
     ]
   );
 
-  return { openDetailsPanel, isLinkEnabled };
+  return { openDetailsPanel, isLinkEnabled: true };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useCallback } from 'react';
 import { EntityType } from '../../../../../common/search_strategy';
@@ -21,18 +22,7 @@ interface UseNavigateToUserDetailsParams {
   isRiskScoreExist: boolean;
   hasMisconfigurationFindings: boolean;
   hasNonClosedAlerts: boolean;
-  isPreviewMode?: boolean;
-}
-
-interface UseNavigateToUserDetailsResult {
-  /**
-   * Opens the user details panel
-   */
-  openDetailsPanel: (path: EntityDetailsPath) => void;
-  /**
-   * Whether the link is enabled
-   */
-  isLinkEnabled: boolean;
+  isPreviewMode: boolean;
 }
 
 export const useNavigateToUserDetails = ({
@@ -44,11 +34,11 @@ export const useNavigateToUserDetails = ({
   hasMisconfigurationFindings,
   hasNonClosedAlerts,
   isPreviewMode,
-}: UseNavigateToUserDetailsParams): UseNavigateToUserDetailsResult => {
+}: UseNavigateToUserDetailsParams): ((path: EntityDetailsPath) => void) => {
   const { telemetry } = useKibana().services;
   const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
 
-  const openDetailsPanel = useCallback(
+  return useCallback(
     (path: EntityDetailsPath) => {
       telemetry.reportEvent(EntityEventTypes.RiskInputsExpandedFlyoutOpened, {
         entity: EntityType.user,
@@ -78,12 +68,9 @@ export const useNavigateToUserDetails = ({
         },
       };
 
-      // When new navigation is enabled, nevigation in preview is enabled and open a new flyout
       if (isPreviewMode) {
         openFlyout({ right, left });
-      }
-      // When not in preview mode, open left panel as usual
-      else {
+      } else {
         openLeftPanel(left);
       }
     },
@@ -101,6 +88,4 @@ export const useNavigateToUserDetails = ({
       contextID,
     ]
   );
-
-  return { openDetailsPanel, isLinkEnabled: true };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.test.tsx
@@ -27,6 +27,7 @@ const mockProps: UserPanelProps = {
   userName: 'test',
   contextID: 'test-user-panel',
   scopeId: 'test-scope-id',
+  isPreviewMode: false,
 };
 
 jest.mock('../../../common/components/visualization_actions/visualization_embeddable');

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -41,7 +41,7 @@ export interface UserPanelProps extends Record<string, unknown> {
   contextID: string;
   scopeId: string;
   userName: string;
-  isPreviewMode?: boolean;
+  isPreviewMode: boolean;
 }
 
 export interface UserPanelExpandableFlyoutProps extends FlyoutPanelProps {
@@ -56,7 +56,12 @@ const FIRST_RECORD_PAGINATION = {
   querySize: 1,
 };
 
-export const UserPanel = ({ contextID, scopeId, userName, isPreviewMode }: UserPanelProps) => {
+export const UserPanel = ({
+  contextID,
+  scopeId,
+  userName,
+  isPreviewMode = false,
+}: UserPanelProps) => {
   const { uiSettings } = useKibana().services;
   const assetInventoryEnabled = uiSettings.get(ENABLE_ASSET_INVENTORY_SETTING, true);
 
@@ -114,7 +119,7 @@ export const UserPanel = ({ contextID, scopeId, userName, isPreviewMode }: UserP
     setQuery,
   });
 
-  const { openDetailsPanel, isLinkEnabled } = useNavigateToUserDetails({
+  const openDetailsPanel = useNavigateToUserDetails({
     userName,
     email,
     scopeId,
@@ -185,7 +190,6 @@ export const UserPanel = ({ contextID, scopeId, userName, isPreviewMode }: UserP
               scopeId={scopeId}
               openDetailsPanel={openDetailsPanel}
               isPreviewMode={isPreviewMode}
-              isLinkEnabled={isLinkEnabled}
             />
             {!isPreviewMode && assetInventoryEnabled && <UserPanelFooter userName={userName} />}
             {isPreviewMode && (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_navigation.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_navigation.tsx
@@ -8,27 +8,26 @@
 import type { FC, SyntheticEvent } from 'react';
 import React, { memo, useCallback, useMemo } from 'react';
 import {
-  EuiFlyoutHeader,
+  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiFlyoutHeader,
   useEuiTheme,
-  EuiButtonEmpty,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import {
   useExpandableFlyoutApi,
-  useExpandableFlyoutState,
   useExpandableFlyoutHistory,
+  useExpandableFlyoutState,
 } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { FlyoutHistory } from './flyout_history';
 import { getProcessedHistory } from '../utils/history_utils';
-import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import {
-  HEADER_ACTIONS_TEST_ID,
   COLLAPSE_DETAILS_BUTTON_TEST_ID,
   EXPAND_DETAILS_BUTTON_TEST_ID,
+  HEADER_ACTIONS_TEST_ID,
 } from './test_ids';
 
 export interface FlyoutNavigationProps {
@@ -63,12 +62,7 @@ export const FlyoutNavigation: FC<FlyoutNavigationProps> = memo(
     const { euiTheme } = useEuiTheme();
 
     const history = useExpandableFlyoutHistory();
-    const isNewNavigationEnabled = !useIsExperimentalFeatureEnabled(
-      'newExpandableFlyoutNavigationDisabled'
-    );
     const historyArray = useMemo(() => getProcessedHistory({ history, maxCount: 10 }), [history]);
-    // Don't show history in rule preview
-    const hasHistory = !isRulePreview && isNewNavigationEnabled;
 
     const panels = useExpandableFlyoutState();
     const isExpanded: boolean = !!panels.left;
@@ -129,7 +123,7 @@ export const FlyoutNavigation: FC<FlyoutNavigationProps> = memo(
       return null;
     }
 
-    return flyoutIsExpandable || actions || hasHistory ? (
+    return flyoutIsExpandable || actions || !isRulePreview ? (
       <EuiFlyoutHeader hasBorder>
         <EuiFlexGroup
           direction="row"
@@ -162,7 +156,7 @@ export const FlyoutNavigation: FC<FlyoutNavigationProps> = memo(
                   {isExpanded ? collapseButton : expandButton}
                 </EuiFlexItem>
               )}
-              {hasHistory && (
+              {!isRulePreview && (
                 <EuiFlexItem>
                   <FlyoutHistory history={historyArray} />
                 </EuiFlexItem>


### PR DESCRIPTION
## Summary

This PR removes the `newExpandableFlyoutNavigationDisabled` feature flag that has been set to `false` for a few months now.

> [!IMPORTANT]
> While no UI or behavior changes should be introduced by this PR, make sure that you test the area impacting your team!

https://github.com/user-attachments/assets/52e9ce58-8068-4696-b08a-30872cbf26a2

https://github.com/user-attachments/assets/af60b8c1-30d3-4580-b759-8a882feaaa0c

### Edit/Update: 

_After the first round of review, @christineweng found a couple of more things to clean up. The `isLinkEnabled` boolean is now unnecessary. I decided to remove it from all the components where it was used, which triggered a few more changes than expected (see the [second commit](https://github.com/elastic/kibana/pull/239060/commits/e6583de5762f06862ad0456d373576e54e0ed916)). While lots of files are impacted, a lot of the changes are in the unit tests and Storybook story files._

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
