### PR TITLE
fix ai assistant new default anon fields not being added

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/common/anonymization/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/common/anonymization/index.ts
@@ -5,6 +5,16 @@
  * 2.0.
  */
 
+export interface AnonymizationField {
+  '@timestamp': string;
+  created_at: string;
+  created_by: string;
+  field: string;
+  anonymized: boolean;
+  allowed: boolean;
+  namespace: string;
+}
+
 /** By default, these fields are allowed to be sent to the assistant */
 export const DEFAULT_ALLOW = [
   '_id',
@@ -134,7 +144,7 @@ export const DEFAULT_ALLOW_REPLACEMENT = [
   'user.target.name',
 ];
 
-export const getDefaultAnonymizationFields = (spaceId: string) => {
+export const getDefaultAnonymizationFields = (spaceId: string): AnonymizationField[] => {
   const changedAt = new Date().toISOString();
   return DEFAULT_ALLOW.map((field) => ({
     '@timestamp': changedAt,


### PR DESCRIPTION
## Summary

Fixes an issue where newly added default anonymized fields for the security AI assistant are not correctly loaded.

Related: https://github.com/elastic/kibana/issues/239041#issuecomment-3410381314