### PR TITLE
[Streams] Drop unmapped fields for feature identification

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/identify_features.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/identify_features.ts
@@ -103,6 +103,7 @@ export async function identifyFeatures({
               condition: system.filter as Condition,
             };
           }),
+          dropUnmapped,
         });
 
         return {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/feature/run_feature_identification.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/feature/run_feature_identification.ts
@@ -35,5 +35,6 @@ export function runFeatureIdentification({
     logger,
     stream,
     features,
+    dropUnmapped: true,
   });
 }


### PR DESCRIPTION
Drops unmapped fields for feature identification. Split out from https://github.com/elastic/kibana/pull/238932 to derisk missing the final BC:

> dropUnmapped is now true - this means the LLM will no longer consider unmapped fields for the conditions that it generates

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->