### PR TITLE
[Search]update api reference link in index details page

### DIFF
--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page.tsx
@@ -264,7 +264,7 @@ export const SearchIndexDetailsPage = () => {
                 ) : (
                   <EuiFlexItem>
                     <EuiButtonEmpty
-                      href={docLinks.links.apiReference}
+                      href={docLinks.links.apis.restApis}
                       target="_blank"
                       isLoading={isInitialLoading}
                       iconType="documentation"


### PR DESCRIPTION
## Summary

Update index management -> index detail page -> api reference link 

- https://www.elastic.co/docs/api/doc/elasticsearch/ for stack
- https://www.elastic.co/docs/api/doc/elasticsearch-serverless/ for serverless 


