### PR TITLE
Fix 'Discover discover async search navigation to context cleans the session' test

### DIFF
--- a/x-pack/platform/test/search_sessions_integration/tests/apps/discover/async_search.ts
+++ b/x-pack/platform/test/search_sessions_integration/tests/apps/discover/async_search.ts
@@ -109,7 +109,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('navigation to context cleans the session', async () => {
-      await timePicker.setCommonlyUsedTime('Last_15 minutes');
+      await timePicker.setCommonlyUsedTime('This_week');
       await dataGrid.clickRowToggle({ rowIndex: 0 });
 
       await retry.try(async () => {

--- a/x-pack/platform/test/search_sessions_integration/tests/apps/discover/async_search.ts
+++ b/x-pack/platform/test/search_sessions_integration/tests/apps/discover/async_search.ts
@@ -31,8 +31,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const toasts = getService('toasts');
   const dataGrid = getService('dataGrid');
 
-  // Failing: See https://github.com/elastic/kibana/issues/239001
-  describe.skip('discover async search', () => {
+  describe('discover async search', () => {
     before(async () => {
       await kibanaServer.importExport.load(
         'x-pack/platform/test/functional/fixtures/kbn_archives/discover/default'


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/239001

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->