### PR TITLE
[Cases] Fix case events fullscreen view

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_events.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_events.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { EuiFlexItem } from '@elastic/eui';
 import React, { useMemo } from 'react';
+import { EuiFlexItem } from '@elastic/eui';
+import { css } from '@emotion/react';
+
 import { type CaseUI } from '../../../../common';
 import { CASE_VIEW_PAGE_TABS } from '../../../../common/types';
 import { CaseViewTabs } from '../case_view_tabs';
@@ -43,7 +45,12 @@ export const CaseViewEvents = ({
   }
 
   return (
-    <EuiFlexItem data-test-subj="case-view-events">
+    <EuiFlexItem
+      css={css`
+        width: 100%;
+      `}
+      data-test-subj="case-view-events"
+    >
       <CaseViewTabs caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.EVENTS} />
       <EventsTable events={events} />
     </EuiFlexItem>


### PR DESCRIPTION
## Summary

This fixes https://github.com/elastic/kibana/issues/236885

## Testing

Going between fullscreen and nested grid view should not break now while in case events table:)



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->