### PR TITLE
[SLO] Fix layout of SLO management page combo box filter

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_management_search_bar.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_management_search_bar.tsx
@@ -52,6 +52,7 @@ export function SloManagementSearchBar({ onRefresh }: Props) {
       renderQueryInputAppend={() => (
         <>
           <EuiComboBox
+            compressed
             aria-label={filterTagsLabel}
             placeholder={filterTagsLabel}
             delimiter=","


### PR DESCRIPTION
## Summary

Hyper tiny fix for SLO management page combo box tag filter. It should be `compressed` so it fits with the layout of the rest of the controls.

### Before

<img width="901" height="390" alt="image" src="https://github.com/user-attachments/assets/4c098008-8db9-490e-b908-8a832abd6e9f" />


### After

<img width="892" height="360" alt="image" src="https://github.com/user-attachments/assets/250bffbe-d137-4877-844d-2e50a1645ac6" />


<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->