### PR TITLE
[8.19] Support var removals on integration upgrade (#238542)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -13,6 +13,7 @@ export {
   packageToPackagePolicy,
   getStreamsForInputType,
   getRegistryStreamWithDataStreamForInputType,
+  varsReducer,
 } from './package_to_package_policy';
 export { fullAgentPolicyToYaml } from './full_agent_policy_to_yaml';
 export { isPackageLimited, doesAgentPolicyAlreadyIncludePackage } from './limited_package';

--- a/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.ts
@@ -85,7 +85,7 @@ export const getRegistryStreamWithDataStreamForInputType = (
 };
 
 // Reduces registry var def into config object entry
-const varsReducer = (
+export const varsReducer = (
   configObject: PackagePolicyConfigRecord,
   registryVar: RegistryVarsEntry
 ): PackagePolicyConfigRecord => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -4847,6 +4847,96 @@ describe('Package policy service', () => {
       });
     });
 
+    describe('when a variable is defined in original object, but not in override', () => {
+      it('it is removed from the resulting object', () => {
+        const basePackagePolicy: NewPackagePolicy = {
+          name: 'base-package-policy',
+          description: 'Base Package Policy',
+          namespace: 'default',
+          enabled: true,
+          policy_id: 'xxxx',
+          policy_ids: ['xxxx'],
+          package: {
+            name: 'test-package',
+            title: 'Test Package',
+            version: '0.0.1',
+          },
+          inputs: [
+            {
+              type: 'logs',
+              policy_template: 'template_1',
+              enabled: true,
+              vars: {
+                path: {
+                  type: 'text',
+                  value: ['/var/log/logfile.log'],
+                },
+              },
+              streams: [],
+            },
+          ],
+        };
+
+        const packageInfo: PackageInfo = {
+          name: 'test-package',
+          description: 'Test Package',
+          title: 'Test Package',
+          version: '0.0.1',
+          latestVersion: '0.0.1',
+          release: 'experimental',
+          format_version: '1.0.0',
+          owner: { github: 'elastic/fleet' },
+          policy_templates: [
+            {
+              name: 'template_1',
+              title: 'Template 1',
+              description: 'Template 1',
+              inputs: [
+                {
+                  type: 'logs',
+                  title: 'Log',
+                  description: 'Log Input',
+                  vars: [
+                    {
+                      name: 'path_2',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          // @ts-ignore
+          assets: {},
+        };
+
+        const inputsOverride: NewPackagePolicyInput[] = [
+          {
+            type: 'logs',
+            enabled: true,
+            streams: [],
+            policy_template: 'template_1',
+            vars: {
+              path_2: {
+                type: 'text',
+                value: '/var/log/custom.log',
+              },
+            },
+          },
+        ];
+
+        const result = updatePackageInputs(
+          basePackagePolicy,
+          packageInfo,
+          inputsOverride as InputsOverride[],
+          false
+        );
+
+        expect(result.inputs[0]?.vars?.path).toBeUndefined();
+        expect(result.inputs[0]?.vars?.path_2.value).toEqual('/var/log/custom.log');
+      });
+    });
+
     describe('when variable is undefined in original object and policy_template is undefined', () => {
       it('adds the variable definition to the resulting object', () => {
         const basePackagePolicy: NewPackagePolicy = {
@@ -4946,8 +5036,8 @@ describe('Package policy service', () => {
       });
     });
 
-    describe('when an input of the same type exists under multiple policy templates', () => {
-      it('adds variable definitions to the proper streams', () => {
+    describe('global variables', () => {
+      it('adds the global variable definitions to the resulting object when they are not defined in the original policy', () => {
         const basePackagePolicy: NewPackagePolicy = {
           name: 'base-package-policy',
           description: 'Base Package Policy',
@@ -4980,9 +5070,117 @@ describe('Package policy service', () => {
                 },
               ],
             },
+          ],
+        };
+
+        const packageInfo: PackageInfo = {
+          name: 'test-package',
+          description: 'Test Package',
+          title: 'Test Package',
+          version: '0.0.1',
+          latestVersion: '0.0.1',
+          release: 'experimental',
+          format_version: '1.0.0',
+          owner: { github: 'elastic/fleet' },
+          vars: [
+            {
+              name: 'global_var_1',
+              type: 'text',
+              default: 'value1',
+            },
+            {
+              name: 'global_var_2',
+              type: 'text',
+            },
+          ],
+          policy_templates: [
+            {
+              name: 'template_1',
+              title: 'Template 1',
+              description: 'Template 1',
+              inputs: [
+                {
+                  type: 'logs',
+                  title: 'Log',
+                  description: 'Log Input',
+                  vars: [
+                    {
+                      name: 'log_file_path',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          // @ts-ignore
+          assets: {},
+        };
+
+        const inputsOverride: NewPackagePolicyInput[] = [
+          {
+            type: 'logs',
+            enabled: true,
+            policy_template: 'template_1',
+            streams: [
+              {
+                enabled: true,
+                data_stream: {
+                  dataset: 'test.logs',
+                  type: 'logfile',
+                },
+                vars: {
+                  log_file_path: {
+                    type: 'text',
+                    value: '/var/log/template1-logfile.log',
+                  },
+                },
+              },
+            ],
+          },
+        ];
+
+        const result = updatePackageInputs(
+          basePackagePolicy,
+          packageInfo,
+          inputsOverride as InputsOverride[],
+          false
+        );
+
+        expect(result.vars).toBeDefined();
+        expect(result.vars?.global_var_1).toBeDefined();
+        expect(result.vars?.global_var_1.value).toBe('value1');
+        expect(result.vars?.global_var_2).toBeDefined();
+        expect(result.vars?.global_var_2.value).toBeUndefined();
+      });
+
+      it('removes the global variable definitions in the resulting object when they are not defined in the package', () => {
+        const basePackagePolicy: NewPackagePolicy = {
+          name: 'base-package-policy',
+          description: 'Base Package Policy',
+          namespace: 'default',
+          enabled: true,
+          policy_id: 'xxxx',
+          policy_ids: ['xxxx'],
+          package: {
+            name: 'test-package',
+            title: 'Test Package',
+            version: '0.0.1',
+          },
+          vars: {
+            global_var_1: {
+              type: 'text',
+              value: 'value1',
+            },
+            global_var_2: {
+              type: 'text',
+              value: 'value2',
+            },
+          },
+          inputs: [
             {
               type: 'logs',
-              policy_template: 'template_2',
+              policy_template: 'template_1',
               enabled: true,
               streams: [
                 {
@@ -5021,14 +5219,377 @@ describe('Package policy service', () => {
                   type: 'logs',
                   title: 'Log',
                   description: 'Log Input',
-                  vars: [],
+                  vars: [
+                    {
+                      name: 'log_file_path',
+                      type: 'text',
+                    },
+                  ],
                 },
               ],
             },
+          ],
+          // @ts-ignore
+          assets: {},
+        };
+
+        const inputsOverride: NewPackagePolicyInput[] = [
+          {
+            type: 'logs',
+            enabled: true,
+            policy_template: 'template_1',
+            streams: [
+              {
+                enabled: true,
+                data_stream: {
+                  dataset: 'test.logs',
+                  type: 'logfile',
+                },
+                vars: {
+                  log_file_path: {
+                    type: 'text',
+                    value: '/var/log/template1-logfile.log',
+                  },
+                },
+              },
+            ],
+          },
+        ];
+
+        const result = updatePackageInputs(
+          basePackagePolicy,
+          packageInfo,
+          inputsOverride as InputsOverride[],
+          false
+        );
+
+        expect(result.vars).toBeUndefined();
+      });
+
+      describe('when global vars are defined in the original policy and defined in the package', () => {
+        it('preserves existing global vars values, and adds new ones', () => {
+          const basePackagePolicy: NewPackagePolicy = {
+            name: 'base-package-policy',
+            description: 'Base Package Policy',
+            namespace: 'default',
+            enabled: true,
+            policy_id: 'xxxx',
+            policy_ids: ['xxxx'],
+            package: {
+              name: 'test-package',
+              title: 'Test Package',
+              version: '0.0.1',
+            },
+            vars: {
+              global_var_1: {
+                type: 'text',
+                value: 'value1',
+              },
+              global_var_2: {
+                type: 'text',
+                value: 'value2',
+              },
+            },
+            inputs: [
+              {
+                type: 'logs',
+                policy_template: 'template_1',
+                enabled: true,
+                streams: [
+                  {
+                    enabled: true,
+                    data_stream: {
+                      dataset: 'test.logs',
+                      type: 'logfile',
+                    },
+                    vars: {
+                      log_file_path: {
+                        type: 'text',
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          };
+
+          const packageInfo: PackageInfo = {
+            name: 'test-package',
+            description: 'Test Package',
+            title: 'Test Package',
+            version: '0.0.1',
+            latestVersion: '0.0.1',
+            release: 'experimental',
+            format_version: '1.0.0',
+            owner: { github: 'elastic/fleet' },
+            vars: [
+              {
+                name: 'global_var_1',
+                type: 'text',
+                default: 'newValue1',
+              },
+              {
+                name: 'global_var_2',
+                type: 'text',
+              },
+              {
+                name: 'global_var_3',
+                type: 'text',
+                default: 'newValue3',
+              },
+            ],
+            policy_templates: [
+              {
+                name: 'template_1',
+                title: 'Template 1',
+                description: 'Template 1',
+                inputs: [
+                  {
+                    type: 'logs',
+                    title: 'Log',
+                    description: 'Log Input',
+                    vars: [
+                      {
+                        name: 'log_file_path',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            // @ts-ignore
+            assets: {},
+          };
+
+          const inputsOverride: NewPackagePolicyInput[] = [
             {
-              name: 'template_2',
-              title: 'Template 2',
-              description: 'Template 2',
+              type: 'logs',
+              enabled: true,
+              policy_template: 'template_1',
+              streams: [
+                {
+                  enabled: true,
+                  data_stream: {
+                    dataset: 'test.logs',
+                    type: 'logfile',
+                  },
+                  vars: {
+                    log_file_path: {
+                      type: 'text',
+                      value: '/var/log/template1-logfile.log',
+                    },
+                  },
+                },
+              ],
+            },
+          ];
+
+          const result = updatePackageInputs(
+            basePackagePolicy,
+            packageInfo,
+            inputsOverride as InputsOverride[],
+            false
+          );
+
+          expect(result.vars).toBeDefined();
+          expect(result.vars?.global_var_1).toBeDefined();
+          expect(result.vars?.global_var_1.value).toBe('value1');
+          expect(result.vars?.global_var_2).toBeDefined();
+          expect(result.vars?.global_var_2.value).toBe('value2');
+          expect(result.vars?.global_var_3).toBeDefined();
+          expect(result.vars?.global_var_3.value).toBe('newValue3');
+        });
+
+        it('preserves existing global vars values, and removes ones no longer defined in the package', () => {
+          const basePackagePolicy: NewPackagePolicy = {
+            name: 'base-package-policy',
+            description: 'Base Package Policy',
+            namespace: 'default',
+            enabled: true,
+            policy_id: 'xxxx',
+            policy_ids: ['xxxx'],
+            package: {
+              name: 'test-package',
+              title: 'Test Package',
+              version: '0.0.1',
+            },
+            vars: {
+              global_var_1: {
+                type: 'text',
+                value: 'value1',
+              },
+              global_var_2: {
+                type: 'text',
+                value: 'value2',
+              },
+            },
+            inputs: [
+              {
+                type: 'logs',
+                policy_template: 'template_1',
+                enabled: true,
+                streams: [
+                  {
+                    enabled: true,
+                    data_stream: {
+                      dataset: 'test.logs',
+                      type: 'logfile',
+                    },
+                    vars: {
+                      log_file_path: {
+                        type: 'text',
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          };
+
+          const packageInfo: PackageInfo = {
+            name: 'test-package',
+            description: 'Test Package',
+            title: 'Test Package',
+            version: '0.0.1',
+            latestVersion: '0.0.1',
+            release: 'experimental',
+            format_version: '1.0.0',
+            owner: { github: 'elastic/fleet' },
+            vars: [
+              {
+                name: 'global_var_1',
+                type: 'text',
+                default: 'newValue1',
+              },
+              {
+                name: 'global_var_2',
+                type: 'text',
+              },
+              {
+                name: 'global_var_3',
+                type: 'text',
+                default: 'newValue3',
+              },
+            ],
+            policy_templates: [
+              {
+                name: 'template_1',
+                title: 'Template 1',
+                description: 'Template 1',
+                inputs: [
+                  {
+                    type: 'logs',
+                    title: 'Log',
+                    description: 'Log Input',
+                    vars: [
+                      {
+                        name: 'log_file_path',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            // @ts-ignore
+            assets: {},
+          };
+
+          const inputsOverride: NewPackagePolicyInput[] = [
+            {
+              type: 'logs',
+              enabled: true,
+              policy_template: 'template_1',
+              streams: [
+                {
+                  enabled: true,
+                  data_stream: {
+                    dataset: 'test.logs',
+                    type: 'logfile',
+                  },
+                  vars: {
+                    log_file_path: {
+                      type: 'text',
+                      value: '/var/log/template1-logfile.log',
+                    },
+                  },
+                },
+              ],
+            },
+          ];
+
+          const result = updatePackageInputs(
+            basePackagePolicy,
+            packageInfo,
+            inputsOverride as InputsOverride[],
+            false
+          );
+
+          expect(result.vars).toBeDefined();
+          expect(result.vars?.global_var_1).toBeDefined();
+          expect(result.vars?.global_var_1.value).toBe('value1');
+          expect(result.vars?.global_var_2).toBeDefined();
+          expect(result.vars?.global_var_2.value).toBe('value2');
+          expect(result.vars?.global_var_3).toBeDefined();
+          expect(result.vars?.global_var_3.value).toBe('newValue3');
+        });
+      });
+    });
+    describe('when a variable is no longer defined in the new version of a stream', () => {
+      it('the old variable definition is removed', () => {
+        const basePackagePolicy: NewPackagePolicy = {
+          name: 'base-package-policy',
+          description: 'Base Package Policy',
+          namespace: 'default',
+          enabled: true,
+          policy_id: 'xxxx',
+          policy_ids: ['xxxx'],
+          package: {
+            name: 'test-package',
+            title: 'Test Package',
+            version: '0.0.1',
+          },
+          inputs: [
+            {
+              type: 'logs',
+              policy_template: 'template_1',
+              enabled: true,
+              streams: [
+                {
+                  enabled: true,
+                  data_stream: {
+                    dataset: 'test.logs',
+                    type: 'logfile',
+                  },
+                  vars: {
+                    log_file_path: {
+                      type: 'text',
+                    },
+                    old_file_path: {
+                      type: 'text',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        const packageInfo: PackageInfo = {
+          name: 'test-package',
+          description: 'Test Package',
+          title: 'Test Package',
+          version: '0.0.1',
+          latestVersion: '0.0.1',
+          release: 'experimental',
+          format_version: '1.0.0',
+          owner: { github: 'elastic/fleet' },
+          policy_templates: [
+            {
+              name: 'template_1',
+              title: 'Template 1',
+              description: 'Template 1',
               inputs: [
                 {
                   type: 'logs',
@@ -5064,26 +5625,6 @@ describe('Package policy service', () => {
               },
             ],
           },
-          {
-            type: 'logs',
-            enabled: true,
-            policy_template: 'template_2',
-            streams: [
-              {
-                enabled: true,
-                data_stream: {
-                  dataset: 'test.logs',
-                  type: 'logfile',
-                },
-                vars: {
-                  log_file_path: {
-                    type: 'text',
-                    value: '/var/log/template2-logfile.log',
-                  },
-                },
-              },
-            ],
-          },
         ];
 
         const result = updatePackageInputs(
@@ -5095,25 +5636,16 @@ describe('Package policy service', () => {
           false
         );
 
-        expect(result.inputs).toHaveLength(2);
+        expect(result.inputs).toHaveLength(1);
 
         const template1Input = result.inputs.find(
           (input) => input.policy_template === 'template_1'
         );
-        const template2Input = result.inputs.find(
-          (input) => input.policy_template === 'template_2'
-        );
-
         expect(template1Input).toBeDefined();
-        expect(template2Input).toBeDefined();
-
         expect(template1Input?.streams[0].vars?.log_file_path.value).toBe(
           '/var/log/template1-logfile.log'
         );
-
-        expect(template2Input?.streams[0].vars?.log_file_path.value).toBe(
-          '/var/log/template2-logfile.log'
-        );
+        expect(template1Input?.streams[0].vars?.old_file_path).toBeUndefined();
       });
     });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -45,6 +45,7 @@ import {
   getNormalizedDataStreams,
   getNormalizedInputs,
   isRootPrivilegesRequired,
+  varsReducer,
 } from '../../common/services';
 import {
   SO_SEARCH_LIMIT,
@@ -74,6 +75,7 @@ import type {
   AssetsMap,
   AgentPolicy,
   PreconfiguredInputs,
+  PackagePolicyConfigRecord,
 } from '../../common/types';
 import {
   FleetError,
@@ -2879,9 +2881,11 @@ export function updatePackageInputs(
       originalInput.policy_template = update.policy_template;
     }
 
-    if (update.vars) {
+    if (update.vars || originalInput.vars) {
       const indexOfInput = inputs.indexOf(originalInput);
-      inputs[indexOfInput] = deepMergeVars(originalInput, update, true) as NewPackagePolicyInput;
+      const mergedVars = deepMergeVars(originalInput, update, true) as NewPackagePolicyInput;
+      const filteredVars = removeStaleVars<NewPackagePolicyInput>(mergedVars, update);
+      inputs[indexOfInput] = filteredVars;
       originalInput = inputs[indexOfInput];
     }
 
@@ -2914,16 +2918,14 @@ export function updatePackageInputs(
           originalStream.enabled = stream.enabled;
         }
 
-        if (stream.vars) {
+        if (stream.vars || originalStream.vars) {
           // streams wont match for input pkgs
           const indexOfStream = isInputPkgUpdate
             ? 0
             : originalInput.streams.indexOf(originalStream);
-          originalInput.streams[indexOfStream] = deepMergeVars(
-            originalStream,
-            stream as InputsOverride,
-            true
-          );
+          const mergedVars = deepMergeVars(originalStream, stream as InputsOverride, true);
+          const filteredVars = removeStaleVars(mergedVars, stream);
+          originalInput.streams[indexOfStream] = filteredVars;
           originalStream = originalInput.streams[indexOfStream];
         }
       }
@@ -2938,9 +2940,12 @@ export function updatePackageInputs(
     });
   }
 
+  const vars = getUpdatedGlobalVars(packageInfo, basePackagePolicy);
+
   const resultingPackagePolicy: NewPackagePolicy = {
     ...basePackagePolicy,
     inputs,
+    vars,
   };
 
   const validationResults = validatePackagePolicy(resultingPackagePolicy, packageInfo, load);
@@ -3189,6 +3194,9 @@ export function sendUpdatePackagePolicyTelemetryEvent(
 }
 
 function deepMergeVars(original: any, override: any, keepOriginalValue = false): any {
+  if (!override.vars) {
+    return original;
+  }
   if (!original.vars) {
     original.vars = { ...override.vars };
   }
@@ -3215,6 +3223,51 @@ function deepMergeVars(original: any, override: any, keepOriginalValue = false):
   }
 
   return result;
+}
+
+function getUpdatedGlobalVars(packageInfo: PackageInfo, packagePolicy: NewPackagePolicy) {
+  if (!packageInfo.vars) {
+    return undefined;
+  }
+
+  const packageInfoVars = packageInfo.vars.reduce(varsReducer, {});
+  const result = deepMergeVars(packagePolicy, { vars: packageInfoVars }, true);
+  return removeStaleVars(result, { vars: packageInfoVars }).vars;
+}
+
+interface SupportsVars {
+  vars?: PackagePolicyConfigRecord;
+}
+
+function removeStaleVars<T extends SupportsVars>(
+  currentWithVars: T,
+  expectedVars: SupportsVars
+): T {
+  if (!currentWithVars.vars) {
+    return currentWithVars;
+  }
+
+  if (!expectedVars.vars) {
+    return {
+      ...currentWithVars,
+      vars: {},
+    };
+  }
+
+  const filteredVars = Object.entries(currentWithVars.vars).reduce<PackagePolicyConfigRecord>(
+    (acc, [key, val]) => {
+      if (key in expectedVars.vars!) {
+        acc[key] = val;
+      }
+      return acc;
+    },
+    {}
+  );
+
+  return {
+    ...currentWithVars,
+    vars: filteredVars,
+  };
 }
 
 async function requireUniqueName(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Support var removals on integration upgrade (#238542)](https://github.com/elastic/kibana/pull/238542)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michel Losier","email":"michel.losier@elastic.co"},"sourceCommit":{"committedDate":"2025-10-15T16:21:04Z","message":"Support var removals on integration upgrade (#238542)\n\nResolves: https://github.com/elastic/kibana/issues/235242\n\n* On package policy upgrade:\n  * Adds support for checking global var additions on package upgrade\n* Removes stale variables (global, input, or stream) from the original\npackage policy that are no longer defined in the new package version.","sha":"1c86d1b098457bebfbf008da7a9da781306bfe07","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:all-open","v9.3.0"],"title":"Support var removals on integration upgrade","number":238542,"url":"https://github.com/elastic/kibana/pull/238542","mergeCommit":{"message":"Support var removals on integration upgrade (#238542)\n\nResolves: https://github.com/elastic/kibana/issues/235242\n\n* On package policy upgrade:\n  * Adds support for checking global var additions on package upgrade\n* Removes stale variables (global, input, or stream) from the original\npackage policy that are no longer defined in the new package version.","sha":"1c86d1b098457bebfbf008da7a9da781306bfe07"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238542","number":238542,"mergeCommit":{"message":"Support var removals on integration upgrade (#238542)\n\nResolves: https://github.com/elastic/kibana/issues/235242\n\n* On package policy upgrade:\n  * Adds support for checking global var additions on package upgrade\n* Removes stale variables (global, input, or stream) from the original\npackage policy that are no longer defined in the new package version.","sha":"1c86d1b098457bebfbf008da7a9da781306bfe07"}},{"url":"https://github.com/elastic/kibana/pull/239189","number":239189,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->