### PR TITLE
[9.2] [Obs AI Assistant] aware of new .integration_knowledge* system index (#237085)

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/common/types.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/common/types.ts
@@ -205,3 +205,12 @@ export enum ConversationAccess {
   SHARED = 'shared',
   PRIVATE = 'private',
 }
+
+export interface IntegrationKnowledgeBaseEntry {
+  content: string;
+  package_name: string;
+  filename: string;
+  version: string;
+  path: string;
+  installed_at: string;
+}

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/index.ts
@@ -13,7 +13,11 @@ import { encode } from 'gpt-tokenizer';
 import { isLockAcquisitionError } from '@kbn/lock-manager';
 import type { DocumentationManagerAPI } from '@kbn/product-doc-base-plugin/server/services/doc_manager';
 import { resourceNames } from '..';
-import type { Instruction, KnowledgeBaseEntry } from '../../../common/types';
+import type {
+  Instruction,
+  IntegrationKnowledgeBaseEntry,
+  KnowledgeBaseEntry,
+} from '../../../common/types';
 import { KnowledgeBaseEntryRole, KnowledgeBaseType } from '../../../common/types';
 import { getAccessQuery, getUserAccessFilters } from '../util/get_access_query';
 import { getCategoryQuery } from '../util/get_category_query';
@@ -35,6 +39,8 @@ import { isSemanticTextUnsupportedError } from '../startup_migrations/run_startu
 import { getInferenceIdFromWriteIndex } from './get_inference_id_from_write_index';
 import { createOrUpdateKnowledgeBaseIndexAssets } from '../index_assets/create_or_update_knowledge_base_index_assets';
 import { LEGACY_CUSTOM_INFERENCE_ID } from '../../../common/preconfigured_inference_ids';
+
+const INTEGRATION_KNOWLEDGE_INDEX = '.integration_knowledge';
 
 interface Dependencies {
   core: CoreSetup<ObservabilityAIAssistantPluginStartDependencies>;
@@ -112,6 +118,45 @@ export class KnowledgeBaseService {
     }));
   }
 
+  private async recallFromIntegrationsKnowledge({
+    queries,
+    esClient,
+  }: {
+    queries: Array<{ text: string; boost?: number }>;
+    esClient: { asCurrentUser: ElasticsearchClient; asInternalUser: ElasticsearchClient };
+  }): Promise<RecalledEntry[]> {
+    try {
+      // Search the .integration_knowledge index using semantic search on the content field
+      const response = await esClient.asInternalUser.search<IntegrationKnowledgeBaseEntry>({
+        index: INTEGRATION_KNOWLEDGE_INDEX,
+        query: {
+          bool: {
+            should: queries.map(({ text, boost = 1 }) => ({
+              semantic: {
+                field: 'content',
+                query: text,
+                boost,
+              },
+            })),
+          },
+        },
+        size: 10,
+        _source: ['package_name', 'filename', 'content', 'version'],
+      });
+      return response.hits.hits.map((hit) => ({
+        text: hit._source?.content!,
+        labels: { filename: hit._source?.filename ?? '', version: hit._source?.version ?? '' },
+        title: hit._source?.package_name,
+        esScore: hit._score!,
+        id: hit._id!,
+      }));
+    } catch (error) {
+      this.dependencies.logger.error(`Error recalling from ${INTEGRATION_KNOWLEDGE_INDEX} index`);
+      this.dependencies.logger.debug(error);
+      return [];
+    }
+  }
+
   recall = async ({
     user,
     queries,
@@ -137,30 +182,42 @@ export class KnowledgeBaseService {
       () => `Recalling entries from KB for queries: "${JSON.stringify(queries)}"`
     );
 
-    const [documentsFromKb, documentsFromConnectors] = await Promise.all([
-      this.recallFromKnowledgeBase({
-        user,
-        queries,
-        categories,
-        namespace,
-      }).catch((error) => {
-        if (isInferenceEndpointMissingOrUnavailable(error)) {
-          throwKnowledgeBaseNotReady(error);
-        }
-        throw error;
-      }),
-      recallFromSearchConnectors({
-        esClient,
-        uiSettingsClient,
-        queries,
-        core: this.dependencies.core,
-        logger: this.dependencies.logger,
-      }).catch((error) => {
-        this.dependencies.logger.error('Error getting data from search indices');
-        this.dependencies.logger.debug(error);
-        return [];
-      }),
-    ]);
+    const [documentsFromKb, documentsFromConnectors, documentsFromIntegrations] = await Promise.all(
+      [
+        this.recallFromKnowledgeBase({
+          user,
+          queries,
+          categories,
+          namespace,
+        }).catch((error) => {
+          if (isInferenceEndpointMissingOrUnavailable(error)) {
+            throwKnowledgeBaseNotReady(error);
+          }
+          throw error;
+        }),
+        recallFromSearchConnectors({
+          esClient,
+          uiSettingsClient,
+          queries,
+          core: this.dependencies.core,
+          logger: this.dependencies.logger,
+        }).catch((error) => {
+          this.dependencies.logger.error('Error getting data from search indices');
+          this.dependencies.logger.debug(error);
+          return [];
+        }),
+        this.recallFromIntegrationsKnowledge({
+          esClient,
+          queries,
+        }).catch((error) => {
+          this.dependencies.logger.error(
+            `Error getting data from ${INTEGRATION_KNOWLEDGE_INDEX} index`
+          );
+          this.dependencies.logger.debug(error);
+          return [];
+        }),
+      ]
+    );
 
     this.dependencies.logger.debug(
       `documentsFromKb: ${JSON.stringify(documentsFromKb.slice(0, 5), null, 2)}`
@@ -168,9 +225,12 @@ export class KnowledgeBaseService {
     this.dependencies.logger.debug(
       `documentsFromConnectors: ${JSON.stringify(documentsFromConnectors.slice(0, 5), null, 2)}`
     );
+    this.dependencies.logger.debug(
+      `documentsFromIntegrations: ${JSON.stringify(documentsFromIntegrations.slice(0, 5), null, 2)}`
+    );
 
     const sortedEntries = orderBy(
-      documentsFromKb.concat(documentsFromConnectors),
+      [...documentsFromKb, ...documentsFromConnectors, ...documentsFromIntegrations],
       'esScore',
       'desc'
     ).slice(0, limit.size ?? 20);


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-assistant-team/issues/380
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Obs AI Assistant] aware of new .integration_knowledge* system index (#237085)](https://github.com/elastic/kibana/pull/237085)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Arturo Lidueña","email":"arturo.liduena@elastic.co"},"sourceCommit":{"committedDate":"2025-10-14T07:13:31Z","message":"[Obs AI Assistant] aware of new .integration_knowledge* system index (#237085)\n\nCloses https://github.com/elastic/obs-ai-assistant-team/issues/357\n## Summary\n\nThis PR adds the awareness of `.integration_knowledge*` index as another\nindex for recalling. The Obs AI Assistant will retrieve integration\nknowledge from the index\n\nValue added to the Obs AI Assistant\n(https://github.com/elastic/obs-ai-assistant-team/issues/357#issuecomment-3303692842):\n> The assistant will become aware of LLM-facing documentation for any\ninstalled integrations in the user's cluster. For example, the Logstash\nintegration might ship documentation that explains how to understand the\nhealth reporting metrics collected by the integration and the assistant\ncould answer prompts like \"why was my logstash server down yesterday?\"\nusing the user's real data.\n\nManual Testing: \n1 -> Follow the instructions from\nhttps://github.com/elastic/kibana/pull/230107#issue-3281157774:\n\n> 1. If https://github.com/elastic/elasticsearch/pull/132506 has been\nmerged, run `yarn es snapshot` in Kibana, otherwise, checkout that\nbranch in your local ES and then in kibana run `yarn es source` in order\nto use that version of ES which contains the index management, mappings,\netc.\n>2. Install a package with any number of knowledge base docs in the\n`docs/knowledge_base` folder. You can use [this sample\npackage](https://github.com/user-attachments/files/21867395/masonstestpackage-0.0.1.zip),\nor create your own following the guide below:\n>\n> - Using `elastic-package`, create a new package using `elastic-package\ncreate integration`\n- Once created add `knowledge_base` as a folder inside of the generated\n`docs` folder of the integration\n- Add an arbitrary amount of `.md` files to the knowledge_base folder\n      - Run `elastic-package build` to build the package\n- There are a lot of different options for installing the package in a\nlocal kibana instance. I prefer to just take the generated .zip folder\nfrom `/build` in `elastic-package` and upload it to kibana using the\ncustom integrations feature. You can also expose the package registry,\nor whatever you see fit.\n>3. Watch the Kibana logs for errors/debug messages etc\n>4. Use the new endpoint or just directly check the index using `GET\n/.integration_knowledge/_search` to verify that the documents are\ningested into the system index of `.integration_knowledge`\n>5. Update the package and verify that the KB documents are updated by\nchecking the response again, they should have the updated pkgVersion on\nthe associated docs.\n>6. Remove the package and then verify (using the endpoint) that the\ndocs are removed from the index\n\n2 - Ask the AI Assistant about information contained in the integration\ndocuments\n\n3- check that the documents are listed on the response of executed the\nfunction context inside learnings\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Sandra G <neptunian@users.noreply.github.com>","sha":"15878ad8a124539d4698de2510fd5d6ad90b8d38","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","backport:skip","Team:Obs AI Assistant","ci:project-deploy-observability","v9.3.0"],"title":"[Obs AI Assistant] aware of new .integration_knowledge* system index","number":237085,"url":"https://github.com/elastic/kibana/pull/237085","mergeCommit":{"message":"[Obs AI Assistant] aware of new .integration_knowledge* system index (#237085)\n\nCloses https://github.com/elastic/obs-ai-assistant-team/issues/357\n## Summary\n\nThis PR adds the awareness of `.integration_knowledge*` index as another\nindex for recalling. The Obs AI Assistant will retrieve integration\nknowledge from the index\n\nValue added to the Obs AI Assistant\n(https://github.com/elastic/obs-ai-assistant-team/issues/357#issuecomment-3303692842):\n> The assistant will become aware of LLM-facing documentation for any\ninstalled integrations in the user's cluster. For example, the Logstash\nintegration might ship documentation that explains how to understand the\nhealth reporting metrics collected by the integration and the assistant\ncould answer prompts like \"why was my logstash server down yesterday?\"\nusing the user's real data.\n\nManual Testing: \n1 -> Follow the instructions from\nhttps://github.com/elastic/kibana/pull/230107#issue-3281157774:\n\n> 1. If https://github.com/elastic/elasticsearch/pull/132506 has been\nmerged, run `yarn es snapshot` in Kibana, otherwise, checkout that\nbranch in your local ES and then in kibana run `yarn es source` in order\nto use that version of ES which contains the index management, mappings,\netc.\n>2. Install a package with any number of knowledge base docs in the\n`docs/knowledge_base` folder. You can use [this sample\npackage](https://github.com/user-attachments/files/21867395/masonstestpackage-0.0.1.zip),\nor create your own following the guide below:\n>\n> - Using `elastic-package`, create a new package using `elastic-package\ncreate integration`\n- Once created add `knowledge_base` as a folder inside of the generated\n`docs` folder of the integration\n- Add an arbitrary amount of `.md` files to the knowledge_base folder\n      - Run `elastic-package build` to build the package\n- There are a lot of different options for installing the package in a\nlocal kibana instance. I prefer to just take the generated .zip folder\nfrom `/build` in `elastic-package` and upload it to kibana using the\ncustom integrations feature. You can also expose the package registry,\nor whatever you see fit.\n>3. Watch the Kibana logs for errors/debug messages etc\n>4. Use the new endpoint or just directly check the index using `GET\n/.integration_knowledge/_search` to verify that the documents are\ningested into the system index of `.integration_knowledge`\n>5. Update the package and verify that the KB documents are updated by\nchecking the response again, they should have the updated pkgVersion on\nthe associated docs.\n>6. Remove the package and then verify (using the endpoint) that the\ndocs are removed from the index\n\n2 - Ask the AI Assistant about information contained in the integration\ndocuments\n\n3- check that the documents are listed on the response of executed the\nfunction context inside learnings\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Sandra G <neptunian@users.noreply.github.com>","sha":"15878ad8a124539d4698de2510fd5d6ad90b8d38"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237085","number":237085,"mergeCommit":{"message":"[Obs AI Assistant] aware of new .integration_knowledge* system index (#237085)\n\nCloses https://github.com/elastic/obs-ai-assistant-team/issues/357\n## Summary\n\nThis PR adds the awareness of `.integration_knowledge*` index as another\nindex for recalling. The Obs AI Assistant will retrieve integration\nknowledge from the index\n\nValue added to the Obs AI Assistant\n(https://github.com/elastic/obs-ai-assistant-team/issues/357#issuecomment-3303692842):\n> The assistant will become aware of LLM-facing documentation for any\ninstalled integrations in the user's cluster. For example, the Logstash\nintegration might ship documentation that explains how to understand the\nhealth reporting metrics collected by the integration and the assistant\ncould answer prompts like \"why was my logstash server down yesterday?\"\nusing the user's real data.\n\nManual Testing: \n1 -> Follow the instructions from\nhttps://github.com/elastic/kibana/pull/230107#issue-3281157774:\n\n> 1. If https://github.com/elastic/elasticsearch/pull/132506 has been\nmerged, run `yarn es snapshot` in Kibana, otherwise, checkout that\nbranch in your local ES and then in kibana run `yarn es source` in order\nto use that version of ES which contains the index management, mappings,\netc.\n>2. Install a package with any number of knowledge base docs in the\n`docs/knowledge_base` folder. You can use [this sample\npackage](https://github.com/user-attachments/files/21867395/masonstestpackage-0.0.1.zip),\nor create your own following the guide below:\n>\n> - Using `elastic-package`, create a new package using `elastic-package\ncreate integration`\n- Once created add `knowledge_base` as a folder inside of the generated\n`docs` folder of the integration\n- Add an arbitrary amount of `.md` files to the knowledge_base folder\n      - Run `elastic-package build` to build the package\n- There are a lot of different options for installing the package in a\nlocal kibana instance. I prefer to just take the generated .zip folder\nfrom `/build` in `elastic-package` and upload it to kibana using the\ncustom integrations feature. You can also expose the package registry,\nor whatever you see fit.\n>3. Watch the Kibana logs for errors/debug messages etc\n>4. Use the new endpoint or just directly check the index using `GET\n/.integration_knowledge/_search` to verify that the documents are\ningested into the system index of `.integration_knowledge`\n>5. Update the package and verify that the KB documents are updated by\nchecking the response again, they should have the updated pkgVersion on\nthe associated docs.\n>6. Remove the package and then verify (using the endpoint) that the\ndocs are removed from the index\n\n2 - Ask the AI Assistant about information contained in the integration\ndocuments\n\n3- check that the documents are listed on the response of executed the\nfunction context inside learnings\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Sandra G <neptunian@users.noreply.github.com>","sha":"15878ad8a124539d4698de2510fd5d6ad90b8d38"}}]}] BACKPORT-->