### PR TITLE
[9.0] [scout] support log level override (#228841)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/common/services/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/index.ts
@@ -12,7 +12,6 @@ export { createScoutConfig } from './config';
 export { getEsArchiver } from './es_archiver';
 export { createKbnUrl } from './kibana_url';
 export { createSamlSessionManager } from './saml_auth';
-export { getLogger } from './logger';
 
 export type { KibanaUrl } from './kibana_url';
 export type { SamlSessionManager } from '@kbn/test';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/worker/core_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/worker/core_fixtures.ts
@@ -17,13 +17,12 @@ import {
   createSamlSessionManager,
   createScoutConfig,
   KibanaUrl,
-  getLogger,
-  ScoutLogger,
   createElasticsearchCustomRole,
   createCustomRole,
   ElasticsearchRoleDescriptor,
   KibanaRole,
 } from '../../../common/services';
+import { ScoutLogger } from '../../../common/services/logger';
 import type { ScoutTestOptions } from '../../types';
 import type { ScoutTestConfig } from '.';
 
@@ -65,7 +64,9 @@ export const coreWorkerFixtures = base.extend<
       const workersCount = workerInfo.config.workers;
       const loggerContext =
         workersCount === 1 ? 'scout-worker' : `scout-worker-${workerInfo.parallelIndex + 1}`;
-      use(getLogger(loggerContext));
+      // The log level is resolved inside the ScoutLogger constructor, which checks the argument,
+      // then SCOUT_LOG_LEVEL, then LOG_LEVEL, and finally defaults to 'info'.
+      use(new ScoutLogger(loggerContext));
     },
     { scope: 'worker' },
   ],

--- a/src/platform/packages/shared/kbn-scout/src/playwright/global_hooks/data_ingestion.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/global_hooks/data_ingestion.ts
@@ -9,17 +9,17 @@
 
 import { FullConfig } from 'playwright/test';
 import {
-  getLogger,
   getEsArchiver,
   createScoutConfig,
   measurePerformanceAsync,
   getEsClient,
   getKbnClient,
 } from '../../common';
+import { ScoutLogger } from '../../common/services/logger';
 import { ScoutTestOptions } from '../types';
 
 export async function ingestTestDataHook(config: FullConfig, archives: string[]) {
-  const log = getLogger();
+  const log = new ScoutLogger('scout: global hook');
 
   if (archives.length === 0) {
     log.debug('[setup] no test data to ingest');

--- a/src/platform/packages/shared/kbn-scout/src/playwright/global_hooks/synthtrace_ingestion.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/global_hooks/synthtrace_ingestion.ts
@@ -18,14 +18,9 @@ import type {
   Serializable,
   SynthtraceGenerator,
 } from '@kbn/apm-synthtrace-client';
-import {
-  getLogger,
-  createScoutConfig,
-  measurePerformanceAsync,
-  getEsClient,
-  ScoutLogger,
-  EsClient,
-} from '../../common';
+import { createScoutConfig, measurePerformanceAsync, getEsClient } from '../../common';
+import type { EsClient } from '../../common';
+import { ScoutLogger } from '../../common/services/logger';
 import { ScoutTestOptions } from '../types';
 import {
   getApmSynthtraceEsClient,
@@ -69,7 +64,7 @@ const getSynthtraceClient = (
  * @deprecated Use `globalSetupHook` and synthtrace fixtures instead
  */
 export async function ingestSynthtraceDataHook(config: FullConfig, data: SynthtraceIngestionData) {
-  const log = getLogger();
+  const log = new ScoutLogger('scout: global hook');
 
   const { apm, infra, otel } = data;
   const hasApmData = apm.length > 0;

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
@@ -8,10 +8,11 @@
  */
 
 import { resolve } from 'path';
-import { ToolingLog } from '@kbn/tooling-log';
+import { ToolingLog, pickLevelFromFlags } from '@kbn/tooling-log';
 import { ProcRunner, withProcRunner } from '@kbn/dev-proc-runner';
 import { getTimeReporter } from '@kbn/ci-stats-reporter';
 import { REPO_ROOT } from '@kbn/repo-info';
+import { getFlags } from '@kbn/dev-cli-runner';
 import { runElasticsearch, runKibanaServer } from '../../servers';
 import { loadServersConfig } from '../../config';
 import { silence } from '../../common';
@@ -31,13 +32,19 @@ export const getPlaywrightProject = (
   return 'local';
 };
 
-async function runPlaywrightTest(procs: ProcRunner, cmd: string, args: string[]) {
+async function runPlaywrightTest(
+  procs: ProcRunner,
+  cmd: string,
+  args: string[],
+  env: Record<string, string> = {}
+) {
   return procs.run(`playwright`, {
     cmd,
     args,
     cwd: resolve(REPO_ROOT),
     env: {
       ...process.env,
+      ...env,
     },
     wait: true,
   });
@@ -70,7 +77,8 @@ async function runLocalServersAndTests(
   log: ToolingLog,
   options: RunTestsOptions,
   cmd: string,
-  cmdArgs: string[]
+  cmdArgs: string[],
+  env: Record<string, string> = {}
 ) {
   const config = await loadServersConfig(options.mode, log);
   const abortCtrl = new AbortController();
@@ -102,7 +110,7 @@ async function runLocalServersAndTests(
     // wait for 5 seconds
     await silence(log, 5000);
 
-    await runPlaywrightTest(procs, cmd, cmdArgs);
+    await runPlaywrightTest(procs, cmd, cmdArgs, env);
   } finally {
     try {
       await procs.stop('kibana');
@@ -122,6 +130,12 @@ export async function runTests(log: ToolingLog, options: RunTestsOptions) {
   const pwConfigPath = options.configPath;
   const pwTestFiles = options.testFiles || [];
   const pwProject = getPlaywrightProject(options.testTarget, options.mode);
+  const globalFlags = getFlags(process.argv.slice(2), {
+    allowUnexpected: true,
+  });
+  // Temporarily use `debug` log level for Playwright tests to better understand performance issues;
+  // We are going to change it to `info` in the future. This change doesn't affect Test Servers logging.
+  const logsLevel = pickLevelFromFlags(globalFlags, { default: 'debug' });
 
   if (pwTestFiles.length > 0) {
     log.info(`scout: Running Scout tests located in:\n${pwTestFiles.join('\n')}`);
@@ -145,9 +159,13 @@ export async function runTests(log: ToolingLog, options: RunTestsOptions) {
     }
 
     if (pwProject === 'local') {
-      await runLocalServersAndTests(procs, log, options, pwBinPath, pwCmdArgs);
+      await runLocalServersAndTests(procs, log, options, pwBinPath, pwCmdArgs, {
+        SCOUT_LOG_LEVEL: logsLevel,
+      });
     } else {
-      await runPlaywrightTest(procs, pwBinPath, pwCmdArgs);
+      await runPlaywrightTest(procs, pwBinPath, pwCmdArgs, {
+        SCOUT_LOG_LEVEL: logsLevel,
+      });
     }
 
     reportTime(runStartTime, 'ready', {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[scout] support log level override (#228841)](https://github.com/elastic/kibana/pull/228841)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-07-22T20:25:49Z","message":"[scout] support log level override (#228841)\n\n## Summary\n\n- default log level for Playwright fixtures is `info` , afaik default\nfor FTR and other scripts (but for now to better understand performance\nissues we pass `debug` through `node scripts/scout`, to be reverted for\nGA)\n- `node scripts/scout` will propagate log level from cli flag (e.g.\n--debug) with `SCOUT_LOG_LEVEL` env variable to playwright exec command\n- since some Team may not use `scripts/scout` command, they can set\n`LOG_LEVEL` variable to override to whatever level is needed\nif both `LOG_LEVEL` and `SCOUT_LOG_LEVEL` are set, the later has\npriority (important for us, shouldn't block others)\n\n### Playwright Integration:\n* Replaced the use of `getLogger` with the updated `ScoutLogger` call in\nPlaywright worker fixtures, enabling log level configuration via\nenvironment variables.\n* Modified the Playwright test runner to propagate the log level to the\ntest environment using the `SCOUT_LOG_LEVEL` variable.\n\n---------\n\nCo-authored-by: David Olaru <dolaru@vaevixen.com>","sha":"d76a5befa5ec73425b44c10b24f66a19556a7e83","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v8.19.0","ci:scout-ui-tests","v9.2.0","v9.1.1","v8.19.1"],"title":"[scout] support log level override","number":228841,"url":"https://github.com/elastic/kibana/pull/228841","mergeCommit":{"message":"[scout] support log level override (#228841)\n\n## Summary\n\n- default log level for Playwright fixtures is `info` , afaik default\nfor FTR and other scripts (but for now to better understand performance\nissues we pass `debug` through `node scripts/scout`, to be reverted for\nGA)\n- `node scripts/scout` will propagate log level from cli flag (e.g.\n--debug) with `SCOUT_LOG_LEVEL` env variable to playwright exec command\n- since some Team may not use `scripts/scout` command, they can set\n`LOG_LEVEL` variable to override to whatever level is needed\nif both `LOG_LEVEL` and `SCOUT_LOG_LEVEL` are set, the later has\npriority (important for us, shouldn't block others)\n\n### Playwright Integration:\n* Replaced the use of `getLogger` with the updated `ScoutLogger` call in\nPlaywright worker fixtures, enabling log level configuration via\nenvironment variables.\n* Modified the Playwright test runner to propagate the log level to the\ntest environment using the `SCOUT_LOG_LEVEL` variable.\n\n---------\n\nCo-authored-by: David Olaru <dolaru@vaevixen.com>","sha":"d76a5befa5ec73425b44c10b24f66a19556a7e83"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230381","number":230381,"state":"MERGED","mergeCommit":{"sha":"d850e332d67734ff96bf6369a3a9747cc7ee6670","message":"[8.19] [scout] support log level override (#228841) (#230381)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[scout] support log level override\n(#228841)](https://github.com/elastic/kibana/pull/228841)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228841","number":228841,"mergeCommit":{"message":"[scout] support log level override (#228841)\n\n## Summary\n\n- default log level for Playwright fixtures is `info` , afaik default\nfor FTR and other scripts (but for now to better understand performance\nissues we pass `debug` through `node scripts/scout`, to be reverted for\nGA)\n- `node scripts/scout` will propagate log level from cli flag (e.g.\n--debug) with `SCOUT_LOG_LEVEL` env variable to playwright exec command\n- since some Team may not use `scripts/scout` command, they can set\n`LOG_LEVEL` variable to override to whatever level is needed\nif both `LOG_LEVEL` and `SCOUT_LOG_LEVEL` are set, the later has\npriority (important for us, shouldn't block others)\n\n### Playwright Integration:\n* Replaced the use of `getLogger` with the updated `ScoutLogger` call in\nPlaywright worker fixtures, enabling log level configuration via\nenvironment variables.\n* Modified the Playwright test runner to propagate the log level to the\ntest environment using the `SCOUT_LOG_LEVEL` variable.\n\n---------\n\nCo-authored-by: David Olaru <dolaru@vaevixen.com>","sha":"d76a5befa5ec73425b44c10b24f66a19556a7e83"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229557","number":229557,"state":"MERGED","mergeCommit":{"sha":"1de8c338657942a87ceaa249b3a220a2ec26af92","message":"[9.1] [scout] support log level override (#228841) (#229557)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[scout] support log level override\n(#228841)](https://github.com/elastic/kibana/pull/228841)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}}]}] BACKPORT-->