### PR TITLE
[9.2] [Lens][ConfigBuilder] Fix internal reference handling (#239431)

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/gauge.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/gauge.test.ts
@@ -26,13 +26,7 @@ test('generates gauge chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -63,7 +57,13 @@ test('generates gauge chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",
@@ -101,13 +101,7 @@ test('generates gauge chart config with goal and max', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -154,7 +148,13 @@ test('generates gauge chart config with goal and max', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/gauge.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/gauge.ts
@@ -14,8 +14,7 @@ import { DEFAULT_LAYER_ID } from '../types';
 import {
   addLayerFormulaColumns,
   buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
+  extractReferences,
   mapToFormula,
 } from '../utils';
 import { getFormulaColumn, getValueColumn } from '../columns';
@@ -119,18 +118,19 @@ export async function buildGauge(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
+
   return {
     title: config.title,
     visualizationType: 'lnsGauge',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.test.ts
@@ -28,13 +28,7 @@ test('generates metric chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -81,7 +75,13 @@ test('generates metric chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.ts
@@ -11,13 +11,7 @@ import type { FormBasedPersistedState, HeatmapVisualizationState } from '@kbn/le
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { BuildDependencies, LensAttributes, LensHeatmapConfig } from '../types';
 import { DEFAULT_LAYER_ID } from '../types';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
 
 const ACCESSOR = 'metric_formula_accessor';
@@ -119,19 +113,19 @@ export async function buildHeatmap(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
 
   return {
     title: config.title,
     visualizationType: 'lnsHeatmap',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.test.ts
@@ -29,13 +29,7 @@ test('generates metric chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -72,7 +66,13 @@ test('generates metric chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",
@@ -110,18 +110,7 @@ test('generates metric chart config with trendline', async () => {
 
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": undefined,
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-        Object {
-          "id": undefined,
-          "name": "indexpattern-datasource-layer-layer_0_trendline",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "3feeaf26-927e-448e-968f-c7e970671564": Object {},

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.ts
@@ -19,8 +19,7 @@ import {
   addLayerColumn,
   addLayerFormulaColumns,
   buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
+  extractReferences,
   mapToFormula,
 } from '../utils';
 import {
@@ -208,18 +207,19 @@ export async function buildMetric(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
+
   return {
     title: config.title,
     visualizationType: 'lnsMetric',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/partition.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/partition.test.ts
@@ -27,13 +27,7 @@ test('generates metric chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -80,7 +74,13 @@ test('generates metric chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/partition.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/partition.ts
@@ -18,13 +18,7 @@ import type {
   LensLegendConfig,
 } from '../types';
 import { DEFAULT_LAYER_ID } from '../types';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
 
 const ACCESSOR = 'metric_formula_accessor';
@@ -122,18 +116,19 @@ export async function buildPartitionChart(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
+
   return {
     title: config.title,
     visualizationType: 'lnsPie',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/region_map.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/region_map.test.ts
@@ -28,13 +28,7 @@ test('generates region map chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -73,7 +67,13 @@ test('generates region map chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/region_map.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/region_map.ts
@@ -17,13 +17,7 @@ import type {
   LensTagCloudConfig,
 } from '../types';
 import { DEFAULT_LAYER_ID } from '../types';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
 
 const ACCESSOR = 'metric_formula_accessor';
@@ -99,19 +93,19 @@ export async function buildRegionMap(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
 
   return {
     title: config.title,
     visualizationType: 'lnsChoropleth',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/table.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/table.test.ts
@@ -27,13 +27,7 @@ test('generates table config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -72,7 +66,13 @@ test('generates table config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/table.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/table.ts
@@ -11,13 +11,7 @@ import type { FormBasedPersistedState, DatatableVisualizationState } from '@kbn/
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { BuildDependencies, LensAttributes, LensTableConfig } from '../types';
 import { DEFAULT_LAYER_ID } from '../types';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
 
 const ACCESSOR = 'metric_formula_accessor';
@@ -112,18 +106,19 @@ export async function buildTable(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
+
   return {
     title: config.title,
     visualizationType: 'lnsDatatable',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/tag_cloud.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/tag_cloud.test.ts
@@ -27,13 +27,7 @@ test('generates tag cloud chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -72,7 +66,13 @@ test('generates tag cloud chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/tag_cloud.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/tag_cloud.ts
@@ -11,13 +11,7 @@ import type { FormBasedPersistedState, TagcloudState } from '@kbn/lens-plugin/pu
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { BuildDependencies, LensAttributes, LensTagCloudConfig } from '../types';
 import { DEFAULT_LAYER_ID } from '../types';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
 
 const ACCESSOR = 'metric_formula_accessor';
@@ -96,18 +90,19 @@ export async function buildTagCloud(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
+
   return {
     title: config.title,
     visualizationType: 'lnsTagcloud',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.test.ts
@@ -41,13 +41,7 @@ test('generates xy chart config', async () => {
 
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -92,7 +86,13 @@ test('generates xy chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
@@ -18,13 +18,7 @@ import type { DataView } from '@kbn/data-views-plugin/public';
 import type { XYByValueAnnotationLayerConfig } from '@kbn/lens-plugin/public/visualizations/xy/types';
 import type { QueryPointEventAnnotationConfig } from '@kbn/event-annotation-common';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
 import type {
   BuildDependencies,
   LensAnnotationLayer,
@@ -272,7 +266,7 @@ export async function buildXY(
     getValueColumns,
     dataViewsAPI
   );
-  const references = buildReferences(dataviews);
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
 
   return {
     title: config.title,
@@ -280,12 +274,11 @@ export async function buildXY(
     references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/config_builder.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/config_builder.ts
@@ -9,8 +9,7 @@
 
 import type { LensEmbeddableInput } from '@kbn/lens-plugin/public';
 import { v4 as uuidv4 } from 'uuid';
-import type { DataViewsService } from '@kbn/data-views-plugin/common';
-import type { LensAttributes, LensConfig, LensConfigOptions } from './types';
+import type { DataViewsCommon, LensAttributes, LensConfig, LensConfigOptions } from './types';
 import {
   buildGauge,
   buildHeatmap,
@@ -25,8 +24,6 @@ import { fromAPItoLensState, fromLensStateToAPI } from './transforms/charts/metr
 import type { LensApiState } from './schema';
 import { isLensLegacyFormat } from './utils';
 import { filtersAndQueryToApiFormat, filtersAndQueryToLensState } from './transforms/utils';
-
-export type DataViewsCommon = Pick<DataViewsService, 'get' | 'create'>;
 
 export class LensConfigBuilder {
   private charts = {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
@@ -12,10 +12,12 @@ import type {
   TermsIndexPatternColumn,
   TypedLensByValueInput,
 } from '@kbn/lens-plugin/public';
+import type { DataViewsService } from '@kbn/data-views-plugin/common';
 import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import type { Datatable } from '@kbn/expressions-plugin/common';
 import type { XYLegendValue } from '@kbn/visualizations-plugin/common';
-import type { DataViewsCommon } from './config_builder';
+
+export type DataViewsCommon = Pick<DataViewsService, 'get' | 'create'>;
 
 export type LensAttributes = TypedLensByValueInput['attributes'];
 export const DEFAULT_LAYER_ID = 'layer_0';

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.test.ts
@@ -66,24 +66,50 @@ describe('isDataViewDataset', () => {
 });
 
 test('build references correctly builds references', () => {
-  const results = buildReferences({
-    layer1: dataView as unknown as DataView,
-    layer2: dataView as unknown as DataView,
-  });
-  expect(results).toMatchInlineSnapshot(`
-    Array [
-      Object {
-        "id": "test-dataview",
-        "name": "indexpattern-datasource-layer-layer1",
-        "type": "index-pattern",
-      },
-      Object {
-        "id": "test-dataview",
-        "name": "indexpattern-datasource-layer-layer2",
-        "type": "index-pattern",
-      },
-    ]
-  `);
+  const results = buildReferences(
+    {
+      layer1: dataView as unknown as DataView,
+      layer2: dataView as unknown as DataView,
+    },
+    {}
+  );
+  expect(results.references).toEqual([
+    {
+      id: 'test-dataview',
+      name: 'indexpattern-datasource-layer-layer1',
+      type: 'index-pattern',
+    },
+    {
+      id: 'test-dataview',
+      name: 'indexpattern-datasource-layer-layer2',
+      type: 'index-pattern',
+    },
+  ]);
+  expect(results.internalReferences).toEqual([]);
+});
+
+test('should split references and internalReferences', () => {
+  const results = buildReferences(
+    {
+      layer1: dataView as unknown as DataView,
+      layer2: { ...dataView, id: 'ad-hoc' } as unknown as DataView,
+    },
+    { 'ad-hoc': {} }
+  );
+  expect(results.references).toEqual([
+    {
+      id: 'test-dataview',
+      name: 'indexpattern-datasource-layer-layer1',
+      type: 'index-pattern',
+    },
+  ]);
+  expect(results.internalReferences).toEqual([
+    {
+      id: 'ad-hoc',
+      name: 'indexpattern-datasource-layer-layer2',
+      type: 'index-pattern',
+    },
+  ]);
 });
 
 test('getAdhocDataviews', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -21,7 +21,8 @@ import type {
 } from '@kbn/lens-plugin/public/datasources/form_based/esql_layer/types';
 import type { AggregateQuery } from '@kbn/es-query';
 import { getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
-import type { DataViewsCommon } from './config_builder';
+import type { Reference } from '@kbn/content-management-utils';
+import type { DataViewsCommon } from './types';
 import type {
   FormulaValueConfig,
   LensAnnotationLayer,
@@ -76,14 +77,43 @@ export function mapToFormula(layer: LensBaseLayer): FormulaValueConfig {
   };
 }
 
-export function buildReferences(dataviews: Record<string, DataView>) {
+export function extractReferences(dataviews: Record<string, DataView>): {
+  references: Reference[];
+  internalReferences: Reference[];
+  adHocDataViews: Record<string, DataViewSpec>;
+} {
+  const adHocDataViews = getAdhocDataviews(dataviews);
+  return {
+    ...buildReferences(dataviews, adHocDataViews),
+    adHocDataViews,
+  };
+}
+
+export function buildReferences(
+  dataviews: Record<string, DataView>,
+  adHocDataViews: Record<string, DataViewSpec>
+): {
+  references: Reference[];
+  internalReferences: Reference[];
+} {
   const references = [];
-  for (const layerid in dataviews) {
-    if (dataviews[layerid]) {
-      references.push(...getDefaultReferences(dataviews[layerid].id!, layerid));
+  const internalReferences = [];
+
+  for (const [layerId, dataview] of Object.entries(dataviews)) {
+    if (dataview.id) {
+      const defaultRefs = getDefaultReferences(dataview.id, layerId);
+      if (adHocDataViews[dataview.id]) {
+        internalReferences.push(...defaultRefs);
+      } else {
+        references.push(...defaultRefs);
+      }
     }
   }
-  return references.flat();
+
+  return {
+    references: references.flat(),
+    internalReferences: internalReferences.flat(),
+  };
 }
 
 const getAdhocDataView = (dataView: DataView): Record<string, DataViewSpec> => {
@@ -94,6 +124,7 @@ const getAdhocDataView = (dataView: DataView): Record<string, DataViewSpec> => {
   };
 };
 
+// Getting the spec from a data view is a heavy operation, that's why the result is cached.
 export const getAdhocDataviews = (dataviews: Record<string, DataView>) => {
   let adHocDataViews = {};
   [...new Set(Object.values(dataviews))].forEach((d) => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/tsconfig.json
@@ -19,5 +19,6 @@
     "@kbn/core-saved-objects-common",
     "@kbn/esql-utils",
     "@kbn/config-schema",
+    "@kbn/content-management-utils",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Lens][ConfigBuilder] Fix internal reference handling (#239431)](https://github.com/elastic/kibana/pull/239431)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Partridge","email":"nicholas.partridge@elastic.co"},"sourceCommit":{"committedDate":"2025-10-20T15:01:19Z","message":"[Lens][ConfigBuilder] Fix internal reference handling (#239431)\n\n## Summary\n\nFixes a bug in the `LensConfigBuilder` that treated all dataview\nreferences the same, causing the UI to throw an error attempting to find\nan ad-hoc dataview that does not exist as a SavedObject.\n\nFixes #239430\n\n## Release Notes\n\nFixes a bug in Lens that incorrectly assigned unsaved (ad-hoc) dataview\nreferences.","sha":"ad143b19f8086f1b027d3c6f4d5dbe436264c5a7","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","backport:all-open","v9.3.0"],"title":"[Lens][ConfigBuilder] Fix internal reference handling","number":239431,"url":"https://github.com/elastic/kibana/pull/239431","mergeCommit":{"message":"[Lens][ConfigBuilder] Fix internal reference handling (#239431)\n\n## Summary\n\nFixes a bug in the `LensConfigBuilder` that treated all dataview\nreferences the same, causing the UI to throw an error attempting to find\nan ad-hoc dataview that does not exist as a SavedObject.\n\nFixes #239430\n\n## Release Notes\n\nFixes a bug in Lens that incorrectly assigned unsaved (ad-hoc) dataview\nreferences.","sha":"ad143b19f8086f1b027d3c6f4d5dbe436264c5a7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239431","number":239431,"mergeCommit":{"message":"[Lens][ConfigBuilder] Fix internal reference handling (#239431)\n\n## Summary\n\nFixes a bug in the `LensConfigBuilder` that treated all dataview\nreferences the same, causing the UI to throw an error attempting to find\nan ad-hoc dataview that does not exist as a SavedObject.\n\nFixes #239430\n\n## Release Notes\n\nFixes a bug in Lens that incorrectly assigned unsaved (ad-hoc) dataview\nreferences.","sha":"ad143b19f8086f1b027d3c6f4d5dbe436264c5a7"}}]}] BACKPORT-->