### PR TITLE
[SharedUX] Add Save changes button to share draft mode callout

### DIFF
--- a/src/platform/plugins/shared/share/public/components/common/draft_mode_callout/draft_mode_callout.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/common/draft_mode_callout/draft_mode_callout.test.tsx
@@ -9,17 +9,12 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { I18nProvider } from '@kbn/i18n-react';
 import { DraftModeCallout } from './draft_mode_callout';
 
 describe('DraftModeCallout', () => {
   describe('Default case', () => {
     it('renders a default callout when custom props are not present', () => {
-      render(
-        <I18nProvider>
-          <DraftModeCallout />
-        </I18nProvider>
-      );
+      render(<DraftModeCallout />);
       const callout = screen.getByTestId('unsavedChangesDraftModeCallOut');
       expect(callout).toMatchSnapshot();
     });
@@ -28,9 +23,7 @@ describe('DraftModeCallout', () => {
   describe('Custom content case', () => {
     it('renders a callout with custom content when custom props are present', () => {
       render(
-        <I18nProvider>
-          <DraftModeCallout message={'Custom message'} data-test-subj="customDraftModeCallOut" />
-        </I18nProvider>
+        <DraftModeCallout message={'Custom message'} data-test-subj="customDraftModeCallOut" />
       );
       const callout = screen.getByTestId('customDraftModeCallOut');
       expect(screen.getByText('Custom message')).toBeInTheDocument();
@@ -41,15 +34,32 @@ describe('DraftModeCallout', () => {
   describe('Node override case', () => {
     it('renders a component override when a node prop is provided', () => {
       render(
-        <I18nProvider>
-          <DraftModeCallout
-            node={<p data-test-subj="overriddenDraftModeCallOut">Component override</p>}
-          />
-        </I18nProvider>
+        <DraftModeCallout
+          node={<p data-test-subj="overriddenDraftModeCallOut">Component override</p>}
+        />
       );
       const callout = screen.getByTestId('overriddenDraftModeCallOut');
       expect(screen.getByText('Component override')).toBeInTheDocument();
       expect(callout).toMatchSnapshot();
+    });
+  });
+
+  describe('Save button case', () => {
+    it('renders a save button when onSave is present', () => {
+      render(<DraftModeCallout saveButtonProps={{ onSave: jest.fn() }} />);
+      const saveButton = screen.getByRole('button', { name: 'Save changes' });
+      expect(saveButton).toBeInTheDocument();
+    });
+    it('renders a loading state when isSaving is true', () => {
+      render(<DraftModeCallout saveButtonProps={{ onSave: jest.fn(), isSaving: true }} />);
+      const saveButton = screen.getByRole('button', { name: 'Save changes' });
+      expect(saveButton).toBeDisabled();
+    });
+    it('renders a custom label when a label is provided', () => {
+      const customLabel = 'Custom label';
+      render(<DraftModeCallout saveButtonProps={{ onSave: jest.fn(), label: customLabel }} />);
+      const saveButton = screen.getByRole('button', { name: customLabel });
+      expect(saveButton).toBeInTheDocument();
     });
   });
 });

--- a/src/platform/plugins/shared/share/public/components/common/draft_mode_callout/draft_mode_callout.tsx
+++ b/src/platform/plugins/shared/share/public/components/common/draft_mode_callout/draft_mode_callout.tsx
@@ -7,23 +7,30 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { CommonProps } from '@elastic/eui';
-import { EuiCallOut, EuiText } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiButton, EuiCallOut, EuiText } from '@elastic/eui';
 
+export interface SaveButtonProps extends CommonProps {
+  onSave: () => Promise<void | object>;
+  label?: string;
+  isSaving?: boolean;
+}
 export interface DraftModeCalloutProps extends CommonProps {
-  message?: React.ReactNode;
-  node?: React.ReactNode;
+  message?: string;
+  node?: ReactNode;
+  saveButtonProps?: SaveButtonProps;
 }
 
-const defaultCalloutMessage = (
-  <FormattedMessage
-    id="share.draftModeCallout.message"
-    defaultMessage="This link might not be permanent. Save your changes to ensure it works as expected."
-  />
-);
+const defaultCalloutMessage = i18n.translate('share.draftModeCallout.message', {
+  defaultMessage:
+    'This link might not be permanent. Save your changes to ensure it works as expected.',
+});
+
+const saveButtonText = i18n.translate('share.draftModeCallout.saveButtonText', {
+  defaultMessage: 'Save changes',
+});
 
 /**
  * A warning callout to indicate the user has unsaved changes.
@@ -32,6 +39,7 @@ export const DraftModeCallout = ({
   node,
   message = defaultCalloutMessage,
   ['data-test-subj']: dataTestSubj = 'unsavedChangesDraftModeCallOut',
+  saveButtonProps,
 }: DraftModeCalloutProps) => {
   return node ? (
     node
@@ -48,6 +56,18 @@ export const DraftModeCallout = ({
       <EuiText component="p" size="s">
         {message}
       </EuiText>
+      {saveButtonProps && (
+        <EuiButton
+          color="warning"
+          fill
+          size="s"
+          data-test-subj={saveButtonProps['data-test-subj']}
+          onClick={saveButtonProps.onSave}
+          isLoading={saveButtonProps.isSaving}
+        >
+          {saveButtonProps.label ?? saveButtonText}
+        </EuiButton>
+      )}
     </EuiCallOut>
   );
 };

--- a/src/platform/plugins/shared/share/public/components/context/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/context/index.tsx
@@ -7,13 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { type PropsWithChildren, createContext, useContext } from 'react';
+import React, { type PropsWithChildren, createContext, useContext, useState } from 'react';
 
 import type { ShareConfigs, ShareTypes, ShowShareMenuOptions } from '../../types';
 
 export interface IShareContext extends Omit<ShowShareMenuOptions, 'onClose'> {
   onClose: () => void;
   shareMenuItems: ShareConfigs[];
+  isSaving?: boolean;
 }
 
 const ShareContext = createContext<IShareContext | null>(null);
@@ -22,7 +23,35 @@ export const ShareProvider = ({
   shareContext,
   children,
 }: PropsWithChildren<{ shareContext: IShareContext }>) => {
-  return <ShareContext.Provider value={shareContext}>{children}</ShareContext.Provider>;
+  // If consumers provide an onSave function, we need to manage the state internally
+  const isStateful = Boolean(shareContext.onSave);
+  const [internalIsDirty, setInternalIsDirty] = useState(shareContext.isDirty);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = async () => {
+    if (shareContext.onSave) {
+      setIsSaving(true);
+      try {
+        await shareContext.onSave();
+        setInternalIsDirty(false);
+      } catch (error) {
+        // onSave function is responsible for handling the error
+        // In case it doesn't, we still want to catch it to
+        // make sure the loading state is reset and allow retries.
+      } finally {
+        setIsSaving(false);
+      }
+    }
+  };
+
+  const value: IShareContext = {
+    ...shareContext,
+    isDirty: isStateful ? internalIsDirty : shareContext.isDirty,
+    isSaving: isStateful ? isSaving : undefined,
+    onSave: isStateful ? handleSave : undefined,
+  };
+
+  return <ShareContext.Provider value={value}>{children}</ShareContext.Provider>;
 };
 
 export const useShareContext = () => {

--- a/src/platform/plugins/shared/share/public/components/export_integrations/export_integrations.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_integrations/export_integrations.tsx
@@ -33,7 +33,12 @@ import {
 import { i18n } from '@kbn/i18n';
 import type { InjectedIntl } from '@kbn/i18n-react';
 import { FormattedMessage, injectI18n } from '@kbn/i18n-react';
-import { ShareProvider, type IShareContext, useShareTypeContext } from '../context';
+import {
+  ShareProvider,
+  type IShareContext,
+  useShareTypeContext,
+  useShareContext,
+} from '../context';
 import type { ExportShareConfig, ExportShareDerivativesConfig } from '../../types';
 import type { DraftModeCalloutProps } from '../common/draft_mode_callout';
 import { DraftModeCallout } from '../common/draft_mode_callout';
@@ -66,6 +71,8 @@ interface ManagedFlyoutProps {
   shareObjectTypeMeta: ReturnType<
     typeof useShareTypeContext<'integration', 'export'>
   >['objectTypeMeta'];
+  onSave?: () => Promise<void | object>;
+  isSaving?: boolean;
 }
 
 function LayoutOptionsSwitch({ usePrintLayout, printLayoutChange }: LayoutOptionsProps) {
@@ -128,6 +135,8 @@ function ManagedFlyout({
   shareObjectTypeMeta,
   shareObjectType,
   shareObjectTypeAlias,
+  onSave,
+  isSaving,
 }: ManagedFlyoutProps) {
   const [usePrintLayout, setPrintLayout] = useState(false);
   const [isCreatingExport, setIsCreatingExport] = useState<boolean>(false);
@@ -227,7 +236,15 @@ function ManagedFlyout({
           <Fragment>
             {publicAPIEnabled && isDirty && draftModeCallout && (
               <EuiFlexItem>
-                <DraftModeCallout {...draftModeCalloutContent} />
+                <DraftModeCallout
+                  {...draftModeCalloutContent}
+                  {...(onSave && {
+                    saveButtonProps: {
+                      onSave,
+                      isSaving,
+                    },
+                  })}
+                />
               </EuiFlexItem>
             )}
           </Fragment>
@@ -263,6 +280,7 @@ function ManagedFlyout({
 }
 
 function ExportMenuPopover({ intl }: ExportMenuProps) {
+  const { onSave, isSaving } = useShareContext();
   const {
     onClose,
     anchorElement,
@@ -444,6 +462,8 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
               publicAPIEnabled={publicAPIEnabled}
               intl={intl}
               onCloseFlyout={flyoutOnCloseHandler}
+              onSave={onSave}
+              isSaving={isSaving}
             />
           ) : (
             (selectedMenuItem as ExportShareDerivativesConfig)?.config.flyoutContent({

--- a/src/platform/plugins/shared/share/public/components/share_tabs.tsx
+++ b/src/platform/plugins/shared/share/public/components/share_tabs.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { type FC } from 'react';
+import React, { useMemo, type FC } from 'react';
 import { TabbedModal, type IModalTabDeclaration } from '@kbn/shared-ux-tabbed-modal';
 
 import { ShareProvider, useShareContext, type IShareContext } from './context';
@@ -27,20 +27,23 @@ export const ShareMenuTabs = () => {
 
   const { objectTypeMeta, onClose, shareMenuItems, anchorElement } = shareContext;
 
-  const tabs: Array<IModalTabDeclaration<any>> = [];
+  const tabs = useMemo(() => {
+    const tabList: Array<IModalTabDeclaration<any>> = [];
 
-  // Do not show the link tab if the share url is disabled
-  if (!objectTypeMeta?.config.link?.disabled) {
-    tabs.push(linkTab);
-  }
+    // Do not show the link tab if the share url is disabled
+    if (!objectTypeMeta?.config.link?.disabled) {
+      tabList.push(linkTab);
+    }
 
-  // Embed is disabled in the serverless offering, hence the need to check if the embed tab should be shown
-  if (
-    shareMenuItems.some(({ shareType }) => shareType === 'embed') &&
-    !objectTypeMeta?.config?.embed?.disabled
-  ) {
-    tabs.push(embedTab);
-  }
+    // Embed is disabled in the serverless offering, hence the need to check if the embed tab should be shown
+    if (
+      shareMenuItems.some(({ shareType }) => shareType === 'embed') &&
+      !objectTypeMeta?.config?.embed?.disabled
+    ) {
+      tabList.push(embedTab);
+    }
+    return tabList;
+  }, [objectTypeMeta, shareMenuItems]);
 
   return Boolean(tabs.length) ? (
     <TabbedModal

--- a/src/platform/plugins/shared/share/public/components/tabs/embed/embed_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/embed/embed_content.tsx
@@ -27,7 +27,7 @@ import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { format as formatUrl, parse as parseUrl } from 'url';
 import type { AnonymousAccessState } from '../../../../common';
 
-import type { IShareContext } from '../../context';
+import { useShareContext, type IShareContext } from '../../context';
 import type { EmbedShareConfig, EmbedShareUIConfig } from '../../../types';
 import type { DraftModeCalloutProps } from '../../common/draft_mode_callout';
 import { DraftModeCallout } from '../../common/draft_mode_callout';
@@ -51,12 +51,10 @@ interface UrlParams {
   };
 }
 
-const draftModeCalloutMessage = (
-  <FormattedMessage
-    id="share.embed.draftModeCallout.message"
-    defaultMessage="This code might not work properly. Save your changes to ensure it works as expected."
-  />
-);
+const draftModeCalloutMessage = i18n.translate('share.embed.draftModeCallout.message', {
+  defaultMessage:
+    'This code might not work properly. Save your changes to ensure it works as expected.',
+});
 
 export const EmbedContent = ({
   shareableUrlForSavedObject,
@@ -70,6 +68,7 @@ export const EmbedContent = ({
   anonymousAccess,
 }: EmbedProps) => {
   const urlParamsRef = useRef<UrlParams | undefined>(undefined);
+  const { onSave, isSaving } = useShareContext();
   const [isLoading, setIsLoading] = useState(false);
   const [snapshotUrl, setSnapshotUrl] = useState<string>('');
   const [isTextCopied, setTextCopied] = useState(false);
@@ -330,7 +329,16 @@ export const EmbedContent = ({
         {isDirty && draftModeCallOut && (
           <>
             <EuiSpacer size="m" />
-            <DraftModeCallout message={draftModeCalloutMessage} {...draftModeCalloutContent} />
+            <DraftModeCallout
+              message={draftModeCalloutMessage}
+              {...draftModeCalloutContent}
+              {...(onSave && {
+                saveButtonProps: {
+                  onSave,
+                  isSaving,
+                },
+              })}
+            />
           </>
         )}
         <EuiSpacer />

--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx
@@ -19,11 +19,32 @@ import type { BrowserShortUrlClientHttp } from '../../../url_service/short_urls/
 import { BrowserShortUrlClient } from '../../../url_service/short_urls/short_url_client';
 import type { BrowserUrlService } from '../../../types';
 import { LinkContent } from './link_content';
+import type { IShareContext } from '../../context';
+import { ShareProvider } from '../../context';
 
-const renderComponent = (props: ComponentProps<typeof LinkContent>) => {
+const mockShareContext: IShareContext = {
+  isDirty: false,
+  onClose: () => {},
+  shareMenuItems: [],
+  objectType: 'dashboard',
+  shareableUrl: '',
+  allowShortUrl: false,
+  objectTypeMeta: {
+    title: 'title',
+    config: {},
+  },
+  sharingData: { title: 'title', url: 'url' },
+};
+
+const renderComponent = (
+  props: ComponentProps<typeof LinkContent>,
+  shareContext: IShareContext = mockShareContext
+) => {
   render(
     <IntlProvider locale="en">
-      <LinkContent {...props} />
+      <ShareProvider shareContext={shareContext}>
+        <LinkContent {...props} />
+      </ShareProvider>
     </IntlProvider>
   );
 };
@@ -192,5 +213,58 @@ describe('LinkContent', () => {
     // should only invoke once no matter how many times the button is clicked
     expect(createFromLongUrlSpy).toHaveBeenCalledTimes(1);
     expect(copyButton.getAttribute('data-share-url')).toBe(shortURL);
+  });
+
+  it('renders a draft mode callout when dirty and triggers its save button', async () => {
+    const user = userEvent.setup();
+    const onSave = jest.fn();
+    const shareContext: IShareContext = {
+      ...mockShareContext,
+      onSave,
+      isDirty: true,
+    };
+    renderComponent(
+      {
+        objectType: 'dashboard',
+        isDirty: true,
+        shareableUrl,
+        shortUrlService,
+        allowShortUrl: false,
+        objectConfig: {
+          draftModeCallOut: true,
+        },
+      },
+      shareContext
+    );
+    const draftModeCallout = screen.getByTestId('unsavedChangesDraftModeCallOut');
+    expect(draftModeCallout).toBeInTheDocument();
+    const saveButton = screen.getByRole('button', { name: 'Save changes' });
+    expect(saveButton).toBeInTheDocument();
+    await user.click(saveButton);
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it('renders a draft mode callout when dirty and does not render a save button when onSave is not provided', () => {
+    const shareContext: IShareContext = {
+      ...mockShareContext,
+      isDirty: true,
+    };
+    renderComponent(
+      {
+        objectType: 'dashboard',
+        isDirty: true,
+        shareableUrl,
+        shortUrlService,
+        allowShortUrl: false,
+        objectConfig: {
+          draftModeCallOut: true,
+        },
+      },
+      shareContext
+    );
+    const draftModeCallout = screen.getByTestId('unsavedChangesDraftModeCallOut');
+    expect(draftModeCallout).toBeInTheDocument();
+    const saveButton = screen.queryByRole('button', { name: 'Save changes' });
+    expect(saveButton).not.toBeInTheDocument();
   });
 });

--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
@@ -21,7 +21,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useState, useRef, useEffect } from 'react';
 import { TimeTypeSection } from './time_type_section';
-import type { IShareContext } from '../../context';
+import { useShareContext, type IShareContext } from '../../context';
 import type { LinkShareConfig, LinkShareUIConfig } from '../../../types';
 import type { DraftModeCalloutProps } from '../../common/draft_mode_callout';
 import { DraftModeCallout } from '../../common/draft_mode_callout';
@@ -54,6 +54,7 @@ export const LinkContent = ({
   shareableUrlLocatorParams,
   allowShortUrl,
 }: LinkProps) => {
+  const { onSave, isSaving } = useShareContext();
   const [snapshotUrl, setSnapshotUrl] = useState<string>('');
   const [isTextCopied, setTextCopied] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -153,7 +154,15 @@ export const LinkContent = ({
         {isDirty && draftModeCallOut && (
           <>
             <EuiSpacer size="m" />
-            <DraftModeCallout {...draftModeCalloutContent} />
+            <DraftModeCallout
+              {...draftModeCalloutContent}
+              {...(onSave && {
+                saveButtonProps: {
+                  onSave,
+                  isSaving,
+                },
+              })}
+            />
           </>
         )}
         <EuiSpacer size="l" />

--- a/src/platform/plugins/shared/share/public/services/share_menu_manager.tsx
+++ b/src/platform/plugins/shared/share/public/services/share_menu_manager.tsx
@@ -81,6 +81,7 @@ export class ShareMenuManager {
       isDirty,
       asExport,
       publicAPIEnabled,
+      onSave,
     }: ShowShareMenuOptions & {
       menuItems: ShareConfigs[];
       onClose: () => void;
@@ -116,6 +117,7 @@ export class ShareMenuManager {
             onClose();
             unmount();
           },
+          onSave,
         },
       }),
       rendering

--- a/src/platform/plugins/shared/share/public/types.ts
+++ b/src/platform/plugins/shared/share/public/types.ts
@@ -397,6 +397,7 @@ export interface ShowShareMenuOptions extends Omit<ShareContext, 'onClose'> {
   allowShortUrl: boolean;
   onClose?: () => void;
   publicAPIEnabled?: boolean;
+  onSave?: () => Promise<void | object>;
 }
 
 export interface ClientConfigType {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/237765

## Summary

- This PR adds the necessary logic and UI for share plugin consumers to include an `onSave` prop for users to be able to save changes directly from the plugin's `DraftModeCallout`
- A new internal `isDirty` state was used and had to be lifted up to the `ShareContext` to avoid inconsistencies between `link|embed` tabs
- No plugin consumer is currently using this, it will be needed for https://github.com/elastic/kibana/pull/233552

### Testing

Testing was done by including the `saveFromShareModal` logic from this related PR https://github.com/elastic/kibana/pull/233552 in Dashboards app.

https://github.com/user-attachments/assets/f73ce77a-3dbe-47b7-8032-c633ae339bde

