### PR TITLE
Allow for a 5ms error margin

### DIFF
--- a/src/core/packages/saved-objects/migration-server-mocks/src/helpers/retry.test.ts
+++ b/src/core/packages/saved-objects/migration-server-mocks/src/helpers/retry.test.ts
@@ -54,7 +54,7 @@ describe('retry', () => {
       { retryAttempts: 3, retryDelayMs: 100 }
     );
     // Would expect it to take 200ms but seems like timing inaccuracies
-    // sometimes causes the duration to be measured as 199ms
-    expect(Date.now() - now).toBeGreaterThanOrEqual(199);
+    // sometimes causes the duration to be measured as 198 or 199ms
+    expect(Date.now() - now).toBeGreaterThanOrEqual(195);
   });
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/234508
Same idea as https://github.com/elastic/kibana/pull/111365
It seems that we might need a bit more margin.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->