### PR TITLE
fix: variable validation on step names with spaces or CamelCase

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/lib/generate_yaml_schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/generate_yaml_schema.ts
@@ -293,5 +293,7 @@ function fixBrokenSchemaReferencesAndEnforceStrictValidation(schema: any): any {
 }
 
 export function getStepId(stepName: string): string {
-  return stepName.toLowerCase().replace(/\s+/g, '-');
+  // Using step name as is, don't do any escaping to match the workflow engine behavior
+  // Leaving this function in case we'd to change behaviour in future.
+  return stepName;
 }

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_steps_collection_schema.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_steps_collection_schema.test.ts
@@ -104,4 +104,69 @@ describe('getStepsCollectionSchema', () => {
     expect(step1Schema.shape.output._def.typeName).toBe('ZodOptional');
     expect(step1Schema.shape.error._def.typeName).toBe('ZodOptional');
   });
+
+  it('should use step names as is', () => {
+    const definition = {
+      version: '1' as const,
+      name: 'Weird Step Names',
+      enabled: true,
+      triggers: [
+        {
+          type: 'manual' as const,
+          enabled: true,
+        },
+      ],
+      steps: [
+        {
+          name: 'Step with spaces',
+          type: 'console',
+          with: {
+            message: 'Hello, world!',
+          },
+        },
+        {
+          name: 'CamelCaseStep',
+          type: 'console',
+          with: {
+            message: 'Hello, world!',
+          },
+        },
+        {
+          name: '$pecial*$ymb0l$',
+          type: 'console',
+          with: {
+            message: 'Hello, world!',
+          },
+        },
+        {
+          name: 'point-of-access',
+          type: 'console',
+          with: {
+            message: 'Hello, world!',
+          },
+        },
+      ],
+    };
+    const workflowGraph = WorkflowGraph.fromWorkflowDefinition(definition);
+    const stepsCollectionSchema = getStepsCollectionSchema(
+      DynamicStepContextSchema,
+      workflowGraph,
+      'point-of-access'
+    );
+
+    expect(stepsCollectionSchema).toBeDefined();
+    expect((stepsCollectionSchema.shape as any)['Step with spaces']).toBeDefined();
+    expect((stepsCollectionSchema.shape as any).CamelCaseStep).toBeDefined();
+    expect((stepsCollectionSchema.shape as any)['$pecial*$ymb0l$']).toBeDefined();
+
+    expect(() =>
+      getStepsCollectionSchema(DynamicStepContextSchema, workflowGraph, 'Step with spaces')
+    ).not.toThrow();
+    expect(() =>
+      getStepsCollectionSchema(DynamicStepContextSchema, workflowGraph, 'CamelCaseStep')
+    ).not.toThrow();
+    expect(() =>
+      getStepsCollectionSchema(DynamicStepContextSchema, workflowGraph, '$pecial*$ymb0l$')
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
Close https://github.com/elastic/security-team/issues/14292

## Before
Variable validation failed with error "Failed to get context schema for path" if the step name inside we access variable contains spaces or upper case. 

<img width="1624" height="1056" alt="Screenshot 2025-10-20 at 14 52 58" src="https://github.com/user-attachments/assets/89f74d5c-3a63-49e5-8d1f-707c72f9ccb1" />

Reason: The `getStepId` function used in `getStepsCollectionSchema` https://github.com/Kiryous/kibana/blob/0e74390fc457cafbeeb0d0e9a76a848022341604/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_steps_collection_schema.ts#L22 used to replace spaces with underscores and convert all chars to lowercase.


## After

<img width="1624" height="1056" alt="Screenshot 2025-10-20 at 15 02 12" src="https://github.com/user-attachments/assets/5b98506d-59f3-43f0-8ad0-6812b5df3f10" />

Step names used as is.

