### PR TITLE
[8.19] [scout] fix failed pw configs retry (#232971)

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -661,8 +661,8 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
             },
             retry: {
               automatic: [
-                { exit_status: '-1', limit: 1 },
-                { exit_status: '*', limit: 0 },
+                { exit_status: '10', limit: 1 },
+                { exit_status: '*', limit: 3 },
               ],
             },
           })

--- a/.buildkite/scripts/steps/test/scout_configs.sh
+++ b/.buildkite/scripts/steps/test/scout_configs.sh
@@ -37,22 +37,25 @@ fi
 
 # The first retry should only run the configs that failed in the previous attempt
 # Any subsequent retries, which would generally only happen by someone clicking the button in the UI, will run everything
+RETRY_FAILED_PAIRS=""
 if [[ -z "$configs" && "${BUILDKITE_RETRY_COUNT:-0}" == "1" ]]; then
-  configs=$(buildkite-agent meta-data get "$FAILED_CONFIGS_KEY" --default '')
-  if [[ -n "$configs" ]]; then
-    echo "--- Retrying only failed configs"
-    echo "$configs"
+  RETRY_FAILED_PAIRS=$(buildkite-agent meta-data get "$FAILED_CONFIGS_KEY" --default '')
+  if [[ -n "$RETRY_FAILED_PAIRS" ]]; then
+    echo "--- Retrying only failed 'Playwright config + mode' pairs"
+    echo "$RETRY_FAILED_PAIRS"
+    # Extract unique configs from failed pairs for processing
+    configs=$(echo "$RETRY_FAILED_PAIRS" | sed 's/ (.*)//' | sort -u)
   fi
 fi
 
 if [ -z "$configs" ] && [ "$SCOUT_CONFIG_GROUP_KEY" != "" ]; then
-  echo "--- downloading scout test configuration"
+  echo "--- Downloading Scout Test Configuration"
   download_artifact scout_playwright_configs.json .
   configs=$(jq -r '.[env.SCOUT_CONFIG_GROUP_KEY].configs[]' scout_playwright_configs.json)
 fi
 
 if [ -z "$configs" ]; then
-  echo "unable to determine configs to run"
+  echo "Unable to determine configs to run"
   exit 1
 fi
 
@@ -77,14 +80,66 @@ configWithoutTests=()
 
 FINAL_EXIT_CODE=0
 
+# Function to upload Scout events if available and clean up
+upload_events_if_available() {
+  local config_path="$1"
+  local mode="$2"
+
+  if [[ "${SCOUT_REPORTER_ENABLED:-}" =~ ^(1|true)$ ]]; then
+    if [ -d ".scout/reports" ] && [ "$(ls -A .scout/reports 2>/dev/null)" ]; then
+      echo "--- Upload Scout reporter events for $config_path ($mode)"
+      # prevent non-zero exit code from breaking the script
+      set +e;
+      node scripts/scout upload-events --dontFailOnError
+      UPLOAD_EXIT_CODE=$?
+      set -e;
+
+      if [[ $UPLOAD_EXIT_CODE -eq 0 ]]; then
+        echo "✅ Upload completed for $config_path ($mode)"
+      else
+        echo "⚠️ Upload failed for $config_path ($mode) with exit code $UPLOAD_EXIT_CODE"
+      fi
+
+      # Clean up reports directory after upload attempt
+      echo "🧹 Cleaning up Scout reports directory"
+      rm -rf .scout/reports
+    else
+      echo "❌ No Scout reports found for $config_path ($mode)"
+    fi
+  else
+    echo "⚠️ The SCOUT_REPORTER_ENABLED environment variable is not 'true'. Skipping event upload."
+  fi
+}
+
 # Run tests for each config
 while read -r config_path; do
   if [[ -z "$config_path" ]]; then
     continue
   fi
 
+  # Run config for each mode
   for mode in $RUN_MODE_LIST; do
+    # If we're retrying specific failed pairs, check if this config+mode pair should be retried
+    if [[ -n "$RETRY_FAILED_PAIRS" ]]; then
+      config_mode_pair="$config_path ($mode)"
+      if ! echo "$RETRY_FAILED_PAIRS" | grep -Fxq "$config_mode_pair"; then
+        continue
+      fi
+    fi
+
+    # Create unique execution key for this config+mode pair
+    CONFIG_MODE_EXECUTION_KEY=$(echo "${config_path}_${mode}_executed" | sed 's/[^a-zA-Z0-9_-]/_/g')
+    IS_CONFIG_MODE_EXECUTED=$(buildkite-agent meta-data get "$CONFIG_MODE_EXECUTION_KEY" --default "false" --log-level error)
+
+    if [[ "${IS_CONFIG_MODE_EXECUTED}" == "true" ]]; then
+      echo "--- [ already-completed ] $config_path ($mode)"
+      results+=("$config_path ($mode) ✅ (cached)")
+      continue
+    fi
+
     echo "--- Running tests: $config_path ($mode)"
+
+    start=$(date +%s)
 
     # prevent non-zero exit code from breaking the loop
     set +e;
@@ -92,13 +147,32 @@ while read -r config_path; do
     EXIT_CODE=$?
     set -e;
 
+    timeSec=$(($(date +%s)-start))
+    if [[ $timeSec -gt 60 ]]; then
+      min=$((timeSec/60))
+      sec=$((timeSec-(min*60)))
+      duration="${min}m ${sec}s"
+    else
+      duration="${timeSec}s"
+    fi
+
+    # Now handle test results - retry logic depends only on test success/failure
     if [[ $EXIT_CODE -eq 2 ]]; then
+      # No tests found - mark as executed so we don't retry it
+      buildkite-agent meta-data set "$CONFIG_MODE_EXECUTION_KEY" "true"
       configWithoutTests+=("$config_path ($mode)")
     elif [[ $EXIT_CODE -ne 0 ]]; then
-      failedConfigs+=("$config_path ($mode) ❌")
+      # Test run failed - try to upload events for observability, then mark as failed
+      upload_events_if_available "$config_path" "$mode"
+      failedConfigs+=("$config_path ($mode)")
       FINAL_EXIT_CODE=10  # Ensure we exit with failure if any test fails with (exit code 10 to match FTR)
+      echo "Scout test exited with code $EXIT_CODE for $config_path ($mode)"
+      echo "^^^ +++"
     else
-      results+=("$config_path ($mode) ✅")
+      # Test run was successful - upload events then mark as executed
+      upload_events_if_available "$config_path" "$mode"
+      buildkite-agent meta-data set "$CONFIG_MODE_EXECUTION_KEY" "true"
+      results+=("$config_path ($mode) ✅ (${duration})")
     fi
   done
 done <<< "$configs"
@@ -125,10 +199,20 @@ fi
 
 if [[ ${#failedConfigs[@]} -gt 0 ]]; then
   echo "❌ Failed tests:"
-  printf '%s\n' "${failedConfigs[@]}"
-  buildkite-agent meta-data set "$FAILED_CONFIGS_KEY" "$failedConfigs"
-fi
+  for config in "${failedConfigs[@]}"; do
+    echo "  $config ❌"
+  done
 
-source .buildkite/scripts/steps/test/scout_upload_report_events.sh
+  # Store failed config+mode pairs for retry
+  failed_pairs=""
+  for config in "${failedConfigs[@]}"; do
+    if [[ -n "$failed_pairs" ]]; then
+      failed_pairs="${failed_pairs}"$'\n'"$config"
+    else
+      failed_pairs="$config"
+    fi
+  done
+  buildkite-agent meta-data set "$FAILED_CONFIGS_KEY" "$failed_pairs"
+fi
 
 exit $FINAL_EXIT_CODE  # Exit with 10 only if there were config failures


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[scout] fix failed pw configs retry (#232971)](https://github.com/elastic/kibana/pull/232971)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-10-14T15:30:24Z","message":"[scout] fix failed pw configs retry (#232971)\n\n## Summary\n\nThis PR fixes how we retry Scout tests on CI:\n- retry Playwright config for the failed mode only\n- check if Scout events were uploaded and only then consider pair of\nconfig+mode to be completed (retry if agent lost before events are\nuploaded)\n- upload Scout events right after each pair config+mode are finished\n(both success and failure case)\n- avoid retrying config+mode without tests","sha":"0a5c63911a6bdf961ebc26ec2cfc41044a75ed77","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.2.0","v9.3.0","v9.1.6","v8.19.6"],"title":"[scout] fix failed pw configs retry","number":232971,"url":"https://github.com/elastic/kibana/pull/232971","mergeCommit":{"message":"[scout] fix failed pw configs retry (#232971)\n\n## Summary\n\nThis PR fixes how we retry Scout tests on CI:\n- retry Playwright config for the failed mode only\n- check if Scout events were uploaded and only then consider pair of\nconfig+mode to be completed (retry if agent lost before events are\nuploaded)\n- upload Scout events right after each pair config+mode are finished\n(both success and failure case)\n- avoid retrying config+mode without tests","sha":"0a5c63911a6bdf961ebc26ec2cfc41044a75ed77"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238954","number":238954,"state":"MERGED","mergeCommit":{"sha":"feb585b27eb95fb323cd1e27bea21e0b3d53a719","message":"[9.2] [scout] fix failed pw configs retry (#232971) (#238954)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[scout] fix failed pw configs retry\n(#232971)](https://github.com/elastic/kibana/pull/232971)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232971","number":232971,"mergeCommit":{"message":"[scout] fix failed pw configs retry (#232971)\n\n## Summary\n\nThis PR fixes how we retry Scout tests on CI:\n- retry Playwright config for the failed mode only\n- check if Scout events were uploaded and only then consider pair of\nconfig+mode to be completed (retry if agent lost before events are\nuploaded)\n- upload Scout events right after each pair config+mode are finished\n(both success and failure case)\n- avoid retrying config+mode without tests","sha":"0a5c63911a6bdf961ebc26ec2cfc41044a75ed77"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/239264","number":239264,"state":"OPEN"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->