### PR TITLE
[9.2] [ResponseOps][Rules] Ignore internal rule types when bulk editing rules (#236672)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_delete/bulk_delete_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_delete/bulk_delete_rules.test.ts
@@ -44,6 +44,7 @@ import { backfillClientMock } from '../../../../backfill_client/backfill_client.
 import { softDeleteGaps } from '../../../../lib/rule_gaps/soft_delete/soft_delete_gaps';
 import { eventLoggerMock } from '@kbn/event-log-plugin/server/event_logger.mock';
 import { eventLogClientMock } from '@kbn/event-log-plugin/server/event_log_client.mock';
+import { nodeBuilder, toKqlExpression } from '@kbn/es-query';
 
 jest.mock('../../../../lib/rule_gaps/soft_delete/soft_delete_gaps');
 
@@ -109,8 +110,8 @@ const getBulkOperationStatusErrorResponse = (statusCode: number) => ({
 });
 
 beforeEach(() => {
-  getBeforeSetup(rulesClientParams, taskManager, ruleTypeRegistry, eventLogClient);
   jest.clearAllMocks();
+  getBeforeSetup(rulesClientParams, taskManager, ruleTypeRegistry, eventLogClient);
 });
 
 setGlobalDate();
@@ -179,6 +180,13 @@ describe('bulkDelete', () => {
     actionsClient = (await rulesClientParams.getActionsClient()) as jest.Mocked<ActionsClient>;
     actionsClient.isSystemAction.mockImplementation((id: string) => id === 'system_action:id');
     rulesClientParams.getActionsClient.mockResolvedValue(actionsClient);
+
+    unsecuredSavedObjectsClient.bulkDelete.mockResolvedValue({
+      statuses: [
+        { id: 'id1', type: 'alert', success: true },
+        { id: 'id2', type: 'alert', success: true },
+      ],
+    });
   });
 
   test('should successfully delete two rule and return right actions', async () => {
@@ -625,6 +633,70 @@ describe('bulkDelete', () => {
 
       expect(auditLogger.log.mock.calls[0][0]?.event?.action).toEqual('rule_delete');
       expect(auditLogger.log.mock.calls[0][0]?.event?.outcome).toEqual('failure');
+    });
+  });
+
+  describe('internally managed rule types', () => {
+    beforeEach(() => {
+      ruleTypeRegistry.list.mockReturnValue(
+        // @ts-expect-error: not all args are required for this test
+        new Map([
+          ['test.internal-rule-type', { id: 'test.internal-rule-type', internallyManaged: true }],
+          [
+            'test.internal-rule-type-2',
+            { id: 'test.internal-rule-type-2', internallyManaged: true },
+          ],
+        ])
+      );
+
+      // @ts-expect-error: not all args are required for this test
+      authorization.getFindAuthorizationFilter.mockResolvedValue({
+        filter: nodeBuilder.and([
+          nodeBuilder.is('alert.attributes.alertTypeId', 'foo'),
+          nodeBuilder.is('alert.attributes.consumer', 'bar'),
+        ]),
+      });
+    });
+
+    it('should ignore updates to internally managed rule types by default and combine all filters correctly', async () => {
+      await rulesClient.bulkDeleteRules({
+        filter: 'alert.attributes.tags: "APM"',
+      });
+
+      const findFilter = unsecuredSavedObjectsClient.find.mock.calls[0][0].filter;
+
+      const encryptedFindFilter =
+        encryptedSavedObjects.createPointInTimeFinderDecryptedAsInternalUser.mock.calls[0][0]
+          .filter;
+
+      expect(toKqlExpression(findFilter)).toMatchInlineSnapshot(
+        `"((alert.attributes.tags: \\"APM\\" AND (alert.attributes.alertTypeId: foo AND alert.attributes.consumer: bar)) AND NOT (alert.attributes.alertTypeId: test.internal-rule-type OR alert.attributes.alertTypeId: test.internal-rule-type-2))"`
+      );
+
+      expect(toKqlExpression(encryptedFindFilter)).toMatchInlineSnapshot(
+        `"((alert.attributes.tags: \\"APM\\" AND (alert.attributes.alertTypeId: foo AND alert.attributes.consumer: bar)) AND NOT (alert.attributes.alertTypeId: test.internal-rule-type OR alert.attributes.alertTypeId: test.internal-rule-type-2))"`
+      );
+    });
+
+    it('should not ignore updates to internally managed rule types by default and combine all filters correctly', async () => {
+      await rulesClient.bulkDeleteRules({
+        filter: 'alert.attributes.tags: "APM"',
+        ignoreInternalRuleTypes: false,
+      });
+
+      const findFilter = unsecuredSavedObjectsClient.find.mock.calls[0][0].filter;
+
+      const encryptedFindFilter =
+        encryptedSavedObjects.createPointInTimeFinderDecryptedAsInternalUser.mock.calls[0][0]
+          .filter;
+
+      expect(toKqlExpression(findFilter)).toMatchInlineSnapshot(
+        `"(alert.attributes.tags: \\"APM\\" AND (alert.attributes.alertTypeId: foo AND alert.attributes.consumer: bar))"`
+      );
+
+      expect(toKqlExpression(encryptedFindFilter)).toMatchInlineSnapshot(
+        `"(alert.attributes.tags: \\"APM\\" AND (alert.attributes.alertTypeId: foo AND alert.attributes.consumer: bar))"`
+      );
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_delete/schemas/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_delete/schemas/index.ts
@@ -10,4 +10,5 @@ import { schema } from '@kbn/config-schema';
 export const bulkDeleteRulesRequestBodySchema = schema.object({
   filter: schema.maybe(schema.string()),
   ids: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1, maxSize: 1000 })),
+  ignoreInternalRuleTypes: schema.maybe(schema.boolean({ defaultValue: true })),
 });

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit/types/bulk_edit_rules_options.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit/types/bulk_edit_rules_options.ts
@@ -27,6 +27,7 @@ export type BulkEditFields = keyof Pick<
 
 export interface BulkEditOptionsCommon<Params extends RuleParams> {
   operations: BulkEditOperation[];
+  ignoreInternalRuleTypes?: boolean;
   paramsModifier?: ParamsModifier<Params>;
   shouldIncrementRevision?: ShouldIncrementRevision<Params>;
 }

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit_params/bulk_edit_rule_params.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit_params/bulk_edit_rule_params.test.ts
@@ -28,6 +28,7 @@ import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_a
 import { ConnectorAdapterRegistry } from '../../../../connector_adapters/connector_adapter_registry';
 import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
 import { backfillClientMock } from '../../../../backfill_client/backfill_client.mock';
+import { toKqlExpression } from '@kbn/es-query';
 
 jest.mock('uuid', () => {
   let uuid = 100;
@@ -680,6 +681,54 @@ describe('bulkEditRuleParamsWithReadAuth()', () => {
           }),
         ],
         { overwrite: true }
+      );
+    });
+  });
+
+  describe('internally managed rule types', () => {
+    beforeEach(() => {
+      ruleTypeRegistry.list.mockReturnValue(
+        // @ts-expect-error: not all args are required for this test
+        new Map([
+          ['test.internal-rule-type', { id: 'test.internal-rule-type', internallyManaged: true }],
+          [
+            'test.internal-rule-type-2',
+            { id: 'test.internal-rule-type-2', internallyManaged: true },
+          ],
+        ])
+      );
+    });
+
+    it('should ignore updates to internally managed rule types by default and combine all filters correctly', async () => {
+      await rulesClient.bulkEditRuleParamsWithReadAuth({
+        operations: [
+          {
+            field: 'exceptionsList',
+            operation: 'set',
+            value: [
+              {
+                id: 'exception-list-id',
+                list_id: 'exception-list',
+                type: 'detection',
+                namespace_type: 'single',
+              },
+            ],
+          },
+        ],
+      });
+
+      const findFilter = unsecuredSavedObjectsClient.find.mock.calls[0][0].filter;
+
+      const encryptedFindFilter =
+        encryptedSavedObjects.createPointInTimeFinderDecryptedAsInternalUser.mock.calls[0][0]
+          .filter;
+
+      expect(toKqlExpression(findFilter)).toMatchInlineSnapshot(
+        `"NOT (alert.attributes.alertTypeId: test.internal-rule-type OR alert.attributes.alertTypeId: test.internal-rule-type-2)"`
+      );
+
+      expect(toKqlExpression(encryptedFindFilter)).toMatchInlineSnapshot(
+        `"NOT (alert.attributes.alertTypeId: test.internal-rule-type OR alert.attributes.alertTypeId: test.internal-rule-type-2)"`
       );
     });
   });

--- a/x-pack/platform/plugins/shared/alerting/server/routes/lib/validate_internal_rule_types_by_query.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/lib/validate_internal_rule_types_by_query.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RulesClient } from '../../rules_client';
+import { rulesClientMock } from '../../mocks';
+import {
+  validateInternalRuleTypesBulkOperation,
+  validateInternalRuleTypesByQuery,
+} from './validate_internal_rule_types_by_query';
+
+describe('internal rule types lib', () => {
+  const req = { ids: ['1', '2'], filter: 'someFilter' };
+  const rulesClient = rulesClientMock.create() as unknown as RulesClient;
+  const ruleTypes = new Map();
+  const operationText = 'edit';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rulesClient.getRuleTypesByQuery = jest.fn().mockResolvedValue({
+      ruleTypes: ['internal'],
+    });
+
+    ruleTypes.set('non-internal', {
+      id: 'non-internal',
+      name: 'Non-Internal',
+      internallyManaged: false,
+    });
+
+    ruleTypes.set('internal', { id: 'internal', name: 'Internal', internallyManaged: true });
+  });
+
+  describe('validateInternalRuleTypesByQuery', () => {
+    it('should throw an error for invalid rule types', async () => {
+      await expect(
+        validateInternalRuleTypesByQuery({ req, rulesClient, ruleTypes, operationText })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Cannot edit rules of type \\"internal\\" because they are internally managed."`
+      );
+    });
+
+    it('should not throw an error for valid rule types', async () => {
+      rulesClient.getRuleTypesByQuery = jest.fn().mockResolvedValue({
+        ruleTypes: ['non-internal'],
+      });
+
+      await expect(
+        validateInternalRuleTypesByQuery({ req, rulesClient, ruleTypes, operationText })
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw an error for non found rule types', async () => {
+      ruleTypes.clear();
+
+      await expect(
+        validateInternalRuleTypesByQuery({ req, rulesClient, ruleTypes, operationText })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"Rule types not found: internal"`);
+    });
+
+    it('should not throw an error if the ids and filter are undefined', async () => {
+      await expect(
+        validateInternalRuleTypesByQuery({
+          req: { ids: undefined, filter: undefined },
+          rulesClient,
+          ruleTypes,
+          operationText,
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('should not throw an error if the ids is empty and the filter is undefined', async () => {
+      await expect(
+        validateInternalRuleTypesByQuery({
+          req: { ids: [], filter: undefined },
+          rulesClient,
+          ruleTypes,
+          operationText,
+        })
+      ).resolves.not.toThrow();
+    });
+
+    describe('validateInternalRuleTypesBulkOperation', () => {
+      it('should throw an error for invalid rule types when passing ids', async () => {
+        rulesClient.getRuleTypesByQuery = jest.fn().mockResolvedValue({
+          ruleTypes: ['internal'],
+        });
+
+        await expect(
+          validateInternalRuleTypesBulkOperation({
+            ids: req.ids,
+            rulesClient,
+            ruleTypes,
+            operationText,
+          })
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Cannot edit rules of type \\"internal\\" because they are internally managed."`
+        );
+      });
+
+      it('should not throw an error if the ids are undefined', async () => {
+        await expect(
+          validateInternalRuleTypesBulkOperation({
+            ids: undefined,
+            rulesClient,
+            ruleTypes,
+            operationText,
+          })
+        ).resolves.not.toThrow();
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/routes/lib/validate_internal_rule_types_by_query.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/lib/validate_internal_rule_types_by_query.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import type { RegistryRuleType } from '../../rule_type_registry';
+import type { RulesClient } from '../../rules_client';
+
+export const validateInternalRuleTypesByQuery = async ({
+  req,
+  ruleTypes,
+  rulesClient,
+  operationText,
+}: {
+  req: { filter?: string; ids?: string[] };
+  ruleTypes: Map<string, RegistryRuleType>;
+  rulesClient: RulesClient;
+  operationText: string;
+}) => {
+  const { filter, ids } = req;
+
+  if (!filter && (!ids || ids.length === 0)) {
+    return;
+  }
+
+  const ruleTypesByQuery = await rulesClient.getRuleTypesByQuery({ filter, ids });
+  const ruleTypeIds = new Set(ruleTypesByQuery.ruleTypes);
+  const notFoundRuleTypeIds = new Set<string>();
+  const internalRuleTypeIds = new Set<string>();
+
+  const constructMessage = (idsToFormat: Set<string>) => Array.from(idsToFormat).join(', ');
+
+  for (const ruleTypeId of ruleTypeIds) {
+    const ruleType = ruleTypes.get(ruleTypeId);
+
+    if (!ruleType) {
+      notFoundRuleTypeIds.add(ruleTypeId);
+    }
+
+    if (ruleType?.internallyManaged) {
+      internalRuleTypeIds.add(ruleTypeId);
+    }
+  }
+
+  if (notFoundRuleTypeIds.size) {
+    throw Boom.badRequest(`Rule types not found: ${constructMessage(notFoundRuleTypeIds)}`);
+  }
+
+  if (internalRuleTypeIds.size) {
+    throw Boom.badRequest(
+      `Cannot ${operationText} rules of type "${constructMessage(
+        internalRuleTypeIds
+      )}" because they are internally managed.`
+    );
+  }
+};
+
+export const validateInternalRuleTypesBulkOperation = async ({
+  ids,
+  ruleTypes,
+  rulesClient,
+  operationText,
+}: {
+  ids?: string[];
+  ruleTypes: Map<string, RegistryRuleType>;
+  rulesClient: RulesClient;
+  operationText: string;
+}) => {
+  await validateInternalRuleTypesByQuery({
+    req: { ids },
+    ruleTypes,
+    rulesClient,
+    operationText,
+  });
+};

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/bulk_delete/bulk_delete_rules_route.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/bulk_delete/bulk_delete_rules_route.ts
@@ -20,6 +20,7 @@ import type { RuleParamsV1 } from '../../../../../common/routes/rule/response';
 import { transformRuleToRuleResponseV1 } from '../../transforms';
 import type { Rule } from '../../../../application/rule/types';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from '../../../constants';
+import { validateInternalRuleTypesBulkOperation } from '../../../lib/validate_internal_rule_types_by_query';
 
 export const bulkDeleteRulesRoute = ({
   router,
@@ -42,11 +43,19 @@ export const bulkDeleteRulesRoute = ({
         verifyAccessAndContext(licenseState, async (context, req, res) => {
           const alertingContext = await context.alerting;
           const rulesClient = await alertingContext.getRulesClient();
+          const ruleTypes = alertingContext.listTypes();
 
           const body: BulkDeleteRulesRequestBodyV1 = req.body;
           const { filter, ids } = body;
 
           try {
+            await validateInternalRuleTypesBulkOperation({
+              ids,
+              ruleTypes,
+              rulesClient,
+              operationText: 'delete',
+            });
+
             const bulkDeleteResult = await rulesClient.bulkDeleteRules({
               filter,
               ids,

--- a/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.mock.ts
@@ -15,7 +15,7 @@ const createRuleTypeRegistryMock = () => {
     has: jest.fn(),
     register: jest.fn(),
     get: jest.fn(),
-    list: jest.fn(),
+    list: jest.fn().mockReturnValue(new Map()),
     getAllTypes: jest.fn(),
     getFilteredTypes: jest.fn(),
     ensureRuleTypeEnabled: jest.fn(),

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/common/construct_ignore_internal_rule_type_filters.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/common/construct_ignore_internal_rule_type_filters.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RegistryRuleType } from '../../rule_type_registry';
+import { nodeBuilder, toKqlExpression } from '@kbn/es-query';
+import {
+  combineFiltersWithInternalRuleTypeFilter,
+  constructIgnoreInternalRuleTypesFilter,
+} from './construct_ignore_internal_rule_type_filters';
+
+describe('constructIgnoreInternalRuleTypesFilter', () => {
+  // @ts-expect-error: not all properties are needed for this test
+  const ruleTypes: Map<string, RegistryRuleType> = new Map([
+    ['internal-type', { id: 'internal-type', name: 'Internal Type', internallyManaged: true }],
+    [
+      'internal-type-2',
+      { id: 'internal-type-2', name: 'Internal Type 2', internallyManaged: true },
+    ],
+    [
+      'non-internal-type',
+      { id: 'non-internal-type', name: 'Non Internal Type', internallyManaged: false },
+    ],
+  ]);
+
+  test('should construct a KQL filter for internal rule types ignoring non-internal types', () => {
+    const filter = constructIgnoreInternalRuleTypesFilter({ ruleTypes })!;
+
+    expect(toKqlExpression(filter)).toMatchInlineSnapshot(
+      `"NOT (alert.attributes.alertTypeId: internal-type OR alert.attributes.alertTypeId: internal-type-2)"`
+    );
+  });
+
+  test('returns null if the ruleTypes map is empty', () => {
+    expect(constructIgnoreInternalRuleTypesFilter({ ruleTypes: new Map() })).toBeNull();
+  });
+});
+
+describe('combineFiltersWithInternalRuleTypeFilter', () => {
+  const filterA = nodeBuilder.is('foo', 'bar');
+  const filterB = nodeBuilder.is('baz', 'qux');
+
+  test('returns null if both filters are null', () => {
+    expect(
+      combineFiltersWithInternalRuleTypeFilter({ filter: null, internalRuleTypeFilter: null })
+    ).toBeNull();
+  });
+
+  test('returns internalRuleTypeFilter if filter is null', () => {
+    expect(
+      combineFiltersWithInternalRuleTypeFilter({ filter: null, internalRuleTypeFilter: filterA })
+    ).toBe(filterA);
+  });
+
+  test('returns filter if internalRuleTypeFilter is null', () => {
+    expect(
+      combineFiltersWithInternalRuleTypeFilter({ filter: filterA, internalRuleTypeFilter: null })
+    ).toBe(filterA);
+  });
+
+  test('returns AND node if both filters are present', () => {
+    const result = combineFiltersWithInternalRuleTypeFilter({
+      filter: filterA,
+      internalRuleTypeFilter: filterB,
+    })!;
+
+    expect(toKqlExpression(result)).toMatchInlineSnapshot(`"(foo: bar AND baz: qux)"`);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/common/construct_ignore_internal_rule_type_filters.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/common/construct_ignore_internal_rule_type_filters.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KueryNode } from '@kbn/es-query';
+import { fromKueryExpression, nodeBuilder, toKqlExpression } from '@kbn/es-query';
+import type { RegistryRuleType } from '../../rule_type_registry';
+import { RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
+
+export const constructIgnoreInternalRuleTypesFilter = ({
+  ruleTypes,
+}: {
+  ruleTypes: Map<string, RegistryRuleType>;
+}) => {
+  const internalRuleTypes = Array.from(ruleTypes.values()).filter((type) => type.internallyManaged);
+
+  if (internalRuleTypes.length === 0) {
+    return null;
+  }
+
+  const internalRuleTypeNode = nodeBuilder.or(
+    internalRuleTypes.map((type) =>
+      nodeBuilder.is(`${RULE_SAVED_OBJECT_TYPE}.attributes.alertTypeId`, type.id)
+    )
+  );
+
+  const internalRuleTypeNodesAsExpression = toKqlExpression(internalRuleTypeNode);
+  const ignoreInternalRuleTypes = `not ${internalRuleTypeNodesAsExpression}`;
+
+  return fromKueryExpression(ignoreInternalRuleTypes);
+};
+
+export const combineFiltersWithInternalRuleTypeFilter = ({
+  filter,
+  internalRuleTypeFilter,
+}: {
+  filter: KueryNode | null;
+  internalRuleTypeFilter: KueryNode | null;
+}) => {
+  if (!filter && !internalRuleTypeFilter) {
+    return null;
+  }
+
+  if (!filter) {
+    return internalRuleTypeFilter;
+  }
+
+  if (!internalRuleTypeFilter) {
+    return filter;
+  }
+
+  return nodeBuilder.and([filter, internalRuleTypeFilter]);
+};

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/lib.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/lib.ts
@@ -136,4 +136,6 @@ export function getBeforeSetup(
   );
 
   rulesClientParams.isSystemAction.mockImplementation((id) => id === 'system_action-id');
+
+  ruleTypeRegistry.list.mockReturnValue(new Map());
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/assets/query/query_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/assets/query/query_client.ts
@@ -232,7 +232,7 @@ export class QueryClient {
 
     const { rulesClient } = this.dependencies;
     await rulesClient
-      .bulkDeleteRules({ ids: queries.map(getRuleIdFromQueryLink) })
+      .bulkDeleteRules({ ids: queries.map(getRuleIdFromQueryLink), ignoreInternalRuleTypes: false })
       .catch((error) => {
         if (isBoom(error) && error.output.statusCode === 400) {
           return;

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group5/tests/alerting/bulk_edit_params.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group5/tests/alerting/bulk_edit_params.ts
@@ -11,7 +11,8 @@ import type { SavedObject } from '@kbn/core-saved-objects-server';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import type { RawRule } from '@kbn/alerting-plugin/server/types';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
-import { GlobalReadAtSpace1, Space1AllAtSpace1 } from '../../../scenarios';
+import { getAlwaysFiringInternalRule } from '../../../../common/lib/alert_utils';
+import { DefaultSpace, GlobalReadAtSpace1, Space1AllAtSpace1, Superuser } from '../../../scenarios';
 import { checkAAD, getTestRuleData, getUrlPrefix, ObjectRemover } from '../../../../common/lib';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { AlertUtils } from '../../../../common/lib';
@@ -24,21 +25,20 @@ export default function createBulkEditRuleParamsWithReadAuthTests({
   const es = getService('es');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const objectRemover = new ObjectRemover(supertest);
-  const alertUtils = new AlertUtils({
-    user: GlobalReadAtSpace1.user,
-    space: GlobalReadAtSpace1.space,
-    supertestWithoutAuth,
-  });
 
-  async function createDetectionRule(actions?: any[]) {
+  async function createDetectionRule({
+    actions,
+    spaceIdToBeCreatedIn = spaceId,
+    tags = [],
+  }: { actions?: any[]; spaceIdToBeCreatedIn?: string; tags?: string[] } = {}): Promise<string> {
     // create a detection rule to be updated
     const response = await supertest
-      .post(`${getUrlPrefix(spaceId)}/api/alerting/rule`)
+      .post(`${getUrlPrefix(spaceIdToBeCreatedIn)}/api/alerting/rule`)
       .set('kbn-xsrf', 'foo')
       .send({
         enabled: true,
         name: 'test siem query rule',
-        tags: [],
+        tags: tags ?? [],
         rule_type_id: 'siem.queryRule',
         consumer: 'siem',
         schedule: { interval: '24h' },
@@ -83,10 +83,17 @@ export default function createBulkEditRuleParamsWithReadAuthTests({
       .expect(200);
 
     const ruleId = response.body.id;
-    objectRemover.add(spaceId, ruleId, 'rule', 'alerting');
+    objectRemover.add(spaceIdToBeCreatedIn, ruleId, 'rule', 'alerting');
     return ruleId;
   }
+
   describe('bulkEditRuleParamsWithReadAuth', () => {
+    const alertUtils = new AlertUtils({
+      user: GlobalReadAtSpace1.user,
+      space: GlobalReadAtSpace1.space,
+      supertestWithoutAuth,
+    });
+
     afterEach(async () => {
       await objectRemover.removeAll();
     });
@@ -447,14 +454,16 @@ export default function createBulkEditRuleParamsWithReadAuthTests({
         .expect(200);
       objectRemover.add(spaceId, createdConnector.id, 'connector', 'actions');
 
-      const ruleId = await createDetectionRule([
-        {
-          id: createdConnector.id,
-          group: 'default',
-          params: {},
-          frequency: { summary: false, notify_when: 'onActiveAlert' },
-        },
-      ]);
+      const ruleId = await createDetectionRule({
+        actions: [
+          {
+            id: createdConnector.id,
+            group: 'default',
+            params: {},
+            frequency: { summary: false, notify_when: 'onActiveAlert' },
+          },
+        ],
+      });
 
       // Get the rule from ES
       const rawRuleBefore = await es.get<SavedObject<RawRule>>({
@@ -555,6 +564,65 @@ export default function createBulkEditRuleParamsWithReadAuthTests({
 
       // Ensure AAD isn't broken
       await checkAAD({ supertest, spaceId, type: RULE_SAVED_OBJECT_TYPE, id: ruleId });
+    });
+
+    describe('internally managed rule types', () => {
+      const rulePayload = getAlwaysFiringInternalRule();
+
+      const payloadWithFilter = {
+        filter: `alert.attributes.tags: "internally-managed"`,
+        operations: [
+          {
+            operation: 'set',
+            field: 'exceptionsList',
+            value: [{ id: 'new', list_id: 'foo', namespace_type: 'single', type: 'rule_default' }],
+          },
+        ],
+      };
+
+      const alertUtilsSuperUser = new AlertUtils({
+        user: Superuser,
+        space: DefaultSpace,
+        supertestWithoutAuth: supertest,
+      });
+
+      it('should ignore internal rule types when trying to bulk update using the filter param', async () => {
+        const { body: internalRuleType } = await supertest
+          .post('/api/alerts_fixture/rule/internally_managed')
+          .set('kbn-xsrf', 'foo')
+          .send({ ...rulePayload, tags: ['internally-managed'] })
+          .expect(200);
+
+        const nonInternalRuleTypeId = await createDetectionRule({
+          spaceIdToBeCreatedIn: 'default',
+          tags: ['internally-managed'],
+        });
+
+        await supertest
+          .post('/api/alerting_fixture/_bulk_edit_params')
+          .set('kbn-xsrf', 'foo')
+          .send(payloadWithFilter)
+          .expect(200);
+
+        const { body: updatedInternalRuleType } = await supertest
+          .get(`/api/alerting/rule/${internalRuleType.id}`)
+          .set('kbn-xsrf', 'foo')
+          .expect(200);
+
+        const { body: updatedNonInternalRuleType } = await supertest
+          .get(`/api/alerting/rule/${nonInternalRuleTypeId}`)
+          .set('kbn-xsrf', 'foo')
+          .expect(200);
+
+        expect(updatedInternalRuleType.params).toEqual({});
+        expect(updatedNonInternalRuleType.params.exceptionsList).toEqual([
+          { id: 'new', list_id: 'foo', namespace_type: 'single', type: 'rule_default' },
+        ]);
+
+        const res = await alertUtilsSuperUser.deleteInternallyManagedRule(internalRuleType.id);
+
+        expect(res.statusCode).toEqual(200);
+      });
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ResponseOps][Rules] Ignore internal rule types when bulk editing rules (#236672)](https://github.com/elastic/kibana/pull/236672)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Christos Nasikas","email":"christos.nasikas@elastic.co"},"sourceCommit":{"committedDate":"2025-10-20T12:54:52Z","message":"[ResponseOps][Rules] Ignore internal rule types when bulk editing rules (#236672)\n\n## Summary\n\nThis PR ignores internally managed rule types in bulk edit and bulk\ndelete operations.\n\nPartial fixes: https://github.com/elastic/kibana/issues/222101\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"092199ecf21fb6fe89c16feeaf6f9252d10441df","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","backport:version","v9.2.0","v9.3.0"],"title":"[ResponseOps][Rules] Ignore internal rule types when bulk editing/deleting rules","number":236672,"url":"https://github.com/elastic/kibana/pull/236672","mergeCommit":{"message":"[ResponseOps][Rules] Ignore internal rule types when bulk editing rules (#236672)\n\n## Summary\n\nThis PR ignores internally managed rule types in bulk edit and bulk\ndelete operations.\n\nPartial fixes: https://github.com/elastic/kibana/issues/222101\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"092199ecf21fb6fe89c16feeaf6f9252d10441df"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236672","number":236672,"mergeCommit":{"message":"[ResponseOps][Rules] Ignore internal rule types when bulk editing rules (#236672)\n\n## Summary\n\nThis PR ignores internally managed rule types in bulk edit and bulk\ndelete operations.\n\nPartial fixes: https://github.com/elastic/kibana/issues/222101\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"092199ecf21fb6fe89c16feeaf6f9252d10441df"}}]}] BACKPORT-->