### PR TITLE
[Fleet] Call agentless API only once during agent policy creation

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -1620,15 +1620,22 @@ class AgentPolicyService {
   public async deployPolicy(
     soClient: SavedObjectsClientContract,
     agentPolicyId: string,
-    agentPolicy?: AgentPolicy | null
+    agentPolicy?: AgentPolicy | null,
+    options?: { skipAgentless?: boolean }
   ) {
-    await this.deployPolicies(soClient, [agentPolicyId], agentPolicy ? [agentPolicy] : undefined);
+    await this.deployPolicies(
+      soClient,
+      [agentPolicyId],
+      agentPolicy ? [agentPolicy] : undefined,
+      options
+    );
   }
 
   public async deployPolicies(
     soClient: SavedObjectsClientContract,
     agentPolicyIds: string[],
-    agentPolicies?: AgentPolicy[]
+    agentPolicies?: AgentPolicy[],
+    options?: { skipAgentless?: boolean }
   ) {
     const logger = this.getLogger('deployPolicies');
     logger.debug(
@@ -1752,7 +1759,7 @@ class AgentPolicyService {
     }
 
     for (const agentPolicy of policies) {
-      if (!agentPolicy.supports_agentless) {
+      if (!agentPolicy.supports_agentless || options?.skipAgentless) {
         continue;
       }
       try {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -1621,7 +1621,7 @@ class AgentPolicyService {
     soClient: SavedObjectsClientContract,
     agentPolicyId: string,
     agentPolicy?: AgentPolicy | null,
-    options?: { skipAgentless?: boolean }
+    options?: { throwOnAgentlessError?: boolean }
   ) {
     await this.deployPolicies(
       soClient,
@@ -1635,7 +1635,7 @@ class AgentPolicyService {
     soClient: SavedObjectsClientContract,
     agentPolicyIds: string[],
     agentPolicies?: AgentPolicy[],
-    options?: { skipAgentless?: boolean }
+    options?: { throwOnAgentlessError?: boolean }
   ) {
     const logger = this.getLogger('deployPolicies');
     logger.debug(
@@ -1759,7 +1759,7 @@ class AgentPolicyService {
     }
 
     for (const agentPolicy of policies) {
-      if (!agentPolicy.supports_agentless || options?.skipAgentless) {
+      if (!agentPolicy.supports_agentless) {
         continue;
       }
       try {
@@ -1773,6 +1773,9 @@ class AgentPolicyService {
           `[Agentless API] Error deploying agentless deployment for single agent policy id ${agentPolicy.id}`,
           { error }
         );
+        if (options?.throwOnAgentlessError) {
+          throw error;
+        }
       }
     }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.test.ts
@@ -249,54 +249,11 @@ describe('createAgentPolicyWithPackages', () => {
       'Disabling monitoring for agentless policy [Agent policy 1]'
     );
 
-    expect(agentlessAgentService.createAgentlessAgent).toHaveBeenCalled();
-  });
-
-  it('should call deployPolicy with skipAgentless', async () => {
-    const response = await createAgentPolicyWithPackages({
-      esClient: esClientMock,
-      soClient: soClientMock,
-      agentPolicyService: mockedAgentPolicyService,
-      newPolicy: {
-        name: 'Agent policy 1',
-        namespace: 'default',
-        supports_agentless: true,
-        monitoring_enabled: [],
-      },
-      withSysMonitoring: true,
-      monitoringEnabled: ['logs', 'metrics'],
-      spaceId: 'default',
-    });
-
-    expect(response.id).toEqual('new_id');
-    expect(mockedBulkInstallPackages).not.toHaveBeenCalled();
-    expect(mockedPackagePolicyService.create).not.toHaveBeenCalled();
-
-    expect(agentPolicyService.create).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      {
-        name: 'Agent policy 1',
-        namespace: 'default',
-        supports_agentless: true,
-        monitoring_enabled: [],
-      },
-      expect.objectContaining({ skipDeploy: true })
-    );
-
-    expect(appContextService.getLogger().info).toHaveBeenCalledWith(
-      'Disabling system monitoring for agentless policy [Agent policy 1]'
-    );
-    expect(appContextService.getLogger().info).toHaveBeenCalledWith(
-      'Disabling monitoring for agentless policy [Agent policy 1]'
-    );
-
-    expect(agentlessAgentService.createAgentlessAgent).toHaveBeenCalled();
     expect(mockedAgentPolicyService.deployPolicy).toHaveBeenCalledWith(
       expect.anything(),
       'new_id',
       undefined,
-      { skipAgentless: true }
+      { throwOnAgentlessError: true }
     );
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.test.ts
@@ -16,7 +16,6 @@ import { createAgentPolicyWithPackages } from './agent_policy_create';
 import { bulkInstallPackages } from './epm/packages';
 import { incrementPackageName } from './package_policies';
 import { ensureDefaultEnrollmentAPIKeyForAgentPolicy } from './api_keys';
-import { agentlessAgentService } from './agents/agentless_agent';
 
 const mockedAgentPolicyService = agentPolicyService as jest.Mocked<typeof agentPolicyService>;
 const mockedPackagePolicyService = packagePolicyService as jest.Mocked<typeof packagePolicyService>;
@@ -46,7 +45,6 @@ jest.mock('./api_keys', () => {
 jest.mock('./agent_policy');
 jest.mock('./package_policy');
 jest.mock('./package_policies');
-jest.mock('./agents/agentless_agent');
 
 function getPackagePolicy(name: string, policyId = '') {
   return {
@@ -88,7 +86,6 @@ describe('createAgentPolicyWithPackages', () => {
       } as PackagePolicy)
     );
 
-    jest.mocked(agentlessAgentService.createAgentlessAgent).mockReset();
     jest.mocked(mockedBulkInstallPackages).mockReset();
     jest.mocked(mockedPackagePolicyService.create).mockReset();
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
@@ -238,7 +238,9 @@ export async function createAgentPolicyWithPackages({
   }
 
   await ensureDefaultEnrollmentAPIKeyForAgentPolicy(soClient, esClient, agentPolicy.id);
-  await agentPolicyService.deployPolicy(soClient, agentPolicy.id);
+  await agentPolicyService.deployPolicy(soClient, agentPolicy.id, undefined, {
+    skipAgentless: true,
+  });
 
   // Create the agentless agent
   if (agentPolicy.supports_agentless) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
@@ -26,7 +26,6 @@ import { type AgentPolicyServiceInterface, appContextService, packagePolicyServi
 import { incrementPackageName } from './package_policies';
 import { bulkInstallPackages } from './epm/packages';
 import { ensureDefaultEnrollmentAPIKeyForAgentPolicy } from './api_keys';
-import { agentlessAgentService } from './agents/agentless_agent';
 
 async function getFleetServerAgentPolicyId(
   soClient: SavedObjectsClientContract,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_update.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_update.ts
@@ -49,10 +49,7 @@ export async function agentPolicyUpdateEventHandler(
       forceRecreate: true,
     });
     if (!options?.skipDeploy) {
-      await agentPolicyService.deployPolicy(internalSoClient, agentPolicyId, options?.agentPolicy, {
-        // Do not call agentless API on creation it's already done in the agentPolicy create service
-        skipAgentless: true,
-      });
+      await agentPolicyService.deployPolicy(internalSoClient, agentPolicyId, options?.agentPolicy);
     }
   }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_update.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_update.ts
@@ -49,7 +49,10 @@ export async function agentPolicyUpdateEventHandler(
       forceRecreate: true,
     });
     if (!options?.skipDeploy) {
-      await agentPolicyService.deployPolicy(internalSoClient, agentPolicyId, options?.agentPolicy);
+      await agentPolicyService.deployPolicy(internalSoClient, agentPolicyId, options?.agentPolicy, {
+        // Do not call agentless API on creation it's already done in the agentPolicy create service
+        skipAgentless: true,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/239375 

 [PR](https://github.com/elastic/kibana/pull/237322) introduced a bug making the agentless API call being called twice consecutively (one explicit call in the `agentPolicyService.create` method, one as a side effect policy deploys) 


That PR fix that by skipping agentless API call in policy deploys during agent policy creation

## Tests

I added unit test to cover that change.
