### PR TITLE
[Security solution][Alerts] Alerts flyout pagination

### DIFF
--- a/x-pack/solutions/security/packages/data-table/store/data_table/actions.ts
+++ b/x-pack/solutions/security/packages/data-table/store/data_table/actions.ts
@@ -126,5 +126,5 @@ export const updateShowThreatIndicatorAlertsFilter = actionCreator<{
 
 export const updateExpandedAlertIndex = actionCreator<{
   id: string;
-  expandedAlertIndex?: number | null;
+  expandedAlertIndex?: number;
 }>('UPDATE_EXPANDED_ALERT_INDEX');

--- a/x-pack/solutions/security/packages/data-table/store/data_table/actions.ts
+++ b/x-pack/solutions/security/packages/data-table/store/data_table/actions.ts
@@ -123,3 +123,8 @@ export const updateShowThreatIndicatorAlertsFilter = actionCreator<{
   id: string;
   showOnlyThreatIndicatorAlerts: boolean;
 }>('UPDATE_SHOW_THREAT_INDICATOR_ALERTS_FILTER');
+
+export const updateExpandedAlertIndex = actionCreator<{
+  id: string;
+  expandedAlertIndex?: number | null;
+}>('UPDATE_EXPANDED_ALERT_INDEX');

--- a/x-pack/solutions/security/packages/data-table/store/data_table/helpers.ts
+++ b/x-pack/solutions/security/packages/data-table/store/data_table/helpers.ts
@@ -313,6 +313,10 @@ export const updateTableItemsPerPage = ({
     [id]: {
       ...dataTable,
       itemsPerPage,
+      expandedAlertIndex:
+        (dataTable?.expandedAlertIndex ?? 0) < itemsPerPage
+          ? dataTable.expandedAlertIndex
+          : itemsPerPage - 1,
     },
   };
 };

--- a/x-pack/solutions/security/packages/data-table/store/data_table/model.ts
+++ b/x-pack/solutions/security/packages/data-table/store/data_table/model.ts
@@ -62,6 +62,7 @@ export interface DataTableModel extends DataTableModelSettings {
   viewMode: ViewSelection;
   /* custom filters applicable to */
   additionalFilters: Record<AlertPageFilterType, boolean>;
+  expandedAlertIndex?: number | null;
 }
 
 export type SubsetDataTableModel = Readonly<

--- a/x-pack/solutions/security/packages/data-table/store/data_table/model.ts
+++ b/x-pack/solutions/security/packages/data-table/store/data_table/model.ts
@@ -62,7 +62,7 @@ export interface DataTableModel extends DataTableModelSettings {
   viewMode: ViewSelection;
   /* custom filters applicable to */
   additionalFilters: Record<AlertPageFilterType, boolean>;
-  expandedAlertIndex?: number | null;
+  expandedAlertIndex?: number;
 }
 
 export type SubsetDataTableModel = Readonly<

--- a/x-pack/solutions/security/packages/data-table/store/data_table/reducer.ts
+++ b/x-pack/solutions/security/packages/data-table/store/data_table/reducer.ts
@@ -24,6 +24,7 @@ import {
   updateColumnOrder,
   updateColumns,
   updateColumnWidth,
+  updateExpandedAlertIndex,
   updateIsLoading,
   updateItemsPerPage,
   updateItemsPerPageOptions,
@@ -275,6 +276,16 @@ export const dataTableReducer = reducerWithInitialState(initialDataTableState)
           ...state.tableById[id].additionalFilters,
           showOnlyThreatIndicatorAlerts,
         },
+      },
+    },
+  }))
+  .case(updateExpandedAlertIndex, (state, { id, expandedAlertIndex }) => ({
+    ...state,
+    tableById: {
+      ...state.tableById,
+      [id]: {
+        ...state.tableById[id],
+        expandedAlertIndex,
       },
     },
   }))

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -8,6 +8,8 @@
 import type { EuiDataGridCellValueElementProps } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useDispatch } from 'react-redux';
+import { dataTableActions } from '@kbn/securitysolution-data-table';
 import { LeftPanelNotesTab } from '../../../../flyout/document_details/left';
 import { useKibana } from '../../../lib/kibana';
 import {
@@ -70,6 +72,7 @@ const RowActionComponent = ({
   const { data: timelineNonEcsData, ecs: ecsData, _id: eventId, _index: indexName } = data ?? {};
   const { telemetry } = useKibana().services;
   const { openFlyout } = useExpandableFlyoutApi();
+  const dispatch = useDispatch();
 
   const columnValues = useMemo(
     () =>
@@ -93,21 +96,14 @@ const RowActionComponent = ({
   const showNotes = canReadNotes;
 
   const handleOnEventDetailPanelOpened = useCallback(() => {
-    openFlyout({
-      right: {
-        id: DocumentDetailsRightPanelKey,
-        params: {
-          id: eventId,
-          indexName,
-          scopeId: tableId,
-        },
-      },
-    });
+    dispatch(
+      dataTableActions.updateExpandedAlertIndex({ id: tableId, expandedAlertIndex: pageRowIndex })
+    );
     telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
       location: tableId,
       panel: 'right',
     });
-  }, [eventId, indexName, tableId, openFlyout, telemetry]);
+  }, [dispatch, pageRowIndex, tableId, telemetry]);
 
   const toggleShowNotes = useCallback(() => {
     openFlyout({

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -492,7 +492,7 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
       dispatch(
         dataTableActions.updateExpandedAlertIndex({
           id: tableType,
-          expandedAlertIndex: typeof newIndex === 'number' ? newIndex : undefined,
+          expandedAlertIndex: newIndex ?? undefined,
         })
       );
     },

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -490,7 +490,10 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
   const onExpandedAlertIndexChange = useCallback(
     (newIndex?: number | null) => {
       dispatch(
-        dataTableActions.updateExpandedAlertIndex({ id: tableType, expandedAlertIndex: newIndex })
+        dataTableActions.updateExpandedAlertIndex({
+          id: tableType,
+          expandedAlertIndex: typeof newIndex === 'number' ? newIndex : undefined,
+        })
       );
     },
     [dispatch, tableType]

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -81,6 +81,8 @@ const DEFAULT_DATA_GRID_HEIGHT = 600;
 
 const ALERT_TABLE_CONSUMERS: ResponseOpsAlertsTableProps['consumers'] = [AlertConsumers.SIEM];
 
+const DEFAULT_TABLE_PAGE_SIZE = 50;
+
 // Highlight rows with building block alerts
 const shouldHighlightRow = (alert: Alert) => !!alert[ALERT_BUILDING_BLOCK_TYPE];
 
@@ -250,6 +252,7 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
     columns,
     totalCount: count,
     expandedAlertIndex,
+    itemsPerPage,
   } = useSelector((state: State) => getTable(state, tableType) ?? licenseDefaults);
 
   const timeRangeFilter = useMemo(() => buildTimeRangeFilter(from, to), [from, to]);
@@ -429,7 +432,17 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
         })),
       })
     );
+    dispatch(
+      dataTableActions.updateItemsPerPage({ id: tableType, itemsPerPage: DEFAULT_TABLE_PAGE_SIZE })
+    );
   }, [dispatch, tableType, finalColumns, isDataTableInitialized]);
+
+  const onPageSizeChange = useCallback(
+    (newPageSize: number) => {
+      dispatch(dataTableActions.updateItemsPerPage({ id: tableType, itemsPerPage: newPageSize }));
+    },
+    [dispatch, tableType]
+  );
 
   const toolbarVisibility = useMemo(
     () => ({
@@ -485,7 +498,7 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
 
   const onExpandedAlertFlyoutClose = useCallback(() => {
     dispatch(
-      dataTableActions.updateExpandedAlertIndex({ id: tableType, expandedAlertIndex: null })
+      dataTableActions.updateExpandedAlertIndex({ id: tableType, expandedAlertIndex: undefined })
     );
   }, [dispatch, tableType]);
 
@@ -529,7 +542,8 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
               onLoaded={onLoaded}
               additionalContext={additionalContext}
               height={alertTableHeight}
-              pageSize={50}
+              pageSize={itemsPerPage}
+              onPageSizeChange={onPageSizeChange}
               runtimeMappings={runtimeMappings}
               toolbarVisibility={toolbarVisibility}
               renderCellValue={CellValue}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -23,6 +23,8 @@ import type { SetOptional } from 'type-fest';
 import { noop } from 'lodash';
 import type { Alert } from '@kbn/alerting-types';
 import { AlertsTable as ResponseOpsAlertsTable } from '@kbn/response-ops-alerts-table';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useOnExpandableFlyoutClose } from '../../../flyout/shared/hooks/use_on_expandable_flyout_close';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { useAlertsContext } from './alerts_context';
 import { useBulkActionsByTableType } from '../../hooks/trigger_actions_alert_table/use_bulk_actions';
@@ -63,6 +65,7 @@ import { useCellActionsOptions } from '../../hooks/trigger_actions_alert_table/u
 import { useAlertsTableFieldsBrowserOptions } from '../../hooks/trigger_actions_alert_table/use_trigger_actions_browser_fields_options';
 import { AlertTableCellContextProvider } from '../../configurations/security_solution_detections/cell_value_context';
 import { useBrowserFields } from '../../../data_view_manager/hooks/use_browser_fields';
+import { DocumentDetailsRightPanelKey } from '../../../flyout/document_details/shared/constants/panel_keys';
 
 const { updateIsLoading, updateTotalCount } = dataTableActions;
 
@@ -148,6 +151,34 @@ const casesConfiguration = {
 };
 const emptyInputFilters: Filter[] = [];
 
+const ExpandedAlertView: GetSecurityAlertsTableProp<'renderExpandedAlertView'> = ({
+  tableType,
+  alerts,
+  pageIndex,
+  pageSize,
+  expandedAlertIndex,
+}) => {
+  const { openFlyout, closeFlyout } = useExpandableFlyoutApi();
+  const alert = alerts[expandedAlertIndex - pageIndex * pageSize] as Alert | undefined;
+
+  useEffect(() => {
+    if (alert) {
+      openFlyout({
+        right: {
+          id: DocumentDetailsRightPanelKey,
+          params: {
+            id: alert._id,
+            indexName: alert._index,
+            scopeId: tableType,
+          },
+        },
+      });
+    }
+  }, [alert, closeFlyout, openFlyout, tableType]);
+
+  return null;
+};
+
 const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
   inputFilters = emptyInputFilters,
   tableType = TableId.alertsOnAlertsPage,
@@ -218,6 +249,7 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
     viewMode: tableView = eventsDefaultModel.viewMode,
     columns,
     totalCount: count,
+    expandedAlertIndex,
   } = useSelector((state: State) => getTable(state, tableType) ?? licenseDefaults);
 
   const timeRangeFilter = useMemo(() => buildTimeRangeFilter(from, to), [from, to]);
@@ -442,6 +474,23 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
 
   const onLoaded = useCallback(({ alerts }: { alerts: Alert[] }) => onLoad(alerts), [onLoad]);
 
+  const onExpandedAlertIndexChange = useCallback(
+    (newIndex?: number | null) => {
+      dispatch(
+        dataTableActions.updateExpandedAlertIndex({ id: tableType, expandedAlertIndex: newIndex })
+      );
+    },
+    [dispatch, tableType]
+  );
+
+  const onExpandedAlertFlyoutClose = useCallback(() => {
+    dispatch(
+      dataTableActions.updateExpandedAlertIndex({ id: tableType, expandedAlertIndex: null })
+    );
+  }, [dispatch, tableType]);
+
+  useOnExpandableFlyoutClose({ callback: onExpandedAlertFlyoutClose });
+
   /**
    * We want to hide additional controls (like grouping) if the table is being rendered
    * in the cases page OR if the user of the table explicitly set `disableAdditionalToolbarControls`
@@ -498,6 +547,9 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
               }
               cellActionsOptions={cellActionsOptions}
               showInspectButton
+              expandedAlertIndex={expandedAlertIndex}
+              onExpandedAlertIndexChange={onExpandedAlertIndexChange}
+              renderExpandedAlertView={ExpandedAlertView}
               services={services}
               {...tablePropsOverrides}
             />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
@@ -6,9 +6,16 @@
  */
 
 import React, { memo, useCallback, useMemo } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiPagination, EuiSpacer } from '@elastic/eui';
 import { ALERT_WORKFLOW_ASSIGNEE_IDS } from '@kbn/rule-data-utils';
 import { FormattedMessage } from '@kbn/i18n-react';
+import {
+  dataTableActions,
+  dataTableSelectors,
+  tableDefaults,
+} from '@kbn/securitysolution-data-table';
+import { useDispatch } from 'react-redux';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { Notes } from './notes';
 import { useRuleDetailsLink } from '../../shared/hooks/use_rule_details_link';
 import { DocumentStatus } from './status';
@@ -28,6 +35,7 @@ import { Assignees } from './assignees';
 import { FlyoutTitle } from '../../../shared/components/flyout_title';
 import { getAlertTitle } from '../../shared/utils';
 import { AlertHeaderBlock } from '../../../shared/components/alert_header_block';
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 
 // minWidth for each block, allows to switch for a 1 row 4 blocks to 2 rows with 2 block each
 const blockStyles = {
@@ -46,6 +54,15 @@ export const AlertHeaderTitle = memo(() => {
     refetchFlyoutData,
     getFieldsData,
   } = useDocumentDetailsContext();
+  const securitySolutionNotesDisabled = useIsExperimentalFeatureEnabled(
+    'securitySolutionNotesDisabled'
+  );
+  const dispatch = useDispatch();
+
+  const { expandedAlertIndex, totalCount } = useDeepEqualSelector((state) => {
+    return dataTableSelectors.getTableByIdSelector()(state, scopeId) ?? tableDefaults;
+  });
+
   const { ruleName, timestamp, ruleId } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
   const title = useMemo(() => getAlertTitle({ ruleName }), [ruleName]);
   const href = useRuleDetailsLink({ ruleId: !isRulePreview ? ruleId : null });
@@ -79,6 +96,14 @@ export const AlertHeaderTitle = memo(() => {
     refetch();
     refetchFlyoutData();
   }, [refetch, refetchFlyoutData]);
+  const onPaginate = useCallback(
+    (pageIndex: number) => {
+      dispatch(
+        dataTableActions.updateExpandedAlertIndex({ id: scopeId, expandedAlertIndex: pageIndex })
+      );
+    },
+    [dispatch, scopeId]
+  );
 
   const riskScore = useMemo(
     () => (
@@ -125,7 +150,20 @@ export const AlertHeaderTitle = memo(() => {
     <>
       <DocumentSeverity getFieldsData={getFieldsData} />
       <EuiSpacer size="m" />
-      {timestamp && <PreferenceFormattedDate value={new Date(timestamp)} />}
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={false}>
+          {timestamp && <PreferenceFormattedDate value={new Date(timestamp)} />}
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiPagination
+            aria-label=""
+            pageCount={totalCount}
+            activePage={expandedAlertIndex}
+            onPageClick={onPaginate}
+            compressed
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
       <EuiSpacer size="xs" />
       {ruleTitle}
       <EuiSpacer size="m" />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
@@ -15,7 +15,6 @@ import {
   tableDefaults,
 } from '@kbn/securitysolution-data-table';
 import { useDispatch } from 'react-redux';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { Notes } from './notes';
 import { useRuleDetailsLink } from '../../shared/hooks/use_rule_details_link';
 import { DocumentStatus } from './status';
@@ -54,12 +53,9 @@ export const AlertHeaderTitle = memo(() => {
     refetchFlyoutData,
     getFieldsData,
   } = useDocumentDetailsContext();
-  const securitySolutionNotesDisabled = useIsExperimentalFeatureEnabled(
-    'securitySolutionNotesDisabled'
-  );
   const dispatch = useDispatch();
 
-  const { expandedAlertIndex, itemsPerPage } = useDeepEqualSelector((state) => {
+  const { expandedAlertIndex, totalCount } = useDeepEqualSelector((state) => {
     return dataTableSelectors.getTableByIdSelector()(state, scopeId) ?? tableDefaults;
   });
 
@@ -157,7 +153,7 @@ export const AlertHeaderTitle = memo(() => {
         <EuiFlexItem grow={false}>
           <EuiPagination
             aria-label=""
-            pageCount={itemsPerPage}
+            pageCount={totalCount}
             activePage={expandedAlertIndex}
             onPageClick={onPaginate}
             compressed

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
@@ -59,7 +59,7 @@ export const AlertHeaderTitle = memo(() => {
   );
   const dispatch = useDispatch();
 
-  const { expandedAlertIndex, totalCount } = useDeepEqualSelector((state) => {
+  const { expandedAlertIndex, itemsPerPage } = useDeepEqualSelector((state) => {
     return dataTableSelectors.getTableByIdSelector()(state, scopeId) ?? tableDefaults;
   });
 
@@ -157,7 +157,7 @@ export const AlertHeaderTitle = memo(() => {
         <EuiFlexItem grow={false}>
           <EuiPagination
             aria-label=""
-            pageCount={totalCount}
+            pageCount={itemsPerPage}
             activePage={expandedAlertIndex}
             onPageClick={onPaginate}
             compressed


### PR DESCRIPTION
https://github.com/elastic/security-team/issues/6838

## Summary

In this contribution we add pagination on top of the alert flyout in security solution.

## 🔭 Feature overview

- the user is now able to navigate through alerts within the flyout
- the navigation is scoped to the current alerts page
  - if the page-size of the alert table is 50, the user will be only able to navigate through the 50 alerts in the page
- if the user changes page-size, the flyout will sync as well, allowing the user to only navigate through the available alerts in the page

### ❗ Limitations & edge-cases

- the [initial PoC](https://github.com/elastic/kibana/pull/238348) allowed the user to navigate through all the results
  - this is not possible as we don't have the alerts data for alerts that are not in the page
- when a user is looking at an alert at row number `87` and then changes the page-size to 50
  - the 50th alert will be opened instead

### 🎬 Screen-recording

https://github.com/user-attachments/assets/c734f2ed-38c3-4637-9e69-830125b2b729

