### PR TITLE
[One Workflow] Copy step execution field path cell action

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_data_view.stories.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_data_view.stories.tsx
@@ -146,7 +146,6 @@ const alertsMockData = {
 
 export const Default: Story = {
   args: {
-    title: 'Step Execution Data View',
     mode: 'input',
     stepExecution: {
       ...stepExecution,
@@ -157,7 +156,6 @@ export const Default: Story = {
 
 export const ArrayData: Story = {
   args: {
-    title: 'Step Execution Data',
     mode: 'input',
     stepExecution: {
       ...stepExecution,
@@ -186,7 +184,6 @@ export const ArrayData: Story = {
 
 export const Empty: Story = {
   args: {
-    title: 'Step Execution Data',
     mode: 'input',
     stepExecution: {
       ...stepExecution,

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_data_view.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_data_view.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { StepExecutionDataView } from './step_execution_data_view';
+
+// Mock the JSONDataView component
+const mockJSONDataView = jest.fn();
+jest.mock('../../../shared/ui/json_data_view', () => ({
+  JSONDataView: (props: any) => {
+    mockJSONDataView(props);
+    return <div data-test-subj="mocked-json-data-view">{props.title}</div>;
+  },
+}));
+
+const baseStepExecution = {
+  stepId: 'my-step',
+  input: { param1: 'value1', param2: 2 },
+  output: { result: 'ok', details: { field: 'abc' } },
+  status: 'completed',
+  startedAt: new Date().toISOString(),
+  id: 'step-execution-1',
+};
+
+describe('StepExecutionDataView', () => {
+  beforeEach(() => {
+    mockJSONDataView.mockClear();
+  });
+
+  it('renders input data correctly', () => {
+    render(<StepExecutionDataView stepExecution={baseStepExecution as any} mode="input" />);
+
+    expect(mockJSONDataView).toHaveBeenCalledWith({
+      data: { param1: 'value1', param2: 2 },
+      title: 'Input',
+      fieldPathActionsPrefix: undefined,
+    });
+  });
+
+  it('renders output data correctly', () => {
+    render(<StepExecutionDataView stepExecution={baseStepExecution as any} mode="output" />);
+
+    expect(mockJSONDataView).toHaveBeenCalledWith({
+      data: { result: 'ok', details: { field: 'abc' } },
+      title: 'Output',
+      fieldPathActionsPrefix: 'steps.my-step.output',
+    });
+  });
+
+  it('renders error data with error title', () => {
+    const errorStepExecution = {
+      ...baseStepExecution,
+      error: {
+        message: 'Something went wrong',
+        code: 'ERROR_CODE',
+      },
+    };
+    render(<StepExecutionDataView stepExecution={errorStepExecution as any} mode="output" />);
+
+    expect(mockJSONDataView).toHaveBeenCalledWith({
+      data: { error: { message: 'Something went wrong', code: 'ERROR_CODE' } },
+      title: 'Error',
+      fieldPathActionsPrefix: undefined,
+    });
+  });
+
+  it('wraps primitive data in an object', () => {
+    const primitiveStepExecution = {
+      ...baseStepExecution,
+      input: 123,
+    };
+    render(<StepExecutionDataView stepExecution={primitiveStepExecution as any} mode="input" />);
+
+    expect(mockJSONDataView).toHaveBeenCalledWith({
+      data: { value: 123 },
+      title: 'Input',
+      fieldPathActionsPrefix: undefined,
+    });
+  });
+
+  it('renders empty state gracefully with empty input', () => {
+    const emptyStepExecution = {
+      ...baseStepExecution,
+      input: undefined,
+    };
+    render(<StepExecutionDataView stepExecution={emptyStepExecution as any} mode="input" />);
+
+    expect(mockJSONDataView).toHaveBeenCalledWith({
+      data: {},
+      title: 'Input',
+      fieldPathActionsPrefix: undefined,
+    });
+  });
+
+  it('sets fieldPathActionsPrefix for array output data', () => {
+    const arrayStepExecution = {
+      ...baseStepExecution,
+      output: [{ item: 'first' }, { item: 'second' }],
+    };
+    render(<StepExecutionDataView stepExecution={arrayStepExecution as any} mode="output" />);
+
+    expect(mockJSONDataView).toHaveBeenCalledWith({
+      data: { item: 'first' },
+      title: 'Output',
+      fieldPathActionsPrefix: 'steps.my-step.output[0]',
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_detail.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_detail.tsx
@@ -106,7 +106,6 @@ export const WorkflowExecutionDetail: React.FC<WorkflowExecutionDetailProps> = (
           <WorkflowStepExecutionDetails
             workflowExecutionId={workflowExecutionId}
             stepExecution={selectedStepExecution}
-            setSelectedStepId={setSelectedStep}
             isLoading={isLoading}
           />
         }

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_detail.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_detail.tsx
@@ -41,8 +41,7 @@ export const WorkflowExecutionDetail: React.FC<WorkflowExecutionDetailProps> = (
   onClose,
 }) => {
   const { workflowExecution, isLoading, error } = useWorkflowExecutionPolling(workflowExecutionId);
-  const { setSelectedStepExecution, selectedStepExecutionId, setSelectedStep } =
-    useWorkflowUrlState();
+  const { setSelectedStepExecution, selectedStepExecutionId } = useWorkflowUrlState();
   const [sidebarWidth = DefaultSidebarWidth, setSidebarWidth] = useLocalStorage(
     WidthStorageKey,
     DefaultSidebarWidth

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.stories.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.stories.tsx
@@ -47,7 +47,6 @@ export const Default: StoryObj<typeof WorkflowStepExecutionDetails> = {
       executionTimeMs: 423,
       error: 'HTTP Error: 422 Unprocessable Entity',
     },
-    setSelectedStepId: () => {},
     isLoading: false,
     workflowExecutionId: 'e2387d33-d626-42f0-a402-c379d4d30d42',
   },

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/field_name.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/field_name.tsx
@@ -17,37 +17,13 @@ interface FieldNameProps {
   highlight?: string;
 }
 
-export function FieldName({ fieldName, fieldType, highlight = '' }: FieldNameProps) {
-  const fieldDisplayName = fieldName;
-
-  return (
-    <EuiFlexGroup responsive={false} gutterSize="s" alignItems="flexStart">
-      <EuiFlexItem grow={false}>
-        <EuiFlexGroup
-          gutterSize="s"
-          responsive={false}
-          alignItems="center"
-          direction="row"
-          wrap={false}
-          className="kbnDocViewer__fieldName_icon"
-        >
-          <EuiFlexItem grow={false}>
-            <FieldIcon type={fieldType} size="s" />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-
-      <EuiFlexItem>
-        <EuiFlexGroup gutterSize="none" responsive={false} alignItems="center" direction="row" wrap>
-          <EuiFlexItem
-            className="kbnDocViewer__fieldName eui-textBreakAll"
-            grow={false}
-            data-test-subj={`tableDocViewRow-${fieldName}-name`}
-          >
-            <EuiHighlight search={highlight}>{fieldDisplayName}</EuiHighlight>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
-}
+export const FieldName = React.memo<FieldNameProps>(({ fieldName, fieldType, highlight = '' }) => (
+  <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+    <EuiFlexItem grow={false}>
+      <FieldIcon type={fieldType} size="s" />
+    </EuiFlexItem>
+    <EuiFlexItem>
+      <EuiHighlight search={highlight}>{fieldName}</EuiHighlight>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+));

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/json_data_table.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/json_data_table.test.tsx
@@ -1,0 +1,492 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { JSONDataTable } from './json_data_table';
+import { usePager } from '@kbn/discover-utils';
+
+// Helper function to render with I18n provider
+const renderWithIntl = (component: React.ReactElement) => {
+  return render(component, { wrapper: I18nProvider });
+};
+
+// Mock child components
+const mockFieldName = jest.fn();
+const mockTableFieldValue = jest.fn();
+
+jest.mock('./field_name', () => ({
+  FieldName: (props: any) => {
+    mockFieldName(props);
+    return (
+      <div data-test-subj={`mocked-field-name-${props.fieldName}`}>
+        {props.fieldName} ({props.fieldType})
+      </div>
+    );
+  },
+}));
+
+jest.mock('./table_field_value', () => ({
+  TableFieldValue: (props: any) => {
+    mockTableFieldValue(props);
+    return <div data-test-subj={`mocked-field-value-${props.field}`}>{props.formattedValue}</div>;
+  },
+}));
+
+// Mock kibanaFlatten
+jest.mock('../../lib/kibana_flatten', () => ({
+  kibanaFlatten: jest.fn((obj: any) => {
+    // Simple mock implementation
+    const result: Record<string, any> = {};
+    const flatten = (o: any, prefix = '') => {
+      Object.keys(o).forEach((key) => {
+        const newKey = prefix ? `${prefix}.${key}` : key;
+        if (typeof o[key] === 'object' && o[key] !== null && !Array.isArray(o[key])) {
+          flatten(o[key], newKey);
+        } else {
+          result[newKey] = o[key];
+        }
+      });
+    };
+    flatten(obj);
+    return result;
+  }),
+}));
+
+// Mock useGetFormattedDateTime hook
+const mockGetFormattedDateTime = jest.fn((date: Date) => date.toISOString());
+
+jest.mock('../use_formatted_date', () => ({
+  useGetFormattedDateTime: () => mockGetFormattedDateTime,
+}));
+
+// Mock usePager hook
+const mockChangePageIndex = jest.fn();
+const mockChangePageSize = jest.fn();
+
+jest.mock('@kbn/discover-utils', () => ({
+  usePager: jest.fn(() => ({
+    curPageIndex: 0,
+    pageSize: 20,
+    changePageIndex: mockChangePageIndex,
+    changePageSize: mockChangePageSize,
+  })),
+  IgnoredReason: {
+    IGNORE_ABOVE: 'ignore_above',
+    MALFORMED: 'malformed',
+    UNKNOWN: 'unknown',
+  },
+}));
+
+// Mock @elastic/eui
+jest.mock('@elastic/eui', () => {
+  const actual = jest.requireActual('@elastic/eui');
+  return {
+    ...actual,
+    copyToClipboard: jest.fn(),
+    useResizeObserver: jest.fn(() => ({ width: 800, height: 600 })),
+  };
+});
+
+describe('JSONDataTable', () => {
+  const mockData = {
+    name: 'test',
+    value: 123,
+    nested: {
+      field: 'abc',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('should render the data grid with data', () => {
+      render(<JSONDataTable data={mockData} />);
+
+      // Check that the grid is rendered
+      const grid = screen.getByRole('grid');
+      expect(grid).toBeInTheDocument();
+    });
+
+    it('should render with custom title', () => {
+      render(<JSONDataTable data={mockData} title="Custom Title" />);
+
+      const grid = screen.getByRole('grid', { name: /Custom Title/ });
+      expect(grid).toBeInTheDocument();
+    });
+
+    it('should render with default title when not provided', () => {
+      render(<JSONDataTable data={mockData} />);
+
+      const grid = screen.getByRole('grid', { name: /JSON Data/ });
+      expect(grid).toBeInTheDocument();
+    });
+
+    it('should flatten nested data and create rows', () => {
+      render(<JSONDataTable data={mockData} />);
+
+      // Should have called FieldName for each flattened field
+      expect(mockFieldName).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fieldName: 'name',
+        })
+      );
+      expect(mockFieldName).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fieldName: 'value',
+        })
+      );
+      expect(mockFieldName).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fieldName: 'nested.field',
+        })
+      );
+    });
+  });
+
+  describe('empty state', () => {
+    it('should show empty prompt when data is empty', () => {
+      renderWithIntl(<JSONDataTable data={{}} />);
+
+      expect(screen.getByText('No data to display')).toBeInTheDocument();
+      expect(screen.queryByRole('grid')).not.toBeInTheDocument();
+    });
+
+    it('should show empty prompt when search returns no results', () => {
+      renderWithIntl(<JSONDataTable data={mockData} searchTerm="nonexistent" />);
+
+      expect(screen.getByText('No data to display')).toBeInTheDocument();
+      expect(screen.queryByRole('grid')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('search functionality', () => {
+    it('should filter by field name', () => {
+      const { rerender } = render(<JSONDataTable data={mockData} />);
+
+      // Initially should show all fields
+      expect(mockFieldName).toHaveBeenCalledTimes(3);
+
+      // Clear mocks
+      mockFieldName.mockClear();
+
+      // Rerender with search term
+      rerender(<JSONDataTable data={mockData} searchTerm="name" />);
+
+      // Should only render field containing "name"
+      const fieldNameCalls = mockFieldName.mock.calls.filter((call) =>
+        call[0].fieldName.includes('name')
+      );
+      expect(fieldNameCalls.length).toBeGreaterThan(0);
+    });
+
+    it('should filter by field value', () => {
+      const { rerender } = render(<JSONDataTable data={mockData} />);
+
+      mockFieldName.mockClear();
+      mockTableFieldValue.mockClear();
+
+      // Rerender with search term that matches a value
+      rerender(<JSONDataTable data={mockData} searchTerm="123" />);
+
+      // Should filter and show only matching rows
+      expect(screen.queryByText('No data to display')).not.toBeInTheDocument();
+    });
+
+    it('should be case insensitive when searching', () => {
+      const { rerender } = render(<JSONDataTable data={mockData} />);
+
+      mockFieldName.mockClear();
+
+      // Rerender with uppercase search term
+      rerender(<JSONDataTable data={mockData} searchTerm="NAME" />);
+
+      // Should still find the field
+      expect(screen.queryByText('No data to display')).not.toBeInTheDocument();
+    });
+
+    it('should pass highlight prop to FieldName when search term matches field name', () => {
+      render(<JSONDataTable data={mockData} searchTerm="name" />);
+
+      // Find the call with matching field name
+      const nameFieldCall = mockFieldName.mock.calls.find((call) => call[0].fieldName === 'name');
+      expect(nameFieldCall).toBeDefined();
+      expect(nameFieldCall[0].highlight).toBe('name');
+    });
+
+    it('should pass isHighlighted prop to TableFieldValue when search term matches value', () => {
+      render(<JSONDataTable data={mockData} searchTerm="123" />);
+
+      // Find the call with matching value
+      const matchingCall = mockTableFieldValue.mock.calls.find((call) =>
+        call[0].formattedValue.includes('123')
+      );
+      expect(matchingCall).toBeDefined();
+      expect(matchingCall[0].isHighlighted).toBe(true);
+    });
+  });
+
+  describe('field type inference', () => {
+    it('should infer string type for string values', () => {
+      render(<JSONDataTable data={{ text: 'hello' }} />);
+
+      expect(mockFieldName).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fieldName: 'text',
+          fieldType: 'string',
+        })
+      );
+    });
+
+    it('should infer number type for numeric values', () => {
+      render(<JSONDataTable data={{ count: 42 }} />);
+
+      expect(mockFieldName).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fieldName: 'count',
+          fieldType: 'long', // Integers are inferred as 'long'
+        })
+      );
+    });
+
+    it('should infer boolean type for boolean values', () => {
+      render(<JSONDataTable data={{ active: true }} />);
+
+      expect(mockFieldName).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fieldName: 'active',
+          fieldType: 'boolean',
+        })
+      );
+    });
+
+    it('should infer date type for ISO date strings', () => {
+      const isoDate = '2024-01-15T10:30:00.000Z';
+      render(<JSONDataTable data={{ timestamp: isoDate }} />);
+
+      expect(mockFieldName).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fieldName: 'timestamp',
+          fieldType: 'date',
+        })
+      );
+    });
+  });
+
+  describe('date formatting', () => {
+    it('should format date values using useGetFormattedDateTime', () => {
+      const isoDate = '2024-01-15T10:30:00.000Z';
+      render(<JSONDataTable data={{ timestamp: isoDate }} />);
+
+      expect(mockGetFormattedDateTime).toHaveBeenCalled();
+    });
+
+    it('should handle non-date values without formatting', () => {
+      mockGetFormattedDateTime.mockClear();
+      render(<JSONDataTable data={{ text: 'not a date' }} />);
+
+      // Date formatter should be called but the value won't be identified as a date
+      expect(mockTableFieldValue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formattedValue: 'not a date',
+        })
+      );
+    });
+  });
+
+  describe('copy field path action', () => {
+    it('should show copy action when fieldPathActionsPrefix is provided', () => {
+      render(<JSONDataTable data={mockData} fieldPathActionsPrefix="test.prefix" />);
+
+      // The copy action should be available in the grid
+      // EuiDataGrid renders actions, we can check if copyToClipboard would be called
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+    });
+
+    it('should not show copy action when fieldPathActionsPrefix is not provided', () => {
+      render(<JSONDataTable data={mockData} />);
+
+      // Grid should still render but without copy actions
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+    });
+  });
+
+  describe('data types handling', () => {
+    it('should handle null values', () => {
+      render(<JSONDataTable data={{ nullField: null }} />);
+
+      expect(mockTableFieldValue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formattedValue: '-', // Null values are formatted as '-'
+        })
+      );
+    });
+
+    it('should handle undefined values', () => {
+      render(<JSONDataTable data={{ undefinedField: undefined }} />);
+
+      expect(mockTableFieldValue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formattedValue: '-', // Undefined values are formatted as '-'
+        })
+      );
+    });
+
+    it('should handle array values', () => {
+      render(<JSONDataTable data={{ arrayField: [1, 2, 3] }} />);
+
+      expect(mockTableFieldValue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formattedValue: expect.stringContaining('1'),
+        })
+      );
+    });
+
+    it('should handle deeply nested objects', () => {
+      const deepData = {
+        level1: {
+          level2: {
+            level3: {
+              value: 'deep',
+            },
+          },
+        },
+      };
+
+      render(<JSONDataTable data={deepData} />);
+
+      expect(mockFieldName).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fieldName: 'level1.level2.level3.value',
+        })
+      );
+    });
+  });
+
+  describe('pagination', () => {
+    it('should use pagination with default page size', () => {
+      render(<JSONDataTable data={mockData} />);
+
+      expect(usePager).toHaveBeenCalledWith({
+        initialPageSize: 20,
+        totalItems: expect.any(Number),
+      });
+    });
+
+    it('should show pagination controls in the grid', () => {
+      render(<JSONDataTable data={mockData} />);
+
+      const grid = screen.getByRole('grid');
+      expect(grid).toBeInTheDocument();
+
+      // Pagination should be part of the EuiDataGrid
+      // The actual controls are rendered by EuiDataGrid
+    });
+  });
+
+  describe('grid configuration', () => {
+    it('should configure grid with field and value columns', () => {
+      render(<JSONDataTable data={mockData} />);
+
+      const grid = screen.getByRole('grid');
+      expect(grid).toBeInTheDocument();
+
+      // The grid should have column headers (rendered by EuiDataGrid)
+      // We can verify through the presence of the grid itself
+    });
+
+    it('should apply static grid settings', () => {
+      render(<JSONDataTable data={mockData} />);
+
+      // Grid should be rendered with proper settings
+      const grid = screen.getByRole('grid');
+      expect(grid).toBeInTheDocument();
+
+      // Verify the grid has the expected ARIA attributes
+      expect(grid).toHaveAttribute('aria-label', expect.stringMatching(/JSON Data/));
+      expect(grid).toHaveAttribute('aria-rowcount');
+    });
+  });
+
+  describe('complex data scenarios', () => {
+    it('should handle mixed data types in one object', () => {
+      const complexData = {
+        string: 'text',
+        number: 42,
+        boolean: true,
+        null: null,
+        date: '2024-01-15T10:30:00.000Z',
+        nested: {
+          value: 'nested',
+        },
+      };
+
+      render(<JSONDataTable data={complexData} />);
+
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+      expect(mockFieldName.mock.calls.length).toBeGreaterThan(0);
+    });
+
+    it('should handle objects with special characters in keys', () => {
+      const dataWithSpecialKeys = {
+        'field-with-dash': 'value1',
+        'field.with.dots': 'value2',
+        field_with_underscore: 'value3',
+      };
+
+      render(<JSONDataTable data={dataWithSpecialKeys} />);
+
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+    });
+
+    it('should handle large datasets', () => {
+      const largeData: Record<string, any> = {};
+      for (let i = 0; i < 100; i++) {
+        largeData[`field${i}`] = `value${i}`;
+      }
+
+      render(<JSONDataTable data={largeData} />);
+
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+    });
+  });
+
+  describe('props propagation', () => {
+    it('should pass all props to child components correctly', () => {
+      render(
+        <JSONDataTable
+          data={mockData}
+          title="Test Title"
+          searchTerm="test"
+          fieldPathActionsPrefix="prefix"
+        />
+      );
+
+      // Verify grid is rendered with correct title
+      const grid = screen.getByRole('grid', { name: /Test Title/ });
+      expect(grid).toBeInTheDocument();
+
+      // Verify search term is passed to FieldName
+      expect(mockFieldName).toHaveBeenCalledWith(
+        expect.objectContaining({
+          highlight: 'test',
+        })
+      );
+    });
+
+    it('should handle missing optional props gracefully', () => {
+      render(<JSONDataTable data={mockData} />);
+
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/json_data_table.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/json_data_table.tsx
@@ -175,7 +175,7 @@ export const JSONDataTable = React.memo<JSONDataTableProps>(
 
     const staticDataGridSettings: Pick<
       EuiDataGridProps,
-      'columnVisibility' | 'sorting' | 'gridStyle'
+      'columnVisibility' | 'sorting' | 'gridStyle' | 'rowHeightsOptions'
     > = useMemo(
       () => ({
         columnVisibility: { visibleColumns: ['name', 'value'], setVisibleColumns: () => {} },

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/json_data_table.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/json_data_table.tsx
@@ -7,20 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo, useRef } from 'react';
-import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils/types';
+import React, { useCallback, useMemo, useRef } from 'react';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
+import type { EuiDataGridColumnCellAction, EuiDataGridRefProps } from '@elastic/eui';
 import {
   EuiDataGrid,
   type UseEuiTheme,
-  euiFontSize,
   type EuiDataGridProps,
   useResizeObserver,
   EuiEmptyPrompt,
+  copyToClipboard,
 } from '@elastic/eui';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { usePager } from '@kbn/discover-utils';
+import { i18n } from '@kbn/i18n';
 import { TableFieldValue } from './table_field_value';
 import { kibanaFlatten } from '../../lib/kibana_flatten';
 import { FieldName } from './field_name';
@@ -31,51 +33,15 @@ import { useGetFormattedDateTime } from '../use_formatted_date';
 const MIN_NAME_COLUMN_WIDTH = 120;
 const MAX_NAME_COLUMN_WIDTH = 300;
 
-/**
- * Props for the JSONDataTable component
- */
 export interface JSONDataTableProps {
-  /**
-   * The JSON data to display. Can be a single object, an array of objects, or any serializable value.
-   * If an array is provided, only the first object will be displayed.
-   * If a primitive value is provided, it will be wrapped in an object.
-   */
+  /** The JSON data object to display as a table */
   data: Record<string, unknown>;
-
-  /**
-   * Optional title for the data view. Defaults to 'JSON Data'
-   */
+  /** Optional title for the data view. Defaults to 'JSON Data' */
   title?: string;
-
-  /**
-   * Optional columns to display. If not provided, all keys from the data will be used.
-   */
-  columns?: string[];
-
-  /**
-   * Optional custom column metadata for type information and formatting
-   */
-  columnsMeta?: DataTableColumnsMeta;
-
-  /**
-   * Whether to hide the actions column in the doc viewer. Defaults to true.
-   */
-  hideActionsColumn?: boolean;
-
-  /**
-   * Additional CSS class name for styling
-   */
-  className?: string;
-
-  /**
-   * Optional search term to filter the data
-   */
+  /** Optional search term to filter the data */
   searchTerm?: string;
-
-  /**
-   * Test subject for testing purposes
-   */
-  'data-test-subj'?: string;
+  /** Optional prefix for the field path actions, such as the copy the field path to the clipboard. */
+  fieldPathActionsPrefix?: string;
 }
 
 interface JSONDataTableRecord extends DataTableRecord {
@@ -88,221 +54,219 @@ interface JSONDataTableRecord extends DataTableRecord {
 
 /**
  * JSONDataTable component that displays arbitrary JSON data using Kibana's unified data table.
- *
- * This component converts JSON objects into a format compatible with UnifiedDataTable,
- * providing a rich tabular view with support for nested objects, arrays, and various data types.
- *
- * @example
- * ```tsx
- * const jsonData = {
- *   id: '123',
- *   name: 'John Doe',
- *   email: 'john@example.com',
- *   metadata: { role: 'admin', lastLogin: '2024-01-15T10:30:00Z' }
- * };
- *
- * <JSONDataTable
- *   data={jsonData}
- *   title="User Data"
- *   columns={['id', 'name', 'email']}
- * />
- * ```
  */
-export function JSONDataTable({
-  data: jsonObject,
-  title = 'JSON Data',
-  columns,
-  searchTerm,
-  'data-test-subj': dataTestSubj = 'jsonDataTable',
-}: JSONDataTableProps) {
-  const styles = useMemoCss(componentStyles);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const getFormattedDateTime = useGetFormattedDateTime();
+export const JSONDataTable = React.memo<JSONDataTableProps>(
+  ({ data: jsonObject, title = 'JSON Data', searchTerm, fieldPathActionsPrefix }) => {
+    const styles = useMemoCss(componentStyles);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const dataGridRef = useRef<EuiDataGridRefProps | null>(null);
+    const getFormattedDateTime = useGetFormattedDateTime();
 
-  // Create DataTableRecord from JSON - each field becomes a row
-  const dataTableRecords = useMemo((): JSONDataTableRecord[] => {
-    // Flatten nested objects for better display
+    // Create DataTableRecord from JSON - each field becomes a row
+    const dataTableRecords = useMemo((): JSONDataTableRecord[] => {
+      // Flatten nested objects for better display
+      const flattened = kibanaFlatten(jsonObject);
 
-    const flattened = kibanaFlatten(jsonObject);
+      // Create a row for each field-value pair
+      return Object.keys(flattened).map((fieldName, index) => {
+        const value = flattened[fieldName];
+        const fieldType = inferFieldType(value);
+        const displayValue =
+          fieldType === 'date'
+            ? getFormattedDateTime(new Date(value as string)) ?? ''
+            : formatValue(value);
 
-    // Filter fields if columns prop is provided
-    const fieldsToShow = columns
-      ? Object.keys(flattened).filter((key) => columns.includes(key))
-      : Object.keys(flattened);
+        return {
+          id: `field-${index}`,
+          raw: {
+            _id: `field-${index}`,
+            _index: title.toLowerCase().replace(/\s+/g, '_'),
+            _source: { field: fieldName, value: displayValue, fieldType },
+          },
+          flattened: {
+            field: fieldName,
+            value: displayValue,
+            fieldType, // Store the field type for the cell renderer
+          },
+        };
+      });
+    }, [jsonObject, getFormattedDateTime, title]);
 
-    // Create a row for each field-value pair
-    return fieldsToShow.map((fieldName, index) => {
-      const value = flattened[fieldName];
-      const fieldType = inferFieldType(value);
-      const displayValue =
-        fieldType === 'date'
-          ? getFormattedDateTime(new Date(value as string)) ?? ''
-          : formatValue(value);
-
-      return {
-        id: `field-${index}`,
-        raw: {
-          _id: `field-${index}`,
-          _index: title.toLowerCase().replace(/\s+/g, '_'),
-          _source: { field: fieldName, value: displayValue, fieldType },
-        },
-        flattened: {
-          field: fieldName,
-          value: displayValue,
-          fieldType, // Store the field type for the cell renderer
-        },
-      };
-    });
-  }, [jsonObject, columns, getFormattedDateTime, title]);
-
-  const filteredDataTableRecords = useMemo(() => {
-    return dataTableRecords.filter((record) => {
-      return (
-        record.flattened.field.toLowerCase().includes(searchTerm?.toLowerCase() || '') ||
-        record.flattened.value.toLowerCase().includes(searchTerm?.toLowerCase() || '')
-      );
-    });
-  }, [dataTableRecords, searchTerm]);
-
-  const { width: containerWidth } = useResizeObserver(containerRef.current);
-  const { curPageIndex, pageSize, changePageIndex, changePageSize } = usePager({
-    initialPageSize: 20,
-    totalItems: filteredDataTableRecords.length,
-  });
-
-  // Grid columns configuration
-  const gridColumns: EuiDataGridProps['columns'] = useMemo(
-    () => [
-      {
-        id: 'name',
-        displayAsText: 'Field',
-        initialWidth: Math.min(
-          Math.max(Math.round(containerWidth * 0.3), MIN_NAME_COLUMN_WIDTH),
-          MAX_NAME_COLUMN_WIDTH
-        ),
-        actions: false,
-      },
-      {
-        id: 'value',
-        displayAsText: 'Value',
-        actions: false,
-      },
-    ],
-    [containerWidth]
-  );
-
-  // Cell renderer for the data grid
-  const renderCellValue: EuiDataGridProps['renderCellValue'] = useMemo(() => {
-    return ({ rowIndex, columnId }) => {
-      const row = filteredDataTableRecords[rowIndex];
-      if (!row) return null;
-
-      if (columnId === 'name') {
-        const fieldName = row.flattened.field as string;
-        const fieldType = row.flattened.fieldType as string;
-
-        return <FieldName fieldName={fieldName} fieldType={fieldType} highlight={searchTerm} />;
+    const filteredDataTableRecords = useMemo(() => {
+      if (!searchTerm) {
+        return dataTableRecords;
       }
-
-      if (columnId === 'value') {
+      return dataTableRecords.filter((record) => {
         return (
-          <TableFieldValue
-            formattedValue={row.flattened.value as string}
-            field={row.flattened.field as string}
-            rawValue={row.flattened.value}
-            isHighlighted={Boolean(
-              searchTerm && row.flattened.value.toLowerCase().includes(searchTerm.toLowerCase())
-            )}
-          />
+          record.flattened.field.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          record.flattened.value.toLowerCase().includes(searchTerm.toLowerCase())
+        );
+      });
+    }, [dataTableRecords, searchTerm]);
+
+    const { width: containerWidth } = useResizeObserver(containerRef.current);
+    const { curPageIndex, pageSize, changePageIndex, changePageSize } = usePager({
+      initialPageSize: 20,
+      totalItems: filteredDataTableRecords.length,
+    });
+
+    const fieldCellActions: EuiDataGridColumnCellAction[] = useMemo(() => {
+      const cellActions = [];
+      const closePopover = () => dataGridRef.current?.closeCellPopover();
+      if (fieldPathActionsPrefix != null) {
+        cellActions.push(
+          getCopyCellActionComponent(filteredDataTableRecords, fieldPathActionsPrefix, closePopover)
         );
       }
+      return cellActions;
+    }, [filteredDataTableRecords, fieldPathActionsPrefix]);
 
-      return null;
-    };
-  }, [filteredDataTableRecords, searchTerm]);
-
-  if (filteredDataTableRecords.length === 0) {
-    return (
-      <EuiEmptyPrompt
-        title={
-          <h2>
-            <FormattedMessage
-              id="workflows.jsonDataTable.noData"
-              defaultMessage="No data to display"
-            />
-          </h2>
-        }
-        iconType="empty"
-      />
+    // Grid columns configuration
+    const gridColumns: EuiDataGridProps['columns'] = useMemo(
+      () => [
+        {
+          id: 'name',
+          displayAsText: 'Field',
+          initialWidth: Math.min(
+            Math.max(Math.round(containerWidth * 0.3), MIN_NAME_COLUMN_WIDTH),
+            MAX_NAME_COLUMN_WIDTH
+          ),
+          actions: false,
+          cellActions: fieldCellActions,
+        },
+        {
+          id: 'value',
+          displayAsText: 'Value',
+          actions: false,
+        },
+      ],
+      [containerWidth, fieldCellActions]
     );
-  }
 
-  return (
-    <EuiDataGrid
-      className="kbnDocViewer__fieldsGrid"
-      css={styles.fieldsGrid}
-      aria-label={title || 'JSON Data Table'}
-      columns={gridColumns}
-      columnVisibility={{
-        visibleColumns: ['name', 'value'],
-        setVisibleColumns: () => {},
-      }}
-      rowCount={filteredDataTableRecords.length}
-      renderCellValue={renderCellValue}
-      toolbarVisibility={false}
-      sorting={{ columns: [], onSort: () => {} }}
-      rowHeightsOptions={{ defaultHeight: 'auto' }}
-      gridStyle={{
-        header: 'underline',
-        border: 'horizontal',
-        fontSize: 's',
-        stripes: true,
-      }}
-      pagination={{
+    // Cell renderer for the data grid
+    const renderCellValue: EuiDataGridProps['renderCellValue'] = useMemo(() => {
+      return ({ rowIndex, columnId }) => {
+        const row = filteredDataTableRecords[rowIndex];
+        if (!row) return null;
+
+        if (columnId === 'name') {
+          const fieldName = row.flattened.field as string;
+          const fieldType = row.flattened.fieldType as string;
+
+          return <FieldName fieldName={fieldName} fieldType={fieldType} highlight={searchTerm} />;
+        }
+
+        if (columnId === 'value') {
+          return (
+            <TableFieldValue
+              formattedValue={row.flattened.value as string}
+              field={row.flattened.field as string}
+              rawValue={row.flattened.value}
+              isHighlighted={Boolean(
+                searchTerm && row.flattened.value.toLowerCase().includes(searchTerm.toLowerCase())
+              )}
+            />
+          );
+        }
+
+        return null;
+      };
+    }, [filteredDataTableRecords, searchTerm]);
+
+    const staticDataGridSettings: Pick<
+      EuiDataGridProps,
+      'columnVisibility' | 'sorting' | 'gridStyle'
+    > = useMemo(
+      () => ({
+        columnVisibility: { visibleColumns: ['name', 'value'], setVisibleColumns: () => {} },
+        sorting: { columns: [], onSort: () => {} },
+        gridStyle: {
+          header: 'underline',
+          border: 'horizontal',
+          fontSize: 's',
+          stripes: true,
+          cellPadding: 'm',
+        },
+        rowHeightsOptions: { defaultHeight: 'auto' },
+      }),
+      []
+    );
+
+    const pagination: EuiDataGridProps['pagination'] = useMemo(
+      () => ({
         pageSizeOptions: [20, 50, 100, 200],
         pageIndex: curPageIndex,
         pageSize,
         onChangeItemsPerPage: changePageSize,
         onChangePage: changePageIndex,
-      }}
-    />
-  );
-}
+      }),
+      [curPageIndex, pageSize, changePageSize, changePageIndex]
+    );
 
+    if (filteredDataTableRecords.length === 0) {
+      return (
+        <EuiEmptyPrompt
+          title={
+            <h2>
+              <FormattedMessage
+                id="workflows.jsonDataTable.noData"
+                defaultMessage="No data to display"
+              />
+            </h2>
+          }
+          iconType="empty"
+        />
+      );
+    }
+
+    return (
+      <EuiDataGrid
+        ref={dataGridRef}
+        css={styles.fieldsGrid}
+        aria-label={title}
+        columns={gridColumns}
+        rowCount={filteredDataTableRecords.length}
+        renderCellValue={renderCellValue}
+        toolbarVisibility={false}
+        pagination={pagination}
+        {...staticDataGridSettings}
+      />
+    );
+  }
+);
 const componentStyles = {
   fieldsGrid: (themeContext: UseEuiTheme) => {
     const { euiTheme } = themeContext;
-    const { fontSize } = euiFontSize(themeContext, 's');
-
-    // taken from src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
     return css({
       '&.euiDataGrid--noControls.euiDataGrid--bordersHorizontal .euiDataGridHeader': {
         borderTop: 'none',
       },
-
       '&.euiDataGrid--headerUnderline .euiDataGridHeader': {
         borderBottom: euiTheme.border.thin,
-      },
-
-      '& [data-gridcell-column-id="name"] .euiDataGridRowCell__content': {
-        paddingTop: 0,
-        paddingBottom: 0,
-      },
-
-      '.kbnDocViewer__fieldName': {
-        padding: euiTheme.size.xs,
-        paddingLeft: 0,
-        lineHeight: euiTheme.font.lineHeightMultiplier,
-
-        '.euiDataGridRowCell__popover &': {
-          fontSize,
-        },
-      },
-
-      '.kbnDocViewer__fieldName_icon': {
-        paddingTop: `calc(${euiTheme.size.xs} * 1.5)`,
-        lineHeight: euiTheme.font.lineHeightMultiplier,
       },
     });
   },
 };
+
+// Cell action component creator, to copy the field path to the clipboard
+const CopyFieldPathText = i18n.translate('workflows.jsonDataTable.copyFieldPath', {
+  defaultMessage: 'Copy field path',
+});
+const getCopyCellActionComponent = (
+  records: JSONDataTableRecord[],
+  fieldPathPrefix: string,
+  closePopover: () => void
+): EuiDataGridColumnCellAction =>
+  React.memo(({ rowIndex, Component }) => {
+    const row = records[rowIndex];
+    const copy = useCallback(() => {
+      copyToClipboard(`${fieldPathPrefix}.${row.flattened.field}`);
+      closePopover();
+    }, [row.flattened.field]);
+
+    return (
+      <Component onClick={copy} iconType="copyClipboard" aria-label={CopyFieldPathText}>
+        {CopyFieldPathText}
+      </Component>
+    );
+  });

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/json_data_view.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/json_data_view.test.tsx
@@ -1,0 +1,290 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { JSONDataView } from './json_data_view';
+
+// Mock the child components
+const mockJSONDataTable = jest.fn();
+const mockJsonDataCode = jest.fn();
+
+jest.mock('./json_data_table', () => ({
+  JSONDataTable: (props: any) => {
+    mockJSONDataTable(props);
+    return <div data-test-subj="mocked-json-data-table">Table View</div>;
+  },
+}));
+
+jest.mock('./json_data_code', () => ({
+  JsonDataCode: (props: any) => {
+    mockJsonDataCode(props);
+    return <div data-test-subj="mocked-json-data-code">JSON View</div>;
+  },
+}));
+
+// Mock useLocalStorage hook
+const mockSetStoredSearchTerm = jest.fn();
+const mockStoredSearchTerm = jest.fn();
+
+jest.mock('react-use/lib/useLocalStorage', () => ({
+  __esModule: true,
+  default: jest.fn(() => [mockStoredSearchTerm(), mockSetStoredSearchTerm]),
+}));
+
+describe('JSONDataView', () => {
+  const mockData = {
+    name: 'test',
+    value: 123,
+    nested: {
+      field: 'abc',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStoredSearchTerm.mockReturnValue('');
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  describe('rendering', () => {
+    it('should render the component with default props', () => {
+      render(<JSONDataView data={mockData} />);
+
+      expect(screen.getByTestId('jsonDataTable')).toBeInTheDocument();
+      expect(screen.getByTestId('mocked-json-data-table')).toBeInTheDocument();
+    });
+
+    it('should render with custom title and fieldPathActionsPrefix', () => {
+      render(
+        <JSONDataView data={mockData} title="Custom Title" fieldPathActionsPrefix="custom.prefix" />
+      );
+
+      expect(mockJSONDataTable).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: mockData,
+          title: 'Custom Title',
+          fieldPathActionsPrefix: 'custom.prefix',
+        })
+      );
+    });
+
+    it('should render in table view mode by default', () => {
+      render(<JSONDataView data={mockData} />);
+
+      expect(screen.getByTestId('mocked-json-data-table')).toBeInTheDocument();
+      expect(screen.queryByTestId('mocked-json-data-code')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('view mode toggle', () => {
+    it('should switch to JSON view when JSON button is clicked', () => {
+      render(<JSONDataView data={mockData} />);
+
+      // Initially in table view
+      expect(screen.getByTestId('mocked-json-data-table')).toBeInTheDocument();
+
+      // Find and click the JSON view button
+      const jsonButton = screen.getByTestId('json');
+
+      fireEvent.click(jsonButton);
+
+      // Should now show JSON view
+      expect(screen.queryByTestId('mocked-json-data-table')).not.toBeInTheDocument();
+      expect(screen.getByTestId('mocked-json-data-code')).toBeInTheDocument();
+    });
+
+    it('should switch back to table view when table button is clicked', () => {
+      render(<JSONDataView data={mockData} />);
+
+      // Switch to JSON view
+      const jsonButton = screen.getByTestId('json');
+      fireEvent.click(jsonButton);
+
+      // Switch back to table view
+      const tableButton = screen.getByTestId('table');
+      fireEvent.click(tableButton);
+
+      // Should show table view again
+      expect(screen.getByTestId('mocked-json-data-table')).toBeInTheDocument();
+      expect(screen.queryByTestId('mocked-json-data-code')).not.toBeInTheDocument();
+    });
+
+    it('should pass data to JsonDataCode when in JSON view', () => {
+      render(<JSONDataView data={mockData} />);
+
+      // Switch to JSON view
+      const jsonButton = screen.getByTestId('json');
+      fireEvent.click(jsonButton);
+
+      expect(mockJsonDataCode).toHaveBeenCalledWith({ json: mockData });
+    });
+  });
+
+  describe('search functionality', () => {
+    it('should display search field in table view', () => {
+      render(<JSONDataView data={mockData} />);
+
+      const searchInput = screen.getByPlaceholderText('Filter by field, value');
+      expect(searchInput).toBeInTheDocument();
+    });
+
+    it('should not display search field in JSON view', () => {
+      render(<JSONDataView data={mockData} />);
+
+      // Switch to JSON view
+      const jsonButton = screen.getByTestId('json');
+      fireEvent.click(jsonButton);
+
+      const searchInput = screen.queryByPlaceholderText('Filter by field, value');
+      expect(searchInput).not.toBeInTheDocument();
+    });
+
+    it('should update search term when user types in search field', async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<JSONDataView data={mockData} />);
+
+      const searchInput = screen.getByPlaceholderText('Filter by field, value');
+      await user.type(searchInput, 'test query');
+
+      expect(searchInput).toHaveValue('test query');
+    });
+
+    it('should pass search term to JSONDataTable', async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<JSONDataView data={mockData} />);
+
+      const searchInput = screen.getByPlaceholderText('Filter by field, value');
+      await user.type(searchInput, 'test');
+
+      // The last call should have the search term
+      const lastCall = mockJSONDataTable.mock.calls[mockJSONDataTable.mock.calls.length - 1][0];
+      expect(lastCall.searchTerm).toBe('test');
+    });
+
+    it('should debounce storing search term in localStorage', async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<JSONDataView data={mockData} />);
+
+      const searchInput = screen.getByPlaceholderText('Filter by field, value');
+      await user.type(searchInput, 'test');
+
+      // Should not have called setStoredSearchTerm yet
+      expect(mockSetStoredSearchTerm).not.toHaveBeenCalled();
+
+      // Fast-forward time by 500ms (debounce delay)
+      jest.advanceTimersByTime(500);
+
+      // Now it should have been called
+      await waitFor(() => {
+        expect(mockSetStoredSearchTerm).toHaveBeenCalledWith('test');
+      });
+    });
+
+    it('should load initial search term from localStorage', () => {
+      mockStoredSearchTerm.mockReturnValue('stored search');
+      render(<JSONDataView data={mockData} />);
+
+      const searchInput = screen.getByPlaceholderText('Filter by field, value');
+      expect(searchInput).toHaveValue('stored search');
+    });
+
+    it('should clear search term when clear button is clicked', async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<JSONDataView data={mockData} />);
+
+      const searchInput = screen.getByPlaceholderText('Filter by field, value');
+      await user.type(searchInput, 'test query');
+
+      // Find and click the clear button (it's inside the search field)
+      const clearButton = searchInput.parentElement?.querySelector(
+        '[data-test-subj*="clearSearchButton"]'
+      );
+      if (clearButton) {
+        await user.click(clearButton);
+      }
+
+      // Search should be cleared
+      expect(searchInput).toHaveValue('');
+    });
+  });
+
+  describe('data handling', () => {
+    it('should handle empty data object', () => {
+      render(<JSONDataView data={{}} />);
+
+      expect(mockJSONDataTable).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {},
+        })
+      );
+    });
+
+    it('should handle complex nested data', () => {
+      const complexData = {
+        level1: {
+          level2: {
+            level3: {
+              value: 'deep',
+            },
+          },
+          array: [1, 2, 3],
+        },
+        date: '2024-01-01',
+        boolean: true,
+        null: null,
+      };
+
+      render(<JSONDataView data={complexData} />);
+
+      expect(mockJSONDataTable).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: complexData,
+        })
+      );
+    });
+  });
+
+  describe('props propagation', () => {
+    it('should propagate all props to JSONDataTable in table view', () => {
+      render(
+        <JSONDataView data={mockData} title="Test Title" fieldPathActionsPrefix="test.prefix" />
+      );
+
+      expect(mockJSONDataTable).toHaveBeenCalledWith({
+        data: mockData,
+        title: 'Test Title',
+        searchTerm: '',
+        fieldPathActionsPrefix: 'test.prefix',
+      });
+    });
+
+    it('should update JSONDataTable props when search term changes', async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<JSONDataView data={mockData} />);
+
+      // Clear previous calls
+      mockJSONDataTable.mockClear();
+
+      const searchInput = screen.getByPlaceholderText('Filter by field, value');
+      await user.type(searchInput, 'new');
+
+      // Should have been called multiple times (once per character)
+      expect(mockJSONDataTable.mock.calls.length).toBeGreaterThan(0);
+      const lastCall = mockJSONDataTable.mock.calls[mockJSONDataTable.mock.calls.length - 1][0];
+      expect(lastCall.searchTerm).toBe('new');
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/json_data_view.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/json_data_view/json_data_view.tsx
@@ -7,11 +7,31 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { EuiFlexItem, EuiFlexGroup, EuiButtonGroup, EuiSpacer, EuiFieldSearch } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { debounce } from 'lodash';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { JsonDataCode } from './json_data_code';
 import { JSONDataTable } from './json_data_table';
+
+const SearchTermStorageKey = 'workflows_management.step_execution.searchTerm';
+const ViewModeOptions = [
+  {
+    id: 'table',
+    label: i18n.translate('workflows.jsonDataTable.viewMode.table', {
+      defaultMessage: 'Table',
+    }),
+    iconType: 'tableDensityNormal',
+  },
+  {
+    id: 'json',
+    label: i18n.translate('workflows.jsonDataTable.viewMode.json', {
+      defaultMessage: 'JSON',
+    }),
+    iconType: 'code',
+  },
+];
 
 export interface JSONDataViewProps {
   /**
@@ -19,138 +39,95 @@ export interface JSONDataViewProps {
    * If an array is provided, only the first object will be displayed.
    * If a primitive value is provided, it will be wrapped in an object.
    */
-  data: Record<string, unknown> | Record<string, unknown>[] | unknown;
-
-  /**
-   * Optional title for the data view. Defaults to 'JSON Data'
-   */
+  data: Record<string, unknown>;
+  /** Optional title for the data view. Defaults to 'JSON Data' */
   title?: string;
-
-  /**
-   * Optional columns to display. If not provided, all keys from the data will be used.
-   */
-  columns?: string[];
-
-  /**
-   * Optional search term to filter the data.
-   */
-  searchTerm?: string;
-
-  /**
-   * Optional function to set the search term.
-   */
-  onSearchTermChange?: (value: string) => void;
-
-  /**
-   * Test subject for testing purposes
-   */
-  'data-test-subj'?: string;
+  /** Optional prefix for the field path actions, such as the copy the field path to the clipboard. */
+  fieldPathActionsPrefix?: string;
 }
 
-export function JSONDataView({
-  data,
-  title = 'JSON Data',
-  columns,
-  searchTerm,
-  onSearchTermChange,
-  'data-test-subj': dataTestSubj = 'jsonDataTable',
-}: JSONDataViewProps) {
-  const [viewMode, setViewMode] = useState<'table' | 'json'>('table');
+export const JSONDataView = React.memo<JSONDataViewProps>(
+  ({ data, title, fieldPathActionsPrefix }) => {
+    const [viewMode, setViewMode] = useState<'table' | 'json'>('table');
 
-  // Convert data to object format if needed
-  const jsonObject = useMemo(() => {
-    if (Array.isArray(data)) {
-      return data[0] || {};
-    }
+    const [storedSearchTerm, setStoredSearchTerm] = useLocalStorage(SearchTermStorageKey, '');
+    const [searchTerm, setSearchTerm] = useState(storedSearchTerm ?? '');
 
-    // If data is already an object, use it directly
-    if (data && typeof data === 'object' && data !== null) {
-      return data as Record<string, unknown>;
-    }
+    const setStoredSearchTermDebounced = useMemo(
+      () => debounce(setStoredSearchTerm, 500),
+      [setStoredSearchTerm]
+    );
 
-    // For primitive values, wrap them in an object
-    if (data !== undefined && data !== null) {
-      return { value: data };
-    }
+    const handleSearchTermChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { value } = e.target;
+        setSearchTerm(value);
+        setStoredSearchTermDebounced(value);
+      },
+      [setStoredSearchTermDebounced]
+    );
 
-    return {};
-  }, [data]);
-
-  return (
-    <EuiFlexGroup
-      data-test-subj={dataTestSubj}
-      direction="column"
-      gutterSize="none"
-      responsive={false}
-      style={{ height: '100%' }}
-    >
-      <EuiFlexItem grow={false}>
-        <EuiFlexGroup responsive={false} gutterSize="s">
-          {viewMode === 'table' && onSearchTermChange && (
-            <EuiFlexItem>
-              <EuiFieldSearch
-                compressed
-                fullWidth
-                placeholder="Filter by field, value"
-                value={searchTerm}
-                onChange={(e) => onSearchTermChange(e.target.value)}
-                isClearable
-                aria-label={i18n.translate('workflows.jsonDataTable.searchAriaLabel', {
-                  defaultMessage: 'Search fields and values',
+    return (
+      <EuiFlexGroup
+        data-test-subj={'jsonDataTable'}
+        direction="column"
+        gutterSize="none"
+        responsive={false}
+        style={{ height: '100%' }}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup responsive={false} gutterSize="s">
+            {viewMode === 'table' && (
+              <EuiFlexItem>
+                <EuiFieldSearch
+                  compressed
+                  fullWidth
+                  placeholder="Filter by field, value"
+                  value={searchTerm}
+                  onChange={handleSearchTermChange}
+                  isClearable
+                  aria-label={i18n.translate('workflows.jsonDataTable.searchAriaLabel', {
+                    defaultMessage: 'Search fields and values',
+                  })}
+                />
+              </EuiFlexItem>
+            )}
+            <EuiFlexItem
+              grow={false}
+              css={{
+                justifySelf: 'flex-end',
+                marginLeft: 'auto',
+              }}
+            >
+              <EuiButtonGroup
+                isIconOnly
+                buttonSize="compressed"
+                color="primary"
+                type="single"
+                idSelected={viewMode}
+                legend={i18n.translate('workflows.jsonDataTable.viewMode', {
+                  defaultMessage: 'View mode',
                 })}
+                onChange={(id) => setViewMode(id as 'table' | 'json')}
+                options={ViewModeOptions}
               />
             </EuiFlexItem>
-          )}
-          <EuiFlexItem
-            grow={false}
-            css={{
-              justifySelf: 'flex-end',
-              marginLeft: 'auto',
-            }}
-          >
-            <EuiButtonGroup
-              isIconOnly
-              buttonSize="compressed"
-              color="primary"
-              type="single"
-              idSelected={viewMode}
-              legend={i18n.translate('workflows.jsonDataTable.viewMode', {
-                defaultMessage: 'View mode',
-              })}
-              onChange={(id) => setViewMode(id as 'table' | 'json')}
-              options={[
-                {
-                  id: 'table',
-                  label: i18n.translate('workflows.jsonDataTable.viewMode.table', {
-                    defaultMessage: 'Table',
-                  }),
-                  iconType: 'tableDensityNormal',
-                },
-                {
-                  id: 'json',
-                  label: i18n.translate('workflows.jsonDataTable.viewMode.json', {
-                    defaultMessage: 'JSON',
-                  }),
-                  iconType: 'code',
-                },
-              ]}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
 
-      <EuiFlexItem grow={true}>
-        <EuiSpacer size="s" />
-        {viewMode === 'table' && (
-          <JSONDataTable
-            data={jsonObject}
-            title={title}
-            columns={columns}
-            searchTerm={searchTerm}
-          />
-        )}
-        {viewMode === 'json' && <JsonDataCode json={jsonObject} />}
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
-}
+        <EuiFlexItem grow={true}>
+          <EuiSpacer size="s" />
+          {viewMode === 'table' && (
+            <JSONDataTable
+              data={data}
+              title={title}
+              searchTerm={searchTerm}
+              fieldPathActionsPrefix={fieldPathActionsPrefix}
+            />
+          )}
+          {viewMode === 'json' && <JsonDataCode json={data} />}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/security-team/issues/14236

Implements the "copy field context path" cell action in the step execution data grid.

It can be executed in the first action icon when hovering the name cell, or after expanding the cell in the popover.

### Demo

https://github.com/user-attachments/assets/3e15e14b-45f9-47ca-b6d1-e70b82bb5bb6




