### PR TITLE
🌊 Streams: Make wired streams visible on serverless and remove tech preview badge.

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/streams_promotion.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/streams_promotion.tsx
@@ -32,7 +32,7 @@ export function StreamsPromotion({ dataStreamName }: { dataStreamName: string })
       <EuiCallOut
         size="s"
         title={i18n.translate('xpack.idxMgmt.streamsPromotion.title', {
-          defaultMessage: 'Explore the New Streams UI in Technical Preview',
+          defaultMessage: 'Explore the New Streams UI',
         })}
         color="primary"
       >

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiFlexGroup,
-  EuiBetaBadge,
   useEuiTheme,
   EuiButton,
   EuiFlexItem,
@@ -50,7 +49,6 @@ export function StreamListView() {
       },
     },
     core,
-    isServerless,
   } = context;
 
   const { timeState } = useTimefilter();
@@ -70,8 +68,6 @@ export function StreamListView() {
     features: { groupStreams },
   } = useStreamsPrivileges();
 
-  // Always show settings flyout button if not serverless
-  const showSettingsFlyoutButton = isServerless === false;
   const overlayRef = React.useRef<OverlayRef | null>(null);
 
   const [isSettingsFlyoutOpen, setIsSettingsFlyoutOpen] = React.useState(false);
@@ -116,22 +112,6 @@ export function StreamListView() {
                 {i18n.translate('xpack.streams.streamsListView.pageHeaderTitle', {
                   defaultMessage: 'Streams',
                 })}
-                {isServerless && (
-                  <EuiBetaBadge
-                    label={i18n.translate('xpack.streams.streamsListView.betaBadgeLabel', {
-                      defaultMessage: 'Technical Preview',
-                    })}
-                    tooltipContent={i18n.translate(
-                      'xpack.streams.streamsListView.betaBadgeDescription',
-                      {
-                        defaultMessage:
-                          'This functionality is experimental and not supported. It may change or be removed at any time.',
-                      }
-                    )}
-                    alignment="middle"
-                    size="s"
-                  />
-                )}
               </EuiFlexGroup>
             </EuiFlexItem>
             {groupStreams?.enabled && (
@@ -143,22 +123,20 @@ export function StreamListView() {
                 </EuiButton>
               </EuiFlexItem>
             )}
-            {showSettingsFlyoutButton && (
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  iconType="gear"
-                  size="s"
-                  onClick={() => setIsSettingsFlyoutOpen(true)}
-                  aria-label={i18n.translate('xpack.streams.streamsListView.settingsButtonLabel', {
-                    defaultMessage: 'Settings',
-                  })}
-                >
-                  {i18n.translate('xpack.streams.streamsListView.settingsButtonLabel', {
-                    defaultMessage: 'Settings',
-                  })}
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-            )}
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                iconType="gear"
+                size="s"
+                onClick={() => setIsSettingsFlyoutOpen(true)}
+                aria-label={i18n.translate('xpack.streams.streamsListView.settingsButtonLabel', {
+                  defaultMessage: 'Settings',
+                })}
+              >
+                {i18n.translate('xpack.streams.streamsListView.settingsButtonLabel', {
+                  defaultMessage: 'Settings',
+                })}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
             <FeedbackButton />
           </EuiFlexGroup>
         }

--- a/x-pack/solutions/observability/plugins/observability/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/plugin.ts
@@ -193,7 +193,6 @@ export class Plugin
   private observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry =
     {} as ObservabilityRuleTypeRegistry;
   private telemetry: TelemetryService;
-  private isServerless: boolean = false;
 
   // Define deep links as constant and hidden. Whether they are shown or hidden
   // in the global navigation will happen in `updateGlobalNavigation`.
@@ -221,7 +220,6 @@ export class Plugin
 
   constructor(private readonly initContext: PluginInitializerContext<ConfigSchema>) {
     this.telemetry = new TelemetryService();
-    this.isServerless = initContext.env.packageInfo.buildFlavor === 'serverless';
   }
 
   public setup(
@@ -475,7 +473,6 @@ export class Plugin
                       }),
                       app: 'streams',
                       path: '/',
-                      isTechnicalPreview: this.isServerless,
                       matchPath(currentPath: string) {
                         return ['/', ''].some((testPath) => currentPath.startsWith(testPath));
                       },

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -143,15 +143,7 @@ export const createNavigationTree = ({
           ...filterForFeatureAvailability(
             {
               link: 'streams' as const,
-              withBadge: true,
               iconV2: LazyIconProductStreamsWired,
-              badgeOptions: {
-                icon: 'beaker',
-                tooltip: i18n.translate('xpack.serverlessObservability.nav.streamsBadgeTooltip', {
-                  defaultMessage:
-                    'This functionality is experimental and not supported. It may change or be removed at any time.',
-                }),
-              },
             },
             streamsAvailable
           ),


### PR DESCRIPTION
Currently, the flyout to enable wired streams is only visible on stateful 9.2 and above.

This PR also makes it visible on serverless and removes the tech preview badge for streams.

## Before

Landing page:
<img width="1117" height="335" alt="Screenshot 2025-10-17 at 09 11 03" src="https://github.com/user-attachments/assets/eef0cf38-e68c-43e9-8f50-facfcc833c64" />

Stack management callout:
<img width="488" height="179" alt="Screenshot 2025-10-17 at 09 23 16" src="https://github.com/user-attachments/assets/5ae91949-1298-4056-92b1-e1ed09964ca8" />

## After

Landing page:
<img width="1133" height="302" alt="Screenshot 2025-10-17 at 09 22 35" src="https://github.com/user-attachments/assets/4dde68b0-cd02-4c50-9b57-fa8784e61045" />

Stack management callout:
<img width="387" height="165" alt="Screenshot 2025-10-17 at 09 22 57" src="https://github.com/user-attachments/assets/f12d81a0-37a6-4c06-b0a7-8fd7e9fc1b89" />
