### PR TITLE
[EDR Workflows][Device Control] Add trusted_devices_all feature to osquery roles

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/lib/kibana_roles/project_controller_security_roles.yml
+++ b/x-pack/platform/plugins/shared/osquery/cypress/lib/kibana_roles/project_controller_security_roles.yml
@@ -126,6 +126,7 @@ editor:
         - feature_siemV3.endpoint_list_all
         - feature_siemV3.global_artifact_management_all
         - feature_siemV3.trusted_applications_all
+        - feature_siemV3.trusted_devices_all
         - feature_siemV3.event_filters_all
         - feature_siemV3.host_isolation_exceptions_all
         - feature_siemV3.blocklist_all
@@ -322,6 +323,7 @@ t3_analyst:
         - feature_siemV3.endpoint_list_all
         - feature_siemV3.global_artifact_management_all
         - feature_siemV3.trusted_applications_all
+        - feature_siemV3.trusted_devices_all
         - feature_siemV3.event_filters_all
         - feature_siemV3.host_isolation_exceptions_all
         - feature_siemV3.blocklist_all
@@ -470,6 +472,7 @@ rule_author:
         - feature_siemV3.endpoint_list_all
         - feature_siemV3.global_artifact_management_all
         - feature_siemV3.trusted_applications_all
+        - feature_siemV3.trusted_devices_all
         - feature_siemV3.event_filters_all
         - feature_siemV3.host_isolation_exceptions_read
         - feature_siemV3.blocklist_all # Elastic Defend Policy Management
@@ -550,6 +553,7 @@ soc_manager:
         - feature_siemV3.endpoint_list_all
         - feature_siemV3.global_artifact_management_all
         - feature_siemV3.trusted_applications_all
+        - feature_siemV3.trusted_devices_all
         - feature_siemV3.event_filters_all
         - feature_siemV3.host_isolation_exceptions_all
         - feature_siemV3.blocklist_all
@@ -695,6 +699,7 @@ platform_engineer:
         - feature_siemV3.endpoint_list_all
         - feature_siemV3.global_artifact_management_all
         - feature_siemV3.trusted_applications_all
+        - feature_siemV3.trusted_devices_all
         - feature_siemV3.event_filters_all
         - feature_siemV3.host_isolation_exceptions_all
         - feature_siemV3.blocklist_all # Elastic Defend Policy Management
@@ -772,6 +777,7 @@ endpoint_operations_analyst:
         - feature_siemV3.endpoint_list_all
         - feature_siemV3.global_artifact_management_all
         - feature_siemV3.trusted_applications_all
+        - feature_siemV3.trusted_devices_all
         - feature_siemV3.event_filters_all
         - feature_siemV3.host_isolation_exceptions_all
         - feature_siemV3.blocklist_all
@@ -855,6 +861,7 @@ endpoint_policy_manager:
         - feature_siemV3.endpoint_list_all
         - feature_siemV3.global_artifact_management_all
         - feature_siemV3.trusted_applications_all
+        - feature_siemV3.trusted_devices_all
         - feature_siemV3.event_filters_all
         - feature_siemV3.host_isolation_exceptions_all
         - feature_siemV3.blocklist_all # Elastic Defend Policy Management


### PR DESCRIPTION
All other project controller roles files already have properly extended roles to include `trusted_devices_all`. It's redundant in this specific one, however, it should make future merges between these files easier. 

