### PR TITLE
[ES|QL] Removes unsupported example from settings

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/set/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/set/index.ts
@@ -23,11 +23,7 @@ export const setCommand = {
       defaultMessage: 'Sets a query setting',
     }),
     declaration: `SET <setting> = <value>`,
-    examples: [
-      'SET project_routing = "_alias:_origin";',
-      'SET project_routing = "_alias: *";',
-      'SET project_routing = "_alias:* AND NOT _alias:_origin";',
-    ],
+    examples: ['SET project_routing = "_alias:_origin";', 'SET project_routing = "_alias: *";'],
     hidden: process.env.NODE_ENV === 'test' ? false : true, // Temporary until making it GA
     preview: true,
     name: 'set',


### PR DESCRIPTION
## Summary

AND / OR logic won't be supported on the tech preview so I am removing here the unsupported example

