### PR TITLE
[9.2] [Metrics][Discover] Refactor chart layers hook (#237390)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-composer/index.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/index.ts
@@ -25,5 +25,6 @@ export { stats } from './src/commands/stats';
 export { limit } from './src/commands/limit';
 export { rename } from './src/commands/rename';
 export { sort, SortOrder } from './src/commands/sort';
+export { replaceParameters } from './src/pipeline/replace_parameters';
 
 export type { QueryOperator } from './src/types';

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_aggregation.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_aggregation.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { replaceFunctionParams } from './create_aggregation';
+
+describe('replaceFunctionParams', () => {
+  it('should substitute a ?? placeholder and add backticks where needed', () => {
+    const result = replaceFunctionParams('AVG(??metricField)', {
+      metricField: 'system.load.1m',
+    });
+    expect(result).toBe('AVG(system.load.`1m`)');
+  });
+
+  it('should substitute a ?? placeholder without adding backticks when not needed', () => {
+    const result = replaceFunctionParams('AVG(??metricField)', {
+      metricField: 'system.load.normal',
+    });
+    expect(result).toBe('AVG(system.load.normal)');
+  });
+
+  it('should handle a mix of ?? and ? placeholders', () => {
+    const result = replaceFunctionParams('AVG(??field) WHERE service.name == ?serviceName', {
+      field: 'system.cpu.total.norm.pct',
+      serviceName: 'auth-service',
+    });
+    expect(result).toBe('AVG(system.cpu.total.norm.pct) WHERE service.name == "auth-service"');
+  });
+
+  it('should handle nested functions like SUM(RATE(??metricField))', () => {
+    const result = replaceFunctionParams('SUM(RATE(??metricField))', {
+      metricField: 'system.network.in.bytes',
+    });
+    expect(result).toBe('SUM(RATE(system.network.`in`.bytes))');
+  });
+});

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_aggregation.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_aggregation.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  Parser,
+  BasicPrettyPrinter,
+  isCommand,
+  isFunctionExpression,
+  type ESQLAstQueryExpression,
+} from '@kbn/esql-ast';
+import { replaceParameters } from '@kbn/esql-composer';
+import type { MetricField } from '@kbn/metrics-experience-plugin/common/types';
+
+type Params = Record<string, string | number | boolean | null>;
+
+// Helper function to safely extract the target AST node
+function getFunctionNodeFromAst(ast: ESQLAstQueryExpression) {
+  const statsCommand = ast.commands?.find((c) => isCommand(c) && c.name.toLowerCase() === 'stats');
+  if (statsCommand) {
+    const functionNode = statsCommand.args?.[0];
+    if (functionNode && isFunctionExpression(functionNode)) {
+      return functionNode;
+    }
+  }
+  return null;
+}
+
+/**
+ * Takes an ES|QL function string with placeholders and a parameters object,
+ * and returns the function string with the placeholders substituted and correctly escaped.
+ *
+ * This function works by using the `@kbn/esql-composer` to build a temporary query,
+ * which handles the AST substitution and escaping internally.
+ *
+ * @param functionString An ES|QL function string with placeholders (e.g., "AVG(??metricField)").
+ * @param params A parameters object (e.g., { metricField: 'system.load.1m' }).
+ * @returns The transformed function string (e.g., "AVG(system.load.`1m`)").
+ */
+export function replaceFunctionParams(functionString: string, params: Params): string {
+  try {
+    // 1. To parse the function string fragment, wrap it in a minimal, valid query.
+    const tempQuery = `TS metrics-* | STATS ${functionString}`;
+    const { root: ast } = Parser.parse(tempQuery);
+
+    // 2. Use the exported `replaceParameters` function to perform the substitution.
+    replaceParameters(ast, params);
+
+    // 3. Extract the modified function node from the temporary AST.
+    const functionNode = getFunctionNodeFromAst(ast);
+
+    if (functionNode) {
+      // 4. Print only the function node back to a string.
+      return BasicPrettyPrinter.print(functionNode).trim();
+    }
+
+    // Fallback if the AST structure isn't what we expect.
+    return functionString;
+  } catch (e) {
+    // If parsing or any other step fails, return the original string as a safe fallback.
+    return functionString;
+  }
+}
+
+/**
+ * Creates the metric aggregation part of an ES|QL query.
+ * It returns `SUM(RATE(...))` for counters and `AVG(...)` for other metric types.
+ * If a metric name is provided, it will be properly escaped and substituted.
+ *
+ * @param instrument - The type of metric instrument (e.g., 'counter').
+ * @param metricName - The actual name of the metric field to aggregate.
+ * @param placeholderName - The name of the placeholder to use in the template.
+ * @returns The ES|QL aggregation string.
+ */
+export function createMetricAggregation({
+  instrument,
+  metricName,
+  placeholderName = 'metricName',
+}: {
+  instrument: MetricField['instrument'];
+  metricName?: string;
+  placeholderName?: string;
+}) {
+  const functionTemplate =
+    instrument === 'counter' ? `SUM(RATE(??${placeholderName}))` : `AVG(??${placeholderName})`;
+  return metricName
+    ? replaceFunctionParams(functionTemplate, { [placeholderName]: metricName })
+    : functionTemplate;
+}
+
+/**
+ * Creates the time bucketing part of an ES|QL query.
+ *
+ * @param targetBuckets - The desired number of buckets for the time series.
+ * @param timestampField - The name of the timestamp field.
+ * @returns The ES|QL BUCKET function string.
+ */
+export function createTimeBucketAggregation({
+  targetBuckets = 100,
+  timestampField = '@timestamp',
+}: {
+  targetBuckets?: number;
+  timestampField?: string;
+}) {
+  return `BUCKET(${timestampField}, ${targetBuckets}, ?_tstart, ?_tend)`;
+}

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
@@ -13,6 +13,7 @@ import { type MetricField } from '@kbn/metrics-experience-plugin/common/types';
 import { ES_FIELD_TYPES } from '@kbn/field-types';
 import { DIMENSION_TYPES } from '../../constants';
 import { DIMENSIONS_COLUMN } from './constants';
+import { createMetricAggregation, createTimeBucketAggregation } from './create_aggregation';
 
 interface CreateESQLQueryParams {
   metric: MetricField;
@@ -46,7 +47,7 @@ function needsStringCasting(fieldType: ES_FIELD_TYPES): boolean {
  * @returns A complete ESQL query string.
  */
 export function createESQLQuery({ metric, dimensions = [], filters }: CreateESQLQueryParams) {
-  const { name: metricField, index, instrument, dimensions: metricDimensions } = metric;
+  const { name: metricField, instrument, index, dimensions: metricDimensions } = metric;
   const source = timeseries(index);
 
   const whereConditions: QueryOperator[] = [];
@@ -76,24 +77,18 @@ export function createESQLQuery({ metric, dimensions = [], filters }: CreateESQL
     unfilteredDimensions.length > 0
       ? where(unfilteredDimensions.map((dim) => `${dim} IS NOT NULL`).join(' AND '))
       : (query) => query,
-    instrument === 'counter'
-      ? stats(
-          `SUM(RATE(??metricField)) BY BUCKET(@timestamp, 100, \?_tstart, \?_tend)${
-            (dimensions ?? []).length > 0 ? `, ${dimensions.join(',')}` : ''
-          }`,
-          {
-            metricField,
-          }
-        )
-      : stats(
-          `AVG(??metricField) BY BUCKET(@timestamp, 100, \?_tstart, \?_tend) ${
-            (dimensions ?? []).length > 0 ? `, ${dimensions.join(',')}` : ''
-          }`,
-          {
-            metricField,
-          }
-        ),
-    ...((dimensions ?? []).length > 0
+    stats(
+      `${createMetricAggregation({
+        instrument,
+        placeholderName: 'metricField',
+      })} BY ${createTimeBucketAggregation({})}${
+        dimensions.length > 0 ? `, ${dimensions.join(',')}` : ''
+      }`,
+      {
+        metricField,
+      }
+    ),
+    ...(dimensions.length > 0
       ? dimensions.length === 1
         ? [rename(`??dim as ${DIMENSIONS_COLUMN}`, { dim: dimensions[0] })]
         : [

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/index.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/index.ts
@@ -11,3 +11,4 @@ export * from './esql/create_esql_query';
 export * from './esql/constants';
 export * from './metric_unit/get_lens_metric_format';
 export * from './metric_unit/get_unit_label';
+export * from './esql/create_aggregation';

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.test.ts
@@ -7,134 +7,82 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
-import { useChartLayers } from './use_chart_layers';
-import * as esqlModule from '@kbn/esql-utils';
-import * as esqlHook from '../../../hooks';
-import type { ChartSectionProps, UnifiedHistogramServices } from '@kbn/unified-histogram/types';
-import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
-import type { TimeRange } from '@kbn/data-plugin/common';
+import { renderHook } from '@testing-library/react';
+import type { MetricField } from '@kbn/metrics-experience-plugin/common/types';
 import { DIMENSIONS_COLUMN } from '../../../common/utils';
+import { useChartLayers } from './use_chart_layers';
 
-jest.mock('@kbn/esql-utils', () => ({
-  ...jest.requireActual('@kbn/esql-utils'),
-  getESQLQueryColumns: jest.fn(),
+jest.mock('../../../common/utils', () => ({
+  ...jest.requireActual('../../../common/utils'),
+  createMetricAggregation: jest.fn(({ metricName }) => `AVG(${metricName})`),
+  createTimeBucketAggregation: jest.fn(() => 'time_bucket_agg'),
 }));
-jest.mock('../../../hooks', () => ({
-  useEsqlQueryInfo: jest.fn(),
-}));
-
-const getESQLQueryColumnsMock = esqlModule.getESQLQueryColumns as jest.MockedFunction<
-  typeof esqlModule.getESQLQueryColumns
->;
-const useEsqlQueryInfoMock = esqlHook.useEsqlQueryInfo as jest.MockedFunction<
-  typeof esqlHook.useEsqlQueryInfo
->;
-
-const servicesMock: Partial<UnifiedHistogramServices> = {
-  data: dataPluginMock.createStartContract(),
-};
 
 describe('useChartLayers', () => {
-  const mockServices: Pick<ChartSectionProps, 'services'> = {
-    services: servicesMock as UnifiedHistogramServices,
+  const mockMetric: MetricField = {
+    name: 'system.cpu.total.norm.pct',
+    type: 'gauge',
+    instrument: 'gauge',
+    unit: 'percent',
+    index: 'metrics-*',
+    dimensions: [],
   };
 
-  const getTimeRange = (): TimeRange => ({ from: 'now-1h', to: 'now' });
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('returns empty yAxis if no columns', async () => {
-    getESQLQueryColumnsMock.mockResolvedValue([]);
-    useEsqlQueryInfoMock.mockReturnValue({
-      dimensions: [],
-      columns: [],
-      metricField: '',
-      indices: [],
-    });
-
+  it('should return an area chart configuration when no dimensions are provided', () => {
     const { result } = renderHook(() =>
       useChartLayers({
-        query: 'FROM metrics-*',
-        getTimeRange,
-        seriesType: 'line',
-        color: 'red',
-        services: mockServices.services,
+        metric: mockMetric,
+        dimensions: [],
+        color: '#000',
       })
     );
 
-    await waitFor(() => {
-      expect(result.current).toHaveLength(0);
-    });
-  });
-
-  it('maps columns correctly to yAxis and uses dimensions for breakdown', async () => {
-    getESQLQueryColumnsMock.mockResolvedValue([
-      { name: '@timestamp', meta: { type: 'date' }, id: '@timestamp' },
-      { name: 'value', meta: { type: 'number' }, id: 'value' },
-      { name: DIMENSIONS_COLUMN, meta: { type: 'number' }, id: DIMENSIONS_COLUMN },
-    ]);
-    useEsqlQueryInfoMock.mockReturnValue({
-      dimensions: [DIMENSIONS_COLUMN],
-      columns: [],
-      metricField: '',
-      indices: [],
-    });
-
-    const { result } = renderHook(() =>
-      useChartLayers({
-        query: 'FROM metrics-*',
-        getTimeRange,
-        seriesType: 'area',
-        color: 'blue',
-        services: mockServices.services,
-      })
-    );
-
-    await waitFor(() => {
-      expect(result.current).toHaveLength(1);
-    });
-
-    const layer = result.current[0];
-    expect(layer.xAxis).toStrictEqual({ field: '@timestamp', type: 'dateHistogram' });
-    expect(layer.yAxis).toHaveLength(1);
-    expect(layer.yAxis[0].label).toBe('value');
-    expect(layer.yAxis[0].seriesColor).toBe('blue');
+    const [layer] = result.current;
     expect(layer.seriesType).toBe('area');
-    expect(layer.breakdown).toBe(DIMENSIONS_COLUMN);
+    expect(layer.breakdown).toBeUndefined();
+    expect(layer.yAxis[0].value).toBe('AVG(system.cpu.total.norm.pct)');
+    expect(layer.yAxis[0].seriesColor).toBe('#000');
   });
 
-  it('uses first date column as xAxis', async () => {
-    getESQLQueryColumnsMock.mockResolvedValue([
-      { name: 'timestamp_field', meta: { type: 'date' }, id: 'timestamp_field' },
-      { name: 'metric', meta: { type: 'number' }, id: 'metric' },
-    ]);
-
-    useEsqlQueryInfoMock.mockReturnValue({
-      dimensions: [],
-      columns: [],
-      metricField: '',
-      indices: [],
-    });
-
+  it('should return a line chart configuration with a breakdown when dimensions are provided', () => {
     const { result } = renderHook(() =>
       useChartLayers({
-        query: 'FROM metrics-*',
-        getTimeRange,
-        seriesType: 'bar',
-        services: mockServices.services,
+        metric: mockMetric,
+        dimensions: ['service.name'],
+        color: '#FFF',
       })
     );
 
-    await waitFor(() => {
-      expect(result.current).toHaveLength(1);
-    });
+    const [layer] = result.current;
+    expect(layer.seriesType).toBe('line');
+    expect(layer.breakdown).toBe(DIMENSIONS_COLUMN);
+    expect(layer.yAxis[0].value).toBe('AVG(system.cpu.total.norm.pct)');
+    expect(layer.yAxis[0].seriesColor).toBe('#FFF');
+  });
 
-    expect(result.current[0].xAxis).toStrictEqual({
-      field: 'timestamp_field',
-      type: 'dateHistogram',
-    });
+  it('should include format options if the metric has a unit', () => {
+    const metricWithUnit: MetricField = { ...mockMetric, unit: 'bytes' };
+    const { result } = renderHook(() =>
+      useChartLayers({
+        metric: metricWithUnit,
+        dimensions: [],
+      })
+    );
+    const [layer] = result.current;
+    expect(layer.yAxis[0]).toHaveProperty('format');
+    expect(layer.yAxis[0]).toHaveProperty('format');
+  });
+
+  it('should not include format options if the metric has no unit', () => {
+    const metricWithoutUnit: MetricField = { ...mockMetric, unit: undefined };
+    const { result } = renderHook(() =>
+      useChartLayers({
+        metric: metricWithoutUnit,
+        dimensions: [],
+      })
+    );
+    const [layer] = result.current;
+    expect(layer.yAxis[0]).not.toHaveProperty('format');
+    expect(layer.yAxis[0]).not.toHaveProperty('formatString');
   });
 });

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts
@@ -7,84 +7,61 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { LensBaseLayer, LensSeriesLayer } from '@kbn/lens-embeddable-utils/config_builder';
-import type { ChartSectionProps } from '@kbn/unified-histogram/types';
-import useAsync from 'react-use/lib/useAsync';
 import { useMemo } from 'react';
-import type { TimeRange } from '@kbn/data-plugin/common';
-import { getESQLQueryColumns } from '@kbn/esql-utils';
-import type { MetricUnit } from '@kbn/metrics-experience-plugin/common/types';
-import { DIMENSIONS_COLUMN, getLensMetricFormat } from '../../../common/utils';
-import { useEsqlQueryInfo } from '../../../hooks';
+import type { LensSeriesLayer } from '@kbn/lens-embeddable-utils/config_builder';
+import type { MetricField } from '@kbn/metrics-experience-plugin/common/types';
+import {
+  createMetricAggregation,
+  createTimeBucketAggregation,
+  DIMENSIONS_COLUMN,
+  getLensMetricFormat,
+} from '../../../common/utils';
 
-export const useChartLayers = ({
-  query,
-  getTimeRange,
-  color,
-  seriesType,
-  services,
-  unit,
-  abortController,
-}: {
-  query: string;
+interface UseChartLayersParams {
+  dimensions: string[];
+  metric: MetricField;
   color?: string;
-  unit?: MetricUnit;
-  getTimeRange: () => TimeRange;
-  seriesType: LensSeriesLayer['seriesType'];
-  services: ChartSectionProps['services'];
-  abortController?: AbortController;
-} & Pick<ChartSectionProps, 'services'>): Array<LensSeriesLayer> => {
-  const queryInfo = useEsqlQueryInfo({ query });
+}
 
-  const { value: columns = [] } = useAsync(
-    () =>
-      getESQLQueryColumns({
-        esqlQuery: query,
-        search: services.data.search.search,
-        signal: abortController?.signal,
-        timeRange: getTimeRange(),
-      }),
+/**
+ * A hook that computes the Lens series layer configuration for the metrics chart.
+ *
+ * @param dimensions - An array of dimension fields to break down the series by.
+ * @param metric - The metric field to be visualized.
+ * @param color - The color to apply to the series.
+ * @returns An array of LensSeriesLayer configurations.
+ */
+export const useChartLayers = ({
+  dimensions,
+  metric,
+  color,
+}: UseChartLayersParams): LensSeriesLayer[] => {
+  return useMemo((): LensSeriesLayer[] => {
+    const metricField = createMetricAggregation({
+      instrument: metric.instrument,
+      metricName: metric.name,
+    });
+    const hasDimensions = dimensions.length > 0;
 
-    [query, services.data.search, abortController, getTimeRange]
-  );
-
-  const layers = useMemo<LensSeriesLayer[]>(() => {
-    if (columns.length === 0) {
-      return [];
-    }
-
-    const xAxisColumn = columns.find((col) => col.meta.type === 'date');
-    const xAxis: LensSeriesLayer['xAxis'] = {
-      type: 'dateHistogram',
-      field: xAxisColumn?.name ?? '@timestamp',
-    };
-
-    const yAxis: LensBaseLayer[] = columns
-      .filter(
-        (col) =>
-          col.name !== DIMENSIONS_COLUMN &&
-          col.meta.type !== 'date' &&
-          !queryInfo.dimensions.some((dim) => dim === col.name)
-      )
-      .map((col) => ({
-        label: col.name,
-        value: col.name,
-        compactValues: true,
-        seriesColor: color,
-        ...(unit ? getLensMetricFormat(unit) : {}),
-      }));
-
-    const hasDimensions = queryInfo.dimensions.length > 0;
     return [
       {
         type: 'series',
-        seriesType,
-        xAxis,
-        yAxis,
+        seriesType: hasDimensions ? 'line' : 'area',
+        xAxis: {
+          field: createTimeBucketAggregation({}),
+          type: 'dateHistogram',
+        },
+        yAxis: [
+          {
+            value: metricField,
+            label: metricField,
+            compactValues: true,
+            seriesColor: color,
+            ...(metric.unit ? getLensMetricFormat(metric.unit) : {}),
+          },
+        ],
         breakdown: hasDimensions ? DIMENSIONS_COLUMN : undefined,
       },
     ];
-  }, [columns, queryInfo.dimensions, seriesType, color, unit]);
-
-  return layers;
+  }, [dimensions, metric, color]);
 };

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.test.ts
@@ -93,11 +93,11 @@ describe('useLensProps', () => {
       useLensProps({
         title: 'Test Chart',
         query: 'FROM metrics-*',
-        seriesType: 'line',
         services: servicesMock as UnifiedHistogramServices,
         getTimeRange,
         discoverFetch$,
         chartRef,
+        chartLayers: mockChartLayers,
       })
     );
 
@@ -120,11 +120,11 @@ describe('useLensProps', () => {
       useLensProps({
         title: 'Test Chart',
         query: 'FROM metrics-*',
-        seriesType: 'line',
         services: servicesMock as UnifiedHistogramServices,
         getTimeRange,
         discoverFetch$,
         chartRef,
+        chartLayers: mockChartLayers,
       })
     );
 
@@ -162,11 +162,11 @@ describe('useLensProps', () => {
       useLensProps({
         title: 'Test Chart',
         query: 'FROM metrics-*',
-        seriesType: 'line',
         services: servicesMock as UnifiedHistogramServices,
         getTimeRange,
         discoverFetch$,
         chartRef,
+        chartLayers: mockChartLayers,
       })
     );
 
@@ -192,11 +192,11 @@ describe('useLensProps', () => {
       useLensProps({
         title: 'Test Chart',
         query: 'FROM metrics-*',
-        seriesType: 'line',
         services: servicesMock as UnifiedHistogramServices,
         getTimeRange,
         discoverFetch$,
         chartRef: { current: null },
+        chartLayers: mockChartLayers,
       })
     );
 

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
@@ -25,9 +25,7 @@ import {
   distinctUntilChanged,
 } from 'rxjs';
 import type { TimeRange } from '@kbn/data-plugin/common';
-import type { MetricUnit } from '@kbn/metrics-experience-plugin/common/types';
 import { useEuiTheme } from '@elastic/eui';
-import { useChartLayers } from './use_chart_layers';
 export type LensProps = Pick<
   EmbeddableComponentProps,
   | 'id'
@@ -43,37 +41,21 @@ export type LensProps = Pick<
 export const useLensProps = ({
   title,
   query,
-  seriesType,
   services,
   getTimeRange,
-  unit,
-  color,
   searchSessionId,
   discoverFetch$,
-  abortController,
   chartRef,
+  chartLayers,
 }: {
   title: string;
   query: string;
   discoverFetch$: Observable<UnifiedHistogramInputMessage>;
-  color?: string;
-  unit?: MetricUnit;
   getTimeRange: () => TimeRange;
-  seriesType: LensSeriesLayer['seriesType'];
   chartRef?: React.RefObject<HTMLDivElement>;
-  abortController?: AbortController;
+  chartLayers: LensSeriesLayer[];
 } & Pick<ChartSectionProps, 'services' | 'searchSessionId'>) => {
   const { euiTheme } = useEuiTheme();
-  const chartLayers = useChartLayers({
-    query,
-    seriesType,
-    services,
-    getTimeRange,
-    unit,
-    color,
-    abortController,
-  });
-
   const attributes$ = useRef(new BehaviorSubject<LensAttributes | undefined>(undefined));
   const lensParams = useMemo<LensConfig | undefined>(
     () =>

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
@@ -17,6 +17,7 @@ import { useBoolean } from '@kbn/react-hooks';
 import { createESQLQuery } from '../../common/utils/esql/create_esql_query';
 import type { LensWrapperProps } from './lens_wrapper';
 import { LensWrapper } from './lens_wrapper';
+import { useChartLayers } from './hooks/use_chart_layers';
 import { useLensProps } from './hooks/use_lens_props';
 
 const ChartSizes = {
@@ -74,18 +75,17 @@ export const Chart = ({
     });
   }, [metric, dimensions, filters]);
 
+  const chartLayers = useChartLayers({ dimensions, metric, color });
+
   const lensProps = useLensProps({
     title: metric.name,
     query: esqlQuery,
-    unit: metric.unit,
-    seriesType: dimensions.length > 0 ? 'line' : 'area',
-    color,
     services,
     searchSessionId,
     discoverFetch$,
-    abortController,
     getTimeRange,
     chartRef,
+    chartLayers,
   });
 
   const handleViewDetails = useCallback(() => {

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/tsconfig.json
@@ -30,7 +30,6 @@
     "@kbn/data-grid-in-table-search",
     "@kbn/es-query",
     "@kbn/fields-metadata-plugin",
-    "@kbn/esql-utils",
     "@kbn/field-utils"
   ]
 }

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/tsconfig.json
@@ -19,7 +19,6 @@
     "@kbn/i18n",
     "@kbn/i18n-react",
     "@kbn/chart-icons",
-    "@kbn/esql-utils",
     "@kbn/data-plugin",
     "@kbn/lens-embeddable-utils",
     "@kbn/data-views-plugin",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Metrics][Discover] Refactor chart layers hook (#237390)](https://github.com/elastic/kibana/pull/237390)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Chris Cowan","email":"chris@elastic.co"},"sourceCommit":{"committedDate":"2025-10-07T18:24:30Z","message":"[Metrics][Discover] Refactor chart layers hook (#237390)\n\n## 🍒 Summary\n\nThis change refactors the `useChartLayers` hook in the Unified Metrics\nGrid to generate the layers based on the metric fields instead of the\nESQL query. The previous `useChartLayers` hook created a request with\n`LIMIT 0` to get the columns for the chart to build the layers, this\ncreated an unnecessary network request for each chart.\n\nThe change also introduces a ES|QL parameter substitution utility to\nensure the columns defined in the chart layers matches the output from\nthe ESQL query. It also introduces a utility to generate the metric\naggregation and time bucket aggregation uses for both the chart layers\nand ESQL creation utility to ensure they match.\n\n## 🛠️ Changes\n\n- Created a comprehensive unit test suite for the new `useChartLayers`\nhook to ensure its correctness.\n- Updated the `Chart` component and `useLensProps` hook to consume the\nnew `useChartLayers` hook, simplifying their implementation.\n- Added a new `create_aggregation.ts` utility with a\n`replaceFunctionParams` function to handle ES|QL parameter substitution\nand escaping.\n- Included a unit test for the new aggregation helpers to verify their\nbehavior.\n- Added JSDoc documentation blocks to `createMetricAggregation` and\n`createTimeBucketAggregation` functions for better code clarity.\n\n## 🎙️ Prompts\n\n- \"Can you create a function like `escapeString(\"system.load.1m\")` that\nwould return \"system.load.`1m`\" using the same technique.\"\n- \"can you add that to\n@src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_aggregation.ts\"\n- \"Hum... Modify it to do this\n`replaceFunctionParams('AVG(??metricField)', { metricField:\n'system.load.1m' })` which would output `AVG(system.load.\\`1m\\`)`\"\n- \"I think you miss understood what I want. I want a function that I can\ncall with `AVG(??metricField)` and `{ metricField: 'system.load.1m' }`\nand it will do the substitution using the AST.\"\n- \"Params and replaceParameters are not exported from the\n`esql-composer` library. Can you read\n@src/platform/packages/shared/kbn-esql-composer/README.md Could use this\nlibrary to basically do the same thing?\"\n- \"Can you write a unit test for this?\"\n- \"I feel like what you originally wrote should work. It's working\npretty much the same way here:\n@src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts\"\n- \"Can you add doc blocks to the other functions in the\ncreate_aggregation file?\"\n- \"Can you convert the `const chartLayers = useMemo...` in\n@src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx\nto a hook called `useChartLayers` and put it in\nsrc/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts\nand add a corresponding test?\"\n\n🤖 This pull request was assisted by Gemini CLI","sha":"ad1b4af90a8a28023df22b127c9db3a9c0c9ed34","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:obs-ux-infra_services","backport:version","v9.2.0","Feature:Metrics in Discover","v9.3.0"],"title":"[Metrics][Discover] Refactor chart layers hook","number":237390,"url":"https://github.com/elastic/kibana/pull/237390","mergeCommit":{"message":"[Metrics][Discover] Refactor chart layers hook (#237390)\n\n## 🍒 Summary\n\nThis change refactors the `useChartLayers` hook in the Unified Metrics\nGrid to generate the layers based on the metric fields instead of the\nESQL query. The previous `useChartLayers` hook created a request with\n`LIMIT 0` to get the columns for the chart to build the layers, this\ncreated an unnecessary network request for each chart.\n\nThe change also introduces a ES|QL parameter substitution utility to\nensure the columns defined in the chart layers matches the output from\nthe ESQL query. It also introduces a utility to generate the metric\naggregation and time bucket aggregation uses for both the chart layers\nand ESQL creation utility to ensure they match.\n\n## 🛠️ Changes\n\n- Created a comprehensive unit test suite for the new `useChartLayers`\nhook to ensure its correctness.\n- Updated the `Chart` component and `useLensProps` hook to consume the\nnew `useChartLayers` hook, simplifying their implementation.\n- Added a new `create_aggregation.ts` utility with a\n`replaceFunctionParams` function to handle ES|QL parameter substitution\nand escaping.\n- Included a unit test for the new aggregation helpers to verify their\nbehavior.\n- Added JSDoc documentation blocks to `createMetricAggregation` and\n`createTimeBucketAggregation` functions for better code clarity.\n\n## 🎙️ Prompts\n\n- \"Can you create a function like `escapeString(\"system.load.1m\")` that\nwould return \"system.load.`1m`\" using the same technique.\"\n- \"can you add that to\n@src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_aggregation.ts\"\n- \"Hum... Modify it to do this\n`replaceFunctionParams('AVG(??metricField)', { metricField:\n'system.load.1m' })` which would output `AVG(system.load.\\`1m\\`)`\"\n- \"I think you miss understood what I want. I want a function that I can\ncall with `AVG(??metricField)` and `{ metricField: 'system.load.1m' }`\nand it will do the substitution using the AST.\"\n- \"Params and replaceParameters are not exported from the\n`esql-composer` library. Can you read\n@src/platform/packages/shared/kbn-esql-composer/README.md Could use this\nlibrary to basically do the same thing?\"\n- \"Can you write a unit test for this?\"\n- \"I feel like what you originally wrote should work. It's working\npretty much the same way here:\n@src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts\"\n- \"Can you add doc blocks to the other functions in the\ncreate_aggregation file?\"\n- \"Can you convert the `const chartLayers = useMemo...` in\n@src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx\nto a hook called `useChartLayers` and put it in\nsrc/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts\nand add a corresponding test?\"\n\n🤖 This pull request was assisted by Gemini CLI","sha":"ad1b4af90a8a28023df22b127c9db3a9c0c9ed34"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237390","number":237390,"mergeCommit":{"message":"[Metrics][Discover] Refactor chart layers hook (#237390)\n\n## 🍒 Summary\n\nThis change refactors the `useChartLayers` hook in the Unified Metrics\nGrid to generate the layers based on the metric fields instead of the\nESQL query. The previous `useChartLayers` hook created a request with\n`LIMIT 0` to get the columns for the chart to build the layers, this\ncreated an unnecessary network request for each chart.\n\nThe change also introduces a ES|QL parameter substitution utility to\nensure the columns defined in the chart layers matches the output from\nthe ESQL query. It also introduces a utility to generate the metric\naggregation and time bucket aggregation uses for both the chart layers\nand ESQL creation utility to ensure they match.\n\n## 🛠️ Changes\n\n- Created a comprehensive unit test suite for the new `useChartLayers`\nhook to ensure its correctness.\n- Updated the `Chart` component and `useLensProps` hook to consume the\nnew `useChartLayers` hook, simplifying their implementation.\n- Added a new `create_aggregation.ts` utility with a\n`replaceFunctionParams` function to handle ES|QL parameter substitution\nand escaping.\n- Included a unit test for the new aggregation helpers to verify their\nbehavior.\n- Added JSDoc documentation blocks to `createMetricAggregation` and\n`createTimeBucketAggregation` functions for better code clarity.\n\n## 🎙️ Prompts\n\n- \"Can you create a function like `escapeString(\"system.load.1m\")` that\nwould return \"system.load.`1m`\" using the same technique.\"\n- \"can you add that to\n@src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_aggregation.ts\"\n- \"Hum... Modify it to do this\n`replaceFunctionParams('AVG(??metricField)', { metricField:\n'system.load.1m' })` which would output `AVG(system.load.\\`1m\\`)`\"\n- \"I think you miss understood what I want. I want a function that I can\ncall with `AVG(??metricField)` and `{ metricField: 'system.load.1m' }`\nand it will do the substitution using the AST.\"\n- \"Params and replaceParameters are not exported from the\n`esql-composer` library. Can you read\n@src/platform/packages/shared/kbn-esql-composer/README.md Could use this\nlibrary to basically do the same thing?\"\n- \"Can you write a unit test for this?\"\n- \"I feel like what you originally wrote should work. It's working\npretty much the same way here:\n@src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts\"\n- \"Can you add doc blocks to the other functions in the\ncreate_aggregation file?\"\n- \"Can you convert the `const chartLayers = useMemo...` in\n@src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx\nto a hook called `useChartLayers` and put it in\nsrc/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts\nand add a corresponding test?\"\n\n🤖 This pull request was assisted by Gemini CLI","sha":"ad1b4af90a8a28023df22b127c9db3a9c0c9ed34"}}]}] BACKPORT-->