### PR TITLE
[Security Solution][Bug] The schedule can not be created with the case as the connector type (#238587)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -70019,27 +70019,9 @@ components:
         - schedule
         - actions
     Security_Attack_discovery_API_AttackDiscoveryApiScheduleAction:
-      type: object
-      properties:
-        action_type_id:
-          description: The action type used for sending notifications.
-          type: string
-        alerts_filter:
-          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionAlertsFilter'
-        frequency:
-          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionFrequency'
-        group:
-          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionGroup'
-        id:
-          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionId'
-        params:
-          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionParams'
-        uuid:
-          $ref: '#/components/schemas/Security_Attack_discovery_API_NonEmptyString'
-      required:
-        - action_type_id
-        - id
-        - params
+      oneOf:
+        - $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleGeneralAction'
+        - $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleSystemAction'
     Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionAlertsFilter:
       additionalProperties: true
       type: object
@@ -70135,6 +70117,29 @@ components:
         - unknown
         - warning
       type: string
+    Security_Attack_discovery_API_AttackDiscoveryApiScheduleGeneralAction:
+      type: object
+      properties:
+        action_type_id:
+          description: The action type used for sending notifications.
+          type: string
+        alerts_filter:
+          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionAlertsFilter'
+        frequency:
+          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionFrequency'
+        group:
+          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionGroup'
+        id:
+          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionId'
+        params:
+          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionParams'
+        uuid:
+          $ref: '#/components/schemas/Security_Attack_discovery_API_NonEmptyString'
+      required:
+        - action_type_id
+        - group
+        - id
+        - params
     Security_Attack_discovery_API_AttackDiscoveryApiScheduleParams:
       description: An attack discovery schedule params
       type: object
@@ -70170,6 +70175,22 @@ components:
         - alerts_index_pattern
         - api_config
         - size
+    Security_Attack_discovery_API_AttackDiscoveryApiScheduleSystemAction:
+      type: object
+      properties:
+        action_type_id:
+          description: The action type used for sending notifications.
+          type: string
+        id:
+          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionId'
+        params:
+          $ref: '#/components/schemas/Security_Attack_discovery_API_AttackDiscoveryApiScheduleActionParams'
+        uuid:
+          $ref: '#/components/schemas/Security_Attack_discovery_API_NonEmptyString'
+      required:
+        - action_type_id
+        - id
+        - params
     Security_Attack_discovery_API_AttackDiscoveryApiScheduleUpdateProps:
       description: An attack discovery schedule update properties
       type: object

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/attack_discovery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/attack_discovery_api_2023_10_31.bundled.schema.yaml
@@ -2558,27 +2558,9 @@ components:
         - schedule
         - actions
     AttackDiscoveryApiScheduleAction:
-      type: object
-      properties:
-        action_type_id:
-          description: The action type used for sending notifications.
-          type: string
-        alerts_filter:
-          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionAlertsFilter'
-        frequency:
-          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionFrequency'
-        group:
-          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionGroup'
-        id:
-          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionId'
-        params:
-          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionParams'
-        uuid:
-          $ref: '#/components/schemas/NonEmptyString'
-      required:
-        - action_type_id
-        - id
-        - params
+      oneOf:
+        - $ref: '#/components/schemas/AttackDiscoveryApiScheduleGeneralAction'
+        - $ref: '#/components/schemas/AttackDiscoveryApiScheduleSystemAction'
     AttackDiscoveryApiScheduleActionAlertsFilter:
       additionalProperties: true
       type: object
@@ -2684,6 +2666,29 @@ components:
         - unknown
         - warning
       type: string
+    AttackDiscoveryApiScheduleGeneralAction:
+      type: object
+      properties:
+        action_type_id:
+          description: The action type used for sending notifications.
+          type: string
+        alerts_filter:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionAlertsFilter'
+        frequency:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionFrequency'
+        group:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionGroup'
+        id:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionId'
+        params:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionParams'
+        uuid:
+          $ref: '#/components/schemas/NonEmptyString'
+      required:
+        - action_type_id
+        - group
+        - id
+        - params
     AttackDiscoveryApiScheduleParams:
       description: An attack discovery schedule params
       type: object
@@ -2719,6 +2724,22 @@ components:
         - alerts_index_pattern
         - api_config
         - size
+    AttackDiscoveryApiScheduleSystemAction:
+      type: object
+      properties:
+        action_type_id:
+          description: The action type used for sending notifications.
+          type: string
+        id:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionId'
+        params:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionParams'
+        uuid:
+          $ref: '#/components/schemas/NonEmptyString'
+      required:
+        - action_type_id
+        - id
+        - params
     AttackDiscoveryApiScheduleUpdateProps:
       description: An attack discovery schedule update properties
       type: object

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/attack_discovery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/attack_discovery_api_2023_10_31.bundled.schema.yaml
@@ -2558,27 +2558,9 @@ components:
         - schedule
         - actions
     AttackDiscoveryApiScheduleAction:
-      type: object
-      properties:
-        action_type_id:
-          description: The action type used for sending notifications.
-          type: string
-        alerts_filter:
-          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionAlertsFilter'
-        frequency:
-          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionFrequency'
-        group:
-          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionGroup'
-        id:
-          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionId'
-        params:
-          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionParams'
-        uuid:
-          $ref: '#/components/schemas/NonEmptyString'
-      required:
-        - action_type_id
-        - id
-        - params
+      oneOf:
+        - $ref: '#/components/schemas/AttackDiscoveryApiScheduleGeneralAction'
+        - $ref: '#/components/schemas/AttackDiscoveryApiScheduleSystemAction'
     AttackDiscoveryApiScheduleActionAlertsFilter:
       additionalProperties: true
       type: object
@@ -2684,6 +2666,29 @@ components:
         - unknown
         - warning
       type: string
+    AttackDiscoveryApiScheduleGeneralAction:
+      type: object
+      properties:
+        action_type_id:
+          description: The action type used for sending notifications.
+          type: string
+        alerts_filter:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionAlertsFilter'
+        frequency:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionFrequency'
+        group:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionGroup'
+        id:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionId'
+        params:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionParams'
+        uuid:
+          $ref: '#/components/schemas/NonEmptyString'
+      required:
+        - action_type_id
+        - group
+        - id
+        - params
     AttackDiscoveryApiScheduleParams:
       description: An attack discovery schedule params
       type: object
@@ -2719,6 +2724,22 @@ components:
         - alerts_index_pattern
         - api_config
         - size
+    AttackDiscoveryApiScheduleSystemAction:
+      type: object
+      properties:
+        action_type_id:
+          description: The action type used for sending notifications.
+          type: string
+        id:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionId'
+        params:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionParams'
+        uuid:
+          $ref: '#/components/schemas/NonEmptyString'
+      required:
+        - action_type_id
+        - id
+        - params
     AttackDiscoveryApiScheduleUpdateProps:
       description: An attack discovery schedule update properties
       type: object

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/internal/schedules/schedules.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/internal/schedules/schedules.gen.ts
@@ -134,19 +134,40 @@ export const AttackDiscoveryScheduleActionFrequency = z.object({
   throttle: AttackDiscoveryScheduleActionThrottle.nullable(),
 });
 
-export type AttackDiscoveryScheduleAction = z.infer<typeof AttackDiscoveryScheduleAction>;
-export const AttackDiscoveryScheduleAction = z.object({
+export type AttackDiscoveryScheduleGeneralAction = z.infer<
+  typeof AttackDiscoveryScheduleGeneralAction
+>;
+export const AttackDiscoveryScheduleGeneralAction = z.object({
   /**
    * The action type used for sending notifications.
    */
   actionTypeId: z.string(),
-  group: AttackDiscoveryScheduleActionGroup.optional(),
+  group: AttackDiscoveryScheduleActionGroup,
   id: AttackDiscoveryScheduleActionId,
   params: AttackDiscoveryScheduleActionParams,
   uuid: NonEmptyString.optional(),
   alertsFilter: AttackDiscoveryScheduleActionAlertsFilter.optional(),
   frequency: AttackDiscoveryScheduleActionFrequency.optional(),
 });
+
+export type AttackDiscoveryScheduleSystemAction = z.infer<
+  typeof AttackDiscoveryScheduleSystemAction
+>;
+export const AttackDiscoveryScheduleSystemAction = z.object({
+  /**
+   * The action type used for sending notifications.
+   */
+  actionTypeId: z.string(),
+  id: AttackDiscoveryScheduleActionId,
+  params: AttackDiscoveryScheduleActionParams,
+  uuid: NonEmptyString.optional(),
+});
+
+export type AttackDiscoveryScheduleAction = z.infer<typeof AttackDiscoveryScheduleAction>;
+export const AttackDiscoveryScheduleAction = z.union([
+  AttackDiscoveryScheduleGeneralAction,
+  AttackDiscoveryScheduleSystemAction,
+]);
 
 /**
  * An attack discovery schedule execution status

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/internal/schedules/schedules.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/internal/schedules/schedules.schema.yaml
@@ -172,7 +172,7 @@ components:
       type: string
       description: The connector ID.
 
-    AttackDiscoveryScheduleAction:
+    AttackDiscoveryScheduleGeneralAction:
       type: object
       properties:
         actionTypeId:
@@ -192,8 +192,31 @@ components:
           $ref: '#/components/schemas/AttackDiscoveryScheduleActionFrequency'
       required:
         - actionTypeId
+        - group
         - id
         - params
+
+    AttackDiscoveryScheduleSystemAction:
+      type: object
+      properties:
+        actionTypeId:
+          type: string
+          description: The action type used for sending notifications.
+        id:
+          $ref: '#/components/schemas/AttackDiscoveryScheduleActionId'
+        params:
+          $ref: '#/components/schemas/AttackDiscoveryScheduleActionParams'
+        uuid:
+          $ref: '../../../../common_attributes.schema.yaml#/components/schemas/NonEmptyString'
+      required:
+        - actionTypeId
+        - id
+        - params
+
+    AttackDiscoveryScheduleAction:
+      oneOf:
+        - $ref: '#/components/schemas/AttackDiscoveryScheduleGeneralAction'
+        - $ref: '#/components/schemas/AttackDiscoveryScheduleSystemAction'
 
     AttackDiscoveryScheduleExecutionStatus:
       type: string

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/schedules.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/schedules.gen.ts
@@ -134,19 +134,40 @@ export const AttackDiscoveryScheduleActionFrequency = z.object({
   throttle: AttackDiscoveryScheduleActionThrottle.nullable(),
 });
 
-export type AttackDiscoveryScheduleAction = z.infer<typeof AttackDiscoveryScheduleAction>;
-export const AttackDiscoveryScheduleAction = z.object({
+export type AttackDiscoveryScheduleGeneralAction = z.infer<
+  typeof AttackDiscoveryScheduleGeneralAction
+>;
+export const AttackDiscoveryScheduleGeneralAction = z.object({
   /**
    * The action type used for sending notifications.
    */
   actionTypeId: z.string(),
-  group: AttackDiscoveryScheduleActionGroup.optional(),
+  group: AttackDiscoveryScheduleActionGroup,
   id: AttackDiscoveryScheduleActionId,
   params: AttackDiscoveryScheduleActionParams,
   uuid: NonEmptyString.optional(),
   alertsFilter: AttackDiscoveryScheduleActionAlertsFilter.optional(),
   frequency: AttackDiscoveryScheduleActionFrequency.optional(),
 });
+
+export type AttackDiscoveryScheduleSystemAction = z.infer<
+  typeof AttackDiscoveryScheduleSystemAction
+>;
+export const AttackDiscoveryScheduleSystemAction = z.object({
+  /**
+   * The action type used for sending notifications.
+   */
+  actionTypeId: z.string(),
+  id: AttackDiscoveryScheduleActionId,
+  params: AttackDiscoveryScheduleActionParams,
+  uuid: NonEmptyString.optional(),
+});
+
+export type AttackDiscoveryScheduleAction = z.infer<typeof AttackDiscoveryScheduleAction>;
+export const AttackDiscoveryScheduleAction = z.union([
+  AttackDiscoveryScheduleGeneralAction,
+  AttackDiscoveryScheduleSystemAction,
+]);
 
 /**
  * An attack discovery schedule execution status

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/schedules.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/schedules.schema.yaml
@@ -172,7 +172,7 @@ components:
       type: string
       description: The connector ID.
 
-    AttackDiscoveryScheduleAction:
+    AttackDiscoveryScheduleGeneralAction:
       type: object
       properties:
         actionTypeId:
@@ -192,8 +192,31 @@ components:
           $ref: '#/components/schemas/AttackDiscoveryScheduleActionFrequency'
       required:
         - actionTypeId
+        - group
         - id
         - params
+
+    AttackDiscoveryScheduleSystemAction:
+      type: object
+      properties:
+        actionTypeId:
+          type: string
+          description: The action type used for sending notifications.
+        id:
+          $ref: '#/components/schemas/AttackDiscoveryScheduleActionId'
+        params:
+          $ref: '#/components/schemas/AttackDiscoveryScheduleActionParams'
+        uuid:
+          $ref: '../../../../common_attributes.schema.yaml#/components/schemas/NonEmptyString'
+      required:
+        - actionTypeId
+        - id
+        - params
+
+    AttackDiscoveryScheduleAction:
+      oneOf:
+        - $ref: '#/components/schemas/AttackDiscoveryScheduleGeneralAction'
+        - $ref: '#/components/schemas/AttackDiscoveryScheduleSystemAction'
 
     AttackDiscoveryScheduleExecutionStatus:
       type: string

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/schedules_api.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/schedules_api.gen.ts
@@ -136,19 +136,40 @@ export const AttackDiscoveryApiScheduleActionFrequency = z.object({
   throttle: AttackDiscoveryApiScheduleActionThrottle.nullable(),
 });
 
-export type AttackDiscoveryApiScheduleAction = z.infer<typeof AttackDiscoveryApiScheduleAction>;
-export const AttackDiscoveryApiScheduleAction = z.object({
+export type AttackDiscoveryApiScheduleGeneralAction = z.infer<
+  typeof AttackDiscoveryApiScheduleGeneralAction
+>;
+export const AttackDiscoveryApiScheduleGeneralAction = z.object({
   /**
    * The action type used for sending notifications.
    */
   action_type_id: z.string(),
-  group: AttackDiscoveryApiScheduleActionGroup.optional(),
+  group: AttackDiscoveryApiScheduleActionGroup,
   id: AttackDiscoveryApiScheduleActionId,
   params: AttackDiscoveryApiScheduleActionParams,
   uuid: NonEmptyString.optional(),
   alerts_filter: AttackDiscoveryApiScheduleActionAlertsFilter.optional(),
   frequency: AttackDiscoveryApiScheduleActionFrequency.optional(),
 });
+
+export type AttackDiscoveryApiScheduleSystemAction = z.infer<
+  typeof AttackDiscoveryApiScheduleSystemAction
+>;
+export const AttackDiscoveryApiScheduleSystemAction = z.object({
+  /**
+   * The action type used for sending notifications.
+   */
+  action_type_id: z.string(),
+  id: AttackDiscoveryApiScheduleActionId,
+  params: AttackDiscoveryApiScheduleActionParams,
+  uuid: NonEmptyString.optional(),
+});
+
+export type AttackDiscoveryApiScheduleAction = z.infer<typeof AttackDiscoveryApiScheduleAction>;
+export const AttackDiscoveryApiScheduleAction = z.union([
+  AttackDiscoveryApiScheduleGeneralAction,
+  AttackDiscoveryApiScheduleSystemAction,
+]);
 
 /**
  * An attack discovery schedule execution status

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/schedules_api.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/schedules/schedules_api.schema.yaml
@@ -172,7 +172,7 @@ components:
       type: string
       description: The connector ID.
 
-    AttackDiscoveryApiScheduleAction:
+    AttackDiscoveryApiScheduleGeneralAction:
       type: object
       properties:
         action_type_id:
@@ -192,8 +192,31 @@ components:
           $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionFrequency'
       required:
         - action_type_id
+        - group
         - id
         - params
+
+    AttackDiscoveryApiScheduleSystemAction:
+      type: object
+      properties:
+        action_type_id:
+          type: string
+          description: The action type used for sending notifications.
+        id:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionId'
+        params:
+          $ref: '#/components/schemas/AttackDiscoveryApiScheduleActionParams'
+        uuid:
+          $ref: '../../../../common_attributes.schema.yaml#/components/schemas/NonEmptyString'
+      required:
+        - action_type_id
+        - id
+        - params
+
+    AttackDiscoveryApiScheduleAction:
+      oneOf:
+        - $ref: '#/components/schemas/AttackDiscoveryApiScheduleGeneralAction'
+        - $ref: '#/components/schemas/AttackDiscoveryApiScheduleSystemAction'
 
     AttackDiscoveryApiScheduleExecutionStatus:
       type: string

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_actions_props_from_api/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_actions_props_from_api/index.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { transformAttackDiscoveryScheduleActionsPropsFromApi } from '.';
+import type { AttackDiscoveryApiScheduleAction } from '../../schemas/attack_discovery/routes/public/schedules/schedules_api.gen';
+
+describe('transformAttackDiscoveryScheduleActionsPropsFromApi', () => {
+  const mockApiActions: AttackDiscoveryApiScheduleAction[] = [
+    {
+      id: 'action1',
+      action_type_id: '.slack',
+      group: 'default',
+      params: {
+        message: 'Test message',
+      },
+      uuid: 'test-uuid',
+      alerts_filter: { query: { match_all: {} } },
+      frequency: {
+        summary: true,
+        notify_when: 'onActiveAlert',
+        throttle: '5m',
+      },
+    },
+    {
+      action_type_id: '.cases',
+      id: 'system-connector-.cases',
+      params: {
+        subAction: 'run',
+        subActionParams: {
+          timeWindow: '7d',
+          reopenClosedCases: false,
+          groupingBy: [],
+          templateId: null,
+        },
+      },
+      uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+    },
+  ];
+
+  it('should correctly transform API actions to schedule actions', () => {
+    const result = transformAttackDiscoveryScheduleActionsPropsFromApi(mockApiActions);
+    expect(result).toEqual([
+      {
+        actionTypeId: '.slack',
+        group: 'default',
+        id: 'action1',
+        params: {
+          message: 'Test message',
+        },
+        uuid: 'test-uuid',
+        alertsFilter: { query: { match_all: {} } },
+        frequency: {
+          summary: true,
+          notifyWhen: 'onActiveAlert',
+          throttle: '5m',
+        },
+      },
+      {
+        actionTypeId: '.cases',
+        id: 'system-connector-.cases',
+        params: {
+          subAction: 'run',
+          subActionParams: {
+            timeWindow: '7d',
+            reopenClosedCases: false,
+            groupingBy: [],
+            templateId: null,
+          },
+        },
+        uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+      },
+    ]);
+  });
+
+  it('should return undefined if no actions are provided', () => {
+    const result = transformAttackDiscoveryScheduleActionsPropsFromApi(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return an empty array if an empty array is provided', () => {
+    const result = transformAttackDiscoveryScheduleActionsPropsFromApi([]);
+    expect(result).toEqual([]);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_actions_props_from_api/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_actions_props_from_api/index.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttackDiscoveryScheduleAction } from '../../schemas/attack_discovery/routes/public/schedules/schedules.gen';
+import type {
+  AttackDiscoveryApiScheduleAction,
+  AttackDiscoveryApiScheduleGeneralAction,
+} from '../../schemas/attack_discovery/routes/public/schedules/schedules_api.gen';
+
+const isGeneralAction = (
+  action: AttackDiscoveryApiScheduleAction
+): action is AttackDiscoveryApiScheduleGeneralAction => {
+  return Object.hasOwn(action, 'group');
+};
+
+export const transformAttackDiscoveryScheduleActionsPropsFromApi = (
+  actions: AttackDiscoveryApiScheduleAction[] | undefined
+): AttackDiscoveryScheduleAction[] | undefined => {
+  return actions?.map((action) => {
+    if (isGeneralAction(action)) {
+      return {
+        actionTypeId: action.action_type_id,
+        group: action.group,
+        id: action.id,
+        params: action.params,
+        uuid: action.uuid,
+        alertsFilter: action.alerts_filter,
+        frequency: action.frequency
+          ? {
+              summary: action.frequency.summary,
+              notifyWhen: action.frequency.notify_when,
+              throttle: action.frequency.throttle,
+            }
+          : undefined,
+      };
+    }
+    return {
+      actionTypeId: action.action_type_id,
+      id: action.id,
+      params: action.params,
+      uuid: action.uuid,
+    };
+  });
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_actions_props_to_api/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_actions_props_to_api/index.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { transformAttackDiscoveryScheduleActionsPropsToApi } from '.';
+import type { AttackDiscoveryScheduleAction } from '../../schemas/attack_discovery/routes/public/schedules/schedules.gen';
+
+describe('transformAttackDiscoveryScheduleActionsPropsToApi', () => {
+  const mockActions: AttackDiscoveryScheduleAction[] = [
+    {
+      id: 'action1',
+      actionTypeId: '.slack',
+      group: 'default',
+      params: {
+        message: 'Test message',
+      },
+      frequency: {
+        summary: true,
+        notifyWhen: 'onActiveAlert',
+        throttle: null,
+      },
+    },
+    {
+      actionTypeId: '.cases',
+      id: 'system-connector-.cases',
+      params: {
+        subAction: 'run',
+        subActionParams: {
+          groupingBy: [],
+          reopenClosedCases: false,
+          templateId: null,
+          timeWindow: '7d',
+        },
+      },
+      uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+    },
+  ];
+
+  it('should correctly transform schedule actions to API actions', () => {
+    const result = transformAttackDiscoveryScheduleActionsPropsToApi(mockActions);
+    expect(result).toEqual([
+      {
+        action_type_id: '.slack',
+        group: 'default',
+        id: 'action1',
+        params: {
+          message: 'Test message',
+        },
+        uuid: undefined,
+        alerts_filter: undefined,
+        frequency: {
+          summary: true,
+          notify_when: 'onActiveAlert',
+          throttle: null,
+        },
+      },
+      {
+        action_type_id: '.cases',
+        id: 'system-connector-.cases',
+        params: {
+          subAction: 'run',
+          subActionParams: {
+            groupingBy: [],
+            reopenClosedCases: false,
+            templateId: null,
+            timeWindow: '7d',
+          },
+        },
+        uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+      },
+    ]);
+  });
+
+  it('should return undefined if no actions are provided', () => {
+    const result = transformAttackDiscoveryScheduleActionsPropsToApi(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return an empty array if an empty array is provided', () => {
+    const result = transformAttackDiscoveryScheduleActionsPropsToApi([]);
+    expect(result).toEqual([]);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_actions_props_to_api/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_actions_props_to_api/index.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AttackDiscoveryScheduleAction,
+  AttackDiscoveryScheduleGeneralAction,
+} from '../../schemas/attack_discovery/routes/public/schedules/schedules.gen';
+import type { AttackDiscoveryApiScheduleAction } from '../../schemas/attack_discovery/routes/public/schedules/schedules_api.gen';
+
+const isGeneralAction = (
+  action: AttackDiscoveryScheduleAction
+): action is AttackDiscoveryScheduleGeneralAction => {
+  return Object.hasOwn(action, 'group');
+};
+
+export const transformAttackDiscoveryScheduleActionsPropsToApi = (
+  actions: AttackDiscoveryScheduleAction[] | undefined
+): AttackDiscoveryApiScheduleAction[] | undefined => {
+  return actions?.map((action) => {
+    if (isGeneralAction(action)) {
+      return {
+        action_type_id: action.actionTypeId,
+        group: action.group,
+        id: action.id,
+        params: action.params,
+        uuid: action.uuid,
+        alerts_filter: action.alertsFilter,
+        frequency: action.frequency
+          ? {
+              summary: action.frequency.summary,
+              notify_when: action.frequency.notifyWhen,
+              throttle: action.frequency.throttle,
+            }
+          : undefined,
+      };
+    }
+    return {
+      action_type_id: action.actionTypeId,
+      id: action.id,
+      params: action.params,
+      uuid: action.uuid,
+    };
+  });
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_create_props_from_api/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_create_props_from_api/index.test.ts
@@ -50,6 +50,20 @@ describe('transformAttackDiscoveryScheduleCreatePropsFromApi', () => {
           throttle: '5m',
         },
       },
+      {
+        action_type_id: '.cases',
+        id: 'system-connector-.cases',
+        params: {
+          subAction: 'run',
+          subActionParams: {
+            timeWindow: '7d',
+            reopenClosedCases: false,
+            groupingBy: [],
+            templateId: null,
+          },
+        },
+        uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+      },
     ],
   };
 
@@ -96,6 +110,20 @@ describe('transformAttackDiscoveryScheduleCreatePropsFromApi', () => {
             notifyWhen: 'onActiveAlert',
             throttle: '5m',
           },
+        },
+        {
+          actionTypeId: '.cases',
+          id: 'system-connector-.cases',
+          params: {
+            subAction: 'run',
+            subActionParams: {
+              groupingBy: [],
+              reopenClosedCases: false,
+              templateId: null,
+              timeWindow: '7d',
+            },
+          },
+          uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
         },
       ],
     });
@@ -174,7 +202,17 @@ describe('transformAttackDiscoveryScheduleCreatePropsFromApi', () => {
       createPropsWithActionWithoutFrequency
     );
 
-    expect(result.actions?.[0].frequency).toBeUndefined();
+    expect(result.actions?.[0]).toEqual({
+      actionTypeId: '.slack',
+      alertsFilter: undefined,
+      frequency: undefined,
+      group: 'default',
+      id: 'action1',
+      params: {
+        message: 'Test message',
+      },
+      uuid: undefined,
+    });
   });
 
   it('should handle actions without optional fields', () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_create_props_from_api/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_create_props_from_api/index.ts
@@ -7,36 +7,25 @@
 
 import type { AttackDiscoveryScheduleCreateProps } from '../../schemas/attack_discovery/routes/public/schedules/schedules.gen';
 import type { AttackDiscoveryApiScheduleCreateProps } from '../../schemas/attack_discovery/routes/public/schedules/schedules_api.gen';
+import { transformAttackDiscoveryScheduleActionsPropsFromApi } from '../transform_attack_discovery_schedule_actions_props_from_api';
 
 export const transformAttackDiscoveryScheduleCreatePropsFromApi = (
   apiCreateProps: AttackDiscoveryApiScheduleCreateProps
-): AttackDiscoveryScheduleCreateProps => ({
-  name: apiCreateProps.name,
-  enabled: apiCreateProps.enabled,
-  params: {
-    alertsIndexPattern: apiCreateProps.params.alerts_index_pattern,
-    apiConfig: apiCreateProps.params.api_config,
-    end: apiCreateProps.params.end,
-    query: apiCreateProps.params.query,
-    filters: apiCreateProps.params.filters,
-    combinedFilter: apiCreateProps.params.combined_filter,
-    size: apiCreateProps.params.size,
-    start: apiCreateProps.params.start,
-  },
-  schedule: apiCreateProps.schedule,
-  actions: apiCreateProps.actions?.map((action) => ({
-    actionTypeId: action.action_type_id,
-    group: action.group,
-    id: action.id,
-    params: action.params,
-    uuid: action.uuid,
-    alertsFilter: action.alerts_filter,
-    frequency: action.frequency
-      ? {
-          summary: action.frequency.summary,
-          notifyWhen: action.frequency.notify_when,
-          throttle: action.frequency.throttle,
-        }
-      : undefined,
-  })),
-});
+): AttackDiscoveryScheduleCreateProps => {
+  return {
+    name: apiCreateProps.name,
+    enabled: apiCreateProps.enabled,
+    params: {
+      alertsIndexPattern: apiCreateProps.params.alerts_index_pattern,
+      apiConfig: apiCreateProps.params.api_config,
+      end: apiCreateProps.params.end,
+      query: apiCreateProps.params.query,
+      filters: apiCreateProps.params.filters,
+      combinedFilter: apiCreateProps.params.combined_filter,
+      size: apiCreateProps.params.size,
+      start: apiCreateProps.params.start,
+    },
+    schedule: apiCreateProps.schedule,
+    actions: transformAttackDiscoveryScheduleActionsPropsFromApi(apiCreateProps.actions),
+  };
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_create_props_to_api/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_create_props_to_api/index.test.ts
@@ -40,6 +40,20 @@ describe('transformAttackDiscoveryScheduleCreatePropsToApi', () => {
           throttle: null,
         },
       },
+      {
+        actionTypeId: '.cases',
+        id: 'system-connector-.cases',
+        params: {
+          subAction: 'run',
+          subActionParams: {
+            groupingBy: [],
+            reopenClosedCases: false,
+            templateId: null,
+            timeWindow: '7d',
+          },
+        },
+        uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+      },
     ],
   };
 
@@ -84,6 +98,20 @@ describe('transformAttackDiscoveryScheduleCreatePropsToApi', () => {
             throttle: null,
           },
         },
+        {
+          action_type_id: '.cases',
+          id: 'system-connector-.cases',
+          params: {
+            subAction: 'run',
+            subActionParams: {
+              groupingBy: [],
+              reopenClosedCases: false,
+              templateId: null,
+              timeWindow: '7d',
+            },
+          },
+          uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+        },
       ],
     });
   });
@@ -118,6 +146,16 @@ describe('transformAttackDiscoveryScheduleCreatePropsToApi', () => {
       createPropsWithActionWithoutFrequency
     );
 
-    expect(result.actions?.[0].frequency).toBeUndefined();
+    expect(result.actions?.[0]).toEqual({
+      action_type_id: '.slack',
+      alerts_filter: undefined,
+      frequency: undefined,
+      group: 'default',
+      id: 'action1',
+      params: {
+        message: 'Test message',
+      },
+      uuid: undefined,
+    });
   });
 });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_create_props_to_api/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_create_props_to_api/index.ts
@@ -7,6 +7,7 @@
 
 import type { AttackDiscoveryScheduleCreateProps } from '../../schemas/attack_discovery/routes/public/schedules/schedules.gen';
 import type { AttackDiscoveryApiScheduleCreateProps } from '../../schemas/attack_discovery/routes/public/schedules/schedules_api.gen';
+import { transformAttackDiscoveryScheduleActionsPropsToApi } from '../transform_attack_discovery_schedule_actions_props_to_api';
 
 export const transformAttackDiscoveryScheduleCreatePropsToApi = (
   createProps: AttackDiscoveryScheduleCreateProps
@@ -24,19 +25,5 @@ export const transformAttackDiscoveryScheduleCreatePropsToApi = (
     start: createProps.params.start,
   },
   schedule: createProps.schedule,
-  actions: createProps.actions?.map((action) => ({
-    action_type_id: action.actionTypeId,
-    group: action.group,
-    id: action.id,
-    params: action.params,
-    uuid: action.uuid,
-    alerts_filter: action.alertsFilter,
-    frequency: action.frequency
-      ? {
-          summary: action.frequency.summary,
-          notify_when: action.frequency.notifyWhen,
-          throttle: action.frequency.throttle,
-        }
-      : undefined,
-  })),
+  actions: transformAttackDiscoveryScheduleActionsPropsToApi(createProps.actions),
 });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_from_api/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_from_api/index.test.ts
@@ -56,6 +56,20 @@ describe('transformAttackDiscoveryScheduleFromApi', () => {
           throttle: '1h',
         },
       },
+      {
+        action_type_id: '.cases',
+        id: 'system-connector-.cases',
+        params: {
+          subAction: 'run',
+          subActionParams: {
+            timeWindow: '7d',
+            reopenClosedCases: false,
+            groupingBy: [],
+            templateId: null,
+          },
+        },
+        uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+      },
     ],
     last_execution: {
       date: '2025-01-01T12:00:00.000Z',
@@ -112,6 +126,20 @@ describe('transformAttackDiscoveryScheduleFromApi', () => {
             notifyWhen: 'onActiveAlert',
             throttle: '1h',
           },
+        },
+        {
+          actionTypeId: '.cases',
+          id: 'system-connector-.cases',
+          params: {
+            subAction: 'run',
+            subActionParams: {
+              groupingBy: [],
+              reopenClosedCases: false,
+              templateId: null,
+              timeWindow: '7d',
+            },
+          },
+          uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
         },
       ],
       lastExecution: {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_from_api/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_from_api/index.ts
@@ -7,6 +7,7 @@
 
 import type { AttackDiscoverySchedule } from '../../schemas/attack_discovery/routes/public/schedules/schedules.gen';
 import type { AttackDiscoveryApiSchedule } from '../../schemas/attack_discovery/routes/public/schedules/schedules_api.gen';
+import { transformAttackDiscoveryScheduleActionsPropsFromApi } from '../transform_attack_discovery_schedule_actions_props_from_api';
 
 export const transformAttackDiscoveryScheduleFromApi = (
   api: AttackDiscoveryApiSchedule
@@ -30,21 +31,7 @@ export const transformAttackDiscoveryScheduleFromApi = (
       start: api.params.start,
     },
     schedule: api.schedule,
-    actions: api.actions.map((action) => ({
-      actionTypeId: action.action_type_id,
-      group: action.group,
-      id: action.id,
-      params: action.params,
-      uuid: action.uuid,
-      alertsFilter: action.alerts_filter,
-      frequency: action.frequency
-        ? {
-            summary: action.frequency.summary,
-            notifyWhen: action.frequency.notify_when,
-            throttle: action.frequency.throttle,
-          }
-        : undefined,
-    })),
+    actions: transformAttackDiscoveryScheduleActionsPropsFromApi(api.actions) ?? [],
     lastExecution: api.last_execution,
   };
 };

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_to_api/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_to_api/index.test.ts
@@ -57,6 +57,20 @@ describe('transformAttackDiscoveryScheduleToApi', () => {
             throttle: '2h',
           },
         },
+        {
+          actionTypeId: '.cases',
+          id: 'system-connector-.cases',
+          params: {
+            subAction: 'run',
+            subActionParams: {
+              groupingBy: [],
+              reopenClosedCases: false,
+              templateId: null,
+              timeWindow: '7d',
+            },
+          },
+          uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+        },
       ],
       lastExecution: {
         date: '2025-09-16T12:00:00.000Z',
@@ -111,6 +125,20 @@ describe('transformAttackDiscoveryScheduleToApi', () => {
             notify_when: 'onActionGroupChange',
             throttle: '2h',
           },
+        },
+        {
+          action_type_id: '.cases',
+          id: 'system-connector-.cases',
+          params: {
+            subAction: 'run',
+            subActionParams: {
+              groupingBy: [],
+              reopenClosedCases: false,
+              templateId: null,
+              timeWindow: '7d',
+            },
+          },
+          uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
         },
       ],
       last_execution: {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_to_api/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_to_api/index.ts
@@ -7,6 +7,7 @@
 
 import type { AttackDiscoverySchedule } from '../../schemas/attack_discovery/routes/public/schedules/schedules.gen';
 import type { AttackDiscoveryApiSchedule } from '../../schemas/attack_discovery/routes/public/schedules/schedules_api.gen';
+import { transformAttackDiscoveryScheduleActionsPropsToApi } from '../transform_attack_discovery_schedule_actions_props_to_api';
 
 export const transformAttackDiscoveryScheduleToApi = (
   attackDiscoverySchedule: AttackDiscoverySchedule
@@ -29,20 +30,6 @@ export const transformAttackDiscoveryScheduleToApi = (
     start: attackDiscoverySchedule.params.start,
   },
   schedule: attackDiscoverySchedule.schedule,
-  actions: attackDiscoverySchedule.actions.map((action) => ({
-    action_type_id: action.actionTypeId,
-    group: action.group,
-    id: action.id,
-    params: action.params,
-    uuid: action.uuid,
-    alerts_filter: action.alertsFilter,
-    frequency: action.frequency
-      ? {
-          summary: action.frequency.summary,
-          notify_when: action.frequency.notifyWhen,
-          throttle: action.frequency.throttle,
-        }
-      : undefined,
-  })),
+  actions: transformAttackDiscoveryScheduleActionsPropsToApi(attackDiscoverySchedule.actions) ?? [],
   last_execution: attackDiscoverySchedule.lastExecution,
 });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_update_props_from_api/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_update_props_from_api/index.test.ts
@@ -49,6 +49,20 @@ describe('transformAttackDiscoveryScheduleUpdatePropsFromApi', () => {
           throttle: '10m',
         },
       },
+      {
+        action_type_id: '.cases',
+        id: 'system-connector-.cases',
+        params: {
+          subAction: 'run',
+          subActionParams: {
+            timeWindow: '7d',
+            reopenClosedCases: false,
+            groupingBy: [],
+            templateId: null,
+          },
+        },
+        uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+      },
     ],
   };
 
@@ -95,6 +109,20 @@ describe('transformAttackDiscoveryScheduleUpdatePropsFromApi', () => {
             throttle: '10m',
           },
         },
+        {
+          actionTypeId: '.cases',
+          id: 'system-connector-.cases',
+          params: {
+            subAction: 'run',
+            subActionParams: {
+              groupingBy: [],
+              reopenClosedCases: false,
+              templateId: null,
+              timeWindow: '7d',
+            },
+          },
+          uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+        },
       ],
     });
   });
@@ -112,7 +140,21 @@ describe('transformAttackDiscoveryScheduleUpdatePropsFromApi', () => {
 
     const result = transformAttackDiscoveryScheduleUpdatePropsFromApi(propsWithoutFrequency);
 
-    expect(result.actions[0].frequency).toBeUndefined();
+    expect(result.actions[0]).toEqual({
+      actionTypeId: '.slack',
+      alertsFilter: {
+        query: {
+          match_all: {},
+        },
+      },
+      frequency: undefined,
+      group: 'default',
+      id: 'action1',
+      params: {
+        message: 'Updated test message',
+      },
+      uuid: 'test-uuid',
+    });
   });
 
   it('should transform multiple actions correctly', () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_update_props_from_api/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_update_props_from_api/index.ts
@@ -7,6 +7,7 @@
 
 import type { AttackDiscoveryScheduleUpdateProps } from '../../schemas/attack_discovery/routes/public/schedules/schedules.gen';
 import type { AttackDiscoveryApiScheduleUpdateProps } from '../../schemas/attack_discovery/routes/public/schedules/schedules_api.gen';
+import { transformAttackDiscoveryScheduleActionsPropsFromApi } from '../transform_attack_discovery_schedule_actions_props_from_api';
 
 export const transformAttackDiscoveryScheduleUpdatePropsFromApi = (
   apiUpdateProps: AttackDiscoveryApiScheduleUpdateProps
@@ -23,19 +24,5 @@ export const transformAttackDiscoveryScheduleUpdatePropsFromApi = (
     start: apiUpdateProps.params.start,
   },
   schedule: apiUpdateProps.schedule,
-  actions: apiUpdateProps.actions.map((action) => ({
-    actionTypeId: action.action_type_id,
-    group: action.group,
-    id: action.id,
-    params: action.params,
-    uuid: action.uuid,
-    alertsFilter: action.alerts_filter,
-    frequency: action.frequency
-      ? {
-          summary: action.frequency.summary,
-          notifyWhen: action.frequency.notify_when,
-          throttle: action.frequency.throttle,
-        }
-      : undefined,
-  })),
+  actions: transformAttackDiscoveryScheduleActionsPropsFromApi(apiUpdateProps.actions) ?? [],
 });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_update_props_to_api/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_update_props_to_api/index.test.ts
@@ -49,6 +49,20 @@ describe('transformAttackDiscoveryScheduleUpdatePropsToApi', () => {
           subject: 'Attack Discovery Alert',
         },
       },
+      {
+        actionTypeId: '.cases',
+        id: 'system-connector-.cases',
+        params: {
+          subAction: 'run',
+          subActionParams: {
+            groupingBy: [],
+            reopenClosedCases: false,
+            templateId: null,
+            timeWindow: '7d',
+          },
+        },
+        uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+      },
     ],
   };
 
@@ -103,6 +117,20 @@ describe('transformAttackDiscoveryScheduleUpdatePropsToApi', () => {
           alerts_filter: undefined,
           frequency: undefined,
         },
+        {
+          action_type_id: '.cases',
+          id: 'system-connector-.cases',
+          params: {
+            subAction: 'run',
+            subActionParams: {
+              groupingBy: [],
+              reopenClosedCases: false,
+              templateId: null,
+              timeWindow: '7d',
+            },
+          },
+          uuid: '2c749fe6-9ae0-4518-98c6-02add52a1fa6',
+        },
       ],
     });
   });
@@ -126,7 +154,17 @@ describe('transformAttackDiscoveryScheduleUpdatePropsToApi', () => {
       updatePropsWithActionWithoutFrequency
     );
 
-    expect(result.actions[0].frequency).toBeUndefined();
+    expect(result.actions[0]).toEqual({
+      action_type_id: '.slack',
+      alerts_filter: undefined,
+      frequency: undefined,
+      group: 'default',
+      id: 'action1',
+      params: {
+        message: 'Test message',
+      },
+      uuid: undefined,
+    });
   });
 
   it('should handle minimal params', () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_update_props_to_api/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/transform_attack_discovery_schedule_update_props_to_api/index.ts
@@ -7,6 +7,7 @@
 
 import type { AttackDiscoveryScheduleUpdateProps } from '../../schemas/attack_discovery/routes/public/schedules/schedules.gen';
 import type { AttackDiscoveryApiScheduleUpdateProps } from '../../schemas/attack_discovery/routes/public/schedules/schedules_api.gen';
+import { transformAttackDiscoveryScheduleActionsPropsToApi } from '../transform_attack_discovery_schedule_actions_props_to_api';
 
 export const transformAttackDiscoveryScheduleUpdatePropsToApi = (
   updateProps: AttackDiscoveryScheduleUpdateProps
@@ -23,19 +24,5 @@ export const transformAttackDiscoveryScheduleUpdatePropsToApi = (
     start: updateProps.params.start,
   },
   schedule: updateProps.schedule,
-  actions: updateProps.actions.map((action) => ({
-    action_type_id: action.actionTypeId,
-    group: action.group,
-    id: action.id,
-    params: action.params,
-    uuid: action.uuid,
-    alerts_filter: action.alertsFilter,
-    frequency: action.frequency
-      ? {
-          summary: action.frequency.summary,
-          notify_when: action.frequency.notifyWhen,
-          throttle: action.frequency.throttle,
-        }
-      : undefined,
-  })),
+  actions: transformAttackDiscoveryScheduleActionsPropsToApi(updateProps.actions) ?? [],
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/data_client/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/data_client/index.ts
@@ -75,7 +75,6 @@ export class AttackDiscoveryScheduleDataClient {
     const { enabled = false, actions: _, ...restScheduleAttributes } = ruleToCreate;
     const { actions, systemActions } = convertScheduleActionsToAlertingActions({
       actionsClient: this.options.actionsClient,
-      logger: this.options.logger,
       scheduleActions: ruleToCreate.actions,
     });
     const rule = await this.options.rulesClient.create<AttackDiscoveryScheduleParams>({
@@ -99,7 +98,6 @@ export class AttackDiscoveryScheduleDataClient {
     const { id, actions: _, ...updatePayload } = ruleToUpdate;
     const { actions, systemActions } = convertScheduleActionsToAlertingActions({
       actionsClient: this.options.actionsClient,
-      logger: this.options.logger,
       scheduleActions: ruleToUpdate.actions,
     });
     const rule = await this.options.rulesClient.update<AttackDiscoveryScheduleParams>({

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/data_client/utils/transform_actions.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/data_client/utils/transform_actions.test.ts
@@ -6,13 +6,11 @@
  */
 
 import { actionsClientMock } from '@kbn/actions-plugin/server/mocks';
-import { loggerMock } from '@kbn/logging-mocks';
 
 import { convertScheduleActionsToAlertingActions } from './transform_actions';
 import { getScheduleActions } from '../../../../../__mocks__/attack_discovery_schedules.mock';
 
 const mockActionsClient = actionsClientMock.create();
-const mockLogger = loggerMock.create();
 
 describe('convertScheduleActionsToAlertingActions', () => {
   const systemAction = getScheduleActions().find((action) => action.actionTypeId === '.cases');
@@ -29,7 +27,6 @@ describe('convertScheduleActionsToAlertingActions', () => {
     const scheduleActions = getScheduleActions();
     const { actions, systemActions } = convertScheduleActionsToAlertingActions({
       actionsClient: mockActionsClient,
-      logger: mockLogger,
       scheduleActions,
     });
 
@@ -53,45 +50,6 @@ describe('convertScheduleActionsToAlertingActions', () => {
         params: { message: 'Rule {{context.rule.name}} generated {{state.signals_count}} alerts' },
       },
     ]);
-    expect(systemActions).toEqual([
-      {
-        id: '74ad56aa-cc3d-45a4-a944-654b625ed054',
-        actionTypeId: '.cases',
-        params: {
-          subAction: 'run',
-          subActionParams: {
-            timeWindow: '5m',
-            reopenClosedCases: false,
-            groupingBy: ['kibana.alert.attack_discovery.alert_ids'],
-            templateId: null,
-          },
-        },
-      },
-    ]);
-  });
-
-  it('should log an error when there is a non system action with undefined group', async () => {
-    const scheduleActions = getScheduleActions().map(({ group, ...restOfAction }) => {
-      return restOfAction;
-    });
-
-    const { actions, systemActions } = convertScheduleActionsToAlertingActions({
-      actionsClient: mockActionsClient,
-      logger: mockLogger,
-      scheduleActions,
-    });
-
-    expect(mockLogger.error).toHaveBeenCalledTimes(2);
-    expect(mockLogger.error).toHaveBeenNthCalledWith(
-      1,
-      'Missing group for non-system action ab81485e-3685-4215-9804-7693d0271d1b of type .email'
-    );
-    expect(mockLogger.error).toHaveBeenNthCalledWith(
-      2,
-      'Missing group for non-system action a6c9e92a-b701-41f3-9e26-aca7563e6908 of type .slack'
-    );
-
-    expect(actions).toEqual([]);
     expect(systemActions).toEqual([
       {
         id: '74ad56aa-cc3d-45a4-a944-654b625ed054',

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/data_client/utils/transform_actions.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/data_client/utils/transform_actions.ts
@@ -6,52 +6,38 @@
  */
 
 import type { ActionsClient } from '@kbn/actions-plugin/server';
-import type { Logger } from '@kbn/core/server';
 import type {
   AttackDiscoveryScheduleAction,
-  AttackDiscoveryScheduleActionGroup,
+  AttackDiscoveryScheduleGeneralAction,
+  AttackDiscoveryScheduleSystemAction,
 } from '@kbn/elastic-assistant-common';
 
-type AlertingAction = Omit<AttackDiscoveryScheduleAction, 'group'> & {
-  group: AttackDiscoveryScheduleActionGroup;
-};
-
-type AlertingSystemAction = Omit<
-  AttackDiscoveryScheduleAction,
-  'group' | 'frequency' | 'alertsFilter' | 'useAlertDataForTemplate'
->;
-
-const isAlertingActions = (action: AttackDiscoveryScheduleAction): action is AlertingAction => {
-  return action.group != null;
+const isSystemAction = (
+  action: AttackDiscoveryScheduleAction,
+  actionsClient: ActionsClient
+): action is AttackDiscoveryScheduleSystemAction => {
+  return actionsClient.isSystemAction(action.id);
 };
 
 export const convertScheduleActionsToAlertingActions = ({
   actionsClient,
-  logger,
   scheduleActions,
 }: {
   actionsClient: ActionsClient;
-  logger: Logger;
   scheduleActions: AttackDiscoveryScheduleAction[] | undefined;
 }) => {
   return (scheduleActions ?? []).reduce(
     (acc, value) => {
-      if (actionsClient.isSystemAction(value.id)) {
+      if (isSystemAction(value, actionsClient)) {
         acc.systemActions.push(value);
       } else {
-        if (isAlertingActions(value)) {
-          acc.actions.push(value);
-        } else {
-          logger.error(
-            `Missing group for non-system action ${value.id} of type ${value.actionTypeId}`
-          );
-        }
+        acc.actions.push(value);
       }
       return acc;
     },
     { actions: [], systemActions: [] } as {
-      actions: AlertingAction[];
-      systemActions: AlertingSystemAction[];
+      actions: AttackDiscoveryScheduleGeneralAction[];
+      systemActions: AttackDiscoveryScheduleSystemAction[];
     }
   );
 };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/public/post/create.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/public/post/create.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { actionsClientMock } from '@kbn/actions-plugin/server/mocks';
 import type { CreateAttackDiscoverySchedulesRequestBody } from '@kbn/elastic-assistant-common';
 import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/common/openai/constants';
 
@@ -39,6 +40,9 @@ const mockSchedulingDataClient = {
   deleteSchedule: jest.fn(),
   enableSchedule: jest.fn(),
   disableSchedule: jest.fn(),
+  options: {
+    actionsClient: actionsClientMock.create(),
+  },
 } as unknown as AttackDiscoveryScheduleDataClient;
 const mockApiConfig = {
   connectorId: 'connector-id',

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/public/post/create.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/public/post/create.test.ts
@@ -6,7 +6,6 @@
  */
 
 import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
-import { actionsClientMock } from '@kbn/actions-plugin/server/mocks';
 import type { CreateAttackDiscoverySchedulesRequestBody } from '@kbn/elastic-assistant-common';
 import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/common/openai/constants';
 
@@ -40,9 +39,6 @@ const mockSchedulingDataClient = {
   deleteSchedule: jest.fn(),
   enableSchedule: jest.fn(),
   disableSchedule: jest.fn(),
-  options: {
-    actionsClient: actionsClientMock.create(),
-  },
 } as unknown as AttackDiscoveryScheduleDataClient;
 const mockApiConfig = {
   connectorId: 'connector-id',

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/public/post/create.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/public/post/create.ts
@@ -91,10 +91,13 @@ export const createAttackDiscoverySchedulesRoute = (
           }
 
           // Transform API format create properties to internal format
-          const internalScheduleData = transformAttackDiscoveryScheduleCreatePropsFromApi({
-            ...request.body,
-            enabled: request.body.enabled ?? false, // Default to disabled for security
-          });
+          const internalScheduleData = transformAttackDiscoveryScheduleCreatePropsFromApi(
+            {
+              ...request.body,
+              enabled: request.body.enabled ?? false, // Default to disabled for security
+            },
+            dataClient.options.actionsClient
+          );
 
           const schedule = await dataClient.createSchedule(internalScheduleData);
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/public/post/create.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/public/post/create.ts
@@ -91,13 +91,10 @@ export const createAttackDiscoverySchedulesRoute = (
           }
 
           // Transform API format create properties to internal format
-          const internalScheduleData = transformAttackDiscoveryScheduleCreatePropsFromApi(
-            {
-              ...request.body,
-              enabled: request.body.enabled ?? false, // Default to disabled for security
-            },
-            dataClient.options.actionsClient
-          );
+          const internalScheduleData = transformAttackDiscoveryScheduleCreatePropsFromApi({
+            ...request.body,
+            enabled: request.body.enabled ?? false, // Default to disabled for security
+          });
 
           const schedule = await dataClient.createSchedule(internalScheduleData);
 


### PR DESCRIPTION
## Summary

BUG: https://github.com/elastic/kibana/issues/238587

These changes fix the issue where user cannot create a new attack discovery schedule when system actions (e.g. cases) added.

Currently we incorrectly transform actions schema to the internal schema accepted by the alerting framework. Alerting framework has two action types `RuleAction` and `RuleSystemAction` defined here https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-alerting-types/rule_types.ts#L54-L70. There is an overlap in these types, though `RuleSystemAction` does not accept `group`, `frequency`, `alertsFilter` and `useAlertDataForTemplate` which are part of the `RuleAction` type - those parameters should not be `undefined` either, which will trigger schema check failure.

This PR, fixes the issue with the schema transformations and makes sure that we separate those two types correctly in attack discovery schedule world.

### Recording with the fix

https://github.com/user-attachments/assets/e73b0aa3-c148-43d1-ab18-3917370340a6


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->