### PR TITLE
[SharedUX][A11y] Fix missing Visualizations legacy iconTip announcement

### DIFF
--- a/src/platform/plugins/shared/visualizations/public/wizard/group_selection/group_selection.tsx
+++ b/src/platform/plugins/shared/visualizations/public/wizard/group_selection/group_selection.tsx
@@ -88,6 +88,10 @@ interface VisCardProps {
   shouldStretch?: boolean;
 }
 
+const legacyTabTitle = i18n.translate('visualizations.newVisWizard.legacyTab', {
+  defaultMessage: 'Legacy',
+});
+
 const tabs: Array<{ id: 'recommended' | 'legacy'; label: ReactNode; dataTestSubj: string }> = [
   {
     id: 'recommended',
@@ -100,12 +104,13 @@ const tabs: Array<{ id: 'recommended' | 'legacy'; label: ReactNode; dataTestSubj
     id: 'legacy',
     dataTestSubj: 'groupModalLegacyTab',
     label: (
-      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-        <EuiFlexItem grow={false}>
-          {i18n.translate('visualizations.newVisWizard.legacyTab', {
-            defaultMessage: 'Legacy',
-          })}
-        </EuiFlexItem>
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="s"
+        responsive={false}
+        aria-label={legacyTabTitle}
+      >
+        <EuiFlexItem grow={false}>{legacyTabTitle}</EuiFlexItem>
 
         <EuiFlexItem grow={false}>
           <EuiIconTip


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/215115

## Summary

Fixed missing Visualizations legacy iconTip announcement. By adding the aria label to the FlexGroup, children's a11y properties are correctly wired. 

## Testing

Tab title announcement:

<img width="1603" height="1012" alt="Screenshot 2025-10-15 at 10 21 12" src="https://github.com/user-attachments/assets/68b898ce-a3b4-4ab9-af58-da5ad2a2c4f5" />

IconTip content announcement:

<img width="1521" height="981" alt="Screenshot 2025-10-15 at 10 22 14" src="https://github.com/user-attachments/assets/45ac08d6-e9a8-43c3-83c0-ac9c31c99fa7" />







<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->