### PR TITLE
Rename feature `name` to `id` in the feature usage service

### DIFF
--- a/x-pack/platform/plugins/shared/licensing/README.md
+++ b/x-pack/platform/plugins/shared/licensing/README.md
@@ -31,7 +31,7 @@ function checkLicense(xpackLicenseInfo: XPackInfo){
       showLinks: true,
      }
   }
-  if (!xpackLicenseInfo.feature('name').isEnabled()) {
+  if (!xpackLicenseInfo.feature('id').isEnabled()) {
     return {
       isAvailable: false,
       showLinks: false,
@@ -72,7 +72,7 @@ class MyPlugin {
     deps.licensing.license$.subscribe(license => {
       const { state, message } = license.check('myPlugin', 'gold')
       const hasRequiredLicense = state === 'valid';
-      if (hasRequiredLicense && license.getFeature('name').isAvailable) {
+      if (hasRequiredLicense && license.getFeature('id').isAvailable) {
         // enable some server side logic 
       } else {
         log(message);
@@ -95,7 +95,7 @@ class MyPlugin {
     deps.licensing.license$.subscribe(license => {
       const { state, message } = license.check('myPlugin', 'gold')
       const hasRequiredLicense = state === 'valid';
-      const showLinks = hasRequiredLicense && license.getFeature('name').isAvailable;
+      const showLinks = hasRequiredLicense && license.getFeature('id').isAvailable;
 
       appUpdater$.next(() => {
         status: showLinks ? AppStatus.accessible : AppStatus.inaccessible,

--- a/x-pack/platform/plugins/shared/licensing/common/license.ts
+++ b/x-pack/platform/plugins/shared/licensing/common/license.ts
@@ -136,9 +136,9 @@ export class License implements ILicense {
     return { state: 'valid' };
   }
 
-  getFeature(name: string) {
-    if (this.isAvailable && this.features && Object.hasOwn(this.features, name)) {
-      return { ...this.features[name] };
+  getFeature(id: string) {
+    if (this.isAvailable && this.features && Object.hasOwn(this.features, id)) {
+      return { ...this.features[id] };
     }
 
     return {

--- a/x-pack/platform/plugins/shared/licensing/public/services/feature_usage_service.test.ts
+++ b/x-pack/platform/plugins/shared/licensing/public/services/feature_usage_service.test.ts
@@ -29,8 +29,8 @@ describe('FeatureUsageService', () => {
         expect(http.post).toHaveBeenCalledTimes(1);
         expect(http.post).toHaveBeenCalledWith('/internal/licensing/feature_usage/register', {
           body: JSON.stringify([
-            { featureName: 'my-feature', licenseType: 'platinum' },
-            { featureName: 'my-other-feature', licenseType: 'gold' },
+            { featureId: 'my-feature', licenseType: 'platinum' },
+            { featureId: 'my-other-feature', licenseType: 'gold' },
           ]),
         });
       });
@@ -61,7 +61,7 @@ describe('FeatureUsageService', () => {
         expect(http.post).toHaveBeenCalledTimes(1);
         expect(http.post).toHaveBeenCalledWith('/internal/licensing/feature_usage/notify', {
           body: JSON.stringify({
-            featureName: 'my-feature',
+            featureId: 'my-feature',
             lastUsed: 42,
           }),
         });
@@ -78,7 +78,7 @@ describe('FeatureUsageService', () => {
         expect(http.post).toHaveBeenCalledTimes(1);
         expect(http.post).toHaveBeenCalledWith('/internal/licensing/feature_usage/notify', {
           body: JSON.stringify({
-            featureName: 'my-feature',
+            featureId: 'my-feature',
             lastUsed: now.getTime(),
           }),
         });

--- a/x-pack/platform/plugins/shared/licensing/public/services/feature_usage_service.ts
+++ b/x-pack/platform/plugins/shared/licensing/public/services/feature_usage_service.ts
@@ -14,7 +14,7 @@ export interface FeatureUsageServiceSetup {
   /**
    * Register a feature to be able to notify of it's usages using the {@link FeatureUsageServiceStart | service start contract}.
    */
-  register(featureName: string, licenseType: LicenseType): void;
+  register(featureId: string, licenseType: LicenseType): void;
 }
 
 /** @public */
@@ -22,10 +22,10 @@ export interface FeatureUsageServiceStart {
   /**
    * Notify of a registered feature usage at given time.
    *
-   * @param featureName - the name of the feature to notify usage of
+   * @param featureId - the identifier of the feature to notify usage of
    * @param usedAt - Either a `Date` or an unix timestamp with ms. If not specified, it will be set to the current time.
    */
-  notifyUsage(featureName: string, usedAt?: Date | number): Promise<void>;
+  notifyUsage(featureId: string, usedAt?: Date | number): Promise<void>;
 }
 
 interface StartDeps {
@@ -36,12 +36,12 @@ interface StartDeps {
  * @internal
  */
 export class FeatureUsageService {
-  private readonly registrations: Array<{ featureName: string; licenseType: LicenseType }> = [];
+  private readonly registrations: Array<{ featureId: string; licenseType: LicenseType }> = [];
 
   public setup(): FeatureUsageServiceSetup {
     return {
-      register: async (featureName, licenseType) => {
-        this.registrations.push({ featureName, licenseType });
+      register: async (featureId, licenseType) => {
+        this.registrations.push({ featureId, licenseType });
       },
     };
   }
@@ -58,7 +58,7 @@ export class FeatureUsageService {
           });
 
     return {
-      notifyUsage: async (featureName, usedAt = Date.now()) => {
+      notifyUsage: async (featureId, usedAt = Date.now()) => {
         // Skip notification if on logged-out page
         if (http.anonymousPaths.isAnonymous(window.location.pathname)) return;
         // Wait for registrations to complete
@@ -67,7 +67,7 @@ export class FeatureUsageService {
         const lastUsed = isDate(usedAt) ? usedAt.getTime() : usedAt;
         await http.post('/internal/licensing/feature_usage/notify', {
           body: JSON.stringify({
-            featureName,
+            featureId,
             lastUsed,
           }),
         });

--- a/x-pack/platform/plugins/shared/licensing/server/license_fetcher.ts
+++ b/x-pack/platform/plugins/shared/licensing/server/license_fetcher.ts
@@ -108,8 +108,8 @@ function normalizeServerLicense(
 
 function normalizeFeatures(rawFeatures: estypes.XpackInfoFeatures) {
   const features: PublicFeatures = {};
-  for (const [name, feature] of Object.entries(rawFeatures)) {
-    features[name] = {
+  for (const [id, feature] of Object.entries(rawFeatures)) {
+    features[id] = {
       isAvailable: feature.available,
       isEnabled: feature.enabled,
     };

--- a/x-pack/platform/plugins/shared/licensing/server/routes/feature_usage.ts
+++ b/x-pack/platform/plugins/shared/licensing/server/routes/feature_usage.ts
@@ -29,7 +29,7 @@ export function registerFeatureUsageRoute(
       return response.ok({
         body: {
           features: featureUsage.getLastUsages().map((usage) => ({
-            name: usage.name,
+            id: usage.id,
             last_used: usage.lastUsed,
             license_level: usage.licenseType,
           })),

--- a/x-pack/platform/plugins/shared/licensing/server/routes/internal/notify_feature_usage.ts
+++ b/x-pack/platform/plugins/shared/licensing/server/routes/internal/notify_feature_usage.ts
@@ -20,15 +20,15 @@ export function registerNotifyFeatureUsageRoute(router: LicensingRouter) {
       },
       validate: {
         body: schema.object({
-          featureName: schema.string(),
+          featureId: schema.string(),
           lastUsed: schema.number(),
         }),
       },
     },
     async (context, request, response) => {
-      const { featureName, lastUsed } = request.body;
+      const { featureId, lastUsed } = request.body;
 
-      (await context.licensing).featureUsage.notifyUsage(featureName, lastUsed);
+      (await context.licensing).featureUsage.notifyUsage(featureId, lastUsed);
 
       return response.ok({
         body: {

--- a/x-pack/platform/plugins/shared/licensing/server/routes/internal/register_feature.ts
+++ b/x-pack/platform/plugins/shared/licensing/server/routes/internal/register_feature.ts
@@ -27,7 +27,7 @@ export function registerRegisterFeatureRoute(
       validate: {
         body: schema.arrayOf(
           schema.object({
-            featureName: schema.string(),
+            featureId: schema.string(),
             licenseType: schema.string({
               validate: (value) => {
                 if (!(value in LICENSE_TYPE)) {
@@ -42,8 +42,8 @@ export function registerRegisterFeatureRoute(
     async (context, request, response) => {
       const registrations = request.body;
 
-      registrations.forEach(({ featureName, licenseType }) => {
-        featureUsageSetup.register(featureName, licenseType as LicenseType);
+      registrations.forEach(({ featureId, licenseType }) => {
+        featureUsageSetup.register(featureId, licenseType as LicenseType);
       });
 
       return response.ok({

--- a/x-pack/platform/plugins/shared/licensing/server/services/feature_usage_service.test.ts
+++ b/x-pack/platform/plugins/shared/licensing/server/services/feature_usage_service.test.ts
@@ -52,7 +52,7 @@ describe('FeatureUsageService', () => {
           {
             lastUsed: new Date(127001),
             licenseType: 'basic',
-            name: 'feature',
+            id: 'feature',
           },
         ]);
       });
@@ -68,7 +68,7 @@ describe('FeatureUsageService', () => {
           {
             lastUsed: usageTime,
             licenseType: 'basic',
-            name: 'feature',
+            id: 'feature',
           },
         ]);
       });
@@ -85,7 +85,7 @@ describe('FeatureUsageService', () => {
           {
             lastUsed: new Date(42),
             licenseType: 'basic',
-            name: 'feature',
+            id: 'feature',
           },
         ]);
       });
@@ -109,8 +109,8 @@ describe('FeatureUsageService', () => {
         start.notifyUsage('featureB', 6666);
 
         expect(start.getLastUsages()).toEqual([
-          { lastUsed: new Date(127001), licenseType: 'basic', name: 'featureA' },
-          { lastUsed: new Date(6666), licenseType: 'gold', name: 'featureB' },
+          { lastUsed: new Date(127001), licenseType: 'basic', id: 'featureA' },
+          { lastUsed: new Date(6666), licenseType: 'gold', id: 'featureB' },
         ]);
       });
 
@@ -122,7 +122,7 @@ describe('FeatureUsageService', () => {
         start.notifyUsage('featureA', 500);
 
         expect(start.getLastUsages()).toEqual([
-          { lastUsed: new Date(1000), licenseType: 'basic', name: 'featureA' },
+          { lastUsed: new Date(1000), licenseType: 'basic', id: 'featureA' },
         ]);
       });
 
@@ -134,8 +134,8 @@ describe('FeatureUsageService', () => {
         start.notifyUsage('featureA', 127001);
 
         expect(start.getLastUsages()).toEqual([
-          { lastUsed: new Date(127001), licenseType: 'basic', name: 'featureA' },
-          { lastUsed: null, licenseType: 'gold', name: 'featureB' },
+          { lastUsed: new Date(127001), licenseType: 'basic', id: 'featureA' },
+          { lastUsed: null, licenseType: 'gold', id: 'featureB' },
         ]);
       });
     });

--- a/x-pack/platform/plugins/shared/licensing/server/services/feature_usage_service.ts
+++ b/x-pack/platform/plugins/shared/licensing/server/services/feature_usage_service.ts
@@ -13,11 +13,11 @@ export interface FeatureUsageServiceSetup {
   /**
    * Register a feature to be able to notify of it's usages using the {@link FeatureUsageServiceStart | service start contract}.
    */
-  register(featureName: string, licenseType: LicenseType): void;
+  register(featureId: string, licenseType: LicenseType): void;
 }
 
 export interface LastFeatureUsage {
-  name: string;
+  id: string;
   lastUsed: Date | null;
   licenseType: LicenseType;
 }
@@ -27,10 +27,10 @@ export interface FeatureUsageServiceStart {
   /**
    * Notify of a registered feature usage at given time.
    *
-   * @param featureName - the name of the feature to notify usage of
+   * @param featureId - the identifer of the feature to notify usage of
    * @param usedAt - Either a `Date` or an unix timestamp with ms. If not specified, it will be set to the current time.
    */
-  notifyUsage(featureName: string, usedAt?: Date | number): void;
+  notifyUsage(featureId: string, usedAt?: Date | number): void;
   /**
    * Return a map containing last usage timestamp for all features.
    * Features that were not used yet do not appear in the map.
@@ -43,17 +43,17 @@ export class FeatureUsageService {
 
   public setup(): FeatureUsageServiceSetup {
     return {
-      register: (featureName, licenseType) => {
-        const registered = this.lastUsages.get(featureName);
+      register: (featureId, licenseType) => {
+        const registered = this.lastUsages.get(featureId);
         if (registered) {
           if (registered.licenseType !== licenseType) {
             throw new Error(
-              `Feature '${featureName}' has already been registered with another license type. (current: ${registered.licenseType}, new: ${licenseType})`
+              `Feature '${featureId}' has already been registered with another license type. (current: ${registered.licenseType}, new: ${licenseType})`
             );
           }
         } else {
-          this.lastUsages.set(featureName, {
-            name: featureName,
+          this.lastUsages.set(featureId, {
+            id: featureId,
             lastUsed: null,
             licenseType,
           });
@@ -64,10 +64,10 @@ export class FeatureUsageService {
 
   public start(): FeatureUsageServiceStart {
     return {
-      notifyUsage: (featureName, usedAt = Date.now()) => {
-        const usage = this.lastUsages.get(featureName);
+      notifyUsage: (featureId, usedAt = Date.now()) => {
+        const usage = this.lastUsages.get(featureId);
         if (!usage) {
-          throw new Error(`Feature '${featureName}' is not registered.`);
+          throw new Error(`Feature '${featureId}' is not registered.`);
         }
 
         const lastUsed = isDate(usedAt) ? usedAt : new Date(usedAt);

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/actions/create.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/actions/create.ts
@@ -133,7 +133,7 @@ export default function createConnectorTests({ getService }: FtrProviderContext)
       } = await supertest.get(`${getUrlPrefix(Spaces.space1.id)}/api/licensing/feature_usage`);
       expect(features).to.be.an(Array);
       const noopFeature = features.find(
-        (feature: { name: string }) => feature.name === 'Connector: Test: Noop'
+        (feature: { id: string }) => feature.id === 'Connector: Test: Noop'
       );
       expect(noopFeature).to.be.ok();
       expect(noopFeature.last_used).to.be.a('string');

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/actions/execute.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/actions/execute.ts
@@ -262,7 +262,7 @@ export default function ({ getService }: FtrProviderContext) {
       } = await supertest.get(`${getUrlPrefix(Spaces.space1.id)}/api/licensing/feature_usage`);
       expect(features).to.be.an(Array);
       const noopFeature = features.find(
-        (feature: { name: string }) => feature.name === 'Connector: Test: Noop'
+        (feature: { id: string }) => feature.id === 'Connector: Test: Noop'
       );
       expect(noopFeature).to.be.ok();
       expect(noopFeature.last_used).to.be.a('string');

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/actions/update.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/actions/update.ts
@@ -179,7 +179,7 @@ export default function updateConnectorTests({ getService }: FtrProviderContext)
       } = await supertest.get(`${getUrlPrefix(Spaces.space1.id)}/api/licensing/feature_usage`);
       expect(features).to.be.an(Array);
       const noopFeature = features.find(
-        (feature: { name: string }) => feature.name === 'Connector: Test: Noop'
+        (feature: { id: string }) => feature.id === 'Connector: Test: Noop'
       );
       expect(noopFeature).to.be.ok();
       expect(noopFeature.last_used).to.be.a('string');

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group1/alerts_base.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group1/alerts_base.ts
@@ -527,7 +527,7 @@ instanceStateValue: true
       } = await supertestWithoutAuth.get(`${getUrlPrefix(space.id)}/api/licensing/feature_usage`);
       expect(features).to.be.an(Array);
       const indexRecordFeature = features.find(
-        (feature: { name: string }) => feature.name === 'Connector: Test: Index Record'
+        (feature: { id: string }) => feature.id === 'Connector: Test: Index Record'
       );
       expect(indexRecordFeature).to.be.ok();
       expect(indexRecordFeature.last_used).to.be.a('string');

--- a/x-pack/platform/test/licensing_plugin/public/feature_usage.ts
+++ b/x-pack/platform/test/licensing_plugin/public/feature_usage.ts
@@ -14,7 +14,7 @@ import '@kbn/core-provider-plugin/types';
 interface FeatureUsage {
   last_used?: number;
   license_level: LicenseType;
-  name: string;
+  id: string;
 }
 
 // eslint-disable-next-line import/no-default-export
@@ -24,7 +24,7 @@ export default function (ftrContext: FtrProviderContext) {
   const browser = getService('browser');
   const PageObjects = getPageObjects(['common', 'security']);
 
-  const notifyFeatureUsage = async (featureName: string, lastUsed: number) => {
+  const notifyFeatureUsage = async (featureId: string, lastUsed: number) => {
     await browser.executeAsync(
       async (feature, time, cb) => {
         const { start } = window._coreProvider;
@@ -32,7 +32,7 @@ export default function (ftrContext: FtrProviderContext) {
         await licensing.featureUsage.notifyUsage(feature, time);
         cb();
       },
-      featureName,
+      featureId,
       lastUsed
     );
   };
@@ -44,7 +44,7 @@ export default function (ftrContext: FtrProviderContext) {
 
     it('allows to register features to the server', async () => {
       const response = await supertest.get('/api/licensing/feature_usage').expect(200);
-      const features = response.body.features.map(({ name }: FeatureUsage) => name);
+      const features = response.body.features.map(({ id }: FeatureUsage) => id);
 
       // These were registered by the plugin in ../plugins/test_feature_usage
       expect(features).to.contain('test-client-A');
@@ -59,8 +59,8 @@ export default function (ftrContext: FtrProviderContext) {
       const response = await supertest.get('/api/licensing/feature_usage').expect(200);
       const features = response.body.features as FeatureUsage[];
 
-      expect(features.find((f) => f.name === 'test-client-A')?.last_used).to.be(now.toISOString());
-      expect(features.find((f) => f.name === 'test-client-B')?.last_used).to.be(null);
+      expect(features.find(({ id }) => id === 'test-client-A')?.last_used).to.be(now.toISOString());
+      expect(features.find(({ id }) => id === 'test-client-B')?.last_used).to.be(null);
     });
   });
 }

--- a/x-pack/platform/test/plugin_api_integration/test_suites/licensed_feature_usage/feature_usage.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/licensed_feature_usage/feature_usage.ts
@@ -29,8 +29,8 @@ export default function ({ getService }: FtrProviderContext) {
 
       const testFeaturesResponse = {
         ...response.body,
-        features: response.body.features.filter((feature: { name: string }) =>
-          feature.name.startsWith('Test feature ')
+        features: response.body.features.filter((feature: { id: string }) =>
+          feature.id.startsWith('Test feature ')
         ),
       };
 
@@ -39,17 +39,17 @@ export default function ({ getService }: FtrProviderContext) {
           {
             last_used: null,
             license_level: 'basic',
-            name: 'Test feature A',
+            id: 'Test feature A',
           },
           {
             last_used: toISO(timeB),
             license_level: 'gold',
-            name: 'Test feature B',
+            id: 'Test feature B',
           },
           {
             last_used: toISO(timeA),
             license_level: 'platinum',
-            name: 'Test feature C',
+            id: 'Test feature C',
           },
         ],
       });


### PR DESCRIPTION
## Summary

Resolves #235750.



