### PR TITLE
[APM] removing unecessary _source from query as we use fields

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_sample_ids.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_sample_ids.ts
@@ -68,6 +68,7 @@ export async function getErrorGroupSampleIds({
       },
     },
     fields: requiredFields,
+    _source: false,
     sort: asMutableArray([
       { _score: { order: 'desc' } }, // sort by _score first to ensure that errors with transaction.sampled:true ends up on top
       { '@timestamp': { order: 'desc' } }, // sort by timestamp to get the most recent error


### PR DESCRIPTION
This PR removes the ES `_sources` from the response as it can be quite big and is not used.

We had cases where this API was returning 12MB
<img width="1548" height="144" alt="Screenshot 2025-10-15 at 13 26 50" src="https://github.com/user-attachments/assets/2ea31823-bede-4b49-bd37-5546ced8e590" />


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->