### PR TITLE
[ObsUX][Infra] Hide filtering capabilities in Hosts Metrics

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/host_charts.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/host_charts.tsx
@@ -109,6 +109,7 @@ export const HostCharts = React.forwardRef<HTMLDivElement, Props>(
               dataView={dataView}
               lensAttributes={chart}
               queryField={findInventoryFields('host').id}
+              overrides={{ settings: { legendAction: 'ignore' } }}
             />
           ))}
         </ChartsGrid>


### PR DESCRIPTION
## Summary

Removes the filtering capabilities in lens since this is on the individual host view, there's no filtering possible.
You can still select one item from the legend to view only that one, this was working and will continue as it is.

### Before
![cleanshot_2025-10-17_at_14 22 30](https://github.com/user-attachments/assets/267c8681-48cf-437d-b49c-ce5996bf1aa7)

### After
<img width="311" height="386" alt="image" src="https://github.com/user-attachments/assets/f1fd5b91-987f-4b2f-9fd4-ca72f5c35336" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->