### PR TITLE
[SharedUX] Replace feedback snippet positive footer icon

### DIFF
--- a/src/platform/packages/shared/shared-ux/feedback_snippet/src/__snapshots__/feedback_panel.test.tsx.snap
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/src/__snapshots__/feedback_panel.test.tsx.snap
@@ -93,10 +93,10 @@ exports[`FeedbackPanel renders with the expected inner components based on the f
     >
       <span
         color="success"
-        data-euiicon-type="faceHappy"
+        data-euiicon-type="thumbUp"
         data-test-subj="feedbackSnippetPanelPositiveIcon"
       >
-        Happy face
+        Thumb up
       </span>
     </div>
   </div>

--- a/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/feedback_snippet/src/feedback_panel.tsx
@@ -50,13 +50,6 @@ const thumbDownIconLabel = i18n.translate(
   }
 );
 
-const faceHappyIconLabel = i18n.translate(
-  'sharedUXPackages.feedbackSnippet.feedbackPanel.faceHappyIconLabel',
-  {
-    defaultMessage: 'Happy face',
-  }
-);
-
 /**
  * A panel to gather user feedback.
  * There are 3 available views:
@@ -139,10 +132,10 @@ export const FeedbackPanel = ({
     <EuiFlexItem grow={false}>
       <EuiIcon
         data-test-subj="feedbackSnippetPanelPositiveIcon"
-        type="faceHappy"
+        type="thumbUp"
         color="success"
         size="l"
-        aria-label={faceHappyIconLabel}
+        aria-label={thumbUpIconLabel}
       />
     </EuiFlexItem>
   );


### PR DESCRIPTION
## Summary

- Replaced `happyFace` icon with `thumbUp` one as suggested by @ek-so 

### Testing

<img width="238" height="125" alt="Screenshot 2025-10-20 at 16 30 20" src="https://github.com/user-attachments/assets/e4742e06-149a-413f-b4eb-282adea1ddbc" />




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->