### PR TITLE
[Dashboards] Log panel errors to console

### DIFF
--- a/src/platform/plugins/private/presentation_panel/public/panel_component/presentation_panel_error_internal.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/presentation_panel_error_internal.tsx
@@ -39,6 +39,13 @@ export const PresentationPanelErrorInternal = ({ api, error }: PresentationPanel
     [api, isEditable]
   );
 
+  useEffect(() => {
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+  }, [error]);
+
   const [label, setLabel] = useState('');
   useEffect(() => {
     if (!isEditable) {


### PR DESCRIPTION
## Summary

Panel Error boundary should still log the error to the console.

It's hard to see where an error occurred when thrown from a panel because it catches it and just shows the message on the panel. But The stack trace is lost.

![Vis Refs - Elastic 2025-10-20 at 7 11 11 AM](https://github.com/user-attachments/assets/b20b6fe4-347b-49ae-9f10-18b45c2ba9bd)