### PR TITLE
Fix a small regression around state sync

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/hooks/use_unified_search.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/hooks/use_unified_search.ts
@@ -217,8 +217,6 @@ export const useUnifiedSearch = () => {
   useEffect(() => {
     const subscription = new Subscription();
 
-    queryStringService.clearQuery();
-
     subscription.add(
       filterManagerService
         .getUpdates$()


### PR DESCRIPTION
## Summary

Found a regression which was recently introduced as part of this [PR](https://github.com/elastic/kibana/pull/231180)

The Search Bar in the Hosts page no more sync back to the URL state on Page Refresh. This is happening because of this line [here](https://github.com/elastic/kibana/blob/b9fbdd665ccc29c6ce92da96b9dc49900cd6bcc2/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/hooks/use_unified_search.ts#L220) .

![Oct-17-2025 14-28-45](https://github.com/user-attachments/assets/2a9739b7-71eb-415f-9a5b-872115b560ec)


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->