### PR TITLE
[Search profiler] Fix 'profiles a simple query' flaky test

### DIFF
--- a/x-pack/platform/test/serverless/functional/test_suites/dev_tools/search_profiler.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/dev_tools/search_profiler.ts
@@ -18,7 +18,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const PageObjects = getPageObjects(['svlCommonPage', 'common', 'searchProfiler']);
   const retry = getService('retry');
   const es = getService('es');
-  const browser = getService('browser');
   const testSubjects = getService('testSubjects');
 
   describe('Search Profiler Editor', () => {
@@ -74,8 +73,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     describe('With a test index', function () {
-      // see details: https://github.com/elastic/kibana/issues/215660
-      this.tags(['failsOnMKI']);
       before(async () => {
         await es.indices.create({ index: indexName });
       });
@@ -85,7 +82,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       it('profiles a simple query', async () => {
-        await browser.refresh();
         await PageObjects.searchProfiler.setIndexName(indexName);
         await PageObjects.searchProfiler.setQuery(testQuery);
 


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/236358
Fixes: https://github.com/elastic/kibana/issues/232619
Fixes: https://github.com/elastic/kibana/issues/231402
Fixes: https://github.com/elastic/kibana/issues/215660

## Summary
https://github.com/elastic/kibana/pull/232365 partially fixed this, but this test keept failing because the test was setting the index name before the page to be fully loaded, which caused that the index was typed twice. Running the test locally with the `--throttle` flag showed it. 

https://github.com/user-attachments/assets/2e93efc0-3f42-4242-bf55-a1ae44b9fb6f

This was the same reason why this test was failing on MKI. And, actually, the refresh at the beginning of the test is not needed, so just removing it would fix the problem.

**Note**: Test MKI locally succeeded 

**Flaky test runner:** https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9550

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->