### PR TITLE
[cypress] Fix APM Cypress report paths

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/reporter_config.json
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/reporter_config.json
@@ -3,8 +3,8 @@
   "reporterOptions": {
     "html": false,
     "json": true,
-    "mochaFile": "../../../../../target/kibana-apm/cypress/results/TEST-apm-cypress-[hash].xml",
+    "mochaFile": "../../../../../../target/kibana-apm/cypress/results/TEST-apm-cypress-[hash].xml",
     "overwrite": false,
-    "reportDir": "../../../../../target/kibana-apm/cypress/results"
+    "reportDir": "../../../../../../target/kibana-apm/cypress/results"
   }
 }


### PR DESCRIPTION
## Summary
I probably broke this in https://github.com/elastic/kibana/pull/236614 when I adjusted multiple paths, and I thought this also needed adjustment. Reverting to what it was before.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->