### PR TITLE
[Attack discovery] Additional Attack discovery API docs updates

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -8153,7 +8153,7 @@ paths:
           name: product_name
   /api/attack_discovery/_bulk:
     post:
-      description: Performs bulk updates on multiple Attack discovery alerts, including workflow status changes and visibility settings. This endpoint allows efficient batch processing of alert modifications without requiring individual API calls for each alert. `Technical preview`
+      description: Performs bulk updates on multiple Attack discoveries, including workflow status changes and visibility settings. This endpoint allows efficient batch processing of alert modifications without requiring individual API calls for each alert. `Technical preview`
       operationId: PostAttackDiscoveryBulk
       requestBody:
         content:
@@ -8202,7 +8202,7 @@ paths:
                     - ids
               required:
                 - update
-        description: Bulk update parameters for Attack discovery alerts
+        description: Bulk update parameters for Attack discoveries
         required: true
       responses:
         '200':
@@ -8242,7 +8242,7 @@ paths:
                   - error
                   - message
           description: Generic Error
-      summary: Bulk update Attack discovery alerts
+      summary: Bulk update Attack discoveries
       tags:
         - Security Attack discovery API
       x-code-samples:
@@ -8268,7 +8268,7 @@ paths:
           name: product_name
   /api/attack_discovery/_find:
     get:
-      description: Finds Attack discoveries that match the search criteria. Supports free text search, filtering, pagination, and sorting. `Technical preview`
+      description: Find Attack discoveries that match the search criteria. Supports free text search, filtering, pagination, and sorting. `Technical preview`
       operationId: AttackDiscoveryFind
       parameters:
         - description: Filter results to Attack discoveries that include any of the provided alert IDs
@@ -8455,7 +8455,7 @@ paths:
                     example: 400
                     type: number
           description: Generic Error
-      summary: Finds Attack discoveries that match the search criteria
+      summary: Find Attack discoveries that match the search criteria
       tags:
         - Security Attack discovery API
       x-code-samples:
@@ -8528,7 +8528,6 @@ paths:
              --request POST 'http://localhost:5601/api/attack_discovery/_generate' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json" \
-             --header "elastic-api-version: 2023-10-31" \
              --data '{
                 "alertsIndexPattern": ".alerts-security.alerts-default",
                 "anonymizationFields": [
@@ -9468,7 +9467,7 @@ paths:
           name: product_name
   /api/attack_discovery/generations:
     get:
-      description: Get the latest attack discovery generations (that are not dismissed) for the current user. This endpoint retrieves generation metadata including execution status and statistics for Attack discovery generations. `Technical preview`
+      description: Get the latest attack discovery generations metadata (that are not dismissed) for the current user. This endpoint retrieves generation metadata including execution status and statistics for Attack discovery generations. `Technical preview`
       operationId: GetAttackDiscoveryGenerations
       parameters:
         - description: End of the time range for filtering generations. Accepts absolute timestamps (ISO 8601) or relative date math (e.g. "now", "now-24h").
@@ -9528,7 +9527,7 @@ paths:
                     example: 400
                     type: number
           description: Bad request
-      summary: Get the latest attack discovery generations (that are not dismissed) for the current user
+      summary: Get the latest attack discovery generations metadata for the current user
       tags:
         - Security Attack discovery API
       x-code-samples:
@@ -9758,7 +9757,7 @@ paths:
               enabled: true
               name: Daily Security Analysis
               params:
-                alerts_index_pattern: .alerts-security.alerts-*
+                alerts_index_pattern: .alerts-security.alerts-default
                 api_config:
                   actionTypeId: bedrock
                   connectorId: my-bedrock-connector
@@ -9784,7 +9783,7 @@ paths:
                 id: 12345678-1234-1234-1234-123456789012
                 name: Daily Security Analysis
                 params:
-                  alerts_index_pattern: .alerts-security.alerts-*
+                  alerts_index_pattern: .alerts-security.alerts-default
                   api_config:
                     actionTypeId: bedrock
                     connectorId: my-bedrock-connector
@@ -9824,7 +9823,7 @@ paths:
                "name": "Daily Security Analysis",
                "enabled": true,
                "params": {
-                 "alerts_index_pattern": ".alerts-security.alerts-*",
+                 "alerts_index_pattern": ".alerts-security.alerts-default",
                  "api_config": {
                    "actionTypeId": "bedrock",
                    "connectorId": "my-bedrock-connector",
@@ -9837,7 +9836,22 @@ paths:
                "schedule": {
                  "interval": "24h"
                },
-               "actions": []
+               "actions": [
+                  {
+                     "action_type_id": ".cases",
+                     "id": "system-connector-.cases",
+                     "params": {
+                       "subAction": "run",
+                       "subActionParams": {
+                         "timeWindow": "7d",
+                         "reopenClosedCases": false,
+                         "groupingBy": [],
+                         "templateId": null
+                       }
+                     },
+                     "uuid": "12345678-1234-1234-1234-123456789012"
+                   }
+               ]
              }'
       x-state: Technical Preview; added in 9.2.0
       x-metaTags:
@@ -9933,7 +9947,7 @@ paths:
           lang: curl
           source: |
             curl \
-             --request GET 'http://localhost:5601/api/attack_discovery/schedules/_find?page=1&per_page=10&sort_field=name&sort_direction=asc' \
+             --request GET 'http://localhost:5601/api/attack_discovery/schedules/_find' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-state: Technical Preview; added in 9.2.0
@@ -10019,7 +10033,7 @@ paths:
                   status: ok
                 name: Daily Security Analysis
                 params:
-                  alerts_index_pattern: .alerts-security.alerts-*
+                  alerts_index_pattern: .alerts-security.alerts-default
                   api_config:
                     actionTypeId: bedrock
                     connectorId: my-bedrock-connector
@@ -10077,7 +10091,7 @@ paths:
               actions: []
               name: Updated Daily Security Analysis
               params:
-                alerts_index_pattern: .alerts-security.alerts-*
+                alerts_index_pattern: .alerts-security.alerts-default
                 api_config:
                   actionTypeId: bedrock
                   connectorId: my-bedrock-connector
@@ -10103,7 +10117,7 @@ paths:
                 id: 12345678-1234-1234-1234-123456789012
                 name: Updated Daily Security Analysis
                 params:
-                  alerts_index_pattern: .alerts-security.alerts-*
+                  alerts_index_pattern: .alerts-security.alerts-default
                   api_config:
                     actionTypeId: bedrock
                     connectorId: my-bedrock-connector
@@ -10142,7 +10156,7 @@ paths:
              --data '{
                "name": "Updated Daily Security Analysis",
                "params": {
-                 "alerts_index_pattern": ".alerts-security.alerts-*",
+                 "alerts_index_pattern": ".alerts-security.alerts-default",
                  "api_config": {
                    "actionTypeId": "bedrock",
                    "connectorId": "my-bedrock-connector",
@@ -10162,7 +10176,7 @@ paths:
         - content: Kibana, Elastic Cloud Serverless
           name: product_name
   /api/attack_discovery/schedules/{id}/_disable:
-    put:
+    post:
       description: Disables an Attack discovery schedule, preventing it from running according to its configured interval. The schedule configuration is preserved and can be re-enabled later. Any currently running executions will complete, but no new executions will be started. `Technical preview`
       operationId: DisableAttackDiscoverySchedules
       parameters:
@@ -10206,7 +10220,7 @@ paths:
           lang: curl
           source: |
             curl \
-             --request PUT 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_disable' \
+             --request POST 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_disable' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-state: Technical Preview; added in 9.2.0
@@ -10214,7 +10228,7 @@ paths:
         - content: Kibana, Elastic Cloud Serverless
           name: product_name
   /api/attack_discovery/schedules/{id}/_enable:
-    put:
+    post:
       description: Enables a previously disabled Attack discovery schedule, allowing it to run according to its configured interval. Once enabled, the schedule will begin executing at the next scheduled time based on its interval configuration. `Technical preview`
       operationId: EnableAttackDiscoverySchedules
       parameters:
@@ -10258,7 +10272,7 @@ paths:
           lang: curl
           source: |
             curl \
-             --request PUT 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_enable' \
+             --request POST 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_enable' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-state: Technical Preview; added in 9.2.0

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/attack_discovery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/attack_discovery_api_2023_10_31.bundled.schema.yaml
@@ -21,10 +21,10 @@ paths:
   /api/attack_discovery/_bulk:
     post:
       description: >-
-        Performs bulk updates on multiple Attack discovery alerts, including
-        workflow status changes and visibility settings. This endpoint allows
-        efficient batch processing of alert modifications without requiring
-        individual API calls for each alert. `Technical preview`
+        Performs bulk updates on multiple Attack discoveries, including workflow
+        status changes and visibility settings. This endpoint allows efficient
+        batch processing of alert modifications without requiring individual API
+        calls for each alert. `Technical preview`
       operationId: PostAttackDiscoveryBulk
       requestBody:
         content:
@@ -92,7 +92,7 @@ paths:
                     - ids
               required:
                 - update
-        description: Bulk update parameters for Attack discovery alerts
+        description: Bulk update parameters for Attack discoveries
         required: true
       responses:
         '200':
@@ -137,7 +137,7 @@ paths:
                   - error
                   - message
           description: Generic Error
-      summary: Bulk update Attack discovery alerts
+      summary: Bulk update Attack discoveries
       tags:
         - Security Attack discovery API
       x-code-samples:
@@ -161,7 +161,7 @@ paths:
   /api/attack_discovery/_find:
     get:
       description: >-
-        Finds Attack discoveries that match the search criteria. Supports free
+        Find Attack discoveries that match the search criteria. Supports free
         text search, filtering, pagination, and sorting. `Technical preview`
       operationId: AttackDiscoveryFind
       parameters:
@@ -397,7 +397,7 @@ paths:
                     example: 400
                     type: number
           description: Generic Error
-      summary: Finds Attack discoveries that match the search criteria
+      summary: Find Attack discoveries that match the search criteria
       tags:
         - Security Attack discovery API
       x-code-samples:
@@ -474,7 +474,6 @@ paths:
              --request POST 'http://localhost:5601/api/attack_discovery/_generate' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json" \
-             --header "elastic-api-version: 2023-10-31" \
              --data '{
                 "alertsIndexPattern": ".alerts-security.alerts-default",
                 "anonymizationFields": [
@@ -1412,10 +1411,10 @@ paths:
   /api/attack_discovery/generations:
     get:
       description: >-
-        Get the latest attack discovery generations (that are not dismissed) for
-        the current user. This endpoint retrieves generation metadata including
-        execution status and statistics for Attack discovery generations.
-        `Technical preview`
+        Get the latest attack discovery generations metadata (that are not
+        dismissed) for the current user. This endpoint retrieves generation
+        metadata including execution status and statistics for Attack discovery
+        generations. `Technical preview`
       operationId: GetAttackDiscoveryGenerations
       parameters:
         - description: >-
@@ -1480,8 +1479,8 @@ paths:
                     type: number
           description: Bad request
       summary: >-
-        Get the latest attack discovery generations (that are not dismissed) for
-        the current user
+        Get the latest attack discovery generations metadata for the current
+        user
       tags:
         - Security Attack discovery API
       x-code-samples:
@@ -1772,7 +1771,7 @@ paths:
               enabled: true
               name: Daily Security Analysis
               params:
-                alerts_index_pattern: .alerts-security.alerts-*
+                alerts_index_pattern: .alerts-security.alerts-default
                 api_config:
                   actionTypeId: bedrock
                   connectorId: my-bedrock-connector
@@ -1800,7 +1799,7 @@ paths:
                 id: 12345678-1234-1234-1234-123456789012
                 name: Daily Security Analysis
                 params:
-                  alerts_index_pattern: .alerts-security.alerts-*
+                  alerts_index_pattern: .alerts-security.alerts-default
                   api_config:
                     actionTypeId: bedrock
                     connectorId: my-bedrock-connector
@@ -1840,7 +1839,7 @@ paths:
                "name": "Daily Security Analysis",
                "enabled": true,
                "params": {
-                 "alerts_index_pattern": ".alerts-security.alerts-*",
+                 "alerts_index_pattern": ".alerts-security.alerts-default",
                  "api_config": {
                    "actionTypeId": "bedrock",
                    "connectorId": "my-bedrock-connector",
@@ -1853,7 +1852,22 @@ paths:
                "schedule": {
                  "interval": "24h"
                },
-               "actions": []
+               "actions": [
+                  {
+                     "action_type_id": ".cases",
+                     "id": "system-connector-.cases",
+                     "params": {
+                       "subAction": "run",
+                       "subActionParams": {
+                         "timeWindow": "7d",
+                         "reopenClosedCases": false,
+                         "groupingBy": [],
+                         "templateId": null
+                       }
+                     },
+                     "uuid": "12345678-1234-1234-1234-123456789012"
+                   }
+               ]
              }'
       x-state: Technical Preview; added in 9.2.0
   /api/attack_discovery/schedules/_find:
@@ -1956,7 +1970,7 @@ paths:
           lang: curl
           source: |
             curl \
-             --request GET 'http://localhost:5601/api/attack_discovery/schedules/_find?page=1&per_page=10&sort_field=name&sort_direction=asc' \
+             --request GET 'http://localhost:5601/api/attack_discovery/schedules/_find' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-state: Technical Preview; added in 9.2.0
@@ -2051,7 +2065,7 @@ paths:
                   status: ok
                 name: Daily Security Analysis
                 params:
-                  alerts_index_pattern: .alerts-security.alerts-*
+                  alerts_index_pattern: .alerts-security.alerts-default
                   api_config:
                     actionTypeId: bedrock
                     connectorId: my-bedrock-connector
@@ -2115,7 +2129,7 @@ paths:
               actions: []
               name: Updated Daily Security Analysis
               params:
-                alerts_index_pattern: .alerts-security.alerts-*
+                alerts_index_pattern: .alerts-security.alerts-default
                 api_config:
                   actionTypeId: bedrock
                   connectorId: my-bedrock-connector
@@ -2143,7 +2157,7 @@ paths:
                 id: 12345678-1234-1234-1234-123456789012
                 name: Updated Daily Security Analysis
                 params:
-                  alerts_index_pattern: .alerts-security.alerts-*
+                  alerts_index_pattern: .alerts-security.alerts-default
                   api_config:
                     actionTypeId: bedrock
                     connectorId: my-bedrock-connector
@@ -2184,7 +2198,7 @@ paths:
              --data '{
                "name": "Updated Daily Security Analysis",
                "params": {
-                 "alerts_index_pattern": ".alerts-security.alerts-*",
+                 "alerts_index_pattern": ".alerts-security.alerts-default",
                  "api_config": {
                    "actionTypeId": "bedrock",
                    "connectorId": "my-bedrock-connector",
@@ -2201,7 +2215,7 @@ paths:
              }'
       x-state: Technical Preview; added in 9.2.0
   /api/attack_discovery/schedules/{id}/_disable:
-    put:
+    post:
       description: >-
         Disables an Attack discovery schedule, preventing it from running
         according to its configured interval. The schedule configuration is
@@ -2257,12 +2271,12 @@ paths:
           lang: curl
           source: |
             curl \
-             --request PUT 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_disable' \
+             --request POST 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_disable' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-state: Technical Preview; added in 9.2.0
   /api/attack_discovery/schedules/{id}/_enable:
-    put:
+    post:
       description: >-
         Enables a previously disabled Attack discovery schedule, allowing it to
         run according to its configured interval. Once enabled, the schedule
@@ -2317,7 +2331,7 @@ paths:
           lang: curl
           source: |
             curl \
-             --request PUT 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_enable' \
+             --request POST 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_enable' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-state: Technical Preview; added in 9.2.0

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/attack_discovery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/attack_discovery_api_2023_10_31.bundled.schema.yaml
@@ -21,10 +21,10 @@ paths:
   /api/attack_discovery/_bulk:
     post:
       description: >-
-        Performs bulk updates on multiple Attack discovery alerts, including
-        workflow status changes and visibility settings. This endpoint allows
-        efficient batch processing of alert modifications without requiring
-        individual API calls for each alert. `Technical preview`
+        Performs bulk updates on multiple Attack discoveries, including workflow
+        status changes and visibility settings. This endpoint allows efficient
+        batch processing of alert modifications without requiring individual API
+        calls for each alert. `Technical preview`
       operationId: PostAttackDiscoveryBulk
       requestBody:
         content:
@@ -92,7 +92,7 @@ paths:
                     - ids
               required:
                 - update
-        description: Bulk update parameters for Attack discovery alerts
+        description: Bulk update parameters for Attack discoveries
         required: true
       responses:
         '200':
@@ -137,7 +137,7 @@ paths:
                   - error
                   - message
           description: Generic Error
-      summary: Bulk update Attack discovery alerts
+      summary: Bulk update Attack discoveries
       tags:
         - Security Attack discovery API
       x-code-samples:
@@ -161,7 +161,7 @@ paths:
   /api/attack_discovery/_find:
     get:
       description: >-
-        Finds Attack discoveries that match the search criteria. Supports free
+        Find Attack discoveries that match the search criteria. Supports free
         text search, filtering, pagination, and sorting. `Technical preview`
       operationId: AttackDiscoveryFind
       parameters:
@@ -397,7 +397,7 @@ paths:
                     example: 400
                     type: number
           description: Generic Error
-      summary: Finds Attack discoveries that match the search criteria
+      summary: Find Attack discoveries that match the search criteria
       tags:
         - Security Attack discovery API
       x-code-samples:
@@ -474,7 +474,6 @@ paths:
              --request POST 'http://localhost:5601/api/attack_discovery/_generate' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json" \
-             --header "elastic-api-version: 2023-10-31" \
              --data '{
                 "alertsIndexPattern": ".alerts-security.alerts-default",
                 "anonymizationFields": [
@@ -1412,10 +1411,10 @@ paths:
   /api/attack_discovery/generations:
     get:
       description: >-
-        Get the latest attack discovery generations (that are not dismissed) for
-        the current user. This endpoint retrieves generation metadata including
-        execution status and statistics for Attack discovery generations.
-        `Technical preview`
+        Get the latest attack discovery generations metadata (that are not
+        dismissed) for the current user. This endpoint retrieves generation
+        metadata including execution status and statistics for Attack discovery
+        generations. `Technical preview`
       operationId: GetAttackDiscoveryGenerations
       parameters:
         - description: >-
@@ -1480,8 +1479,8 @@ paths:
                     type: number
           description: Bad request
       summary: >-
-        Get the latest attack discovery generations (that are not dismissed) for
-        the current user
+        Get the latest attack discovery generations metadata for the current
+        user
       tags:
         - Security Attack discovery API
       x-code-samples:
@@ -1772,7 +1771,7 @@ paths:
               enabled: true
               name: Daily Security Analysis
               params:
-                alerts_index_pattern: .alerts-security.alerts-*
+                alerts_index_pattern: .alerts-security.alerts-default
                 api_config:
                   actionTypeId: bedrock
                   connectorId: my-bedrock-connector
@@ -1800,7 +1799,7 @@ paths:
                 id: 12345678-1234-1234-1234-123456789012
                 name: Daily Security Analysis
                 params:
-                  alerts_index_pattern: .alerts-security.alerts-*
+                  alerts_index_pattern: .alerts-security.alerts-default
                   api_config:
                     actionTypeId: bedrock
                     connectorId: my-bedrock-connector
@@ -1840,7 +1839,7 @@ paths:
                "name": "Daily Security Analysis",
                "enabled": true,
                "params": {
-                 "alerts_index_pattern": ".alerts-security.alerts-*",
+                 "alerts_index_pattern": ".alerts-security.alerts-default",
                  "api_config": {
                    "actionTypeId": "bedrock",
                    "connectorId": "my-bedrock-connector",
@@ -1853,7 +1852,22 @@ paths:
                "schedule": {
                  "interval": "24h"
                },
-               "actions": []
+               "actions": [
+                  {
+                     "action_type_id": ".cases",
+                     "id": "system-connector-.cases",
+                     "params": {
+                       "subAction": "run",
+                       "subActionParams": {
+                         "timeWindow": "7d",
+                         "reopenClosedCases": false,
+                         "groupingBy": [],
+                         "templateId": null
+                       }
+                     },
+                     "uuid": "12345678-1234-1234-1234-123456789012"
+                   }
+               ]
              }'
       x-state: Technical Preview; added in 9.2.0
   /api/attack_discovery/schedules/_find:
@@ -1956,7 +1970,7 @@ paths:
           lang: curl
           source: |
             curl \
-             --request GET 'http://localhost:5601/api/attack_discovery/schedules/_find?page=1&per_page=10&sort_field=name&sort_direction=asc' \
+             --request GET 'http://localhost:5601/api/attack_discovery/schedules/_find' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-state: Technical Preview; added in 9.2.0
@@ -2051,7 +2065,7 @@ paths:
                   status: ok
                 name: Daily Security Analysis
                 params:
-                  alerts_index_pattern: .alerts-security.alerts-*
+                  alerts_index_pattern: .alerts-security.alerts-default
                   api_config:
                     actionTypeId: bedrock
                     connectorId: my-bedrock-connector
@@ -2115,7 +2129,7 @@ paths:
               actions: []
               name: Updated Daily Security Analysis
               params:
-                alerts_index_pattern: .alerts-security.alerts-*
+                alerts_index_pattern: .alerts-security.alerts-default
                 api_config:
                   actionTypeId: bedrock
                   connectorId: my-bedrock-connector
@@ -2143,7 +2157,7 @@ paths:
                 id: 12345678-1234-1234-1234-123456789012
                 name: Updated Daily Security Analysis
                 params:
-                  alerts_index_pattern: .alerts-security.alerts-*
+                  alerts_index_pattern: .alerts-security.alerts-default
                   api_config:
                     actionTypeId: bedrock
                     connectorId: my-bedrock-connector
@@ -2184,7 +2198,7 @@ paths:
              --data '{
                "name": "Updated Daily Security Analysis",
                "params": {
-                 "alerts_index_pattern": ".alerts-security.alerts-*",
+                 "alerts_index_pattern": ".alerts-security.alerts-default",
                  "api_config": {
                    "actionTypeId": "bedrock",
                    "connectorId": "my-bedrock-connector",
@@ -2201,7 +2215,7 @@ paths:
              }'
       x-state: Technical Preview; added in 9.2.0
   /api/attack_discovery/schedules/{id}/_disable:
-    put:
+    post:
       description: >-
         Disables an Attack discovery schedule, preventing it from running
         according to its configured interval. The schedule configuration is
@@ -2257,12 +2271,12 @@ paths:
           lang: curl
           source: |
             curl \
-             --request PUT 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_disable' \
+             --request POST 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_disable' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-state: Technical Preview; added in 9.2.0
   /api/attack_discovery/schedules/{id}/_enable:
-    put:
+    post:
       description: >-
         Enables a previously disabled Attack discovery schedule, allowing it to
         run according to its configured interval. Once enabled, the schedule
@@ -2317,7 +2331,7 @@ paths:
           lang: curl
           source: |
             curl \
-             --request PUT 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_enable' \
+             --request POST 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_enable' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-state: Technical Preview; added in 9.2.0

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/find_attack_discoveries_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/find_attack_discoveries_route.schema.yaml
@@ -17,8 +17,8 @@ paths:
       x-labels: [ess, serverless]
       operationId: AttackDiscoveryFind
       x-state: Technical Preview; added in 9.2.0
-      summary: Finds Attack discoveries that match the search criteria
-      description: Finds Attack discoveries that match the search criteria. Supports free text search, filtering, pagination, and sorting. `Technical preview`
+      summary: Find Attack discoveries that match the search criteria
+      description: Find Attack discoveries that match the search criteria. Supports free text search, filtering, pagination, and sorting. `Technical preview`
       parameters:
         - name: 'alert_ids'
           description: Filter results to Attack discoveries that include any of the provided alert IDs

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/get_attack_discovery_generations_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/get_attack_discovery_generations_route.schema.yaml
@@ -17,8 +17,8 @@ paths:
       x-labels: [ess, serverless]
       operationId: GetAttackDiscoveryGenerations
       x-state: Technical Preview; added in 9.2.0
-      description: Get the latest attack discovery generations (that are not dismissed) for the current user. This endpoint retrieves generation metadata including execution status and statistics for Attack discovery generations. `Technical preview`
-      summary: Get the latest attack discovery generations (that are not dismissed) for the current user
+      description: Get the latest attack discovery generations metadata (that are not dismissed) for the current user. This endpoint retrieves generation metadata including execution status and statistics for Attack discovery generations. `Technical preview`
+      summary: Get the latest attack discovery generations metadata for the current user
       parameters:
         - name: end
           in: query

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/post/post_attack_discovery_bulk_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/post/post_attack_discovery_bulk_route.schema.yaml
@@ -26,10 +26,10 @@ paths:
       x-labels: [ess, serverless]
       operationId: PostAttackDiscoveryBulk
       x-state: Technical Preview; added in 9.2.0
-      summary: Bulk update Attack discovery alerts
-      description: Performs bulk updates on multiple Attack discovery alerts, including workflow status changes and visibility settings. This endpoint allows efficient batch processing of alert modifications without requiring individual API calls for each alert. `Technical preview`
+      summary: Bulk update Attack discoveries
+      description: Performs bulk updates on multiple Attack discoveries, including workflow status changes and visibility settings. This endpoint allows efficient batch processing of alert modifications without requiring individual API calls for each alert. `Technical preview`
       requestBody:
-        description: Bulk update parameters for Attack discovery alerts
+        description: Bulk update parameters for Attack discoveries
         required: true
         content:
           application/json:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/post/post_attack_discovery_generate.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/post/post_attack_discovery_generate.schema.yaml
@@ -14,7 +14,6 @@ paths:
              --request POST 'http://localhost:5601/api/attack_discovery/_generate' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json" \
-             --header "elastic-api-version: 2023-10-31" \
              --data '{
                 "alertsIndexPattern": ".alerts-security.alerts-default",
                 "anonymizationFields": [

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/crud_attack_discovery_schedules_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/crud_attack_discovery_schedules_route.schema.yaml
@@ -55,7 +55,22 @@ paths:
                "schedule": {
                  "interval": "24h"
                },
-               "actions": []
+               "actions": [
+                  {
+                     "action_type_id": ".cases",
+                     "id": "system-connector-.cases",
+                     "params": {
+                       "subAction": "run",
+                       "subActionParams": {
+                         "timeWindow": "7d",
+                         "reopenClosedCases": false,
+                         "groupingBy": [],
+                         "templateId": null
+                       }
+                     },
+                     "uuid": "12345678-1234-1234-1234-123456789012"
+                   }
+               ]
              }'
       x-labels: [ess, serverless]
       operationId: CreateAttackDiscoverySchedules

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/crud_attack_discovery_schedules_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/crud_attack_discovery_schedules_route.schema.yaml
@@ -42,7 +42,7 @@ paths:
                "name": "Daily Security Analysis",
                "enabled": true,
                "params": {
-                 "alerts_index_pattern": ".alerts-security.alerts-*",
+                 "alerts_index_pattern": ".alerts-security.alerts-default",
                  "api_config": {
                    "actionTypeId": "bedrock",
                    "connectorId": "my-bedrock-connector",
@@ -73,7 +73,7 @@ paths:
               name: "Daily Security Analysis"
               enabled: true
               params:
-                alerts_index_pattern: ".alerts-security.alerts-*"
+                alerts_index_pattern: ".alerts-security.alerts-default"
                 api_config:
                   actionTypeId: "bedrock"
                   connectorId: "my-bedrock-connector"
@@ -100,7 +100,7 @@ paths:
                 updated_at: "2023-10-31T10:00:00.000Z"
                 enabled: true
                 params:
-                  alerts_index_pattern: ".alerts-security.alerts-*"
+                  alerts_index_pattern: ".alerts-security.alerts-default"
                   api_config:
                     actionTypeId: "bedrock"
                     connectorId: "my-bedrock-connector"
@@ -162,7 +162,7 @@ paths:
                 updated_at: "2023-10-31T10:00:00.000Z"
                 enabled: true
                 params:
-                  alerts_index_pattern: ".alerts-security.alerts-*"
+                  alerts_index_pattern: ".alerts-security.alerts-default"
                   api_config:
                     actionTypeId: "bedrock"
                     connectorId: "my-bedrock-connector"
@@ -200,7 +200,7 @@ paths:
              --data '{
                "name": "Updated Daily Security Analysis",
                "params": {
-                 "alerts_index_pattern": ".alerts-security.alerts-*",
+                 "alerts_index_pattern": ".alerts-security.alerts-default",
                  "api_config": {
                    "actionTypeId": "bedrock",
                    "connectorId": "my-bedrock-connector",
@@ -238,7 +238,7 @@ paths:
             example:
               name: "Updated Daily Security Analysis"
               params:
-                alerts_index_pattern: ".alerts-security.alerts-*"
+                alerts_index_pattern: ".alerts-security.alerts-default"
                 api_config:
                   actionTypeId: "bedrock"
                   connectorId: "my-bedrock-connector"
@@ -265,7 +265,7 @@ paths:
                 updated_at: "2023-10-31T12:00:00.000Z"
                 enabled: true
                 params:
-                  alerts_index_pattern: ".alerts-security.alerts-*"
+                  alerts_index_pattern: ".alerts-security.alerts-default"
                   api_config:
                     actionTypeId: "bedrock"
                     connectorId: "my-bedrock-connector"
@@ -336,14 +336,14 @@ paths:
                 message: "Invalid request parameters"
 
   /api/attack_discovery/schedules/{id}/_enable:
-    put:
+    post:
       x-codegen-enabled: true
       x-code-samples:
         - lang: curl
           label: Enable an Attack discovery schedule
           source: |
             curl \
-             --request PUT 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_enable' \
+             --request POST 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_enable' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-labels: [ess, serverless]
@@ -386,14 +386,14 @@ paths:
                 message: "Invalid request parameters"
 
   /api/attack_discovery/schedules/{id}/_disable:
-    put:
+    post:
       x-codegen-enabled: true
       x-code-samples:
         - lang: curl
           label: Disable an Attack discovery schedule
           source: |
             curl \
-             --request PUT 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_disable' \
+             --request POST 'http://localhost:5601/api/attack_discovery/schedules/12345678-1234-1234-1234-123456789012/_disable' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-labels: [ess, serverless]

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/get/find_attack_discovery_schedules_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/get/find_attack_discovery_schedules_route.schema.yaml
@@ -11,7 +11,7 @@ paths:
           label: Example request
           source: |
             curl \
-             --request GET 'http://localhost:5601/api/attack_discovery/schedules/_find?page=1&per_page=10&sort_field=name&sort_direction=asc' \
+             --request GET 'http://localhost:5601/api/attack_discovery/schedules/_find' \
              --header "Authorization: $API_KEY" \
              --header "Content-Type: application/json"
       x-labels: [ess, serverless]


### PR DESCRIPTION
## [Attack discovery] Additional Attack discovery API docs updates

This PR includes additional updates to the [Security Attack discovery](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-security-attack-discovery-api) API documentation, for the public [Attack discovery and Attack discovery schedules public APIs](https://github.com/elastic/kibana/pull/236736).

### Summary of updates

- Changed routes and examples for enabling/disabling schedules from `PUT` to `POST`
- Improved descriptions for clarity and brevity
- Replaced example index patterns with a specific (default) index to make the examples more concrete
- Removed query parameters from some examples


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->