### PR TITLE
Fix typos on Elasticsearch home page

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/security.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/security.tsx
@@ -73,7 +73,7 @@ export const Security: React.FC = () => {
                   <EuiFlexItem grow={false}>
                     <EuiLink data-test-subj="setupSiemLink" href={docLinks.ingestDataToSecurity}>
                       {i18n.translate('xpack.searchHomepage.security.setupSiem', {
-                        defaultMessage: 'Setup your SIEM',
+                        defaultMessage: 'Set up your SIEM',
                       })}
                     </EuiLink>
                   </EuiFlexItem>
@@ -96,7 +96,7 @@ export const Security: React.FC = () => {
                       href={docLinks.installElasticDefend}
                     >
                       {i18n.translate('xpack.searchHomepage.security.setupElasticDefend', {
-                        defaultMessage: 'Setup Elastic Defend',
+                        defaultMessage: 'Set up Elastic Defend',
                       })}
                     </EuiLink>
                   </EuiFlexItem>


### PR DESCRIPTION
This PR fixes some small typos on the ES home page. More specifically, by writing "set up" correctly as a verb ("set up" is a verb, "setup" is a noun).

This typo looks to be present since 9.1

<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->