### PR TITLE
[Ingest Pipelines] Fix filter button focus behavior in pipelines table

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/table.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/table.tsx
@@ -26,7 +26,6 @@ import {
   EuiPopover,
   EuiBetaBadge,
   EuiToolTip,
-  EuiFilterGroup,
   EuiSelectable,
   EuiFilterButton,
   EuiFlexGroup,
@@ -107,6 +106,62 @@ export function deserializeFilterOptions(options: FilterQueryParams) {
 function isDefaultFilterOptions(options: FilterQueryParams) {
   return options.managed === 'unset' && options.deprecated === 'off';
 }
+
+interface PipelineFilterComponentProps {
+  filterOptions: EuiSelectableOption[];
+  setFilterOptions: (options: EuiSelectableOption[]) => void;
+}
+
+const PipelineFilterComponent = ({
+  filterOptions,
+  setFilterOptions,
+}: PipelineFilterComponentProps) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  const onButtonClick = () => {
+    setIsPopoverOpen((prev) => !prev);
+  };
+
+  const closePopover = () => {
+    setIsPopoverOpen(false);
+  };
+
+  return (
+    <EuiPopover
+      id="popoverID"
+      button={
+        <EuiFilterButton
+          iconType="arrowDown"
+          badgeColor="success"
+          data-test-subj="filtersDropdown"
+          onClick={onButtonClick}
+          isSelected={isPopoverOpen}
+          numFilters={filterOptions.filter((item) => item.checked !== 'off').length}
+          hasActiveFilters={!!filterOptions.find((item) => item.checked === 'on')}
+          numActiveFilters={filterOptions.filter((item) => item.checked === 'on').length}
+        >
+          {i18n.translate('xpack.ingestPipelines.list.table.filtersButtonLabel', {
+            defaultMessage: 'Filters',
+          })}
+        </EuiFilterButton>
+      }
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+    >
+      <EuiSelectable
+        allowExclusions
+        aria-label={i18n.translate('xpack.ingestPipelines.list.table.filtersAriaLabel', {
+          defaultMessage: 'Filters',
+        })}
+        options={filterOptions as EuiSelectableOption[]}
+        onChange={setFilterOptions}
+      >
+        {(list) => <div style={{ width: 300 }}>{list}</div>}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+};
 
 export const PipelineTable: FunctionComponent<Props> = ({
   pipelines,
@@ -193,31 +248,6 @@ export const PipelineTable: FunctionComponent<Props> = ({
     }
   }, [history, queryText, filterOptions]);
 
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  const onButtonClick = () => {
-    setIsPopoverOpen(!isPopoverOpen);
-  };
-  const closePopover = () => {
-    setIsPopoverOpen(false);
-  };
-
-  const button = (
-    <EuiFilterButton
-      iconType="arrowDown"
-      badgeColor="success"
-      data-test-subj="filtersDropdown"
-      onClick={onButtonClick}
-      isSelected={isPopoverOpen}
-      numFilters={filterOptions.filter((item) => item.checked !== 'off').length}
-      hasActiveFilters={!!filterOptions.find((item) => item.checked === 'on')}
-      numActiveFilters={filterOptions.filter((item) => item.checked === 'on').length}
-    >
-      {i18n.translate('xpack.ingestPipelines.list.table.filtersButtonLabel', {
-        defaultMessage: 'Filters',
-      })}
-    </EuiFilterButton>
-  );
-
   const tableProps: EuiInMemoryTableProps<Pipeline> = {
     itemId: 'name',
     'data-test-subj': 'pipelinesTable',
@@ -277,29 +307,10 @@ export const PipelineTable: FunctionComponent<Props> = ({
           type: 'custom_component',
           component: () => {
             return (
-              <EuiFilterGroup>
-                <EuiPopover
-                  id="popoverID"
-                  button={button}
-                  isOpen={isPopoverOpen}
-                  closePopover={closePopover}
-                  panelPaddingSize="none"
-                >
-                  <EuiSelectable
-                    allowExclusions
-                    aria-label={i18n.translate(
-                      'xpack.ingestPipelines.list.table.filtersAriaLabel',
-                      {
-                        defaultMessage: 'Filters',
-                      }
-                    )}
-                    options={filterOptions as EuiSelectableOption[]}
-                    onChange={setFilterOptions}
-                  >
-                    {(list) => <div style={{ width: 300 }}>{list}</div>}
-                  </EuiSelectable>
-                </EuiPopover>
-              </EuiFilterGroup>
+              <PipelineFilterComponent
+                filterOptions={filterOptions}
+                setFilterOptions={setFilterOptions}
+              />
             );
           },
         },


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/217801

This PR fixes an issue with keyboard navigation focus for filter button in pipelines table.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->