### PR TITLE
[Navigation] Remove performance, reintroduce missing ML links, maintenance windows

### DIFF
--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -472,9 +472,6 @@ export const createNavigationTree = ({
                     cloudLink: 'billingAndSub',
                   },
                   {
-                    cloudLink: 'performance',
-                  },
-                  {
                     cloudLink: 'userAndRoles',
                     title: i18n.translate('xpack.serverlessObservability.navLinks.usersAndRoles', {
                       defaultMessage: 'Members',
@@ -495,6 +492,7 @@ export const createNavigationTree = ({
                   { link: 'management:triggersActionsAlerts' },
                   { link: 'management:triggersActions' },
                   { link: 'management:triggersActionsConnectors', breadcrumbStatus: 'hidden' },
+                  { link: 'management:maintenanceWindows' },
                 ],
               },
               {
@@ -506,7 +504,12 @@ export const createNavigationTree = ({
                   }
                 ),
                 breadcrumbStatus: 'hidden',
-                children: [{ link: 'management:trained_models' }],
+                children: [
+                  { link: 'management:overview' },
+                  { link: 'management:anomaly_detection' },
+                  { link: 'management:analytics' },
+                  { link: 'management:trained_models' },
+                ],
               },
               ...filterForFeatureAvailability(
                 {

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -436,6 +436,7 @@ export const createNavigationTree = ({
                   { link: 'management:transform' },
                   { link: 'management:rollup_jobs' },
                   { link: 'management:data_quality' },
+                  { link: 'management:data_usage' },
                 ],
               },
             ],
@@ -532,14 +533,6 @@ export const createNavigationTree = ({
                 },
                 overviewAvailable
               ),
-              {
-                id: 'data',
-                title: i18n.translate('xpack.serverlessObservability.nav.projectSettings.data', {
-                  defaultMessage: 'Data',
-                }),
-                breadcrumbStatus: 'hidden',
-                children: [{ link: 'management:data_usage' }],
-              },
               {
                 id: 'content',
                 title: i18n.translate('xpack.serverlessObservability.nav.projectSettings.content', {

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -495,22 +495,25 @@ export const createNavigationTree = ({
                   { link: 'management:maintenanceWindows' },
                 ],
               },
-              {
-                id: 'machine_learning',
-                title: i18n.translate(
-                  'xpack.serverlessObservability.nav.projectSettings.machineLearning',
-                  {
-                    defaultMessage: 'Machine Learning',
-                  }
-                ),
-                breadcrumbStatus: 'hidden',
-                children: [
-                  { link: 'management:overview' },
-                  { link: 'management:anomaly_detection' },
-                  { link: 'management:analytics' },
-                  { link: 'management:trained_models' },
-                ],
-              },
+              ...filterForFeatureAvailability(
+                {
+                  id: 'machine_learning',
+                  title: i18n.translate(
+                    'xpack.serverlessObservability.nav.projectSettings.machineLearning',
+                    {
+                      defaultMessage: 'Machine Learning',
+                    }
+                  ),
+                  breadcrumbStatus: 'hidden',
+                  children: [
+                    { link: 'management:overview' },
+                    { link: 'management:anomaly_detection' },
+                    { link: 'management:analytics' },
+                    { link: 'management:trained_models' },
+                  ],
+                },
+                overviewAvailable
+              ),
               ...filterForFeatureAvailability(
                 {
                   title: i18n.translate('xpack.serverlessObservability.nav.projectSettings.ai', {


### PR DESCRIPTION
## Summary

Earlier this week we pushed updates for the v2 serverless nav. We noted that a few links are still missing from that nav that must be reintroduced, and we do not want to include the performance cloud link.

This patch will:
- add in Overview, Anomaly Detection, Data Frame Analytics links to the management -> ml portion of the o11y serverless nav.
- remove the performance cloud link
- add maintenance windows to management -> alerts and insights

Updated screenshot:

<img width="329" height="1252" alt="image" src="https://github.com/user-attachments/assets/bfce777b-051b-4bc7-a229-4391bda5ab0a" />
