### PR TITLE
[9.2] [Metrics][Discover] Limit dimension selection to single dimension and optimize ESQL generation (#239010)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/constants.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/constants.ts
@@ -17,7 +17,7 @@ export const METRICS_GRID_RESTRICT_BODY_CLASS = 'metricsExperienceGrid--restrict
 
 // Selection limits
 export const MAX_VALUES_SELECTIONS = 10;
-export const MAX_DIMENSIONS_SELECTIONS = 10;
+export const MAX_DIMENSIONS_SELECTIONS = 1;
 export const PAGE_SIZE = 20;
 
 export const DIMENSION_TYPES = [

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.test.ts
@@ -63,7 +63,6 @@ TS metrics-*
 TS metrics-*
   | WHERE host.name IS NOT NULL
   | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend), host.name
-  | RENAME host.name AS ${DIMENSIONS_COLUMN}
 `.trim()
     );
   });
@@ -218,7 +217,6 @@ TS metrics-*
 TS metrics-*
   | WHERE host.name IN ("host-1")
   | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend), host.name
-  | RENAME host.name AS ${DIMENSIONS_COLUMN}
 `.trim()
     );
   });

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
@@ -8,7 +8,7 @@
  */
 
 import type { QueryOperator } from '@kbn/esql-composer';
-import { drop, evaluate, stats, timeseries, where, rename } from '@kbn/esql-composer';
+import { drop, evaluate, stats, timeseries, where } from '@kbn/esql-composer';
 import { type MetricField } from '@kbn/metrics-experience-plugin/common/types';
 import { ES_FIELD_TYPES } from '@kbn/field-types';
 import { DIMENSION_TYPES } from '../../constants';
@@ -90,7 +90,7 @@ export function createESQLQuery({ metric, dimensions = [], filters }: CreateESQL
     ),
     ...(dimensions.length > 0
       ? dimensions.length === 1
-        ? [rename(`??dim as ${DIMENSIONS_COLUMN}`, { dim: dimensions[0] })]
+        ? []
         : [
             evaluate(
               `${DIMENSIONS_COLUMN} = CONCAT(${dimensions

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.test.ts
@@ -44,7 +44,7 @@ describe('useChartLayers', () => {
     expect(layer.yAxis[0].seriesColor).toBe('#000');
   });
 
-  it('should return a line chart configuration with a breakdown when dimensions are provided', () => {
+  it('should return a line chart configuration with a breakdown when single dimension is provided', () => {
     const { result } = renderHook(() =>
       useChartLayers({
         metric: mockMetric,
@@ -55,7 +55,23 @@ describe('useChartLayers', () => {
 
     const [layer] = result.current;
     expect(layer.seriesType).toBe('line');
-    expect(layer.breakdown).toBe(DIMENSIONS_COLUMN);
+    expect(layer.breakdown).toBe('service.name'); // Single dimension uses actual dimension name
+    expect(layer.yAxis[0].value).toBe('AVG(system.cpu.total.norm.pct)');
+    expect(layer.yAxis[0].seriesColor).toBe('#FFF');
+  });
+
+  it('should return a line chart configuration with DIMENSIONS_COLUMN when multiple dimensions are provided', () => {
+    const { result } = renderHook(() =>
+      useChartLayers({
+        metric: mockMetric,
+        dimensions: ['service.name', 'host.name'],
+        color: '#FFF',
+      })
+    );
+
+    const [layer] = result.current;
+    expect(layer.seriesType).toBe('line');
+    expect(layer.breakdown).toBe(DIMENSIONS_COLUMN); // Multiple dimensions use DIMENSIONS_COLUMN
     expect(layer.yAxis[0].value).toBe('AVG(system.cpu.total.norm.pct)');
     expect(layer.yAxis[0].seriesColor).toBe('#FFF');
   });

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts
@@ -60,7 +60,11 @@ export const useChartLayers = ({
             ...(metric.unit ? getLensMetricFormat(metric.unit) : {}),
           },
         ],
-        breakdown: hasDimensions ? DIMENSIONS_COLUMN : undefined,
+        breakdown: hasDimensions
+          ? dimensions.length === 1
+            ? dimensions[0]
+            : DIMENSIONS_COLUMN
+          : undefined,
       },
     ];
   }, [dimensions, metric, color]);

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/hooks/use_toolbar_actions.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/hooks/use_toolbar_actions.tsx
@@ -14,6 +14,7 @@ import { keys } from '@elastic/eui';
 import { useMetricsGridState } from '../../../hooks';
 import { DimensionsSelector } from '../dimensions_selector';
 import { ValuesSelector } from '../values_selector';
+import { MAX_DIMENSIONS_SELECTIONS } from '../../../common/constants';
 
 interface UseToolbarActionsProps
   extends Pick<ChartSectionProps, 'requestParams' | 'renderToggleActions'> {
@@ -105,6 +106,7 @@ export const useToolbarActions = ({
         onChange={onDimensionsChange}
         selectedDimensions={dimensions}
         onClear={onClearAllDimensions}
+        singleSelection={MAX_DIMENSIONS_SELECTIONS === 1}
       />,
       dimensions.length > 0 ? (
         <ValuesSelector


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Metrics][Discover] Limit dimension selection to single dimension and optimize ESQL generation (#239010)](https://github.com/elastic/kibana/pull/239010)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Chris Cowan","email":"chris@elastic.co"},"sourceCommit":{"committedDate":"2025-10-16T19:16:20Z","message":"[Metrics][Discover] Limit dimension selection to single dimension and optimize ESQL generation (#239010)\n\n## 🍒 Summary\n\n- Changed MAX_DIMENSIONS_SELECTIONS from 10 to 1 in constants\n- Removed RENAME operation for single dimensions in ESQL query\ngeneration\n- Updated chart layers to use actual dimension name instead of\nDIMENSIONS_COLUMN for single dimensions\n- Modified dimensions selector to use singleSelection mode and updated\nUI messaging to singular\n- Modified the selection behavior so users can easily switch from one\ndimension to the next without having to click \"Clear selection\"\n- Updated all related tests to reflect single dimension behavior\n- Made singleSelection dynamic based on MAX_DIMENSIONS_SELECTIONS\nconstant\n- Removed unused rename import from ESQL composer\n\nFixes #238878\n\n## 🎙️ Prompts\n\n- \"I would like to limit the number of dimension the user can select to\n1\"\n- \"I also like to modify the ESQL query that is generated to remove the\nRENAME for a single dimension\"\n- \"We also need to update useChartLayers to use just the dimension name\nwhen there is a single dimension specified instead of the\nDIMENSION_COLUMN\"\n- \"When the MAX_DIMENSION_SELECTIONS is greater than one, set the single\nselection to false\"\n- \"Can you update the test for create_esql_query\"\n- \"Can you check to see if there are tests for use_chart_layers and\nuse_chart_layers_from_esql\"\n- \"I would like to change the behavior so that I can just click a\ndifferent dimension without having to click \"Clear selection\" so that it\nswitches from one dimension to another.\"\n- \"That worked. I would now like to remove the `statusMessage` but keep\n`Clear selection`\"\n- \"Can you just omit the `selectedOptionsMessage` attribute instead of\nproviding `undefined`\"\n- \"Can we set `selectedOptionsMessage` to \"Select a dimension to break\ndown your metrics\"?\"\n\n🤖 This commit was assisted by Cursor","sha":"0d1c5e9535f10ad4087e1e481e9e23a00598ea3e","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.2.0","Feature:Metrics in Discover","v9.3.0"],"title":"[Metrics][Discover] Limit dimension selection to single dimension and optimize ESQL generation","number":239010,"url":"https://github.com/elastic/kibana/pull/239010","mergeCommit":{"message":"[Metrics][Discover] Limit dimension selection to single dimension and optimize ESQL generation (#239010)\n\n## 🍒 Summary\n\n- Changed MAX_DIMENSIONS_SELECTIONS from 10 to 1 in constants\n- Removed RENAME operation for single dimensions in ESQL query\ngeneration\n- Updated chart layers to use actual dimension name instead of\nDIMENSIONS_COLUMN for single dimensions\n- Modified dimensions selector to use singleSelection mode and updated\nUI messaging to singular\n- Modified the selection behavior so users can easily switch from one\ndimension to the next without having to click \"Clear selection\"\n- Updated all related tests to reflect single dimension behavior\n- Made singleSelection dynamic based on MAX_DIMENSIONS_SELECTIONS\nconstant\n- Removed unused rename import from ESQL composer\n\nFixes #238878\n\n## 🎙️ Prompts\n\n- \"I would like to limit the number of dimension the user can select to\n1\"\n- \"I also like to modify the ESQL query that is generated to remove the\nRENAME for a single dimension\"\n- \"We also need to update useChartLayers to use just the dimension name\nwhen there is a single dimension specified instead of the\nDIMENSION_COLUMN\"\n- \"When the MAX_DIMENSION_SELECTIONS is greater than one, set the single\nselection to false\"\n- \"Can you update the test for create_esql_query\"\n- \"Can you check to see if there are tests for use_chart_layers and\nuse_chart_layers_from_esql\"\n- \"I would like to change the behavior so that I can just click a\ndifferent dimension without having to click \"Clear selection\" so that it\nswitches from one dimension to another.\"\n- \"That worked. I would now like to remove the `statusMessage` but keep\n`Clear selection`\"\n- \"Can you just omit the `selectedOptionsMessage` attribute instead of\nproviding `undefined`\"\n- \"Can we set `selectedOptionsMessage` to \"Select a dimension to break\ndown your metrics\"?\"\n\n🤖 This commit was assisted by Cursor","sha":"0d1c5e9535f10ad4087e1e481e9e23a00598ea3e"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239010","number":239010,"mergeCommit":{"message":"[Metrics][Discover] Limit dimension selection to single dimension and optimize ESQL generation (#239010)\n\n## 🍒 Summary\n\n- Changed MAX_DIMENSIONS_SELECTIONS from 10 to 1 in constants\n- Removed RENAME operation for single dimensions in ESQL query\ngeneration\n- Updated chart layers to use actual dimension name instead of\nDIMENSIONS_COLUMN for single dimensions\n- Modified dimensions selector to use singleSelection mode and updated\nUI messaging to singular\n- Modified the selection behavior so users can easily switch from one\ndimension to the next without having to click \"Clear selection\"\n- Updated all related tests to reflect single dimension behavior\n- Made singleSelection dynamic based on MAX_DIMENSIONS_SELECTIONS\nconstant\n- Removed unused rename import from ESQL composer\n\nFixes #238878\n\n## 🎙️ Prompts\n\n- \"I would like to limit the number of dimension the user can select to\n1\"\n- \"I also like to modify the ESQL query that is generated to remove the\nRENAME for a single dimension\"\n- \"We also need to update useChartLayers to use just the dimension name\nwhen there is a single dimension specified instead of the\nDIMENSION_COLUMN\"\n- \"When the MAX_DIMENSION_SELECTIONS is greater than one, set the single\nselection to false\"\n- \"Can you update the test for create_esql_query\"\n- \"Can you check to see if there are tests for use_chart_layers and\nuse_chart_layers_from_esql\"\n- \"I would like to change the behavior so that I can just click a\ndifferent dimension without having to click \"Clear selection\" so that it\nswitches from one dimension to another.\"\n- \"That worked. I would now like to remove the `statusMessage` but keep\n`Clear selection`\"\n- \"Can you just omit the `selectedOptionsMessage` attribute instead of\nproviding `undefined`\"\n- \"Can we set `selectedOptionsMessage` to \"Select a dimension to break\ndown your metrics\"?\"\n\n🤖 This commit was assisted by Cursor","sha":"0d1c5e9535f10ad4087e1e481e9e23a00598ea3e"}}]}] BACKPORT-->