### PR TITLE
[Cases][a11y] Add manual focus to action buttons' actions

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/actions/assignees/edit_assignees_flyout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/actions/assignees/edit_assignees_flyout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 import {
   EuiButton,
@@ -16,6 +16,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
+  type EuiFocusTrapProps,
   euiFullHeight,
   EuiText,
   EuiTitle,
@@ -30,6 +31,7 @@ interface Props {
   selectedCases: CasesUI;
   onClose: () => void;
   onSaveAssignees: (args: ItemsSelectionState) => void;
+  focusButtonRef?: React.Ref<HTMLButtonElement>;
 }
 
 const FlyoutBodyCss = css`
@@ -44,6 +46,7 @@ const EditAssigneesFlyoutComponent: React.FC<Props> = ({
   selectedCases,
   onClose,
   onSaveAssignees,
+  focusButtonRef,
 }) => {
   const [assigneesSelection, setAssigneesSelection] = useState<ItemsSelectionState>({
     selectedItems: [],
@@ -53,6 +56,19 @@ const EditAssigneesFlyoutComponent: React.FC<Props> = ({
   const onSave = useCallback(
     () => onSaveAssignees(assigneesSelection),
     [onSaveAssignees, assigneesSelection]
+  );
+
+  const focusTrapProps: Pick<EuiFocusTrapProps, 'returnFocus'> = useMemo(
+    () => ({
+      returnFocus() {
+        if (focusButtonRef && 'current' in focusButtonRef && focusButtonRef.current) {
+          focusButtonRef.current.focus();
+          return false;
+        }
+        return true;
+      },
+    }),
+    [focusButtonRef]
   );
 
   const headerSubtitle =
@@ -66,6 +82,7 @@ const EditAssigneesFlyoutComponent: React.FC<Props> = ({
       data-test-subj="cases-edit-assignees-flyout"
       size="s"
       paddingSize="m"
+      focusTrapProps={focusTrapProps}
     >
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">

--- a/x-pack/platform/plugins/shared/cases/public/components/actions/assignees/edit_assignees_flyout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/actions/assignees/edit_assignees_flyout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { css } from '@emotion/react';
 import {
   EuiButton,
@@ -16,7 +16,6 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
-  type EuiFocusTrapProps,
   euiFullHeight,
   EuiText,
   EuiTitle,
@@ -26,6 +25,7 @@ import type { CasesUI } from '../../../../common';
 import { EditAssigneesSelectable } from './edit_assignees_selectable';
 import * as i18n from './translations';
 import type { ItemsSelectionState } from '../types';
+import { useFocusButtonTrap } from '../../use_focus_button';
 
 interface Props {
   selectedCases: CasesUI;
@@ -57,19 +57,7 @@ const EditAssigneesFlyoutComponent: React.FC<Props> = ({
     () => onSaveAssignees(assigneesSelection),
     [onSaveAssignees, assigneesSelection]
   );
-
-  const focusTrapProps: Pick<EuiFocusTrapProps, 'returnFocus'> = useMemo(
-    () => ({
-      returnFocus() {
-        if (focusButtonRef && 'current' in focusButtonRef && focusButtonRef.current) {
-          focusButtonRef.current.focus();
-          return false;
-        }
-        return true;
-      },
-    }),
-    [focusButtonRef]
-  );
+  const focusTrapProps = useFocusButtonTrap(focusButtonRef);
 
   const headerSubtitle =
     selectedCases.length > 1 ? i18n.SELECTED_CASES(selectedCases.length) : selectedCases[0].title;

--- a/x-pack/platform/plugins/shared/cases/public/components/actions/tags/edit_tags_flyout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/actions/tags/edit_tags_flyout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 import {
   EuiButton,
@@ -16,6 +16,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
+  type EuiFocusTrapProps,
   euiFullHeight,
   EuiLoadingSpinner,
   EuiText,
@@ -32,6 +33,7 @@ interface Props {
   selectedCases: CasesUI;
   onClose: () => void;
   onSaveTags: (args: ItemsSelectionState) => void;
+  focusButtonRef?: React.Ref<HTMLButtonElement>;
 }
 
 const FlyoutBodyCss = css`
@@ -42,7 +44,12 @@ const FlyoutBodyCss = css`
   }
 `;
 
-const EditTagsFlyoutComponent: React.FC<Props> = ({ selectedCases, onClose, onSaveTags }) => {
+const EditTagsFlyoutComponent: React.FC<Props> = ({
+  selectedCases,
+  onClose,
+  onSaveTags,
+  focusButtonRef,
+}) => {
   const { data: tags, isLoading } = useGetTags();
 
   const [tagsSelection, setTagsSelection] = useState<ItemsSelectionState>({
@@ -51,6 +58,19 @@ const EditTagsFlyoutComponent: React.FC<Props> = ({ selectedCases, onClose, onSa
   });
 
   const onSave = useCallback(() => onSaveTags(tagsSelection), [onSaveTags, tagsSelection]);
+
+  const focusTrapProps: Pick<EuiFocusTrapProps, 'returnFocus'> = useMemo(
+    () => ({
+      returnFocus() {
+        if (focusButtonRef && 'current' in focusButtonRef && focusButtonRef.current) {
+          focusButtonRef.current.focus();
+          return false;
+        }
+        return true;
+      },
+    }),
+    [focusButtonRef]
+  );
 
   const headerSubtitle =
     selectedCases.length > 1 ? i18n.SELECTED_CASES(selectedCases.length) : selectedCases[0].title;
@@ -63,6 +83,7 @@ const EditTagsFlyoutComponent: React.FC<Props> = ({ selectedCases, onClose, onSa
       data-test-subj="cases-edit-tags-flyout"
       size="s"
       paddingSize="m"
+      focusTrapProps={focusTrapProps}
     >
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">

--- a/x-pack/platform/plugins/shared/cases/public/components/actions/tags/edit_tags_flyout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/actions/tags/edit_tags_flyout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { css } from '@emotion/react';
 import {
   EuiButton,
@@ -16,7 +16,6 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
-  type EuiFocusTrapProps,
   euiFullHeight,
   EuiLoadingSpinner,
   EuiText,
@@ -28,6 +27,7 @@ import { useGetTags } from '../../../containers/use_get_tags';
 import { EditTagsSelectable } from './edit_tags_selectable';
 import * as i18n from './translations';
 import type { ItemsSelectionState } from '../types';
+import { useFocusButtonTrap } from '../../use_focus_button';
 
 interface Props {
   selectedCases: CasesUI;
@@ -58,19 +58,7 @@ const EditTagsFlyoutComponent: React.FC<Props> = ({
   });
 
   const onSave = useCallback(() => onSaveTags(tagsSelection), [onSaveTags, tagsSelection]);
-
-  const focusTrapProps: Pick<EuiFocusTrapProps, 'returnFocus'> = useMemo(
-    () => ({
-      returnFocus() {
-        if (focusButtonRef && 'current' in focusButtonRef && focusButtonRef.current) {
-          focusButtonRef.current.focus();
-          return false;
-        }
-        return true;
-      },
-    }),
-    [focusButtonRef]
-  );
+  const focusTrapProps = useFocusButtonTrap(focusButtonRef);
 
   const headerSubtitle =
     selectedCases.length > 1 ? i18n.SELECTED_CASES(selectedCases.length) : selectedCases[0].title;

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_actions.tsx
@@ -39,6 +39,7 @@ const ActionColumnComponent: React.FC<{ theCase: CaseUI; disableActions: boolean
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
   const refreshCases = useRefreshCases();
   const { permissions } = useCasesContext();
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
 
   const shouldDisable = useShouldDisableStatus();
 
@@ -195,6 +196,7 @@ const ActionColumnComponent: React.FC<{ theCase: CaseUI; disableActions: boolean
             key={`case-action-popover-button-${theCase.id}`}
             data-test-subj={`case-action-popover-button-${theCase.id}`}
             disabled={disableActions}
+            buttonRef={buttonRef}
           />
         }
         isOpen={isPopoverOpen}
@@ -214,6 +216,7 @@ const ActionColumnComponent: React.FC<{ theCase: CaseUI; disableActions: boolean
           totalCasesToBeDeleted={1}
           onCancel={deleteAction.onCloseModal}
           onConfirm={deleteAction.onConfirmDeletion}
+          focusButtonRef={buttonRef}
         />
       ) : null}
       {tagsAction.isFlyoutOpen ? (
@@ -221,6 +224,7 @@ const ActionColumnComponent: React.FC<{ theCase: CaseUI; disableActions: boolean
           onClose={tagsAction.onFlyoutClosed}
           selectedCases={[theCase]}
           onSaveTags={tagsAction.onSaveTags}
+          focusButtonRef={buttonRef}
         />
       ) : null}
       {assigneesAction.isFlyoutOpen ? (
@@ -228,6 +232,7 @@ const ActionColumnComponent: React.FC<{ theCase: CaseUI; disableActions: boolean
           onClose={assigneesAction.onFlyoutClosed}
           selectedCases={[theCase]}
           onSaveAssignees={assigneesAction.onSaveAssignees}
+          focusButtonRef={buttonRef}
         />
       ) : null}
     </>

--- a/x-pack/platform/plugins/shared/cases/public/components/case_action_bar/actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_action_bar/actions.tsx
@@ -29,6 +29,7 @@ const ActionsComponent: React.FC<CaseViewActions> = ({ caseData, currentExternal
   const { permissions } = useCasesContext();
   const { showSuccessToast } = useCasesToast();
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
+  const buttonRef = React.useRef<HTMLAnchorElement>(null);
 
   const openModal = useCallback(() => {
     setIsModalVisible(true);
@@ -88,12 +89,17 @@ const ActionsComponent: React.FC<CaseViewActions> = ({ caseData, currentExternal
 
   return (
     <EuiFlexItem grow={false} data-test-subj="case-view-actions">
-      <PropertyActions propertyActions={propertyActions} customDataTestSubj={'case'} />
+      <PropertyActions
+        propertyActions={propertyActions}
+        customDataTestSubj={'case'}
+        buttonRef={buttonRef}
+      />
       {isModalVisible ? (
         <ConfirmDeleteCaseModal
           totalCasesToBeDeleted={1}
           onCancel={closeModal}
           onConfirm={onConfirmDeletion}
+          focusButtonRef={buttonRef}
         />
       ) : null}
     </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/cases/public/components/confirm_delete_case/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/confirm_delete_case/index.tsx
@@ -13,7 +13,7 @@ interface ConfirmDeleteCaseModalProps {
   totalCasesToBeDeleted: number;
   onCancel: () => void;
   onConfirm: () => void;
-  focusButtonRef?: React.Ref<HTMLAnchorElement>;
+  focusButtonRef?: React.Ref<HTMLAnchorElement | HTMLButtonElement>;
 }
 
 const ConfirmDeleteCaseModalComp: React.FC<ConfirmDeleteCaseModalProps> = ({

--- a/x-pack/platform/plugins/shared/cases/public/components/confirm_delete_case/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/confirm_delete_case/index.tsx
@@ -5,22 +5,36 @@
  * 2.0.
  */
 
-import React from 'react';
-import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { EuiConfirmModal, type EuiFocusTrapProps, useGeneratedHtmlId } from '@elastic/eui';
 import * as i18n from './translations';
 
 interface ConfirmDeleteCaseModalProps {
   totalCasesToBeDeleted: number;
   onCancel: () => void;
   onConfirm: () => void;
+  focusButtonRef?: React.Ref<HTMLAnchorElement>;
 }
 
 const ConfirmDeleteCaseModalComp: React.FC<ConfirmDeleteCaseModalProps> = ({
   totalCasesToBeDeleted,
   onCancel,
   onConfirm,
+  focusButtonRef,
 }) => {
   const titleId = useGeneratedHtmlId();
+  const focusTrapProps: Pick<EuiFocusTrapProps, 'returnFocus'> = useMemo(
+    () => ({
+      returnFocus() {
+        if (focusButtonRef && 'current' in focusButtonRef && focusButtonRef.current) {
+          focusButtonRef.current.focus();
+          return false;
+        }
+        return true;
+      },
+    }),
+    [focusButtonRef]
+  );
 
   return (
     <EuiConfirmModal
@@ -36,6 +50,7 @@ const ConfirmDeleteCaseModalComp: React.FC<ConfirmDeleteCaseModalProps> = ({
         id: titleId,
       }}
       aria-labelledby={titleId}
+      focusTrapProps={focusTrapProps}
     >
       {i18n.CONFIRM_QUESTION(totalCasesToBeDeleted)}
     </EuiConfirmModal>

--- a/x-pack/platform/plugins/shared/cases/public/components/confirm_delete_case/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/confirm_delete_case/index.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
-import { EuiConfirmModal, type EuiFocusTrapProps, useGeneratedHtmlId } from '@elastic/eui';
+import React from 'react';
+import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
 import * as i18n from './translations';
+import { useFocusButtonTrap } from '../use_focus_button';
 
 interface ConfirmDeleteCaseModalProps {
   totalCasesToBeDeleted: number;
@@ -23,18 +24,7 @@ const ConfirmDeleteCaseModalComp: React.FC<ConfirmDeleteCaseModalProps> = ({
   focusButtonRef,
 }) => {
   const titleId = useGeneratedHtmlId();
-  const focusTrapProps: Pick<EuiFocusTrapProps, 'returnFocus'> = useMemo(
-    () => ({
-      returnFocus() {
-        if (focusButtonRef && 'current' in focusButtonRef && focusButtonRef.current) {
-          focusButtonRef.current.focus();
-          return false;
-        }
-        return true;
-      },
-    }),
-    [focusButtonRef]
-  );
+  const focusTrapProps = useFocusButtonTrap(focusButtonRef);
 
   return (
     <EuiConfirmModal

--- a/x-pack/platform/plugins/shared/cases/public/components/files/file_actions_popover_button.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/files/file_actions_popover_button.tsx
@@ -30,6 +30,7 @@ export const FileActionsPopoverButton: React.FC<{ caseId: string; theFile: FileJ
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const { owner, permissions } = useCasesContext();
   const { client: filesClient } = useFilesContext();
+  const buttonRef = React.useRef<HTMLAnchorElement>(null);
 
   const { showSuccessToast } = useCasesToast();
   const { isLoading, mutate: deleteFileAttachment } = useDeleteFileAttachment();
@@ -162,6 +163,7 @@ export const FileActionsPopoverButton: React.FC<{ caseId: string; theFile: FileJ
             color="text"
             key={`cases-files-actions-popover-button-${theFile.id}`}
             data-test-subj={`cases-files-actions-popover-button-${theFile.id}`}
+            buttonRef={buttonRef}
           />
         }
         isOpen={isPopoverOpen}
@@ -181,6 +183,7 @@ export const FileActionsPopoverButton: React.FC<{ caseId: string; theFile: FileJ
           confirmButtonText={i18n.DELETE}
           onCancel={onCancel}
           onConfirm={onConfirm}
+          focusButtonRef={buttonRef}
         />
       )}
     </>

--- a/x-pack/platform/plugins/shared/cases/public/components/files/file_delete_button.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/files/file_delete_button.tsx
@@ -28,6 +28,8 @@ const FileDeleteButtonComponent: React.FC<FileDeleteButtonProps> = ({ caseId, fi
     onDelete: () => deleteFileAttachment({ caseId, fileId }),
   });
 
+  const buttonRef = React.useRef<HTMLAnchorElement>(null);
+
   const buttonProps = {
     iconType: 'trash',
     'aria-label': i18n.DELETE_FILE,
@@ -35,6 +37,7 @@ const FileDeleteButtonComponent: React.FC<FileDeleteButtonProps> = ({ caseId, fi
     isDisabled: isLoading,
     onClick: onModalOpen,
     'data-test-subj': 'cases-files-delete-button',
+    buttonRef,
   };
 
   return permissions.delete ? (
@@ -50,6 +53,7 @@ const FileDeleteButtonComponent: React.FC<FileDeleteButtonProps> = ({ caseId, fi
           confirmButtonText={i18n.DELETE}
           onCancel={onCancel}
           onConfirm={onConfirm}
+          focusButtonRef={buttonRef}
         />
       ) : null}
     </>

--- a/x-pack/platform/plugins/shared/cases/public/components/observables/observable_actions_popover_button.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/observables/observable_actions_popover_button.tsx
@@ -28,6 +28,7 @@ export const ObservableActionsPopoverButton: React.FC<{
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const { permissions } = useCasesContext();
   const [showEditModal, setShowEditModal] = useState(false);
+  const buttonRef = React.useRef<HTMLAnchorElement>(null);
 
   const { isLoading: isDeleteLoading, mutateAsync: deleteObservable } = useDeleteObservable(
     caseData.id,
@@ -102,6 +103,7 @@ export const ObservableActionsPopoverButton: React.FC<{
             color="text"
             key={`cases-observables-actions-popover-button-${observable.id}`}
             data-test-subj={`cases-observables-actions-popover-button-${observable.id}`}
+            buttonRef={buttonRef}
           />
         }
         isOpen={isPopoverOpen}
@@ -121,6 +123,7 @@ export const ObservableActionsPopoverButton: React.FC<{
           confirmButtonText={i18n.DELETE_OBSERVABLE}
           onCancel={onCancel}
           onConfirm={onConfirm}
+          focusButtonRef={buttonRef}
         />
       )}
       {showEditModal && (

--- a/x-pack/platform/plugins/shared/cases/public/components/property_actions/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/property_actions/index.tsx
@@ -57,10 +57,11 @@ PropertyActionButton.displayName = 'PropertyActionButton';
 export interface PropertyActionsProps {
   propertyActions: AttachmentAction[];
   customDataTestSubj?: string;
+  buttonRef?: React.Ref<HTMLAnchorElement>;
 }
 
 export const PropertyActions = React.memo<PropertyActionsProps>(
-  ({ propertyActions, customDataTestSubj }) => {
+  ({ propertyActions, customDataTestSubj, buttonRef }) => {
     const [showActions, setShowActions] = useState(false);
 
     const onButtonClick = useCallback(() => {
@@ -87,6 +88,7 @@ export const PropertyActions = React.memo<PropertyActionsProps>(
             aria-label={i18n.ACTIONS_ARIA}
             iconType="boxesHorizontal"
             onClick={onButtonClick}
+            buttonRef={buttonRef}
           />
         }
         id="settingsPopover"

--- a/x-pack/platform/plugins/shared/cases/public/components/use_focus_button/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/use_focus_button/index.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiFocusTrapProps } from '@elastic/eui';
+import { useMemo } from 'react';
+
+export const useFocusButtonTrap = (
+  focusButtonRef?: React.Ref<HTMLButtonElement | HTMLAnchorElement>
+) => {
+  const focusTrapProps: Pick<EuiFocusTrapProps, 'returnFocus'> = useMemo(
+    () => ({
+      returnFocus() {
+        if (focusButtonRef && 'current' in focusButtonRef && focusButtonRef.current) {
+          focusButtonRef.current.focus();
+          return false;
+        }
+        return true;
+      },
+    }),
+    [focusButtonRef]
+  );
+
+  return focusTrapProps;
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/delete_attachment_confirmation_modal.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/delete_attachment_confirmation_modal.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
-import type { EuiConfirmModalProps, EuiFocusTrapProps } from '@elastic/eui';
+import React from 'react';
+import type { EuiConfirmModalProps } from '@elastic/eui';
 import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
 import { CANCEL_BUTTON } from './property_actions/translations';
+import { useFocusButtonTrap } from '../use_focus_button';
 
 type Props = Pick<
   EuiConfirmModalProps,
@@ -17,7 +18,7 @@ type Props = Pick<
   /**
    * The ref of the button to focus when the modal is closed
    */
-  focusButtonRef?: React.Ref<HTMLAnchorElement>;
+  focusButtonRef?: React.Ref<HTMLButtonElement | HTMLAnchorElement>;
 };
 
 const DeleteAttachmentConfirmationModalComponent: React.FC<Props> = ({
@@ -28,18 +29,7 @@ const DeleteAttachmentConfirmationModalComponent: React.FC<Props> = ({
   focusButtonRef,
 }) => {
   const modalTitleId = useGeneratedHtmlId();
-  const focusTrapProps: Pick<EuiFocusTrapProps, 'returnFocus'> = useMemo(
-    () => ({
-      returnFocus() {
-        if (focusButtonRef && 'current' in focusButtonRef && focusButtonRef.current) {
-          focusButtonRef.current.focus();
-          return false;
-        }
-        return true;
-      },
-    }),
-    [focusButtonRef]
-  );
+  const focusTrapProps = useFocusButtonTrap(focusButtonRef);
 
   return (
     <EuiConfirmModal

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/delete_attachment_confirmation_modal.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/delete_attachment_confirmation_modal.tsx
@@ -5,20 +5,41 @@
  * 2.0.
  */
 
-import React from 'react';
-import type { EuiConfirmModalProps } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import type { EuiConfirmModalProps, EuiFocusTrapProps } from '@elastic/eui';
 import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
 import { CANCEL_BUTTON } from './property_actions/translations';
 
-type Pros = Pick<EuiConfirmModalProps, 'title' | 'confirmButtonText' | 'onConfirm' | 'onCancel'>;
+type Props = Pick<
+  EuiConfirmModalProps,
+  'title' | 'confirmButtonText' | 'onConfirm' | 'onCancel'
+> & {
+  /**
+   * The ref of the button to focus when the modal is closed
+   */
+  focusButtonRef?: React.Ref<HTMLAnchorElement>;
+};
 
-const DeleteAttachmentConfirmationModalComponent: React.FC<Pros> = ({
+const DeleteAttachmentConfirmationModalComponent: React.FC<Props> = ({
   title,
   confirmButtonText,
   onConfirm,
   onCancel,
+  focusButtonRef,
 }) => {
   const modalTitleId = useGeneratedHtmlId();
+  const focusTrapProps: Pick<EuiFocusTrapProps, 'returnFocus'> = useMemo(
+    () => ({
+      returnFocus() {
+        if (focusButtonRef && 'current' in focusButtonRef && focusButtonRef.current) {
+          focusButtonRef.current.focus();
+          return false;
+        }
+        return true;
+      },
+    }),
+    [focusButtonRef]
+  );
 
   return (
     <EuiConfirmModal
@@ -34,6 +55,7 @@ const DeleteAttachmentConfirmationModalComponent: React.FC<Pros> = ({
       defaultFocusedButton="confirm"
       data-test-subj="property-actions-confirm-modal"
       aria-labelledby={modalTitleId}
+      focusTrapProps={focusTrapProps}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/property_actions/alert_property_actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/property_actions/alert_property_actions.tsx
@@ -25,6 +25,7 @@ const AlertPropertyActionsComponent: React.FC<Props> = ({ isLoading, totalAlerts
   const { showDeletionModal, onModalOpen, onConfirm, onCancel } = useDeletePropertyAction({
     onDelete,
   });
+  const buttonRef = React.useRef<HTMLAnchorElement>(null);
 
   const propertyActions = useMemo(() => {
     const showRemoveAlertIcon = permissions.delete;
@@ -47,13 +48,18 @@ const AlertPropertyActionsComponent: React.FC<Props> = ({ isLoading, totalAlerts
 
   return (
     <>
-      <UserActionPropertyActions isLoading={isLoading} propertyActions={propertyActions} />
+      <UserActionPropertyActions
+        isLoading={isLoading}
+        propertyActions={propertyActions}
+        buttonRef={buttonRef}
+      />
       {showDeletionModal ? (
         <DeleteAttachmentConfirmationModal
           title={i18n.REMOVE_ALERTS(totalAlerts)}
           confirmButtonText={i18n.REMOVE}
           onCancel={onCancel}
           onConfirm={onConfirm}
+          focusButtonRef={buttonRef}
         />
       ) : null}
     </>

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/property_actions/event_property_actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/property_actions/event_property_actions.tsx
@@ -25,6 +25,7 @@ const EventPropertyActionsComponent: React.FC<Props> = ({ isLoading, totalEvents
   const { showDeletionModal, onModalOpen, onConfirm, onCancel } = useDeletePropertyAction({
     onDelete,
   });
+  const buttonRef = React.useRef<HTMLAnchorElement>(null);
 
   const propertyActions = useMemo(() => {
     const showRemoveEventIcon = permissions.delete;
@@ -47,13 +48,18 @@ const EventPropertyActionsComponent: React.FC<Props> = ({ isLoading, totalEvents
 
   return (
     <>
-      <UserActionPropertyActions isLoading={isLoading} propertyActions={propertyActions} />
+      <UserActionPropertyActions
+        isLoading={isLoading}
+        propertyActions={propertyActions}
+        buttonRef={buttonRef}
+      />
       {showDeletionModal ? (
         <DeleteAttachmentConfirmationModal
           title={i18n.REMOVE_EVENTS(totalEvents)}
           confirmButtonText={i18n.REMOVE}
           onCancel={onCancel}
           onConfirm={onConfirm}
+          focusButtonRef={buttonRef}
         />
       ) : null}
     </>

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/property_actions/property_actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/property_actions/property_actions.tsx
@@ -14,12 +14,14 @@ interface Props {
   isLoading: boolean;
   propertyActions: AttachmentAction[];
   customDataTestSubj?: string;
+  buttonRef?: React.Ref<HTMLAnchorElement>;
 }
 
 const UserActionPropertyActionsComponent: React.FC<Props> = ({
   isLoading,
   propertyActions,
   customDataTestSubj = 'user-action',
+  buttonRef,
 }) => {
   if (propertyActions.length === 0) {
     return null;
@@ -33,6 +35,7 @@ const UserActionPropertyActionsComponent: React.FC<Props> = ({
         <PropertyActions
           propertyActions={propertyActions}
           customDataTestSubj={customDataTestSubj}
+          buttonRef={buttonRef}
         />
       )}
     </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.tsx
@@ -33,6 +33,7 @@ const RegisteredAttachmentsPropertyActionsComponent: React.FC<Props> = ({
   const { showDeletionModal, onModalOpen, onConfirm, onCancel } = useDeletePropertyAction({
     onDelete,
   });
+  const buttonRef = React.useRef<HTMLAnchorElement>(null);
 
   const propertyActions = useMemo(() => {
     const showTrashIcon = permissions.delete && !hideDefaultActions;
@@ -56,13 +57,18 @@ const RegisteredAttachmentsPropertyActionsComponent: React.FC<Props> = ({
 
   return (
     <>
-      <UserActionPropertyActions isLoading={isLoading} propertyActions={propertyActions} />
+      <UserActionPropertyActions
+        isLoading={isLoading}
+        propertyActions={propertyActions}
+        buttonRef={buttonRef}
+      />
       {showDeletionModal ? (
         <DeleteAttachmentConfirmationModal
           title={i18n.DELETE_ATTACHMENT}
           confirmButtonText={i18n.DELETE}
           onCancel={onCancel}
           onConfirm={onConfirm}
+          focusButtonRef={buttonRef}
         />
       ) : null}
     </>

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/property_actions/user_comment_property_actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/property_actions/user_comment_property_actions.tsx
@@ -34,6 +34,7 @@ const UserCommentPropertyActionsComponent: React.FC<Props> = ({
   const { showDeletionModal, onModalOpen, onConfirm, onCancel } = useDeletePropertyAction({
     onDelete,
   });
+  const buttonRef = React.useRef<HTMLAnchorElement>(null);
 
   const { canUseEditor, actionConfig } = useLensOpenVisualization({
     comment: commentContent ?? '',
@@ -93,13 +94,18 @@ const UserCommentPropertyActionsComponent: React.FC<Props> = ({
 
   return (
     <>
-      <UserActionPropertyActions isLoading={isLoading} propertyActions={propertyActions} />
+      <UserActionPropertyActions
+        isLoading={isLoading}
+        propertyActions={propertyActions}
+        buttonRef={buttonRef}
+      />
       {showDeletionModal ? (
         <DeleteAttachmentConfirmationModal
           title={i18n.DELETE_COMMENT_TITLE}
           confirmButtonText={i18n.DELETE}
           onCancel={onCancel}
           onConfirm={onConfirm}
+          focusButtonRef={buttonRef}
         />
       ) : null}
     </>


### PR DESCRIPTION
## Summary

<img width="953" height="558" alt="Screenshot 2025-10-17 at 11 25 59" src="https://github.com/user-attachments/assets/86915980-5ce1-434c-8484-b9d5fe26ec86" />

Many of the action button's actions open new flyouts or modals. In those cases, the focus trap isn't working correctly and we need to manually assign focus to the original action button after the performed action is done.

Fixes https://github.com/elastic/kibana/issues/195073
Fixes https://github.com/elastic/kibana/issues/195021
Fixes https://github.com/elastic/kibana/issues/195024

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->