### PR TITLE
[Discover] Fix aborted and recovered histogram

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.tsx
@@ -182,6 +182,11 @@ export function UnifiedHistogramChart({
         | undefined;
       const response = json?.rawResponse;
 
+      if (response && !Object.keys(response).length) {
+        // it was aborted
+        return;
+      }
+
       if (requestFailed) {
         onTotalHitsChange?.(UnifiedHistogramFetchStatus.error, undefined);
         onChartLoad?.({ adapters: adapters ?? {} });

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import type { AggregateQuery, Query } from '@kbn/es-query';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { FetchStatus } from '../../../types';
 import type { DiscoverStateContainer } from '../../state_management/discover_state';
@@ -438,7 +438,9 @@ describe('useDiscoverHistogram', () => {
       act(() => {
         savedSearchFetch$.next();
       });
-      expect(api.fetch).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(api.fetch).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
@@ -280,7 +280,9 @@ export const useDiscoverHistogram = (
         esqlFetchComplete$.pipe(map(() => 'discover'))
       ).pipe(debounceTime(50));
     } else {
-      fetchChart$ = stateContainer.dataState.fetchChart$.pipe(map(() => 'discover'));
+      fetchChart$ = stateContainer.dataState.fetchChart$
+        .pipe(map(() => 'discover'))
+        .pipe(debounceTime(50)); // wait until new props are applied to the unified histogram including the new abort controller
     }
 
     const subscription = fetchChart$.subscribe((source) => {

--- a/src/platform/test/functional/apps/discover/group10/_lens_vis.ts
+++ b/src/platform/test/functional/apps/discover/group10/_lens_vis.ts
@@ -17,6 +17,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const monacoEditor = getService('monacoEditor');
   const browser = getService('browser');
   const dataViews = getService('dataViews');
+  const filterBar = getService('filterBar');
+  const retry = getService('retry');
   const { common, discover, header, timePicker } = getPageObjects([
     'common',
     'discover',
@@ -665,6 +667,54 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(await discover.getCurrentVisTitle()).to.be('Treemap');
       await testSubjects.existOrFail('partitionVisChart');
       expect(await discover.getVisContextSuggestionType()).to.be('lensSuggestion');
+    });
+
+    it('should be able to recover after a request was previously aborted', async () => {
+      const reducedTimeRange = {
+        from: 'Sep 20, 2015 @ 00:00:00.000',
+        to: 'Sep 20, 2015 @ 23:50:13.253',
+      };
+      const reducedTimeSpan = `${reducedTimeRange.from} - ${reducedTimeRange.to} (interval: Auto - 30 minutes)`;
+      const reducedTotalCount = '4,756';
+
+      // add a shorter time range to the recently used list in the time picker
+      await timePicker.setAbsoluteRange(reducedTimeRange.from, reducedTimeRange.to);
+      await discover.waitUntilTabIsLoaded();
+
+      // go back to default time range
+      await timePicker.setDefaultAbsoluteRange();
+      await checkHistogramVis(defaultTimespan, defaultTotalCount);
+
+      // trigger the first request
+      await filterBar.addDslFilter(
+        JSON.stringify({
+          error_query: {
+            indices: [
+              {
+                error_type: 'warning',
+                message: "'Fake slow request'",
+                name: '*',
+                stall_time_seconds: 15,
+              },
+            ],
+          },
+        }),
+        false
+      );
+
+      // wait a moment to ensure the request is in flight
+      await retry.waitFor('loading state', async () => {
+        return (
+          (await header.isGlobalLoadingIndicatorVisible()) && (await discover.isDataGridUpdating())
+        );
+      });
+
+      // by changing the time range it should abort the previous request, fire a new one and recover from the aborted state
+      await timePicker.setRecentlyUsedTime(`${reducedTimeRange.from} to ${reducedTimeRange.to}`);
+
+      await retry.try(async () => {
+        await checkHistogramVis(reducedTimeSpan, reducedTotalCount);
+      });
     });
   });
 }

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -113,10 +113,15 @@ export class DiscoverPageObject extends FtrService {
     await this.testSubjects.click('addFilter');
   }
 
+  public async isDataGridUpdating() {
+    return await this.testSubjects.exists('discoverDataGridUpdating');
+  }
+
   public async waitUntilSearchingHasFinished() {
     await this.testSubjects.missingOrFail('loadingSpinner', {
       timeout: this.defaultFindTimeout * 10,
     });
+    // FIXME: extend with discoverDataGridUpdating in a future PR
   }
 
   public async waitUntilTabIsLoaded() {

--- a/src/platform/test/functional/page_objects/time_picker.ts
+++ b/src/platform/test/functional/page_objects/time_picker.ts
@@ -100,6 +100,24 @@ export class TimePickerPageObject extends FtrService {
     await this.testSubjects.click(`superDatePickerCommonlyUsed_${option}`);
   }
 
+  /**
+   * Sets recently used time (including custom ranges)
+   * @param option custom recent time range
+   */
+  async setRecentlyUsedTime(option: string) {
+    await this.testSubjects.exists('superDatePickerToggleQuickMenuButton', { timeout: 5000 });
+    await this.testSubjects.click('superDatePickerToggleQuickMenuButton');
+    const panel = await this.testSubjects.find('superDatePickerQuickMenu');
+    const allOptions = await panel.findAllByCssSelector('button');
+    for (const optionElement of allOptions) {
+      const optionText = await optionElement.getVisibleText();
+      if (optionText.includes(option)) {
+        await optionElement.click();
+        break;
+      }
+    }
+  }
+
   public async inputValue(dataTestSubj: string, value: string) {
     if (this.browser.isFirefox) {
       const input = await this.testSubjects.find(dataTestSubj);


### PR DESCRIPTION
- Fixes https://github.com/elastic/kibana/issues/239564

## Summary

This PR fixes a race condition: `fetchChart$` triggers a new fetch and we need to make sure that the histogram gets a reference to the new abort controller instead of the already aborted one.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



