### PR TITLE
remove versions, to avoid proto installing tools

### DIFF
--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -2,10 +2,8 @@
 $schema: 'https://moonrepo.dev/schemas/toolchain.json'
 
 node:
-  version: 22.17.1
   packageManager: yarn
   yarn:
-    version: 1.22.21
     installArgs:
       - '--non-interactive'
   inferTasksFromScripts: true # Automatically infer tasks from package.json scripts.


### PR DESCRIPTION
## Summary
As I recall, having these versions might prompt moon to drag in proto to the game, and proto would try to get specific versions of these tools. This can cause issues on developers' machines where the preferred binaries and versions are controlled through NVM or other tools, and not proto. 

Removing this won't affect how kibana is installed, it relies (as we've intended) on the developer to have the correct versions on the PATH.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->