### PR TITLE
[ES|QL] consolidates cascade documents related helpers into esql-utils package

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -49,6 +49,9 @@ export {
   getRemoteClustersFromESQLQuery,
   getLookupIndicesFromQuery,
   convertTimeseriesCommandToFrom,
+  getESQLStatsQueryMeta,
+  constructCascadeQuery,
+  mutateQueryStatsGrouping,
 } from './src';
 
 export { ENABLE_ESQL, FEEDBACK_LINK } from './constants';

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -55,3 +55,8 @@ export { sanitazeESQLInput } from './utils/sanitaze_input';
 export { replaceESQLQueryIndexPattern } from './utils/replace_index_pattern';
 export { extractCategorizeTokens } from './utils/extract_categorize_tokens';
 export { getLookupIndicesFromQuery } from './utils/get_lookup_indices';
+export {
+  getESQLStatsQueryMeta,
+  constructCascadeQuery,
+  mutateQueryStatsGrouping,
+} from './utils/cascaded_documents_helpers';

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers.test.ts
@@ -1,0 +1,349 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { AggregateQuery } from '@kbn/es-query';
+import {
+  getESQLStatsQueryMeta,
+  constructCascadeQuery,
+  mutateQueryStatsGrouping,
+} from './cascaded_documents_helpers';
+
+describe('cascaded documents helpers utils', () => {
+  describe('getESQLStatsQueryMeta', () => {
+    it('should return an array of the columns the query has been denoted to be grouped by with the STATS command', () => {
+      const queryString = `
+        FROM kibana_sample_data_logs, another_index
+        | KEEP bytes, clientip, url.keyword, response.keyword
+        | STATS Visits = COUNT(), Unique = COUNT_DISTINCT(clientip),
+            p95 = PERCENTILE(bytes, 95), median = MEDIAN(bytes)
+                BY type, url.keyword
+        | EVAL total_records = TO_DOUBLE(count_4xx + count_5xx + count_rest)
+        | DROP count_4xx, count_rest, total_records
+        | LIMIT 123
+      `;
+
+      const result = getESQLStatsQueryMeta(queryString);
+      expect(result.groupByFields).toEqual([
+        {
+          field: 'type',
+          type: 'column',
+        },
+        {
+          field: 'url.keyword',
+          type: 'column',
+        },
+      ]);
+      expect(result.appliedFunctions).toEqual([
+        { identifier: 'Visits', aggregation: 'COUNT' },
+        { identifier: 'Unique', aggregation: 'COUNT_DISTINCT' },
+        { identifier: 'p95', aggregation: 'PERCENTILE' },
+        { identifier: 'median', aggregation: 'MEDIAN' },
+      ]);
+    });
+
+    it('should return the appropriate metadata when there are multiple stats commands in the query', () => {
+      const queryString = `
+        FROM kibana_sample_data_logs
+        // First aggregate per client + per URL
+        | STATS
+            visits_per_client =
+              COUNT(), // how many hits this client made to this URL
+            p95_bytes_client =
+              PERCENTILE(bytes, 95), // 95th percentile of bytes for this client+URL
+            median_bytes_client =
+              MEDIAN(bytes) // median of bytes for this client+URL
+              BY url.keyword, clientip
+        // Now roll up those per-client stats to the URL level
+        | STATS
+            unique_visitors =
+              COUNT_DISTINCT(clientip), // how many distinct clients hit this URL
+            total_visits =
+              SUM(visits_per_client), // median across client-level medians
+            p95_bytes_url =
+              PERCENTILE(p95_bytes_client, 95), // 95th percentile across client-level p95s
+            median_bytes_url =
+              MEDIAN(median_bytes_client) // median across client-level medians
+              BY url.keyword
+        // Sort to see the busiest URLs on top
+        | SORT total_visits DESC
+      `;
+
+      const result = getESQLStatsQueryMeta(queryString);
+
+      expect(result.groupByFields).toEqual([
+        {
+          field: 'url.keyword',
+          type: 'column',
+        },
+      ]);
+      expect(result.appliedFunctions).toEqual([
+        { identifier: 'unique_visitors', aggregation: 'COUNT_DISTINCT' },
+        { identifier: 'total_visits', aggregation: 'SUM' },
+        { identifier: 'p95_bytes_url', aggregation: 'PERCENTILE' },
+        { identifier: 'median_bytes_url', aggregation: 'MEDIAN' },
+      ]);
+    });
+
+    it('should return the appropriate metadata when there are multiple stats commands in the query if value of a group references a field that was defined by a preceding command', () => {
+      const queryString = `
+       FROM kibana_sample_data_logs 
+        | STATS count_per_day=COUNT(*) BY category=CATEGORIZE(message), @timestamp=BUCKET(@timestamp, 1 day) 
+        | STATS count = SUM(count_per_day), Trend=VALUES(count_per_day) BY category
+      `;
+
+      const result = getESQLStatsQueryMeta(queryString);
+
+      expect(result.groupByFields).toEqual([
+        {
+          field: 'category',
+          type: 'categorize',
+        },
+      ]);
+
+      expect(result.appliedFunctions).toEqual([
+        { identifier: 'count', aggregation: 'SUM' },
+        { identifier: 'Trend', aggregation: 'VALUES' },
+      ]);
+    });
+
+    it(`when the stats query provides unsupported functions as the by option, said functions should not be present in the returned metadata`, () => {
+      const queryString = `FROM kibana_sample_data_logs | STATS var0 = AVG(bytes) BY BUCKET(@timestamp, 1 hour), CATEGORIZE(bytes)`;
+
+      const result = getESQLStatsQueryMeta(queryString);
+
+      expect(result.groupByFields).toEqual([
+        {
+          field: 'CATEGORIZE(bytes)',
+          type: 'categorize',
+        },
+      ]);
+      expect(result.appliedFunctions).toEqual([{ identifier: 'var0', aggregation: 'AVG' }]);
+    });
+
+    it('should return empty arrays if there is a where command targeting a column on the last STATS command in the query', () => {
+      const queryString = `
+        FROM kibana_sample_data_logs
+        | STATS COUNT() BY clientip
+        | WHERE clientip == "192.168.1.1"
+      `;
+
+      const result = getESQLStatsQueryMeta(queryString);
+
+      expect(result.groupByFields).toEqual([
+        {
+          field: 'clientip',
+          type: 'column',
+        },
+      ]);
+      expect(result.appliedFunctions).toEqual([
+        {
+          identifier: 'COUNT()',
+          aggregation: 'COUNT',
+        },
+      ]);
+    });
+  });
+
+  describe('constructCascadeQuery', () => {
+    describe('column options', () => {
+      describe('leaf queries', () => {
+        const nodeType = 'leaf';
+
+        it('should construct a valid cascade leaf query for a query with just one column', () => {
+          const editorQuery: AggregateQuery = {
+            esql: `
+                FROM kibana_sample_data_logs
+                | STATS count() BY clientip
+                | LIMIT 100
+              `,
+          };
+
+          const nodePath = ['clientip'];
+          const nodePathMap = { clientip: '192.168.1.1' };
+
+          const cascadeQuery = constructCascadeQuery({
+            query: editorQuery,
+            nodeType,
+            nodePath,
+            nodePathMap,
+          });
+
+          expect(cascadeQuery.esql).toMatchInlineSnapshot(
+            `"FROM kibana_sample_data_logs | WHERE clientip == \\"192.168.1.1\\""`
+          );
+        });
+
+        it('should construct a valid cascade leaf query for a query with multiple columns and multiple STATS commands', () => {
+          const editorQuery: AggregateQuery = {
+            esql: `
+                FROM kibana_sample_data_logs
+                // First aggregate per client + per URL
+                | STATS
+                    visits_per_client =
+                      COUNT(), // how many hits this client made to this URL
+                    p95_bytes_client =
+                      PERCENTILE(bytes, 95), // 95th percentile of bytes for this client+URL
+                    median_bytes_client =
+                      MEDIAN(bytes) // median of bytes for this client+URL
+                      BY url.keyword, clientip
+                // Now roll up those per-client stats to the URL level
+                | STATS
+                    unique_visitors =
+                      COUNT_DISTINCT(clientip), // how many distinct clients hit this URL
+                    total_visits =
+                      SUM(visits_per_client), // median across client-level medians
+                    p95_bytes_url =
+                      PERCENTILE(p95_bytes_client, 95), // 95th percentile across client-level p95s
+                    median_bytes_url =
+                      MEDIAN(median_bytes_client) // median across client-level medians
+                      BY url.keyword
+                // Sort to see the busiest URLs on top
+                | SORT total_visits DESC
+              `,
+          };
+
+          const nodePath = ['url.keyword'];
+          const nodePathMap = {
+            'url.keyword': 'https://www.elastic.co/downloads/beats/metricbeat',
+          };
+
+          const cascadeQuery = constructCascadeQuery({
+            query: editorQuery,
+            nodeType,
+            nodePath,
+            nodePathMap,
+          });
+
+          expect(cascadeQuery.esql).toMatchInlineSnapshot(
+            `"FROM kibana_sample_data_logs | WHERE \`url.keyword\` == \\"https://www.elastic.co/downloads/beats/metricbeat\\""`
+          );
+        });
+      });
+    });
+
+    describe('function options', () => {
+      describe('categorize operation', () => {
+        it('should construct a valid cascade query for an un-named categorize operation', () => {
+          const editorQuery: AggregateQuery = {
+            esql: `
+                  FROM kibana_sample_data_logs | STATS var0 = AVG(bytes) BY CATEGORIZE(message)
+                `,
+          };
+
+          const nodeType = 'leaf';
+          const nodePath = ['CATEGORIZE(message)'];
+          const nodePathMap = { 'CATEGORIZE(message)': 'some random pattern' };
+
+          const cascadeQuery = constructCascadeQuery({
+            query: editorQuery,
+            nodeType,
+            nodePath,
+            nodePathMap,
+          });
+
+          expect(cascadeQuery.esql).toMatchInlineSnapshot(
+            `"FROM kibana_sample_data_logs | WHERE MATCH(message, \\"some random pattern\\", {\\"auto_generate_synonyms_phrase_query\\": FALSE, \\"fuzziness\\": 0, \\"operator\\": \\"AND\\"})"`
+          );
+        });
+
+        it('should construct a valid cascade query for a named categorize operation', () => {
+          const editorQuery: AggregateQuery = {
+            esql: `
+                  FROM kibana_sample_data_logs 
+                  | WHERE @timestamp <=?_tend and @timestamp >?_tstart
+                    | SAMPLE .001
+                    | STATS Count=COUNT(*)/.001 BY Pattern=CATEGORIZE(message)
+                    | SORT Count DESC
+                `,
+          };
+
+          const nodeType = 'leaf';
+          const nodePath = ['Pattern'];
+          const nodePathMap = { Pattern: 'some random pattern' };
+
+          const cascadeQuery = constructCascadeQuery({
+            query: editorQuery,
+            nodeType,
+            nodePath,
+            nodePathMap,
+          });
+
+          expect(cascadeQuery.esql).toMatchInlineSnapshot(
+            `"FROM kibana_sample_data_logs | WHERE MATCH(message, \\"some random pattern\\", {\\"auto_generate_synonyms_phrase_query\\": FALSE, \\"fuzziness\\": 0, \\"operator\\": \\"AND\\"})"`
+          );
+        });
+      });
+    });
+  });
+
+  describe('mutateQueryStatsGrouping', () => {
+    it('should return a valid query that only contains the root group by column in the stats by option', () => {
+      const editorQuery: AggregateQuery = {
+        esql: `
+          FROM kibana_sample_data_logs
+            | STATS count = COUNT(bytes), average = AVG(memory)
+              BY CATEGORIZE(message), agent.keyword, url.keyword
+        `,
+      };
+
+      const result = mutateQueryStatsGrouping(editorQuery, ['agent.keyword']);
+
+      expect(result.esql).toMatchInlineSnapshot(
+        `"FROM kibana_sample_data_logs | STATS count = COUNT(bytes), average = AVG(memory) BY \`agent.keyword\`"`
+      );
+    });
+
+    it('should return a valid query that only contains the root group by column in the stats by option when the root group is a named function', () => {
+      const editorQuery: AggregateQuery = {
+        esql: `
+          FROM kibana_sample_data_logs
+            | STATS Count=COUNT(*) BY Pattern=CATEGORIZE(message), agent.keyword, url.keyword
+        `,
+      };
+
+      const result = mutateQueryStatsGrouping(editorQuery, ['Pattern']);
+
+      expect(result.esql).toMatchInlineSnapshot(
+        `"FROM kibana_sample_data_logs | STATS Count = COUNT(*) BY Pattern = CATEGORIZE(message)"`
+      );
+    });
+
+    it('should return the original query if the root group is the only column in the stats by option', () => {
+      const editorQuery: AggregateQuery = {
+        esql: `
+          FROM kibana_sample_data_logs
+          | STATS COUNT() BY clientip
+          | LIMIT 100
+        `,
+      };
+
+      const result = mutateQueryStatsGrouping(editorQuery, ['clientip']);
+
+      expect(result.esql).toMatchInlineSnapshot(
+        `"FROM kibana_sample_data_logs | STATS COUNT() BY clientip | LIMIT 100"`
+      );
+    });
+
+    it('ignores specified columns to pick that are not present in the stats by option', () => {
+      const editorQuery: AggregateQuery = {
+        esql: `
+          FROM kibana_sample_data_logs
+            | STATS count = COUNT(bytes), average = AVG(memory)
+              BY CATEGORIZE(message), agent.keyword, url.keyword
+        `,
+      };
+
+      const result = mutateQueryStatsGrouping(editorQuery, ['non_existent_column']);
+
+      expect(result.esql).toMatchInlineSnapshot(
+        `"FROM kibana_sample_data_logs | STATS count = COUNT(bytes), average = AVG(memory) BY CATEGORIZE(message), agent.keyword, url.keyword"`
+      );
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers.test.ts
@@ -174,7 +174,8 @@ describe('cascaded documents helpers utils', () => {
             nodePathMap,
           });
 
-          expect(cascadeQuery.esql).toMatchInlineSnapshot(
+          expect(cascadeQuery).toBeDefined();
+          expect(cascadeQuery!.esql).toMatchInlineSnapshot(
             `"FROM kibana_sample_data_logs | WHERE clientip == \\"192.168.1.1\\""`
           );
         });
@@ -220,7 +221,8 @@ describe('cascaded documents helpers utils', () => {
             nodePathMap,
           });
 
-          expect(cascadeQuery.esql).toMatchInlineSnapshot(
+          expect(cascadeQuery).toBeDefined();
+          expect(cascadeQuery!.esql).toMatchInlineSnapshot(
             `"FROM kibana_sample_data_logs | WHERE \`url.keyword\` == \\"https://www.elastic.co/downloads/beats/metricbeat\\""`
           );
         });
@@ -247,7 +249,8 @@ describe('cascaded documents helpers utils', () => {
             nodePathMap,
           });
 
-          expect(cascadeQuery.esql).toMatchInlineSnapshot(
+          expect(cascadeQuery).toBeDefined();
+          expect(cascadeQuery!.esql).toMatchInlineSnapshot(
             `"FROM kibana_sample_data_logs | WHERE MATCH(message, \\"some random pattern\\", {\\"auto_generate_synonyms_phrase_query\\": FALSE, \\"fuzziness\\": 0, \\"operator\\": \\"AND\\"})"`
           );
         });
@@ -274,7 +277,8 @@ describe('cascaded documents helpers utils', () => {
             nodePathMap,
           });
 
-          expect(cascadeQuery.esql).toMatchInlineSnapshot(
+          expect(cascadeQuery).toBeDefined();
+          expect(cascadeQuery!.esql).toMatchInlineSnapshot(
             `"FROM kibana_sample_data_logs | WHERE MATCH(message, \\"some random pattern\\", {\\"auto_generate_synonyms_phrase_query\\": FALSE, \\"fuzziness\\": 0, \\"operator\\": \\"AND\\"})"`
           );
         });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers.ts
@@ -1,0 +1,489 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { type AggregateQuery } from '@kbn/es-query';
+import {
+  BasicPrettyPrinter,
+  Builder,
+  EsqlQuery,
+  isColumn,
+  isOptionNode,
+  isFunctionExpression,
+  mutate,
+  synth,
+  type ESQLCommand,
+  type ESQLFunction,
+  type ESQLAstItem,
+  type ESQLCommandOption,
+  type ESQLColumn,
+} from '@kbn/esql-ast';
+import type {
+  StatsCommandSummary,
+  StatsFieldSummary,
+} from '@kbn/esql-ast/src/mutate/commands/stats';
+import { extractCategorizeTokens } from './extract_categorize_tokens';
+
+type NodeType = 'group' | 'leaf';
+
+type StatsCommand = ESQLCommand<'stats'>;
+
+export interface AppliedStatsFunction {
+  identifier: string;
+  aggregation: string;
+}
+
+// list of stats functions we support for grouping in the cascade experience
+const SUPPORTED_STATS_COMMAND_OPTION_FUNCTIONS = ['categorize' as const];
+
+export type SupportedStatsFunction = (typeof SUPPORTED_STATS_COMMAND_OPTION_FUNCTIONS)[number];
+
+const isSupportedStatsFunction = (fnName: string): fnName is SupportedStatsFunction =>
+  SUPPORTED_STATS_COMMAND_OPTION_FUNCTIONS.includes(fnName as SupportedStatsFunction);
+
+// helper for removing backticks from field names of function names
+const removeBackticks = (str: string) => str.replace(/`/g, '');
+
+export interface ESQLStatsQueryMeta {
+  groupByFields: Array<{ field: string; type: string }>;
+  appliedFunctions: AppliedStatsFunction[];
+}
+
+function getStatsCommandToOperateOn(esqlQuery: EsqlQuery): StatsCommandSummary | null {
+  let summarizedStatsCommand: StatsCommandSummary | null = null;
+
+  const statsCommands = Array.from(mutate.commands.stats.list(esqlQuery.ast));
+
+  if (statsCommands.length === 0) {
+    return summarizedStatsCommand;
+  }
+
+  // accounting for the possibility of multiple stats commands in the query,
+  // we always want to operate on the last stats command that has valid grouping options
+  for (let i = statsCommands.length - 1; i >= 0; i--) {
+    summarizedStatsCommand = mutate.commands.stats.summarizeCommand(esqlQuery, statsCommands[i]);
+
+    if (summarizedStatsCommand.grouping && Object.keys(summarizedStatsCommand.grouping).length) {
+      break;
+    }
+  }
+
+  return summarizedStatsCommand;
+}
+
+/**
+ * Returns the summary of the stats command at the given command index in the esql query
+ */
+function getStatsCommandAtIndexSummary(esqlQuery: EsqlQuery, commandIndex: number) {
+  const declarationCommand = mutate.commands.stats.byIndex(esqlQuery.ast, commandIndex);
+
+  if (!declarationCommand) {
+    return null;
+  }
+
+  return mutate.commands.stats.summarizeCommand(esqlQuery, declarationCommand);
+}
+
+export const getESQLStatsQueryMeta = (queryString: string): ESQLStatsQueryMeta => {
+  const groupByFields: ESQLStatsQueryMeta['groupByFields'] = [];
+  const appliedFunctions: ESQLStatsQueryMeta['appliedFunctions'] = [];
+
+  const esqlQuery = EsqlQuery.fromSrc(queryString);
+
+  const summarizedStatsCommand = getStatsCommandToOperateOn(esqlQuery);
+
+  if (!summarizedStatsCommand) {
+    return { groupByFields, appliedFunctions };
+  }
+
+  // get all the new fields created by the stats commands in the query,
+  // so we might tell if the command we are operating on is referencing a field that was defined by a preceding command
+  const queryRuntimeFields = Array.from(mutate.commands.stats.summarize(esqlQuery)).map(
+    (command) => command.newFields
+  );
+
+  const grouping = Object.values(summarizedStatsCommand.grouping);
+
+  for (let j = 0; j < grouping.length; j++) {
+    const group = grouping[j];
+
+    if (!group.definition) {
+      // query received is malformed without complete grouping definition, there's no need to proceed further
+      return { groupByFields: [], appliedFunctions: [] };
+    }
+
+    const groupFieldName = removeBackticks(group.field);
+    let groupFieldNode = group;
+
+    const groupDeclarationCommandIndex = queryRuntimeFields.findIndex((field) =>
+      field.has(groupFieldName)
+    );
+
+    let groupDeclarationCommandSummary: StatsCommandSummary | null = null;
+
+    if (
+      groupDeclarationCommandIndex !== -1 &&
+      (groupDeclarationCommandSummary = getStatsCommandAtIndexSummary(
+        esqlQuery,
+        groupDeclarationCommandIndex
+      ))
+    ) {
+      // update the group field node to it's actual definition
+      groupFieldNode = groupDeclarationCommandSummary.grouping[groupFieldName];
+    }
+
+    // check if there is a where command targeting the group field in the stats command
+    const whereCommandGroupFieldSearch = mutate.commands.where.byField(
+      esqlQuery.ast,
+      Builder.expression.column({
+        args: [Builder.identifier({ name: groupFieldName })],
+      })
+    );
+
+    if (whereCommandGroupFieldSearch?.length) {
+      if (groupByFields.length > 0) {
+        // if there's a where command targeting the group in this current iteration,
+        // then this specific query can only be grouped by the current group, pivoting on any other columns though they exist
+        // in the query would be invalid, hence we clear out any previously added group by fields since they are no longer valid
+        groupByFields.splice(0, groupByFields.length);
+      }
+
+      // add the current group and break out of the loop
+      // since there's no need to continue processing other groups
+      // as they are not valid in this context
+      groupByFields.push({
+        field: groupFieldName,
+        type:
+          groupFieldNode.definition.type === 'function'
+            ? groupFieldNode.definition.name
+            : groupFieldNode.definition.type,
+      });
+
+      break;
+    }
+
+    if (isFunctionExpression(groupFieldNode.definition)) {
+      const functionName = groupFieldNode.definition.name;
+      if (!isSupportedStatsFunction(functionName)) {
+        continue;
+      }
+    }
+
+    groupByFields.push({
+      field: groupFieldName,
+      type:
+        groupFieldNode.definition.type === 'function'
+          ? groupFieldNode.definition.name
+          : groupFieldNode.definition.type,
+    });
+  }
+
+  Object.values(summarizedStatsCommand.aggregates).forEach((aggregate) => {
+    appliedFunctions.push({
+      identifier: removeBackticks(aggregate.field), // we remove backticks to have a clean identifier that gets displayed in the UI
+      aggregation:
+        (aggregate.definition as ESQLFunction).operator?.name ?? aggregate.definition.text,
+    });
+  });
+
+  return { groupByFields, appliedFunctions };
+};
+
+export interface CascadeQueryArgs {
+  /**
+   * anchor query for generating the next valid query
+   */
+  query: AggregateQuery;
+  /**
+   * Node type (group or leaf) for which we are constructing the cascade query
+   */
+  nodeType: NodeType;
+  /**
+   * Node path for the current node in the cascade experience we'd like to generate a query for
+   */
+  nodePath: string[];
+  /**
+   * Mapping of node paths to their corresponding values, used to populate the query with literal values
+   */
+  nodePathMap: Record<string, string>;
+}
+
+/**
+ * Constructs a cascade query from the provided query, based on the node type, node path and node path map.
+ */
+export const constructCascadeQuery = ({
+  query,
+  nodeType,
+  nodePath,
+  nodePathMap,
+}: // @ts-expect-error -- temporary stop gap to fix deployment
+CascadeQueryArgs): AggregateQuery => {
+  const EditorESQLQuery = EsqlQuery.fromSrc(query.esql);
+
+  const dataSourceCommand = mutate.generic.commands.find(
+    EditorESQLQuery.ast,
+    (cmd) => cmd.name === 'from'
+  ) as ESQLCommand<'from'> | undefined;
+
+  const queryRuntimeFields = Array.from(mutate.commands.stats.summarize(EditorESQLQuery)).map(
+    (command) => command.newFields
+  );
+
+  if (!dataSourceCommand) {
+    throw new Error('Query does not have a data source');
+  }
+
+  const summarizedStatsCommand = getStatsCommandToOperateOn(EditorESQLQuery);
+
+  if (!summarizedStatsCommand) {
+    throw new Error('Query does not have a valid stats command with grouping options');
+  }
+
+  if (nodeType === 'leaf') {
+    const pathSegment = nodePath[nodePath.length - 1];
+
+    const groupDeclarationCommandIndex = queryRuntimeFields.findIndex((field) =>
+      field.has(pathSegment)
+    );
+
+    let groupDeclarationCommandSummary: StatsCommandSummary | null = null;
+
+    if (groupDeclarationCommandIndex !== -1) {
+      groupDeclarationCommandSummary = getStatsCommandAtIndexSummary(
+        EditorESQLQuery,
+        groupDeclarationCommandIndex
+      );
+    }
+
+    const groupValue =
+      (groupDeclarationCommandSummary ?? summarizedStatsCommand).grouping[pathSegment] ??
+      // when a column name is not assigned, one is created automatically that includes backticks
+      (groupDeclarationCommandSummary ?? summarizedStatsCommand).grouping[`\`${pathSegment}\``];
+
+    const isOperable = groupValue && nodePathMap[pathSegment];
+
+    if (isOperable && isColumn(groupValue.definition)) {
+      return handleStatsByColumnLeafOperation(dataSourceCommand, {
+        [pathSegment]: nodePathMap[pathSegment],
+      });
+    } else if (isOperable && isFunctionExpression(groupValue.definition)) {
+      switch (groupValue.definition.name) {
+        case 'categorize': {
+          return handleStatsByCategorizeLeafOperation(dataSourceCommand, groupValue, nodePathMap);
+        }
+        default: {
+          throw new Error(
+            `The "${groupValue.definition.name}" function is not supported for leaf node operations`
+          );
+        }
+      }
+    }
+  } else if (nodeType === 'group') {
+    throw new Error('Group node operations are not yet supported');
+  }
+};
+
+/**
+ * @description adds a where command with current value for a matched column option as a side-effect on the passed query,
+ * helps us with fetching leaf node data for stats operation in the data cascade experience.
+ */
+function handleStatsByColumnLeafOperation(
+  dataSourceCommand: ESQLCommand<'from'>,
+  columnInterpolationRecord: Record<string, string>
+) {
+  // create new query which we will modify to contain the valid query for the cascade experience
+  const cascadeOperationQuery = EsqlQuery.fromSrc('');
+
+  // append data source to to new query
+  mutate.generic.commands.append(cascadeOperationQuery.ast, dataSourceCommand);
+
+  const newCommands = Object.entries(columnInterpolationRecord).map(([key, value]) => {
+    return Builder.command({
+      name: 'where',
+      args: [
+        Builder.expression.func.binary('==', [
+          Builder.expression.column({
+            args: [Builder.identifier({ name: key })],
+          }),
+          Builder.expression.literal.string(value),
+        ]),
+      ],
+    });
+  });
+
+  newCommands.forEach((command) => {
+    mutate.generic.commands.append(cascadeOperationQuery.ast, command);
+  });
+
+  return {
+    esql: BasicPrettyPrinter.print(cascadeOperationQuery.ast),
+  };
+}
+
+/**
+ * Handles the stats command for a leaf operation that contains a categorize function by modifying the query and adding necessary commands.
+ */
+function handleStatsByCategorizeLeafOperation(
+  dataSourceCommand: ESQLCommand<'from'>,
+  categorizeCommand: StatsFieldSummary,
+  nodePathMap: Record<string, string>
+) {
+  // create new query which we will modify to contain the valid query for the cascade experience
+  const cascadeOperationQuery = EsqlQuery.fromSrc('');
+
+  // append data source to to new query
+  mutate.generic.commands.append(cascadeOperationQuery.ast, dataSourceCommand);
+
+  // build a where command with match expressions for the selected categorize function
+  const categorizeWhereCommand = Builder.command({
+    name: 'where',
+    args: (categorizeCommand.definition as ESQLFunction<'variadic-call', 'categorize'>).args
+      .map((arg) => {
+        const namedColumn = categorizeCommand.column.name;
+
+        const matchValue = nodePathMap[removeBackticks(namedColumn)];
+
+        if (!matchValue) {
+          return null;
+        }
+
+        return Builder.expression.func.call('match', [
+          Builder.identifier({ name: (arg as ESQLColumn).text }),
+          Builder.expression.literal.string(extractCategorizeTokens(matchValue).join(' ')),
+          Builder.expression.map({
+            entries: [
+              Builder.expression.entry(
+                'auto_generate_synonyms_phrase_query',
+                Builder.expression.literal.boolean(false)
+              ),
+              Builder.expression.entry('fuzziness', Builder.expression.literal.integer(0)),
+              Builder.expression.entry('operator', Builder.expression.literal.string('AND')),
+            ],
+          }),
+        ]);
+      })
+      .filter(Boolean) as ESQLAstItem[],
+  });
+
+  mutate.generic.commands.append(cascadeOperationQuery.ast, categorizeWhereCommand);
+
+  return {
+    esql: BasicPrettyPrinter.print(cascadeOperationQuery.ast),
+  };
+}
+
+/**
+ * Modifies the provided ESQL query to only include the specified columns in the stats by option.
+ */
+export function mutateQueryStatsGrouping(query: AggregateQuery, pick: string[]): AggregateQuery {
+  const EditorESQLQuery = EsqlQuery.fromSrc(query.esql);
+
+  const dataSourceCommand = mutate.generic.commands.find(
+    EditorESQLQuery.ast,
+    (cmd) => cmd.name === 'from'
+  ) as ESQLCommand<'from'> | undefined;
+
+  if (!dataSourceCommand) {
+    throw new Error('Query does not have a data source');
+  }
+
+  const statsCommands = Array.from(mutate.commands.stats.list(EditorESQLQuery.ast));
+
+  if (statsCommands.length === 0) {
+    throw new Error(`Query does not include a "stats" command`);
+  }
+
+  let statsCommandToOperateOn: StatsCommand | null = null;
+  let statsCommandToOperateOnGrouping: StatsCommandSummary['grouping'] | null = null;
+
+  // accounting for the possibility of multiple stats commands in the query,
+  // we always want to operate on the last stats command that has valid grouping options
+  for (let i = statsCommands.length - 1; i >= 0; i--) {
+    ({ grouping: statsCommandToOperateOnGrouping } = mutate.commands.stats.summarizeCommand(
+      EditorESQLQuery,
+      statsCommands[i]
+    ));
+
+    if (statsCommandToOperateOnGrouping && Object.keys(statsCommandToOperateOnGrouping).length) {
+      statsCommandToOperateOn = statsCommands[i] as StatsCommand;
+      break;
+    }
+  }
+
+  if (!statsCommandToOperateOn) {
+    throw new Error(`No valid "stats" command was found in the query`);
+  }
+
+  const isValidPick = pick.every(
+    (col) =>
+      Object.keys(statsCommandToOperateOnGrouping!).includes(col) ||
+      Object.keys(statsCommandToOperateOnGrouping!).includes(`\`${col}\``)
+  );
+
+  if (!isValidPick) {
+    // nothing to do, return query as is
+    return {
+      esql: BasicPrettyPrinter.print(EditorESQLQuery.ast),
+    };
+  }
+
+  // Create a modified stats command with only the specified column as args for the "by" option
+  const modifiedStatsCommand = Builder.command({
+    name: 'stats',
+    args: statsCommandToOperateOn.args.map((statsCommandArg) => {
+      if (isOptionNode(statsCommandArg) && statsCommandArg.name === 'by') {
+        return Builder.option({
+          name: statsCommandArg.name,
+          args: statsCommandArg.args.reduce<Array<ESQLAstItem>>((acc, cur) => {
+            if (isColumn(cur) && pick.includes(removeBackticks(cur.name))) {
+              acc.push(
+                Builder.expression.column({
+                  args: [Builder.identifier({ name: cur.name })],
+                })
+              );
+            } else if (
+              isFunctionExpression(cur) &&
+              isSupportedStatsFunction(
+                cur.subtype === 'variadic-call'
+                  ? cur.name
+                  : (cur.args[1] as ESQLAstItem[]).find(isFunctionExpression)?.name ?? ''
+              ) &&
+              pick.includes(
+                cur.subtype === 'variadic-call'
+                  ? cur.text
+                  : removeBackticks(cur.args.find(isColumn)?.name ?? '')
+              )
+            ) {
+              acc.push(synth.exp(cur.text, { withFormatting: false }));
+            }
+
+            return acc;
+          }, []),
+        });
+      }
+
+      // leverage synth to clone the rest of the args since we'd want to use those parts as is
+      return synth.exp((statsCommandArg as ESQLCommandOption).text, { withFormatting: false });
+    }),
+  });
+
+  // Get the position of the original stats command
+  const statsCommandIndex = EditorESQLQuery.ast.commands.findIndex(
+    (cmd) => cmd === statsCommandToOperateOn
+  );
+
+  // remove stats command
+  mutate.generic.commands.remove(EditorESQLQuery.ast, statsCommandToOperateOn);
+
+  // insert modified stats command at same position previous one was at
+  mutate.generic.commands.insert(EditorESQLQuery.ast, modifiedStatsCommand, statsCommandIndex);
+
+  return {
+    esql: BasicPrettyPrinter.print(EditorESQLQuery.ast),
+  };
+}


### PR DESCRIPTION
## Summary

Culled from https://github.com/elastic/kibana/pull/220119

This PR extracts the helpers used for the cascade documents experience into the `@kbn/esql-utils` package. 

Notable about the helpers included in this PR;
- `getESQLStatsQueryMeta`: this method returns meta information for an `ES|QL` query that contains any number of `STATS` command that can be leveraged for the discover cascade experience. 
- `constructCascadeQuery`: This method accepts a base query, ideally it would be the query the user inputed to the  ES|QL editor in discover, in addition tp some configuration options which would in turn return a valid query based on the configuration passed in.

<!--

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...
-->


