### PR TITLE
[8.19] [Scout] Capture test run target, mode and parallel info (#229846)

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -533,6 +533,9 @@ export async function pickTestGroupRunOrder() {
               ...expandAgentQueue('n2-4-spot'),
               diskSizeGb: 100,
             },
+            env: {
+              SCOUT_TARGET_TYPE: 'local',
+            },
             retry: {
               automatic: [
                 { exit_status: '-1', limit: 3 },
@@ -551,6 +554,9 @@ export async function pickTestGroupRunOrder() {
             timeout_in_minutes: 120,
             key: 'jest-integration',
             agents: expandAgentQueue('n2-4-spot'),
+            env: {
+              SCOUT_TARGET_TYPE: 'local',
+            },
             retry: {
               automatic: [
                 { exit_status: '-1', limit: 3 },
@@ -586,6 +592,7 @@ export async function pickTestGroupRunOrder() {
                   timeout_in_minutes: 120,
                   agents: expandAgentQueue(queue),
                   env: {
+                    SCOUT_TARGET_TYPE: 'local',
                     FTR_CONFIG_GROUP_KEY: key,
                     ...ftrExtraArgs,
                     ...envFromlabels,

--- a/src/platform/packages/private/kbn-scout-info/src/runtime.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/runtime.ts
@@ -7,6 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './src/paths';
-export * from './src/reporting';
-export * from './src/runtime';
+export const SCOUT_TARGET_TYPE: string = process.env.SCOUT_TARGET_TYPE || 'unknown';
+export const SCOUT_TARGET_MODE: string = process.env.SCOUT_TARGET_MODE || 'unknown';

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/jest/reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/jest/reporter.ts
@@ -18,7 +18,7 @@ import {
   getCodeOwnersEntries,
   getOwningTeamsForPath,
 } from '@kbn/code-owners';
-import { SCOUT_REPORT_OUTPUT_ROOT } from '@kbn/scout-info';
+import { SCOUT_REPORT_OUTPUT_ROOT, SCOUT_TARGET_MODE, SCOUT_TARGET_TYPE } from '@kbn/scout-info';
 import path from 'node:path';
 import { REPO_ROOT } from '@kbn/repo-info';
 import stripAnsi from 'strip-ansi';
@@ -61,6 +61,10 @@ export class ScoutJestReporter extends BaseReporter {
     this.report = new ScoutEventsReport(this.scoutLog);
     this.baseTestRunInfo = {
       id: this.runId,
+      target: {
+        type: SCOUT_TARGET_TYPE,
+        mode: SCOUT_TARGET_MODE,
+      },
       config: {
         category: reporterOptions.configCategory,
       },

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
@@ -30,6 +30,7 @@ import {
   getOwningTeamsForPath,
   findAreaForCodeOwner,
 } from '@kbn/code-owners';
+import { SCOUT_TARGET_TYPE, SCOUT_TARGET_MODE } from '@kbn/scout-info';
 import {
   ScoutEventsReport,
   ScoutFileInfo,
@@ -62,7 +63,13 @@ export class ScoutPlaywrightReporter implements Reporter {
     this.log.info(`Scout test run ID: ${this.runId}`);
 
     this.report = new ScoutEventsReport(this.log);
-    this.baseTestRunInfo = { id: this.runId };
+    this.baseTestRunInfo = {
+      id: this.runId,
+      target: {
+        type: SCOUT_TARGET_TYPE,
+        mode: SCOUT_TARGET_MODE,
+      },
+    };
     this.codeOwnersEntries = getCodeOwnersEntries();
   }
 
@@ -112,6 +119,7 @@ export class ScoutPlaywrightReporter implements Reporter {
 
     this.baseTestRunInfo = {
       ...this.baseTestRunInfo,
+      fully_parallel: config.fullyParallel,
       config: configInfo,
     };
 

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
@@ -60,6 +60,11 @@ export interface ScoutFileInfo {
  */
 export interface ScoutTestRunInfo {
   id: string;
+  target: {
+    type: string;
+    mode: string;
+  };
+  fully_parallel?: boolean;
   config?: {
     file?: ScoutFileInfo;
     category?: ScoutTestRunConfigCategory;

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
@@ -48,7 +48,7 @@ export const reporterMappings: ClusterPutComponentTemplateRequest = {
 
 export const testRunMappings: ClusterPutComponentTemplateRequest = {
   name: 'scout-test-event.mappings.test-run',
-  version: 2,
+  version: 3,
   template: {
     mappings: {
       properties: {

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
@@ -120,6 +120,20 @@ export const testRunProperties: Record<PropertyName, MappingProperty> = {
   id: {
     type: 'wildcard',
   },
+  target: {
+    type: 'object',
+    properties: {
+      type: {
+        type: 'keyword',
+      },
+      mode: {
+        type: 'keyword',
+      },
+    },
+  },
+  fully_parallel: {
+    type: 'boolean',
+  },
   status: {
     type: 'keyword',
   },

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
@@ -165,19 +165,20 @@ export async function runTests(log: ToolingLog, options: RunTestsOptions) {
 
   await withProcRunner(log, async (procs) => {
     const exitCode = await hasTestsInPlaywrightConfig(log, pwBinPath, pwCmdArgs, pwConfigPath);
+    const pwEnv = {
+      SCOUT_LOG_LEVEL: logsLevel,
+      SCOUT_TARGET_TYPE: options.testTarget,
+      SCOUT_TARGET_MODE: options.mode,
+    };
 
     if (exitCode !== 0) {
       process.exit(exitCode);
     }
 
     if (pwProject === 'local') {
-      await runLocalServersAndTests(procs, log, options, pwBinPath, pwCmdArgs, {
-        SCOUT_LOG_LEVEL: logsLevel,
-      });
+      await runLocalServersAndTests(procs, log, options, pwBinPath, pwCmdArgs, pwEnv);
     } else {
-      await runPlaywrightTest(procs, pwBinPath, pwCmdArgs, {
-        SCOUT_LOG_LEVEL: logsLevel,
-      });
+      await runPlaywrightTest(procs, pwBinPath, pwCmdArgs, pwEnv);
     }
 
     reportTime(runStartTime, 'ready', {

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/scout_ftr_reporter.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/scout_ftr_reporter.ts
@@ -9,7 +9,7 @@
 
 import path from 'node:path';
 import { ToolingLog } from '@kbn/tooling-log';
-import { SCOUT_REPORT_OUTPUT_ROOT } from '@kbn/scout-info';
+import { SCOUT_REPORT_OUTPUT_ROOT, SCOUT_TARGET_MODE, SCOUT_TARGET_TYPE } from '@kbn/scout-info';
 import { REPO_ROOT } from '@kbn/repo-info';
 import {
   datasources,
@@ -67,6 +67,10 @@ export class ScoutFTRReporter {
     this.codeOwnersEntries = getCodeOwnersEntries();
     this.baseTestRunInfo = {
       id: this.runId,
+      target: {
+        type: SCOUT_TARGET_TYPE,
+        mode: SCOUT_TARGET_MODE,
+      },
       config: {
         file: this.getScoutFileInfoForPath(path.relative(REPO_ROOT, config.path)),
         category: config.get('testConfigCategory'),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Scout] Capture test run target, mode and parallel info (#229846)](https://github.com/elastic/kibana/pull/229846)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"David Olaru","email":"dolaru@elastic.co"},"sourceCommit":{"committedDate":"2025-07-31T16:01:41Z","message":"[Scout] Capture test run target, mode and parallel info (#229846)\n\n## Summary\n\nAdds 3 new fields to Scout events collected by the Playwright reporter:\n- `test_run.target.type` - `local` or `cloud`\n- `test_run.target.mode` - the mode the stack is running in (`stateful`,\n`ess`, `serverless=es`, etc.)\n- `test_run.fully_parallel` - whether the tests are running in parallel\nmode; collected from the Playwright config","sha":"55bd9843c4b240d623a2079daee597a509019524","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.2.0","v9.0.5","v9.1.1","v8.19.1"],"title":"[Scout] Capture test run target, mode and parallel info","number":229846,"url":"https://github.com/elastic/kibana/pull/229846","mergeCommit":{"message":"[Scout] Capture test run target, mode and parallel info (#229846)\n\n## Summary\n\nAdds 3 new fields to Scout events collected by the Playwright reporter:\n- `test_run.target.type` - `local` or `cloud`\n- `test_run.target.mode` - the mode the stack is running in (`stateful`,\n`ess`, `serverless=es`, etc.)\n- `test_run.fully_parallel` - whether the tests are running in parallel\nmode; collected from the Playwright config","sha":"55bd9843c4b240d623a2079daee597a509019524"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229846","number":229846,"mergeCommit":{"message":"[Scout] Capture test run target, mode and parallel info (#229846)\n\n## Summary\n\nAdds 3 new fields to Scout events collected by the Playwright reporter:\n- `test_run.target.type` - `local` or `cloud`\n- `test_run.target.mode` - the mode the stack is running in (`stateful`,\n`ess`, `serverless=es`, etc.)\n- `test_run.fully_parallel` - whether the tests are running in parallel\nmode; collected from the Playwright config","sha":"55bd9843c4b240d623a2079daee597a509019524"}},{"branch":"9.0","label":"v9.0.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230098","number":230098,"state":"MERGED","mergeCommit":{"sha":"7fedd5465a6238da23bc92e53c19f5a058e52019","message":"[9.1] [Scout] Capture test run target, mode and parallel info (#229846) (#230098)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Scout] Capture test run target, mode and parallel info\n(#229846)](https://github.com/elastic/kibana/pull/229846)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: David Olaru <dolaru@elastic.co>"}},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->