### PR TITLE
[UII] Add `installIntegrationsKnowledge` feature flag

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
@@ -18,6 +18,7 @@ const _allowedExperimentalValues = {
   enableOtelIntegrations: true,
   enableAgentStatusAlerting: true,
   enableAgentPrivilegeLevelChange: false,
+  installIntegrationsKnowledge: false,
 };
 
 /**

--- a/x-pack/platform/plugins/shared/fleet/common/types/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/index.ts
@@ -111,6 +111,7 @@ export interface FleetConfigType {
   integrationsHomeOverride?: string;
   prereleaseEnabledByDefault?: boolean;
   hideDashboards?: boolean;
+  installIntegrationsKnowledge?: boolean;
 }
 
 // Calling Object.entries(PackagesGroupedByStatus) gave `status: string`

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -389,6 +389,7 @@ export const config: PluginConfigDescriptor = {
       integrationsHomeOverride: schema.maybe(schema.string()),
       prereleaseEnabledByDefault: schema.boolean({ defaultValue: false }),
       hideDashboards: schema.boolean({ defaultValue: false }),
+      installIntegrationsKnowledge: schema.boolean({ defaultValue: false }),
     },
     {
       validate: (configToValidate) => {

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -389,7 +389,6 @@ export const config: PluginConfigDescriptor = {
       integrationsHomeOverride: schema.maybe(schema.string()),
       prereleaseEnabledByDefault: schema.boolean({ defaultValue: false }),
       hideDashboards: schema.boolean({ defaultValue: false }),
-      installIntegrationsKnowledge: schema.boolean({ defaultValue: false }),
     },
     {
       validate: (configToValidate) => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.test.ts
@@ -23,7 +23,7 @@ jest.mock('../../../../app_context', () => ({
       info: jest.fn(),
       debug: jest.fn(),
     }),
-    getConfig: jest.fn().mockReturnValue({
+    getExperimentalFeatures: jest.fn().mockReturnValue({
       installIntegrationsKnowledge: true,
     }),
   },
@@ -604,9 +604,9 @@ describe('stepSaveKnowledgeBase', () => {
     });
 
     it('should skip knowledge base processing when installIntegrationsKnowledge feature flag is disabled', async () => {
-      // Mock app context service to return config with feature flag disabled
+      // Mock app context service to return experimental features with flag disabled
       const { appContextService } = jest.requireMock('../../../../app_context');
-      appContextService.getConfig.mockReturnValue({
+      appContextService.getExperimentalFeatures.mockReturnValue({
         installIntegrationsKnowledge: false,
       });
 
@@ -630,15 +630,15 @@ describe('stepSaveKnowledgeBase', () => {
       expect(updateEsAssetReferences).not.toHaveBeenCalled();
 
       // Reset the mock back to enabled for other tests
-      appContextService.getConfig.mockReturnValue({
+      appContextService.getExperimentalFeatures.mockReturnValue({
         installIntegrationsKnowledge: true,
       });
     });
 
     it('should process knowledge base when installIntegrationsKnowledge feature flag is enabled', async () => {
-      // Ensure app context service returns config with feature flag enabled
+      // Ensure app context service returns experimental features with flag enabled
       const { appContextService } = jest.requireMock('../../../../app_context');
-      appContextService.getConfig.mockReturnValue({
+      appContextService.getExperimentalFeatures.mockReturnValue({
         installIntegrationsKnowledge: true,
       });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.test.ts
@@ -23,6 +23,9 @@ jest.mock('../../../../app_context', () => ({
       info: jest.fn(),
       debug: jest.fn(),
     }),
+    getConfig: jest.fn().mockReturnValue({
+      installIntegrationsKnowledge: true,
+    }),
   },
 }));
 
@@ -536,7 +539,7 @@ describe('stepSaveKnowledgeBase', () => {
     });
   });
 
-  describe('License Validation', () => {
+  describe('Gating Validation', () => {
     it('should skip knowledge base processing when Enterprise license is not available', async () => {
       // Mock license service to return false for Enterprise license
       const { licenseService } = jest.requireMock('../../../../license');
@@ -583,6 +586,75 @@ describe('stepSaveKnowledgeBase', () => {
       await stepSaveKnowledgeBase(context);
 
       // Verify that saveKnowledgeBaseContentToIndex WAS called with Enterprise license
+      expect(saveKnowledgeBaseContentToIndex).toHaveBeenCalledWith({
+        esClient,
+        pkgName: 'test-package',
+        pkgVersion: '1.0.0',
+        knowledgeBaseContent: [
+          {
+            fileName: 'guide.md',
+            content: '# User Guide\n\nThis is a comprehensive guide.',
+          },
+        ],
+      });
+
+      // Verify that updateEsAssetReferences WAS called
+      const { updateEsAssetReferences } = jest.requireMock('../../es_assets_reference');
+      expect(updateEsAssetReferences).toHaveBeenCalled();
+    });
+
+    it('should skip knowledge base processing when installIntegrationsKnowledge feature flag is disabled', async () => {
+      // Mock app context service to return config with feature flag disabled
+      const { appContextService } = jest.requireMock('../../../../app_context');
+      appContextService.getConfig.mockReturnValue({
+        installIntegrationsKnowledge: false,
+      });
+
+      const entries: ArchiveEntry[] = [
+        {
+          path: 'test-package-1.0.0/docs/knowledge_base/guide.md',
+          buffer: Buffer.from('# User Guide\n\nThis is a comprehensive guide.', 'utf8'),
+        },
+      ];
+
+      const mockArchiveIterator = createMockArchiveIterator(entries);
+      const context = createMockContext(mockArchiveIterator);
+
+      await stepSaveKnowledgeBase(context);
+
+      // Verify that saveKnowledgeBaseContentToIndex was NOT called due to feature flag being disabled
+      expect(saveKnowledgeBaseContentToIndex).not.toHaveBeenCalled();
+
+      // Verify that updateEsAssetReferences was NOT called
+      const { updateEsAssetReferences } = jest.requireMock('../../es_assets_reference');
+      expect(updateEsAssetReferences).not.toHaveBeenCalled();
+
+      // Reset the mock back to enabled for other tests
+      appContextService.getConfig.mockReturnValue({
+        installIntegrationsKnowledge: true,
+      });
+    });
+
+    it('should process knowledge base when installIntegrationsKnowledge feature flag is enabled', async () => {
+      // Ensure app context service returns config with feature flag enabled
+      const { appContextService } = jest.requireMock('../../../../app_context');
+      appContextService.getConfig.mockReturnValue({
+        installIntegrationsKnowledge: true,
+      });
+
+      const entries: ArchiveEntry[] = [
+        {
+          path: 'test-package-1.0.0/docs/knowledge_base/guide.md',
+          buffer: Buffer.from('# User Guide\n\nThis is a comprehensive guide.', 'utf8'),
+        },
+      ];
+
+      const mockArchiveIterator = createMockArchiveIterator(entries);
+      const context = createMockContext(mockArchiveIterator);
+
+      await stepSaveKnowledgeBase(context);
+
+      // Verify that saveKnowledgeBaseContentToIndex WAS called with feature flag enabled
       expect(saveKnowledgeBaseContentToIndex).toHaveBeenCalledWith({
         esClient,
         pkgName: 'test-package',

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.ts
@@ -69,11 +69,11 @@ export async function stepSaveKnowledgeBase(context: InstallContext): Promise<vo
     `Knowledge base step: Starting for package ${packageInfo.name}@${packageInfo.version}`
   );
 
-  // Check if knowledge base installation is enabled via feature flag
-  const config = appContextService.getConfig();
-  if (!config?.installIntegrationsKnowledge) {
+  // Check if knowledge base installation is enabled via experimental feature flag
+  const experimentalFeatures = appContextService.getExperimentalFeatures();
+  if (!experimentalFeatures.installIntegrationsKnowledge) {
     logger.debug(
-      `Knowledge base step: Skipping knowledge base save - installIntegrationsKnowledge feature flag is disabled`
+      `Knowledge base step: Skipping knowledge base save - installIntegrationsKnowledge experimental feature is disabled`
     );
     return;
   }

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.ts
@@ -23,6 +23,7 @@ import {
 import { updateEsAssetReferences } from '../../es_assets_reference';
 import type { KnowledgeBaseItem } from '../../../../../../common/types/models/epm';
 import { licenseService } from '../../../../license';
+import { appContextService } from '../../../../app_context';
 export const KNOWLEDGE_BASE_PATH = 'docs/knowledge_base/';
 
 /**
@@ -67,6 +68,15 @@ export async function stepSaveKnowledgeBase(context: InstallContext): Promise<vo
   logger.debug(
     `Knowledge base step: Starting for package ${packageInfo.name}@${packageInfo.version}`
   );
+
+  // Check if knowledge base installation is enabled via feature flag
+  const config = appContextService.getConfig();
+  if (!config?.installIntegrationsKnowledge) {
+    logger.debug(
+      `Knowledge base step: Skipping knowledge base save - installIntegrationsKnowledge feature flag is disabled`
+    );
+    return;
+  }
 
   // Check if user has appropriate license for knowledge base functionality
   // You can adjust the license requirement as needed (e.g., isGoldPlus(), isPlatinum(), isEnterprise())

--- a/x-pack/platform/test/fleet_api_integration/apis/epm/get.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/epm/get.ts
@@ -374,7 +374,9 @@ export default function (providerContext: FtrProviderContext) {
       expect(dataStream?.elasticsearch?.source_mode).equal(undefined);
     });
 
-    describe('Knowledge Base', () => {
+    // Re-enable when feature flag is on by default
+    // https://github.com/elastic/kibana/issues/239796
+    describe.skip('Knowledge Base', () => {
       const knowledgeBasePkgName = 'knowledge_base_test';
       const knowledgeBasePkgVersion = '1.0.0';
 


### PR DESCRIPTION
## Summary

Relates to #239796. This PR gates Fleet's support for [integration knowledge base](https://github.com/elastic/kibana/pull/230107) under a new feature flag that defaults to `false`:
```
xpack.fleet.experimentalFeatures:
  installIntegrationsKnowledge: false
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->