### PR TITLE
[Automatic Migrations] Copy fix in the tour guide

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/tours/translation_guide/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/tours/translation_guide/index.tsx
@@ -72,7 +72,13 @@ export const SiemTranslatedRulesTour: React.FC = React.memo(() => {
           anchorPosition={selectMigrationStepData.anchorPosition}
           maxWidth={tourState.tourPopoverWidth}
           footerAction={
-            <EuiButtonEmpty size="xs" color="text" flush="right" onClick={onTourNext}>
+            <EuiButtonEmpty
+              aria-label={i18n.NEXT_TOUR_STEP_BUTTON}
+              size="xs"
+              color="text"
+              flush="right"
+              onClick={onTourNext}
+            >
               {i18n.NEXT_TOUR_STEP_BUTTON}
             </EuiButtonEmpty>
           }
@@ -90,7 +96,13 @@ export const SiemTranslatedRulesTour: React.FC = React.memo(() => {
           anchorPosition={statusHeaderStepData.anchorPosition}
           maxWidth={tourState.tourPopoverWidth}
           footerAction={
-            <EuiButtonEmpty size="xs" color="text" flush="right" onClick={onTourNext}>
+            <EuiButtonEmpty
+              aria-label={i18n.NEXT_TOUR_STEP_BUTTON}
+              size="xs"
+              color="text"
+              flush="right"
+              onClick={onTourNext}
+            >
               {i18n.NEXT_TOUR_STEP_BUTTON}
             </EuiButtonEmpty>
           }
@@ -108,7 +120,13 @@ export const SiemTranslatedRulesTour: React.FC = React.memo(() => {
           anchorPosition={getStartedStepData.anchorPosition}
           maxWidth={tourState.tourPopoverWidth}
           footerAction={
-            <EuiButtonEmpty size="xs" color="text" flush="right" onClick={onTourFinished}>
+            <EuiButtonEmpty
+              aria-label={i18n.FINISH_TOUR_BUTTON}
+              size="xs"
+              color="text"
+              flush="right"
+              onClick={onTourFinished}
+            >
               {i18n.FINISH_TOUR_BUTTON}
             </EuiButtonEmpty>
           }

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/tours/translation_guide/step_config.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/tours/translation_guide/step_config.tsx
@@ -44,7 +44,7 @@ export const tourSteps: {
     content: (
       <FormattedMessage
         id="xpack.securitySolution.siemMigrations.rules.tour.statusStepContent"
-        defaultMessage="{installed} rules have a check mark. Click {view} to access rule details. {translated} rules are ready to {install}, or for your to {edit}. Rules with errors can be {reprocessed}.
+        defaultMessage="{installed} rules have a check mark. Click {view} to access rule details. {translated} rules are ready to {install}, or for you to {edit}. Rules with errors can be {reprocessed}.
         {lineBreak}{lineBreak}
         Learn more about our {link}"
         values={{


### PR DESCRIPTION
## Summary

These changes fix a type in "Translation page" tour guide description - it should say "you to Edit" instead of "your to edit"

<img width="720" height="363" alt="image" src="https://github.com/user-attachments/assets/c733b914-34a2-44ec-89e7-f3fe94459c11" />

### Fixed text

<img width="1445" height="1034" alt="Screenshot 2025-10-17 at 14 24 44" src="https://github.com/user-attachments/assets/609d71cc-db09-4a02-ab65-a1f966477c6e" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->