### PR TITLE
[Streams] Remove enqueueActions where not necessary from state machines

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/state_management/stream_routing_state_machine/stream_routing_state_machine.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/state_management/stream_routing_state_machine/stream_routing_state_machine.ts
@@ -145,31 +145,29 @@ export const streamRoutingMachine = setup({
           reenter: true,
         },
         'routingSamples.setDocumentMatchFilter': {
-          actions: enqueueActions(({ enqueue, event }) => {
-            enqueue.sendTo('routingSamplesMachine', {
-              type: 'routingSamples.setDocumentMatchFilter',
-              filter: event.filter,
-            });
-          }),
+          actions: sendTo('routingSamplesMachine', ({ event }) => ({
+            type: 'routingSamples.setDocumentMatchFilter',
+            filter: event.filter,
+          })),
         },
         'suggestion.preview': {
           target: '#idle',
-          actions: enqueueActions(({ enqueue, event }) => {
-            enqueue.sendTo('routingSamplesMachine', {
+          actions: [
+            sendTo('routingSamplesMachine', ({ event }) => ({
               type: 'routingSamples.setSelectedPreview',
               preview: event.toggle
                 ? { type: 'suggestion', name: event.name, index: event.index }
                 : undefined,
-            });
-            enqueue.sendTo('routingSamplesMachine', {
+            })),
+            sendTo('routingSamplesMachine', ({ event }) => ({
               type: 'routingSamples.updateCondition',
               condition: event.toggle ? event.condition : undefined,
-            });
-            enqueue.sendTo('routingSamplesMachine', {
+            })),
+            sendTo('routingSamplesMachine', {
               type: 'routingSamples.setDocumentMatchFilter',
               filter: 'matched',
-            });
-          }),
+            }),
+          ],
         },
         'routingRule.reviewSuggested': {
           target: '#ready.reviewSuggestedRule',


### PR DESCRIPTION
## 📓 Summary

Remove the usage of `enqueueActions` when not required for machines where actions are not conditionally executed.