### PR TITLE
[Fleet] Prevent indexing of integration knowledge base content on ECH deployments without ML nodes

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.test.ts
@@ -12,10 +12,9 @@ import type { ArchiveIterator, ArchiveEntry } from '../../../../../../common/typ
 import { saveKnowledgeBaseContentToIndex } from '../../knowledge_base_index';
 import type { InstallContext } from '../_state_machine_package_install';
 
-import { appContextService } from "../../../../app_context"
+import { appContextService } from '../../../../app_context';
 
 import { stepSaveKnowledgeBase, cleanupKnowledgeBaseStep } from './step_save_knowledge_base';
-
 
 // Mock the app context service
 jest.mock('../../../../app_context', () => ({
@@ -26,7 +25,7 @@ jest.mock('../../../../app_context', () => ({
       info: jest.fn(),
       debug: jest.fn(),
     }),
-    getCloud: jest.fn()
+    getCloud: jest.fn(),
   },
 }));
 
@@ -639,7 +638,7 @@ describe('stepSaveKnowledgeBase', () => {
       const { updateEsAssetReferences } = jest.requireMock('../../es_assets_reference');
       expect(updateEsAssetReferences).not.toHaveBeenCalled();
     });
-  })
+  });
 
   it('should proceed with knowledge base processing when ML node is detected in ECH deployment', async () => {
     (mockedAppContextService.getCloud as any).mockReturnValue({
@@ -684,7 +683,7 @@ describe('stepSaveKnowledgeBase', () => {
     expect(updateEsAssetReferences).toHaveBeenCalled();
   });
 
-  it('should proceed with knowledge base processing for serverless deployments', async() => {
+  it('should proceed with knowledge base processing for serverless deployments', async () => {
     (mockedAppContextService.getCloud as any).mockReturnValue({
       isCloudEnabled: true,
       isServerlessEnabled: true,

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.ts
@@ -7,6 +7,7 @@
 
 import path from 'path';
 
+import { appContextService } from '../../../../app_context';
 import { FleetError } from '../../../../../errors';
 import {
   saveKnowledgeBaseContentToIndex,
@@ -23,7 +24,6 @@ import {
 import { updateEsAssetReferences } from '../../es_assets_reference';
 import type { KnowledgeBaseItem } from '../../../../../../common/types/models/epm';
 import { licenseService } from '../../../../license';
-import { appContextService } from '@kbn/fleet-plugin/server/services/app_context';
 export const KNOWLEDGE_BASE_PATH = 'docs/knowledge_base/';
 
 /**
@@ -80,7 +80,9 @@ export async function stepSaveKnowledgeBase(context: InstallContext): Promise<vo
     });
 
     if (!hasMlNode) {
-      logger.debug('Knowledge base step: Skipping knowledge base save - no ML node detected for ECH deployment');
+      logger.debug(
+        'Knowledge base step: Skipping knowledge base save - no ML node detected for ECH deployment'
+      );
       return;
     }
   }

--- a/x-pack/platform/plugins/shared/fleet/tsconfig.json
+++ b/x-pack/platform/plugins/shared/fleet/tsconfig.json
@@ -125,5 +125,6 @@
     "@kbn/licensing-types",
     "@kbn/alerting-plugin",
     "@kbn/spaces-utils",
+    "@kbn/fleet-plugin",
   ]
 }


### PR DESCRIPTION
## Summary

For ECH deployments without an available ML node, Fleet won't attempt to index integration knowledge base content. This prevents unexpected billing for customers without an ML node who have ML autoscaling enabled. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


