### PR TITLE
[Controls] Fix error when selecting "(blank)" value in options list

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.test.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.test.tsx
@@ -242,7 +242,32 @@ describe('Options List Control Api', () => {
           { value: 'woof', docCount: 10 },
           { value: 'bark', docCount: 15 },
           { value: 'meow', docCount: 12 },
+          { value: '', docCount: 20 },
         ],
+      });
+    });
+
+    test('renders a "(blank)" option', async () => {
+      const { Component } = await factory.buildControl({
+        initialState: {
+          dataViewId: 'myDataViewId',
+          fieldName: 'myFieldName',
+          existsSelected: true,
+        },
+        finalizeApi,
+        uuid,
+        controlGroupApi,
+      });
+
+      const control = render(<Component className={'controlPanel'} />);
+      await userEvent.click(control.getByTestId(`optionsList-control-${uuid}`));
+      await waitFor(() => {
+        expect(control.getAllByRole('option').length).toBe(5);
+      });
+      const option = control.getByTestId('optionsList-control-selection-');
+      await userEvent.click(option);
+      await waitFor(async () => {
+        expect(option).toBeChecked();
       });
     });
 
@@ -261,7 +286,7 @@ describe('Options List Control Api', () => {
       const control = render(<Component className={'controlPanel'} />);
       await userEvent.click(control.getByTestId(`optionsList-control-${uuid}`));
       await waitFor(() => {
-        expect(control.getAllByRole('option').length).toBe(4);
+        expect(control.getAllByRole('option').length).toBe(5);
       });
 
       expect(control.getByTestId('optionsList-control-selection-exists')).toBeChecked();
@@ -290,7 +315,7 @@ describe('Options List Control Api', () => {
       const control = render(<Component className={'controlPanel'} />);
       await userEvent.click(control.getByTestId(`optionsList-control-${uuid}`));
       await waitFor(() => {
-        expect(control.getAllByRole('option').length).toEqual(4);
+        expect(control.getAllByRole('option').length).toEqual(5);
       });
 
       const existsOption = control.getByTestId('optionsList-control-selection-exists');
@@ -324,7 +349,7 @@ describe('Options List Control Api', () => {
       const control = render(<Component className={'controlPanel'} />);
       await userEvent.click(control.getByTestId(`optionsList-control-${uuid}`));
       await waitFor(() => {
-        expect(control.getAllByRole('option').length).toEqual(4);
+        expect(control.getAllByRole('option').length).toEqual(5);
       });
       await userEvent.click(control.getByTestId('optionsList-control-show-only-selected'));
 
@@ -386,7 +411,7 @@ describe('Options List Control Api', () => {
 
       await userEvent.click(control.getByTestId(`optionsList-control-${uuid}`));
       await waitFor(() => {
-        expect(control.getAllByRole('option').length).toEqual(4);
+        expect(control.getAllByRole('option').length).toEqual(5);
       });
       expect(control.getByTestId('optionsList-control-selection-woof')).toBeChecked();
       expect(control.queryByTestId('optionsList-control-selection-bark')).not.toBeChecked();

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
@@ -379,7 +379,7 @@ export const getOptionsListControlFactory = (): DataControlFactory<
         },
         makeSelection: (key: string | undefined, showOnlySelected: boolean) => {
           const field = api.field$.getValue();
-          if (!key || !field) {
+          if (key == null || !field) {
             api.setBlockingError(
               new Error(OptionsListStrings.control.getInvalidSelectionMessage())
             );


### PR DESCRIPTION
Fixes #239735

## Summary

Fixes an error in the Options list control when selecting a "(blank)" value.

Makes the boolean check for key more explicit using [loose equality to check if the key is null or undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness#loose_equality_using). Without this, selecting a `""` value causes the control to error.




<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->