### PR TITLE
Check for integrations permissions before loading component

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index.tsx
@@ -9,12 +9,12 @@ import { EuiCallOut, EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useState } from 'react';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { CsvUploadManageDataSource } from './csv_upload_manage_data_source';
 import { HeaderPage } from '../../../common/components/header_page';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { IndexImportManageDataSource } from './index_import_manage_data_source';
 import { IntegrationsManageDataSource } from './integrations_manage_data_source';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
 
 export interface AddDataSourceResult {
   successful: boolean;
@@ -28,7 +28,7 @@ export const PrivilegedUserMonitoringManageDataSources = ({
 }) => {
   const spaceId = useSpaceId();
   const [addDataSourceResult, setAddDataSourceResult] = useState<AddDataSourceResult | undefined>();
-  
+
   const { application } = useKibana().services;
   const fleetRead = application?.capabilities?.fleetv2?.read ?? false;
 
@@ -88,18 +88,18 @@ export const PrivilegedUserMonitoringManageDataSources = ({
         </>
       )}
 
-        {!fleetRead && (
-            <EuiCallOut
-              title={
-                <FormattedMessage
-                  id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.file.retrievalError"
-                  defaultMessage="Insufficient privileges to view or manage integrations data source. Please contact your administrator."
-                />
-              }
-              color="warning"
+      {!fleetRead && (
+        <EuiCallOut
+          title={
+            <FormattedMessage
+              id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.file.retrievalError"
+              defaultMessage="Insufficient privileges to view or manage integrations data source. Please contact your administrator."
             />
-          )}
-      { fleetRead && <IntegrationsManageDataSource /> }
+          }
+          color="warning"
+        />
+      )}
+      {fleetRead && <IntegrationsManageDataSource />}
       <EuiSpacer size="xxl" />
       <IndexImportManageDataSource setAddDataSourceResult={setAddDataSourceResult} />
       <EuiSpacer size="xxl" />

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index.tsx
@@ -14,6 +14,7 @@ import { HeaderPage } from '../../../common/components/header_page';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { IndexImportManageDataSource } from './index_import_manage_data_source';
 import { IntegrationsManageDataSource } from './integrations_manage_data_source';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 
 export interface AddDataSourceResult {
   successful: boolean;
@@ -27,6 +28,9 @@ export const PrivilegedUserMonitoringManageDataSources = ({
 }) => {
   const spaceId = useSpaceId();
   const [addDataSourceResult, setAddDataSourceResult] = useState<AddDataSourceResult | undefined>();
+  
+  const { application } = useKibana().services;
+  const fleetRead = application?.capabilities?.fleetv2?.read ?? false;
 
   return (
     <>
@@ -84,7 +88,18 @@ export const PrivilegedUserMonitoringManageDataSources = ({
         </>
       )}
 
-      <IntegrationsManageDataSource />
+        {!fleetRead && (
+            <EuiCallOut
+              title={
+                <FormattedMessage
+                  id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.file.retrievalError"
+                  defaultMessage="Insufficient privileges to view or manage integrations data source. Please contact your administrator."
+                />
+              }
+              color="warning"
+            />
+          )}
+      { fleetRead && <IntegrationsManageDataSource /> }
       <EuiSpacer size="xxl" />
       <IndexImportManageDataSource setAddDataSourceResult={setAddDataSourceResult} />
       <EuiSpacer size="xxl" />

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index.tsx
@@ -92,7 +92,7 @@ export const PrivilegedUserMonitoringManageDataSources = ({
         <EuiCallOut
           title={
             <FormattedMessage
-              id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.file.retrievalError"
+              id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.integrations.noAccessMessage"
               defaultMessage="Insufficient privileges to view or manage integrations data source. Please contact your administrator."
             />
           }

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/integrations_manage_data_source.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/integrations_manage_data_source.tsx
@@ -29,7 +29,7 @@ export const IntegrationsManageDataSource = () => {
         <p>
           <FormattedMessage
             id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.integrations.infoText"
-            defaultMessage="By default, all users with admin roles or groups are considered privileged. You can customize which roles or groups are monitored as privileged."
+            defaultMessage="By default, all users with admin roles or groups are considered privileged."
           />
         </p>
       </EuiText>


### PR DESCRIPTION
### Summary
This PR introduces a check for fleet read permissions before loading in the integrations data source component. If the permissions are not available, a warning is shown. 

This solves the bug: https://github.com/elastic/kibana/issues/238852

Also removes text for customising roles and groups for privileged users - as this has not been implemented yet. (screenshot at bottom) 

**New, Expected outcome:** 
<img width="2758" height="1778" alt="image" src="https://github.com/user-attachments/assets/6624a885-240c-417c-b9f3-d2b0f317249c" />

#### Testing Steps 
1. Login to Kibana
2. From stack management create a user with fleet and integrations permissions set to none (screenshot below).
    - I find its easiest to copy all settings from superuser and edit just the two above. 
3. Login with that user. 
4. Navigate to Security -> Entity Analytics -> Privileged user monitoring.
3. Click on Manage Data Sources
4. Observer above warning should now show instead of generic - unable to load page. Both CSV and Index sources should also be visible and usable. 


**Customise Groups and Roles Text Removal** 
<img width="2650" height="1608" alt="image" src="https://github.com/user-attachments/assets/476feca4-c813-400d-810a-e80b8a17bd84" />



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->