### PR TITLE
[Streams] always show processing button in Discover flyout

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_processing_link.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_processing_link.tsx
@@ -43,16 +43,16 @@ export function DiscoverFlyoutStreamProcessingLink({
     doc,
   });
 
-  if (!doc.raw._id) return null;
-
   if (loading) return <EuiLoadingSpinner size="s" />;
 
   if (!value || error) return null;
 
+  const hasDocumentId = !!doc.raw._id;
+
   const href = locator.getRedirectUrl({
     name: value,
     managementTab: 'processing',
-    pageState: {
+    pageState: hasDocumentId ? {
       v: 1,
       dataSources: [
         {
@@ -67,12 +67,16 @@ export function DiscoverFlyoutStreamProcessingLink({
           },
         },
       ],
-    },
+    } : undefined,
   });
 
-  const message = i18n.translate('xpack.streams.discoverFlyoutStreamProcessingLink', {
-    defaultMessage: 'Parse content in Streams',
-  });
+  const message = hasDocumentId 
+    ? i18n.translate('xpack.streams.discoverFlyoutStreamProcessingLink', {
+        defaultMessage: 'Parse content in Streams',
+      })
+    : i18n.translate('xpack.streams.discoverFlyoutStreamProcessingLinkEdit', {
+        defaultMessage: 'Edit processing in Streams',
+      });
 
   return (
     <RedirectAppLinks

--- a/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_processing_link.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_processing_link.tsx
@@ -52,25 +52,27 @@ export function DiscoverFlyoutStreamProcessingLink({
   const href = locator.getRedirectUrl({
     name: value,
     managementTab: 'processing',
-    pageState: hasDocumentId ? {
-      v: 1,
-      dataSources: [
-        {
-          type: 'kql-samples',
-          enabled: true,
-          name: i18n.translate('xpack.streams.discoverFlyoutStreamProcessingLink', {
-            defaultMessage: 'Discover document',
-          }),
-          query: {
-            language: 'kuery',
-            query: `_id: ${doc.raw._id}`,
-          },
-        },
-      ],
-    } : undefined,
+    pageState: hasDocumentId
+      ? {
+          v: 1,
+          dataSources: [
+            {
+              type: 'kql-samples',
+              enabled: true,
+              name: i18n.translate('xpack.streams.discoverFlyoutStreamProcessingLink', {
+                defaultMessage: 'Discover document',
+              }),
+              query: {
+                language: 'kuery',
+                query: `_id: ${doc.raw._id}`,
+              },
+            },
+          ],
+        }
+      : undefined,
   });
 
-  const message = hasDocumentId 
+  const message = hasDocumentId
     ? i18n.translate('xpack.streams.discoverFlyoutStreamProcessingLink', {
         defaultMessage: 'Parse content in Streams',
       })


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/238828 we stopped showing the `Parse content in Streams` button when no _id is present. 

This was to fix a bug in https://github.com/elastic/kibana/issues/231397, where we maybe moved a little too fast with just removing all functionality.

This PR adds a intermediate solution where we preserve the button in all cases, and conditionally rename it from 

`Parse content in Streams`
to 
`Edit processing in Streams`


before: 
<img width="924" height="722" alt="CleanShot 2025-10-16 at 20 40 12@2x" src="https://github.com/user-attachments/assets/79e041c9-3ca4-47b4-96a6-185d33655ae8" />

after:
<img width="930" height="724" alt="CleanShot 2025-10-16 at 20 38 08@2x" src="https://github.com/user-attachments/assets/5c83c792-c2c4-429e-bb63-9ae7586dad8a" />


if no _id is available, no state will be passed as part of the redirect
<img width="1922" height="740" alt="CleanShot 2025-10-16 at 20 41 16@2x" src="https://github.com/user-attachments/assets/55f6e7b4-1387-4fdc-bdaa-dc597ab78984" />




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->