### PR TITLE
[9.2] Improve maximum shards error detection (#238398)

### DIFF
--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/es_errors.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/es_errors.ts
@@ -36,7 +36,8 @@ export const isClusterShardLimitExceeded = (errorCause?: ErrorCause): boolean =>
     hasAllKeywordsInOrder(errorCause?.reason, [
       'this action would add',
       'shards, but this cluster currently has',
-      'maximum normal shards open',
+      'maximum',
+      'shards open',
     ])
   );
 };

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -1811,8 +1811,7 @@ export const runActionTestSuite = ({
     });
   });
 
-  // Failing: See https://github.com/elastic/kibana/issues/188963
-  describe.skip('createIndex', () => {
+  describe('createIndex', () => {
     afterEach(async () => {
       // Restore the default setting of 1000 shards per node
       await client.cluster.putSettings({ persistent: { cluster: { max_shards_per_node: null } } });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Improve maximum shards error detection (#238398)](https://github.com/elastic/kibana/pull/238398)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gerard Soldevila","email":"gerard.soldevila@elastic.co"},"sourceCommit":{"committedDate":"2025-10-10T11:29:26Z","message":"Improve maximum shards error detection (#238398)\n\n## Summary\nAddresses build failures such as\nhttps://buildkite.com/elastic/kibana-elasticsearch-serverless-verify-and-promote/builds/4419/steps/canvas?jid=0199c911-61a6-45da-8dde-5051d866945f\n\n```\nillegal_argument_exception: Validation Failed: 1: this action would add [3] shards, but this cluster currently has [56]/[1] maximum index shards open; for more information, see https://www.elastic.co/docs/deploy-manage/production-guidance/optimize-performance/size-shards?version=current#troubleshooting-max-shards-open;]\n```\n\nThe PR improves the detection to support different error strings\n```\n# before\nbut this cluster currently has [56]/[1] maximum normal shards open\n\n# after\nbut this cluster currently has [56]/[1] maximum .* shards open\n```","sha":"9a7c4570a522c815cd9a3f9b53b1c129aedf009e","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Team:Core","release_note:skip","backport:skip","v9.3.0"],"title":"Improve maximum shards error detection","number":238398,"url":"https://github.com/elastic/kibana/pull/238398","mergeCommit":{"message":"Improve maximum shards error detection (#238398)\n\n## Summary\nAddresses build failures such as\nhttps://buildkite.com/elastic/kibana-elasticsearch-serverless-verify-and-promote/builds/4419/steps/canvas?jid=0199c911-61a6-45da-8dde-5051d866945f\n\n```\nillegal_argument_exception: Validation Failed: 1: this action would add [3] shards, but this cluster currently has [56]/[1] maximum index shards open; for more information, see https://www.elastic.co/docs/deploy-manage/production-guidance/optimize-performance/size-shards?version=current#troubleshooting-max-shards-open;]\n```\n\nThe PR improves the detection to support different error strings\n```\n# before\nbut this cluster currently has [56]/[1] maximum normal shards open\n\n# after\nbut this cluster currently has [56]/[1] maximum .* shards open\n```","sha":"9a7c4570a522c815cd9a3f9b53b1c129aedf009e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238398","number":238398,"mergeCommit":{"message":"Improve maximum shards error detection (#238398)\n\n## Summary\nAddresses build failures such as\nhttps://buildkite.com/elastic/kibana-elasticsearch-serverless-verify-and-promote/builds/4419/steps/canvas?jid=0199c911-61a6-45da-8dde-5051d866945f\n\n```\nillegal_argument_exception: Validation Failed: 1: this action would add [3] shards, but this cluster currently has [56]/[1] maximum index shards open; for more information, see https://www.elastic.co/docs/deploy-manage/production-guidance/optimize-performance/size-shards?version=current#troubleshooting-max-shards-open;]\n```\n\nThe PR improves the detection to support different error strings\n```\n# before\nbut this cluster currently has [56]/[1] maximum normal shards open\n\n# after\nbut this cluster currently has [56]/[1] maximum .* shards open\n```","sha":"9a7c4570a522c815cd9a3f9b53b1c129aedf009e"}}]}] BACKPORT-->