### PR TITLE
[9.2] [Metrics][Discover] Enable overlay in metrics details flyout (#239317)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/flyout/metrics_insights_flyout.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/flyout/metrics_insights_flyout.tsx
@@ -34,7 +34,6 @@ import { useFieldsMetadataContext } from '../../context/fields_metadata';
 interface MetricInsightsFlyoutProps {
   metric: MetricField;
   esqlQuery?: string;
-  isOpen: boolean;
   onClose: () => void;
   chartRef: { current: HTMLDivElement | null };
 }
@@ -43,7 +42,6 @@ export const MetricInsightsFlyout = ({
   metric,
   esqlQuery,
   chartRef,
-  isOpen,
   onClose,
 }: MetricInsightsFlyoutProps) => {
   const { euiTheme } = useEuiTheme();
@@ -67,8 +65,6 @@ export const MetricInsightsFlyout = ({
     [onClose]
   );
 
-  if (!isOpen) return null;
-
   const minWidth = euiTheme.base * 24;
   const maxWidth = euiTheme.breakpoint.xl;
 
@@ -76,10 +72,9 @@ export const MetricInsightsFlyout = ({
     <EuiPortal>
       <EuiFlyoutResizable
         onClose={onClose}
-        type="push"
+        type="overlay"
         size={flyoutWidth}
         onKeyDown={onKeyDown}
-        pushMinBreakpoint="xl"
         data-test-subj="metricsExperienceFlyout"
         aria-label={i18n.translate(
           'metricsExperience.metricInsightsFlyout.euiFlyoutResizable.metricInsightsFlyoutLabel',

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.tsx
@@ -7,14 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useMemo, useState, useRef, useEffect } from 'react';
+import React, { useCallback, useMemo, useState, useRef } from 'react';
 import type { EuiFlexGridProps } from '@elastic/eui';
 import { EuiFlexGrid, EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { MetricField } from '@kbn/metrics-experience-plugin/common/types';
 import type { ChartSectionProps, UnifiedHistogramInputMessage } from '@kbn/unified-histogram/types';
 import type { Observable } from 'rxjs';
-import { DiscoverFlyouts, dismissAllFlyoutsExceptFor } from '@kbn/discover-utils';
 import { Chart } from './chart';
 import { MetricInsightsFlyout } from './flyout/metrics_insights_flyout';
 import { EmptyState } from './empty_state/empty_state';
@@ -107,7 +106,6 @@ export const MetricsGrid = ({
       const { rowIndex, colIndex } = getRowColFromIndex(chartIndex);
 
       setExpandedMetric({ metric, esqlQuery, chartId, rowIndex, colIndex });
-      dismissAllFlyoutsExceptFor(DiscoverFlyouts.metricInsights);
     },
     [rows, getRowColFromIndex]
   );
@@ -131,26 +129,6 @@ export const MetricsGrid = ({
     }
     return { current: null };
   }, [expandedMetric?.chartId]);
-
-  // TODO: find a better way to handle conflicts with other flyouts
-  // https://github.com/elastic/kibana/issues/237965
-  useEffect(() => {
-    const handleClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
-
-      if (target.closest('[data-test-subj="embeddablePanelAction-openInspector"]')) {
-        if (expandedMetric) {
-          handleCloseFlyout();
-        }
-      }
-    };
-
-    document.addEventListener('click', handleClick);
-
-    return () => {
-      document.removeEventListener('click', handleClick);
-    };
-  }, [expandedMetric, handleCloseFlyout]);
 
   const normalizedFields = useMemo(() => (Array.isArray(fields) ? fields : [fields]), [fields]);
 
@@ -229,7 +207,6 @@ export const MetricsGrid = ({
           chartRef={getChartRefForFocus()}
           metric={expandedMetric.metric}
           esqlQuery={expandedMetric.esqlQuery}
-          isOpen
           onClose={handleCloseFlyout}
         />
       )}

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/tsconfig.json
@@ -30,7 +30,6 @@
     "@kbn/react-hooks",
     "@kbn/data-grid-in-table-search",
     "@kbn/es-query",
-    "@kbn/discover-utils",
     "@kbn/fields-metadata-plugin",
     "@kbn/esql-utils",
     "@kbn/field-utils"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Metrics][Discover] Enable overlay in metrics details flyout (#239317)](https://github.com/elastic/kibana/pull/239317)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miłosz Marcinkowski","email":"38698566+miloszmarcinkowski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-16T14:53:46Z","message":"[Metrics][Discover] Enable overlay in metrics details flyout (#239317)\n\n## Summary\n\nCloses #238815\n\nAs a temporary fix for #238815, enable the overlay in the metrics\ndetails flyout. That prevents users from switching over directly to Lens\ninspect flyout.\n\nBefore:\n<img width=\"1728\" height=\"976\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b5e79dd8-84b4-49c5-80b1-a96be066ef17\"\n/>\n\nAfter:\n<img width=\"1728\" height=\"976\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0686f88c-e2d4-4e3e-8cfb-9a083ca5a06e\"\n/>","sha":"d620135772481fd85bf838268e7d9898c326af09","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.2.0","v9.3.0"],"title":"[Metrics][Discover] Enable overlay in metrics details flyout","number":239317,"url":"https://github.com/elastic/kibana/pull/239317","mergeCommit":{"message":"[Metrics][Discover] Enable overlay in metrics details flyout (#239317)\n\n## Summary\n\nCloses #238815\n\nAs a temporary fix for #238815, enable the overlay in the metrics\ndetails flyout. That prevents users from switching over directly to Lens\ninspect flyout.\n\nBefore:\n<img width=\"1728\" height=\"976\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b5e79dd8-84b4-49c5-80b1-a96be066ef17\"\n/>\n\nAfter:\n<img width=\"1728\" height=\"976\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0686f88c-e2d4-4e3e-8cfb-9a083ca5a06e\"\n/>","sha":"d620135772481fd85bf838268e7d9898c326af09"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239317","number":239317,"mergeCommit":{"message":"[Metrics][Discover] Enable overlay in metrics details flyout (#239317)\n\n## Summary\n\nCloses #238815\n\nAs a temporary fix for #238815, enable the overlay in the metrics\ndetails flyout. That prevents users from switching over directly to Lens\ninspect flyout.\n\nBefore:\n<img width=\"1728\" height=\"976\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b5e79dd8-84b4-49c5-80b1-a96be066ef17\"\n/>\n\nAfter:\n<img width=\"1728\" height=\"976\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0686f88c-e2d4-4e3e-8cfb-9a083ca5a06e\"\n/>","sha":"d620135772481fd85bf838268e7d9898c326af09"}}]}] BACKPORT-->