### PR TITLE
[9.0] [Visualize] Improve list error handling (#238355)

### DIFF
--- a/src/platform/plugins/shared/visualizations/public/vis_types/vis_type_alias_registry.ts
+++ b/src/platform/plugins/shared/visualizations/public/vis_types/vis_type_alias_registry.ts
@@ -23,7 +23,7 @@ export interface VisualizationListItem {
   error?: string;
   icon: string;
   id: string;
-  stage: VisualizationStage;
+  stage?: VisualizationStage;
   savedObjectType: string;
   title: string;
   description?: string;
@@ -31,7 +31,7 @@ export interface VisualizationListItem {
   typeTitle: string;
   image?: string;
   type?: BaseVisType | string;
-  editor:
+  editor?:
     | { editUrl: string; editApp?: string }
     | { onEdit: (savedObjectId: string) => Promise<void> };
 }

--- a/src/platform/plugins/shared/visualizations/public/visualize_app/components/visualize_listing.tsx
+++ b/src/platform/plugins/shared/visualizations/public/visualize_app/components/visualize_listing.tsx
@@ -46,10 +46,10 @@ import type { VisualizationListItem } from '../..';
 import type { VisualizeServices } from '../types';
 import { VisualizeConstants } from '../../../common/constants';
 import { getNoItemsMessage, getCustomColumn, getCustomSortingOptions } from '../utils';
-import { getVisualizeListItemLink } from '../utils/get_visualize_list_item_link';
+import { getVisualizeListItemLinkFn } from '../utils/get_visualize_list_item_link';
 import type { VisualizationStage } from '../../vis_types/vis_type_alias_registry';
 
-type VisualizeUserContent = VisualizationListItem &
+export type VisualizeUserContent = VisualizationListItem &
   UserContentCommonSchema & {
     type: string;
     attributes: {
@@ -119,7 +119,7 @@ const useTableListViewProps = (
   }, [closeNewVisModal]);
 
   const editItem = useCallback(
-    async ({ attributes: { id }, editor }: VisualizeUserContent) => {
+    async ({ attributes: { id }, editor = { editUrl: '' } }: VisualizeUserContent) => {
       if (!('editApp' in editor || 'editUrl' in editor)) {
         await editor.onEdit(id);
         return;
@@ -345,6 +345,11 @@ export const VisualizeListing = () => {
   });
   useUnmount(() => closeNewVisModal.current());
 
+  const getVisualizeListItemLink = useMemo(
+    () => getVisualizeListItemLinkFn(application, kbnUrlStateStorage),
+    [application, kbnUrlStateStorage]
+  );
+
   const listingLimit = uiSettings.get(SAVED_OBJECTS_LIMIT_SETTING);
   const initialPageSize = uiSettings.get(SAVED_OBJECTS_PER_PAGE_SETTING);
 
@@ -406,19 +411,11 @@ export const VisualizeListing = () => {
               defaultMessage: 'visualizations',
             })}
             getOnClickTitle={(item) =>
-              item.attributes.readOnly ? undefined : () => tableViewProps.editItem?.(item)
-            }
-            getDetailViewLink={({ editor, attributes: { error, readOnly } }) =>
-              readOnly || (editor && 'onEdit' in editor)
+              item.attributes.readOnly || item.error
                 ? undefined
-                : getVisualizeListItemLink(
-                    application,
-                    kbnUrlStateStorage,
-                    editor.editApp,
-                    editor.editUrl,
-                    error
-                  )
+                : () => tableViewProps.editItem?.(item)
             }
+            getDetailViewLink={getVisualizeListItemLink}
             tableCaption={visualizeLibraryTitle}
             {...tableViewProps}
             {...propsFromParent}
@@ -429,8 +426,8 @@ export const VisualizeListing = () => {
   }, [
     application,
     dashboardCapabilities.createNew,
+    getVisualizeListItemLink,
     initialPageSize,
-    kbnUrlStateStorage,
     listingLimit,
     tableViewProps,
     visualizeLibraryTitle,

--- a/src/platform/plugins/shared/visualizations/public/visualize_app/utils/get_table_columns.tsx
+++ b/src/platform/plugins/shared/visualizations/public/visualize_app/utils/get_table_columns.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { EuiBetaBadge, EuiButton, EuiEmptyPrompt, EuiIcon, EuiBadge } from '@elastic/eui';
+import { EuiBetaBadge, EuiButton, EuiEmptyPrompt, EuiIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { CustomSortingOptions } from '@kbn/content-management-table-list-view-table';
@@ -49,23 +49,20 @@ const getBadge = (item: VisualizationListItem) => {
 };
 
 const renderItemTypeIcon = (item: VisualizationListItem) => {
-  let icon;
   if (item.image) {
-    icon = (
+    return (
       <img className="visListingTable__typeImage" aria-hidden="true" alt="" src={item.image} />
-    );
-  } else {
-    icon = (
-      <EuiIcon
-        className="visListingTable__typeIcon"
-        aria-hidden="true"
-        type={item.icon || 'empty'}
-        size="m"
-      />
     );
   }
 
-  return icon;
+  return (
+    <EuiIcon
+      className="visListingTable__typeIcon"
+      aria-hidden="true"
+      type={item.icon || 'empty'}
+      size="m"
+    />
+  );
 };
 
 export const getCustomColumn = () => {
@@ -76,18 +73,50 @@ export const getCustomColumn = () => {
     }),
     sortable: true,
     width: '150px',
-    render: (field: string, record: VisualizationListItem) =>
-      !record.error ? (
-        <span>
-          {renderItemTypeIcon(record)}
-          {record.typeTitle}
-          {getBadge(record)}
-        </span>
-      ) : (
-        <EuiBadge iconType="warning" color="warning">
-          {record.error}
-        </EuiBadge>
-      ),
+    render: (field: string, record: VisualizationListItem) => {
+      if (!record.error) {
+        return (
+          <span>
+            {renderItemTypeIcon(record)}
+            {record.typeTitle}
+            {getBadge(record)}
+          </span>
+        );
+      }
+
+      if (!record.typeTitle) {
+        return (
+          <EuiToolTip position="left" content={record.error}>
+            <span>
+              <EuiIcon
+                className="visListingTable__typeIcon"
+                aria-hidden="true"
+                color="warning"
+                type="warning"
+                size="m"
+              />
+              <FormattedMessage id="visualizations.listing.type.unknown" defaultMessage="Unknown" />
+            </span>
+          </EuiToolTip>
+        );
+      }
+
+      // We should have a way to display generic item errors from TableListViewTable
+      return (
+        <EuiToolTip position="left" content={record.error}>
+          <span>
+            <EuiIcon
+              className="visListingTable__typeIcon"
+              aria-hidden="true"
+              color="danger"
+              type="error"
+              size="m"
+            />
+            <FormattedMessage id="visualizations.listing.type.error" defaultMessage="Error" />
+          </span>
+        </EuiToolTip>
+      );
+    },
   };
 };
 

--- a/src/platform/plugins/shared/visualizations/public/visualize_app/utils/get_visualize_list_item_link.test.ts
+++ b/src/platform/plugins/shared/visualizations/public/visualize_app/utils/get_visualize_list_item_link.test.ts
@@ -7,12 +7,35 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getVisualizeListItemLink } from './get_visualize_list_item_link';
-import { ApplicationStart } from '@kbn/core/public';
+import { getVisualizeListItemLinkFn } from './get_visualize_list_item_link';
+import type { ApplicationStart } from '@kbn/core/public';
 import { createHashHistory } from 'history';
 import { FilterStateStore } from '@kbn/es-query';
 import { createKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 import { GLOBAL_STATE_STORAGE_KEY } from '../../../common/constants';
+import type { VisualizeUserContent } from '../components/visualize_listing';
+
+const mockItem: VisualizeUserContent = {
+  id: '9886b410-4c8b-11e8-b3d7-01146121b73d',
+  updatedAt: '2025-10-09T20:35:02.807Z',
+  managed: false,
+  references: [],
+  type: 'visualization',
+  icon: 'visBarVertical',
+  savedObjectType: 'visualization',
+  typeTitle: 'Vertical bar',
+  title: '[Flights] Delay Buckets',
+  error: '',
+  editor: {
+    editUrl: '/edit/9886b410-4c8b-11e8-b3d7-01146121b73d',
+  },
+  attributes: {
+    id: '9886b410-4c8b-11e8-b3d7-01146121b73d',
+    title: '[Flights] Delay Buckets',
+    description: '',
+    readOnly: false,
+  },
+};
 
 jest.mock('../../services', () => {
   return {
@@ -36,17 +59,74 @@ const kbnUrlStateStorage = createKbnUrlStateStorage({
 kbnUrlStateStorage.set(GLOBAL_STATE_STORAGE_KEY, { time: { from: 'now-7d', to: 'now' } });
 
 describe('listing item link is correct for each app', () => {
+  const getVisualizeListItemLink = getVisualizeListItemLinkFn(application, kbnUrlStateStorage);
+
+  test('returns undefined if readOnly', async () => {
+    const testItem: VisualizeUserContent = {
+      ...mockItem,
+      attributes: {
+        ...mockItem.attributes,
+        readOnly: true,
+      },
+    };
+    const url = getVisualizeListItemLink(testItem);
+    expect(url).toBe(undefined);
+  });
+
+  test('returns undefined if has error', async () => {
+    const testItem: VisualizeUserContent = {
+      ...mockItem,
+      attributes: {
+        ...mockItem.attributes,
+        error: 'error here',
+      },
+    };
+    const url = getVisualizeListItemLink(testItem);
+    expect(url).toBe(undefined);
+  });
+
+  test('returns undefined if onEdit is in editor', async () => {
+    const testItem: VisualizeUserContent = {
+      ...mockItem,
+      editor: { onEdit: async () => {} },
+    };
+    const url = getVisualizeListItemLink(testItem);
+    expect(url).toBe(undefined);
+  });
+
+  test('returns undefined if no editor', async () => {
+    const testItem: VisualizeUserContent = {
+      ...mockItem,
+      editor: undefined,
+    };
+    const url = getVisualizeListItemLink(testItem);
+    expect(url).toBe(undefined);
+  });
+
   test('creates a link to classic visualization if editApp is not defined', async () => {
     const editUrl = 'edit/id';
-    const url = getVisualizeListItemLink(application, kbnUrlStateStorage, undefined, editUrl);
-    expect(url).toMatchInlineSnapshot(`"/app/visualize#${editUrl}?_g=(time:(from:now-7d,to:now))"`);
+    const testItem: VisualizeUserContent = {
+      ...mockItem,
+      editor: {
+        editUrl,
+      },
+    };
+    const url = getVisualizeListItemLink(testItem);
+    expect(url).toBe(`/app/visualize#${editUrl}?_g=(time:(from:now-7d,to:now))`);
   });
 
   test('creates a link for the app given if editApp is defined', async () => {
     const editUrl = '#/edit/id';
     const editApp = 'lens';
-    const url = getVisualizeListItemLink(application, kbnUrlStateStorage, editApp, editUrl);
-    expect(url).toMatchInlineSnapshot(`"/app/${editApp}${editUrl}?_g=(time:(from:now-7d,to:now))"`);
+    const testItem: VisualizeUserContent = {
+      ...mockItem,
+      editor: {
+        editUrl,
+        editApp,
+      },
+    };
+    const url = getVisualizeListItemLink(testItem);
+    expect(url).toBe(`/app/${editApp}${editUrl}?_g=(time:(from:now-7d,to:now))`);
   });
 
   describe('when global time changes', () => {
@@ -62,9 +142,16 @@ describe('listing item link is correct for each app', () => {
     test('it propagates the correct time on the query', async () => {
       const editUrl = '#/edit/id';
       const editApp = 'lens';
-      const url = getVisualizeListItemLink(application, kbnUrlStateStorage, editApp, editUrl);
-      expect(url).toMatchInlineSnapshot(
-        `"/app/${editApp}${editUrl}?_g=(time:(from:'2021-01-05T11:45:53.375Z',to:'2021-01-21T11:46:00.990Z'))"`
+      const testItem: VisualizeUserContent = {
+        ...mockItem,
+        editor: {
+          editUrl,
+          editApp,
+        },
+      };
+      const url = getVisualizeListItemLink(testItem);
+      expect(url).toBe(
+        `/app/${editApp}${editUrl}?_g=(time:(from:'2021-01-05T11:45:53.375Z',to:'2021-01-21T11:46:00.990Z'))`
       );
     });
   });
@@ -79,10 +166,15 @@ describe('listing item link is correct for each app', () => {
     test('it propagates the refreshInterval on the query', async () => {
       const editUrl = '#/edit/id';
       const editApp = 'lens';
-      const url = getVisualizeListItemLink(application, kbnUrlStateStorage, editApp, editUrl);
-      expect(url).toMatchInlineSnapshot(
-        `"/app/${editApp}${editUrl}?_g=(refreshInterval:(pause:!f,value:300))"`
-      );
+      const testItem: VisualizeUserContent = {
+        ...mockItem,
+        editor: {
+          editUrl,
+          editApp,
+        },
+      };
+      const url = getVisualizeListItemLink(testItem);
+      expect(url).toBe(`/app/${editApp}${editUrl}?_g=(refreshInterval:(pause:!f,value:300))`);
     });
   });
 
@@ -117,9 +209,16 @@ describe('listing item link is correct for each app', () => {
     test('propagates the filters on the query', async () => {
       const editUrl = '#/edit/id';
       const editApp = 'lens';
-      const url = getVisualizeListItemLink(application, kbnUrlStateStorage, editApp, editUrl);
-      expect(url).toMatchInlineSnapshot(
-        `"/app/${editApp}${editUrl}?_g=(filters:!((meta:(alias:!n,disabled:!f,negate:!f),query:(query:q1)),('$state':(store:globalState),meta:(alias:!n,disabled:!f,negate:!f),query:(query:q1))))"`
+      const testItem: VisualizeUserContent = {
+        ...mockItem,
+        editor: {
+          editUrl,
+          editApp,
+        },
+      };
+      const url = getVisualizeListItemLink(testItem);
+      expect(url).toBe(
+        `/app/${editApp}${editUrl}?_g=(filters:!((meta:(alias:!n,disabled:!f,negate:!f),query:(query:q1)),('$state':(store:globalState),meta:(alias:!n,disabled:!f,negate:!f),query:(query:q1))))`
       );
     });
   });

--- a/src/platform/plugins/shared/visualizations/public/visualize_app/utils/get_visualize_list_item_link.ts
+++ b/src/platform/plugins/shared/visualizations/public/visualize_app/utils/get_visualize_list_item_link.ts
@@ -13,31 +13,33 @@ import { GlobalQueryStateFromUrl } from '@kbn/data-plugin/public';
 import { setStateToKbnUrl } from '@kbn/kibana-utils-plugin/public';
 import { getUISettings } from '../../services';
 import { GLOBAL_STATE_STORAGE_KEY, VISUALIZE_APP_NAME } from '../../../common/constants';
+import type { VisualizeUserContent } from '../components/visualize_listing';
 
-export const getVisualizeListItemLink = (
-  application: ApplicationStart,
-  kbnUrlStateStorage: IKbnUrlStateStorage,
-  editApp: string | undefined,
-  editUrl: string | undefined,
-  error: string | undefined = undefined
-) => {
-  if (error || (!editApp && !editUrl)) {
-    return undefined;
-  }
+export const getVisualizeListItemLinkFn =
+  (application: ApplicationStart, kbnUrlStateStorage: IKbnUrlStateStorage) =>
+  (item: VisualizeUserContent) => {
+    const {
+      editor,
+      attributes: { error, readOnly },
+    } = item;
+    if (readOnly || (editor && 'onEdit' in editor)) return;
 
-  // for visualizations the editApp is undefined
-  let url = application.getUrlForApp(editApp ?? VISUALIZE_APP_NAME, {
-    path: editApp ? editUrl : `#${editUrl}`,
-  });
-  const useHash = getUISettings().get('state:storeInSessionStorage');
-  const globalStateInUrl =
-    kbnUrlStateStorage.get<GlobalQueryStateFromUrl>(GLOBAL_STATE_STORAGE_KEY) || {};
+    const { editApp, editUrl } = editor ?? {};
+    if (error || (!editApp && !editUrl)) return;
 
-  url = setStateToKbnUrl<GlobalQueryStateFromUrl>(
-    GLOBAL_STATE_STORAGE_KEY,
-    globalStateInUrl,
-    { useHash },
-    url
-  );
-  return url;
-};
+    // for visualizations the editApp is undefined
+    let url = application.getUrlForApp(editApp ?? VISUALIZE_APP_NAME, {
+      path: editApp ? editUrl : `#${editUrl}`,
+    });
+    const useHash = getUISettings().get('state:storeInSessionStorage');
+    const globalStateInUrl =
+      kbnUrlStateStorage.get<GlobalQueryStateFromUrl>(GLOBAL_STATE_STORAGE_KEY) || {};
+
+    url = setStateToKbnUrl<GlobalQueryStateFromUrl>(
+      GLOBAL_STATE_STORAGE_KEY,
+      globalStateInUrl,
+      { useHash },
+      url
+    );
+    return url;
+  };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Visualize] Improve list error handling (#238355)](https://github.com/elastic/kibana/pull/238355)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Partridge","email":"nicholas.partridge@elastic.co"},"sourceCommit":{"committedDate":"2025-10-13T16:55:35Z","message":"[Visualize] Improve list error handling (#238355)\n\nFixes an error in the **Visualize Listing** page in which an error in\nthe vis could cause the entire page to error. This improves the error\nhandling to make it easier to identity which visualization is causing\nthe problem in order to address it.","sha":"8a591b5d4e769c6f1449117777040c47669691e4","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Visualizations","release_note:fix","Team:Visualizations","backport:all-open","v9.2.0","v9.3.0"],"title":"[Visualize] Improve list error handling","number":238355,"url":"https://github.com/elastic/kibana/pull/238355","mergeCommit":{"message":"[Visualize] Improve list error handling (#238355)\n\nFixes an error in the **Visualize Listing** page in which an error in\nthe vis could cause the entire page to error. This improves the error\nhandling to make it easier to identity which visualization is causing\nthe problem in order to address it.","sha":"8a591b5d4e769c6f1449117777040c47669691e4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238708","number":238708,"state":"MERGED","mergeCommit":{"sha":"d4232881d7081254e998e5dfdc7307e5d4129060","message":"[9.2] [Visualize] Improve list error handling (#238355) (#238708)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Visualize] Improve list error handling\n(#238355)](https://github.com/elastic/kibana/pull/238355)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238355","number":238355,"mergeCommit":{"message":"[Visualize] Improve list error handling (#238355)\n\nFixes an error in the **Visualize Listing** page in which an error in\nthe vis could cause the entire page to error. This improves the error\nhandling to make it easier to identity which visualization is causing\nthe problem in order to address it.","sha":"8a591b5d4e769c6f1449117777040c47669691e4"}},{"url":"https://github.com/elastic/kibana/pull/239192","number":239192,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->