### PR TITLE
[Discover][Traces] Replace charts indices

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
@@ -26,6 +26,7 @@ import {
 } from 'rxjs';
 import type { TimeRange } from '@kbn/data-plugin/common';
 import { useEuiTheme } from '@elastic/eui';
+import type { LensYBoundsConfig } from '@kbn/lens-embeddable-utils/config_builder/types';
 export type LensProps = Pick<
   EmbeddableComponentProps,
   | 'id'
@@ -47,6 +48,7 @@ export const useLensProps = ({
   discoverFetch$,
   chartRef,
   chartLayers,
+  yBounds,
 }: {
   title: string;
   query: string;
@@ -54,6 +56,7 @@ export const useLensProps = ({
   getTimeRange: () => TimeRange;
   chartRef?: React.RefObject<HTMLDivElement>;
   chartLayers: LensSeriesLayer[];
+  yBounds?: LensYBoundsConfig;
 } & Pick<ChartSectionProps, 'services' | 'searchSessionId'>) => {
   const { euiTheme } = useEuiTheme();
   const attributes$ = useRef(new BehaviorSubject<LensAttributes | undefined>(undefined));
@@ -76,9 +79,10 @@ export const useLensProps = ({
             },
             layers: chartLayers,
             fittingFunction: 'Linear',
+            yBounds,
           }
         : undefined,
-    [query, title, chartLayers]
+    [query, title, chartLayers, yBounds]
   );
 
   useAsync(async () => {

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
@@ -14,6 +14,7 @@ import { useBoolean } from '@kbn/react-hooks';
 import type { ChartSectionProps, UnifiedHistogramInputMessage } from '@kbn/unified-histogram/types';
 import React, { useRef } from 'react';
 import type { Observable } from 'rxjs';
+import type { LensYBoundsConfig } from '@kbn/lens-embeddable-utils/config_builder/types';
 import { useLensProps } from './hooks/use_lens_props';
 import type { LensWrapperProps } from './lens_wrapper';
 import { LensWrapper } from './lens_wrapper';
@@ -32,6 +33,7 @@ export type ChartProps = Pick<ChartSectionProps, 'searchSessionId' | 'requestPar
     esqlQuery: string;
     title: string;
     chartLayers: LensSeriesLayer[];
+    yBounds?: LensYBoundsConfig;
   };
 
 const LensWrapperMemo = React.memo(LensWrapper);
@@ -50,6 +52,7 @@ export const Chart = ({
   chartLayers,
   syncCursor,
   syncTooltips,
+  yBounds,
 }: ChartProps) => {
   const chartRef = useRef<HTMLDivElement>(null);
   const { euiTheme } = useEuiTheme();
@@ -67,6 +70,7 @@ export const Chart = ({
     getTimeRange,
     chartRef,
     chartLayers,
+    yBounds,
   });
 
   return (

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/error_rate.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/error_rate.tsx
@@ -8,10 +8,13 @@
  */
 
 import React from 'react';
+import type { LensYBoundsConfig } from '@kbn/lens-embeddable-utils/config_builder/types';
 import { useTraceMetricsContext } from '../../context/trace_metrics_context';
 import { Chart } from '../chart';
 import { useChartLayersFromEsql } from '../chart/hooks/use_chart_layers_from_esql';
 import { getErrorRateChart } from './trace_charts_definition';
+
+const ERROR_RATE_Y_BOUNDS: LensYBoundsConfig = { mode: 'custom', lowerBound: 0, upperBound: 1 };
 
 export const ErrorRateChart = () => {
   const {
@@ -59,6 +62,7 @@ export const ErrorRateChart = () => {
       chartLayers={chartLayers}
       syncCursor
       syncTooltips
+      yBounds={ERROR_RATE_Y_BOUNDS}
     />
   );
 };

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/index.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/index.tsx
@@ -8,11 +8,7 @@
  */
 import { EuiFlexGrid, EuiFlexItem, EuiPanel, euiPaletteColorBlind } from '@elastic/eui';
 import { css } from '@emotion/react';
-import {
-  DiscoverFlyouts,
-  dismissAllFlyoutsExceptFor,
-  type TraceIndexes,
-} from '@kbn/discover-utils/src';
+import { DiscoverFlyouts, dismissAllFlyoutsExceptFor } from '@kbn/discover-utils/src';
 import { useFetch } from '@kbn/unified-histogram';
 import type { ChartSectionProps, UnifiedHistogramInputMessage } from '@kbn/unified-histogram/types';
 import React, { useEffect, useMemo } from 'react';
@@ -38,14 +34,13 @@ function TraceMetricsGrid({
   onBrushEnd,
   onFilter,
   abortController,
-  indexes,
   query,
   dataSource,
   renderToggleActions,
   chartToolbarCss,
   isComponentVisible,
+  dataView,
 }: ChartSectionProps & {
-  indexes: TraceIndexes;
   dataSource: DataSource;
 }) {
   const esqlQuery = useEsqlQueryInfo({
@@ -91,14 +86,16 @@ function TraceMetricsGrid({
     };
   }, []);
 
-  if (!indexes.apm.traces) {
+  const indexPattern = dataView?.getIndexPattern();
+
+  if (!indexPattern) {
     return undefined;
   }
 
   return (
     <Provider store={store}>
       <MetricsGridWrapper
-        indexPattern={indexes.apm.traces}
+        indexPattern={indexPattern}
         renderToggleActions={renderToggleActions}
         chartToolbarCss={chartToolbarCss}
         requestParams={requestParams}
@@ -110,7 +107,7 @@ function TraceMetricsGrid({
         <TraceMetricsProvider
           value={{
             dataSource,
-            indexes: indexes.apm.traces,
+            indexes: indexPattern,
             filters,
             requestParams,
             services,

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/accessors/chart_session.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/accessors/chart_session.tsx
@@ -12,11 +12,9 @@ import type { ChartSectionProps } from '@kbn/unified-histogram/types';
 import { TraceMetricsGrid, type DataSource } from '@kbn/unified-metrics-grid';
 import React from 'react';
 import { once } from 'lodash';
-import type { TraceIndexes } from '@kbn/discover-utils/src';
 import type { DataSourceProfileProvider } from '../../../../profiles';
 
 export const createChartSection = (
-  indexes: TraceIndexes,
   dataSource: DataSource
 ): DataSourceProfileProvider['profile']['getChartSectionConfiguration'] =>
   // prevents unmounting the component when the query changes but the index pattern is still valid
@@ -25,7 +23,7 @@ export const createChartSection = (
       return {
         ...(prev ? prev() : {}),
         Component: (props: ChartSectionProps) => (
-          <TraceMetricsGrid {...props} indexes={indexes} dataSource={dataSource} />
+          <TraceMetricsGrid {...props} dataSource={dataSource} />
         ),
         replaceDefaultChart: true,
         defaultTopPanelHeight: 'max-content',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/create_profile_providers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/create_profile_providers.ts
@@ -20,8 +20,8 @@ export const createObservabilityTracesDataSourceProfileProviders = (
   const tracesDataSourceProfileProvider = createTracesDataSourceProfileProvider(providerServices);
 
   return [
-    createTracesAPMDataSourceProfileProvider(tracesDataSourceProfileProvider, providerServices),
-    createTracesOtelDataSourceProfileProvider(tracesDataSourceProfileProvider, providerServices),
+    createTracesAPMDataSourceProfileProvider(tracesDataSourceProfileProvider),
+    createTracesOtelDataSourceProfileProvider(tracesDataSourceProfileProvider),
     tracesDataSourceProfileProvider,
   ];
 };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/sub_profiles/apm.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/sub_profiles/apm.ts
@@ -19,13 +19,11 @@ import {
 import { DataSourceCategory, type DataSourceProfileProvider } from '../../../../profiles';
 import { extendProfileProvider } from '../../../extend_profile_provider';
 import { extractIndexPatternFrom } from '../../../extract_index_pattern_from';
-import type { ProfileProviderServices } from '../../../profile_provider_services';
 import { createChartSection } from '../accessors/chart_session';
 import { reContainsTracesApm, reContainsTracesOtel } from './reg_exps';
 
 export const createTracesAPMDataSourceProfileProvider = (
-  tracesDataSourceProfileProvider: DataSourceProfileProvider,
-  services: ProfileProviderServices
+  tracesDataSourceProfileProvider: DataSourceProfileProvider
 ): DataSourceProfileProvider => {
   const resolve: DataSourceProfileProvider['resolve'] = async (params) => {
     const baseResult = await tracesDataSourceProfileProvider.resolve(params);
@@ -65,16 +63,7 @@ export const createTracesAPMDataSourceProfileProvider = (
           rowHeight: 1,
         };
       },
-      getChartSectionConfiguration: createChartSection(
-        {
-          apm: {
-            errors: services.apmErrorsContextService.getErrorsIndexPattern(),
-            traces: services.tracesContextService.getAllTracesIndexPattern(),
-          },
-          logs: services.logsContextService.getAllLogsIndexPattern(),
-        },
-        'apm'
-      ),
+      getChartSectionConfiguration: createChartSection('apm'),
     },
     resolve,
   });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/sub_profiles/otel.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/sub_profiles/otel.ts
@@ -18,13 +18,11 @@ import {
 import { DataSourceCategory, type DataSourceProfileProvider } from '../../../../profiles';
 import { extendProfileProvider } from '../../../extend_profile_provider';
 import { extractIndexPatternFrom } from '../../../extract_index_pattern_from';
-import type { ProfileProviderServices } from '../../../profile_provider_services';
 import { createChartSection } from '../accessors/chart_session';
 import { reContainsTracesApm, reContainsTracesOtel } from './reg_exps';
 
 export const createTracesOtelDataSourceProfileProvider = (
-  tracesDataSourceProfileProvider: DataSourceProfileProvider,
-  services: ProfileProviderServices
+  tracesDataSourceProfileProvider: DataSourceProfileProvider
 ): DataSourceProfileProvider => {
   const resolve: DataSourceProfileProvider['resolve'] = async (params) => {
     const baseResult = await tracesDataSourceProfileProvider.resolve(params);
@@ -63,16 +61,7 @@ export const createTracesOtelDataSourceProfileProvider = (
           rowHeight: 1,
         };
       },
-      getChartSectionConfiguration: createChartSection(
-        {
-          apm: {
-            errors: services.apmErrorsContextService.getErrorsIndexPattern(),
-            traces: services.tracesContextService.getAllTracesIndexPattern(),
-          },
-          logs: services.logsContextService.getAllLogsIndexPattern(),
-        },
-        'otel'
-      ),
+      getChartSectionConfiguration: createChartSection('otel'),
     },
     resolve,
   });


### PR DESCRIPTION
Uses only the indices used in the ESQL query or dataview to fetch the trace charts.

<img width="2249" height="884" alt="Screenshot 2025-10-15 at 10 49 03" src="https://github.com/user-attachments/assets/9d2a4e4f-46cd-4f8c-b345-5c22d1ff2b13" />
<img width="2285" height="808" alt="Screenshot 2025-10-15 at 10 49 22" src="https://github.com/user-attachments/assets/0547208d-107a-466d-b9e7-2638cc7bd4e4" />


--
Fixing error rate bounds:
<img width="804" height="279" alt="Screenshot 2025-10-15 at 11 12 30" src="https://github.com/user-attachments/assets/22a7a315-b61a-4fed-a2f4-5a488394317d" />
