### PR TITLE
[dataset quality] Fix breakdown doc trend charts for wired streams

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_dataset_details_telemetry.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_dataset_details_telemetry.ts
@@ -170,9 +170,9 @@ function getDatasetDetailsEbtProps({
 }): DatasetDetailsEbtProps {
   const indexName = datasetDetails.rawName;
   const dataStream = {
-    dataset: datasetDetails.name,
-    namespace: datasetDetails.namespace,
-    type: datasetDetails.type,
+    dataset: datasetDetails.name ?? '',
+    namespace: datasetDetails.namespace ?? '',
+    type: datasetDetails.name && datasetDetails.namespace ? datasetDetails.type : '',
   };
   const degradedDocs = dataStreamDetails?.degradedDocsCount ?? 0;
   const failedDocs = dataStreamDetails?.failedDocsCount ?? 0;


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/239138.

When we were sending the telemetry events we were relying on the dataset being in the shape of `${type}-${name}-${namespace}`, however this is not true anymore now that we support streams. 

Instead of saving a wrong value for `type`, we now send an empty value, we still can get the whole dataset name by looking into `index_name`. For the other values (`name`, `namespace`) we are also sending an empty value now.

### 🎥  Demo

#### Before

https://github.com/user-attachments/assets/e99adb3c-7e51-45fe-a9f3-1f88462ac573

#### After

https://github.com/user-attachments/assets/ea1e0046-5b3f-4f86-83be-46e1b81f84c1


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->