### PR TITLE
Prevent ESM errors in LLM Proxy dynamic importing p-timeout package

### DIFF
--- a/x-pack/platform/test/onechat_api_integration/utils/llm_proxy/proxy.ts
+++ b/x-pack/platform/test/onechat_api_integration/utils/llm_proxy/proxy.ts
@@ -27,7 +27,9 @@ interface RequestInterceptor {
 }
 
 export class LlmProxy {
-  // Cache for the dynamically imported p-timeout module
+  // Dynamic import required: p-timeout v6+ is ESM-only, incompatible with Kibana's CommonJS compilation.
+  // Cached to avoid repeated imports on every intercept() call.
+  // TODO: Remove when tsconfig.base.json "module" changes from "commonjs" to "esnext" or "node16".
   private static pTimeoutModule: Promise<typeof import('p-timeout')> | null = null;
 
   server: Server;

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/utils/model_and_inference.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/utils/model_and_inference.ts
@@ -14,7 +14,9 @@ import { SUPPORTED_TRAINED_MODELS } from '@kbn/test-suites-xpack-platform/functi
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { setupKnowledgeBase, waitForKnowledgeBaseReady } from './knowledge_base';
 
-// Cache for the dynamically imported p-timeout module
+// Dynamic import required: p-timeout v6+ is ESM-only, incompatible with Kibana's CommonJS compilation.
+// Cached to avoid repeated imports on every retryOnTimeout() call.
+// TODO: Remove when tsconfig.base.json "module" changes from "commonjs" to "esnext" or "node16".
 const getPTimeoutModule = (() => {
   let cached: Promise<typeof import('p-timeout')> | null = null;
   return () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/utils/model_and_inference.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/utils/model_and_inference.ts
@@ -10,7 +10,6 @@ import { errors } from '@elastic/elasticsearch';
 import type { ToolingLog } from '@kbn/tooling-log';
 import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import pRetry, { AbortError } from 'p-retry';
-import pTimeout, { TimeoutError } from 'p-timeout';
 import { SUPPORTED_TRAINED_MODELS } from '@kbn/test-suites-xpack-platform/functional/services/ml/api';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { setupKnowledgeBase, waitForKnowledgeBaseReady } from './knowledge_base';
@@ -257,6 +256,7 @@ export async function stopTinyElserModel(
 }
 
 async function retryOnTimeout<T>(fn: () => Promise<T>, timeout = 60_000): Promise<T> {
+  const { default: pTimeout, TimeoutError } = await import('p-timeout');
   return pRetry(
     async () => {
       try {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/utils/model_and_inference.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/utils/model_and_inference.ts
@@ -14,6 +14,17 @@ import { SUPPORTED_TRAINED_MODELS } from '@kbn/test-suites-xpack-platform/functi
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { setupKnowledgeBase, waitForKnowledgeBaseReady } from './knowledge_base';
 
+// Cache for the dynamically imported p-timeout module
+const getPTimeoutModule = (() => {
+  let cached: Promise<typeof import('p-timeout')> | null = null;
+  return () => {
+    if (!cached) {
+      cached = import('p-timeout');
+    }
+    return cached;
+  };
+})();
+
 // tiny models
 export const TINY_ELSER_MODEL_ID = SUPPORTED_TRAINED_MODELS.TINY_ELSER.name;
 export const TINY_TEXT_EMBEDDING_MODEL_ID = SUPPORTED_TRAINED_MODELS.TINY_TEXT_EMBEDDING.name;
@@ -256,7 +267,7 @@ export async function stopTinyElserModel(
 }
 
 async function retryOnTimeout<T>(fn: () => Promise<T>, timeout = 60_000): Promise<T> {
-  const { default: pTimeout, TimeoutError } = await import('p-timeout');
+  const { default: pTimeout, TimeoutError } = await getPTimeoutModule();
   return pRetry(
     async () => {
       try {


### PR DESCRIPTION
## Summary

`p-timeout` v6.x works as ESM-only package. However, Kibana compiles ESM modules to CommonJS. This is NOT compatible with v6.x.

To solve this:
- Option 1 would be to downgrade the package to v5.x
- Instead, option 2 leverages dynamic imports, which are natively supported by Node.js for ES modules and do NOT compile to CommonJS. This allows us to keep using v6.x and works with our setup without causing any Typescript errors.

### How to test

The way I reproduced the issue was running this FTR test server:

```bash
yarn test:ftr:server --config x-pack/solutions/security/test/cloud_security_posture_api/config.ts
```

Reverting the commits and running the command above should fail and return this error instead:

```
ERROR UNHANDLED ERROR
ERROR Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/alberto/git/kibana/node_modules/p-timeout/index.js from /Users/alberto/git/kibana/x-pack/platform/test/onechat_api_integration/utils/llm_proxy/proxy.ts not supported.
      Instead change the require of index.js in /Users/alberto/git/kibana/x-pack/platform/test/onechat_api_integration/utils/llm_proxy/proxy.ts to a dynamic import() which is available in all CommonJS modules.
```

Of course, we also need to verify the proxy module and the entire feature it belongs to still works. Though I have no context about it.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Risk of breaking LLM proxy if this approach is not 100% correct. Verify proxy module still works.