### PR TITLE
[Obs AI Assistant] Update Knowledge Base model label in AI Assistant settings

### DIFF
--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
@@ -390,7 +390,13 @@ export function ChangeKbModel({
           </>
         }
       >
-        <EuiFormRow fullWidth label="aiAssistantResponseLanguage">
+        <EuiFormRow
+          fullWidth
+          label={i18n.translate(
+            'xpack.observabilityAiAssistantManagement.knowledgeBase.semanticSearchModelLabel',
+            { defaultMessage: 'Semantic search model' }
+          )}
+        >
           {selectInferenceModelDropdown}
         </EuiFormRow>
       </EuiDescribedFormGroup>


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/235256

## Summary

Changes `aiAssistantResponseLanguage` to `Semantic search model` as `aiAssistantResponseLanguage` doesn't represent the correct functionality of this feature.

<img width="926" height="326" alt="image" src="https://github.com/user-attachments/assets/60343884-c6e5-467b-bb2d-4e6a68ccb62d" />

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Release note

Fixes Knowledge base model label in AI Assistant Setttings

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->