### PR TITLE
[8.18] [Discover][Advanced Settings] Fix missing fields when using combined filters with `ignoreFilterIfFieldNotInIndex` UI setting (#238945)

### DIFF
--- a/src/platform/plugins/shared/data/common/search/search_source/query_to_fields.test.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/query_to_fields.test.ts
@@ -7,8 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EsQuerySortValue, queryToFields, SearchRequest, SortDirection } from '../..';
-import { DataViewLazy } from '@kbn/data-views-plugin/common';
+import type { EsQuerySortValue, SearchRequest } from '../..';
+import { queryToFields, SortDirection } from '../..';
+import type { DataViewLazy } from '@kbn/data-views-plugin/common';
+import { type Filter, FILTERS } from '@kbn/es-query';
 
 describe('SearchSource#queryToFields', () => {
   it('should include time field', async () => {
@@ -79,5 +81,56 @@ describe('SearchSource#queryToFields', () => {
     await queryToFields({ dataView: dataView as unknown as DataViewLazy, request });
     const { fieldName } = dataView.getFields.mock.calls[0][0];
     expect(fieldName).toEqual(['@timestamp']);
+  });
+
+  it('should include fields from nested combined filters', async () => {
+    const dataView = {
+      getSourceFiltering: jest.fn().mockReturnValue({ excludes: [] }),
+      getFields: jest.fn().mockResolvedValue({
+        getFieldMapSorted: jest.fn(),
+      }),
+    };
+
+    const combinedFilter: Filter = {
+      meta: {
+        type: FILTERS.COMBINED,
+        disabled: false,
+        params: [
+          {
+            meta: { disabled: false },
+            query: {
+              exists: { field: 'process.name' },
+            },
+          } as Filter,
+          {
+            meta: {
+              type: FILTERS.COMBINED,
+              disabled: false,
+              params: [
+                {
+                  meta: { key: 'attributes.process.name', disabled: false },
+                } as Filter,
+                {
+                  meta: { disabled: false },
+                  query: {
+                    exists: { field: 'stream.name' },
+                  },
+                } as Filter,
+              ],
+            },
+          } as Filter,
+        ],
+      },
+    } as Filter;
+
+    const request: SearchRequest = {
+      query: [],
+      filters: [combinedFilter],
+    };
+
+    await queryToFields({ dataView: dataView as unknown as DataViewLazy, request });
+
+    const { fieldName } = dataView.getFields.mock.calls[0][0];
+    expect(fieldName).toEqual(['process.name', 'attributes.process.name', 'stream.name']);
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Discover][Advanced Settings] Fix missing fields when using combined filters with `ignoreFilterIfFieldNotInIndex` UI setting (#238945)](https://github.com/elastic/kibana/pull/238945)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miłosz Radzyński","email":"mradzynski.elastic@gmail.com"},"sourceCommit":{"committedDate":"2025-10-15T16:22:50Z","message":"[Discover][Advanced Settings] Fix missing fields when using combined filters with `ignoreFilterIfFieldNotInIndex` UI setting (#238945)\n\n## Summary\n\nThis PR ensures that the combined filters will be taken into account\nwhen selecting the correct fields for the query, with the advanced\nsetting: `courier:ignoreFilterIfFieldNotInIndex` enabled.\nCloses: #233042\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"251535685b558fb52e9a62d9f7fcece79a57a26c","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:DataDiscovery","backport:version","v9.2.0","v9.3.0","v9.1.6","v8.18.9","v8.19.6"],"title":"[Discover][Advanced Settings] Fix missing fields when using combined filters with `ignoreFilterIfFieldNotInIndex` UI setting","number":238945,"url":"https://github.com/elastic/kibana/pull/238945","mergeCommit":{"message":"[Discover][Advanced Settings] Fix missing fields when using combined filters with `ignoreFilterIfFieldNotInIndex` UI setting (#238945)\n\n## Summary\n\nThis PR ensures that the combined filters will be taken into account\nwhen selecting the correct fields for the query, with the advanced\nsetting: `courier:ignoreFilterIfFieldNotInIndex` enabled.\nCloses: #233042\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"251535685b558fb52e9a62d9f7fcece79a57a26c"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.18","8.19"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/239190","number":239190,"state":"MERGED","mergeCommit":{"sha":"c020ab9bb0a7353d138b9cfad3de71e3e5cafa98","message":"[9.2] [Discover][Advanced Settings] Fix missing fields when using combined filters with `ignoreFilterIfFieldNotInIndex` UI setting (#238945) (#239190)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Discover][Advanced Settings] Fix missing fields when using combined\nfilters with `ignoreFilterIfFieldNotInIndex` UI setting\n(#238945)](https://github.com/elastic/kibana/pull/238945)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Miłosz Radzyński <mradzynski.elastic@gmail.com>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238945","number":238945,"mergeCommit":{"message":"[Discover][Advanced Settings] Fix missing fields when using combined filters with `ignoreFilterIfFieldNotInIndex` UI setting (#238945)\n\n## Summary\n\nThis PR ensures that the combined filters will be taken into account\nwhen selecting the correct fields for the query, with the advanced\nsetting: `courier:ignoreFilterIfFieldNotInIndex` enabled.\nCloses: #233042\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"251535685b558fb52e9a62d9f7fcece79a57a26c"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->