### PR TITLE
[Security Solution] PLEASE IGNORE. Allow partial matches on rule name when searching installed rules.

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
@@ -25,15 +25,56 @@ describe('convertRulesFilterToKQL', () => {
     const kql = convertRulesFilterToKQL({ ...filterOptions, filter: 'foo' });
 
     expect(kql).toBe(
-      '(alert.attributes.name: *foo* OR alert.attributes.params.index: "foo" OR alert.attributes.params.threat.tactic.id: "foo" OR alert.attributes.params.threat.tactic.name: "foo" OR alert.attributes.params.threat.technique.id: "foo" OR alert.attributes.params.threat.technique.name: "foo" OR alert.attributes.params.threat.technique.subtechnique.id: "foo" OR alert.attributes.params.threat.technique.subtechnique.name: "foo")'
+      '(' +
+        'alert.attributes.name.keyword: *foo* ' +
+        'OR alert.attributes.params.index: "foo" ' +
+        'OR alert.attributes.params.threat.tactic.id: "foo" ' +
+        'OR alert.attributes.params.threat.tactic.name: "foo" ' +
+        'OR alert.attributes.params.threat.technique.id: "foo" ' +
+        'OR alert.attributes.params.threat.technique.name: "foo" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.id: "foo" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.name: "foo"' +
+        ')'
     );
   });
 
-  it('escapes "filter" value properly', () => {
-    const kql = convertRulesFilterToKQL({ ...filterOptions, filter: '" OR (foo: bar)' });
+  it('escapes "filter" value for single term searches', () => {
+    const kql = convertRulesFilterToKQL({
+      ...filterOptions,
+      filter: '"a<detection\\-rule*with)a<surprise:',
+    });
 
     expect(kql).toBe(
-      '(alert.attributes.name: *OR foo bar* OR alert.attributes.params.index: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo: bar)")'
+      '(' +
+        'alert.attributes.name.keyword: *\\"a\\<detection\\\\-rule\\*with\\)a\\<surprise\\:* ' +
+        'OR alert.attributes.params.index: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.name: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.name: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.name: "\\"a<detection\\\\-rule*with)a<surprise:"' +
+        ')'
+    );
+  });
+
+  it('escapes "filter" value for multiple term searches', () => {
+    const kql = convertRulesFilterToKQL({
+      ...filterOptions,
+      filter: '"a <detection rule with)\\a< surprise:',
+    });
+
+    expect(kql).toBe(
+      '(' +
+        'alert.attributes.name: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.index: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.id: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.name: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.id: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.name: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.id: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.name: "\\"a <detection rule with)\\\\a< surprise:"' +
+        ')'
     );
   });
 
@@ -74,7 +115,19 @@ describe('convertRulesFilterToKQL', () => {
     });
 
     expect(kql).toBe(
-      `(alert.attributes.name: *foo* OR alert.attributes.params.index: "foo" OR alert.attributes.params.threat.tactic.id: "foo" OR alert.attributes.params.threat.tactic.name: "foo" OR alert.attributes.params.threat.technique.id: "foo" OR alert.attributes.params.threat.technique.name: "foo" OR alert.attributes.params.threat.technique.subtechnique.id: "foo" OR alert.attributes.params.threat.technique.subtechnique.name: "foo") AND alert.attributes.params.immutable: true AND alert.attributes.tags:(\"tag1\" AND \"tag2\")`
+      `(` +
+        `alert.attributes.name.keyword: *foo* OR ` +
+        `alert.attributes.params.index: "foo" OR ` +
+        `alert.attributes.params.threat.tactic.id: "foo" OR ` +
+        `alert.attributes.params.threat.tactic.name: "foo" OR ` +
+        `alert.attributes.params.threat.technique.id: "foo" OR ` +
+        `alert.attributes.params.threat.technique.name: "foo" OR ` +
+        `alert.attributes.params.threat.technique.subtechnique.id: "foo" OR ` +
+        `alert.attributes.params.threat.technique.subtechnique.name: "foo")` +
+        ` AND ` +
+        `alert.attributes.params.immutable: true` +
+        ` AND ` +
+        `alert.attributes.tags:(\"tag1\" AND \"tag2\")`
     );
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
@@ -25,7 +25,7 @@ describe('convertRulesFilterToKQL', () => {
     const kql = convertRulesFilterToKQL({ ...filterOptions, filter: 'foo' });
 
     expect(kql).toBe(
-      '(alert.attributes.name: "foo" OR alert.attributes.params.index: "foo" OR alert.attributes.params.threat.tactic.id: "foo" OR alert.attributes.params.threat.tactic.name: "foo" OR alert.attributes.params.threat.technique.id: "foo" OR alert.attributes.params.threat.technique.name: "foo" OR alert.attributes.params.threat.technique.subtechnique.id: "foo" OR alert.attributes.params.threat.technique.subtechnique.name: "foo")'
+      '(alert.attributes.name: *foo* OR alert.attributes.params.index: "foo" OR alert.attributes.params.threat.tactic.id: "foo" OR alert.attributes.params.threat.tactic.name: "foo" OR alert.attributes.params.threat.technique.id: "foo" OR alert.attributes.params.threat.technique.name: "foo" OR alert.attributes.params.threat.technique.subtechnique.id: "foo" OR alert.attributes.params.threat.technique.subtechnique.name: "foo")'
     );
   });
 
@@ -33,7 +33,7 @@ describe('convertRulesFilterToKQL', () => {
     const kql = convertRulesFilterToKQL({ ...filterOptions, filter: '" OR (foo: bar)' });
 
     expect(kql).toBe(
-      '(alert.attributes.name: "\\" OR (foo: bar)" OR alert.attributes.params.index: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo: bar)")'
+      '(alert.attributes.name: *\\" OR (foo: bar)* OR alert.attributes.params.index: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo: bar)")'
     );
   });
 
@@ -74,7 +74,7 @@ describe('convertRulesFilterToKQL', () => {
     });
 
     expect(kql).toBe(
-      `(alert.attributes.name: "foo" OR alert.attributes.params.index: "foo" OR alert.attributes.params.threat.tactic.id: "foo" OR alert.attributes.params.threat.tactic.name: "foo" OR alert.attributes.params.threat.technique.id: "foo" OR alert.attributes.params.threat.technique.name: "foo" OR alert.attributes.params.threat.technique.subtechnique.id: "foo" OR alert.attributes.params.threat.technique.subtechnique.name: "foo") AND alert.attributes.params.immutable: true AND alert.attributes.tags:(\"tag1\" AND \"tag2\")`
+      `(alert.attributes.name: *foo* OR alert.attributes.params.index: "foo" OR alert.attributes.params.threat.tactic.id: "foo" OR alert.attributes.params.threat.tactic.name: "foo" OR alert.attributes.params.threat.technique.id: "foo" OR alert.attributes.params.threat.technique.name: "foo" OR alert.attributes.params.threat.technique.subtechnique.id: "foo" OR alert.attributes.params.threat.technique.subtechnique.name: "foo") AND alert.attributes.params.immutable: true AND alert.attributes.tags:(\"tag1\" AND \"tag2\")`
     );
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
@@ -33,7 +33,7 @@ describe('convertRulesFilterToKQL', () => {
     const kql = convertRulesFilterToKQL({ ...filterOptions, filter: '" OR (foo: bar)' });
 
     expect(kql).toBe(
-      '(alert.attributes.name: *\\" OR (foo: bar)* OR alert.attributes.params.index: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo: bar)")'
+      '(alert.attributes.name: *OR foo bar* OR alert.attributes.params.index: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo: bar)")'
     );
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
@@ -27,6 +27,7 @@ describe('convertRulesFilterToKQL', () => {
     expect(kql).toBe(
       '(' +
         'alert.attributes.name.keyword: *foo* ' +
+        'OR alert.attributes.name: "foo" ' +
         'OR alert.attributes.params.index: "foo" ' +
         'OR alert.attributes.params.threat.tactic.id: "foo" ' +
         'OR alert.attributes.params.threat.tactic.name: "foo" ' +
@@ -47,6 +48,28 @@ describe('convertRulesFilterToKQL', () => {
     expect(kql).toBe(
       '(' +
         'alert.attributes.name.keyword: *\\"a\\<detection\\\\-rule\\*with\\)a\\<surprise\\:* ' +
+        'OR alert.attributes.name: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.index: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.name: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.name: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.name: "\\"a<detection\\\\-rule*with)a<surprise:"' +
+        ')'
+    );
+  });
+
+  it('skips expensive queries (allowExpensiveQueries = false) for single term searches', () => {
+    const kql = convertRulesFilterToKQL({
+      ...filterOptions,
+      allowExpensiveQueries: false,
+      filter: '"a<detection\\-rule*with)a<surprise:',
+    });
+
+    expect(kql).toBe(
+      '(' +
+        'alert.attributes.name: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
         'OR alert.attributes.params.index: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
         'OR alert.attributes.params.threat.tactic.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
         'OR alert.attributes.params.threat.tactic.name: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
@@ -117,6 +140,7 @@ describe('convertRulesFilterToKQL', () => {
     expect(kql).toBe(
       `(` +
         `alert.attributes.name.keyword: *foo* OR ` +
+        `alert.attributes.name: "foo" OR ` +
         `alert.attributes.params.index: "foo" OR ` +
         `alert.attributes.params.threat.tactic.id: "foo" OR ` +
         `alert.attributes.params.threat.tactic.name: "foo" OR ` +

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.ts
@@ -8,7 +8,7 @@
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import type { RuleExecutionStatus } from '../../api/detection_engine';
 import { RuleCustomizationStatus, RuleExecutionStatusEnum } from '../../api/detection_engine';
-import { escapeKQLStringParam, prepareKQLStringParam } from '../../utils/kql';
+import { cleanupKQLStringParam, prepareKQLStringParam } from '../../utils/kql';
 import {
   ENABLED_FIELD,
   IS_CUSTOMIZED_FIELD,
@@ -126,7 +126,7 @@ const SEARCHABLE_RULE_PARAMS = [
  * @returns KQL String
  */
 export function convertRuleSearchTermToKQL(searchTerm: string): string {
-  const ruleNameCondition = `${RULE_NAME_FIELD}: *${escapeKQLStringParam(searchTerm)}*`;
+  const ruleNameCondition = `${RULE_NAME_FIELD}: *${cleanupKQLStringParam(searchTerm)}*`;
   const remainingConditions = SEARCHABLE_RULE_PARAMS.map(
     (param) => `${param}: ${prepareKQLStringParam(searchTerm)}`
   );

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.ts
@@ -8,7 +8,7 @@
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import type { RuleExecutionStatus } from '../../api/detection_engine';
 import { RuleCustomizationStatus, RuleExecutionStatusEnum } from '../../api/detection_engine';
-import { cleanupKQLStringParam, prepareKQLStringParam } from '../../utils/kql';
+import { fullyEscapeKQLStringParam, prepareKQLStringParam } from '../../utils/kql';
 import {
   ENABLED_FIELD,
   IS_CUSTOMIZED_FIELD,
@@ -118,15 +118,32 @@ const SEARCHABLE_RULE_PARAMS = [
 /**
  * Build KQL search terms.
  *
- * Note that RULE_NAME_FIELD is special, it includes partial matches.
- * Ie "win" => "match: *win*" -> Windows, winter, Darwin.
- * Whereas the rest of the fields, we use exact match.
+ * Note that RULE_NAME_FIELD is special, for single term searches
+ * it includes partial matches, supporting special characters.
+ *
+ * Ie - "sql" =KQL=> *sql* --matches-->  sql, Postgreslq, SQLCMD.EXE
+ *    - "sql:" =KQL=> *sql\:* --matches-->  sql:x64, but NOT sql_x64
+ *
+ * Whereas the rest of the fields, and multiple term searches,
+ * we use exact term match with quotations.
+ *
+ * Ie - "sql" =KQL=> "sql" --matches--> sql server, but NOT mssql or SQLCMD.EXE
  *
  * @param searchTerm search term (ie from the search bar)
  * @returns KQL String
  */
 export function convertRuleSearchTermToKQL(searchTerm: string): string {
-  const ruleNameCondition = `${RULE_NAME_FIELD}: *${cleanupKQLStringParam(searchTerm)}*`;
+  let ruleNameCondition = '';
+  // Single search term?
+  // Allow partial matches using wildcards.
+  // Use `.keyword` index matches to support special characters.
+  const fullyEscapedSearchTerm = fullyEscapeKQLStringParam(searchTerm);
+  if (fullyEscapedSearchTerm.split(' ').length === 1) {
+    ruleNameCondition = `${RULE_NAME_FIELD}.keyword: *${fullyEscapedSearchTerm}*`;
+  } else {
+    // Multiple search terms? Use exact match with quotations.
+    ruleNameCondition = `${RULE_NAME_FIELD}: ${prepareKQLStringParam(searchTerm)}`;
+  }
   const remainingConditions = SEARCHABLE_RULE_PARAMS.map(
     (param) => `${param}: ${prepareKQLStringParam(searchTerm)}`
   );

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.ts
@@ -8,7 +8,7 @@
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import type { RuleExecutionStatus } from '../../api/detection_engine';
 import { RuleCustomizationStatus, RuleExecutionStatusEnum } from '../../api/detection_engine';
-import { prepareKQLStringParam } from '../../utils/kql';
+import { escapeKQLStringParam, prepareKQLStringParam } from '../../utils/kql';
 import {
   ENABLED_FIELD,
   IS_CUSTOMIZED_FIELD,
@@ -105,8 +105,7 @@ export function convertRulesFilterToKQL({
   return kql.join(' AND ');
 }
 
-const SEARCHABLE_RULE_ATTRIBUTES = [
-  RULE_NAME_FIELD,
+const SEARCHABLE_RULE_PARAMS = [
   RULE_PARAMS_FIELDS.INDEX,
   RULE_PARAMS_FIELDS.TACTIC_ID,
   RULE_PARAMS_FIELDS.TACTIC_NAME,
@@ -116,11 +115,22 @@ const SEARCHABLE_RULE_ATTRIBUTES = [
   RULE_PARAMS_FIELDS.SUBTECHNIQUE_NAME,
 ];
 
-export function convertRuleSearchTermToKQL(
-  searchTerm: string,
-  attributes = SEARCHABLE_RULE_ATTRIBUTES
-): string {
-  return attributes.map((param) => `${param}: ${prepareKQLStringParam(searchTerm)}`).join(' OR ');
+/**
+ * Build KQL search terms.
+ *
+ * Note that RULE_NAME_FIELD is special, it includes partial matches.
+ * Ie "win" => "match: *win*" -> Windows, winter, Darwin.
+ * Whereas the rest of the fields, we use exact match.
+ *
+ * @param searchTerm search term (ie from the search bar)
+ * @returns KQL String
+ */
+export function convertRuleSearchTermToKQL(searchTerm: string): string {
+  const ruleNameCondition = `${RULE_NAME_FIELD}: *${escapeKQLStringParam(searchTerm)}*`;
+  const remainingConditions = SEARCHABLE_RULE_PARAMS.map(
+    (param) => `${param}: ${prepareKQLStringParam(searchTerm)}`
+  );
+  return [ruleNameCondition].concat(remainingConditions).join(' OR ');
 }
 
 export function convertRuleTagsToKQL(tags: string[]): string {

--- a/x-pack/solutions/security/plugins/security_solution/common/utils/kql.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/utils/kql.test.ts
@@ -5,9 +5,14 @@
  * 2.0.
  */
 
-import { escapeKQLStringParam, prepareKQLParam, prepareKQLStringParam } from './kql';
+import {
+  escapeKQLStringParam,
+  prepareKQLParam,
+  prepareKQLStringParam,
+  cleanupKQLStringParam,
+} from './kql';
 
-const testCases = [
+const escapeTestCases = [
   ['does NOT remove white spaces quotes', ' netcat', ' netcat'],
   ['escapes quotes', 'I said, "Hello."', 'I said, \\"Hello.\\"'],
   [
@@ -42,10 +47,15 @@ const testCases = [
     'This\nhas\tnewlines\r\nwith\ttabs',
     'This\\nhas\\tnewlines\\r\\nwith\\ttabs',
   ],
+  [
+    'removes backslashes at the end of the string',
+    'Try not to break the search\\',
+    'Try not to break the search',
+  ],
 ];
 
 describe('prepareKQLParam', () => {
-  it.each(testCases)('%s', (_, input, expected) => {
+  it.each(escapeTestCases)('%s', (_, input, expected) => {
     expect(prepareKQLParam(input)).toBe(`"${expected}"`);
   });
 
@@ -65,13 +75,44 @@ describe('prepareKQLParam', () => {
 });
 
 describe('prepareKQLStringParam', () => {
-  it.each(testCases)('%s', (_, input, expected) => {
+  it.each(escapeTestCases)('%s', (_, input, expected) => {
     expect(prepareKQLStringParam(input)).toBe(`"${expected}"`);
   });
 });
 
 describe('escapeKQLStringParam', () => {
-  it.each(testCases)('%s', (_, input, expected) => {
+  it.each(escapeTestCases)('%s', (_, input, expected) => {
     expect(escapeKQLStringParam(input)).toBe(expected);
+  });
+});
+
+const cleanupTestCases = [
+  ['removes quotes, but keeps commas and dots', 'I said, "Hello."', 'I said, Hello.'],
+  [
+    'should cleanup special characters',
+    `This \\ has (a lot of) <special> characters, don't you *think*? "Yes."`,
+    `This has a lot of special characters, don't you think ? Yes.`,
+  ],
+  [
+    'should cleanup special characters and trim whitespace',
+    `a \"user-agent+ \t }with \n a *\\:(surprise{)   \t`,
+    `a user agent with a surprise`,
+  ],
+  [
+    "should keep certain characters that are not problematic (.,'&^%$#)",
+    `\t some -characters *are ok "to use ({.,'&^%$#})`,
+    `some characters are ok to use .,'&^%$#`,
+  ],
+  ['does NOT escape keywords', 'foo and bar or baz not qux', 'foo and bar or baz not qux'],
+  [
+    'It can also handle creepy unicode',
+    'It can also handle c̶̛̫̜̞̜͕̼̱̘̤̔̿̽́̉̓̋͠͠r̵̨̨̳̯̬͔̰̙͕̲̭̞̈́͒́͋͛̕͝ȩ̷̨͖̻͓̭̮͙͖̬̿͛͐̀̐̄̀͆̾̀̏̓͗̇͘͜ḛ̷̲̖͚̼͇̖̖̩̤͖̪̠̍͂̆͒̂̿̐p̸̹͇̲͇̬̞̞̐̃̎̍͂͐̐́̋̂͝y̶̧̝͔̙̮͖̹̯̺͇̞̰̹͉̏͗̿͑̿͆̐̈́ unicode',
+    'It can also handle c̶̛̫̜̞̜͕̼̱̘̤̔̿̽́̉̓̋͠͠r̵̨̨̳̯̬͔̰̙͕̲̭̞̈́͒́͋͛̕͝ȩ̷̨͖̻͓̭̮͙͖̬̿͛͐̀̐̄̀͆̾̀̏̓͗̇͘͜ḛ̷̲̖͚̼͇̖̖̩̤͖̪̠̍͂̆͒̂̿̐p̸̹͇̲͇̬̞̞̐̃̎̍͂͐̐́̋̂͝y̶̧̝͔̙̮͖̹̯̺͇̞̰̹͉̏͗̿͑̿͆̐̈́ unicode',
+  ],
+];
+
+describe('cleanupKQLStringParam', () => {
+  it.each(cleanupTestCases)('%s', (_, input, expected) => {
+    expect(cleanupKQLStringParam(input)).toBe(expected);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/common/utils/kql.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/utils/kql.ts
@@ -33,51 +33,54 @@ export function prepareKQLStringParam(value: string): string {
 }
 
 /**
- * Escapes string param intended to be passed to KQL. As official docs
- * [here](https://www.elastic.co/guide/en/kibana/current/kuery-query.html) say
+ * Partially escapes string param intended to be passed to KQL.
+ *
+ * This is intended to be used for KQL search terms surrounded by quotes.
+ * It escapes quotes, backslashes, tabs and new line symbols.
+ *
+ * @param param a string param value intended to be passed to KQL
+ * @returns a partially escaped KQL string param
+ */
+export function escapeKQLStringParam(value = ''): string {
+  return partiallyEscapeStringValue(value);
+}
+
+const escapeQuotes = (val: string) => val.replace(/["]/g, '\\$&'); // $& means the whole matched string
+
+const escapeBackslash = (val: string) => val.replace(/\\/g, '\\$&');
+
+const escapeTabs = (val: string) =>
+  val.replace(/\t/g, '\\t').replace(/\r/g, '\\r').replace(/\n/g, '\\n');
+
+const partiallyEscapeStringValue = flow(escapeBackslash, escapeQuotes, escapeTabs);
+
+/**
+ * Fully escapes special characters to improve matching on KQL.
+ *
+ * As per official docs [here](https://www.elastic.co/guide/en/kibana/current/kuery-query.html)
  * `Certain characters must be escaped by a backslash (unless surrounded by quotes).` and
  * `You must escape following characters: \():<>"*`.
  *
- * This function assumes the value is surrounded by quotes so it escapes quotes, tabs and new line symbols.
- *
- * @param param a string param value intended to be passed to KQL
- * @returns an escaped string param value
- */
-export function escapeKQLStringParam(value = ''): string {
-  return escapeStringValue(value);
-}
-/**
- * Cleans up special characters to improve matching on KQL.
- * Instead of escaping them, we replace them with spaces to improve search results,
- * since the underlying reverse index does not contain special characters to match against.
- * (they get stripped out automatically during indexing and tokenization)
- *
  * This is intended to be used on KQL search terms WITHOUT quotes.
  *
- * @example "a \"user-agent+ \t }with \n a *\:(surprise)" => "a user agent with a surprise"
+ * @example "a \"user-agent+ \t }with \n a *\:(surprise!) " => "a \\\\"user-agent+ \\}with a \\*\\\\:\\(surprise!\\)"
  *
  * @see https://www.elastic.co/docs/reference/query-languages/kql
+ *
+ * @param param a string param value intended to be passed to KQL
+ * @returns a fully escaped KQL string value
  */
-export function cleanupKQLStringParam(value = ''): string {
-  return cleanupStringValue(value);
+export function fullyEscapeKQLStringParam(value = ''): string {
+  return fullyEscapeStringValue(value);
 }
 
-const SPECIAL_KQL_CHARACTERS = '\\(){}:<>"*-+';
+const SPECIAL_KQL_CHARACTERS = '\\(){}:<>"*';
 
-const removeSpecialCharacters = (val: string) =>
-  val.replace(new RegExp(`[${SPECIAL_KQL_CHARACTERS.split('').join('\\')}]`, 'g'), ' ');
+const escapeSpecialCharacters = (val: string) =>
+  val.replace(new RegExp(`[${SPECIAL_KQL_CHARACTERS.split('').join('\\')}]`, 'g'), '\\$&');
 
 const simplifyWhitespace = (val: string) => val.replace(/\s+|\t+|\r+|\n+/g, ' ');
 
 const trim = (val: string) => val.trim();
 
-const cleanupStringValue = flow(removeSpecialCharacters, simplifyWhitespace, trim);
-
-const escapeQuotes = (val: string) => val.replace(/["]/g, '\\$&'); // $& means the whole matched string
-
-const removeEndingBackslash = (val: string) => val.replace(/\\$/, '');
-
-const escapeTabs = (val: string) =>
-  val.replace(/\t/g, '\\t').replace(/\r/g, '\\r').replace(/\n/g, '\\n');
-
-const escapeStringValue = flow(escapeQuotes, removeEndingBackslash, escapeTabs);
+const fullyEscapeStringValue = flow(escapeSpecialCharacters, simplifyWhitespace, trim);

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
@@ -220,6 +220,7 @@ describe('Detections Rules API', () => {
             filter:
               '(' +
               'alert.attributes.name.keyword: *\\"user\\\\-agent\\*with\\)a\\<surprise\\:* ' +
+              'OR alert.attributes.name: "\\"user\\\\-agent*with)a<surprise:" ' +
               'OR alert.attributes.params.index: "\\"user\\\\-agent*with)a<surprise:" ' +
               'OR alert.attributes.params.threat.tactic.id: "\\"user\\\\-agent*with)a<surprise:" ' +
               'OR alert.attributes.params.threat.tactic.name: "\\"user\\\\-agent*with)a<surprise:" ' +
@@ -493,6 +494,7 @@ describe('Detections Rules API', () => {
             filter:
               '(' +
               'alert.attributes.name.keyword: *ruleName* ' +
+              'OR alert.attributes.name: "ruleName" ' +
               'OR alert.attributes.params.index: "ruleName" ' +
               'OR alert.attributes.params.threat.tactic.id: "ruleName" ' +
               'OR alert.attributes.params.threat.tactic.name: "ruleName" ' +

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
@@ -179,7 +179,16 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: *hello world* OR alert.attributes.params.index: "hello world" OR alert.attributes.params.threat.tactic.id: "hello world" OR alert.attributes.params.threat.tactic.name: "hello world" OR alert.attributes.params.threat.technique.id: "hello world" OR alert.attributes.params.threat.technique.name: "hello world" OR alert.attributes.params.threat.technique.subtechnique.id: "hello world" OR alert.attributes.params.threat.technique.subtechnique.name: "hello world")',
+              '(' +
+              'alert.attributes.name: "hello world" ' +
+              'OR alert.attributes.params.index: "hello world" ' +
+              'OR alert.attributes.params.threat.tactic.id: "hello world" ' +
+              'OR alert.attributes.params.threat.tactic.name: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.id: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.name: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "hello world"' +
+              ')',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',
@@ -189,7 +198,46 @@ describe('Detections Rules API', () => {
       );
     });
 
-    test('check parameter url, query with a filter get escaped correctly', async () => {
+    test('check parameter url, query with a filter get escaped correctly (single term)', async () => {
+      await fetchRules({
+        filterOptions: {
+          filter: '"user\\-agent*with)a<surprise:',
+          showCustomRules: false,
+          showElasticRules: false,
+          tags: [],
+        },
+        sortingOptions: {
+          field: 'enabled',
+          order: 'desc',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_find',
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            filter:
+              '(' +
+              'alert.attributes.name.keyword: *\\"user\\\\-agent\\*with\\)a\\<surprise\\:* ' +
+              'OR alert.attributes.params.index: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.tactic.id: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.tactic.name: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.id: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.name: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "\\"user\\\\-agent*with)a<surprise:"' +
+              ')',
+            page: 1,
+            per_page: 20,
+            sort_field: 'enabled',
+            sort_order: 'desc',
+          },
+        })
+      );
+    });
+
+    test('check parameter url, query with a filter get escaped correctly (multiple terms)', async () => {
       await fetchRules({
         filterOptions: {
           filter: '" OR (foo:bar)',
@@ -209,7 +257,16 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: *OR foo bar* OR alert.attributes.params.index: "\\" OR (foo:bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo:bar)")',
+              '(' +
+              'alert.attributes.name: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.index: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.tactic.id: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.tactic.name: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.id: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.name: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo:bar)"' +
+              ')',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',
@@ -434,7 +491,16 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: *ruleName* OR alert.attributes.params.index: "ruleName" OR alert.attributes.params.threat.tactic.id: "ruleName" OR alert.attributes.params.threat.tactic.name: "ruleName" OR alert.attributes.params.threat.technique.id: "ruleName" OR alert.attributes.params.threat.technique.name: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.id: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.name: "ruleName") AND alert.attributes.tags:("hello" AND "world")',
+              '(' +
+              'alert.attributes.name.keyword: *ruleName* ' +
+              'OR alert.attributes.params.index: "ruleName" ' +
+              'OR alert.attributes.params.threat.tactic.id: "ruleName" ' +
+              'OR alert.attributes.params.threat.tactic.name: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.id: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.name: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "ruleName") ' +
+              'AND alert.attributes.tags:("hello" AND "world")',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
@@ -179,7 +179,7 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: "hello world" OR alert.attributes.params.index: "hello world" OR alert.attributes.params.threat.tactic.id: "hello world" OR alert.attributes.params.threat.tactic.name: "hello world" OR alert.attributes.params.threat.technique.id: "hello world" OR alert.attributes.params.threat.technique.name: "hello world" OR alert.attributes.params.threat.technique.subtechnique.id: "hello world" OR alert.attributes.params.threat.technique.subtechnique.name: "hello world")',
+              '(alert.attributes.name: *hello world* OR alert.attributes.params.index: "hello world" OR alert.attributes.params.threat.tactic.id: "hello world" OR alert.attributes.params.threat.tactic.name: "hello world" OR alert.attributes.params.threat.technique.id: "hello world" OR alert.attributes.params.threat.technique.name: "hello world" OR alert.attributes.params.threat.technique.subtechnique.id: "hello world" OR alert.attributes.params.threat.technique.subtechnique.name: "hello world")',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',
@@ -209,7 +209,7 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: "\\" OR (foo:bar)" OR alert.attributes.params.index: "\\" OR (foo:bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo:bar)")',
+              '(alert.attributes.name: *OR foo bar* OR alert.attributes.params.index: "\\" OR (foo:bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo:bar)")',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',
@@ -352,7 +352,11 @@ describe('Detections Rules API', () => {
           },
         ],
       ] = fetchMock.mock.calls;
-      expect(() => buildEsQuery(undefined, { query: filter, language: 'kuery' }, [])).not.toThrow();
+      expect(() =>
+        buildEsQuery(undefined, { query: filter, language: 'kuery' }, [], {
+          allowLeadingWildcards: true,
+        })
+      ).not.toThrow();
     });
 
     test('query KQL parses without errors when filter contains characters such as double quotes', async () => {
@@ -376,7 +380,11 @@ describe('Detections Rules API', () => {
           },
         ],
       ] = fetchMock.mock.calls;
-      expect(() => buildEsQuery(undefined, { query: filter, language: 'kuery' }, [])).not.toThrow();
+      expect(() =>
+        buildEsQuery(undefined, { query: filter, language: 'kuery' }, [], {
+          allowLeadingWildcards: true,
+        })
+      ).not.toThrow();
     });
 
     test('query KQL parses without errors when tags contains characters such as double quotes', async () => {
@@ -400,7 +408,11 @@ describe('Detections Rules API', () => {
           },
         ],
       ] = fetchMock.mock.calls;
-      expect(() => buildEsQuery(undefined, { query: filter, language: 'kuery' }, [])).not.toThrow();
+      expect(() =>
+        buildEsQuery(undefined, { query: filter, language: 'kuery' }, [], {
+          allowLeadingWildcards: true,
+        })
+      ).not.toThrow();
     });
 
     test('check parameter url, query with all options', async () => {
@@ -422,7 +434,7 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: "ruleName" OR alert.attributes.params.index: "ruleName" OR alert.attributes.params.threat.tactic.id: "ruleName" OR alert.attributes.params.threat.tactic.name: "ruleName" OR alert.attributes.params.threat.technique.id: "ruleName" OR alert.attributes.params.threat.technique.name: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.id: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.name: "ruleName") AND alert.attributes.tags:("hello" AND "world")',
+              '(alert.attributes.name: *ruleName* OR alert.attributes.params.index: "ruleName" OR alert.attributes.params.threat.tactic.id: "ruleName" OR alert.attributes.params.threat.tactic.name: "ruleName" OR alert.attributes.params.threat.technique.id: "ruleName" OR alert.attributes.params.threat.technique.name: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.id: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.name: "ruleName") AND alert.attributes.tags:("hello" AND "world")',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
@@ -184,6 +184,7 @@ export const fetchRules = async ({
     showCustomRules: false,
     showElasticRules: false,
     tags: [],
+    allowExpensiveQueries: true,
   },
   sortingOptions = {
     field: 'enabled',

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/logic/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/logic/types.ts
@@ -110,6 +110,7 @@ export interface FilterOptions {
   showRulesWithGaps?: boolean;
   gapSearchRange?: GapRangeValue;
   includeRuleTypes?: Type[];
+  allowExpensiveQueries?: boolean;
 }
 
 export interface FetchRulesResponse {


### PR DESCRIPTION

## Summary

When a user navigates to `Rules` > `Detection Rules (SIEM)` and wishes to find all rules matching a partial string on the rule name (like `win` to get all rules about `Windows`) they receive 0 matches. This is in contrast to the behavior they experience when searching available prebuilt "Elastic Rules", where partial name searches are available.

This PR fixes this UX inconsistency by modifying the KQL output generated by the search query.

Whereas previously a search for `"win"` would have generated the following KQL:

```sql
(alert.attributes.name: "win" 
  OR alert.attributes.params.index: "win"
  OR alert.attributes.params.threat.tactic.id: "win"
  ...
```

It now treats the `alert.attributes.name` differently, allowing it to match on partial terms (ie `*win*` instead of `"win"`) and using `.keyword` index for better special character support.

```sql
(alert.attributes.name.keyword: *win*
  OR alert.attributes.params.index: "win"
  OR alert.attributes.params.threat.tactic.id: "win"
  ...
```
