### PR TITLE
[Discover] [Unified Data Table] Fix control column headers alignment when headers wrap

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/custom_control_columns/actions_column/actions_column.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/custom_control_columns/actions_column/actions_column.tsx
@@ -61,6 +61,7 @@ export const getActionsColumn = ({
   return {
     id: COLUMN_ID,
     width: columnWidth,
+    headerCellProps: { className: 'unifiedDataTable__headerCell' },
     rowCellRender: (props: EuiDataGridCellValueElementProps) => (
       <EuiFlexGroup
         data-test-subj="unifiedDataTable_actionsColumnCell"

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.tsx
@@ -76,6 +76,7 @@ export const SELECT_ROW = 'select';
 const getSelect = (rows: DataTableRecord[]) => ({
   id: SELECT_ROW,
   width: DEFAULT_CONTROL_COLUMN_WIDTH,
+  headerCellProps: { className: 'unifiedDataTable__headerCell' },
   rowCellRender: SelectButton,
   headerCellRender: getSelectAllButton(rows),
 });


### PR DESCRIPTION
## Summary

This PR fixes the alignment of control column headers when there are multiline headers that wrap, ensuring they're top-aligned too.

Before:
<img src="https://github.com/user-attachments/assets/7394cb6d-3a40-4292-bdbf-b0614cf2641a" />

After:
<img src="https://github.com/user-attachments/assets/25f23e4c-636e-4121-ae34-bb9e448bd597" />

Followup to #239148.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->