### PR TITLE
[Streams] Add Processor duplication and quick editing

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_display.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_display.tsx
@@ -6,16 +6,7 @@
  */
 
 import React from 'react';
-import {
-  useEuiTheme,
-  EuiPanel,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiText,
-  EuiBadge,
-  EuiButtonEmpty,
-  EuiToolTip,
-} from '@elastic/eui';
+import { useEuiTheme, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText, EuiBadge } from '@elastic/eui';
 import type { Condition, FilterCondition } from '@kbn/streamlang';
 import {
   getFilterOperator,
@@ -29,10 +20,15 @@ import {
   operatorToHumanReadableNameMap,
 } from '@kbn/streamlang';
 import { css } from '@emotion/css';
-import { i18n } from '@kbn/i18n';
 import { ConditionEditor } from './condition_editor';
 
-export const ConditionPanel = ({ condition }: { condition: Condition }) => {
+export const ConditionPanel = ({
+  condition,
+  keywordWrapper,
+}: {
+  condition: Condition;
+  keywordWrapper?: (children: React.ReactNode) => React.ReactNode;
+}) => {
   const { euiTheme } = useEuiTheme();
   return (
     <EuiPanel
@@ -42,7 +38,12 @@ export const ConditionPanel = ({ condition }: { condition: Condition }) => {
         border-radius: ${euiTheme.size.s};
       `}
     >
-      <ConditionDisplay condition={condition} showKeyword={true} keyword="WHERE" />
+      <ConditionDisplay
+        condition={condition}
+        showKeyword={true}
+        keyword="WHERE"
+        keywordWrapper={keywordWrapper}
+      />
     </EuiPanel>
   );
 };
@@ -67,41 +68,18 @@ interface ConditionDisplayProps {
   condition: Condition;
   showKeyword?: boolean;
   keyword?: string;
-  onTitleClick?: () => void;
+  keywordWrapper?: (children: React.ReactNode) => React.ReactNode;
 }
 
 export const ConditionDisplay = ({
   condition,
   showKeyword = false,
   keyword = 'WHERE',
-  onTitleClick = () => {},
+  keywordWrapper = (children: React.ReactNode) => children,
 }: ConditionDisplayProps) => {
   return (
     <EuiFlexGroup gutterSize="s" alignItems="center" wrap>
-      {showKeyword && (
-        <EuiToolTip
-          position="top"
-          content={
-            <p>
-              {i18n.translate('xpack.streams.actionBlockListItem.tooltip.editConditionLabel', {
-                defaultMessage: 'Edit condition',
-              })}
-            </p>
-          }
-        >
-          <EuiButtonEmpty
-            onClick={onTitleClick}
-            color="text"
-            size="xs"
-            aria-label={i18n.translate('xpack.streams.conditionDisplay.editConditionLabel', {
-              defaultMessage: 'Edit condition',
-            })}
-            data-test-subj="streamsAppConditionTitleEditButton"
-          >
-            <OperatorText operator={keyword} bold />
-          </EuiButtonEmpty>
-        </EuiToolTip>
-      )}
+      {showKeyword && keywordWrapper(<OperatorText operator={keyword} bold />)}
       <RecursiveConditionDisplay condition={condition} />
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_display.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_display.tsx
@@ -6,7 +6,16 @@
  */
 
 import React from 'react';
-import { useEuiTheme, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText, EuiBadge } from '@elastic/eui';
+import {
+  useEuiTheme,
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiBadge,
+  EuiButtonEmpty,
+  EuiToolTip,
+} from '@elastic/eui';
 import type { Condition, FilterCondition } from '@kbn/streamlang';
 import {
   getFilterOperator,
@@ -20,6 +29,7 @@ import {
   operatorToHumanReadableNameMap,
 } from '@kbn/streamlang';
 import { css } from '@emotion/css';
+import { i18n } from '@kbn/i18n';
 import { ConditionEditor } from './condition_editor';
 
 export const ConditionPanel = ({ condition }: { condition: Condition }) => {
@@ -57,16 +67,41 @@ interface ConditionDisplayProps {
   condition: Condition;
   showKeyword?: boolean;
   keyword?: string;
+  onTitleClick?: () => void;
 }
 
 export const ConditionDisplay = ({
   condition,
   showKeyword = false,
   keyword = 'WHERE',
+  onTitleClick = () => {},
 }: ConditionDisplayProps) => {
   return (
     <EuiFlexGroup gutterSize="s" alignItems="center" wrap>
-      {showKeyword && <OperatorText operator={keyword} bold />}
+      {showKeyword && (
+        <EuiToolTip
+          position="top"
+          content={
+            <p>
+              {i18n.translate('xpack.streams.actionBlockListItem.tooltip.editConditionLabel', {
+                defaultMessage: 'Edit condition',
+              })}
+            </p>
+          }
+        >
+          <EuiButtonEmpty
+            onClick={onTitleClick}
+            color="text"
+            size="xs"
+            aria-label={i18n.translate('xpack.streams.conditionDisplay.editConditionLabel', {
+              defaultMessage: 'Edit condition',
+            })}
+            data-test-subj="streamsAppConditionTitleEditButton"
+          >
+            <OperatorText operator={keyword} bold />
+          </EuiButtonEmpty>
+        </EuiToolTip>
+      )}
       <RecursiveConditionDisplay condition={condition} />
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/types.ts
@@ -75,6 +75,10 @@ export type StreamEnrichmentEvent =
       options?: { parentId: StreamlangStepWithUIAttributes['parentId'] };
     }
   | {
+      type: 'step.duplicateProcessor';
+      processorStepId: string;
+    }
+  | {
       type: 'step.addCondition';
       step?: StreamlangWhereBlock;
       options?: { parentId: StreamlangStepWithUIAttributes['parentId'] };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/use_stream_enrichment.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/use_stream_enrichment.tsx
@@ -53,6 +53,10 @@ export const useStreamEnrichmentEvents = () => {
         service.send({ type: 'step.addProcessor', step, options });
       },
 
+      duplicateProcessor: (id: string) => {
+        service.send({ type: 'step.duplicateProcessor', processorStepId: id });
+      },
+
       addCondition: (
         step?: StreamlangWhereBlock,
         options?: { parentId: StreamlangStepWithUIAttributes['parentId'] }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -14,6 +14,8 @@ import {
   EuiTextTruncate,
   useEuiTheme,
   euiTextTruncate,
+  EuiButtonEmpty,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isActionBlock } from '@kbn/streamlang';
@@ -53,6 +55,10 @@ export const ActionBlockListItem = ({
 
   const stepDescription = getStepDescription(step);
 
+  const handleTitleClick = () => {
+    stepRef.send({ type: 'step.edit' });
+  };
+
   return (
     <>
       {/* The step under edit is part of the same root level hierarchy,
@@ -78,15 +84,46 @@ export const ActionBlockListItem = ({
                 margin-right: ${euiTheme.size.s};
               `}
             >
-              <strong
-                data-test-subj="streamsAppProcessorLegend"
-                css={css`
-                  display: block;
-                  ${euiTextTruncate()}
-                `}
-              >
-                {step.action.toUpperCase()}
-              </strong>
+              <EuiFlexGroup alignItems="center" gutterSize="xs">
+                <EuiToolTip
+                  position="top"
+                  content={
+                    <p>
+                      {i18n.translate(
+                        'xpack.streams.actionBlockListItem.tooltip.editProcessorLabel',
+                        {
+                          defaultMessage: 'Edit {stepAction} processor',
+                          values: {
+                            stepAction: step.action,
+                          },
+                        }
+                      )}
+                    </p>
+                  }
+                >
+                  <EuiButtonEmpty
+                    onClick={handleTitleClick}
+                    color="text"
+                    aria-label={i18n.translate(
+                      'xpack.streams.actionBlockListItem.euiButtonEmpty.editProcessorLabel',
+                      { defaultMessage: 'Edit processor' }
+                    )}
+                    size="xs"
+                    data-test-subj="streamsAppProcessorTitleEditButton"
+                  >
+                    <EuiText
+                      size="s"
+                      style={{ fontWeight: euiTheme.font.weight.bold }}
+                      css={css`
+                        display: block;
+                        ${euiTextTruncate()}
+                      `}
+                    >
+                      {step.action.toUpperCase()}
+                    </EuiText>
+                  </EuiButtonEmpty>
+                </EuiToolTip>
+              </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiFlexGroup alignItems="center" gutterSize="xs">

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/context_menu.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/context_menu.tsx
@@ -44,7 +44,14 @@ const moveDownItemText = i18n.translate(
 const editItemText = i18n.translate(
   'xpack.streams.streamDetailView.managementTab.enrichment.editItemButtonText',
   {
-    defaultMessage: 'Edit item',
+    defaultMessage: 'Edit',
+  }
+);
+
+const duplicateItemText = i18n.translate(
+  'xpack.streams.streamDetailView.managementTab.enrichment.duplicateItemButtonText',
+  {
+    defaultMessage: 'Duplicate',
   }
 );
 
@@ -66,8 +73,11 @@ export const StepContextMenu: React.FC<StepContextMenuProps> = ({
   isFirstStepInLevel,
   isLastStepInLevel,
 }) => {
-  const { reorderStep } = useStreamEnrichmentEvents();
+  const { reorderStep, duplicateProcessor } = useStreamEnrichmentEvents();
   const canEdit = useStreamEnrichmentSelector((snapshot) => snapshot.can({ type: 'step.edit' }));
+  const canDuplicate = useStreamEnrichmentSelector((snapshot) =>
+    snapshot.can({ type: 'step.duplicateProcessor', processorStepId: stepRef.id })
+  );
   const canReorder = useStreamEnrichmentSelector(
     (snapshot) =>
       snapshot.can({ type: 'step.reorder', stepId: stepRef.id, direction: 'up' }) ||
@@ -91,6 +101,10 @@ export const StepContextMenu: React.FC<StepContextMenuProps> = ({
 
   const handleEdit = () => {
     stepRef.send({ type: 'step.edit' });
+  };
+
+  const handleDuplicate = () => {
+    duplicateProcessor(stepRef.id);
   };
 
   const getChildStepsLength = () => {
@@ -152,6 +166,22 @@ export const StepContextMenu: React.FC<StepContextMenuProps> = ({
     >
       {editItemText}
     </EuiContextMenuItem>,
+    ...(!isWhere
+      ? [
+          <EuiContextMenuItem
+            data-test-subj="stepContextMenuDuplicateItem"
+            key="duplicateStep"
+            icon="copy"
+            disabled={!canDuplicate}
+            onClick={() => {
+              togglePopover(false);
+              handleDuplicate();
+            }}
+          >
+            {duplicateItemText}
+          </EuiContextMenuItem>,
+        ]
+      : []),
     <EuiContextMenuItem
       data-test-subj="stepContextMenuDeleteItem"
       key="deleteStep"

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/where/summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/where/summary.tsx
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { isWhereBlock } from '@kbn/streamlang';
 import React from 'react';
 import { useSelector } from '@xstate5/react';
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import { CreateStepButton } from '../../../create_step_button';
 import { StepContextMenu } from '../context_menu';
 import { BlockDisableOverlay } from '../block_disable_overlay';
@@ -55,7 +56,32 @@ export const WhereBlockSummary = ({
           condition={step.where}
           showKeyword={true}
           keyword="WHERE"
-          onTitleClick={handleTitleClick}
+          keywordWrapper={(children) => (
+            <EuiToolTip
+              position="top"
+              content={i18n.translate(
+                'xpack.streams.streamDetailEnrichment.whereBlockSummary.editConditionTooltip',
+                {
+                  defaultMessage: 'Edit condition',
+                }
+              )}
+            >
+              <EuiButtonEmpty
+                onClick={handleTitleClick}
+                color="text"
+                size="xs"
+                aria-label={i18n.translate(
+                  'xpack.streams.streamDetailEnrichment.whereBlockSummary.editConditionLabel',
+                  {
+                    defaultMessage: 'Edit condition',
+                  }
+                )}
+                data-test-subj="streamsAppDetailEnrichmentConditionTitleEditButton"
+              >
+                {children}
+              </EuiButtonEmpty>
+            </EuiToolTip>
+          )}
         />
       </EuiFlexItem>
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/where/summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/where/summary.tsx
@@ -26,6 +26,10 @@ export const WhereBlockSummary = ({
 }: StepConfigurationProps) => {
   const step = useSelector(stepRef, (snapshot) => snapshot.context.step);
 
+  const handleTitleClick = () => {
+    stepRef.send({ type: 'step.edit' });
+  };
+
   if (!isWhereBlock(step)) return null;
 
   return (
@@ -47,7 +51,12 @@ export const WhereBlockSummary = ({
           overflow: hidden;
         `}
       >
-        <ConditionDisplay condition={step.where} showKeyword={true} keyword="WHERE" />
+        <ConditionDisplay
+          condition={step.where}
+          showKeyword={true}
+          keyword="WHERE"
+          onTitleClick={handleTitleClick}
+        />
       </EuiFlexItem>
 
       <EuiFlexItem

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/child_stream_list.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/child_stream_list.tsx
@@ -197,7 +197,7 @@ export function ChildStreamList({ availableStreams }: { availableStreams: string
                               type: 'routingRule.edit',
                               id: routingRule.id,
                             })}
-                            onEditIconClick={editRule}
+                            onEditClick={editRule}
                             routingRule={routingRule}
                             canReorder={canReorderRoutingRules}
                           />

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/idle_routing_stream_entry.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/idle_routing_stream_entry.tsx
@@ -17,6 +17,7 @@ import {
   EuiButtonIcon,
   useEuiTheme,
   EuiToolTip,
+  EuiButtonEmpty,
 } from '@elastic/eui';
 import type { DraggableProvided } from '@hello-pangea/dnd';
 import { i18n } from '@kbn/i18n';
@@ -52,14 +53,14 @@ export function IdleRoutingStreamEntry({
   availableStreams,
   draggableProvided,
   isEditingEnabled,
-  onEditIconClick,
+  onEditClick,
   routingRule,
   canReorder,
 }: {
   availableStreams: string[];
   draggableProvided: DraggableProvided;
   isEditingEnabled: boolean;
-  onEditIconClick: (id: string) => void;
+  onEditClick: (id: string) => void;
   routingRule: RoutingDefinitionWithUIAttributes;
   canReorder: boolean;
 }) {
@@ -169,7 +170,7 @@ export function IdleRoutingStreamEntry({
               data-test-subj={`routingRuleEditButton-${routingRule.destination}`}
               iconType="pencil"
               disabled={!isEditingEnabled}
-              onClick={() => onEditIconClick(routingRule.id)}
+              onClick={() => onEditClick(routingRule.id)}
               aria-label={i18n.translate('xpack.streams.streamDetailRouting.edit', {
                 defaultMessage: 'Edit',
               })}
@@ -183,7 +184,32 @@ export function IdleRoutingStreamEntry({
             padding: ${euiTheme.size.xs} 0px;
           `}
         >
-          <ConditionPanel condition={routingRule.where} />
+          <ConditionPanel
+            condition={routingRule.where}
+            keywordWrapper={(children) => (
+              <EuiToolTip
+                position="top"
+                content={i18n.translate('xpack.streams.streamDetailRouting.editConditionTooltip', {
+                  defaultMessage: 'Edit routing condition',
+                })}
+              >
+                <EuiButtonEmpty
+                  onClick={() => onEditClick(routingRule.id)}
+                  color="text"
+                  size="xs"
+                  aria-label={i18n.translate(
+                    'xpack.streams.streamsDetailRouting.editConditionLabel',
+                    {
+                      defaultMessage: 'Edit routing condition',
+                    }
+                  )}
+                  data-test-subj="streamsAppRoutingConditionTitleEditButton"
+                >
+                  {children}
+                </EuiButtonEmpty>
+              </EuiToolTip>
+            )}
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -398,6 +398,11 @@ export class StreamsApp {
     await processorEditButton.click();
   }
 
+  async clickDuplicateProcessor(pos: number) {
+    const processorDuplicateButton = await this.getProcessorDuplicateButton(pos);
+    await processorDuplicateButton.click();
+  }
+
   async clickEditCondition(pos: number) {
     const conditionEditButton = await this.getConditionEditButton(pos);
     await conditionEditButton.click();
@@ -421,6 +426,13 @@ export class StreamsApp {
     const targetProcessor = processors[pos];
     await targetProcessor.getByRole('button', { name: 'Step context menu' }).first().click();
     return this.page.getByTestId('stepContextMenuEditItem');
+  }
+
+  async getProcessorDuplicateButton(pos: number) {
+    const processors = await this.getProcessorsListItems();
+    const targetProcessor = processors[pos];
+    await targetProcessor.getByRole('button', { name: 'Step context menu' }).first().click();
+    return this.page.getByTestId('stepContextMenuDuplicateItem');
   }
 
   async getConditionEditButton(pos: number) {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
@@ -155,4 +155,42 @@ test.describe('Stream data processing - creating steps', { tag: ['@ess', '@svlOb
     const createButton = page.getByTestId('streamsAppStreamDetailEnrichmentCreateStepButton');
     await expect(createButton).toBeHidden();
   });
+
+  test('should duplicate a processor', async ({ pageObjects }) => {
+    await pageObjects.streams.clickAddProcessor();
+    await pageObjects.streams.fillProcessorFieldInput('message');
+    await pageObjects.streams.fillGrokPatternInput('%{WORD:attributes.method}');
+    await pageObjects.streams.clickSaveProcessor();
+
+    await pageObjects.streams.clickDuplicateProcessor(0);
+    await pageObjects.streams.fillGrokPatternInput('%{WORD:attributes.method2}');
+    await pageObjects.streams.clickSaveProcessor();
+
+    await pageObjects.streams.saveStepsListChanges();
+    expect(await pageObjects.streams.getProcessorsListItems()).toHaveLength(2);
+  });
+
+  test('should duplicate a processor under a condition', async ({ pageObjects }) => {
+    // Create a condition first
+    await pageObjects.streams.clickAddCondition();
+    await pageObjects.streams.fillCondition('test_field', 'contains', 'logs');
+    await pageObjects.streams.clickSaveCondition();
+    expect(await pageObjects.streams.getConditionsListItems()).toHaveLength(1);
+
+    // Add a processor under the condition
+    const addStepButton = await pageObjects.streams.getConditionAddStepMenuButton(0);
+    await addStepButton.click();
+    await pageObjects.streams.clickAddProcessor(false);
+    await pageObjects.streams.fillProcessorFieldInput('message');
+    await pageObjects.streams.fillGrokPatternInput('%{WORD:attributes.method}');
+    await pageObjects.streams.clickSaveProcessor();
+    expect(await pageObjects.streams.getProcessorsListItems()).toHaveLength(1);
+
+    await pageObjects.streams.clickDuplicateProcessor(0);
+    await pageObjects.streams.fillGrokPatternInput('%{WORD:attributes.method2}');
+    await pageObjects.streams.clickSaveProcessor();
+
+    await pageObjects.streams.saveStepsListChanges();
+    expect(await pageObjects.streams.getProcessorsListItems()).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/229246

* Adds a processor duplication feature using the context menu
* Adds a quick edit feature to click on the step title to open its editor

https://github.com/user-attachments/assets/fe7d8b94-ccf7-453c-8cd1-34537d6855bf

### How to test

1. Open a child stream with some data
2. Create a new processor
3. Click on the processor's context menu and then Duplicate
4. Make sure the editor open, save the new processor
5. Create a condition step
6. Repeat steps 2,3,4 under the condition
7. Make sure the editor opens when clicking on the step's title