### PR TITLE
[9.2] [Infra] Increase `diskUsageByMountPoint` lens chart size to 15 and add statistics (#239297)

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.test.ts
@@ -10,6 +10,7 @@
 import { buildXY } from './xy';
 import { mockDataViewsService } from './mock_utils';
 import type { XYState } from '@kbn/lens-plugin/public';
+import { LegendValue } from '@elastic/charts';
 
 test('generates xy chart config', async () => {
   const result = await buildXY(
@@ -154,6 +155,47 @@ test('generates xy chart config', async () => {
       "visualizationType": "lnsXY",
     }
   `);
+});
+
+test('generates xy chart config with legend stats', async () => {
+  const result = await buildXY(
+    {
+      chartType: 'xy',
+      title: 'test',
+      dataset: {
+        esql: 'from test | count=count() by @timestamp',
+      },
+      layers: [
+        {
+          type: 'series',
+          seriesType: 'bar',
+          xAxis: '@timestamp',
+          yAxis: [
+            {
+              label: 'test',
+              value: 'count',
+            },
+          ],
+        },
+      ],
+      legend: {
+        show: true,
+        position: 'right',
+        legendStats: [LegendValue.Average, LegendValue.Max],
+      },
+    },
+    {
+      dataViewsAPI: mockDataViewsService() as any,
+    }
+  );
+
+  expect(result.state.visualization).toMatchObject({
+    legend: {
+      isVisible: true,
+      position: 'right',
+      legendStats: [LegendValue.Average, LegendValue.Max],
+    },
+  });
 });
 
 test('it generates xy chart with multiple reference lines', async () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
@@ -47,6 +47,7 @@ function buildVisualizationState(config: LensXYConfig): XYState {
     legend: {
       isVisible: config.legend?.show ?? true,
       position: config.legend?.position ?? 'left',
+      ...(config.legend?.legendStats ? { legendStats: config.legend.legendStats } : {}),
     },
     hideEndzones: true,
     preferredSeriesType: 'line',

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
@@ -14,8 +14,8 @@ import type {
 } from '@kbn/lens-plugin/public';
 import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import type { Datatable } from '@kbn/expressions-plugin/common';
-import type { DataViewsCommon } from './config_builder';
 import type { XYLegendValue } from '@kbn/visualizations-plugin/common';
+import type { DataViewsCommon } from './config_builder';
 
 export type LensAttributes = TypedLensByValueInput['attributes'];
 export const DEFAULT_LAYER_ID = 'layer_0';

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
@@ -15,6 +15,7 @@ import type {
 import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import type { Datatable } from '@kbn/expressions-plugin/common';
 import type { DataViewsCommon } from './config_builder';
+import type { XYLegendValue } from '@kbn/visualizations-plugin/common';
 
 export type LensAttributes = TypedLensByValueInput['attributes'];
 export const DEFAULT_LAYER_ID = 'layer_0';
@@ -120,6 +121,7 @@ export interface LensYBoundsConfig {
 export interface LensLegendConfig {
   show?: boolean;
   position?: 'top' | 'left' | 'bottom' | 'right';
+  legendStats?: XYLegendValue[];
 }
 
 export interface LensBreakdownDateHistogramConfig {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/charts/disk.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/charts/disk.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import { LegendValue } from '@elastic/charts';
 import type { LensConfigWithId } from '../../../types';
 import type { HostFormulas } from '../formulas';
 import {
@@ -70,7 +71,7 @@ export const init = (formulas: FormulasCatalog<HostFormulas>) => {
           type: 'topValues',
           field:
             formulas.schema === 'ecs' ? 'system.filesystem.mount_point' : 'attributes.mountpoint',
-          size: 5,
+          size: 15,
         },
         yAxis: [
           {
@@ -86,7 +87,15 @@ export const init = (formulas: FormulasCatalog<HostFormulas>) => {
       },
     ],
     ...DEFAULT_XY_FITTING_FUNCTION,
-    ...DEFAULT_XY_LEGEND,
+    legend: {
+      ...DEFAULT_XY_LEGEND.legend,
+      legendStats: [
+        LegendValue.Average,
+        LegendValue.Min,
+        LegendValue.Max,
+        LegendValue.LastNonNullValue,
+      ],
+    },
     ...DEFAULT_XY_YBOUNDS,
     ...DEFAULT_XY_HIDDEN_AXIS_TITLE,
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Infra] Increase `diskUsageByMountPoint` lens chart size to 15 and add statistics (#239297)](https://github.com/elastic/kibana/pull/239297)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-10-16T21:01:20Z","message":"[Infra] Increase `diskUsageByMountPoint` lens chart size to 15 and add statistics (#239297)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/235358\n\nThis PR increases the size to `15` and adds `avg, min, max,\nlastNonNullValue` statistics in the legend for the\n`diskUsageByMountPoint` lens area chart in Asset details for a host.\n\n### Screenshots\n\n| Before | After |\n|--------|--------|\n| <img width=\"400\" alt=\"Image\"\nsrc=\"https://github.com/user-attachments/assets/659a81ea-70dc-43c3-994c-bfc24186360b\"\n/> | <img width=\"415\" height=\"333\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c095a31c-a265-4423-90d0-8500b0feda8d\"\n/> |","sha":"99777bee1e551230e911d551cd551212096b96db","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.2.0","v9.3.0"],"title":"[Infra] Increase `diskUsageByMountPoint` lens chart size to 15 and add statistics","number":239297,"url":"https://github.com/elastic/kibana/pull/239297","mergeCommit":{"message":"[Infra] Increase `diskUsageByMountPoint` lens chart size to 15 and add statistics (#239297)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/235358\n\nThis PR increases the size to `15` and adds `avg, min, max,\nlastNonNullValue` statistics in the legend for the\n`diskUsageByMountPoint` lens area chart in Asset details for a host.\n\n### Screenshots\n\n| Before | After |\n|--------|--------|\n| <img width=\"400\" alt=\"Image\"\nsrc=\"https://github.com/user-attachments/assets/659a81ea-70dc-43c3-994c-bfc24186360b\"\n/> | <img width=\"415\" height=\"333\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c095a31c-a265-4423-90d0-8500b0feda8d\"\n/> |","sha":"99777bee1e551230e911d551cd551212096b96db"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239297","number":239297,"mergeCommit":{"message":"[Infra] Increase `diskUsageByMountPoint` lens chart size to 15 and add statistics (#239297)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/235358\n\nThis PR increases the size to `15` and adds `avg, min, max,\nlastNonNullValue` statistics in the legend for the\n`diskUsageByMountPoint` lens area chart in Asset details for a host.\n\n### Screenshots\n\n| Before | After |\n|--------|--------|\n| <img width=\"400\" alt=\"Image\"\nsrc=\"https://github.com/user-attachments/assets/659a81ea-70dc-43c3-994c-bfc24186360b\"\n/> | <img width=\"415\" height=\"333\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c095a31c-a265-4423-90d0-8500b0feda8d\"\n/> |","sha":"99777bee1e551230e911d551cd551212096b96db"}}]}] BACKPORT-->