### PR TITLE
[Lens][Table] Fix filtering on tables with formula columns

### DIFF
--- a/x-pack/platform/plugins/shared/lens/common/expressions/impl/datatable/datatable_fn.test.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/impl/datatable/datatable_fn.test.ts
@@ -119,4 +119,31 @@ describe('datatableFn', () => {
     expect(resultColumnIds).toEqual(expectedColumnIds);
     expect(resultColumnIds).toEqual(['bucket1', 'bucket2', 'bucket3', 'metric1', 'metric2']);
   });
+
+  // This is needed for ghost formula columns, see https://github.com/elastic/kibana/issues/239170
+  it('should sort unknown columns in table by order of args.columns', async () => {
+    const table = buildTable();
+    const shuffledTable: Datatable = {
+      ...table,
+      columns: shuffle([
+        ...table.columns,
+        { id: 'unknown', name: 'unknown', meta: { type: 'number' } },
+      ]),
+    };
+    const args = buildArgs();
+    const result = await datatableFn(() => mockFormatFactory)(shuffledTable, args, context);
+
+    const resultColumnIds = result.value.data.columns.map((c) => c.id);
+    const expectedColumnIds = args.columns.map((c) => c.columnId).concat('unknown');
+
+    expect(resultColumnIds).toEqual(expectedColumnIds);
+    expect(resultColumnIds).toEqual([
+      'bucket1',
+      'bucket2',
+      'bucket3',
+      'metric1',
+      'metric2',
+      'unknown',
+    ]);
+  });
 });

--- a/x-pack/platform/plugins/shared/lens/common/expressions/impl/datatable/datatable_fn.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/impl/datatable/datatable_fn.ts
@@ -21,7 +21,7 @@ export const datatableFn =
   ): DatatableExpressionFunction['fn'] =>
   async (table, args, context) => {
     const columnSortMap = args.columns.reduce((acc, c, i) => acc.set(c.columnId, i), new Map());
-    const getColumnSort = (id: string) => columnSortMap.get(id) ?? -1;
+    const getColumnSort = (id: string) => columnSortMap.get(id) ?? Infinity;
     const sortedTable: Datatable = {
       ...table,
       columns: table.columns.slice().sort((a, b) => getColumnSort(a.id) - getColumnSort(b.id)),


### PR DESCRIPTION
## Summary

Fixes a bug in the Lens Table that broke **click to filter** on table rows when any column is used as a formula.

https://github.com/user-attachments/assets/d6b74245-a051-4e66-8187-52ed9e03eebc

Fixes #239170

### Details

In #236673 We added column sorting to export the correct order to csv. The issue is that the formula columns create **ghost** columns in the datatable used to build-up the real columns. These use the id `<colId>X<number>` and are removed from the export so as long as the order of the real columns was correct it was fine.

However, with filtering we use the `colIndex` to define the column to filter.

https://github.com/elastic/kibana/blob/c8bccc3f994b396bf7ed185b847bf417ae1d269e/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/table_actions.ts#L83-L102

With the non-bucketed (aka **Metrics**) columns, we a lookup table to map the column id to the meta data including the column index of the full table, including the ghost columns. This is why this filtering was not also broken.

![Untitled](https://github.com/user-attachments/assets/280ecfca-e2bd-4547-b6cd-7066aa80ed05)

https://github.com/elastic/kibana/blob/c8bccc3f994b396bf7ed185b847bf417ae1d269e/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/columns.tsx#L62

But with the bucketed columns (aka **Rows**), we determine the column index from the `columnConfig` with excludes the ghost columns. Hence the issue, we were sorting the ghost columns to the front of the array such that all the indices of the real columns would be offset by the number of ghost columns.

All that said, a simple fix would be to just sort the real columns to the start of the array and leave unknown/ghost columns to the end as their order does not matter. Alternatively, we could create a lookup similar to above to lookup the index on the full table but I don't think that is necessary if we enforce the correct order.

Ideally, we filter by passing the `columnId` and not the `colIndex`. In this way there is no ambiguity and the `createGridFilterHandler` has the table to lookup the correct index from the `table.columns`. See #239224.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Minimal as sorting is the only impact.

## Release Notes

Fixes a bug in the Lens Table that broke **click to filter** on table rows when any column is used as a formula.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.1","9.2"]} ONMERGE-->