### PR TITLE
[9.1] [EDR Workflows] TelemetryConfigWatcher auth fix (#237796)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/license_watch.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/license_watch.ts
@@ -45,9 +45,6 @@ export class PolicyWatcher {
       this.endpointServices.experimentalFeatures.endpointManagementSpaceAwarenessEnabled;
     const fleetServices = this.endpointServices.getInternalFleetServices();
     const esClient = this.endpointServices.getInternalEsClient();
-    const soClient = isSpacesEnabled
-      ? this.endpointServices.savedObjects.createInternalUnscopedSoClient(false)
-      : this.endpointServices.savedObjects.createInternalScopedSoClient({ readonly: false });
 
     this.logger.debug(
       `Checking endpoint policies for compliance with license level [${license.type}]`
@@ -65,6 +62,12 @@ export class PolicyWatcher {
       try {
         await pRetry(
           async () => {
+            const soClient = isSpacesEnabled
+              ? this.endpointServices.savedObjects.createInternalUnscopedSoClient(false)
+              : this.endpointServices.savedObjects.createInternalScopedSoClient({
+                  readonly: false,
+                });
+
             response = await fleetServices.packagePolicy.list(soClient, {
               page: page++,
               perPage: 100,
@@ -117,7 +120,9 @@ export class PolicyWatcher {
                   spaceId: policy.spaceIds?.at(0) ?? DEFAULT_SPACE_ID,
                   readonly: false,
                 })
-              : soClient;
+              : this.endpointServices.savedObjects.createInternalScopedSoClient({
+                  readonly: false,
+                });
 
             await pRetry(
               async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[EDR Workflows] TelemetryConfigWatcher auth fix (#237796)](https://github.com/elastic/kibana/pull/237796)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gergő Ábrahám","email":"gergo.abraham@elastic.co"},"sourceCommit":{"committedDate":"2025-10-14T09:24:26Z","message":"[EDR Workflows] TelemetryConfigWatcher auth fix (#237796)\n\n## Summary\n\nThe goal of this PR is to make the following warning produced by\n`TelemetryConfigWatcher` disappear, or, rather solve:\n```\n[WARN][plugins.securitySolution.TelemetryConfigWatcher] Unable to verify endpoint policies in line with telemetry change: failed to fetch package policies: {\n  name: 'ResponseError',\n  message: 'missing authentication credentials for REST request \n...\n```\n\nThis is mostly an annoyance towards devs as it happens most of the time\non local instances, but it can also happen sporadically on cloud and\nserverless deployments based on telemetry. That shouldn't be a serious\nproblem, as the next cloud deployment restart or serverless release\ntriggers it to run again, so eventually we can expect it to succeed, but\nanyway, the goal here is to fix the underlying issue.\n\n### The underlying issue\nThere are 2 different subscribers\n([`TelemetryConfigWatcher`](https://github.com/gergoabraham/kibana/blob/fix-telemetry-config-watcher-not-authorized/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/telemetry_watch.ts#L28)\nand\n[`PolicyWatcher`](https://github.com/gergoabraham/kibana/blob/fix-telemetry-config-watcher-not-authorized/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/license_watch.ts#L24))\nsubscribed to two different observables (telemetry plugin and license\npackage), subscribing in the same plugin start phase\n([here](https://github.com/gergoabraham/kibana/blob/fix-telemetry-config-watcher-not-authorized/x-pack/solutions/security/plugins/security_solution/server/plugin.ts#L745-L753))\nand therefore receiving the initial values at start phase. They have the\nsame issue, although with a different frequency compared to each other,\nand also compared between cloud and serverless envs based on telemetry\ndata.\n\nThis is related to a similar issue earlier, caused by the saved object\nclient (soClient) not being green on cloud and serverless instances\nduring plugin start phase:\n- #210406\n\nIn the meantime, seems like the issue appeared again, as the creation of\nthe soClient was moved outside of the retry block - this is what this PR\nsolves, **it recreates the saved object client on every retry** to fix\nthis issue.\n\nSo this PR contains the following changes:\n- recreates the saved object client *inside the retry logic* both in\n`TelemetryConfigWatcher` and `PolicyWatcher`\n- decreases the log level of update conflicts from `warn` to `debug`, as\nit is most probably not a real issue, just multiple Kibana instances\nstarting up and competing.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n## Release note\nFixes the 'missing authentication credentials' issue in\n`TelemetryConfigWatcher` and `PolicyWatcher`, which should result in\nless warning log entries in the Security Solution plugin.","sha":"47a637daea707d887c760d755ce188bbe75f414e","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Defend Workflows","backport:version","v9.2.0","v9.3.0","v9.1.6"],"title":"[EDR Workflows] TelemetryConfigWatcher auth fix","number":237796,"url":"https://github.com/elastic/kibana/pull/237796","mergeCommit":{"message":"[EDR Workflows] TelemetryConfigWatcher auth fix (#237796)\n\n## Summary\n\nThe goal of this PR is to make the following warning produced by\n`TelemetryConfigWatcher` disappear, or, rather solve:\n```\n[WARN][plugins.securitySolution.TelemetryConfigWatcher] Unable to verify endpoint policies in line with telemetry change: failed to fetch package policies: {\n  name: 'ResponseError',\n  message: 'missing authentication credentials for REST request \n...\n```\n\nThis is mostly an annoyance towards devs as it happens most of the time\non local instances, but it can also happen sporadically on cloud and\nserverless deployments based on telemetry. That shouldn't be a serious\nproblem, as the next cloud deployment restart or serverless release\ntriggers it to run again, so eventually we can expect it to succeed, but\nanyway, the goal here is to fix the underlying issue.\n\n### The underlying issue\nThere are 2 different subscribers\n([`TelemetryConfigWatcher`](https://github.com/gergoabraham/kibana/blob/fix-telemetry-config-watcher-not-authorized/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/telemetry_watch.ts#L28)\nand\n[`PolicyWatcher`](https://github.com/gergoabraham/kibana/blob/fix-telemetry-config-watcher-not-authorized/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/license_watch.ts#L24))\nsubscribed to two different observables (telemetry plugin and license\npackage), subscribing in the same plugin start phase\n([here](https://github.com/gergoabraham/kibana/blob/fix-telemetry-config-watcher-not-authorized/x-pack/solutions/security/plugins/security_solution/server/plugin.ts#L745-L753))\nand therefore receiving the initial values at start phase. They have the\nsame issue, although with a different frequency compared to each other,\nand also compared between cloud and serverless envs based on telemetry\ndata.\n\nThis is related to a similar issue earlier, caused by the saved object\nclient (soClient) not being green on cloud and serverless instances\nduring plugin start phase:\n- #210406\n\nIn the meantime, seems like the issue appeared again, as the creation of\nthe soClient was moved outside of the retry block - this is what this PR\nsolves, **it recreates the saved object client on every retry** to fix\nthis issue.\n\nSo this PR contains the following changes:\n- recreates the saved object client *inside the retry logic* both in\n`TelemetryConfigWatcher` and `PolicyWatcher`\n- decreases the log level of update conflicts from `warn` to `debug`, as\nit is most probably not a real issue, just multiple Kibana instances\nstarting up and competing.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n## Release note\nFixes the 'missing authentication credentials' issue in\n`TelemetryConfigWatcher` and `PolicyWatcher`, which should result in\nless warning log entries in the Security Solution plugin.","sha":"47a637daea707d887c760d755ce188bbe75f414e"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238807","number":238807,"state":"MERGED","mergeCommit":{"sha":"ad944caf21e27fe2e7e8673614d0b886ed7ac998","message":"[9.2] [EDR Workflows] TelemetryConfigWatcher auth fix (#237796) (#238807)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[EDR Workflows] TelemetryConfigWatcher auth fix\n(#237796)](https://github.com/elastic/kibana/pull/237796)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Gergő Ábrahám <gergo.abraham@elastic.co>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237796","number":237796,"mergeCommit":{"message":"[EDR Workflows] TelemetryConfigWatcher auth fix (#237796)\n\n## Summary\n\nThe goal of this PR is to make the following warning produced by\n`TelemetryConfigWatcher` disappear, or, rather solve:\n```\n[WARN][plugins.securitySolution.TelemetryConfigWatcher] Unable to verify endpoint policies in line with telemetry change: failed to fetch package policies: {\n  name: 'ResponseError',\n  message: 'missing authentication credentials for REST request \n...\n```\n\nThis is mostly an annoyance towards devs as it happens most of the time\non local instances, but it can also happen sporadically on cloud and\nserverless deployments based on telemetry. That shouldn't be a serious\nproblem, as the next cloud deployment restart or serverless release\ntriggers it to run again, so eventually we can expect it to succeed, but\nanyway, the goal here is to fix the underlying issue.\n\n### The underlying issue\nThere are 2 different subscribers\n([`TelemetryConfigWatcher`](https://github.com/gergoabraham/kibana/blob/fix-telemetry-config-watcher-not-authorized/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/telemetry_watch.ts#L28)\nand\n[`PolicyWatcher`](https://github.com/gergoabraham/kibana/blob/fix-telemetry-config-watcher-not-authorized/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/license_watch.ts#L24))\nsubscribed to two different observables (telemetry plugin and license\npackage), subscribing in the same plugin start phase\n([here](https://github.com/gergoabraham/kibana/blob/fix-telemetry-config-watcher-not-authorized/x-pack/solutions/security/plugins/security_solution/server/plugin.ts#L745-L753))\nand therefore receiving the initial values at start phase. They have the\nsame issue, although with a different frequency compared to each other,\nand also compared between cloud and serverless envs based on telemetry\ndata.\n\nThis is related to a similar issue earlier, caused by the saved object\nclient (soClient) not being green on cloud and serverless instances\nduring plugin start phase:\n- #210406\n\nIn the meantime, seems like the issue appeared again, as the creation of\nthe soClient was moved outside of the retry block - this is what this PR\nsolves, **it recreates the saved object client on every retry** to fix\nthis issue.\n\nSo this PR contains the following changes:\n- recreates the saved object client *inside the retry logic* both in\n`TelemetryConfigWatcher` and `PolicyWatcher`\n- decreases the log level of update conflicts from `warn` to `debug`, as\nit is most probably not a real issue, just multiple Kibana instances\nstarting up and competing.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n## Release note\nFixes the 'missing authentication credentials' issue in\n`TelemetryConfigWatcher` and `PolicyWatcher`, which should result in\nless warning log entries in the Security Solution plugin.","sha":"47a637daea707d887c760d755ce188bbe75f414e"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->