### PR TITLE
[ES|QL] Displays the available options when editing an existing variable control

### DIFF
--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.test.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.test.tsx
@@ -289,6 +289,54 @@ describe('ValueControlForm', () => {
           );
         });
       });
+
+      it('should preserve custom esqlQuery when editing an existing VALUES_FROM_QUERY control', async () => {
+        const customQuery = 'FROM custom-logs* | STATS BY custom_field';
+        const initialState = {
+          grow: false,
+          width: 'medium',
+          title: 'Custom Query Control',
+          availableOptions: [],
+          selectedOptions: [], // Start with empty to trigger the useEffect
+          variableName: 'customVar',
+          variableType: ESQLVariableType.VALUES,
+          esqlQuery: customQuery,
+          controlType: EsqlControlType.VALUES_FROM_QUERY,
+        } as ESQLControlState;
+
+        const getESQLResultsMock = getESQLResults as jest.Mock;
+        getESQLResultsMock.mockClear();
+
+        render(
+          <KibanaContextProvider services={services}>
+            <IntlProvider locale="en">
+              <ESQLControlsFlyout
+                {...defaultProps}
+                initialVariableType={ESQLVariableType.VALUES}
+                queryString="FROM foo | WHERE field =="
+                initialState={initialState}
+              />
+            </IntlProvider>
+          </KibanaContextProvider>
+        );
+
+        await waitFor(() => {
+          // Verify that getESQLResults was called with the custom query
+          expect(getESQLResultsMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+              esqlQuery: customQuery,
+            })
+          );
+        });
+
+        // Custom query is displayed in the query editor
+        const queryEditor = await waitFor(() =>
+          document.querySelector('[data-test-subj*="queryInput"]')
+        );
+        if (queryEditor) {
+          expect(queryEditor.textContent).toContain('custom-logs');
+        }
+      });
     });
   });
 });

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -191,18 +191,18 @@ export function ValueControlForm({
   );
 
   useEffect(() => {
-    if (
-      !selectedValues?.length &&
-      controlFlyoutType === EsqlControlType.VALUES_FROM_QUERY &&
-      valuesRetrieval
-    ) {
-      const queryForValues =
-        variableName !== ''
-          ? `FROM ${getIndexPatternFromESQLQuery(queryString)} | STATS BY ${valuesRetrieval}`
-          : '';
-      onValuesQuerySubmit(queryForValues);
+    if (!selectedValues?.length && controlFlyoutType === EsqlControlType.VALUES_FROM_QUERY) {
+      if (initialState?.esqlQuery) {
+        onValuesQuerySubmit(initialState.esqlQuery);
+      } else if (valuesRetrieval) {
+        const queryForValues = `FROM ${getIndexPatternFromESQLQuery(
+          queryString
+        )} | STATS BY ${valuesRetrieval}`;
+        onValuesQuerySubmit(queryForValues);
+      }
     }
   }, [
+    initialState?.esqlQuery,
     controlFlyoutType,
     onValuesQuerySubmit,
     queryString,


### PR DESCRIPTION
## Summary

Regression caused from this PR https://github.com/elastic/kibana/pull/231690

When you have an existing control and edit it, the query doesnt run to get the available options. As a result the UX is kinda broken.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->