### PR TITLE
[8.19] [Synthetics] Fix broken colors for status panels !! (#211422)

### DIFF
--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.tsx
@@ -241,6 +241,7 @@ const Wrapper = styled.div<{
 }>`
   height: ${(props) => (props.$customHeight ? `${props.$customHeight};` : `100%;`)};
   position: relative;
+  min-width: 80px;
   &&& {
     > :nth-child(2) {
       height: ${(props) =>
@@ -260,16 +261,16 @@ const Wrapper = styled.div<{
             : 'center;'};
       }
       justify-content: flex-end;
-      .legacyMtrVis__container {
+      &__container {
         padding: 0;
-        > :nth-child(2) {
+        [data-test-subj='metric_label'] {
           ${({ noLabel }) =>
             noLabel &&
             ` display: none;
         `}
         }
       }
-      .legacyMtrVis__value {
+      &__value {
         line-height: ${({ lineHeight }) => lineHeight}px !important;
         font-size: ${({ fontSize }) => fontSize}px !important;
       }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_cell_tooltip.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_cell_tooltip.tsx
@@ -7,11 +7,11 @@
 
 import React from 'react';
 import moment from 'moment';
-import { EuiProgress } from '@elastic/eui';
+import { EuiProgress, useEuiTheme, VISUALIZATION_COLORS } from '@elastic/eui';
 
 import { TooltipTable, TooltipHeader, TooltipValue, TooltipContainer } from '@elastic/charts';
 
-import { MonitorStatusTimeBin, SUCCESS_VIZ_COLOR, DANGER_VIZ_COLOR } from './monitor_status_data';
+import { MonitorStatusTimeBin } from './monitor_status_data';
 import * as labels from './labels';
 
 export const MonitorStatusCellTooltip = ({
@@ -21,6 +21,14 @@ export const MonitorStatusCellTooltip = ({
   timeBin?: MonitorStatusTimeBin;
   isLoading: boolean;
 }) => {
+  const { euiTheme } = useEuiTheme();
+
+  const isAmsterdam = euiTheme.flags.hasVisColorAdjustment;
+
+  const SUCCESS_COLOR = isAmsterdam ? VISUALIZATION_COLORS[0] : euiTheme.colors.success;
+  const DANGER_COLOR = isAmsterdam
+    ? VISUALIZATION_COLORS[VISUALIZATION_COLORS.length - 1]
+    : euiTheme.colors.danger;
   if (!timeBin) {
     return <>{''}</>;
   }
@@ -58,14 +66,14 @@ export const MonitorStatusCellTooltip = ({
           ...commonTooltipValuesProps,
         },
         {
-          color: SUCCESS_VIZ_COLOR,
+          color: SUCCESS_COLOR,
           label: labels.COMPLETE_LABEL,
           value: timeBin.ups,
           formattedValue: `${timeBin.ups}`,
           ...commonTooltipValuesProps,
         },
         {
-          color: DANGER_VIZ_COLOR,
+          color: DANGER_COLOR,
           label: labels.FAILED_LABEL,
           value: timeBin.downs,
           formattedValue: `${timeBin.downs}`,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_data.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_data.ts
@@ -18,8 +18,6 @@ import {
 import type { BrushEvent } from '@elastic/charts';
 import { MonitorStatusHeatmapBucket } from '../../../../../../common/runtime_types';
 
-export const SUCCESS_VIZ_COLOR = VISUALIZATION_COLORS[0];
-export const DANGER_VIZ_COLOR = VISUALIZATION_COLORS[VISUALIZATION_COLORS.length - 1];
 export const CHART_CELL_WIDTH = 17;
 
 export interface MonitorStatusTimeBucket {
@@ -58,23 +56,29 @@ export interface MonitorStatusPanelProps {
 
 export function getColorBands(euiTheme: EuiThemeComputed, colorMode: EuiThemeColorModeStandard) {
   const colorTransitionFn = colorMode === COLOR_MODES_STANDARD.dark ? transparentize : tint;
+  const isAmsterdam = euiTheme.flags.hasVisColorAdjustment;
+
+  const SUCCESS_COLOR = isAmsterdam ? VISUALIZATION_COLORS[0] : euiTheme.colors.success;
+  const DANGER_COLOR = isAmsterdam
+    ? VISUALIZATION_COLORS[VISUALIZATION_COLORS.length - 1]
+    : euiTheme.colors.danger;
 
   return [
-    { color: DANGER_VIZ_COLOR, start: -Infinity, end: -1 },
-    { color: DANGER_VIZ_COLOR, start: -1, end: -0.75 },
-    { color: colorTransitionFn(DANGER_VIZ_COLOR, 0.25), start: -0.75, end: -0.5 },
-    { color: colorTransitionFn(DANGER_VIZ_COLOR, 0.5), start: -0.5, end: -0.25 },
-    { color: colorTransitionFn(DANGER_VIZ_COLOR, 0.75), start: -0.25, end: -0.000000001 },
+    { color: DANGER_COLOR, start: -Infinity, end: -1 },
+    { color: DANGER_COLOR, start: -1, end: -0.75 },
+    { color: colorTransitionFn(DANGER_COLOR, 0.25), start: -0.75, end: -0.5 },
+    { color: colorTransitionFn(DANGER_COLOR, 0.5), start: -0.5, end: -0.25 },
+    { color: colorTransitionFn(DANGER_COLOR, 0.75), start: -0.25, end: -0.000000001 },
     {
       color: getSkippedVizColor(euiTheme),
       start: -0.000000001,
       end: 0.000000001,
     },
-    { color: colorTransitionFn(SUCCESS_VIZ_COLOR, 0.5), start: 0.000000001, end: 0.25 },
-    { color: colorTransitionFn(SUCCESS_VIZ_COLOR, 0.35), start: 0.25, end: 0.5 },
-    { color: colorTransitionFn(SUCCESS_VIZ_COLOR, 0.2), start: 0.5, end: 0.8 },
-    { color: SUCCESS_VIZ_COLOR, start: 0.8, end: 1 },
-    { color: SUCCESS_VIZ_COLOR, start: 1, end: Infinity },
+    { color: colorTransitionFn(SUCCESS_COLOR, 0.5), start: 0.000000001, end: 0.25 },
+    { color: colorTransitionFn(SUCCESS_COLOR, 0.35), start: 0.25, end: 0.5 },
+    { color: colorTransitionFn(SUCCESS_COLOR, 0.2), start: 0.5, end: 0.8 },
+    { color: SUCCESS_COLOR, start: 0.8, end: 1 },
+    { color: SUCCESS_COLOR, start: 1, end: Infinity },
   ];
 }
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_legend.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_legend.tsx
@@ -6,12 +6,25 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, useEuiTheme } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiText,
+  useEuiTheme,
+  VISUALIZATION_COLORS,
+} from '@elastic/eui';
 import * as labels from './labels';
-import { DANGER_VIZ_COLOR, getSkippedVizColor, SUCCESS_VIZ_COLOR } from './monitor_status_data';
+import { getSkippedVizColor } from './monitor_status_data';
 
 export const MonitorStatusLegend = ({ brushable }: { brushable: boolean }) => {
   const { euiTheme } = useEuiTheme();
+  const isAmsterdam = euiTheme.flags.hasVisColorAdjustment;
+
+  const SUCCESS_COLOR = isAmsterdam ? VISUALIZATION_COLORS[0] : euiTheme.colors.success;
+  const DANGER_COLOR = isAmsterdam
+    ? VISUALIZATION_COLORS[VISUALIZATION_COLORS.length - 1]
+    : euiTheme.colors.danger;
 
   const LegendItem = useMemo(() => {
     return ({
@@ -39,8 +52,8 @@ export const MonitorStatusLegend = ({ brushable }: { brushable: boolean }) => {
 
   return (
     <EuiFlexGroup wrap={true} responsive={false}>
-      <LegendItem color={SUCCESS_VIZ_COLOR} label={labels.COMPLETE_LABEL} />
-      <LegendItem color={DANGER_VIZ_COLOR} label={labels.FAILED_LABEL} />
+      <LegendItem color={SUCCESS_COLOR} label={labels.COMPLETE_LABEL} />
+      <LegendItem color={DANGER_COLOR} label={labels.FAILED_LABEL} />
       <LegendItem color={getSkippedVizColor(euiTheme)} label={labels.SKIPPED_LABEL} />
       {/*
         // Hiding error for now until @elastic/chart's Heatmap chart supports annotations

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
@@ -8,8 +8,9 @@
 import React, { useMemo, useRef } from 'react';
 
 import { EuiPanel, useEuiTheme, EuiResizeObserver, EuiSpacer, EuiProgress } from '@elastic/eui';
-import { Chart, Settings, Heatmap, ScaleType, Tooltip, LEGACY_LIGHT_THEME } from '@elastic/charts';
+import { Chart, Settings, Heatmap, ScaleType, Tooltip } from '@elastic/charts';
 import { i18n } from '@kbn/i18n';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { MonitorStatusHeader } from './monitor_status_header';
 import { MonitorStatusCellTooltip } from './monitor_status_cell_tooltip';
 import { MonitorStatusLegend } from './monitor_status_legend';
@@ -21,6 +22,7 @@ import {
   MonitorStatusPanelProps,
 } from './monitor_status_data';
 import { useMonitorStatusData } from './use_monitor_status_data';
+import { ClientPluginsStart } from '../../../../../plugin';
 
 export const MonitorStatusPanel = ({
   from = 'now-24h',
@@ -34,6 +36,8 @@ export const MonitorStatusPanel = ({
   const initialSizeRef = useRef<HTMLDivElement | null>(null);
   const { loading, timeBins, handleResize, getTimeBinByXValue, xDomain, minsPerBin } =
     useMonitorStatusData({ from, to, initialSizeRef });
+  const { charts } = useKibana<ClientPluginsStart>().services;
+  const baseTheme = charts.theme.useChartsBaseTheme();
 
   const heatmap = useMemo(() => {
     return getMonitorStatusChartTheme(euiTheme, brushable);
@@ -59,7 +63,7 @@ export const MonitorStatusPanel = ({
               {minsPerBin && (
                 <Chart
                   size={{
-                    height: 60,
+                    height: 80,
                   }}
                 >
                   <Tooltip
@@ -74,8 +78,7 @@ export const MonitorStatusPanel = ({
                     showLegend={false}
                     xDomain={xDomain}
                     theme={{ heatmap }}
-                    // TODO connect to charts.theme service see src/plugins/charts/public/services/theme/README.md
-                    baseTheme={LEGACY_LIGHT_THEME}
+                    baseTheme={baseTheme}
                     onBrushEnd={(brushArea) => {
                       onBrushed?.(getBrushData(brushArea));
                     }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Fix broken colors for status panels !! (#211422)](https://github.com/elastic/kibana/pull/211422)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2025-02-19T17:15:28Z","message":"[Synthetics] Fix broken colors for status panels !! (#211422)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/208951\r\n\r\nFix broken colors for status panels, i have also fixed broken metric viz\r\nwhich had some styling issues with new theme by setting minimum width.\r\n\r\n### After\r\n<img width=\"1724\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/aea9c9a1-0be1-4b82-82e8-721d61a0fd05\"\r\n/>","sha":"5908bf4195647ccd1cd7a15109bae427a0cec52d","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:obs-ux-management","backport:version","v9.1.0","v9.3.0","v8.19.6"],"title":"[Synthetics] Fix broken colors for status panels !!","number":211422,"url":"https://github.com/elastic/kibana/pull/211422","mergeCommit":{"message":"[Synthetics] Fix broken colors for status panels !! (#211422)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/208951\r\n\r\nFix broken colors for status panels, i have also fixed broken metric viz\r\nwhich had some styling issues with new theme by setting minimum width.\r\n\r\n### After\r\n<img width=\"1724\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/aea9c9a1-0be1-4b82-82e8-721d61a0fd05\"\r\n/>","sha":"5908bf4195647ccd1cd7a15109bae427a0cec52d"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/211819","number":211819,"state":"MERGED","mergeCommit":{"sha":"f0a376d69dbb25a9273a78af2c75e37438548373","message":"[9.0] [Synthetics] Fix broken colors for status panels !! (#211422) (#211819)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Synthetics] Fix broken colors for status panels !!\n(#211422)](https://github.com/elastic/kibana/pull/211422)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211422","number":211422,"mergeCommit":{"message":"[Synthetics] Fix broken colors for status panels !! (#211422)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/208951\r\n\r\nFix broken colors for status panels, i have also fixed broken metric viz\r\nwhich had some styling issues with new theme by setting minimum width.\r\n\r\n### After\r\n<img width=\"1724\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/aea9c9a1-0be1-4b82-82e8-721d61a0fd05\"\r\n/>","sha":"5908bf4195647ccd1cd7a15109bae427a0cec52d"}},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->