### PR TITLE
[SLO] Add search features and status filtering to SLO management page

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/find_definition.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/find_definition.ts
@@ -15,6 +15,9 @@ const findSloDefinitionsParamsSchema = t.partial({
     includeHealth: toBooleanRt,
     tags: t.string,
     page: t.string,
+    enabledFilter: t.string,
+    sortField: t.union([t.literal('version'), t.literal('enabled')]),
+    sortOrder: t.union([t.literal('asc'), t.literal('desc')]),
     perPage: t.string,
   }),
 });

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/query_key_factory.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/query_key_factory.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Indicator, Objective } from '@kbn/slo-schema';
+import { type SLODefinitionSortableFields } from './use_fetch_slo_definitions';
 
 interface SloListFilter {
   kqlQuery: string;
@@ -58,6 +59,9 @@ export const sloKeys = {
     perPage: number;
     includeOutdatedOnly: boolean;
     validTags: string;
+    enabledFilter?: string;
+    sortField?: SLODefinitionSortableFields;
+    sortOrder?: 'asc' | 'desc';
   }) => [...sloKeys.allDefinitions(), params],
   globalDiagnosis: () => [...sloKeys.all, 'globalDiagnosis'] as const,
   health: (list: Array<{ sloId: string; sloInstanceId: string }>) =>

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_management_search_bar.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_management_search_bar.tsx
@@ -8,7 +8,7 @@
 import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
-import { EuiComboBox, EuiText } from '@elastic/eui';
+import { EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { observabilityAppId } from '@kbn/observability-shared-plugin/common';
 import { useFetchSLOSuggestions } from '../../slo_edit/hooks/use_fetch_suggestions';
 import { useKibana } from '../../../hooks/use_kibana';
@@ -50,25 +50,64 @@ export function SloManagementSearchBar({ onRefresh }: Props) {
       }}
       onRefresh={onRefresh}
       renderQueryInputAppend={() => (
-        <>
-          <EuiComboBox
-            compressed
-            aria-label={filterTagsLabel}
-            placeholder={filterTagsLabel}
-            delimiter=","
-            options={suggestions?.tags ? [existOption, ...suggestions?.tags] : []}
-            selectedOptions={selectedOptions}
-            onChange={(newOptions) => {
-              setSelectedOptions(newOptions);
-              onStateChange({
-                ...state,
-                tags: newOptions.map((option) => String(option.value)),
-              });
-            }}
-            isClearable={true}
-            data-test-subj="filter-slos-by-tag"
-          />
-        </>
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem>
+            <EuiComboBox
+              compressed
+              options={enabledOptions}
+              aria-label={i18n.translate('xpack.slo.sloDefinitions.filterByStatus', {
+                defaultMessage: 'Filter by status',
+              })}
+              singleSelection={{ asPlainText: true }}
+              placeholder={i18n.translate('xpack.slo.sloDefinitions.filterByStatus', {
+                defaultMessage: 'Filter by status',
+              })}
+              selectedOptions={
+                state.enabledFilter !== undefined
+                  ? [
+                      {
+                        label: state.enabledFilter === 'true' ? RUNNING_LABEL : PAUSED_LABEL,
+                        value: state.enabledFilter === 'true' ? 'enabled' : 'disabled',
+                      },
+                    ]
+                  : []
+              }
+              onChange={(newOptions) => {
+                if (newOptions.length === 0) {
+                  onStateChange({ ...state, enabledFilter: undefined });
+                } else {
+                  const option = newOptions[0];
+                  onStateChange({
+                    ...state,
+                    enabledFilter: option.value === 'enabled' ? 'true' : 'false',
+                  });
+                }
+              }}
+              isClearable={true}
+              data-test-subj="filter-slos-by-status"
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiComboBox
+              compressed
+              aria-label={filterTagsLabel}
+              placeholder={filterTagsLabel}
+              delimiter=","
+              options={suggestions?.tags ? [existOption, ...suggestions?.tags] : []}
+              selectedOptions={selectedOptions}
+              onChange={(newOptions) => {
+                setSelectedOptions(newOptions);
+                onStateChange({
+                  ...state,
+                  tags: newOptions.map((option) => String(option.value)),
+                });
+              }}
+              isClearable={true}
+              data-test-subj="filter-slos-by-tag"
+            />
+          </EuiFlexItem>
+          <EuiFlexItem />
+        </EuiFlexGroup>
       )}
     />
   );
@@ -93,3 +132,21 @@ const existOption = {
   label: '',
   value: '*',
 };
+
+const RUNNING_LABEL = i18n.translate('xpack.slo.sloDefinitions.statusOptions.enabled', {
+  defaultMessage: 'Running',
+});
+const PAUSED_LABEL = i18n.translate('xpack.slo.sloDefinitions.statusOptions.disabled', {
+  defaultMessage: 'Paused',
+});
+
+const enabledOptions = [
+  {
+    label: RUNNING_LABEL,
+    value: 'enabled',
+  },
+  {
+    label: PAUSED_LABEL,
+    value: 'disabled',
+  },
+];

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/hooks/use_url_search_state.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/hooks/use_url_search_state.ts
@@ -13,6 +13,7 @@ import deepmerge from 'deepmerge';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { DEFAULT_SLO_PAGE_SIZE } from '../../../../common/constants';
+import { type SLODefinitionSortableFields } from '../../../hooks/use_fetch_slo_definitions';
 
 export const SLO_MANAGEMENT_SEARCH_URL_STORAGE_KEY = 'search';
 export const SLO_MANAGEMENT_SEARCH_SESSION_STORAGE_KEY = 'slo.management_page_search_state';
@@ -23,6 +24,9 @@ export interface SearchState {
   page: number;
   perPage: number;
   includeOutdatedOnly?: boolean;
+  sortField?: SLODefinitionSortableFields;
+  sortOrder?: 'asc' | 'desc';
+  enabledFilter?: string;
 }
 
 export const DEFAULT_STATE: SearchState = {

--- a/x-pack/solutions/observability/plugins/slo/server/saved_objects/slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/saved_objects/slo.ts
@@ -49,12 +49,22 @@ export const slo: SavedObjectsType = {
         },
       ],
     },
+    2: {
+      changes: [
+        { type: 'mappings_addition', addedMappings: { name_keyword: { type: 'keyword' } } },
+        {
+          type: 'data_backfill',
+          backfillFn: (doc) => ({ attributes: { name_keyword: doc.attributes.name ?? '' } }),
+        },
+      ],
+    },
   },
   mappings: {
     dynamic: false,
     properties: {
       id: { type: 'keyword' },
       name: { type: 'text' },
+      name_keyword: { type: 'keyword' },
       description: { type: 'text' },
       indicator: {
         properties: {

--- a/x-pack/solutions/observability/plugins/slo/server/services/find_slo_definitions.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/find_slo_definitions.ts
@@ -37,6 +37,9 @@ export class FindSLODefinitions {
 
     const result = await this.repository.search(params.search ?? '', toPagination(params), {
       includeOutdatedOnly: !!params.includeOutdatedOnly,
+      enabled: this.parseEnabledFilter(params.enabledFilter),
+      sortField: params.sortField,
+      sortOrder: params.sortOrder,
       tags: requestTags,
     });
 
@@ -74,6 +77,13 @@ export class FindSLODefinitions {
       total: result.total,
       results: result.results,
     });
+  }
+  private parseEnabledFilter(enabledFilter: string | undefined): boolean | undefined {
+    if (enabledFilter === 'true') {
+      return true;
+    } else if (enabledFilter === 'false') {
+      return false;
+    }
   }
 }
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_repository.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_repository.ts
@@ -31,6 +31,9 @@ export interface SLORepository {
     pagination: Pagination,
     options?: {
       includeOutdatedOnly: boolean;
+      enabled?: boolean;
+      sortField?: string;
+      sortOrder?: 'asc' | 'desc';
       tags: string[];
     }
   ): Promise<Paginated<SLODefinition>>;
@@ -122,14 +125,21 @@ export class KibanaSavedObjectsSLORepository implements SLORepository {
     search: string,
     pagination: Pagination,
     options: {
-      includeOutdatedOnly?: boolean;
+      includeOutdatedOnly: boolean;
+      enabled?: boolean;
       tags: string[];
-    } = { tags: [] }
+      sortField?: string;
+      sortOrder?: 'asc' | 'desc';
+    }
   ): Promise<Paginated<SLODefinition>> {
-    const { includeOutdatedOnly, tags } = options;
+    const { includeOutdatedOnly, tags, sortField, sortOrder } = options;
     const filter = [];
     if (tags.length > 0) {
       filter.push(`slo.attributes.tags: (${tags.join(' OR ')})`);
+    }
+
+    if (options.enabled !== undefined) {
+      filter.push(`slo.attributes.enabled: ${options.enabled}`);
     }
 
     if (!!includeOutdatedOnly) {
@@ -143,8 +153,8 @@ export class KibanaSavedObjectsSLORepository implements SLORepository {
       search,
       searchFields: ['name'],
       ...(filter.length && { filter: filter.join(' AND ') }),
-      sortField: 'id',
-      sortOrder: 'asc',
+      sortField: sortField ?? 'id',
+      sortOrder: sortOrder ?? 'asc',
     });
 
     return {


### PR DESCRIPTION
## Summary

Resolves #237457.

Adds filtering by status and sorting by columns to the SLO management page.

The sorting right now is a bit limited. Right now, sort is limited to `version` and `enabled`. 

We could potentially add `tag` as well. `slo.name` is a text field, and there's no keyword subfield, so we can't sort by name right now.