### PR TITLE
[APM] Make `captureHeaders: false` default config

### DIFF
--- a/src/platform/packages/private/kbn-apm-config-loader/src/config.test.ts
+++ b/src/platform/packages/private/kbn-apm-config-loader/src/config.test.ts
@@ -88,6 +88,7 @@ describe('ApmConfiguration', () => {
       Object {
         "active": true,
         "breakdownMetrics": true,
+        "captureHeaders": false,
         "captureSpanStackTraces": false,
         "centralConfig": false,
         "contextPropagationOnly": true,

--- a/src/platform/packages/private/kbn-apm-config-loader/src/config.ts
+++ b/src/platform/packages/private/kbn-apm-config-loader/src/config.ts
@@ -22,6 +22,7 @@ import type { ApmConfigSchema } from './apm_config';
 // https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html
 const DEFAULT_CONFIG: AgentConfigOptions = {
   active: true,
+  captureHeaders: false,
   contextPropagationOnly: true,
   environment: 'development',
   globalLabels: {},
@@ -48,7 +49,6 @@ export const CENTRALIZED_SERVICE_BASE_CONFIG: AgentConfigOptions | RUMAgentConfi
 const CENTRALIZED_SERVICE_DIST_CONFIG: AgentConfigOptions = {
   breakdownMetrics: false,
   captureBody: 'off',
-  captureHeaders: false,
   metricsInterval: '120s',
   transactionSampleRate: 0.1,
 };


### PR DESCRIPTION
## Summary

Updates our APM configuration to default to not capturing headers. Can be overridden by setting `elastic.apm.captureHeaders: true` ([see docs](https://www.elastic.co/guide/en/apm/agent/dotnet/current/config-http.html#config-capture-headers) on `captureHeaders` setting)

Tested by running Kibana locally and verifying that headers are not present in payloads sent to APM server.

<details>

<summary>Sample before</summary>


```jsonc
{
  "transaction": {
    "name": "GET /api/spaces/space",
    "type": "request",
    "result": "HTTP 2xx",
    "id": "6017a0f6357055f5",
    "trace_id": "86dfd7e5bf54968de5df8faed9748ead",
    "parent_id": "049a6120ea2cdd3b",
    "duration": 23.346,
    "timestamp": 1760518906374005,
    "sampled": true,
    "context": {
      "tags": {
        "name": "management",
        "event_loop_utilization": 0.6425041822655005,
        "event_loop_active": 14.610999993506994
      },
      "custom": {},
      "service": {},
      "cloud": {},
      "message": {},
      "request": {
        "http_version": "1.1",
        "method": "GET",
        "url": {
          "raw": "/api/spaces/space",
          "protocol": "http:",
          "hostname": "localhost",
          "port": "5601",
          "pathname": "/api/spaces/space",
          "full": "http://localhost:5601/api/spaces/space"
        },
        "headers": {
          "host": "localhost:5601",
          "connection": "keep-alive"
          // …
        },
        "socket": {
          "remote_address": "127.0.0.1"
        }
      },
      "response": {
        "status_code": 200,
        "headers": {
          "content-type": "application/json; charset=utf-8"
          // …
        }
      }
    },
    "span_count": {
      "started": 6
    },
    "outcome": "success"
  }
}
```

</details>


<details>

<summary>Sample after</summary>


```jsonc
{
  "transaction": {
    "name": "GET /api/spaces/space",
    "type": "request",
    "result": "HTTP 2xx",
    "id": "0933083e58eeccd3",
    "trace_id": "745a11a9b14228e6240278edffce0777",
    "parent_id": "2f6d206c0aedaa0c",
    "duration": 44.466,
    "timestamp": 1760519365964000,
    "sampled": true,
    "context": {
      "tags": {
        "name": "management",
        "event_loop_utilization": 1,
        "event_loop_active": 44.18816697597504
      },
      "custom": {},
      "service": {},
      "cloud": {},
      "message": {},
      "request": {
        "http_version": "1.1",
        "method": "GET",
        "url": {
          "raw": "/api/spaces/space",
          "protocol": "http:",
          "hostname": "localhost",
          "port": "5601",
          "pathname": "/api/spaces/space",
          "full": "http://localhost:5601/api/spaces/space"
        },
        "socket": {
          "remote_address": "127.0.0.1"
        }
      },
      "response": {
        "status_code": 200
      }
    },
    "span_count": {
      "started": 6
    },
    "outcome": "success"
  }
}
```


</details>

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->