### PR TITLE
Add docs for cloud vis settings

### DIFF
--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -47,7 +47,27 @@ If you want to allow anonymous authentication in Kibana, these settings are supp
 `xpack.security.authc.providers.anonymous.<provider-name>.credentials`
 :   Specifies which credentials Kibana should use for anonymous users.
 
+### Visualizations [ec_visualizations]
 
+
+
+#### Supported versions before 8.0.0 [ec_vis_supported_versions_before_8_0_0]
+
+`vis_type_table.legacyVisEnabled`
+:   Starting from version 7.11, a new datatable visualization is used. Set to `true` to enable the legacy version. In version 8.0 and later, the old implementation is removed and this setting is no longer supported.
+
+`vega.enableExternalUrls`
+:   Set to `true` to allow Vega vizualizations to use data from sources other than the linked Elasticsearch cluster. In version 8.0 and later, the `vega.enableExternalUrls` is not supported. Use `vis_type_vega.enableExternalUrls` instead.
+
+#### Version 7.7+ [ec_vis_supported_versions_7_7]
+
+`vis_type_vega.enable`
+:   For 7.7 version and later, set to `false` to disable Vega vizualizations. **Default: `true`**
+
+#### Version 7.8+ [ec_vis_supported_versions_7_8]
+
+`vis_type_vega.enableExternalUrls`
+:   Set this value to true to allow Vega to use any URL to access external data sources and images. When false, Vega can only get data from {{es}}. **Default: `false`**
 
 
 ## X-Pack configuration settings [ec-xpack-config]

--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -67,7 +67,7 @@ If you want to allow anonymous authentication in Kibana, these settings are supp
 #### Version 7.8+ [ec_vis_supported_versions_7_8]
 
 `vis_type_vega.enableExternalUrls`
-:   Set this value to true to allow Vega to use any URL to access external data sources and images. When false, Vega can only get data from {{es}}. **Default: `false`**
+:   Set this value to `true` to allow Vega to use any URL to access external data sources and images. When `false`, Vega can only get data from {{es}}. **Default: `false`**
 
 
 ## X-Pack configuration settings [ec-xpack-config]

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -523,11 +523,14 @@ $$$settings-telemetry-optIn$$$ `telemetry.optIn`
     To reload the logging settings, send a SIGHUP signal to {{kib}}. For more logging configuration options, see the [Configure Logging in {{kib}}](docs-content://deploy-manage/monitor/logging-configuration/kibana-logging.md) guide.
     ::::
 
+`vis_type_table.legacyVisEnabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
+:   Starting from version 7.11, a new datatable visualization is used. Set to `true` to enable the legacy version. In version 8.0 and later, the old implementation is removed and this setting is no longer supported.
+
+`vis_type_vega.enable` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
+:   For 7.7 version and later, set to `false` to disable Vega vizualizations. **Default: `true`**
+
 `vega.enableExternalUrls` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to `true` to allow Vega vizualizations to use data from sources other than the linked Elasticsearch cluster. In version 8.0 and later, the `vega.enableExternalUrls` is not supported. Use `vis_type_vega.enableExternalUrls` instead.
-
-`vis_type_table.legacyVisEnabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
-:   For 7.x versions version 7.11 and later, a new version of the datatable visualization is used. Set to `true` to enable the legacy version. In version 8.0 and later, the old implementation is removed and this setting is no longer supported.
 
 `vis_type_vega.enableExternalUrls` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set this value to true to allow Vega to use any URL to access external data sources and images. When false, Vega can only get data from {{es}}. **Default: `false`**


### PR DESCRIPTION
## Summary

Add documentation for the `vis_type_vega.enable` settings in cloud.
Cleaned up documentation for the other existing settings related to visualizations.
Added the the other Visualizations settings available in cloud


