### PR TITLE
[Security Solution] [Bug] The schedule can not be created if any LLM model is selected as the default (#239049)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
@@ -42,6 +42,12 @@ interface Props {
   displayFancy?: (label: string, aIConnector?: AIConnector) => React.ReactNode;
   setIsOpen?: (isOpen: boolean) => void;
   stats?: AttackDiscoveryStats | null;
+
+  /**
+   * Allows parent components to control whether the default connector should be
+   * automatically selected or the explicit user selection action required.
+   */
+  explicitConnectorSelection?: boolean;
 }
 
 export type AIConnector = ActionConnector & {
@@ -59,6 +65,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
     onConnectorSelectionChange,
     setIsOpen,
     stats = null,
+    explicitConnectorSelection,
   }) => {
     const {
       actionTypeRegistry,
@@ -129,7 +136,9 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
     );
 
     // Use effective value (optimistic or actual) or fall back to default
-    const selectedOrDefaultConnectorId = effectiveSelectedConnectorId ?? defaultAIConnectorId;
+    const selectedOrDefaultConnectorId =
+      effectiveSelectedConnectorId ??
+      (explicitConnectorSelection ? undefined : defaultAIConnectorId);
     const selectedOrDefaultConnector = aiConnectors?.find(
       (connector) => connector.id === selectedOrDefaultConnectorId
     );

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/connector_selector_inline.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/connector_selector_inline.tsx
@@ -27,6 +27,12 @@ interface Props {
   onConnectorIdSelected?: (connectorId: string) => void;
   onConnectorSelected?: (conversation: Conversation, apiConfig?: ApiConfig) => void;
   stats?: AttackDiscoveryStats | null;
+
+  /**
+   * Allows parent components to control whether the default connector should be
+   * automatically selected or the explicit user selection action required.
+   */
+  explicitConnectorSelection?: boolean;
 }
 
 const inputContainerClassName = css`
@@ -77,6 +83,7 @@ export const ConnectorSelectorInline: React.FC<Props> = React.memo(
     onConnectorIdSelected,
     onConnectorSelected,
     stats = null,
+    explicitConnectorSelection,
   }) => {
     const { euiTheme } = useEuiTheme();
     const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -159,6 +166,7 @@ export const ConnectorSelectorInline: React.FC<Props> = React.memo(
             setIsOpen={setIsOpen}
             onConnectorSelectionChange={onChange}
             stats={stats}
+            explicitConnectorSelection={explicitConnectorSelection}
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/form_fields/connector_selector_field/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/form_fields/connector_selector_field/index.tsx
@@ -37,6 +37,7 @@ export const ConnectorSelectorField: React.FC<Props> = React.memo(
           onConnectorSelected={noop}
           onConnectorIdSelected={onConnectorIdSelected}
           selectedConnectorId={connectorId}
+          explicitConnectorSelection={true}
         />
       </EuiFormRow>
     );


### PR DESCRIPTION
## Summary

BUG: https://github.com/elastic/kibana/issues/239049

These changes fix the issue where user cannot create a new attack discovery schedule when the default LLM has been selected.

The issue happens because internally the connector selector implicitly sets the default connector without notifying parent controls. Also, the nature of the form that we use for the create and edit schedules flows is that we need to initialize it with the correct value or update it once the form ha been mounted and rendered.

As a fix for the upcoming release, we would allow parent components to enforce user to select connector while creating the attack discovery schedule - even when the default LLM exists.

### Recording of the fix

https://github.com/user-attachments/assets/f05d4959-e218-4c99-81a6-02b657bcb39d


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->