### PR TITLE
[Automatic Migrations] Deselect current selection after index pattern updated

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/index.tsx
@@ -219,6 +219,7 @@ export const MigrationRulesTable: React.FC<MigrationRulesTableProps> = React.mem
           ids: selectedMigrationRules.map((rule) => rule.id),
         });
         setTableLoading(false);
+        setSelectedMigrationRules([]);
       },
       [migrationId, updateIndexPattern, selectedMigrationRules, setTableLoading]
     );


### PR DESCRIPTION
## Summary

Issue: [#239062](https://github.com/elastic/kibana/issues/239062)

When a user selects some rule migrations on the page and updates the index pattern placeholder to an actual index pattern, previously the selection would remain. This fixes that problem by setting the selection to an empty array on successfully applying the new pattern. 


https://github.com/user-attachments/assets/21816e68-a80e-4730-8d09-957f0a705cfe



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->