### PR TITLE
[ES|QL] fix: model disposed when switching tabs

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -828,6 +828,7 @@ const ESQLEditorInternal = function ESQLEditor({
     return () => {
       model.current?.dispose();
       editor1ref.current?.dispose();
+      editorModel.current = undefined;
     };
   }, []);
 


### PR DESCRIPTION
## Summary
Fixes `Model is disposed` error when switching between tabs.

The error occurs due to a race condition, `showSuggestionsIfEmptyQuery` was trying to use a disposed instance of the editor model before the editor recreated it again on `editorDidMount` async call.

To solve it, the proposal is to reset the `editorModel` to `undefined` on unmount, as the code it's already prepared to deal with an `undefined` `editorModel` (natural state before the editor is mounted) no errors are expected.

The editorModel will be recreated and correctly assigned again when `editorDidMount` is executed again.





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->