### PR TITLE
Prevent object from being considered 4 days old

### DIFF
--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
@@ -63,7 +63,7 @@ function createRawEventLoopDelaysDailyDocs() {
     createRawObject(moment()),
     createRawObject(moment()),
     createRawObject(moment().subtract(1, 'days')),
-    createRawObject(moment().subtract(3, 'days')),
+    createRawObject(moment().subtract(2.5, 'days')), // could be considered 4 days if we use 3 and the check is performed the following hour
   ];
 
   const outdatedRawEventLoopDelaysDaily = [


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/231367
If an object is inserted in the hour H and queried in H+1 it can be considered a day older, causing the test to fail.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->