### PR TITLE
[Fleet] Only sync integrations installed from registry

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_task.test.ts
@@ -59,6 +59,7 @@ jest.mock('../../services/epm/packages/get', () => ({
           version: '0.1.0',
           updated_at: new Date().toISOString(),
           install_status: 'installed',
+          install_source: 'registry',
         },
       },
       {
@@ -67,6 +68,16 @@ jest.mock('../../services/epm/packages/get', () => ({
           version: '0.2.0',
           updated_at: new Date().toISOString(),
           install_status: 'installed',
+          install_source: 'registry',
+        },
+      },
+      {
+        attributes: {
+          name: 'custom-package',
+          version: '0.1.0',
+          updated_at: new Date().toISOString(),
+          install_status: 'installed',
+          install_source: 'upload',
         },
       },
     ],
@@ -196,7 +207,7 @@ describe('SyncIntegrationsTask', () => {
         expect(result).toEqual(getDeleteTaskRunResult());
       });
 
-      it('Should create fleet-synced-integrations doc', async () => {
+      it('Should create fleet-synced-integrations doc for packages installed from registry', async () => {
         mockOutputService.list.mockResolvedValue({
           items: [
             {
@@ -249,12 +260,14 @@ describe('SyncIntegrationsTask', () => {
                   package_version: '0.1.0',
                   updated_at: expect.any(String),
                   install_status: 'installed',
+                  install_source: 'registry',
                 },
                 {
                   package_name: 'package-2',
                   package_version: '0.2.0',
                   updated_at: expect.any(String),
                   install_status: 'installed',
+                  install_source: 'registry',
                 },
               ],
               remote_es_hosts: [
@@ -332,12 +345,14 @@ describe('SyncIntegrationsTask', () => {
                   package_version: '0.1.0',
                   updated_at: expect.any(String),
                   install_status: 'installed',
+                  install_source: 'registry',
                 },
                 {
                   package_name: 'package-2',
                   package_version: '0.2.0',
                   updated_at: expect.any(String),
                   install_status: 'installed',
+                  install_source: 'registry',
                 },
               ],
               remote_es_hosts: [
@@ -469,18 +484,21 @@ describe('SyncIntegrationsTask', () => {
                 package_version: '0.1.0',
                 updated_at: new Date().toISOString(),
                 install_status: 'installed',
+                install_source: 'registry',
               },
               {
                 package_name: 'package-2',
                 package_version: '0.2.0',
                 updated_at: new Date().toISOString(),
                 install_status: 'installed',
+                install_source: 'registry',
               },
               {
                 package_name: 'package-3',
                 package_version: '0.3.0',
                 updated_at: new Date().toISOString(),
                 install_status: 'installed',
+                install_source: 'registry',
               },
             ],
             custom_assets: {},
@@ -500,18 +518,21 @@ describe('SyncIntegrationsTask', () => {
                   package_version: '0.1.0',
                   updated_at: expect.any(String),
                   install_status: 'installed',
+                  install_source: 'registry',
                 },
                 {
                   package_name: 'package-2',
                   package_version: '0.2.0',
                   updated_at: expect.any(String),
                   install_status: 'installed',
+                  install_source: 'registry',
                 },
                 {
                   package_name: 'package-3',
                   package_version: '0.3.0',
                   updated_at: expect.any(String),
                   install_status: 'not_installed',
+                  install_source: 'registry',
                 },
               ],
               remote_es_hosts: [

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_task.ts
@@ -240,16 +240,18 @@ export class SyncIntegrationsTask {
       perPage: SO_SEARCH_LIMIT,
       sortOrder: 'asc',
     });
-    newDoc.integrations = packageSavedObjects.saved_objects.map((item) => {
-      return {
-        package_name: item.attributes.name,
-        package_version: item.attributes.version,
-        updated_at: item.updated_at ?? new Date().toISOString(),
-        install_status: item.attributes.install_status,
-        install_source: item.attributes.install_source,
-        rolled_back: item.attributes.rolled_back,
-      };
-    });
+    newDoc.integrations = packageSavedObjects.saved_objects
+      .filter((item) => item.attributes.install_source === 'registry')
+      .map((item) => {
+        return {
+          package_name: item.attributes.name,
+          package_version: item.attributes.version,
+          updated_at: item.updated_at ?? new Date().toISOString(),
+          install_status: item.attributes.install_status,
+          install_source: item.attributes.install_source,
+          rolled_back: item.attributes.rolled_back,
+        };
+      });
 
     const isSyncUninstalledEnabled = remoteESOutputs.some(
       (output) => (output as NewRemoteElasticsearchOutput).sync_uninstalled_integrations


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/228570

This PR limits integration syncing in Fleet to packages installed from the registry. Other packages won't be picked up or shown in the sync status.

To test:
1. Set up remote syncing (cf. https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/remote_clusters_ccr.md).
2. Install a custom integration and a package from registry.
3. Wait for the integrations sync task to complete.
4. Check that only the package from registry was synced.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


