### PR TITLE
[EDR Workflows][FF Cleanup] Remove unifiedManifestEnabled feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -131,11 +131,6 @@ export const allowedExperimentalValues = Object.freeze({
   malwareOnWriteScanOptionAvailable: true,
 
   /**
-   * Enables unified manifest that replaces existing user artifacts manifest SO with a new approach of creating a SO per package policy.
-   */
-  unifiedManifestEnabled: true,
-
-  /**
    * Enables the new modal for the value list items
    */
   valueListItemsModalEnabled: true,

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.test.ts
@@ -219,7 +219,6 @@ describe('ManifestManager', () => {
       const savedObjectsClient = savedObjectsClientMock.create();
       const manifestManagerContext = buildManifestManagerContextMock({
         savedObjectsClient,
-        experimentalFeatures: ['unifiedManifestEnabled'],
       });
       const manifestManager = new ManifestManager(manifestManagerContext);
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.ts
@@ -594,23 +594,19 @@ export class ManifestManager {
   public async getLastComputedManifest(): Promise<Manifest | null> {
     try {
       let manifestSo;
-      if (this.experimentalFeatures.unifiedManifestEnabled) {
-        const unifiedManifestsSo = await this.getAllUnifiedManifestsSO();
-        // On first run, there will be no existing Unified Manifests SO, so we need to copy the semanticVersion from the legacy manifest
-        // This is to ensure that the first Unified Manifest created has the same semanticVersion as the legacy manifest and is not too far
-        // behind for package policy to pick it up.
-        if (unifiedManifestsSo.length === 0) {
-          const legacyManifestSo = await this.getManifestClient().getManifest();
-          const legacySemanticVersion = legacyManifestSo?.attributes?.semanticVersion;
-          manifestSo = this.transformUnifiedManifestSOtoLegacyManifestSO(
-            unifiedManifestsSo,
-            legacySemanticVersion
-          );
-        } else {
-          manifestSo = this.transformUnifiedManifestSOtoLegacyManifestSO(unifiedManifestsSo);
-        }
+      const unifiedManifestsSo = await this.getAllUnifiedManifestsSO();
+      // On first run, there will be no existing Unified Manifests SO, so we need to copy the semanticVersion from the legacy manifest
+      // This is to ensure that the first Unified Manifest created has the same semanticVersion as the legacy manifest and is not too far
+      // behind for package policy to pick it up.
+      if (unifiedManifestsSo.length === 0) {
+        const legacyManifestSo = await this.getManifestClient().getManifest();
+        const legacySemanticVersion = legacyManifestSo?.attributes?.semanticVersion;
+        manifestSo = this.transformUnifiedManifestSOtoLegacyManifestSO(
+          unifiedManifestsSo,
+          legacySemanticVersion
+        );
       } else {
-        manifestSo = await this.getManifestClient().getManifest();
+        manifestSo = this.transformUnifiedManifestSOtoLegacyManifestSO(unifiedManifestsSo);
       }
 
       if (manifestSo.version === undefined) {
@@ -983,23 +979,7 @@ export class ManifestManager {
   public async commit(manifest: Manifest) {
     const manifestSo = manifest.toSavedObject();
 
-    if (this.experimentalFeatures.unifiedManifestEnabled) {
-      await this.commitUnified(manifestSo);
-    } else {
-      const manifestClient = this.getManifestClient();
-
-      const version = manifest.getSavedObjectVersion();
-
-      if (version == null) {
-        await manifestClient.createManifest(manifestSo);
-      } else {
-        await manifestClient.updateManifest(manifestSo, {
-          version,
-        });
-      }
-
-      this.logger.debug(`Committed manifest ${manifest.getSemanticVersion()}`);
-    }
+    await this.commitUnified(manifestSo);
   }
 
   private fetchAllPolicies(): Promise<AsyncIterable<PackagePolicy[]>> {


### PR DESCRIPTION
Removes the `unifiedManifestEnabled` feature flag as the unified manifest approach (creating a saved object per package policy) is now permanently enabled and the legacy approach is no longer needed.


### Source Code
- **manifest_manager.ts**:
  - `getLastComputedManifest()`: Removed conditional logic - now always uses unified manifest approach via `getAllUnifiedManifestsSO()`
  - `commit()`: Simplified to always call `commitUnified()`, removed legacy code path that used `createManifest()` and `updateManifest()`
  - Removed legacy manifest retrieval code that used `getManifestClient().getManifest()`

### Test Files
- **manifest_manager.test.ts**: Removed `experimentalFeatures: ['unifiedManifestEnabled']` from test context mock

### Configuration
- Removed feature flag definition from `experimental_features.ts`
