### PR TITLE
[Fleet] Fix download agent policy privileges

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -17400,7 +17400,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/download": {
       "get": {
-        "description": "Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-download",
         "parameters": [
           {
@@ -31033,7 +31033,7 @@
     },
     "/api/fleet/kubernetes": {
       "get": {
-        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-kubernetes",
         "parameters": [
           {
@@ -31119,7 +31119,7 @@
     },
     "/api/fleet/kubernetes/download": {
       "get": {
-        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-kubernetes-download",
         "parameters": [
           {

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -17400,7 +17400,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/download": {
       "get": {
-        "description": "Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-download",
         "parameters": [
           {
@@ -31033,7 +31033,7 @@
     },
     "/api/fleet/kubernetes": {
       "get": {
-        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-kubernetes",
         "parameters": [
           {
@@ -31119,7 +31119,7 @@
     },
     "/api/fleet/kubernetes/download": {
       "get": {
-        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-kubernetes-download",
         "parameters": [
           {

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -24037,7 +24037,7 @@ paths:
           name: product_name
   /api/fleet/agent_policies/{agentPolicyId}/download:
     get:
-      description: 'Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.'
+      description: 'Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.'
       operationId: get-fleet-agent-policies-agentpolicyid-download
       parameters:
         - in: path
@@ -33551,7 +33551,7 @@ paths:
           name: product_name
   /api/fleet/kubernetes:
     get:
-      description: '[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.'
       operationId: get-fleet-kubernetes
       parameters:
         - in: query
@@ -33609,7 +33609,7 @@ paths:
           name: product_name
   /api/fleet/kubernetes/download:
     get:
-      description: '[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.'
       operationId: get-fleet-kubernetes-download
       parameters:
         - in: query

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/index.ts
@@ -426,8 +426,9 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       security: {
         authz: {
           requiredPrivileges: [
-            FLEET_API_PRIVILEGES.AGENT_POLICIES.READ,
-            FLEET_API_PRIVILEGES.SETUP,
+            {
+              anyRequired: [FLEET_API_PRIVILEGES.AGENT_POLICIES.READ, FLEET_API_PRIVILEGES.SETUP],
+            },
           ],
         },
       },
@@ -466,8 +467,9 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       security: {
         authz: {
           requiredPrivileges: [
-            FLEET_API_PRIVILEGES.AGENT_POLICIES.READ,
-            FLEET_API_PRIVILEGES.SETUP,
+            {
+              anyRequired: [FLEET_API_PRIVILEGES.AGENT_POLICIES.READ, FLEET_API_PRIVILEGES.SETUP],
+            },
           ],
         },
       },
@@ -501,8 +503,9 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       security: {
         authz: {
           requiredPrivileges: [
-            FLEET_API_PRIVILEGES.AGENT_POLICIES.READ,
-            FLEET_API_PRIVILEGES.SETUP,
+            {
+              anyRequired: [FLEET_API_PRIVILEGES.AGENT_POLICIES.READ, FLEET_API_PRIVILEGES.SETUP],
+            },
           ],
         },
       },

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/privileges.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/privileges.ts
@@ -163,6 +163,27 @@ export default function (providerContext: FtrProviderContext) {
       scenarios: READ_SCENARIOS,
     },
     {
+      method: 'GET',
+      path: '/api/fleet/agent_policies/policy-test-privileges-1/download',
+      scenarios: READ_SCENARIOS.filter(
+        (scenario) => scenario.user.username !== testUsers.fleet_agents_read_only.username
+      ),
+    },
+    {
+      method: 'GET',
+      path: '/api/fleet/kubernetes',
+      scenarios: READ_SCENARIOS.filter(
+        (scenario) => scenario.user.username !== testUsers.fleet_agents_read_only.username
+      ),
+    },
+    {
+      method: 'GET',
+      path: '/api/fleet/kubernetes/download',
+      scenarios: READ_SCENARIOS.filter(
+        (scenario) => scenario.user.username !== testUsers.fleet_agents_read_only.username
+      ),
+    },
+    {
       method: 'POST',
       path: '/api/fleet/agent_policies/_bulk_get',
       scenarios: READ_SCENARIOS,


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/239155

When moving to Kibana authz privileges a typo was made, on the download agent policy API endpoints, requiring both setup and agent policy READ permissions instead of any of them. that PR fix that and add missing API integration tests that would have catch that.

<!--ONMERGE {"backportTargets":["8.19","9.2"]} ONMERGE-->