### PR TITLE
[DOCS] Update publish_oas_docs.sh for temporary preview

### DIFF
--- a/.buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
+++ b/.buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
@@ -49,6 +49,13 @@ if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
   exit 0;
 fi
 
+if [[ "$BUILDKITE_BRANCH" == "9.2" ]]; then
+  BUMP_KIBANA_DOC_NAME="$(vault_get kibana-bump-sh kibana-doc-name)"
+  BUMP_KIBANA_DOC_TOKEN="$(vault_get kibana-bump-sh kibana-token)"
+  deploy_to_bump "$(pwd)/oas_docs/output/kibana.yaml" $BUMP_KIBANA_DOC_NAME $BUMP_KIBANA_DOC_TOKEN 9x-unreleased;
+  exit 0;
+fi
+
 if [[ "$BUILDKITE_BRANCH" == "9.1" ]]; then
   BUMP_KIBANA_DOC_NAME="$(vault_get kibana-bump-sh kibana-doc-name)"
   BUMP_KIBANA_DOC_TOKEN="$(vault_get kibana-bump-sh kibana-token)"


### PR DESCRIPTION
## Summary

This PR updates `publish_oas_docs.sh` such that the OpenAPI document in the 9.2 branch will be deployed to a temporary unreleased branch of the API docs for preview purposes.

This behaviour will be overwritten when 9.2 is released and https://github.com/elastic/kibana/pull/239833 is backported.

### Checklist

N/A

### Identify risks

N/A


