### PR TITLE
[Console] Fix multi-response status backgrounds

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output.tsx
@@ -60,31 +60,31 @@ const useStatusCodeClassNames = (): StatusCodeClassNames => {
   return useMemo(
     () => ({
       monacoStatusCodeLinePrimary: cssClassName`
-        background-color: ${transparentize(euiTheme.colors.primary, 0.9)};
+        background-color: ${transparentize(euiTheme.colors.primary, 0.1)};
       `,
       monacoStatusCodeLineNumberPrimary: cssClassName`
         background-color: ${transparentize(euiTheme.colors.primary, 0.5)};
       `,
       monacoStatusCodeLineSuccess: cssClassName`
-        background-color: ${transparentize(euiTheme.colors.success, 0.9)};
+        background-color: ${transparentize(euiTheme.colors.success, 0.1)};
       `,
       monacoStatusCodeLineNumberSuccess: cssClassName`
         background-color: ${transparentize(euiTheme.colors.success, 0.5)};
       `,
       monacoStatusCodeLineDefault: cssClassName`
-        background-color: ${transparentize(euiTheme.colors.lightShade, 0.9)};
+        background-color: ${transparentize(euiTheme.colors.lightShade, 0.1)};
       `,
       monacoStatusCodeLineNumberDefault: cssClassName`
         background-color: ${transparentize(euiTheme.colors.lightShade, 0.5)};
       `,
       monacoStatusCodeLineWarning: cssClassName`
-        background-color: ${transparentize(euiTheme.colors.warning, 0.9)};
+        background-color: ${transparentize(euiTheme.colors.warning, 0.1)};
       `,
       monacoStatusCodeLineNumberWarning: cssClassName`
         background-color: ${transparentize(euiTheme.colors.warning, 0.5)};
       `,
       monacoStatusCodeLineDanger: cssClassName`
-        background-color: ${transparentize(euiTheme.colors.danger, 0.9)};
+        background-color: ${transparentize(euiTheme.colors.danger, 0.1)};
       `,
       monacoStatusCodeLineNumberDanger: cssClassName`
         background-color: ${transparentize(euiTheme.colors.danger, 0.5)};


### PR DESCRIPTION
fixes #239337

<img width="3163" height="1129" alt="SCR-20251016-pghx" src="https://github.com/user-attachments/assets/ab3ce0d8-48ed-4a99-ac72-638374730222" />

## How to test:

1. Open devtools
2. Select and run multiple queries
3. See background colors of statuses properly transparent.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->