### PR TITLE
Remove faulty Kibana-loaded performance mark

### DIFF
--- a/src/core/packages/rendering/server-internal/src/bootstrap/render_template.ts
+++ b/src/core/packages/rendering/server-internal/src/bootstrap/render_template.ts
@@ -155,10 +155,6 @@ if (window.__kbnStrictCsp__ && window.__kbnCspNotEnforced__) {
       });
     }
 
-    performance.mark('kbnLoad', {
-      detail: 'load_started',
-    })
-
     load([
       ${jsDependencyPaths.map((path) => `'${path}'`).join(',')}
     ], function () {


### PR DESCRIPTION
## Summary

This mark is set many times, almost certainly as an accident and I couldn't see anywhere it is currently used.

<img width="1051" height="157" alt="Screenshot 2025-10-09 at 2 48 56 PM" src="https://github.com/user-attachments/assets/22b845c3-edf6-41dd-9aec-8a9ee2f35d6d" />

I thought it was worth cleaning up because it could be misleading to those doing performance investigations.