### PR TITLE
[Streams] Generate significant events from Advanced tab and UI improvements

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_feature_configuration.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_feature_configuration.tsx
@@ -20,7 +20,7 @@ interface StreamConfigurationProps {
 
 export function StreamFeatureConfiguration({ definition }: StreamConfigurationProps) {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
-  const { identifyFeatures } = useStreamFeaturesApi(definition);
+  const { identifyFeatures, abort } = useStreamFeaturesApi(definition);
   const aiFeatures = useAIFeatures();
   const [features, setFeatures] = useState<Feature[]>([]);
   const {
@@ -74,19 +74,24 @@ export function StreamFeatureConfiguration({ definition }: StreamConfigurationPr
             </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
-        <EuiSpacer size="m" />
-        <StreamFeaturesAccordion
-          definition={definition}
-          features={existingFeatures}
-          loading={featuresLoading}
-          refresh={refreshFeatures}
-        />
+        {existingFeatures.length > 0 && (
+          <>
+            <EuiSpacer size="m" />
+            <StreamFeaturesAccordion
+              definition={definition}
+              features={existingFeatures}
+              loading={featuresLoading}
+              refresh={refreshFeatures}
+            />
+          </>
+        )}
         {isFlyoutVisible && (
           <StreamFeaturesFlyout
             definition={definition}
             features={features}
             isLoading={isLoading}
             closeFlyout={() => {
+              abort();
               refreshFeatures();
               setIsFlyoutVisible(false);
             }}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/hooks/use_stream_features_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/hooks/use_stream_features_table.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { type Feature } from '@kbn/streams-schema';
+import { EuiMarkdownFormat, type EuiBasicTableColumn } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+// TODO: check if all columns from the stream_existing_features_table and stream_features_table can be moved to this hook to be shared between them
+export const useStreamFeaturesTable = () => {
+  const descriptionColumn: EuiBasicTableColumn<Feature> = {
+    field: 'description',
+    name: DESCRIPTION_LABEL,
+    width: '30%',
+    truncateText: {
+      lines: 4,
+    },
+    render: (description: string) => (
+      <EuiMarkdownFormat textSize="xs">{description}</EuiMarkdownFormat>
+    ),
+  };
+  return {
+    descriptionColumn,
+  };
+};
+
+const DESCRIPTION_LABEL = i18n.translate('xpack.streams.streamFeaturesTable.columns.description', {
+  defaultMessage: 'Description',
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_existing_features_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_existing_features_table.tsx
@@ -19,12 +19,18 @@ import {
 import { EuiButtonIcon, EuiScreenReaderOnly } from '@elastic/eui';
 import { type Streams, type Feature } from '@kbn/streams-schema';
 import { i18n } from '@kbn/i18n';
+import {
+  OPEN_SIGNIFICANT_EVENTS_FLYOUT_URL_PARAM,
+  SELECTED_FEATURES_URL_PARAM,
+} from '../../../../constants';
 import { ConditionPanel } from '../../shared';
 import { useStreamsAppRouter } from '../../../../hooks/use_streams_app_router';
 import { useStreamFeaturesApi } from '../../../../hooks/use_stream_features_api';
 import { StreamFeatureDetailsFlyout } from './stream_feature_details_flyout';
 import { FeatureEventsSparkline } from './feature_events_sparkline';
 import { TableTitle } from './table_title';
+import { useAIFeatures } from '../../../stream_detail_significant_events_view/add_significant_event_flyout/generated_flow_form/use_ai_features';
+import { useStreamFeaturesTable } from './hooks/use_stream_features_table';
 
 export function StreamExistingFeaturesTable({
   isLoading,
@@ -45,6 +51,18 @@ export function StreamExistingFeaturesTable({
   const [isDeleting, setIsDeleting] = useState(false);
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(5);
+  const aiFeatures = useAIFeatures();
+  const { descriptionColumn } = useStreamFeaturesTable();
+
+  const goToGenerateSignificantEvents = (significantEventsFeatures: Feature[]) => {
+    router.push('/{key}/management/{tab}', {
+      path: { key: definition.name, tab: 'significantEvents' },
+      query: {
+        [OPEN_SIGNIFICANT_EVENTS_FLYOUT_URL_PARAM]: 'true',
+        [SELECTED_FEATURES_URL_PARAM]: significantEventsFeatures.map((f) => f.name).join(','),
+      },
+    });
+  };
 
   const columns: Array<EuiBasicTableColumn<Feature>> = [
     {
@@ -54,14 +72,7 @@ export function StreamExistingFeaturesTable({
       sortable: true,
       truncateText: true,
     },
-    {
-      field: 'description',
-      name: DESCRIPTION_LABEL,
-      width: '30%',
-      truncateText: {
-        lines: 4,
-      },
-    },
+    descriptionColumn,
     {
       field: 'filter',
       name: FILTER_LABEL,
@@ -86,7 +97,10 @@ export function StreamExistingFeaturesTable({
           description: GENERATE_SIGNIFICANT_EVENTS,
           type: 'icon',
           icon: 'crosshairs',
-          onClick: () => '',
+          enabled: () => (aiFeatures?.genAiConnectors.selectedConnector ? true : false),
+          onClick: (feature) => {
+            goToGenerateSignificantEvents([feature]);
+          },
         },
         {
           name: EDIT_ACTION_NAME_LABEL,
@@ -145,6 +159,9 @@ export function StreamExistingFeaturesTable({
     ...columns,
   ];
 
+  const isGenerateSignificantEventsButtonDisabled =
+    selectedFeatures.length === 0 || !aiFeatures?.genAiConnectors.selectedConnector;
+
   return (
     <div css={{ padding: '16px' }}>
       <EuiFlexGroup alignItems="center">
@@ -158,12 +175,12 @@ export function StreamExistingFeaturesTable({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiLink
-            href={router.link('/{key}/management/{tab}', {
-              path: { key: definition.name, tab: 'significantEvents' },
-            })}
+            onClick={() => {
+              goToGenerateSignificantEvents(selectedFeatures);
+            }}
           >
             <EuiButtonEmpty
-              disabled={features.length === 0}
+              disabled={isGenerateSignificantEventsButtonDisabled}
               iconType="crosshairs"
               size="xs"
               aria-label={GENERATE_SIGNIFICANT_EVENTS}
@@ -273,10 +290,6 @@ const GENERATE_SIGNIFICANT_EVENTS = i18n.translate(
 // i18n labels moved to end of file
 const TITLE_LABEL = i18n.translate('xpack.streams.streamFeaturesTable.columns.title', {
   defaultMessage: 'Title',
-});
-
-const DESCRIPTION_LABEL = i18n.translate('xpack.streams.streamFeaturesTable.columns.description', {
-  defaultMessage: 'Description',
 });
 
 const FILTER_LABEL = i18n.translate('xpack.streams.streamFeaturesTable.columns.filter', {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_features_accordion.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_features_accordion.tsx
@@ -9,7 +9,15 @@ import React from 'react';
 import { EuiAccordion, EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import type { Streams, Feature } from '@kbn/streams-schema';
 import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
 import { StreamExistingFeaturesTable } from './stream_existing_features_table';
+
+const getUnderlineOnHoverStyle = (textDecorationValue: 'underline' | 'none') => css`
+  &:hover,
+  &:focus {
+    text-decoration: ${textDecorationValue};
+  }
+`;
 
 export const StreamFeaturesAccordion = ({
   definition,
@@ -28,7 +36,7 @@ export const StreamFeaturesAccordion = ({
       id="stream-features-accordion"
       buttonContent={
         <EuiFlexGroup gutterSize="s" alignItems="center">
-          <EuiFlexItem grow={false}>
+          <EuiFlexItem grow={false} css={getUnderlineOnHoverStyle('underline')}>
             {i18n.translate('xpack.streams.streamFeaturesAccordion.buttonLabel', {
               defaultMessage: 'Features',
             })}
@@ -38,6 +46,7 @@ export const StreamFeaturesAccordion = ({
           </EuiFlexItem>
         </EuiFlexGroup>
       }
+      buttonProps={{ css: getUnderlineOnHoverStyle('none') }}
     >
       <EuiSpacer size="s" />
       <StreamExistingFeaturesTable

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_features_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_features_flyout.tsx
@@ -86,7 +86,7 @@ export const StreamFeaturesFlyout = ({
             setFeatures={setFeatures}
           />
         ) : (
-          <LoadingState />
+          <LoadingState stopGeneration={closeFlyout} />
         )}
       </EuiFlyoutBody>
       <EuiFlyoutFooter>
@@ -134,7 +134,7 @@ export const StreamFeaturesFlyout = ({
   );
 };
 
-function LoadingState() {
+function LoadingState({ stopGeneration }: { stopGeneration: () => void }) {
   const label = useWaitingForAiMessage();
 
   return (
@@ -143,11 +143,25 @@ function LoadingState() {
       alignItems="center"
       justifyContent="center"
       css={{ height: '100%' }}
+      gutterSize="m"
     >
       <EuiFlexItem grow={false} css={{ textAlign: 'center' }}>
         <EuiLoadingElastic size="xxl" />
         <EuiSpacer size="m" />
         <EuiText>{label}</EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          onClick={stopGeneration}
+          aria-label={i18n.translate('xpack.streams.streamFeaturesFlyout.stopButtonAriaLabel', {
+            defaultMessage: 'Stop feature identification',
+          })}
+        >
+          <FormattedMessage
+            id="xpack.streams.streamFeaturesFlyout.stopButton"
+            defaultMessage="Stop"
+          />
+        </EuiButtonEmpty>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_features_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_features_flyout.tsx
@@ -86,7 +86,7 @@ export const StreamFeaturesFlyout = ({
             setFeatures={setFeatures}
           />
         ) : (
-          <LoadingState stopGeneration={closeFlyout} />
+          <LoadingState closeFlyout={closeFlyout} />
         )}
       </EuiFlyoutBody>
       <EuiFlyoutFooter>
@@ -134,7 +134,7 @@ export const StreamFeaturesFlyout = ({
   );
 };
 
-function LoadingState({ stopGeneration }: { stopGeneration: () => void }) {
+function LoadingState({ closeFlyout }: { closeFlyout: () => void }) {
   const label = useWaitingForAiMessage();
 
   return (
@@ -152,7 +152,7 @@ function LoadingState({ stopGeneration }: { stopGeneration: () => void }) {
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiButtonEmpty
-          onClick={stopGeneration}
+          onClick={closeFlyout}
           aria-label={i18n.translate('xpack.streams.streamFeaturesFlyout.stopButtonAriaLabel', {
             defaultMessage: 'Stop feature identification',
           })}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_features_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/stream_features/stream_features_table.tsx
@@ -18,6 +18,7 @@ import { ConditionPanel } from '../../shared';
 import { FeatureEventsSparkline } from './feature_events_sparkline';
 import { FeatureDetailExpanded } from './feature_detail_expanded';
 import { TableTitle } from './table_title';
+import { useStreamFeaturesTable } from './hooks/use_stream_features_table';
 
 // Helper function to generate unique copy name
 const generateCopyName = (originalName: string, existingFeatures: Feature[]) => {
@@ -69,6 +70,8 @@ export function StreamFeaturesTable({
     [setSelectedFeatureNames]
   );
 
+  const { descriptionColumn } = useStreamFeaturesTable();
+
   const columns: Array<EuiBasicTableColumn<Feature>> = [
     {
       field: 'name',
@@ -79,16 +82,7 @@ export function StreamFeaturesTable({
       sortable: true,
       truncateText: true,
     },
-    {
-      field: 'description',
-      name: i18n.translate('xpack.streams.streamFeatureTable.columns.description', {
-        defaultMessage: 'Description',
-      }),
-      width: '30%',
-      truncateText: {
-        lines: 4,
-      },
-    },
+    descriptionColumn,
     {
       field: 'filter',
       name: i18n.translate('xpack.streams.streamFeatureTable.columns.filter', {

--- a/x-pack/platform/plugins/shared/streams_app/public/constants.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/constants.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const OPEN_SIGNIFICANT_EVENTS_FLYOUT_URL_PARAM = 'openFlyout';
+export const SELECTED_FEATURES_URL_PARAM = 'selectedFeatures';

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_stream_features_api.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_stream_features_api.ts
@@ -23,6 +23,7 @@ interface StreamFeaturesApi {
   ) => Promise<IdentifiedFeaturesEvent>;
   addFeaturesToStream: (features: Feature[]) => Promise<StorageClientBulkResponse>;
   removeFeaturesFromStream: (featureNames: string[]) => Promise<StorageClientBulkResponse>;
+  abort: () => void;
 }
 
 export function useStreamFeaturesApi(definition: Streams.all.Definition): StreamFeaturesApi {
@@ -34,7 +35,7 @@ export function useStreamFeaturesApi(definition: Streams.all.Definition): Stream
     },
   } = useKibana();
 
-  const { signal } = useAbortController();
+  const { signal, abort, refresh } = useAbortController();
 
   return {
     identifyFeatures: async (connectorId: string, to: string, from: string) => {
@@ -100,6 +101,10 @@ export function useStreamFeaturesApi(definition: Streams.all.Definition): Stream
           body: request,
         },
       });
+    },
+    abort: () => {
+      abort();
+      refresh();
     },
   };
 }


### PR DESCRIPTION
This PR enables the generation of significant events from the Advanced tab when clicking on a feature action or when selecting multiple features. This functionality is available only if an AI connector is detected.

It also adds some UI improvements.

In this video:

- The Features table is hidden if no features have been added
- Stop button when identifying features
- Generate significant events from Advanced tab (single and bulk)
- Rendered markdown in the description column. This is a temporary change, the final goal would be to have a short, meaningful description that the user can read without having to expand the feature.

https://github.com/user-attachments/assets/e74f62c9-a30b-4c8b-a0d5-28ea34f4c84f

Other UI improvements:
- Removed underline from the badge of the features table
<img width="144" height="62" alt="Screenshot 2025-10-15 at 09 27 41" src="https://github.com/user-attachments/assets/89a2e203-8729-4c58-92ed-a434e744e045" />




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->