### PR TITLE
[Streams ]remove tech preview badge from streams in Discover flyout

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_field.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_field.tsx
@@ -31,10 +31,6 @@ export function DiscoverFlyoutStreamField(props: DiscoverFlyoutStreamFieldProps)
         title={i18n.translate('xpack.streams.discoverFlyoutStreamField.title', {
           defaultMessage: 'Stream',
         })}
-        isTechPreview={true}
-        description={i18n.translate('xpack.streams.betaBadgeLabel', {
-          defaultMessage: 'Streams is currently in tech preview',
-        })}
       >
         <DiscoverFlyoutStreamFieldContent {...props} />
       </ContentFrameworkSection>


### PR DESCRIPTION
Before:
<img width="342" height="180" alt="CleanShot 2025-10-16 at 20 23 43@2x" src="https://github.com/user-attachments/assets/bf1a4cff-3636-404e-81f1-3ad8683676f2" />

After:
<img width="302" height="198" alt="CleanShot 2025-10-16 at 20 24 19@2x" src="https://github.com/user-attachments/assets/3a23a22b-d53e-4e62-8537-783744245d32" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->