### PR TITLE
[Agent builder] agent knowledge (name TBD) POC

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-common/agents/definition.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/agents/definition.ts
@@ -79,7 +79,10 @@ export interface AgentConfiguration {
    * List of tools exposed to the agent
    */
   tools: ToolSelection[];
-
+  /**
+   * Optional list of skills associated with the agent.
+   */
+  skills?: string[];
   /**
    * Custom configuration for the research step of the agent.
    */

--- a/x-pack/platform/packages/shared/onechat/onechat-server/agents/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-server/agents/index.ts
@@ -22,3 +22,10 @@ export type {
   RunAgentOnEventFn,
 } from './runner';
 export type { BuiltInAgentDefinition, BuiltInAgentConfiguration } from './builtin_definition';
+export type {
+  AgentKnowledge,
+  KnowledgeConfiguration,
+  AgentKnowledgeResolverContext,
+  KnowledgePerStepInstructions,
+  KnowledgeConfigurationProvider,
+} from './knowledge';

--- a/x-pack/platform/packages/shared/onechat/onechat-server/agents/knowledge.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-server/agents/knowledge.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MaybePromise } from '@kbn/utility-types';
+import type { KibanaRequest } from '@kbn/core-http-server';
+
+export interface AgentKnowledge {
+  /** unique id for the knowledge */
+  id: string;
+  /** human-readable name */
+  name: string;
+  /** human-readable description */
+  description: string;
+  /** configuration or accessor function */
+  configuration: KnowledgeConfiguration | KnowledgeConfigurationProvider;
+}
+
+export interface AgentKnowledgeResolverContext {
+  request: KibanaRequest;
+}
+
+export interface KnowledgeConfiguration {
+  /** additional instructions which will be appended to the default ones */
+  instructions?: string | KnowledgePerStepInstructions;
+  /** context which will be appended to the conversation for each round */
+  context?: string;
+}
+
+export type KnowledgeConfigurationProvider = (
+  context: AgentKnowledgeResolverContext
+) => MaybePromise<KnowledgeConfiguration>;
+
+export interface KnowledgePerStepInstructions {
+  research?: string;
+  answer?: string;
+}

--- a/x-pack/platform/packages/shared/onechat/onechat-server/agents/provider.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-server/agents/provider.ts
@@ -14,7 +14,13 @@ import {
 } from '@kbn/onechat-common';
 import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { ModelProvider, ScopedRunner, ToolProvider, WritableToolResultStore } from '../runner';
+import type {
+  ModelProvider,
+  ScopedRunner,
+  ToolProvider,
+  WritableToolResultStore,
+  AgentService,
+} from '../runner';
 
 export type AgentHandlerFn = (
   params: AgentHandlerParams,
@@ -68,6 +74,10 @@ export interface AgentHandlerContext {
    * Event emitter that can be used to emits custom events
    */
   events: AgentEventEmitter;
+  /**
+   * Services to interact with the agent system.
+   */
+  agentService: AgentService;
   /**
    * Logger scoped to this execution
    */

--- a/x-pack/platform/packages/shared/onechat/onechat-server/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-server/index.ts
@@ -58,5 +58,10 @@ export type {
   AgentEventEmitter,
   AgentEventEmitterFn,
   RunAgentOnEventFn,
+  AgentKnowledge,
+  KnowledgeConfiguration,
+  AgentKnowledgeResolverContext,
+  KnowledgePerStepInstructions,
+  KnowledgeConfigurationProvider,
 } from './agents';
 export { chatSystemIndex, chatSystemIndexPrefix } from './indices';

--- a/x-pack/platform/packages/shared/onechat/onechat-server/runner/agents.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-server/runner/agents.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentKnowledge } from '../agents/knowledge';
+
+export interface AgentService {
+  knowledge: AgentKnowledgeRegistry;
+}
+
+export interface AgentKnowledgeRegistry {
+  get(id: string): AgentKnowledge | undefined;
+}

--- a/x-pack/platform/packages/shared/onechat/onechat-server/runner/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-server/runner/index.ts
@@ -36,3 +36,4 @@ export type {
 } from './tool_provider';
 export type { ModelProvider, ScopedModel } from './model_provider';
 export type { ToolResultStore, WritableToolResultStore } from './result_store';
+export type { AgentKnowledgeRegistry, AgentService } from './agents';

--- a/x-pack/platform/plugins/shared/onechat/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/plugin.ts
@@ -76,6 +76,7 @@ export class OnechatPlugin
       },
       agents: {
         register: serviceSetups.agents.register.bind(serviceSetups.agents),
+        registerKnowledge: serviceSetups.agents.registerKnowledge.bind(serviceSetups.agents),
       },
     };
   }

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/agents_service.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/agents_service.ts
@@ -25,6 +25,7 @@ import {
 } from './builtin';
 import { createPersistedProviderFn } from './persisted';
 import { createAgentRegistry } from './agent_registry';
+import { createAgentKnowledgeRegistry, type AgentKnowledgeRegistry } from './knowledge_registry';
 
 export interface AgentsServiceSetupDeps {
   logger: Logger;
@@ -40,11 +41,13 @@ export interface AgentsServiceStartDeps {
 
 export class AgentsService {
   private builtinRegistry: BuiltinAgentRegistry;
+  private knowledgeRegistry: AgentKnowledgeRegistry;
 
   private setupDeps?: AgentsServiceSetupDeps;
 
   constructor() {
     this.builtinRegistry = createBuiltinAgentRegistry();
+    this.knowledgeRegistry = createAgentKnowledgeRegistry();
   }
 
   setup(setupDeps: AgentsServiceSetupDeps): AgentsServiceSetup {
@@ -59,6 +62,9 @@ export class AgentsService {
              Please add it to the list of allowed built-in agents in the "@kbn/onechat-server/allow_lists.ts" file.`);
         }
         this.builtinRegistry.register(agent);
+      },
+      registerKnowledge: (knowledge) => {
+        return this.knowledgeRegistry.register(knowledge);
       },
     };
   }
@@ -91,6 +97,7 @@ export class AgentsService {
 
     return {
       getRegistry,
+      getKnowledgeRegistry: async () => this.knowledgeRegistry,
       execute: async (args) => {
         return getRunner().runAgent(args);
       },

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/knowledge_registry.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/knowledge_registry.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentKnowledge } from '@kbn/onechat-server/agents';
+
+export interface AgentKnowledgeRegistry {
+  register(agent: AgentKnowledge): void;
+  has(agentId: string): boolean;
+  get(agentId: string): AgentKnowledge | undefined;
+  list(): AgentKnowledge[];
+}
+
+export const createAgentKnowledgeRegistry = (): AgentKnowledgeRegistry => {
+  return new AgentKnowledgeRegistryImpl();
+};
+
+class AgentKnowledgeRegistryImpl implements AgentKnowledgeRegistry {
+  private entries: Map<string, AgentKnowledge> = new Map();
+
+  constructor() {}
+
+  register(knowledge: AgentKnowledge) {
+    if (this.entries.has(knowledge.id)) {
+      throw new Error(`Agent knowledge with id ${knowledge.id} already registered`);
+    }
+    this.entries.set(knowledge.id, knowledge);
+  }
+
+  has(knowledgeId: string): boolean {
+    return this.entries.has(knowledgeId);
+  }
+
+  get(knowledgeId: string) {
+    return this.entries.get(knowledgeId);
+  }
+
+  list() {
+    return [...this.entries.values()];
+  }
+}

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/graph.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/graph.ts
@@ -65,6 +65,7 @@ export const createAgentGraph = ({
     const response = await model.invoke(
       getActPrompt({
         customInstructions: configuration.research.instructions,
+        knowledge: configuration.knowledge,
         capabilities,
         messages: [...state.initialMessages, ...state.addedMessages],
       })
@@ -106,6 +107,7 @@ export const createAgentGraph = ({
     const response = await answeringModel.invoke(
       getAnswerPrompt({
         customInstructions: configuration.answer.instructions,
+        knowledge: configuration.knowledge,
         capabilities,
         handoverNote: state.handoverNote,
         discussion: [...state.initialMessages, ...state.addedMessages],

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/run_chat_agent.ts
@@ -44,11 +44,15 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
     agentId,
     abortSignal,
   },
-  { logger, request, modelProvider, toolProvider, events }
+  context
 ) => {
+  const { logger, request, modelProvider, toolProvider, events } = context;
   const model = await modelProvider.getDefaultModel();
   const resolvedCapabilities = resolveCapabilities(capabilities);
-  const resolvedConfiguration = resolveConfiguration(agentConfiguration);
+  const resolvedConfiguration = await resolveConfiguration({
+    configuration: agentConfiguration,
+    context,
+  });
   logger.debug(`Running chat agent with connector: ${model.connector.name}, runId: ${runId}`);
 
   const selectedTools = await selectProviderTools({

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/types.ts
@@ -9,6 +9,7 @@ import type {
   AgentAnswerStepConfiguration,
   AgentResearchStepConfiguration,
 } from '@kbn/onechat-common';
+import type { AgentKnowledge } from '@kbn/onechat-server/agents';
 
 export type ResolvedAnswerStepConfiguration = Required<AgentAnswerStepConfiguration>;
 export type ResolvedResearchStepConfiguration = Required<AgentResearchStepConfiguration>;
@@ -16,4 +17,15 @@ export type ResolvedResearchStepConfiguration = Required<AgentResearchStepConfig
 export interface ResolvedConfiguration {
   research: ResolvedResearchStepConfiguration;
   answer: ResolvedAnswerStepConfiguration;
+  knowledge: ResolvedAgentKnowledge[];
+}
+
+export type ResolvedAgentKnowledge = Omit<AgentKnowledge, 'configuration'> & {
+  configuration: ResolvedAgentKnowledgeConfiguration;
+};
+
+export interface ResolvedAgentKnowledgeConfiguration {
+  researchInstructions?: string;
+  answerInstructions?: string;
+  context?: string;
 }

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/configuration.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/configuration.ts
@@ -5,10 +5,27 @@
  * 2.0.
  */
 
+import type { KibanaRequest } from '@kbn/core-http-server';
 import type { AgentConfiguration } from '@kbn/onechat-common';
-import type { ResolvedConfiguration } from '../types';
+import type {
+  AgentKnowledge,
+  KnowledgeConfiguration,
+  AgentKnowledgeResolverContext,
+  AgentHandlerContext,
+} from '@kbn/onechat-server/agents';
+import type {
+  ResolvedConfiguration,
+  ResolvedAgentKnowledge,
+  ResolvedAgentKnowledgeConfiguration,
+} from '../types';
 
-export const resolveConfiguration = (configuration: AgentConfiguration): ResolvedConfiguration => {
+export const resolveConfiguration = async ({
+  configuration,
+  context,
+}: {
+  configuration: AgentConfiguration;
+  context: AgentHandlerContext;
+}): Promise<ResolvedConfiguration> => {
   let researchInstructions = configuration.research?.instructions ?? '';
   let answerInstructions = configuration.answer?.instructions ?? '';
   if (configuration.instructions) {
@@ -27,5 +44,54 @@ export const resolveConfiguration = (configuration: AgentConfiguration): Resolve
     answer: {
       instructions: answerInstructions,
     },
+    knowledge: configuration.skills
+      ? (
+          await Promise.all(
+            configuration.skills.map(async (knowledgeId) => {
+              const knowledge = context.agentService.knowledge.get(knowledgeId);
+              return knowledge
+                ? [await resolveAgentKnowledge({ knowledge, request: context.request })]
+                : [];
+            })
+          )
+        ).flat()
+      : [],
+  };
+};
+
+export const resolveAgentKnowledge = async ({
+  knowledge,
+  request,
+}: {
+  knowledge: AgentKnowledge;
+  request: KibanaRequest;
+}): Promise<ResolvedAgentKnowledge> => {
+  const { configuration: configOrAccessor, ...knowledgeProps } = knowledge;
+
+  let configuration: KnowledgeConfiguration;
+  if (typeof configOrAccessor === 'function') {
+    const context: AgentKnowledgeResolverContext = {
+      request,
+    };
+    configuration = await configOrAccessor(context);
+  } else {
+    configuration = configOrAccessor;
+  }
+
+  const resolvedConf: ResolvedAgentKnowledgeConfiguration = {
+    answerInstructions:
+      typeof configuration.instructions === 'string'
+        ? configuration.instructions
+        : configuration.instructions?.answer,
+    researchInstructions:
+      typeof configuration.instructions === 'string'
+        ? configuration.instructions
+        : configuration.instructions?.research,
+    context: configuration.context,
+  };
+
+  return {
+    ...knowledgeProps,
+    configuration: resolvedConf,
   };
 };

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/types.ts
@@ -7,14 +7,17 @@
 
 import type { KibanaRequest } from '@kbn/core/server';
 import type { RunAgentFn } from '@kbn/onechat-server';
-import type { BuiltInAgentDefinition } from '@kbn/onechat-server/agents';
+import type { BuiltInAgentDefinition, AgentKnowledge } from '@kbn/onechat-server/agents';
 import type { AgentRegistry } from './agent_registry';
+import type { AgentKnowledgeRegistry } from './knowledge_registry';
 
 export interface AgentsServiceSetup {
   register(agent: BuiltInAgentDefinition): void;
+  registerKnowledge(knowledge: AgentKnowledge): void;
 }
 
 export interface AgentsServiceStart {
   execute: RunAgentFn;
   getRegistry: (opts: { request: KibanaRequest }) => Promise<AgentRegistry>;
+  getKnowledgeRegistry: () => Promise<AgentKnowledgeRegistry>;
 }

--- a/x-pack/platform/plugins/shared/onechat/server/services/runner/run_agent.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/runner/run_agent.ts
@@ -13,7 +13,7 @@ import type {
 import { withAgentSpan } from '../../tracing';
 import { registryToProvider } from '../tools/utils';
 import { createAgentHandler } from '../agents/modes/create_handler';
-import { createAgentEventEmitter, forkContextForAgentRun } from './utils';
+import { createAgentEventEmitter, forkContextForAgentRun, createAgentService } from './utils';
 import type { RunnerManager } from './runner';
 
 export const createAgentHandlerContext = async <TParams = Record<string, unknown>>({
@@ -30,6 +30,7 @@ export const createAgentHandlerContext = async <TParams = Record<string, unknown
     elasticsearch,
     modelProviderFactory,
     toolsService,
+    agentsService,
     resultStore,
     logger,
   } = manager.deps;
@@ -44,6 +45,7 @@ export const createAgentHandlerContext = async <TParams = Record<string, unknown
       getRunner: manager.getRunner,
       request,
     }),
+    agentService: await createAgentService({ agentsStart: agentsService }),
     resultStore,
     events: createAgentEventEmitter({ eventHandler: onEvent, context: manager.context }),
   };

--- a/x-pack/platform/plugins/shared/onechat/server/services/runner/utils/agent_service.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/runner/utils/agent_service.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentService, AgentKnowledgeRegistry } from '@kbn/onechat-server/runner';
+import type { AgentsServiceStart } from '../../agents/types';
+
+export const createAgentService = async ({
+  agentsStart,
+}: {
+  agentsStart: AgentsServiceStart;
+}): Promise<AgentService> => {
+  const internalRegistry = await agentsStart.getKnowledgeRegistry();
+
+  const knowledgeRegistry: AgentKnowledgeRegistry = {
+    get: (id) => {
+      return internalRegistry.get(id);
+    },
+  };
+
+  return {
+    knowledge: knowledgeRegistry,
+  };
+};

--- a/x-pack/platform/plugins/shared/onechat/server/services/runner/utils/index.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/runner/utils/index.ts
@@ -12,3 +12,4 @@ export {
 } from './run_context';
 export { createToolEventEmitter, createAgentEventEmitter } from './events';
 export { extractConversationToolResults } from './extract_conversation_tool_results';
+export { createAgentService } from './agent_service';

--- a/x-pack/platform/plugins/shared/onechat/server/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/types.ts
@@ -13,7 +13,7 @@ import type { CloudStart, CloudSetup } from '@kbn/cloud-plugin/server';
 import type { SpacesPluginSetup, SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { InferenceServerSetup, InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
-import type { BuiltInAgentDefinition } from '@kbn/onechat-server/agents';
+import type { BuiltInAgentDefinition, AgentKnowledge } from '@kbn/onechat-server/agents';
 import type { ToolsServiceSetup, ToolRegistry } from './services/tools';
 
 export interface OnechatSetupDependencies {
@@ -60,6 +60,11 @@ export interface AgentsSetup {
    * Register a built-in agent to be available in onechat.
    */
   register: (definition: BuiltInAgentDefinition) => void;
+  /**
+   * Register an agent skill to be available in onechat.
+   * @param knowledge
+   */
+  registerKnowledge: (knowledge: AgentKnowledge) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary


```ts
    serviceSetups.agents.registerKnowledge({
      id: 'apm_context',
      name: 'Apm Context',
      description: "Expose the APM stuff in the agent's context",
      configuration: async ({ request }) => {
        const indices = await fetchIndices(request);
        return {
          instructions: {
            research:
              'The list of available indices are available in the apm_indices part of the context...',
            answer: 'Answer like one of your french girls',
          },
          context: `<apm_indices>${indices}</apm_indices>`,
        };
      },
    });
```




