### PR TITLE
[Security Solution] remove unnecessary redux slice for experimental feature flags

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -288,4 +288,4 @@ export const parseExperimentalConfigValue = (
   };
 };
 
-export const getExperimentalAllowedValues = (): string[] => [...allowedKeys];
+export const getExperimentalAllowedValuesKeys = (): string[] => [...allowedKeys];

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/use_host_isolation_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/use_host_isolation_action.test.tsx
@@ -22,8 +22,11 @@ import {
   NOT_FROM_ENDPOINT_HOST_TOOLTIP,
 } from '../..';
 import { HostStatus } from '../../../../../../common/endpoint/types';
+import { ExperimentalFeaturesService } from '../../../../experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../../common';
 
 jest.mock('../../../user_privileges');
+jest.mock('../../../../experimental_features_service');
 
 const useUserPrivilegesMock = _useUserPrivileges as jest.Mock;
 
@@ -51,6 +54,8 @@ describe('useHostIsolationAction', () => {
   };
 
   beforeEach(() => {
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue(allowedExperimentalValues);
+
     appContextMock = createAppRootMockRenderer();
     authMockSetter = appContextMock.getUserPrivilegesMockSetter(useUserPrivilegesMock);
     hookProps = {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.test.ts
@@ -6,9 +6,9 @@
  */
 
 import type {
-  UseWithResponderActionDataFromAlertProps,
   ResponderActionData,
   UseResponderActionDataProps,
+  UseWithResponderActionDataFromAlertProps,
 } from './use_responder_action_data';
 import {
   useResponderActionData,
@@ -26,7 +26,7 @@ import { createAppRootMockRenderer, endpointAlertDataMock } from '../../../../mo
 import { HOST_METADATA_LIST_ROUTE } from '../../../../../../common/endpoint/constants';
 import { endpointMetadataHttpMocks } from '../../../../../management/pages/endpoint_hosts/mocks';
 import type { RenderHookResult } from '@testing-library/react';
-import { waitFor, act } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { createHttpFetchError } from '@kbn/core-http-browser-mocks';
 import { HostStatus } from '../../../../../../common/endpoint/types';
 import {
@@ -35,6 +35,10 @@ import {
 } from '../../../../../../common/endpoint/service/response_actions/constants';
 import { getAgentTypeName } from '../../../../translations';
 import { ALERT_EVENT_DATA_MISSING_AGENT_ID_FIELD } from '../../../../hooks/endpoint/use_alert_response_actions_support';
+import { ExperimentalFeaturesService } from '../../../../experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../../common';
+
+jest.mock('../../../../experimental_features_service');
 
 describe('use responder action data hooks', () => {
   let appContextMock: AppContextTestRender;
@@ -52,6 +56,8 @@ describe('use responder action data hooks', () => {
   };
 
   beforeEach(() => {
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue(allowedExperimentalValues);
+
     appContextMock = createAppRootMockRenderer();
     onClickMock = jest.fn();
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/with_security_context/store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/with_security_context/store.ts
@@ -10,7 +10,6 @@ import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
 import type { CoreStart } from '@kbn/core/public';
 import { managementReducer } from '../../../management/store/reducer';
 import { appReducer } from '../../store/app';
-import { ExperimentalFeaturesService } from '../../experimental_features_service';
 import { managementMiddlewareFactory } from '../../../management/store/middleware';
 import type { StartPlugins } from '../../../types';
 import type { State } from '../../store';
@@ -46,10 +45,6 @@ export const createFleetContextReduxStore = ({
   preloadedState = {
     // @ts-expect-error TS2322
     management: undefined,
-    // @ts-expect-error TS2322
-    app: {
-      enableExperimental: ExperimentalFeaturesService.get(),
-    },
   },
   additionalMiddleware = [],
 }: CreateFleetContextReduxStoreProps) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/endpoint/use_alert_response_actions_support.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/endpoint/use_alert_response_actions_support.test.ts
@@ -22,6 +22,8 @@ import { isAgentTypeAndActionSupported } from '../../lib/endpoint';
 import type { DeepPartial } from 'utility-types';
 import { merge } from 'lodash';
 
+jest.mock('../../experimental_features_service');
+
 describe('When using `useAlertResponseActionsSupport()` hook', () => {
   let appContextMock: AppContextTestRender;
   let alertDetailItemData: TimelineEventsDetailsItem[];

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_experimental_features.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_experimental_features.test.ts
@@ -5,40 +5,30 @@
  * 2.0.
  */
 
-import { useSelector } from 'react-redux';
 import type { ExperimentalFeatures } from '../../../common/experimental_features';
 import { useIsExperimentalFeatureEnabled } from './use_experimental_features';
 
-jest.mock('react-redux');
-const useSelectorMock = useSelector as jest.Mock;
-const mockAppState = {
-  app: {
-    enableExperimental: {
-      featureA: true,
-      featureB: false,
-    },
+jest.mock('../../../common/experimental_features', () => ({
+  allowedExperimentalValues: {
+    featureA: true,
+    featureB: false,
   },
-};
+  getExperimentalAllowedValuesKeys: jest.fn(),
+}));
 
 describe('useExperimentalFeatures', () => {
-  beforeEach(() => {
-    useSelectorMock.mockImplementation((cb) => {
-      return cb(mockAppState);
-    });
-  });
-  afterEach(() => {
-    useSelectorMock.mockClear();
-  });
   it('throws an error when unexisting feature', async () => {
     expect(() =>
       useIsExperimentalFeatureEnabled('unexistingFeature' as keyof ExperimentalFeatures)
     ).toThrowError();
   });
+
   it('returns true when existing feature and is enabled', async () => {
     const result = useIsExperimentalFeatureEnabled('featureA' as keyof ExperimentalFeatures);
 
     expect(result).toBeTruthy();
   });
+
   it('returns false when existing feature and is disabled', async () => {
     const result = useIsExperimentalFeatureEnabled('featureB' as keyof ExperimentalFeatures);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_experimental_features.ts
@@ -5,23 +5,21 @@
  * 2.0.
  */
 
-import { useSelector } from 'react-redux';
-import type { State } from '../store';
 import type { ExperimentalFeatures } from '../../../common/experimental_features';
-import { getExperimentalAllowedValues } from '../../../common/experimental_features';
+import {
+  allowedExperimentalValues,
+  getExperimentalAllowedValuesKeys,
+} from '../../../common/experimental_features';
 
-const allowedExperimentalValues = getExperimentalAllowedValues();
-
-const useEnableExperimental = (): ExperimentalFeatures =>
-  useSelector(({ app: { enableExperimental } }: State) => enableExperimental);
+const allowedExperimentalValuesKeys = getExperimentalAllowedValuesKeys();
 
 export const useIsExperimentalFeatureEnabled = (feature: keyof ExperimentalFeatures): boolean => {
-  const enableExperimental = useEnableExperimental();
-
-  if (!enableExperimental || !(feature in enableExperimental)) {
+  if (!allowedExperimentalValues || !(feature in allowedExperimentalValues)) {
     throw new Error(
-      `Invalid enable value ${feature}. Allowed values are: ${allowedExperimentalValues.join(', ')}`
+      `Invalid enable value ${feature}. Allowed values are: ${allowedExperimentalValuesKeys.join(
+        ', '
+      )}`
     );
   }
-  return enableExperimental[feature];
+  return allowedExperimentalValues[feature];
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/global_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/global_state.ts
@@ -40,7 +40,6 @@ import { TimelineStatusEnum, TimelineTypeEnum } from '../../../common/api/timeli
 import { mockManagementState } from '../../management/store/reducer';
 import type { ManagementState } from '../../management/types';
 import { initialSourcererState } from '../../sourcerer/store/model';
-import { allowedExperimentalValues } from '../../../common/experimental_features';
 import { getScopePatternListSelection } from '../../sourcerer/store/helpers';
 import { mockBrowserFields, mockIndexFields } from '../containers/source/mock';
 import { usersModel } from '../../explore/users/store';
@@ -88,7 +87,6 @@ export const mockGlobalState: State = {
       { id: 'error-id-1', title: 'title-1', message: ['error-message-1'] },
       { id: 'error-id-2', title: 'title-2', message: ['error-message-2'] },
     ],
-    enableExperimental: allowedExperimentalValues,
   },
   hosts: {
     page: {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/store/app/model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/store/app/model.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { ExperimentalFeatures } from '../../../../common/experimental_features';
 import type { Note } from '../../lib/note';
 
 export type ErrorState = ErrorModel;
@@ -27,5 +26,4 @@ export type ErrorModel = Error[];
 export interface AppModel {
   notesById: NotesById;
   errors: ErrorState;
-  enableExperimental: ExperimentalFeatures;
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/common/store/app/reducer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/store/app/reducer.ts
@@ -6,19 +6,15 @@
  */
 
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
-
 import type { Note } from '../../lib/note';
-
-import { addError, addErrorHash, addNotes, removeError, updateNote, deleteNote } from './actions';
+import { addError, addErrorHash, addNotes, deleteNote, removeError, updateNote } from './actions';
 import type { AppModel, NotesById } from './model';
-import { allowedExperimentalValues } from '../../../../common/experimental_features';
 
 export type AppState = AppModel;
 
 export const initialAppState: AppState = {
   notesById: {},
   errors: [],
-  enableExperimental: { ...allowedExperimentalValues },
 };
 
 interface UpdateNotesByIdParams {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/store/reducer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/store/reducer.test.tsx
@@ -5,10 +5,9 @@
  * 2.0.
  */
 import React from 'react';
-import { parseExperimentalConfigValue } from '../../../common/experimental_features';
 import type { SecuritySubPlugins } from '../../app/types';
 import { createInitialState } from './reducer';
-import { mockIndexPattern, mockSourcererState, TestProviders, createMockStore } from '../mock';
+import { createMockStore, mockIndexPattern, mockSourcererState, TestProviders } from '../mock';
 import { useSourcererDataView } from '../../sourcerer/containers';
 import { renderHook } from '@testing-library/react';
 import { initialGroupingState } from './grouping/reducer';
@@ -54,7 +53,6 @@ describe('createInitialState', () => {
     >;
     const defaultState = {
       defaultDataView: mockSourcererState.defaultDataView,
-      enableExperimental: parseExperimentalConfigValue([]).features,
       kibanaDataViews: [mockSourcererState.defaultDataView],
       signalIndexName: 'siem-signals-default',
       signalIndexMappingOutdated: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/store/reducer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/store/reducer.ts
@@ -7,7 +7,6 @@
 
 import type { AnyAction, Reducer } from 'redux';
 import { combineReducers } from 'redux';
-
 import type { DataTableState } from '@kbn/securitysolution-data-table';
 import { dataTableReducer } from '@kbn/securitysolution-data-table';
 import { enableMapSet } from 'immer';
@@ -16,19 +15,17 @@ import { appReducer, initialAppState } from './app';
 import { dragAndDropReducer, initialDragAndDropState } from './drag_and_drop';
 import { createInitialInputsState, inputsReducer } from './inputs';
 import { sourcererModel, sourcererReducer } from '../../sourcerer/store';
-
 import type { HostsPluginReducer } from '../../explore/hosts/store';
 import type { NetworkPluginReducer } from '../../explore/network/store';
 import type { UsersPluginReducer } from '../../explore/users/store';
 import type { TimelinePluginReducer } from '../../timelines/store';
-
 import type { SecuritySubPlugins } from '../../app/types';
 import type { ManagementPluginReducer } from '../../management';
 import type { State } from './types';
 import type { AppAction } from './actions';
 import type { SourcererModel } from '../../sourcerer/store/model';
 import { initDataView } from '../../sourcerer/store/model';
-import type { ExperimentalFeatures } from '../../../common/experimental_features';
+import { allowedExperimentalValues } from '../../../common/experimental_features';
 import { getScopePatternListSelection } from '../../sourcerer/store/helpers';
 import { globalUrlParamReducer, initialGlobalUrlParam } from './global_url_param';
 import { groupsReducer } from './grouping/reducer';
@@ -63,13 +60,11 @@ export const createInitialState = (
     kibanaDataViews,
     signalIndexName,
     signalIndexMappingOutdated,
-    enableExperimental,
   }: {
     defaultDataView: SourcererModel['defaultDataView'];
     kibanaDataViews: SourcererModel['kibanaDataViews'];
     signalIndexName: SourcererModel['signalIndexName'];
     signalIndexMappingOutdated: SourcererModel['signalIndexMappingOutdated'];
-    enableExperimental: ExperimentalFeatures;
   },
   dataTableState: DataTableState,
   groupsState: GroupState,
@@ -99,9 +94,9 @@ export const createInitialState = (
 
   const preloadedState: State = {
     ...pluginsInitState,
-    app: { ...initialAppState, enableExperimental },
+    app: { ...initialAppState },
     dragAndDrop: initialDragAndDropState,
-    inputs: createInitialInputsState(enableExperimental.socTrendsEnabled),
+    inputs: createInitialInputsState(allowedExperimentalValues.socTrendsEnabled),
     sourcerer: {
       ...sourcererModel.initialSourcererState,
       sourcererScopes: {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/store/store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/store/store.ts
@@ -8,12 +8,12 @@
 import thunk from 'redux-thunk';
 import type {
   Action,
-  Store,
-  Middleware,
-  Dispatch,
-  PreloadedState,
   AnyAction,
+  Dispatch,
+  Middleware,
+  PreloadedState,
   Reducer,
+  Store,
 } from 'redux';
 import { applyMiddleware, createStore as createReduxStore } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
@@ -36,7 +36,7 @@ import type { State } from './types';
 import type { TimelineState } from '../../timelines/store/types';
 import type { SourcererDataView } from '../../sourcerer/store/model';
 import type { StartedSubPlugins, StartPlugins } from '../../types';
-import type { ExperimentalFeatures } from '../../../common/experimental_features';
+import { allowedExperimentalValues } from '../../../common/experimental_features';
 import type { AnalyzerState } from '../../resolver/types';
 import { resolverMiddlewareFactory } from '../../resolver/store/middleware';
 import { dataAccessLayerFactory } from '../../resolver/data_access_layer/factory';
@@ -52,8 +52,7 @@ export const createStoreFactory = async (
   coreStart: CoreStart,
   startPlugins: StartPlugins,
   subPlugins: StartedSubPlugins,
-  storage: Storage,
-  enableExperimental: ExperimentalFeatures
+  storage: Storage
 ): Promise<Store<State, Action>> => {
   const { kibanaDataViews, defaultDataView, signal } = await createDefaultDataView({
     application: coreStart.application,
@@ -62,7 +61,7 @@ export const createStoreFactory = async (
     uiSettings: coreStart.uiSettings,
     spaces: startPlugins.spaces,
     // TODO: (new data view picker) remove this in cleanup phase https://github.com/elastic/security-team/issues/12665
-    skip: enableExperimental.newDataViewPickerEnabled,
+    skip: allowedExperimentalValues.newDataViewPickerEnabled,
   });
 
   const timelineInitialState = {
@@ -124,7 +123,6 @@ export const createStoreFactory = async (
       kibanaDataViews,
       signalIndexName: signal.name,
       signalIndexMappingOutdated: signal.index_mapping_outdated,
-      enableExperimental,
     },
     dataTableInitialState,
     groupsInitialState,

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/runscript_config.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/runscript_config.test.tsx
@@ -25,7 +25,10 @@ import type {
 } from '../../../../common/endpoint/types';
 import { waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import { ExperimentalFeaturesService } from '../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../common';
 
+jest.mock('../../../common/experimental_features_service');
 jest.mock('../../../common/components/user_privileges');
 
 const useUserPrivilegesMock = _useUserPrivileges as jest.Mock;
@@ -38,8 +41,13 @@ describe('Automated Response actions - Runscript Configuration', () => {
 
   beforeEach(() => {
     testContext = createAppRootMockRenderer();
-    testContext.setExperimentalFlag({ responseActionsEndpointAutomatedRunScript: true });
-    testContext.setExperimentalFlag({ responseActionsScriptLibraryManagement: true });
+
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+      ...allowedExperimentalValues,
+      responseActionsEndpointAutomatedRunScript: true,
+      responseActionsScriptLibraryManagement: true,
+    });
+
     testContext.getUserPrivilegesMockSetter(useUserPrivilegesMock).set({
       canWriteExecuteOperations: true,
     });
@@ -76,7 +84,12 @@ describe('Automated Response actions - Runscript Configuration', () => {
   });
 
   it('should render nothing if feature flag is disabled', () => {
-    testContext.setExperimentalFlag({ responseActionsEndpointAutomatedRunScript: false });
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+      ...allowedExperimentalValues,
+      responseActionsEndpointAutomatedRunScript: false,
+      responseActionsScriptLibraryManagement: true,
+    });
+
     const { queryByTestId } = render();
 
     expect(queryByTestId('runscript-config-field')).toBeNull();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/isolate_host/content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/isolate_host/content.test.tsx
@@ -10,12 +10,19 @@ import type { AppContextTestRender } from '../../../common/mock/endpoint';
 import { createAppRootMockRenderer, endpointAlertDataMock } from '../../../common/mock/endpoint';
 import { FLYOUT_HOST_ISOLATION_PANEL_TEST_ID } from './test_ids';
 import { IsolateHostPanelContent } from './content';
+import { ExperimentalFeaturesService } from '../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../common';
+
+jest.mock('../../../common/experimental_features_service');
 
 describe('<IsolateHostPanelContent />', () => {
   let appContextMock: AppContextTestRender;
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue(allowedExperimentalValues);
+
     appContextMock = createAppRootMockRenderer();
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/isolate_host/header.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/isolate_host/header.test.tsx
@@ -9,14 +9,17 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import type { IsolateHostPanelContext } from './context';
 import { useIsolateHostPanelContext } from './context';
-import { PanelHeader, IsolateHostPanelHeader } from './header';
+import { IsolateHostPanelHeader, PanelHeader } from './header';
 import type { AppContextTestRender } from '../../../common/mock/endpoint';
 import { createAppRootMockRenderer, endpointAlertDataMock } from '../../../common/mock/endpoint';
 import type { ResponseActionAgentType } from '../../../../common/endpoint/service/response_actions/constants';
 import { RESPONSE_ACTION_AGENT_TYPE } from '../../../../common/endpoint/service/response_actions/constants';
 import { ISOLATE_HOST, UNISOLATE_HOST } from '../../../common/components/endpoint/host_isolation';
+import { ExperimentalFeaturesService } from '../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../common';
 
 jest.mock('./context');
+jest.mock('../../../common/experimental_features_service');
 
 describe('Isolation Flyout PanelHeader', () => {
   let renderComponent: () => ReturnType<AppContextTestRender['render']>;
@@ -35,8 +38,9 @@ describe('Isolation Flyout PanelHeader', () => {
   };
 
   beforeEach(() => {
-    const appContextMock = createAppRootMockRenderer();
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue(allowedExperimentalValues);
 
+    const appContextMock = createAppRootMockRenderer();
     renderComponent = () => appContextMock.render(<PanelHeader />);
 
     setUseIsolateHostPanelContext({

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/components/no_data_empty_state.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/components/no_data_empty_state.test.ts
@@ -13,6 +13,10 @@ import type { AppContextTestRender } from '../../../../common/mock/endpoint';
 import type { getFormComponentMock } from '../mocks';
 import { getArtifactListPageRenderingSetup } from '../mocks';
 import { artifactListPageLabels } from '../translations';
+import { ExperimentalFeaturesService } from '../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../common';
+
+jest.mock('../../../../common/experimental_features_service');
 
 describe('When showing the Empty State in ArtifactListPage', () => {
   let render: (
@@ -20,7 +24,6 @@ describe('When showing the Empty State in ArtifactListPage', () => {
   ) => ReturnType<AppContextTestRender['render']>;
   let renderResult: ReturnType<AppContextTestRender['render']>;
   let history: AppContextTestRender['history'];
-  let setExperimentalFlag: AppContextTestRender['setExperimentalFlag'];
   let mockedApi: ReturnType<typeof trustedAppsAllHttpMocks>;
   let getLastFormComponentProps: ReturnType<
     typeof getFormComponentMock
@@ -30,7 +33,7 @@ describe('When showing the Empty State in ArtifactListPage', () => {
   beforeEach(() => {
     const renderSetup = getArtifactListPageRenderingSetup();
 
-    ({ history, mockedApi, getLastFormComponentProps, setExperimentalFlag } = renderSetup);
+    ({ history, mockedApi, getLastFormComponentProps } = renderSetup);
 
     originalListApiResponseProvider =
       mockedApi.responseProvider.trustedAppsList.getMockImplementation()!;
@@ -64,7 +67,10 @@ describe('When showing the Empty State in ArtifactListPage', () => {
 
   describe('and user is allowed to Create entries', () => {
     it('should show title, about info, add and import buttons', async () => {
-      setExperimentalFlag({ endpointExceptionsMovedUnderManagement: true });
+      (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+        ...allowedExperimentalValues,
+        endpointExceptionsMovedUnderManagement: true,
+      });
 
       const { getByTestId, queryByTestId } = render();
 
@@ -90,7 +96,7 @@ describe('When showing the Empty State in ArtifactListPage', () => {
     });
 
     it('should not show import button when experimental flag is disabled', async () => {
-      setExperimentalFlag({ endpointExceptionsMovedUnderManagement: false });
+      (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue(allowedExperimentalValues);
 
       const { getByTestId, queryByTestId } = render();
 
@@ -113,7 +119,10 @@ describe('When showing the Empty State in ArtifactListPage', () => {
     });
 
     it('should open import flyout when import button is clicked', async () => {
-      setExperimentalFlag({ endpointExceptionsMovedUnderManagement: true });
+      (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+        ...allowedExperimentalValues,
+        endpointExceptionsMovedUnderManagement: true,
+      });
 
       render();
       const importButton = await renderResult.findByTestId('testPage-emptyState-importButton');
@@ -158,7 +167,10 @@ describe('When showing the Empty State in ArtifactListPage', () => {
 
   describe('and user is not allowed to Create entries', () => {
     it('should hide title, about info and add/import buttons promoting entry creation', async () => {
-      setExperimentalFlag({ endpointExceptionsMovedUnderManagement: true });
+      (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+        ...allowedExperimentalValues,
+        endpointExceptionsMovedUnderManagement: true,
+      });
 
       render({ allowCardCreateAction: false });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/integration_tests/artifact_list_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/integration_tests/artifact_list_page.test.tsx
@@ -13,13 +13,17 @@ import { act, fireEvent, waitFor, waitForElementToBeRemoved } from '@testing-lib
 import userEvent from '@testing-library/user-event';
 import type { ArtifactListPageRenderingSetup } from '../mocks';
 import {
-  getArtifactImportFlyoutUiMocks,
   getArtifactImportExportUiMocks,
+  getArtifactImportFlyoutUiMocks,
   getArtifactListPageRenderingSetup,
 } from '../mocks';
 import { getDeferred } from '../../../mocks/utils';
 import { useGetEndpointSpecificPolicies } from '../../../services/policies/hooks';
 import type { ArtifactEntryCardDecoratorProps } from '../../artifact_entry_card';
+import { ExperimentalFeaturesService } from '../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../common';
+
+jest.mock('../../../../common/experimental_features_service');
 
 jest.mock('../../../services/policies/hooks', () => ({
   useGetEndpointSpecificPolicies: jest.fn(),
@@ -38,12 +42,11 @@ describe('When using the ArtifactListPage component', () => {
   let getFirstCard: ArtifactListPageRenderingSetup['getFirstCard'];
   let importExportUi: ReturnType<typeof getArtifactImportExportUiMocks>;
   let importFlyoutUi: ReturnType<typeof getArtifactImportFlyoutUiMocks>;
-  let setExperimentalFlag: ArtifactListPageRenderingSetup['setExperimentalFlag'];
 
   beforeEach(() => {
     const renderSetup = getArtifactListPageRenderingSetup();
 
-    ({ history, mockedApi, getFirstCard, setExperimentalFlag } = renderSetup);
+    ({ history, mockedApi, getFirstCard } = renderSetup);
 
     mockUseGetEndpointSpecificPolicies.mockReturnValue({
       data: mockedApi.responseProvider.endpointPackagePolicyList(),
@@ -164,11 +167,17 @@ describe('When using the ArtifactListPage component', () => {
 
     describe('Import and export', () => {
       beforeEach(() => {
-        setExperimentalFlag({ endpointExceptionsMovedUnderManagement: true });
+        (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+          ...allowedExperimentalValues,
+          endpointExceptionsMovedUnderManagement: true,
+        });
       });
 
       it('should not show import and export actions with feature flag disabled', async () => {
-        setExperimentalFlag({ endpointExceptionsMovedUnderManagement: false });
+        (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+          ...allowedExperimentalValues,
+          endpointExceptionsMovedUnderManagement: false,
+        });
 
         await renderWithListData();
 
@@ -218,7 +227,10 @@ describe('When using the ArtifactListPage component', () => {
       });
 
       it('should not display the import flyout if it is requested via URL param without FF enabled', async () => {
-        setExperimentalFlag({ endpointExceptionsMovedUnderManagement: false });
+        (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+          ...allowedExperimentalValues,
+          endpointExceptionsMovedUnderManagement: false,
+        });
         history.push('somepage?show=import');
         await renderWithListData();
 
@@ -297,7 +309,10 @@ describe('When using the ArtifactListPage component', () => {
       ])(
         'should NOT show flyout if url has a show param of %s but the action is not allowed',
         async (_, urlParam) => {
-          setExperimentalFlag({ endpointExceptionsMovedUnderManagement: true });
+          (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+            ...allowedExperimentalValues,
+            endpointExceptionsMovedUnderManagement: true,
+          });
           history.push(`somepage?${urlParam}`);
           const { queryByTestId } = await renderWithListData({
             allowCardCreateAction: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/mocks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/mocks.tsx
@@ -87,7 +87,6 @@ export interface ArtifactListPageRenderingSetup {
   ) => ReturnType<AppContextTestRender['render']>;
   history: AppContextTestRender['history'];
   coreStart: AppContextTestRender['coreStart'];
-  setExperimentalFlag: AppContextTestRender['setExperimentalFlag'];
   mockedApi: ReturnType<typeof trustedAppsAllHttpMocks>;
   FormComponentMock: ReturnType<typeof getFormComponentMock>['FormComponentMock'];
   getLastFormComponentProps: ReturnType<typeof getFormComponentMock>['getLastFormComponentProps'];
@@ -142,7 +141,6 @@ export const getArtifactListPageRenderingSetup = (): ArtifactListPageRenderingSe
     FormComponentMock,
     getLastFormComponentProps,
     getFirstCard: getCard,
-    setExperimentalFlag: mockedContext.setExperimentalFlag,
   };
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/mocks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/mocks.tsx
@@ -48,7 +48,7 @@ interface ConsoleSelectorsAndActionsMock {
 export interface ConsoleTestSetup
   extends Pick<
     AppContextTestRender,
-    'startServices' | 'coreStart' | 'depsStart' | 'queryClient' | 'history' | 'setExperimentalFlag'
+    'startServices' | 'coreStart' | 'depsStart' | 'queryClient' | 'history'
   > {
   renderConsole(props?: Partial<ConsoleProps>): ReturnType<AppContextTestRender['render']>;
 
@@ -248,8 +248,7 @@ export const getConsoleTestSetup = (): ConsoleTestSetup => {
   // Workaround for timeout via https://github.com/testing-library/user-event/issues/833#issuecomment-1171452841
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   const mockedContext = createAppRootMockRenderer();
-  const { startServices, coreStart, depsStart, queryClient, history, setExperimentalFlag } =
-    mockedContext;
+  const { startServices, coreStart, depsStart, queryClient, history } = mockedContext;
 
   let renderResult: ReturnType<AppContextTestRender['render']>;
 
@@ -294,7 +293,6 @@ export const getConsoleTestSetup = (): ConsoleTestSetup => {
     depsStart,
     queryClient,
     history,
-    setExperimentalFlag,
     renderConsole,
     user,
     commands: commandList,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/cancel_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/cancel_action.test.tsx
@@ -22,6 +22,7 @@ import { getEndpointAuthzInitialStateMock } from '../../../../../../common/endpo
 import { ENDPOINT_CAPABILITIES } from '../../../../../../common/endpoint/service/response_actions/constants';
 import type { PendingActionsResponse } from '../../../../../../common/endpoint/types';
 import { ExperimentalFeaturesService } from '../../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../../common';
 
 jest.mock('../../../../../common/experimental_features_service');
 
@@ -98,16 +99,6 @@ describe('When using cancel action from response actions console', () => {
   beforeEach(() => {
     user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     mockedContext = createAppRootMockRenderer();
-
-    // Set default experimental flags
-    mockedContext.setExperimentalFlag({ microsoftDefenderEndpointCancelEnabled: true });
-
-    // Reset the ExperimentalFeaturesService mock to default enabled state
-    // @ts-expect-error - we do not need to specify whole object for testing purposes
-    mockedExperimentalFeaturesService.get.mockReturnValue({
-      microsoftDefenderEndpointCancelEnabled: true,
-      microsoftDefenderEndpointRunScriptEnabled: true,
-    });
 
     apiMocks = responseActionsHttpMocks(mockedContext.coreStart.http);
   });
@@ -237,12 +228,10 @@ describe('When using cancel action from response actions console', () => {
     });
 
     it('should disable cancel command for Microsoft Defender Endpoint when feature flag is disabled', async () => {
-      // @ts-expect-error - we do not need to specify whole object for testing purposes
       mockedExperimentalFeaturesService.get.mockReturnValue({
+        ...allowedExperimentalValues,
         microsoftDefenderEndpointCancelEnabled: false,
-        microsoftDefenderEndpointRunScriptEnabled: true,
       });
-      mockedContext.setExperimentalFlag({ microsoftDefenderEndpointCancelEnabled: false });
 
       const renderResult = await renderConsole('microsoft_defender_endpoint');
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/get_file_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/get_file_action.test.tsx
@@ -33,8 +33,13 @@ import {
 } from '../../../../../common/translations';
 import type { HttpFetchOptionsWithPath } from '@kbn/core-http-browser';
 import { endpointActionResponseCodes } from '../../lib/endpoint_action_response_codes';
+import { ExperimentalFeaturesService } from '../../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../../common';
 
 jest.mock('../../../../../common/components/user_privileges');
+
+jest.mock('../../../../../common/experimental_features_service');
+const mockedExperimentalFeaturesService = jest.mocked(ExperimentalFeaturesService);
 
 describe('When using get-file action from response actions console', () => {
   let user: UserEvent;
@@ -59,6 +64,8 @@ describe('When using get-file action from response actions console', () => {
   });
 
   beforeEach(() => {
+    mockedExperimentalFeaturesService.get.mockReturnValue(allowedExperimentalValues);
+
     // Workaround for timeout via https://github.com/testing-library/user-event/issues/833#issuecomment-1171452841
     user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     mockedContext = createAppRootMockRenderer();

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/get_processes_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/get_processes_action.test.tsx
@@ -26,10 +26,14 @@ import { ENDPOINT_CAPABILITIES } from '../../../../../../common/endpoint/service
 import { UPGRADE_AGENT_FOR_RESPONDER } from '../../../../../common/translations';
 import type { CommandDefinition } from '../../../console';
 import { useUserPrivileges as _useUserPrivileges } from '../../../../../common/components/user_privileges';
+import { ExperimentalFeaturesService } from '../../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../../common';
 
 jest.mock('../../../../../common/components/user_privileges');
-
 const useUserPrivilegesMock = _useUserPrivileges as jest.Mock;
+
+jest.mock('../../../../../common/experimental_features_service');
+const mockedExperimentalFeaturesService = jest.mocked(ExperimentalFeaturesService);
 
 describe('When using processes action from response actions console', () => {
   let user: UserEvent;
@@ -72,6 +76,8 @@ describe('When using processes action from response actions console', () => {
   });
 
   beforeEach(() => {
+    mockedExperimentalFeaturesService.get.mockReturnValue(allowedExperimentalValues);
+
     // Workaround for timeout via https://github.com/testing-library/user-event/issues/833#issuecomment-1171452841
     user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     mockedContext = createAppRootMockRenderer();

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/memory_dump_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/memory_dump_action.test.tsx
@@ -96,7 +96,6 @@ describe('Memory dump response action', () => {
 
   describe('and agent type is Endpoint', () => {
     beforeEach(() => {
-      mockedContext.setExperimentalFlag({ responseActionsEndpointMemoryDump: true });
       (ExperimentalFeaturesServiceMock.get as jest.Mock).mockReturnValue({
         responseActionsEndpointMemoryDump: true,
       });
@@ -106,7 +105,6 @@ describe('Memory dump response action', () => {
       (ExperimentalFeaturesServiceMock.get as jest.Mock).mockReturnValue({
         responseActionsEndpointMemoryDump: false,
       });
-      mockedContext.setExperimentalFlag({ responseActionsEndpointMemoryDump: false });
       await render();
       await enterConsoleCommand(renderResult, user, 'memory-dump --kernel');
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/runscript_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/runscript_action.test.tsx
@@ -24,6 +24,11 @@ import React from 'react';
 import type { EndpointPrivileges } from '../../../../../../common/endpoint/types';
 import { enterConsoleCommand, getConsoleSelectorsAndActionMock } from '../../../console/mocks';
 import { SCRIPTS_LIBRARY_ITEM_DOWNLOAD_ROUTE } from '../../../../../../common/endpoint/constants';
+import { ExperimentalFeaturesService } from '../../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../../common';
+
+jest.mock('../../../../../common/experimental_features_service');
+const mockedExperimentalFeaturesService = jest.mocked(ExperimentalFeaturesService);
 
 describe('When using runscript action from response console', () => {
   let mockedContext: AppContextTestRender;
@@ -48,6 +53,8 @@ describe('When using runscript action from response console', () => {
   });
 
   beforeEach(() => {
+    mockedExperimentalFeaturesService.get.mockReturnValue(allowedExperimentalValues);
+
     // Workaround for timeout via https://github.com/testing-library/user-event/issues/833#issuecomment-1171452841
     user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     mockedContext = createAppRootMockRenderer();
@@ -92,8 +99,6 @@ describe('When using runscript action from response console', () => {
 
       render = () => _render('sentinel_one');
 
-      mockedContext.setExperimentalFlag({ responseActionsSentinelOneRunScriptEnabled: true });
-
       apiMocks.responseProvider.fetchScriptList.mockReturnValue({
         data: [
           {
@@ -129,7 +134,10 @@ describe('When using runscript action from response console', () => {
     });
 
     it('should error when the feature flag is disabled', async () => {
-      mockedContext.setExperimentalFlag({ responseActionsSentinelOneRunScriptEnabled: false });
+      mockedExperimentalFeaturesService.get.mockReturnValue({
+        ...allowedExperimentalValues,
+        responseActionsSentinelOneRunScriptEnabled: false,
+      });
       await render();
       await enterConsoleCommand(renderResult, user, 'runscript');
 
@@ -232,7 +240,8 @@ describe('When using runscript action from response console', () => {
 
       render = () => _render('endpoint');
 
-      mockedContext.setExperimentalFlag({
+      mockedExperimentalFeaturesService.get.mockReturnValue({
+        ...allowedExperimentalValues,
         responseActionsEndpointRunScript: true,
         responseActionsScriptLibraryManagement: true,
       });
@@ -296,7 +305,11 @@ describe('When using runscript action from response console', () => {
     });
 
     it('should error when the feature flag is disabled', async () => {
-      mockedContext.setExperimentalFlag({ responseActionsEndpointRunScript: false });
+      mockedExperimentalFeaturesService.get.mockReturnValue({
+        ...allowedExperimentalValues,
+        responseActionsEndpointRunScript: false,
+      });
+
       await render();
       await enterConsoleCommand(renderResult, user, 'runscript');
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/scan_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/scan_action.test.tsx
@@ -41,8 +41,13 @@ import {
   UPGRADE_AGENT_FOR_RESPONDER,
 } from '../../../../../common/translations';
 import { endpointActionResponseCodes } from '../../lib/endpoint_action_response_codes';
+import { ExperimentalFeaturesService } from '../../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../../common';
 
 jest.mock('../../../../../common/components/user_privileges');
+
+jest.mock('../../../../../common/experimental_features_service');
+const mockedExperimentalFeaturesService = jest.mocked(ExperimentalFeaturesService);
 
 describe('When using scan action from response actions console', () => {
   let user: UserEvent;
@@ -67,6 +72,8 @@ describe('When using scan action from response actions console', () => {
   });
 
   beforeEach(() => {
+    mockedExperimentalFeaturesService.get.mockReturnValue(allowedExperimentalValues);
+
     // Workaround for timeout via https://github.com/testing-library/user-event/issues/833#issuecomment-1171452841
     user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     mockedContext = createAppRootMockRenderer();

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
@@ -61,6 +61,10 @@ import { agentStatusMocks } from '../../../../../common/endpoint/service/respons
 import { useBulkGetAgentPolicies } from '../../../services/policies/hooks';
 import type { PartialEndpointPolicyData } from '../../../../../common/endpoint/data_generators/fleet_package_policy_generator';
 import type { AgentPolicy } from '@kbn/fleet-plugin/common';
+import { ExperimentalFeaturesService } from '../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../common';
+
+jest.mock('../../../../common/experimental_features_service');
 
 const mockUserPrivileges = useUserPrivileges as jest.Mock;
 // not sure why this can't be imported from '../../../../common/mock/formatted_relative';
@@ -901,6 +905,8 @@ describe('when on the endpoint list page', () => {
         });
 
         it('should show the activity log content when selected', async () => {
+          (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue(allowedExperimentalValues);
+
           render();
           const detailsTab = renderResult.getByTestId('endpoint-details-flyout-tab-details');
           const activityLogTab = renderResult.getByTestId(

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/integration_tests/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/integration_tests/index.test.tsx
@@ -12,8 +12,10 @@ import type { AppContextTestRender } from '../../../common/mock/endpoint';
 import { createAppRootMockRenderer } from '../../../common/mock/endpoint';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
 import { endpointPageHttpMock } from '../endpoint_hosts/mocks';
+import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 
 jest.mock('../../../common/components/user_privileges');
+jest.mock('../../../common/hooks/use_experimental_features');
 
 const useUserPrivilegesMock = useUserPrivileges as jest.Mock;
 
@@ -26,7 +28,7 @@ describe('when in the Administration tab', () => {
     render = () => mockedContext.render(<ManagementContainer />);
     mockedContext.history.push('/administration/endpoints');
 
-    mockedContext.setExperimentalFlag({ endpointExceptionsMovedUnderManagement: true });
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -172,7 +174,7 @@ describe('when in the Administration tab', () => {
 
   describe('when `endpointExceptionsMovedUnderManagement` feature flag is disabled', () => {
     beforeEach(() => {
-      mockedContext.setExperimentalFlag({ endpointExceptionsMovedUnderManagement: false });
+      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
     });
 
     it('should display `notFoundPage` for the endpoint exceptions page with read privilege', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/artifacts/layout/policy_artifacts_layout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/artifacts/layout/policy_artifacts_layout.test.tsx
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import React from 'react';
 import { act, waitFor } from '@testing-library/react';
 import type { AppContextTestRender } from '../../../../../../common/mock/endpoint';
@@ -25,7 +26,10 @@ import { EventFiltersApiClient } from '../../../../event_filters/service/api_cli
 import { SEARCHABLE_FIELDS as EVENT_FILTERS_SEARCHABLE_FIELDS } from '../../../../event_filters/constants';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useUserPrivileges } from '../../../../../../common/components/user_privileges';
+import { ExperimentalFeaturesService } from '../../../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../../../common';
 
+jest.mock('../../../../../../common/experimental_features_service');
 jest.mock('../../../../../../common/components/user_privileges');
 
 interface MockedAPIArgs {
@@ -39,7 +43,6 @@ let policyItem: ImmutableObject<PolicyData>;
 const generator = new EndpointDocGenerator();
 let mockedApi: ReturnType<typeof eventFiltersListQueryHttpMock>;
 let history: AppContextTestRender['history'];
-let setExperimentalFlag: AppContextTestRender['setExperimentalFlag'];
 const useUserPrivilegesMock = useUserPrivileges as jest.Mock;
 
 const getEventFiltersLabels = () => ({
@@ -62,7 +65,7 @@ describe('Policy artifacts layout', () => {
     mockedApi = eventFiltersListQueryHttpMock(mockedContext.coreStart.http);
     mockedApi.responseProvider.eventFiltersList.mockClear();
     policyItem = generator.generatePolicyPackagePolicy();
-    ({ history, setExperimentalFlag } = mockedContext);
+    ({ history } = mockedContext);
 
     useUserPrivilegesMock.mockReturnValue({
       endpointPrivileges: {
@@ -108,7 +111,10 @@ describe('Policy artifacts layout', () => {
   });
 
   it('should render layout with no assigned artifacts data when there are no artifacts', async () => {
-    setExperimentalFlag({ endpointExceptionsMovedUnderManagement: true });
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+      ...allowedExperimentalValues,
+      endpointExceptionsMovedUnderManagement: true,
+    });
     mockedApi.responseProvider.eventFiltersList.mockReturnValue(
       getFoundExceptionListItemSchemaMock(0)
     );
@@ -124,7 +130,7 @@ describe('Policy artifacts layout', () => {
   });
 
   it('should not render import button when experimental flag is disabled', async () => {
-    setExperimentalFlag({ endpointExceptionsMovedUnderManagement: false });
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue(allowedExperimentalValues);
     mockedApi.responseProvider.eventFiltersList.mockReturnValue(
       getFoundExceptionListItemSchemaMock(0)
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/endpoint_package_custom_extension.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/endpoint_package_custom_extension.test.tsx
@@ -12,7 +12,10 @@ import { EndpointPackageCustomExtension } from './endpoint_package_custom_extens
 import { getEndpointPrivilegesInitialStateMock } from '../../../../../../common/components/user_privileges/endpoint/mocks';
 import { useUserPrivileges as _useUserPrivileges } from '../../../../../../common/components/user_privileges';
 import { getUserPrivilegesMockDefaultValue } from '../../../../../../common/components/user_privileges/__mocks__';
+import { ExperimentalFeaturesService } from '../../../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../../../common';
 
+jest.mock('../../../../../../common/experimental_features_service');
 jest.mock('../../../../../../common/components/user_privileges');
 const useUserPrivilegesMock = _useUserPrivileges as jest.Mock;
 
@@ -31,8 +34,8 @@ describe('When displaying the EndpointPackageCustomExtension fleet UI extension'
   beforeEach(() => {
     mockedTestContext = createFleetContextRendererMock();
 
-    // Mock experimental feature flag
-    mockedTestContext.setExperimentalFlag({
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+      ...allowedExperimentalValues,
       endpointExceptionsMovedUnderManagement: true,
     });
 
@@ -94,9 +97,8 @@ describe('When displaying the EndpointPackageCustomExtension fleet UI extension'
   });
 
   it('should hide endpoint exceptions card when feature flag is disabled', () => {
-    mockedTestContext.setExperimentalFlag({
-      endpointExceptionsMovedUnderManagement: false,
-    });
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue(allowedExperimentalValues);
+
     render();
 
     // Verify endpoint exceptions card is not present

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_policy_edit_extension/endpoint_policy_edit_extension.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_policy_edit_extension/endpoint_policy_edit_extension.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import type { PackagePolicy, NewPackagePolicy } from '@kbn/fleet-plugin/common';
+import type { NewPackagePolicy, PackagePolicy } from '@kbn/fleet-plugin/common';
 
 import { useUserPrivileges } from '../../../../../../common/components/user_privileges';
 import { getEndpointPrivilegesInitialStateMock } from '../../../../../../common/components/user_privileges/endpoint/mocks';
@@ -16,6 +16,10 @@ import { createFleetContextRendererMock } from '../mocks';
 import { getUserPrivilegesMockDefaultValue } from '../../../../../../common/components/user_privileges/__mocks__';
 import { FleetPackagePolicyGenerator } from '../../../../../../../common/endpoint/data_generators/fleet_package_policy_generator';
 import { getPolicyDataForUpdate } from '../../../../../../../common/endpoint/service/policy';
+import { ExperimentalFeaturesService } from '../../../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../../../common';
+
+jest.mock('../../../../../../common/experimental_features_service');
 
 jest.mock('../../../../../../common/components/user_privileges');
 const useUserPrivilegesMock = useUserPrivileges as jest.Mock;
@@ -35,7 +39,8 @@ describe('When displaying the EndpointPolicyEditExtension fleet UI extension', (
     mockedTestContext = createFleetContextRendererMock();
 
     // Enable endpoint exceptions feature
-    mockedTestContext.setExperimentalFlag({
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+      ...allowedExperimentalValues,
       endpointExceptionsMovedUnderManagement: true,
     });
 
@@ -106,9 +111,7 @@ describe('When displaying the EndpointPolicyEditExtension fleet UI extension', (
   );
 
   it('should not display endpoint exceptions card when feature flag is disabled', () => {
-    mockedTestContext.setExperimentalFlag({
-      endpointExceptionsMovedUnderManagement: false,
-    });
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue(allowedExperimentalValues);
 
     const renderResult = render();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/mocks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/mocks.tsx
@@ -6,8 +6,7 @@
  */
 
 import type { PropsWithChildren } from 'react';
-import React, { useEffect } from 'react';
-import type { Action, Reducer } from 'redux';
+import React from 'react';
 import type { RenderOptions } from '@testing-library/react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { render as reactRender } from '@testing-library/react';
@@ -19,49 +18,11 @@ import { deepFreeze } from '@kbn/std';
 import { createFleetContextReduxStore } from '../../../../../common/components/with_security_context/store';
 import type { AppContextTestRender, UiRender } from '../../../../../common/mock/endpoint';
 import { createAppRootMockRenderer } from '../../../../../common/mock/endpoint';
-import type { ExperimentalFeatures } from '../../../../../../common/experimental_features';
-import { allowedExperimentalValues } from '../../../../../../common/experimental_features';
-import type { State } from '../../../../../common/store';
-import { mockGlobalState } from '../../../../../common/mock';
 import { managementReducer } from '../../../../store/reducer';
-import { appReducer } from '../../../../../common/store/app';
-import { ExperimentalFeaturesService } from '../../../../../common/experimental_features_service';
 import { RenderContextProviders } from '../../../../../common/components/with_security_context/render_context_providers';
-import type { AppAction } from '../../../../../common/store/actions';
 import { SECURITY_FEATURE_ID } from '../../../../../../common/constants';
 
-// Defined a private custom reducer that reacts to an action that enables us to update the
-// store with new values for technical preview features/flags. Because the `action.type` is a `Symbol`,
-// and its not exported the action can only be `dispatch`'d from this module
-const UpdateExperimentalFeaturesTestActionType = Symbol('updateExperimentalFeaturesTestAction');
-
-type UpdateExperimentalFeaturesTestAction = Action<
-  typeof UpdateExperimentalFeaturesTestActionType
-> & {
-  payload: Partial<ExperimentalFeatures>;
-};
-
-const experimentalFeaturesReducer: Reducer<
-  State['app'],
-  AppAction | UpdateExperimentalFeaturesTestAction
-> = (state = mockGlobalState.app, action) => {
-  if (action.type === UpdateExperimentalFeaturesTestActionType) {
-    return {
-      ...state,
-      enableExperimental: {
-        ...state.enableExperimental,
-        ...action.payload,
-      },
-    };
-  }
-  return state;
-};
-
 export const createFleetContextRendererMock = (): AppContextTestRender => {
-  ExperimentalFeaturesService.init({
-    experimentalFeatures: { ...allowedExperimentalValues },
-  });
-
   const mockedContext = createAppRootMockRenderer();
   const { coreStart, depsStart, queryClient, startServices } = mockedContext;
   const store = createFleetContextReduxStore({
@@ -69,32 +30,15 @@ export const createFleetContextRendererMock = (): AppContextTestRender => {
     depsStart,
     reducersObject: {
       management: managementReducer,
-      app: (state, action: AppAction | UpdateExperimentalFeaturesTestAction) => {
-        return appReducer(experimentalFeaturesReducer(state, action), action);
-      },
     },
     preloadedState: {
       // @ts-expect-error TS2322
       management: undefined,
-      // @ts-expect-error TS2322
-      app: {
-        enableExperimental: ExperimentalFeaturesService.get(),
-      },
     },
     additionalMiddleware: [mockedContext.middlewareSpy.actionSpyMiddleware],
   });
 
   const Wrapper: RenderOptions['wrapper'] = ({ children }: PropsWithChildren<unknown>) => {
-    useEffect(() => {
-      return () => {
-        // When the component un-mounts, reset the Experimental features since
-        // `ExperimentalFeaturesService` is a global singleton
-        ExperimentalFeaturesService.init({
-          experimentalFeatures: { ...allowedExperimentalValues },
-        });
-      };
-    }, []);
-
     startServices.application.capabilities = deepFreeze({
       ...startServices.application.capabilities,
       [SECURITY_FEATURE_ID]: { show: true, crud: true },
@@ -125,24 +69,10 @@ export const createFleetContextRendererMock = (): AppContextTestRender => {
     });
   };
 
-  const setExperimentalFlag: AppContextTestRender['setExperimentalFlag'] = (flags) => {
-    // TODO: Is this context even using the Redux store `app` namespace?
-    //    `ExperimentalFeaturesService` seems to be used instead
-    store.dispatch({
-      type: UpdateExperimentalFeaturesTestActionType,
-      payload: flags,
-    });
-
-    ExperimentalFeaturesService.init({
-      experimentalFeatures: { ...allowedExperimentalValues, ...flags },
-    });
-  };
-
   return {
     ...mockedContext,
     store,
     render,
-    setExperimentalFlag,
   };
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/linux_event_collection_card.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/linux_event_collection_card.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expectIsViewOnly, getPolicySettingsFormTestSubjects, exactMatchText } from '../../mocks';
+import { exactMatchText, expectIsViewOnly, getPolicySettingsFormTestSubjects } from '../../mocks';
 import type { AppContextTestRender } from '../../../../../../../common/mock/endpoint';
 import { createAppRootMockRenderer } from '../../../../../../../common/mock/endpoint';
 import { FleetPackagePolicyGenerator } from '../../../../../../../../common/endpoint/data_generators/fleet_package_policy_generator';
@@ -13,6 +13,10 @@ import React from 'react';
 import type { LinuxEventCollectionCardProps } from './linux_event_collection_card';
 import { LinuxEventCollectionCard } from './linux_event_collection_card';
 import { set } from '@kbn/safer-lodash-set';
+import { ExperimentalFeaturesService } from '../../../../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../../../../common';
+
+jest.mock('../../../../../../../common/experimental_features_service');
 
 describe('Policy Linux Event Collection Card', () => {
   const testSubj = getPolicySettingsFormTestSubjects('test').linuxEvents;
@@ -26,7 +30,10 @@ describe('Policy Linux Event Collection Card', () => {
     mockedContext = createAppRootMockRenderer();
 
     // Mock linuxDnsEvents FF as enabled by default
-    mockedContext.setExperimentalFlag({ linuxDnsEvents: true });
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+      ...allowedExperimentalValues,
+      linuxDnsEvents: true,
+    });
 
     formProps = {
       policy: new FleetPackagePolicyGenerator('seed').generateEndpointPackagePolicy().inputs[0]
@@ -117,7 +124,7 @@ describe('Policy Linux Event Collection Card', () => {
 
   describe('when linuxDnsEvents feature flag is disabled', () => {
     beforeEach(() => {
-      mockedContext.setExperimentalFlag({ linuxDnsEvents: false });
+      (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue(allowedExperimentalValues);
       // Remove dns field from policy when FF is disabled
       delete formProps.policy.linux.events.dns;
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/response_actions/view/response_actions_list_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/response_actions/view/response_actions_list_page.test.tsx
@@ -19,6 +19,8 @@ import type { ActionListApiResponse } from '../../../../../common/endpoint/types
 import { MANAGEMENT_PATH } from '../../../../../common/constants';
 import { getActionListMock } from '../../../components/endpoint_response_actions_list/mocks';
 import { useGetEndpointsList } from '../../../hooks/endpoint/use_get_endpoints_list';
+import { ExperimentalFeaturesService } from '../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../common';
 
 let mockUseGetEndpointActionList: {
   isFetched?: boolean;
@@ -36,6 +38,8 @@ jest.mock('../../../hooks/response_actions/use_get_endpoint_action_list', () => 
     useGetEndpointActionList: () => mockUseGetEndpointActionList,
   };
 });
+
+jest.mock('../../../../common/experimental_features_service');
 
 jest.mock('@kbn/kibana-react-plugin/public', () => {
   const original = jest.requireActual('@kbn/kibana-react-plugin/public');
@@ -145,6 +149,9 @@ describe('Response actions history page', () => {
       advanceTimers: jest.advanceTimersByTime,
       pointerEventsCheck: 0,
     });
+
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue(allowedExperimentalValues);
+
     mockedContext = createAppRootMockRenderer();
     ({ history } = mockedContext);
     render = () => (renderResult = mockedContext.render(<ResponseActionsListPage />));

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_apps/view/components/form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_apps/view/components/form.test.tsx
@@ -6,11 +6,11 @@
  */
 
 import React from 'react';
-import { screen, cleanup, act, fireEvent, getByTestId } from '@testing-library/react';
+import { act, cleanup, fireEvent, getByTestId, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 import type { TrustedAppEntryTypes } from '@kbn/securitysolution-utils';
-import { OperatingSystem, ConditionEntryField } from '@kbn/securitysolution-utils';
+import { ConditionEntryField, OperatingSystem } from '@kbn/securitysolution-utils';
 import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
 import { stubIndexPattern } from '@kbn/data-plugin/common/stubs';
 import { useFetchIndex } from '../../../../../common/containers/source';
@@ -31,9 +31,13 @@ import { forceHTMLElementOffsetWidth } from '../../../../components/effected_pol
 import type { TrustedAppConditionEntry } from '../../../../../../common/endpoint/types';
 import type { IHttpFetchError } from '@kbn/core-http-browser';
 import { TRUSTED_PROCESS_DESCENDANTS_TAG } from '../../../../../../common/endpoint/service/artifacts/constants';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
+import type { ExperimentalFeatures } from '../../../../../../common';
+import { allowedExperimentalValues } from '../../../../../../common';
 
 jest.mock('../../../../../common/components/user_privileges');
 jest.mock('../../../../../common/containers/source');
+jest.mock('../../../../../common/hooks/use_experimental_features');
 jest.mock('../../../../../common/hooks/use_license', () => {
   const licenseServiceInstance = {
     isPlatinumPlus: jest.fn(),
@@ -184,7 +188,12 @@ describe('Trusted apps form', () => {
     resetHTMLElementOffsetWidth = forceHTMLElementOffsetWidth();
     (licenseService.isPlatinumPlus as jest.Mock).mockReturnValue(true);
     mockedContext = createAppRootMockRenderer();
-    mockedContext.setExperimentalFlag({ trustedAppsAdvancedMode: true });
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation(
+      (flag: keyof ExperimentalFeatures) => {
+        if (flag === 'trustedAppsAdvancedMode') return true;
+        return allowedExperimentalValues[flag];
+      }
+    );
     latestUpdatedItem = createItem();
     (useFetchIndex as jest.Mock).mockImplementation(() => [
       false,
@@ -536,15 +545,23 @@ describe('Trusted apps form', () => {
 
       describe('Process Descendants', () => {
         beforeEach(() => {
-          mockedContext.setExperimentalFlag({
-            filterProcessDescendantsForTrustedAppsEnabled: true,
-          });
+          (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation(
+            (flag: keyof ExperimentalFeatures) => {
+              if (flag === 'trustedAppsAdvancedMode') return true;
+              if (flag === 'filterProcessDescendantsForTrustedAppsEnabled') return true;
+              return allowedExperimentalValues[flag];
+            }
+          );
         });
 
         it('should not display button when feature flag is disabled', () => {
-          mockedContext.setExperimentalFlag({
-            filterProcessDescendantsForTrustedAppsEnabled: false,
-          });
+          (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation(
+            (flag: keyof ExperimentalFeatures) => {
+              if (flag === 'trustedAppsAdvancedMode') return true;
+              if (flag === 'filterProcessDescendantsForTrustedAppsEnabled') return false;
+              return allowedExperimentalValues[flag];
+            }
+          );
           const propsItem: Partial<ArtifactFormComponentProps['item']> = {
             tags: ['policy:all', 'form_mode:advanced'],
           };

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_apps/view/trusted_apps_list.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_apps/view/trusted_apps_list.test.tsx
@@ -19,7 +19,10 @@ import { useUserPrivileges } from '../../../../common/components/user_privileges
 import type { EndpointPrivileges } from '../../../../../common/endpoint/types';
 import { ExceptionsListItemGenerator } from '../../../../../common/endpoint/data_generators/exceptions_list_item_generator';
 import { TRUSTED_PROCESS_DESCENDANTS_TAG } from '../../../../../common/endpoint/service/artifacts';
+import { ExperimentalFeaturesService } from '../../../../common/experimental_features_service';
+import { allowedExperimentalValues } from '../../../../../common';
 
+jest.mock('../../../../common/experimental_features_service');
 jest.mock('../../../../common/components/user_privileges');
 const mockUserPrivileges = useUserPrivileges as jest.Mock;
 
@@ -45,7 +48,10 @@ describe('When on the trusted applications page', () => {
     user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     mockedContext = createAppRootMockRenderer();
     // enable process descendants feature flag
-    mockedContext.setExperimentalFlag({ filterProcessDescendantsForTrustedAppsEnabled: true });
+    (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
+      ...allowedExperimentalValues,
+      filterProcessDescendantsForTrustedAppsEnabled: true,
+    });
     ({ history } = mockedContext);
     render = () => (renderResult = mockedContext.render(<TrustedAppsList />));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/view/trusted_devices_list.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/view/trusted_devices_list.test.tsx
@@ -18,6 +18,9 @@ import { SEARCHABLE_FIELDS } from '../constants';
 import { parseQueryFilterToKQL } from '../../../common/utils';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import type { EndpointPrivileges } from '../../../../../common/endpoint/types';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+
+jest.mock('../../../../common/hooks/use_experimental_features');
 
 jest.mock('../../../../common/components/user_privileges');
 const mockUserPrivileges = useUserPrivileges as jest.Mock;
@@ -43,7 +46,7 @@ describe('When on the trusted devices page', () => {
     // Workaround for timeout via https://github.com/testing-library/user-event/issues/833#issuecomment-1171452841
     user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     mockedContext = createAppRootMockRenderer();
-    mockedContext.setExperimentalFlag({ trustedDevices: true });
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
     ({ history } = mockedContext);
     render = () => (renderResult = mockedContext.render(<TrustedDevicesList />));
 
@@ -90,7 +93,7 @@ describe('When on the trusted devices page', () => {
   });
 
   it('should not render when feature flag is disabled', async () => {
-    mockedContext.setExperimentalFlag({ trustedDevices: false });
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
     const { queryByTestId } = render();
     await waitFor(() => {
       expect(queryByTestId('trustedDevicesList')).toBeNull();

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -482,13 +482,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     if (!this._store) {
       const { createStoreFactory } = await this.lazyApplicationDependencies();
 
-      this._store = await createStoreFactory(
-        coreStart,
-        startPlugins,
-        subPlugins,
-        this.storage,
-        this.experimentalFeatures
-      );
+      this._store = await createStoreFactory(coreStart, startPlugins, subPlugins, this.storage);
     }
     if (startPlugins.timelines) {
       startPlugins.timelines.setTimelineEmbeddedStore(this._store);

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/timeline_save.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/timeline_save.ts
@@ -19,8 +19,8 @@ import {
   isRangeFilter,
   isScriptedRangeFilter,
 } from '@kbn/es-query';
-
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { PageScope } from '../../../data_view_manager/constants';
 import { sourcererAdapterSelector } from '../../../data_view_manager/redux/selectors';
 import { sourcererSelectors } from '../../../sourcerer/store';
@@ -81,8 +81,9 @@ export const saveTimelineMiddleware: (kibana: CoreStart) => Middleware<{}, State
       storeState
     );
 
-    const experimentalIsDataViewEnabled =
-      storeState.app.enableExperimental.newDataViewPickerEnabled;
+    const experimentalIsDataViewEnabled = useIsExperimentalFeatureEnabled(
+      'newDataViewPickerEnabled'
+    );
 
     let experimentalSelectedPatterns: string[] = [];
     let dataViewId: string | null = null;


### PR DESCRIPTION
## Summary

> [!NOTE]
> This PR is a follow up of [this previous one](https://github.com/elastic/kibana/pull/238690), continuing the clean up of the experimental features code. The intent is to facilitate the review of [this next PR](https://github.com/elastic/kibana/pull/235462) that will move all the logic to a package.

This PR removes the `enableExperimental` slice of Redux state from Security Solution. This slice of state isn't necessary, as we have the `allowedExperimentalValues` available at all times, anywhere.
Removing the slice of state reduces complexity in the code, as we had most places reaching out to the const via the hook and only a couple of places using the store. Also the unit and integration tests  were doing things differently, so removing the Redux slice brings consistency.

> [!CAUTION]
> This PR should not make any code behavior or UI changes whatsoever!

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
