### PR TITLE
[9.2] [Metrics]Discover] The search bar stays open in case there is a value (#238958)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/right_side_actions/right_side_actions.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/right_side_actions/right_side_actions.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   EuiFieldSearch,
   EuiFlexGroup,
@@ -53,6 +53,12 @@ export const RightSideActions = ({
     renderToggleActions,
     requestParams,
   });
+
+  useEffect(() => {
+    if (searchTerm) {
+      onShowSearch();
+    }
+  }, [onShowSearch, searchTerm]);
 
   const onSearchChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Metrics]Discover] The search bar stays open in case there is a value (#238958)](https://github.com/elastic/kibana/pull/238958)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-10-14T19:42:31Z","message":"[Metrics]Discover] The search bar stays open in case there is a value (#238958)\n\nCloses #238938 \n## Summary\n\nThis PR fixes the search input visibility issue: \n- If there is a value in the search input, it should stay visible\n- If the value is cleared, the search input should be hidden\n\nBefore: \n\n\n\nhttps://github.com/user-attachments/assets/cc417519-e9cd-4a03-9b89-4c0a2f382afb\n\n\n\nAfter: \n\n\nhttps://github.com/user-attachments/assets/6fa84f33-6e5e-4236-8cc5-d78383d15a34","sha":"ffe13900917270dfb7b1b787ae6e9c554f3ea5ff","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.2.0","v9.3.0"],"title":"[Metrics]Discover] The search bar stays open in case there is a value","number":238958,"url":"https://github.com/elastic/kibana/pull/238958","mergeCommit":{"message":"[Metrics]Discover] The search bar stays open in case there is a value (#238958)\n\nCloses #238938 \n## Summary\n\nThis PR fixes the search input visibility issue: \n- If there is a value in the search input, it should stay visible\n- If the value is cleared, the search input should be hidden\n\nBefore: \n\n\n\nhttps://github.com/user-attachments/assets/cc417519-e9cd-4a03-9b89-4c0a2f382afb\n\n\n\nAfter: \n\n\nhttps://github.com/user-attachments/assets/6fa84f33-6e5e-4236-8cc5-d78383d15a34","sha":"ffe13900917270dfb7b1b787ae6e9c554f3ea5ff"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238958","number":238958,"mergeCommit":{"message":"[Metrics]Discover] The search bar stays open in case there is a value (#238958)\n\nCloses #238938 \n## Summary\n\nThis PR fixes the search input visibility issue: \n- If there is a value in the search input, it should stay visible\n- If the value is cleared, the search input should be hidden\n\nBefore: \n\n\n\nhttps://github.com/user-attachments/assets/cc417519-e9cd-4a03-9b89-4c0a2f382afb\n\n\n\nAfter: \n\n\nhttps://github.com/user-attachments/assets/6fa84f33-6e5e-4236-8cc5-d78383d15a34","sha":"ffe13900917270dfb7b1b787ae6e9c554f3ea5ff"}}]}] BACKPORT-->