### PR TITLE
[DOCS] Update publish_oas_docs.sh for 9.2

### DIFF
--- a/.buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
+++ b/.buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
@@ -49,7 +49,7 @@ if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
   exit 0;
 fi
 
-if [[ "$BUILDKITE_BRANCH" == "9.1" ]]; then
+if [[ "$BUILDKITE_BRANCH" == "9.2" ]]; then
   BUMP_KIBANA_DOC_NAME="$(vault_get kibana-bump-sh kibana-doc-name)"
   BUMP_KIBANA_DOC_TOKEN="$(vault_get kibana-bump-sh kibana-token)"
   deploy_to_bump "$(pwd)/oas_docs/output/kibana.yaml" $BUMP_KIBANA_DOC_NAME $BUMP_KIBANA_DOC_TOKEN v9;


### PR DESCRIPTION
## Summary

This PR updates `publish_oas_docs.sh` such that https://www.elastic.co/docs/api/doc/kibana/v9/ will be deployed from the `9.2` branch instead of the `9.1` branch.

### Checklist

N/A

### Identify risks

N/A





<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->