### PR TITLE
[SharedUX] Remove unnecessary padding from FeedbackButton

### DIFF
--- a/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_button.tsx
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_button.tsx
@@ -52,7 +52,6 @@ export const FeedbackButton = ({
         onClick={handleOpenSurvey}
         css={css`
           width: 100%;
-          padding: ${euiTheme.size.s};
         `}
         color="text"
         iconType="popout"


### PR DESCRIPTION
## Summary

Removed unnecessary padding from `FeedbackButton` noticed [here](https://github.com/elastic/kibana/pull/235197/files#r2432316464).

### Testing

Button size is not affected, no visual consequences (before | after):

<img width="999" height="229" alt="Screenshot 2025-10-15 at 17 13 01" src="https://github.com/user-attachments/assets/a9a24aa6-1a18-4b0b-a14e-77ebb047ccbd" />






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->