### PR TITLE
[8.19] [Lens][ConfigBuilder] Fix internal reference handling (#239431)

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/gauge.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/gauge.test.ts
@@ -68,13 +68,7 @@ test('generates gauge chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -105,7 +99,13 @@ test('generates gauge chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",
@@ -144,13 +144,7 @@ test('generates gauge chart config with goal and max', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -197,7 +191,13 @@ test('generates gauge chart config with goal and max', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/gauge.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/gauge.ts
@@ -17,8 +17,7 @@ import { BuildDependencies, DEFAULT_LAYER_ID, LensAttributes, LensGaugeConfig } 
 import {
   addLayerFormulaColumns,
   buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
+  extractReferences,
   mapToFormula,
 } from '../utils';
 import { getFormulaColumn, getValueColumn } from '../columns';
@@ -138,18 +137,19 @@ export async function buildGauge(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
+
   return {
     title: config.title,
     visualizationType: 'lnsGauge',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.test.ts
@@ -70,13 +70,7 @@ test('generates metric chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -123,7 +117,13 @@ test('generates metric chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.ts
@@ -13,14 +13,9 @@ import type {
   HeatmapVisualizationState,
 } from '@kbn/lens-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
-import { BuildDependencies, DEFAULT_LAYER_ID, LensAttributes, LensHeatmapConfig } from '../types';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
+import type { BuildDependencies, LensAttributes, LensHeatmapConfig } from '../types';
+import { DEFAULT_LAYER_ID } from '../types';
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
 
 const ACCESSOR = 'metric_formula_accessor';
@@ -123,19 +118,19 @@ export async function buildHeatmap(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
 
   return {
     title: config.title,
     visualizationType: 'lnsHeatmap',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.test.ts
@@ -72,13 +72,7 @@ test('generates metric chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -115,7 +109,13 @@ test('generates metric chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",
@@ -191,18 +191,7 @@ test('generates metric chart config with trendline', async () => {
 
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": undefined,
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-        Object {
-          "id": undefined,
-          "name": "indexpattern-datasource-layer-layer_0_trendline",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "3feeaf26-927e-448e-968f-c7e970671564": Object {},

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.ts
@@ -19,8 +19,7 @@ import {
   addLayerColumn,
   addLayerFormulaColumns,
   buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
+  extractReferences,
   mapToFormula,
 } from '../utils';
 import {
@@ -221,18 +220,19 @@ export async function buildMetric(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
+
   return {
     title: config.title,
     visualizationType: 'lnsMetric',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/partition.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/partition.test.ts
@@ -69,13 +69,7 @@ test('generates metric chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -122,7 +116,13 @@ test('generates metric chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/partition.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/partition.ts
@@ -22,13 +22,7 @@ import {
   LensMosaicConfig,
   LensLegendConfig,
 } from '../types';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
 
 const ACCESSOR = 'metric_formula_accessor';
@@ -127,18 +121,19 @@ export async function buildPartitionChart(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
+
   return {
     title: config.title,
     visualizationType: 'lnsPie',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/region_map.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/region_map.test.ts
@@ -69,13 +69,7 @@ test('generates region map chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -114,7 +108,13 @@ test('generates region map chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/region_map.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/region_map.ts
@@ -17,13 +17,7 @@ import {
   LensRegionMapConfig,
   LensTagCloudConfig,
 } from '../types';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
 
 const ACCESSOR = 'metric_formula_accessor';
@@ -100,19 +94,19 @@ export async function buildRegionMap(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
 
   return {
     title: config.title,
     visualizationType: 'lnsChoropleth',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/table.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/table.test.ts
@@ -69,13 +69,7 @@ test('generates table config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -114,7 +108,13 @@ test('generates table config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/table.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/table.ts
@@ -13,14 +13,9 @@ import type {
   DatatableVisualizationState,
 } from '@kbn/lens-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
-import { BuildDependencies, DEFAULT_LAYER_ID, LensAttributes, LensTableConfig } from '../types';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
+import type { BuildDependencies, LensAttributes, LensTableConfig } from '../types';
+import { DEFAULT_LAYER_ID } from '../types';
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
 
 const ACCESSOR = 'metric_formula_accessor';
@@ -116,18 +111,19 @@ export async function buildTable(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
+
   return {
     title: config.title,
     visualizationType: 'lnsDatatable',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/tag_cloud.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/tag_cloud.test.ts
@@ -69,13 +69,7 @@ test('generates tag cloud chart config', async () => {
   );
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -114,7 +108,13 @@ test('generates tag cloud chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/tag_cloud.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/tag_cloud.ts
@@ -13,14 +13,9 @@ import type {
   TagcloudState,
 } from '@kbn/lens-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
-import { BuildDependencies, DEFAULT_LAYER_ID, LensAttributes, LensTagCloudConfig } from '../types';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
+import type { BuildDependencies, LensAttributes, LensTagCloudConfig } from '../types';
+import { DEFAULT_LAYER_ID } from '../types';
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
 
 const ACCESSOR = 'metric_formula_accessor';
@@ -100,18 +95,19 @@ export async function buildTagCloud(
     getValueColumns,
     dataViewsAPI
   );
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
+
   return {
     title: config.title,
     visualizationType: 'lnsTagcloud',
-    references: buildReferences(dataviews),
+    references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.test.ts
@@ -81,13 +81,7 @@ test('generates xy chart config', async () => {
 
   expect(result).toMatchInlineSnapshot(`
     Object {
-      "references": Array [
-        Object {
-          "id": "test",
-          "name": "indexpattern-datasource-layer-layer_0",
-          "type": "index-pattern",
-        },
-      ],
+      "references": Array [],
       "state": Object {
         "adHocDataViews": Object {
           "test": Object {},
@@ -132,7 +126,13 @@ test('generates xy chart config', async () => {
           },
         },
         "filters": Array [],
-        "internalReferences": Array [],
+        "internalReferences": Array [
+          Object {
+            "id": "test",
+            "name": "indexpattern-datasource-layer-layer_0",
+            "type": "index-pattern",
+          },
+        ],
         "query": Object {
           "language": "kuery",
           "query": "",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
@@ -19,14 +19,8 @@ import type { DataView } from '@kbn/data-views-plugin/public';
 import type { XYByValueAnnotationLayerConfig } from '@kbn/lens-plugin/public/visualizations/xy/types';
 import type { QueryPointEventAnnotationConfig } from '@kbn/event-annotation-common';
 import { getBreakdownColumn, getFormulaColumn, getValueColumn } from '../columns';
-import {
-  addLayerColumn,
-  buildDatasourceStates,
-  buildReferences,
-  getAdhocDataviews,
-  mapToFormula,
-} from '../utils';
-import {
+import { addLayerColumn, buildDatasourceStates, extractReferences, mapToFormula } from '../utils';
+import type {
   BuildDependencies,
   LensAnnotationLayer,
   LensAttributes,
@@ -232,7 +226,7 @@ export async function buildXY(
     getValueColumns,
     dataViewsAPI
   );
-  const references = buildReferences(dataviews);
+  const { references, internalReferences, adHocDataViews } = extractReferences(dataviews);
 
   return {
     title: config.title,
@@ -240,12 +234,11 @@ export async function buildXY(
     references,
     state: {
       datasourceStates,
-      internalReferences: [],
+      internalReferences,
       filters: [],
       query: { language: 'kuery', query: '' },
       visualization: buildVisualizationState(config),
-      // Getting the spec from a data view is a heavy operation, that's why the result is cached.
-      adHocDataViews: getAdhocDataviews(dataviews),
+      adHocDataViews,
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/config_builder.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/config_builder.ts
@@ -9,8 +9,7 @@
 
 import type { FormulaPublicApi, LensEmbeddableInput } from '@kbn/lens-plugin/public';
 import { v4 as uuidv4 } from 'uuid';
-import { DataViewsService } from '@kbn/data-views-plugin/common';
-import { LensAttributes, LensConfig, LensConfigOptions } from './types';
+import { DataViewsCommon, LensAttributes, LensConfig, LensConfigOptions } from './types';
 import {
   buildGauge,
   buildHeatmap,
@@ -21,8 +20,6 @@ import {
   buildXY,
   buildPartitionChart,
 } from './charts';
-
-export type DataViewsCommon = Pick<DataViewsService, 'get' | 'create'>;
 
 export class LensConfigBuilder {
   private charts = {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
@@ -10,7 +10,9 @@
 import type { FormulaPublicApi, TypedLensByValueInput } from '@kbn/lens-plugin/public';
 import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import type { Datatable } from '@kbn/expressions-plugin/common';
-import { DataViewsCommon } from './config_builder';
+import type { DataViewsService } from '@kbn/data-views-plugin/common';
+
+export type DataViewsCommon = Pick<DataViewsService, 'get' | 'create'>;
 
 export type LensAttributes = TypedLensByValueInput['attributes'];
 export const DEFAULT_LAYER_ID = 'layer_0';

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.test.ts
@@ -66,24 +66,50 @@ describe('isFormulaDataset', () => {
 });
 
 test('build references correctly builds references', () => {
-  const results = buildReferences({
-    layer1: dataView as unknown as DataView,
-    layer2: dataView as unknown as DataView,
-  });
-  expect(results).toMatchInlineSnapshot(`
-    Array [
-      Object {
-        "id": "test-dataview",
-        "name": "indexpattern-datasource-layer-layer1",
-        "type": "index-pattern",
-      },
-      Object {
-        "id": "test-dataview",
-        "name": "indexpattern-datasource-layer-layer2",
-        "type": "index-pattern",
-      },
-    ]
-  `);
+  const results = buildReferences(
+    {
+      layer1: dataView as unknown as DataView,
+      layer2: dataView as unknown as DataView,
+    },
+    {}
+  );
+  expect(results.references).toEqual([
+    {
+      id: 'test-dataview',
+      name: 'indexpattern-datasource-layer-layer1',
+      type: 'index-pattern',
+    },
+    {
+      id: 'test-dataview',
+      name: 'indexpattern-datasource-layer-layer2',
+      type: 'index-pattern',
+    },
+  ]);
+  expect(results.internalReferences).toEqual([]);
+});
+
+test('should split references and internalReferences', () => {
+  const results = buildReferences(
+    {
+      layer1: dataView as unknown as DataView,
+      layer2: { ...dataView, id: 'ad-hoc' } as unknown as DataView,
+    },
+    { 'ad-hoc': {} }
+  );
+  expect(results.references).toEqual([
+    {
+      id: 'test-dataview',
+      name: 'indexpattern-datasource-layer-layer1',
+      type: 'index-pattern',
+    },
+  ]);
+  expect(results.internalReferences).toEqual([
+    {
+      id: 'ad-hoc',
+      name: 'indexpattern-datasource-layer-layer2',
+      type: 'index-pattern',
+    },
+  ]);
 });
 
 test('getAdhocDataviews', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/tsconfig.json
@@ -18,5 +18,6 @@
     "@kbn/visualizations-plugin",
     "@kbn/core-saved-objects-common",
     "@kbn/esql-utils",
+    "@kbn/content-management-utils",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Lens][ConfigBuilder] Fix internal reference handling (#239431)](https://github.com/elastic/kibana/pull/239431)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Partridge","email":"nicholas.partridge@elastic.co"},"sourceCommit":{"committedDate":"2025-10-20T15:01:19Z","message":"[Lens][ConfigBuilder] Fix internal reference handling (#239431)\n\n## Summary\n\nFixes a bug in the `LensConfigBuilder` that treated all dataview\nreferences the same, causing the UI to throw an error attempting to find\nan ad-hoc dataview that does not exist as a SavedObject.\n\nFixes #239430\n\n## Release Notes\n\nFixes a bug in Lens that incorrectly assigned unsaved (ad-hoc) dataview\nreferences.","sha":"ad143b19f8086f1b027d3c6f4d5dbe436264c5a7","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","backport:all-open","v9.3.0"],"title":"[Lens][ConfigBuilder] Fix internal reference handling","number":239431,"url":"https://github.com/elastic/kibana/pull/239431","mergeCommit":{"message":"[Lens][ConfigBuilder] Fix internal reference handling (#239431)\n\n## Summary\n\nFixes a bug in the `LensConfigBuilder` that treated all dataview\nreferences the same, causing the UI to throw an error attempting to find\nan ad-hoc dataview that does not exist as a SavedObject.\n\nFixes #239430\n\n## Release Notes\n\nFixes a bug in Lens that incorrectly assigned unsaved (ad-hoc) dataview\nreferences.","sha":"ad143b19f8086f1b027d3c6f4d5dbe436264c5a7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239431","number":239431,"mergeCommit":{"message":"[Lens][ConfigBuilder] Fix internal reference handling (#239431)\n\n## Summary\n\nFixes a bug in the `LensConfigBuilder` that treated all dataview\nreferences the same, causing the UI to throw an error attempting to find\nan ad-hoc dataview that does not exist as a SavedObject.\n\nFixes #239430\n\n## Release Notes\n\nFixes a bug in Lens that incorrectly assigned unsaved (ad-hoc) dataview\nreferences.","sha":"ad143b19f8086f1b027d3c6f4d5dbe436264c5a7"}}]}] BACKPORT-->