### PR TITLE
cloud: add isInTrial helper function

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -11,7 +11,7 @@ pageLoadAssetSize:
   canvas: 15210
   cases: 153204
   charts: 40269
-  cloud: 9300
+  cloud: 9676
   cloudDataMigration: 5687
   cloudExperiments: 103984
   cloudFullStory: 4752

--- a/src/platform/plugins/shared/navigation/public/plugin.test.ts
+++ b/src/platform/plugins/shared/navigation/public/plugin.test.ts
@@ -197,7 +197,7 @@ describe('Navigation Plugin', () => {
       const { plugin, coreStart, unifiedSearch, cloud: cloudStart, spaces } = setup();
       const coreSetup = coreMock.createSetup();
       const cloudSetup = cloudMock.createSetup();
-      cloudSetup.trialEndDate = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30); // 30 days from now
+      cloudSetup.getInTrial.mockReturnValue(true);
       plugin.setup(coreSetup, { cloud: cloudSetup });
 
       for (const solution of ['es', 'oblt', 'security']) {
@@ -214,7 +214,7 @@ describe('Navigation Plugin', () => {
       const { plugin, coreStart, unifiedSearch, cloud: cloudStart, spaces } = setup();
       const coreSetup = coreMock.createSetup();
       const cloudSetup = cloudMock.createSetup();
-      cloudSetup.serverless = { organizationInTrial: true };
+      cloudSetup.getInTrial.mockReturnValue(true);
       plugin.setup(coreSetup, { cloud: cloudSetup });
 
       for (const solution of ['es', 'oblt', 'security']) {

--- a/src/platform/plugins/shared/navigation/public/plugin.test.ts
+++ b/src/platform/plugins/shared/navigation/public/plugin.test.ts
@@ -197,7 +197,7 @@ describe('Navigation Plugin', () => {
       const { plugin, coreStart, unifiedSearch, cloud: cloudStart, spaces } = setup();
       const coreSetup = coreMock.createSetup();
       const cloudSetup = cloudMock.createSetup();
-      cloudSetup.getInTrial.mockReturnValue(true);
+      cloudSetup.isInTrial.mockReturnValue(true);
       plugin.setup(coreSetup, { cloud: cloudSetup });
 
       for (const solution of ['es', 'oblt', 'security']) {
@@ -214,7 +214,7 @@ describe('Navigation Plugin', () => {
       const { plugin, coreStart, unifiedSearch, cloud: cloudStart, spaces } = setup();
       const coreSetup = coreMock.createSetup();
       const cloudSetup = cloudMock.createSetup();
-      cloudSetup.getInTrial.mockReturnValue(true);
+      cloudSetup.isInTrial.mockReturnValue(true);
       plugin.setup(coreSetup, { cloud: cloudSetup });
 
       for (const solution of ['es', 'oblt', 'security']) {

--- a/src/platform/plugins/shared/navigation/public/plugin.test.ts
+++ b/src/platform/plugins/shared/navigation/public/plugin.test.ts
@@ -193,11 +193,28 @@ describe('Navigation Plugin', () => {
       }
     });
 
-    it('should set the feedback button visibility to "false" for deployment in trial', async () => {
+    it('should set the feedback button visibility to "false" for deployment in trial via endDate', async () => {
       const { plugin, coreStart, unifiedSearch, cloud: cloudStart, spaces } = setup();
       const coreSetup = coreMock.createSetup();
       const cloudSetup = cloudMock.createSetup();
       cloudSetup.trialEndDate = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30); // 30 days from now
+      plugin.setup(coreSetup, { cloud: cloudSetup });
+
+      for (const solution of ['es', 'oblt', 'security']) {
+        spaces.getActiveSpace$ = jest
+          .fn()
+          .mockReturnValue(of({ solution } as Pick<Space, 'solution'>));
+        plugin.start(coreStart, { unifiedSearch, cloud: cloudStart, spaces });
+        await new Promise((resolve) => setTimeout(resolve));
+        expect(coreStart.chrome.sideNav.setIsFeedbackBtnVisible).toHaveBeenCalledWith(false);
+        coreStart.chrome.sideNav.setIsFeedbackBtnVisible.mockReset();
+      }
+    });
+    it('should set the feedback button visibility to "false" for deployment in trial in serverless', async () => {
+      const { plugin, coreStart, unifiedSearch, cloud: cloudStart, spaces } = setup();
+      const coreSetup = coreMock.createSetup();
+      const cloudSetup = cloudMock.createSetup();
+      cloudSetup.serverless = { organizationInTrial: true };
       plugin.setup(coreSetup, { cloud: cloudSetup });
 
       for (const solution of ['es', 'oblt', 'security']) {

--- a/src/platform/plugins/shared/navigation/public/plugin.tsx
+++ b/src/platform/plugins/shared/navigation/public/plugin.tsx
@@ -55,7 +55,7 @@ export class NavigationPublicPlugin
   public setup(core: CoreSetup, deps: NavigationPublicSetupDependencies): NavigationPublicSetup {
     registerNavigationEventTypes(core);
 
-    this.isCloudTrialUser = deps.cloud?.getInTrial() ?? false;
+    this.isCloudTrialUser = deps.cloud?.isInTrial() ?? false;
 
     return {
       registerMenuItem: this.topNavMenuExtensionsRegistry.register.bind(

--- a/src/platform/plugins/shared/navigation/public/plugin.tsx
+++ b/src/platform/plugins/shared/navigation/public/plugin.tsx
@@ -55,10 +55,7 @@ export class NavigationPublicPlugin
   public setup(core: CoreSetup, deps: NavigationPublicSetupDependencies): NavigationPublicSetup {
     registerNavigationEventTypes(core);
 
-    const cloudTrialEndDate = deps.cloud?.trialEndDate;
-    if (cloudTrialEndDate) {
-      this.isCloudTrialUser = cloudTrialEndDate.getTime() > Date.now();
-    }
+    this.isCloudTrialUser = deps.cloud?.getInTrial() ?? false;
 
     return {
       registerMenuItem: this.topNavMenuExtensionsRegistry.register.bind(

--- a/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
@@ -13,7 +13,7 @@ import {
   type Logger,
 } from '@kbn/core/server';
 import type { InterceptSetup, InterceptStart } from '@kbn/intercepts-plugin/server';
-import type { CloudSetup } from '@kbn/cloud-plugin/server';
+import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/server';
 import {
   TRIGGER_DEF_ID,
   UPGRADE_TRIGGER_DEF_PREFIX_ID,
@@ -22,11 +22,12 @@ import {
 import type { ServerConfigSchema } from '../common/config';
 
 interface ProductInterceptServerPluginSetup {
-  cloud: CloudSetup;
+  cloud?: CloudSetup;
   intercepts: InterceptSetup;
 }
 
 interface ProductInterceptServerPluginStart {
+  cloud?: CloudStart;
   intercepts: InterceptStart;
 }
 
@@ -39,7 +40,6 @@ export class ProductInterceptServerPlugin
   private readonly logger: Logger;
   private readonly config: ServerConfigSchema;
   private readonly buildVersion: string;
-  private trialEndDate?: Date;
 
   constructor(initContext: PluginInitializerContext<unknown>) {
     this.logger = initContext.logger.get();
@@ -48,12 +48,10 @@ export class ProductInterceptServerPlugin
   }
 
   setup(core: CoreSetup, { cloud }: ProductInterceptServerPluginSetup) {
-    this.trialEndDate = cloud?.trialEndDate;
-
     return {};
   }
 
-  start(core: CoreStart, { intercepts }: ProductInterceptServerPluginStart) {
+  start(core: CoreStart, { cloud, intercepts }: ProductInterceptServerPluginStart) {
     if (this.config.enabled) {
       void intercepts.registerTriggerDefinition?.(TRIGGER_DEF_ID, () => {
         this.logger.debug('Registering global product intercept trigger definition');
@@ -69,7 +67,7 @@ export class ProductInterceptServerPlugin
       );
 
       // Register trial intercept only if the trial end date is set and not passed
-      if (Date.now() <= (this.trialEndDate?.getTime() ?? 0)) {
+      if (cloud?.getInTrial()) {
         void intercepts.registerTriggerDefinition?.(
           `${TRIAL_TRIGGER_DEF_ID}:${this.buildVersion}`,
           () => {

--- a/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
@@ -67,7 +67,7 @@ export class ProductInterceptServerPlugin
       );
 
       // Register trial intercept only if the trial end date is set and not passed
-      if (cloud?.getInTrial()) {
+      if (cloud?.isInTrial()) {
         void intercepts.registerTriggerDefinition?.(
           `${TRIAL_TRIGGER_DEF_ID}:${this.buildVersion}`,
           () => {

--- a/x-pack/platform/plugins/shared/cloud/public/mocks.tsx
+++ b/x-pack/platform/plugins/shared/cloud/public/mocks.tsx
@@ -41,7 +41,7 @@ function createSetupMock(): jest.Mocked<CloudSetup> {
     },
     getUrls: jest.fn().mockReturnValue({}),
     getPrivilegedUrls: jest.fn().mockResolvedValue({}),
-    getInTrial: jest.fn().mockReturnValue(false),
+    isInTrial: jest.fn().mockReturnValue(false),
     ...mockCloudUrls,
   };
 }
@@ -62,7 +62,7 @@ const createStartMock = (): jest.Mocked<CloudStart> => ({
   fetchElasticsearchConfig: jest.fn().mockResolvedValue({ elasticsearchUrl: 'elasticsearch-url' }),
   getUrls: jest.fn().mockReturnValue({}),
   getPrivilegedUrls: jest.fn().mockResolvedValue({}),
-  getInTrial: jest.fn().mockReturnValue(false),
+  isInTrial: jest.fn().mockReturnValue(false),
   ...mockCloudUrls,
 });
 

--- a/x-pack/platform/plugins/shared/cloud/public/mocks.tsx
+++ b/x-pack/platform/plugins/shared/cloud/public/mocks.tsx
@@ -41,6 +41,7 @@ function createSetupMock(): jest.Mocked<CloudSetup> {
     },
     getUrls: jest.fn().mockReturnValue({}),
     getPrivilegedUrls: jest.fn().mockResolvedValue({}),
+    getInTrial: jest.fn().mockReturnValue(false),
     ...mockCloudUrls,
   };
 }
@@ -61,6 +62,7 @@ const createStartMock = (): jest.Mocked<CloudStart> => ({
   fetchElasticsearchConfig: jest.fn().mockResolvedValue({ elasticsearchUrl: 'elasticsearch-url' }),
   getUrls: jest.fn().mockReturnValue({}),
   getPrivilegedUrls: jest.fn().mockResolvedValue({}),
+  getInTrial: jest.fn().mockReturnValue(false),
   ...mockCloudUrls,
 });
 

--- a/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
@@ -375,30 +375,12 @@ describe('Cloud Plugin', () => {
       expect(result).toEqual({ elasticsearchUrl: 'elasticsearch-url' });
     });
     describe('exposes isInTrial', () => {
-      const getStart = (configParts?: Partial<CloudConfigType>) => {
+      const getStart = (configParts: Partial<CloudConfigType> = {}) => {
         const { plugin } = startPlugin(configParts);
         const coreStart = coreMock.createStart();
+        coreStart.http.get.mockResolvedValue({ elasticsearch_url: 'elasticsearch-url' });
         return plugin.start(coreStart);
       };
-      it('is `true` when `serverless.in_trial` is set', () => {
-        const pluginStart = getStart({
-          serverless: {
-            project_id: 'my-awesome-project',
-            in_trial: true,
-          },
-        });
-
-        expect(pluginStart.isInTrial()).toBe(true);
-      });
-      it('is `false` when `serverless.in_trial` is set to false', () => {
-        const pluginStart = getStart({
-          serverless: {
-            project_id: 'my-awesome-project',
-            in_trial: false,
-          },
-        });
-        expect(pluginStart.isInTrial()).toBe(false);
-      });
       it('is `true` when `trial_end_date` is set and is in the future', () => {
         const pluginStart = getStart({
           trial_end_date: new Date(Date.now() + 10000).toISOString(),
@@ -414,7 +396,7 @@ describe('Cloud Plugin', () => {
         expect(pluginStart.isInTrial()).toBe(false);
       });
       it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
-        const pluginStart = getStart({});
+        const pluginStart = getStart();
         expect(pluginStart.isInTrial()).toBe(false);
       });
     });

--- a/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
@@ -199,6 +199,45 @@ describe('Cloud Plugin', () => {
         const result = await setup.fetchElasticsearchConfig();
         expect(result).toEqual({ elasticsearchUrl: 'elasticsearch-url' });
       });
+      describe('exposes getInTrial', () => {
+        it('is `true` when `serverless.in_trial` is set', () => {
+          const { setup } = setupPlugin({
+            serverless: {
+              project_id: 'my-awesome-project',
+              in_trial: true,
+            },
+          });
+
+          expect(setup.getInTrial()).toBe(true);
+        });
+        it('is `false` when `serverless.in_trial` is set to false', () => {
+          const { setup } = setupPlugin({
+            serverless: {
+              project_id: 'my-awesome-project',
+              in_trial: false,
+            },
+          });
+          expect(setup.getInTrial()).toBe(false);
+        });
+        it('is `true` when `trial_end_date` is set and is in the future', () => {
+          const { setup } = setupPlugin({
+            trial_end_date: new Date(Date.now() + 10000).toISOString(),
+          });
+
+          expect(setup.getInTrial()).toBe(true);
+        });
+        it('is `false` when `trial_end_date` is set and is in the past', () => {
+          const { setup } = setupPlugin({
+            trial_end_date: new Date(Date.now() - 10000).toISOString(),
+          });
+
+          expect(setup.getInTrial()).toBe(false);
+        });
+        it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
+          const { setup } = setupPlugin({});
+          expect(setup.getInTrial()).toBe(false);
+        });
+      });
     });
   });
 
@@ -331,6 +370,50 @@ describe('Cloud Plugin', () => {
       const start = plugin.start(coreStart);
       const result = await start.fetchElasticsearchConfig();
       expect(result).toEqual({ elasticsearchUrl: 'elasticsearch-url' });
+    });
+    describe('exposes getInTrial', () => {
+      const getStartAndSetup = (configParts?: Partial<CloudConfigType>) => {
+        const { plugin } = startPlugin(configParts);
+        const coreStart = coreMock.createStart();
+        return plugin.start(coreStart);
+      };
+      it('is `true` when `serverless.in_trial` is set', () => {
+        const pluginStart = getStartAndSetup({
+          serverless: {
+            project_id: 'my-awesome-project',
+            in_trial: true,
+          },
+        });
+
+        expect(pluginStart.getInTrial()).toBe(true);
+      });
+      it('is `false` when `serverless.in_trial` is set to false', () => {
+        const pluginStart = getStartAndSetup({
+          serverless: {
+            project_id: 'my-awesome-project',
+            in_trial: false,
+          },
+        });
+        expect(pluginStart.getInTrial()).toBe(false);
+      });
+      it('is `true` when `trial_end_date` is set and is in the future', () => {
+        const pluginStart = getStartAndSetup({
+          trial_end_date: new Date(Date.now() + 10000).toISOString(),
+        });
+
+        expect(pluginStart.getInTrial()).toBe(true);
+      });
+      it('is `false` when `trial_end_date` is set and is in the past', () => {
+        const pluginStart = getStartAndSetup({
+          trial_end_date: new Date(Date.now() - 10000).toISOString(),
+        });
+
+        expect(pluginStart.getInTrial()).toBe(false);
+      });
+      it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
+        const pluginStart = getStartAndSetup({});
+        expect(pluginStart.getInTrial()).toBe(false);
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
@@ -395,6 +395,13 @@ describe('Cloud Plugin', () => {
 
         expect(pluginStart.isInTrial()).toBe(false);
       });
+      it('is `false` when `trial_end_date` is not a valid date', () => {
+        const pluginStart = getStart({
+          trial_end_date: 'invalid-date',
+        });
+
+        expect(pluginStart.isInTrial()).toBe(false);
+      });
       it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
         const pluginStart = getStart();
         expect(pluginStart.isInTrial()).toBe(false);

--- a/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
@@ -199,7 +199,7 @@ describe('Cloud Plugin', () => {
         const result = await setup.fetchElasticsearchConfig();
         expect(result).toEqual({ elasticsearchUrl: 'elasticsearch-url' });
       });
-      describe('exposes getInTrial', () => {
+      describe('exposes isInTrial', () => {
         it('is `true` when `serverless.in_trial` is set', () => {
           const { setup } = setupPlugin({
             serverless: {
@@ -208,7 +208,7 @@ describe('Cloud Plugin', () => {
             },
           });
 
-          expect(setup.getInTrial()).toBe(true);
+          expect(setup.isInTrial()).toBe(true);
         });
         it('is `false` when `serverless.in_trial` is set to false', () => {
           const { setup } = setupPlugin({
@@ -217,25 +217,25 @@ describe('Cloud Plugin', () => {
               in_trial: false,
             },
           });
-          expect(setup.getInTrial()).toBe(false);
+          expect(setup.isInTrial()).toBe(false);
         });
         it('is `true` when `trial_end_date` is set and is in the future', () => {
           const { setup } = setupPlugin({
             trial_end_date: new Date(Date.now() + 10000).toISOString(),
           });
 
-          expect(setup.getInTrial()).toBe(true);
+          expect(setup.isInTrial()).toBe(true);
         });
         it('is `false` when `trial_end_date` is set and is in the past', () => {
           const { setup } = setupPlugin({
             trial_end_date: new Date(Date.now() - 10000).toISOString(),
           });
 
-          expect(setup.getInTrial()).toBe(false);
+          expect(setup.isInTrial()).toBe(false);
         });
         it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
           const { setup } = setupPlugin({});
-          expect(setup.getInTrial()).toBe(false);
+          expect(setup.isInTrial()).toBe(false);
         });
       });
     });
@@ -371,7 +371,7 @@ describe('Cloud Plugin', () => {
       const result = await start.fetchElasticsearchConfig();
       expect(result).toEqual({ elasticsearchUrl: 'elasticsearch-url' });
     });
-    describe('exposes getInTrial', () => {
+    describe('exposes isInTrial', () => {
       const getStartAndSetup = (configParts?: Partial<CloudConfigType>) => {
         const { plugin } = startPlugin(configParts);
         const coreStart = coreMock.createStart();
@@ -385,7 +385,7 @@ describe('Cloud Plugin', () => {
           },
         });
 
-        expect(pluginStart.getInTrial()).toBe(true);
+        expect(pluginStart.isInTrial()).toBe(true);
       });
       it('is `false` when `serverless.in_trial` is set to false', () => {
         const pluginStart = getStartAndSetup({
@@ -394,25 +394,25 @@ describe('Cloud Plugin', () => {
             in_trial: false,
           },
         });
-        expect(pluginStart.getInTrial()).toBe(false);
+        expect(pluginStart.isInTrial()).toBe(false);
       });
       it('is `true` when `trial_end_date` is set and is in the future', () => {
         const pluginStart = getStartAndSetup({
           trial_end_date: new Date(Date.now() + 10000).toISOString(),
         });
 
-        expect(pluginStart.getInTrial()).toBe(true);
+        expect(pluginStart.isInTrial()).toBe(true);
       });
       it('is `false` when `trial_end_date` is set and is in the past', () => {
         const pluginStart = getStartAndSetup({
           trial_end_date: new Date(Date.now() - 10000).toISOString(),
         });
 
-        expect(pluginStart.getInTrial()).toBe(false);
+        expect(pluginStart.isInTrial()).toBe(false);
       });
       it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
         const pluginStart = getStartAndSetup({});
-        expect(pluginStart.getInTrial()).toBe(false);
+        expect(pluginStart.isInTrial()).toBe(false);
       });
     });
   });

--- a/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
@@ -163,62 +163,64 @@ describe('Cloud Plugin', () => {
           });
           expect(setup.isServerlessEnabled).toBe(false);
         });
+        it('exposes `serverless.projectId`', () => {
+          const { setup } = setupPlugin({
+            serverless: {
+              project_id: 'my-awesome-project',
+            },
+          });
+          expect(setup.serverless.projectId).toBe('my-awesome-project');
+        });
+
+        it('exposes `serverless.projectName`', () => {
+          const { setup } = setupPlugin({
+            serverless: {
+              project_id: 'my-awesome-project',
+              project_name: 'My Awesome Project',
+            },
+          });
+          expect(setup.serverless.projectName).toBe('My Awesome Project');
+        });
+
+        it('exposes `serverless.projectType`', () => {
+          const { setup } = setupPlugin({
+            serverless: {
+              project_id: 'my-awesome-project',
+              project_name: 'My Awesome Project',
+              project_type: 'security',
+            },
+          });
+          expect(setup.serverless.projectType).toBe('security');
+        });
+        describe('exposes isInTrial', () => {
+          it('is `true` when `serverless.in_trial` is set', () => {
+            const { setup } = setupPlugin({
+              serverless: {
+                project_id: 'my-awesome-project',
+                in_trial: true,
+              },
+            });
+
+            expect(setup.isInTrial()).toBe(true);
+          });
+          it('is `false` when `serverless.in_trial` is set to false', () => {
+            const { setup } = setupPlugin({
+              serverless: {
+                project_id: 'my-awesome-project',
+                in_trial: false,
+              },
+            });
+            expect(setup.isInTrial()).toBe(false);
+          });
+        });
       });
 
-      it('exposes `serverless.projectId`', () => {
-        const { setup } = setupPlugin({
-          serverless: {
-            project_id: 'my-awesome-project',
-          },
-        });
-        expect(setup.serverless.projectId).toBe('my-awesome-project');
-      });
-
-      it('exposes `serverless.projectName`', () => {
-        const { setup } = setupPlugin({
-          serverless: {
-            project_id: 'my-awesome-project',
-            project_name: 'My Awesome Project',
-          },
-        });
-        expect(setup.serverless.projectName).toBe('My Awesome Project');
-      });
-
-      it('exposes `serverless.projectType`', () => {
-        const { setup } = setupPlugin({
-          serverless: {
-            project_id: 'my-awesome-project',
-            project_name: 'My Awesome Project',
-            project_type: 'security',
-          },
-        });
-        expect(setup.serverless.projectType).toBe('security');
-      });
       it('exposes fetchElasticsearchConfig', async () => {
         const { setup } = setupPlugin();
         const result = await setup.fetchElasticsearchConfig();
         expect(result).toEqual({ elasticsearchUrl: 'elasticsearch-url' });
       });
       describe('exposes isInTrial', () => {
-        it('is `true` when `serverless.in_trial` is set', () => {
-          const { setup } = setupPlugin({
-            serverless: {
-              project_id: 'my-awesome-project',
-              in_trial: true,
-            },
-          });
-
-          expect(setup.isInTrial()).toBe(true);
-        });
-        it('is `false` when `serverless.in_trial` is set to false', () => {
-          const { setup } = setupPlugin({
-            serverless: {
-              project_id: 'my-awesome-project',
-              in_trial: false,
-            },
-          });
-          expect(setup.isInTrial()).toBe(false);
-        });
         it('is `true` when `trial_end_date` is set and is in the future', () => {
           const { setup } = setupPlugin({
             trial_end_date: new Date(Date.now() + 10000).toISOString(),
@@ -339,30 +341,31 @@ describe('Cloud Plugin', () => {
         const start = plugin.start(coreStart);
         expect(start.isServerlessEnabled).toBe(false);
       });
+
+      it('exposes `serverless.projectId`', () => {
+        const { plugin } = startPlugin({
+          serverless: {
+            project_id: 'my-awesome-project',
+          },
+        });
+        const coreStart = coreMock.createStart();
+        const start = plugin.start(coreStart);
+        expect(start.serverless.projectId).toBe('my-awesome-project');
+      });
+
+      it('exposes `serverless.projectName`', () => {
+        const { plugin } = startPlugin({
+          serverless: {
+            project_id: 'my-awesome-project',
+            project_name: 'My Awesome Project',
+          },
+        });
+        const coreStart = coreMock.createStart();
+        const start = plugin.start(coreStart);
+        expect(start.serverless.projectName).toBe('My Awesome Project');
+      });
     });
 
-    it('exposes `serverless.projectId`', () => {
-      const { plugin } = startPlugin({
-        serverless: {
-          project_id: 'my-awesome-project',
-        },
-      });
-      const coreStart = coreMock.createStart();
-      const start = plugin.start(coreStart);
-      expect(start.serverless.projectId).toBe('my-awesome-project');
-    });
-
-    it('exposes `serverless.projectName`', () => {
-      const { plugin } = startPlugin({
-        serverless: {
-          project_id: 'my-awesome-project',
-          project_name: 'My Awesome Project',
-        },
-      });
-      const coreStart = coreMock.createStart();
-      const start = plugin.start(coreStart);
-      expect(start.serverless.projectName).toBe('My Awesome Project');
-    });
     it('exposes fetchElasticsearchConfig', async () => {
       const { plugin } = startPlugin();
       const coreStart = coreMock.createStart();
@@ -372,13 +375,13 @@ describe('Cloud Plugin', () => {
       expect(result).toEqual({ elasticsearchUrl: 'elasticsearch-url' });
     });
     describe('exposes isInTrial', () => {
-      const getStartAndSetup = (configParts?: Partial<CloudConfigType>) => {
+      const getStart = (configParts?: Partial<CloudConfigType>) => {
         const { plugin } = startPlugin(configParts);
         const coreStart = coreMock.createStart();
         return plugin.start(coreStart);
       };
       it('is `true` when `serverless.in_trial` is set', () => {
-        const pluginStart = getStartAndSetup({
+        const pluginStart = getStart({
           serverless: {
             project_id: 'my-awesome-project',
             in_trial: true,
@@ -388,7 +391,7 @@ describe('Cloud Plugin', () => {
         expect(pluginStart.isInTrial()).toBe(true);
       });
       it('is `false` when `serverless.in_trial` is set to false', () => {
-        const pluginStart = getStartAndSetup({
+        const pluginStart = getStart({
           serverless: {
             project_id: 'my-awesome-project',
             in_trial: false,
@@ -397,21 +400,21 @@ describe('Cloud Plugin', () => {
         expect(pluginStart.isInTrial()).toBe(false);
       });
       it('is `true` when `trial_end_date` is set and is in the future', () => {
-        const pluginStart = getStartAndSetup({
+        const pluginStart = getStart({
           trial_end_date: new Date(Date.now() + 10000).toISOString(),
         });
 
         expect(pluginStart.isInTrial()).toBe(true);
       });
       it('is `false` when `trial_end_date` is set and is in the past', () => {
-        const pluginStart = getStartAndSetup({
+        const pluginStart = getStart({
           trial_end_date: new Date(Date.now() - 10000).toISOString(),
         });
 
         expect(pluginStart.isInTrial()).toBe(false);
       });
       it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
-        const pluginStart = getStartAndSetup({});
+        const pluginStart = getStart({});
         expect(pluginStart.isInTrial()).toBe(false);
       });
     });

--- a/x-pack/platform/plugins/shared/cloud/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/cloud/public/plugin.tsx
@@ -119,7 +119,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
       ...this.cloudUrls.getUrls(), // TODO: Deprecate directly accessing URLs, use `getUrls` instead
       getPrivilegedUrls: this.cloudUrls.getPrivilegedUrls.bind(this.cloudUrls),
       getUrls: this.cloudUrls.getUrls.bind(this.cloudUrls),
-      getInTrial: this.isInTrial.bind(this),
+      isInTrial: this.isInTrial.bind(this),
     };
   }
 
@@ -169,7 +169,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
       ...this.cloudUrls.getUrls(), // TODO: Deprecate directly accessing URLs, use `getUrls` instead
       getPrivilegedUrls: this.cloudUrls.getPrivilegedUrls.bind(this.cloudUrls),
       getUrls: this.cloudUrls.getUrls.bind(this.cloudUrls),
-      getInTrial: this.isInTrial.bind(this),
+      isInTrial: this.isInTrial.bind(this),
     };
   }
 

--- a/x-pack/platform/plugins/shared/cloud/public/types.ts
+++ b/x-pack/platform/plugins/shared/cloud/public/types.ts
@@ -101,7 +101,7 @@ export interface CloudStart extends CloudBasicUrls {
   /**
    * Method to retrieve if the organization is in trial.
    */
-  getInTrial: () => boolean;
+  isInTrial: () => boolean;
   /**
    * `true` when running on Serverless Elastic Cloud
    * Note that `isCloudEnabled` will always be true when `isServerlessEnabled` is.
@@ -251,7 +251,7 @@ export interface CloudSetup extends CloudBasicUrls {
   /**
    * Method to retrieve if the organization is in trial.
    */
-  getInTrial: () => boolean;
+  isInTrial: () => boolean;
 }
 
 export interface PublicElasticsearchConfigType {

--- a/x-pack/platform/plugins/shared/cloud/public/types.ts
+++ b/x-pack/platform/plugins/shared/cloud/public/types.ts
@@ -99,6 +99,10 @@ export interface CloudStart extends CloudBasicUrls {
    */
   getUrls: () => CloudBasicUrls;
   /**
+   * Method to retrieve if the organization is in trial.
+   */
+  getInTrial: () => boolean;
+  /**
    * `true` when running on Serverless Elastic Cloud
    * Note that `isCloudEnabled` will always be true when `isServerlessEnabled` is.
    */
@@ -244,6 +248,10 @@ export interface CloudSetup extends CloudBasicUrls {
      */
     organizationInTrial?: boolean;
   };
+  /**
+   * Method to retrieve if the organization is in trial.
+   */
+  getInTrial: () => boolean;
 }
 
 export interface PublicElasticsearchConfigType {

--- a/x-pack/platform/plugins/shared/cloud/server/__snapshots__/plugin.test.ts.snap
+++ b/x-pack/platform/plugins/shared/cloud/server/__snapshots__/plugin.test.ts.snap
@@ -13,6 +13,7 @@ Object {
   "csp": "aws",
   "deploymentId": "deployment-id",
   "elasticsearchUrl": undefined,
+  "getInTrial": [Function],
   "instanceSizeMb": undefined,
   "isCloudEnabled": true,
   "isElasticStaffOwned": undefined,
@@ -38,6 +39,7 @@ Object {
 exports[`Cloud Plugin #start interface snapshot 1`] = `
 Object {
   "baseUrl": "https://cloud.elastic.co",
+  "getInTrial": [Function],
   "isCloudEnabled": true,
   "projectsUrl": "https://cloud.elastic.co/projects/",
 }

--- a/x-pack/platform/plugins/shared/cloud/server/__snapshots__/plugin.test.ts.snap
+++ b/x-pack/platform/plugins/shared/cloud/server/__snapshots__/plugin.test.ts.snap
@@ -13,10 +13,10 @@ Object {
   "csp": "aws",
   "deploymentId": "deployment-id",
   "elasticsearchUrl": undefined,
-  "isInTrial": [Function],
   "instanceSizeMb": undefined,
   "isCloudEnabled": true,
   "isElasticStaffOwned": undefined,
+  "isInTrial": [Function],
   "isServerlessEnabled": false,
   "kibanaUrl": undefined,
   "onboarding": Object {
@@ -39,8 +39,8 @@ Object {
 exports[`Cloud Plugin #start interface snapshot 1`] = `
 Object {
   "baseUrl": "https://cloud.elastic.co",
-  "isInTrial": [Function],
   "isCloudEnabled": true,
+  "isInTrial": [Function],
   "projectsUrl": "https://cloud.elastic.co/projects/",
 }
 `;

--- a/x-pack/platform/plugins/shared/cloud/server/__snapshots__/plugin.test.ts.snap
+++ b/x-pack/platform/plugins/shared/cloud/server/__snapshots__/plugin.test.ts.snap
@@ -13,7 +13,7 @@ Object {
   "csp": "aws",
   "deploymentId": "deployment-id",
   "elasticsearchUrl": undefined,
-  "getInTrial": [Function],
+  "isInTrial": [Function],
   "instanceSizeMb": undefined,
   "isCloudEnabled": true,
   "isElasticStaffOwned": undefined,
@@ -39,7 +39,7 @@ Object {
 exports[`Cloud Plugin #start interface snapshot 1`] = `
 Object {
   "baseUrl": "https://cloud.elastic.co",
-  "getInTrial": [Function],
+  "isInTrial": [Function],
   "isCloudEnabled": true,
   "projectsUrl": "https://cloud.elastic.co/projects/",
 }

--- a/x-pack/platform/plugins/shared/cloud/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/cloud/server/mocks.ts
@@ -35,6 +35,7 @@ function createSetupMock(): jest.Mocked<CloudSetup> {
       productTier: undefined,
       orchestratorTarget: undefined,
     },
+    getInTrial: jest.fn().mockReturnValue(false),
   };
 }
 
@@ -43,6 +44,7 @@ function createStartMock(): jest.Mocked<CloudStart> {
     isCloudEnabled: true,
     projectsUrl: 'projects-url',
     baseUrl: 'base-url',
+    getInTrial: jest.fn().mockReturnValue(false),
   };
 }
 

--- a/x-pack/platform/plugins/shared/cloud/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/cloud/server/mocks.ts
@@ -35,7 +35,7 @@ function createSetupMock(): jest.Mocked<CloudSetup> {
       productTier: undefined,
       orchestratorTarget: undefined,
     },
-    getInTrial: jest.fn().mockReturnValue(false),
+    isInTrial: jest.fn().mockReturnValue(false),
   };
 }
 
@@ -44,7 +44,7 @@ function createStartMock(): jest.Mocked<CloudStart> {
     isCloudEnabled: true,
     projectsUrl: 'projects-url',
     baseUrl: 'base-url',
-    getInTrial: jest.fn().mockReturnValue(false),
+    isInTrial: jest.fn().mockReturnValue(false),
   };
 }
 

--- a/x-pack/platform/plugins/shared/cloud/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cloud/server/plugin.test.ts
@@ -160,7 +160,7 @@ describe('Cloud Plugin', () => {
         });
         expect(setup.serverless.projectType).toBe('security');
       });
-      describe('exposes getInTrial', () => {
+      describe('exposes isInTrial', () => {
         it('is `true` when `serverless.in_trial` is set', () => {
           const { setup } = setupPlugin({
             serverless: {
@@ -169,7 +169,7 @@ describe('Cloud Plugin', () => {
             },
           });
 
-          expect(setup.getInTrial()).toBe(true);
+          expect(setup.isInTrial()).toBe(true);
         });
         it('is `false` when `serverless.in_trial` is set to false', () => {
           const { setup } = setupPlugin({
@@ -178,25 +178,25 @@ describe('Cloud Plugin', () => {
               in_trial: false,
             },
           });
-          expect(setup.getInTrial()).toBe(false);
+          expect(setup.isInTrial()).toBe(false);
         });
         it('is `true` when `trial_end_date` is set and is in the future', () => {
           const { setup } = setupPlugin({
             trial_end_date: new Date(Date.now() + 10000).toISOString(),
           });
 
-          expect(setup.getInTrial()).toBe(true);
+          expect(setup.isInTrial()).toBe(true);
         });
         it('is `false` when `trial_end_date` is set and is in the past', () => {
           const { setup } = setupPlugin({
             trial_end_date: new Date(Date.now() - 10000).toISOString(),
           });
 
-          expect(setup.getInTrial()).toBe(false);
+          expect(setup.isInTrial()).toBe(false);
         });
         it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
           const { setup } = setupPlugin({});
-          expect(setup.getInTrial()).toBe(false);
+          expect(setup.isInTrial()).toBe(false);
         });
       });
     });
@@ -213,7 +213,7 @@ describe('Cloud Plugin', () => {
         expect(start.isCloudEnabled).toBe(true);
       });
 
-      describe('exposes getInTrial', () => {
+      describe('exposes isInTrial', () => {
         it('is `true` when `serverless.in_trial` is set', () => {
           const { start } = setupPlugin({
             serverless: {
@@ -222,7 +222,7 @@ describe('Cloud Plugin', () => {
             },
           });
 
-          expect(start.getInTrial()).toBe(true);
+          expect(start.isInTrial()).toBe(true);
         });
         it('is `false` when `serverless.in_trial` is set to false', () => {
           const { start } = setupPlugin({
@@ -231,25 +231,25 @@ describe('Cloud Plugin', () => {
               in_trial: false,
             },
           });
-          expect(start.getInTrial()).toBe(false);
+          expect(start.isInTrial()).toBe(false);
         });
         it('is `true` when `trial_end_date` is set and is in the future', () => {
           const { start } = setupPlugin({
             trial_end_date: new Date(Date.now() + 10000).toISOString(),
           });
 
-          expect(start.getInTrial()).toBe(true);
+          expect(start.isInTrial()).toBe(true);
         });
         it('is `false` when `trial_end_date` is set and is in the past', () => {
           const { start } = setupPlugin({
             trial_end_date: new Date(Date.now() - 10000).toISOString(),
           });
 
-          expect(start.getInTrial()).toBe(false);
+          expect(start.isInTrial()).toBe(false);
         });
         it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
           const { start } = setupPlugin({});
-          expect(start.getInTrial()).toBe(false);
+          expect(start.isInTrial()).toBe(false);
         });
       });
     });

--- a/x-pack/platform/plugins/shared/cloud/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cloud/server/plugin.test.ts
@@ -247,6 +247,13 @@ describe('Cloud Plugin', () => {
 
           expect(start.isInTrial()).toBe(false);
         });
+        it('is `false` when `trial_end_date` is not a valid date', () => {
+          const { start } = setupPlugin({
+            trial_end_date: 'invalid-date',
+          });
+
+          expect(start.isInTrial()).toBe(false);
+        });
         it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
           const { start } = setupPlugin({});
           expect(start.isInTrial()).toBe(false);

--- a/x-pack/platform/plugins/shared/cloud/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cloud/server/plugin.test.ts
@@ -160,6 +160,45 @@ describe('Cloud Plugin', () => {
         });
         expect(setup.serverless.projectType).toBe('security');
       });
+      describe('exposes getInTrial', () => {
+        it('is `true` when `serverless.in_trial` is set', () => {
+          const { setup } = setupPlugin({
+            serverless: {
+              project_id: 'my-awesome-project',
+              in_trial: true,
+            },
+          });
+
+          expect(setup.getInTrial()).toBe(true);
+        });
+        it('is `false` when `serverless.in_trial` is set to false', () => {
+          const { setup } = setupPlugin({
+            serverless: {
+              project_id: 'my-awesome-project',
+              in_trial: false,
+            },
+          });
+          expect(setup.getInTrial()).toBe(false);
+        });
+        it('is `true` when `trial_end_date` is set and is in the future', () => {
+          const { setup } = setupPlugin({
+            trial_end_date: new Date(Date.now() + 10000).toISOString(),
+          });
+
+          expect(setup.getInTrial()).toBe(true);
+        });
+        it('is `false` when `trial_end_date` is set and is in the past', () => {
+          const { setup } = setupPlugin({
+            trial_end_date: new Date(Date.now() - 10000).toISOString(),
+          });
+
+          expect(setup.getInTrial()).toBe(false);
+        });
+        it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
+          const { setup } = setupPlugin({});
+          expect(setup.getInTrial()).toBe(false);
+        });
+      });
     });
   });
 
@@ -172,6 +211,46 @@ describe('Cloud Plugin', () => {
       it('exposes isCloudEnabled', () => {
         const { start } = setupPlugin();
         expect(start.isCloudEnabled).toBe(true);
+      });
+
+      describe('exposes getInTrial', () => {
+        it('is `true` when `serverless.in_trial` is set', () => {
+          const { start } = setupPlugin({
+            serverless: {
+              project_id: 'my-awesome-project',
+              in_trial: true,
+            },
+          });
+
+          expect(start.getInTrial()).toBe(true);
+        });
+        it('is `false` when `serverless.in_trial` is set to false', () => {
+          const { start } = setupPlugin({
+            serverless: {
+              project_id: 'my-awesome-project',
+              in_trial: false,
+            },
+          });
+          expect(start.getInTrial()).toBe(false);
+        });
+        it('is `true` when `trial_end_date` is set and is in the future', () => {
+          const { start } = setupPlugin({
+            trial_end_date: new Date(Date.now() + 10000).toISOString(),
+          });
+
+          expect(start.getInTrial()).toBe(true);
+        });
+        it('is `false` when `trial_end_date` is set and is in the past', () => {
+          const { start } = setupPlugin({
+            trial_end_date: new Date(Date.now() - 10000).toISOString(),
+          });
+
+          expect(start.getInTrial()).toBe(false);
+        });
+        it('is `false` when `serverless.in_trial` & `trial_end_date` are not set', () => {
+          const { start } = setupPlugin({});
+          expect(start.getInTrial()).toBe(false);
+        });
       });
     });
   });

--- a/x-pack/platform/plugins/shared/cloud/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cloud/server/plugin.ts
@@ -169,7 +169,7 @@ export interface CloudSetup {
   /**
    * Method to retrieve if the organization is in trial.
    */
-  getInTrial: () => boolean;
+  isInTrial: () => boolean;
 }
 
 /**
@@ -195,7 +195,7 @@ export interface CloudStart {
   /**
    * Method to retrieve if the organization is in trial.
    */
-  getInTrial: () => boolean;
+  isInTrial: () => boolean;
 }
 
 export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
@@ -397,7 +397,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
         productTier,
         organizationInTrial: this.config.serverless?.in_trial,
       },
-      getInTrial: this.isInTrial.bind(this),
+      isInTrial: this.isInTrial.bind(this),
     };
   }
 
@@ -405,7 +405,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
     return {
       ...this.getCloudUrls(),
       isCloudEnabled: getIsCloudEnabled(this.config.id),
-      getInTrial: this.isInTrial.bind(this),
+      isInTrial: this.isInTrial.bind(this),
     };
   }
 

--- a/x-pack/platform/plugins/shared/cloud/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cloud/server/plugin.ts
@@ -421,7 +421,14 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
   private isInTrial(): boolean {
     if (this.config.serverless?.in_trial) return true;
     if (this.trialEndDate !== undefined) {
-      return Date.now() <= this.trialEndDate.getTime();
+      if (this.config.trial_end_date) {
+        const endDateMs = this.trialEndDate.getTime();
+        if (!Number.isNaN(endDateMs)) {
+          return Date.now() <= endDateMs;
+        } else {
+          this.logger.error('cloud.trial_end_date config value could not be parsed.');
+        }
+      }
     }
     return false;
   }

--- a/x-pack/platform/plugins/shared/cloud/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cloud/server/plugin.ts
@@ -166,6 +166,10 @@ export interface CloudSetup {
      */
     organizationInTrial?: boolean;
   };
+  /**
+   * Method to retrieve if the organization is in trial.
+   */
+  getInTrial: () => boolean;
 }
 
 /**
@@ -188,15 +192,23 @@ export interface CloudStart {
    * @example `https://cloud.elastic.co` (on the ESS production environment)
    */
   baseUrl?: string;
+  /**
+   * Method to retrieve if the organization is in trial.
+   */
+  getInTrial: () => boolean;
 }
 
 export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
   private readonly config: CloudConfigType;
   private readonly logger: Logger;
+  private readonly trialEndDate: Date | undefined;
 
   constructor(private readonly context: PluginInitializerContext) {
     this.config = this.context.config.get<CloudConfigType>();
     this.logger = this.context.logger.get();
+    this.trialEndDate = this.config.trial_end_date
+      ? new Date(this.config.trial_end_date)
+      : undefined;
   }
 
   public setup(core: CoreSetup, { usageCollection }: PluginsSetup): CloudSetup {
@@ -364,7 +376,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
       cloudHost: decodedId?.host,
       cloudDefaultPort: decodedId?.defaultPort,
       isCloudEnabled,
-      trialEndDate: this.config.trial_end_date ? new Date(this.config.trial_end_date) : undefined,
+      trialEndDate: this.trialEndDate,
       isElasticStaffOwned: this.config.is_elastic_staff_owned,
       apm: {
         url: this.config.apm?.url,
@@ -385,6 +397,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
         productTier,
         organizationInTrial: this.config.serverless?.in_trial,
       },
+      getInTrial: this.isInTrial.bind(this),
     };
   }
 
@@ -392,6 +405,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
     return {
       ...this.getCloudUrls(),
       isCloudEnabled: getIsCloudEnabled(this.config.id),
+      getInTrial: this.isInTrial.bind(this),
     };
   }
 
@@ -402,5 +416,13 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
       baseUrl,
       projectsUrl,
     };
+  }
+
+  private isInTrial(): boolean {
+    if (this.config.serverless?.in_trial) return true;
+    if (this.trialEndDate !== undefined) {
+      return Date.now() <= this.trialEndDate.getTime();
+    }
+    return false;
   }
 }

--- a/x-pack/platform/plugins/shared/fleet/.storybook/context/cloud.ts
+++ b/x-pack/platform/plugins/shared/fleet/.storybook/context/cloud.ts
@@ -32,7 +32,7 @@ export const getCloud = ({ isCloudEnabled }: { isCloudEnabled: boolean }) => {
     ...cloudBasicUrls({ isCloudEnabled }),
     getUrls: () => cloudBasicUrls({ isCloudEnabled }),
     getPrivilegedUrls: () => Promise.resolve({}),
-    getInTrial: () => false,
+    isInTrial: () => false,
   };
 
   return cloud;

--- a/x-pack/platform/plugins/shared/fleet/.storybook/context/cloud.ts
+++ b/x-pack/platform/plugins/shared/fleet/.storybook/context/cloud.ts
@@ -32,6 +32,7 @@ export const getCloud = ({ isCloudEnabled }: { isCloudEnabled: boolean }) => {
     ...cloudBasicUrls({ isCloudEnabled }),
     getUrls: () => cloudBasicUrls({ isCloudEnabled }),
     getPrivilegedUrls: () => Promise.resolve({}),
+    getInTrial: () => false,
   };
 
   return cloud;

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_server_host.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_server_host.test.ts
@@ -274,7 +274,7 @@ describe('getCloudFleetServersHosts', () => {
       serverless: {
         projectId: undefined,
       },
-      getInTrial: () => false,
+      isInTrial: () => false,
     });
 
     expect(getCloudFleetServersHosts()).toBeUndefined();
@@ -293,7 +293,7 @@ describe('getCloudFleetServersHosts', () => {
       serverless: {
         projectId: undefined,
       },
-      getInTrial: () => false,
+      isInTrial: () => false,
     });
 
     expect(getCloudFleetServersHosts()).toMatchInlineSnapshot(`
@@ -317,7 +317,7 @@ describe('getCloudFleetServersHosts', () => {
       serverless: {
         projectId: undefined,
       },
-      getInTrial: () => false,
+      isInTrial: () => false,
     });
 
     expect(getCloudFleetServersHosts()).toMatchInlineSnapshot(`
@@ -359,7 +359,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: undefined,
       },
-      getInTrial: () => false,
+      isInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: true },
@@ -406,7 +406,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: undefined,
       },
-      getInTrial: () => false,
+      isInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: false },
@@ -455,7 +455,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: undefined,
       },
-      getInTrial: () => false,
+      isInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: true },
@@ -488,7 +488,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: undefined,
       },
-      getInTrial: () => false,
+      isInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: true },
@@ -520,7 +520,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: undefined,
       },
-      getInTrial: () => false,
+      isInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: false },
@@ -552,7 +552,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: 'project-123',
       },
-      getInTrial: () => false,
+      isInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: true },

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_server_host.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_server_host.test.ts
@@ -274,6 +274,7 @@ describe('getCloudFleetServersHosts', () => {
       serverless: {
         projectId: undefined,
       },
+      getInTrial: () => false,
     });
 
     expect(getCloudFleetServersHosts()).toBeUndefined();
@@ -292,6 +293,7 @@ describe('getCloudFleetServersHosts', () => {
       serverless: {
         projectId: undefined,
       },
+      getInTrial: () => false,
     });
 
     expect(getCloudFleetServersHosts()).toMatchInlineSnapshot(`
@@ -315,6 +317,7 @@ describe('getCloudFleetServersHosts', () => {
       serverless: {
         projectId: undefined,
       },
+      getInTrial: () => false,
     });
 
     expect(getCloudFleetServersHosts()).toMatchInlineSnapshot(`
@@ -356,6 +359,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: undefined,
       },
+      getInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: true },
@@ -402,6 +406,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: undefined,
       },
+      getInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: false },
@@ -450,6 +455,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: undefined,
       },
+      getInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: true },
@@ -482,6 +488,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: undefined,
       },
+      getInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: true },
@@ -513,6 +520,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: undefined,
       },
+      getInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: false },
@@ -544,6 +552,7 @@ describe('createCloudFleetServerHostsIfNeeded', () => {
       serverless: {
         projectId: 'project-123',
       },
+      getInTrial: () => false,
     });
     mockedAppContextService.getConfig.mockReturnValue({
       agentless: { enabled: true },

--- a/x-pack/platform/plugins/shared/ml/server/routes/system.ts
+++ b/x-pack/platform/plugins/shared/ml/server/routes/system.ts
@@ -183,7 +183,7 @@ export function systemRoutes(
         try {
           const body = await mlClient.info();
           const cloudId = cloud?.cloudId;
-          const isCloudTrial = cloud?.getInTrial() ?? false;
+          const isCloudTrial = cloud?.isInTrial() ?? false;
 
           let isMlAutoscalingEnabled = false;
           try {

--- a/x-pack/platform/plugins/shared/ml/server/routes/system.ts
+++ b/x-pack/platform/plugins/shared/ml/server/routes/system.ts
@@ -183,7 +183,7 @@ export function systemRoutes(
         try {
           const body = await mlClient.info();
           const cloudId = cloud?.cloudId;
-          const isCloudTrial = cloud?.trialEndDate && Date.now() < cloud.trialEndDate.getTime();
+          const isCloudTrial = cloud?.getInTrial() ?? false;
 
           let isMlAutoscalingEnabled = false;
           try {


### PR DESCRIPTION
## Summary

Added the isInTrial helper function to the cloud plugin setup & start interfaces that allow checking if the deployment or serverless project are in trial based on either the trial_end_date or serverless.in_trial config values being set. Adding a function allows the date comparison to be handled by the cloud plugin and possibly updated in the future without consumers needing to know the details of how we verify if the cluster is within a trial cloud organization.

This is a follow-up to [#232703](https://github.com/elastic/kibana/pull/232703) where I added the `serverless.in_trial` config value. In subsequent PRs it was discussed we should have a helper on the cloud function to give uniform way to access "in trial".

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.