### PR TITLE
[Metrics][Discover] Enable overlay in metrics details flyout

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/flyout/metrics_insights_flyout.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/flyout/metrics_insights_flyout.tsx
@@ -34,7 +34,6 @@ import { useFieldsMetadataContext } from '../../context/fields_metadata';
 interface MetricInsightsFlyoutProps {
   metric: MetricField;
   esqlQuery?: string;
-  isOpen: boolean;
   onClose: () => void;
   chartRef: { current: HTMLDivElement | null };
 }
@@ -43,7 +42,6 @@ export const MetricInsightsFlyout = ({
   metric,
   esqlQuery,
   chartRef,
-  isOpen,
   onClose,
 }: MetricInsightsFlyoutProps) => {
   const { euiTheme } = useEuiTheme();
@@ -67,8 +65,6 @@ export const MetricInsightsFlyout = ({
     [onClose]
   );
 
-  if (!isOpen) return null;
-
   const minWidth = euiTheme.base * 24;
   const maxWidth = euiTheme.breakpoint.xl;
 
@@ -76,10 +72,9 @@ export const MetricInsightsFlyout = ({
     <EuiPortal>
       <EuiFlyoutResizable
         onClose={onClose}
-        type="push"
+        type="overlay"
         size={flyoutWidth}
         onKeyDown={onKeyDown}
-        pushMinBreakpoint="xl"
         data-test-subj="metricsExperienceFlyout"
         aria-label={i18n.translate(
           'metricsExperience.metricInsightsFlyout.euiFlyoutResizable.metricInsightsFlyoutLabel',

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useMemo, useState, useRef, useEffect } from 'react';
+import React, { useCallback, useMemo, useState, useRef } from 'react';
 import type { EuiFlexGridProps } from '@elastic/eui';
 import { EuiFlexGrid, EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -15,7 +15,6 @@ import type { MetricField } from '@kbn/metrics-experience-plugin/common/types';
 import type { ChartSectionProps, UnifiedHistogramInputMessage } from '@kbn/unified-histogram/types';
 import type { Observable } from 'rxjs';
 import { css } from '@emotion/react';
-import { DiscoverFlyouts, dismissAllFlyoutsExceptFor } from '@kbn/discover-utils';
 import type { ChartSize } from './chart';
 import { Chart } from './chart';
 import { MetricInsightsFlyout } from './flyout/metrics_insights_flyout';
@@ -105,7 +104,6 @@ export const MetricsGrid = ({
       const { rowIndex, colIndex } = getRowColFromIndex(chartIndex);
 
       setExpandedMetric({ metric, esqlQuery, chartId, rowIndex, colIndex });
-      dismissAllFlyoutsExceptFor(DiscoverFlyouts.metricInsights);
     },
     [rows, getRowColFromIndex]
   );
@@ -129,26 +127,6 @@ export const MetricsGrid = ({
     }
     return { current: null };
   }, [expandedMetric?.chartId]);
-
-  // TODO: find a better way to handle conflicts with other flyouts
-  // https://github.com/elastic/kibana/issues/237965
-  useEffect(() => {
-    const handleClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
-
-      if (target.closest('[data-test-subj="embeddablePanelAction-openInspector"]')) {
-        if (expandedMetric) {
-          handleCloseFlyout();
-        }
-      }
-    };
-
-    document.addEventListener('click', handleClick);
-
-    return () => {
-      document.removeEventListener('click', handleClick);
-    };
-  }, [expandedMetric, handleCloseFlyout]);
 
   const normalizedFields = useMemo(() => (Array.isArray(fields) ? fields : [fields]), [fields]);
 
@@ -202,7 +180,6 @@ export const MetricsGrid = ({
           chartRef={getChartRefForFocus()}
           metric={expandedMetric.metric}
           esqlQuery={expandedMetric.esqlQuery}
-          isOpen
           onClose={handleCloseFlyout}
         />
       )}


### PR DESCRIPTION
## Summary

Closes #238815

As a temporary fix for #238815, enable the overlay in the metrics details flyout. That prevents users from switching over directly to Lens inspect flyout.

Before:
<img width="1728" height="976" alt="image" src="https://github.com/user-attachments/assets/b5e79dd8-84b4-49c5-80b1-a96be066ef17" />

After:
<img width="1728" height="976" alt="image" src="https://github.com/user-attachments/assets/0686f88c-e2d4-4e3e-8cfb-9a083ca5a06e" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->