### PR TITLE
[8.19] [Security Solution] Unskip Related Integrations Cypress test (#239532)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/related_integrations/related_integrations.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/related_integrations/related_integrations.cy.ts
@@ -47,276 +47,271 @@ import {
   waitForPageToBeLoaded,
 } from '../../../../tasks/rule_details';
 
-// Failing: See https://github.com/elastic/kibana/issues/239356
-describe.skip(
-  'Related integrations',
-  { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
-  () => {
-    const DATA_STREAM_NAME = 'logs-related-integrations-test';
-    const PREBUILT_RULE_NAME = 'Prebuilt rule with related integrations';
-    const RELATED_INTEGRATIONS: RelatedIntegration[] = [
-      {
-        package: 'auditd',
-        version: '1.16.0',
-      },
-      {
-        package: 'aws',
-        version: '1.17.0',
-        integration: 'cloudfront',
-      },
-      {
-        package: 'aws',
-        version: '1.17.0',
-        integration: 'cloudtrail',
-      },
-      {
-        package: 'aws',
-        version: '1.17.0',
-        integration: 'unknown',
-      },
-      { package: 'system', version: '1.17.0' },
-    ];
+describe('Related integrations', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  const DATA_STREAM_NAME = 'logs-related-integrations-test';
+  const PREBUILT_RULE_NAME = 'Prebuilt rule with related integrations';
+  const RELATED_INTEGRATIONS: RelatedIntegration[] = [
+    {
+      package: 'auditd',
+      version: '1.16.0',
+    },
+    {
+      package: 'aws',
+      version: '1.17.0',
+      integration: 'cloudfront',
+    },
+    {
+      package: 'aws',
+      version: '1.17.0',
+      integration: 'cloudtrail',
+    },
+    {
+      package: 'aws',
+      version: '1.17.0',
+      integration: 'unknown',
+    },
+    { package: 'system', version: '1.17.0' },
+  ];
 
-    const PREBUILT_RULE = createRuleAssetSavedObject({
-      name: PREBUILT_RULE_NAME,
-      index: [DATA_STREAM_NAME],
-      query: '*:*',
-      rule_id: 'rule_1',
-      related_integrations: RELATED_INTEGRATIONS,
-    });
+  const PREBUILT_RULE = createRuleAssetSavedObject({
+    name: PREBUILT_RULE_NAME,
+    index: [DATA_STREAM_NAME],
+    query: '*:*',
+    rule_id: 'rule_1',
+    related_integrations: RELATED_INTEGRATIONS,
+  });
 
-    const EXPECTED_RELATED_INTEGRATIONS: ExpectedRelatedIntegration[] = [
-      {
-        title: 'Auditd Logs',
-        status: 'Not installed',
-      },
-      {
-        title: 'AWS Amazon cloudfront',
-        status: 'Enabled',
-      },
-      {
-        title: 'AWS Aws cloudtrail',
-        status: 'Disabled',
-      },
-      {
-        title: 'Aws Unknown',
-      },
-      {
-        title: 'System',
-        status: 'Enabled',
-      },
-    ];
+  const EXPECTED_RELATED_INTEGRATIONS: ExpectedRelatedIntegration[] = [
+    {
+      title: 'Auditd Logs',
+      status: 'Not installed',
+    },
+    {
+      title: 'AWS Amazon cloudfront',
+      status: 'Enabled',
+    },
+    {
+      title: 'AWS Aws cloudtrail',
+      status: 'Disabled',
+    },
+    {
+      title: 'Aws Unknown',
+    },
+    {
+      title: 'System',
+      status: 'Enabled',
+    },
+  ];
 
-    const EXPECTED_KNOWN_RELATED_INTEGRATIONS = EXPECTED_RELATED_INTEGRATIONS.filter((x) =>
-      Boolean(x.status)
-    );
+  const EXPECTED_KNOWN_RELATED_INTEGRATIONS = EXPECTED_RELATED_INTEGRATIONS.filter((x) =>
+    Boolean(x.status)
+  );
 
-    beforeEach(() => {
-      login();
-      cleanFleet();
-      deleteAlertsAndRules();
-      addAndInstallPrebuiltRules([PREBUILT_RULE]);
-    });
+  beforeEach(() => {
+    login();
+    cleanFleet();
+    deleteAlertsAndRules();
+    addAndInstallPrebuiltRules([PREBUILT_RULE]);
+  });
 
-    describe('integrations not installed', () => {
-      describe('rules management table', () => {
-        beforeEach(() => {
-          visitRulesManagementTable();
-          disableAutoRefresh();
-        });
-
-        it('should display a badge with the installed integrations', () => {
-          cy.get(INTEGRATIONS_POPOVER).should(
-            'have.text',
-            `0/${EXPECTED_RELATED_INTEGRATIONS.length}`
-          );
-        });
-
-        it('should display a popover when clicking the badge with the installed integrations', () => {
-          openIntegrationsPopover();
-
-          cy.get(INTEGRATIONS_POPOVER_TITLE).should(
-            'have.text',
-            `[${EXPECTED_RELATED_INTEGRATIONS.length}] Related integrations available`
-          );
-          cy.get(INTEGRATION_LINK).should('have.length', EXPECTED_RELATED_INTEGRATIONS.length);
-          cy.get(INTEGRATION_STATUS).should(
-            'have.length',
-            EXPECTED_KNOWN_RELATED_INTEGRATIONS.length
-          );
-
-          EXPECTED_RELATED_INTEGRATIONS.forEach((expected, index) => {
-            cy.get(INTEGRATION_LINK).eq(index).contains(expected.title);
-          });
-
-          EXPECTED_KNOWN_RELATED_INTEGRATIONS.forEach((_, index) => {
-            cy.get(INTEGRATION_STATUS).eq(index).should('have.text', 'Not installed');
-          });
-        });
-      });
-
-      describe('rule details', () => {
-        beforeEach(() => {
-          visitFirstInstalledPrebuiltRuleDetailsPage();
-        });
-
-        it('should display the integrations in the definition section', () => {
-          cy.get(INTEGRATION_LINK).should('have.length', EXPECTED_RELATED_INTEGRATIONS.length);
-          cy.get(INTEGRATION_STATUS).should(
-            'have.length',
-            EXPECTED_KNOWN_RELATED_INTEGRATIONS.length
-          );
-
-          EXPECTED_RELATED_INTEGRATIONS.forEach((expected, index) => {
-            cy.get(INTEGRATION_LINK).eq(index).contains(expected.title);
-          });
-
-          EXPECTED_KNOWN_RELATED_INTEGRATIONS.forEach((_, index) => {
-            cy.get(INTEGRATION_STATUS).eq(index).should('have.text', 'Not installed');
-          });
-        });
-      });
-    });
-
-    describe('integrations installed (AWS CloudFront (enabled), AWS CloudTrail (disabled), System (enabled))', () => {
+  describe('integrations not installed', () => {
+    describe('rules management table', () => {
       beforeEach(() => {
-        installIntegrations({
-          packages: [
-            { name: 'aws', version: '1.17.0' },
-            { name: 'system', version: '1.17.0' },
-          ],
-          agentPolicy: {
-            name: 'Agent policy',
-            namespace: 'default',
-            monitoring_enabled: ['logs'],
-            inactivity_timeout: 1209600,
-          },
-          packagePolicy: AWS_PACKAGE_POLICY,
-        });
+        visitRulesManagementTable();
+        disableAutoRefresh();
       });
 
-      describe('rules management table', () => {
-        beforeEach(() => {
-          visitRulesManagementTable();
-          disableAutoRefresh();
-        });
-
-        it('should display a badge with the installed integrations', () => {
-          cy.get(INTEGRATIONS_POPOVER).should(
-            'have.text',
-            `2/${EXPECTED_RELATED_INTEGRATIONS.length}`
-          );
-        });
-
-        it('should display a popover when clicking the badge with the installed integrations', () => {
-          openIntegrationsPopover();
-
-          cy.get(INTEGRATIONS_POPOVER_TITLE).should(
-            'have.text',
-            `[${EXPECTED_RELATED_INTEGRATIONS.length}] Related integrations available`
-          );
-          cy.get(INTEGRATION_LINK).should('have.length', EXPECTED_RELATED_INTEGRATIONS.length);
-          cy.get(INTEGRATION_STATUS).should(
-            'have.length',
-            EXPECTED_KNOWN_RELATED_INTEGRATIONS.length
-          );
-
-          EXPECTED_RELATED_INTEGRATIONS.forEach((expected, index) => {
-            cy.get(INTEGRATION_LINK).eq(index).contains(expected.title);
-          });
-
-          EXPECTED_KNOWN_RELATED_INTEGRATIONS.forEach((expected, index) => {
-            cy.get(INTEGRATION_STATUS).eq(index).should('have.text', expected.status);
-          });
-        });
+      it('should display a badge with the installed integrations', () => {
+        cy.get(INTEGRATIONS_POPOVER).should(
+          'have.text',
+          `0/${EXPECTED_RELATED_INTEGRATIONS.length}`
+        );
       });
 
-      describe('rule details', () => {
-        beforeEach(() => {
-          visitFirstInstalledPrebuiltRuleDetailsPage();
-          waitForPageToBeLoaded(PREBUILT_RULE_NAME);
+      it('should display a popover when clicking the badge with the installed integrations', () => {
+        openIntegrationsPopover();
+
+        cy.get(INTEGRATIONS_POPOVER_TITLE).should(
+          'have.text',
+          `[${EXPECTED_RELATED_INTEGRATIONS.length}] Related integrations available`
+        );
+        cy.get(INTEGRATION_LINK).should('have.length', EXPECTED_RELATED_INTEGRATIONS.length);
+        cy.get(INTEGRATION_STATUS).should(
+          'have.length',
+          EXPECTED_KNOWN_RELATED_INTEGRATIONS.length
+        );
+
+        EXPECTED_RELATED_INTEGRATIONS.forEach((expected, index) => {
+          cy.get(INTEGRATION_LINK).eq(index).contains(expected.title);
         });
 
-        it('should display the integrations in the definition section', () => {
-          cy.get(INTEGRATION_LINK).should('have.length', EXPECTED_RELATED_INTEGRATIONS.length);
-          cy.get(INTEGRATION_STATUS).should(
-            'have.length',
-            EXPECTED_KNOWN_RELATED_INTEGRATIONS.length
-          );
-
-          EXPECTED_RELATED_INTEGRATIONS.forEach((expected, index) => {
-            cy.get(INTEGRATION_LINK).eq(index).contains(expected.title);
-          });
-
-          EXPECTED_KNOWN_RELATED_INTEGRATIONS.forEach((expected, index) => {
-            cy.get(INTEGRATION_STATUS).eq(index).should('have.text', expected.status);
-          });
-        });
-
-        const RELATED_INTEGRATION_FIELD = 'kibana.alert.rule.parameters.related_integrations';
-
-        it(`the alerts generated should have a "${RELATED_INTEGRATION_FIELD}" field containing the integrations`, () => {
-          deleteDataStream(DATA_STREAM_NAME);
-          createDocument(DATA_STREAM_NAME, generateEvent());
-
-          clickEnableRuleSwitch();
-          waitForAlertsToPopulate();
-
-          fetchRuleAlerts({
-            ruleId: 'rule_1',
-            fields: [RELATED_INTEGRATION_FIELD],
-            size: 1,
-          }).then((alertsResponse) => {
-            expect(alertsResponse.body.hits.hits[0].fields).to.deep.equal({
-              [RELATED_INTEGRATION_FIELD]: RELATED_INTEGRATIONS,
-            });
-          });
+        EXPECTED_KNOWN_RELATED_INTEGRATIONS.forEach((_, index) => {
+          cy.get(INTEGRATION_STATUS).eq(index).should('have.text', 'Not installed');
         });
       });
     });
 
-    describe('related Integrations Advanced Setting is disabled', () => {
-      describe('rules management table', () => {
-        beforeEach(() => {
-          disableRelatedIntegrations();
-          visitRulesManagementTable();
-          disableAutoRefresh();
+    describe('rule details', () => {
+      beforeEach(() => {
+        visitFirstInstalledPrebuiltRuleDetailsPage();
+      });
+
+      it('should display the integrations in the definition section', () => {
+        cy.get(INTEGRATION_LINK).should('have.length', EXPECTED_RELATED_INTEGRATIONS.length);
+        cy.get(INTEGRATION_STATUS).should(
+          'have.length',
+          EXPECTED_KNOWN_RELATED_INTEGRATIONS.length
+        );
+
+        EXPECTED_RELATED_INTEGRATIONS.forEach((expected, index) => {
+          cy.get(INTEGRATION_LINK).eq(index).contains(expected.title);
         });
 
-        afterEach(() => {
-          enableRelatedIntegrations();
+        EXPECTED_KNOWN_RELATED_INTEGRATIONS.forEach((_, index) => {
+          cy.get(INTEGRATION_STATUS).eq(index).should('have.text', 'Not installed');
+        });
+      });
+    });
+  });
+
+  describe('integrations installed (AWS CloudFront (enabled), AWS CloudTrail (disabled), System (enabled))', () => {
+    beforeEach(() => {
+      installIntegrations({
+        packages: [
+          { name: 'aws', version: '1.17.0' },
+          { name: 'system', version: '1.17.0' },
+        ],
+        agentPolicy: {
+          name: 'Agent policy',
+          namespace: 'default',
+          monitoring_enabled: ['logs'],
+          inactivity_timeout: 1209600,
+        },
+        packagePolicy: AWS_PACKAGE_POLICY,
+      });
+    });
+
+    describe('rules management table', () => {
+      beforeEach(() => {
+        visitRulesManagementTable();
+        disableAutoRefresh();
+      });
+
+      it('should display a badge with the installed integrations', () => {
+        cy.get(INTEGRATIONS_POPOVER).should(
+          'have.text',
+          `2/${EXPECTED_RELATED_INTEGRATIONS.length}`
+        );
+      });
+
+      it('should display a popover when clicking the badge with the installed integrations', () => {
+        openIntegrationsPopover();
+
+        cy.get(INTEGRATIONS_POPOVER_TITLE).should(
+          'have.text',
+          `[${EXPECTED_RELATED_INTEGRATIONS.length}] Related integrations available`
+        );
+        cy.get(INTEGRATION_LINK).should('have.length', EXPECTED_RELATED_INTEGRATIONS.length);
+        cy.get(INTEGRATION_STATUS).should(
+          'have.length',
+          EXPECTED_KNOWN_RELATED_INTEGRATIONS.length
+        );
+
+        EXPECTED_RELATED_INTEGRATIONS.forEach((expected, index) => {
+          cy.get(INTEGRATION_LINK).eq(index).contains(expected.title);
         });
 
-        it('should not display a badge with the installed integrations', () => {
-          cy.get(RULE_NAME).should('have.text', PREBUILT_RULE_NAME);
-          cy.get(INTEGRATION_LINK).should('not.exist');
+        EXPECTED_KNOWN_RELATED_INTEGRATIONS.forEach((expected, index) => {
+          cy.get(INTEGRATION_STATUS).eq(index).should('have.text', expected.status);
+        });
+      });
+    });
+
+    describe('rule details', () => {
+      beforeEach(() => {
+        visitFirstInstalledPrebuiltRuleDetailsPage();
+        waitForPageToBeLoaded(PREBUILT_RULE_NAME);
+      });
+
+      it('should display the integrations in the definition section', () => {
+        cy.get(INTEGRATION_LINK).should('have.length', EXPECTED_RELATED_INTEGRATIONS.length);
+        cy.get(INTEGRATION_STATUS).should(
+          'have.length',
+          EXPECTED_KNOWN_RELATED_INTEGRATIONS.length
+        );
+
+        EXPECTED_RELATED_INTEGRATIONS.forEach((expected, index) => {
+          cy.get(INTEGRATION_LINK).eq(index).contains(expected.title);
+        });
+
+        EXPECTED_KNOWN_RELATED_INTEGRATIONS.forEach((expected, index) => {
+          cy.get(INTEGRATION_STATUS).eq(index).should('have.text', expected.status);
         });
       });
 
-      describe('rule details', () => {
-        beforeEach(() => {
-          visitFirstInstalledPrebuiltRuleDetailsPage();
-        });
+      const RELATED_INTEGRATION_FIELD = 'kibana.alert.rule.parameters.related_integrations';
 
-        it('should display the integrations in the definition section', () => {
-          cy.get(INTEGRATION_LINK).should('have.length', EXPECTED_RELATED_INTEGRATIONS.length);
-          cy.get(INTEGRATION_STATUS).should(
-            'have.length',
-            EXPECTED_KNOWN_RELATED_INTEGRATIONS.length
-          );
+      it(`the alerts generated should have a "${RELATED_INTEGRATION_FIELD}" field containing the integrations`, () => {
+        deleteDataStream(DATA_STREAM_NAME);
+        createDocument(DATA_STREAM_NAME, generateEvent());
 
-          EXPECTED_RELATED_INTEGRATIONS.forEach((expected, index) => {
-            cy.get(INTEGRATION_LINK).eq(index).contains(expected.title);
-          });
+        clickEnableRuleSwitch();
+        waitForAlertsToPopulate();
 
-          EXPECTED_KNOWN_RELATED_INTEGRATIONS.forEach((_, index) => {
-            cy.get(INTEGRATION_STATUS).eq(index).should('have.text', 'Not installed');
+        fetchRuleAlerts({
+          ruleId: 'rule_1',
+          fields: [RELATED_INTEGRATION_FIELD],
+          size: 1,
+        }).then((alertsResponse) => {
+          expect(alertsResponse.body.hits.hits[0].fields).to.deep.equal({
+            [RELATED_INTEGRATION_FIELD]: RELATED_INTEGRATIONS,
           });
         });
       });
     });
-  }
-);
+  });
+
+  describe('related Integrations Advanced Setting is disabled', () => {
+    describe('rules management table', () => {
+      beforeEach(() => {
+        disableRelatedIntegrations();
+        visitRulesManagementTable();
+        disableAutoRefresh();
+      });
+
+      afterEach(() => {
+        enableRelatedIntegrations();
+      });
+
+      it('should not display a badge with the installed integrations', () => {
+        cy.get(RULE_NAME).should('have.text', PREBUILT_RULE_NAME);
+        cy.get(INTEGRATION_LINK).should('not.exist');
+      });
+    });
+
+    describe('rule details', () => {
+      beforeEach(() => {
+        visitFirstInstalledPrebuiltRuleDetailsPage();
+      });
+
+      it('should display the integrations in the definition section', () => {
+        cy.get(INTEGRATION_LINK).should('have.length', EXPECTED_RELATED_INTEGRATIONS.length);
+        cy.get(INTEGRATION_STATUS).should(
+          'have.length',
+          EXPECTED_KNOWN_RELATED_INTEGRATIONS.length
+        );
+
+        EXPECTED_RELATED_INTEGRATIONS.forEach((expected, index) => {
+          cy.get(INTEGRATION_LINK).eq(index).contains(expected.title);
+        });
+
+        EXPECTED_KNOWN_RELATED_INTEGRATIONS.forEach((_, index) => {
+          cy.get(INTEGRATION_STATUS).eq(index).should('have.text', 'Not installed');
+        });
+      });
+    });
+  });
+});
 
 const INSTALLED_PREBUILT_RULES_RESPONSE_ALIAS = 'prebuiltRules';
 


### PR DESCRIPTION
ℹ️ The diff appears large, but the only functional change is the removal of `.only`. The rest comes from Prettier formatting.

# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Unskip Related Integrations Cypress test (#239532)](https://github.com/elastic/kibana/pull/239532)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nikita Indik","email":"nikita.indik@elastic.co"},"sourceCommit":{"committedDate":"2025-10-21T09:00:12Z","message":"[Security Solution] Unskip Related Integrations Cypress test (#239532)\n\n**Resolves: https://github.com/elastic/kibana/issues/239356**\n\n🟢 Flaky test runner:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9560\n\n# Summary\nThis PR unskips the Related Integrations Cypress tests. The tests were\npreviously failing because one of the Fleet packages they depend on\ncontained a YAML syntax error. That issue has now been fixed\n([PR](https://github.com/elastic/integrations/pull/15669)), so the tests\ncan be safely re-enabled.\n\nThe diff appears large, but the only functional change is the removal of\n`.only`. The rest comes from Prettier formatting.","sha":"1bfd3c1046ae74295d77a33d68a0aa91071ce5e5","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Related Integrations","backport:version","v9.2.0","v9.3.0","v9.1.6","v8.19.6"],"title":"[Security Solution] Unskip Related Integrations Cypress test","number":239532,"url":"https://github.com/elastic/kibana/pull/239532","mergeCommit":{"message":"[Security Solution] Unskip Related Integrations Cypress test (#239532)\n\n**Resolves: https://github.com/elastic/kibana/issues/239356**\n\n🟢 Flaky test runner:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9560\n\n# Summary\nThis PR unskips the Related Integrations Cypress tests. The tests were\npreviously failing because one of the Fleet packages they depend on\ncontained a YAML syntax error. That issue has now been fixed\n([PR](https://github.com/elastic/integrations/pull/15669)), so the tests\ncan be safely re-enabled.\n\nThe diff appears large, but the only functional change is the removal of\n`.only`. The rest comes from Prettier formatting.","sha":"1bfd3c1046ae74295d77a33d68a0aa91071ce5e5"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/239869","number":239869,"state":"MERGED","mergeCommit":{"sha":"36efd601450c4dbebcd441ae9639bbdfe6cf055f","message":"[9.2] [Security Solution] Unskip Related Integrations Cypress test (#239532) (#239869)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Security Solution] Unskip Related Integrations Cypress test\n(#239532)](https://github.com/elastic/kibana/pull/239532)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nikita Indik <nikita.indik@elastic.co>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239532","number":239532,"mergeCommit":{"message":"[Security Solution] Unskip Related Integrations Cypress test (#239532)\n\n**Resolves: https://github.com/elastic/kibana/issues/239356**\n\n🟢 Flaky test runner:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9560\n\n# Summary\nThis PR unskips the Related Integrations Cypress tests. The tests were\npreviously failing because one of the Fleet packages they depend on\ncontained a YAML syntax error. That issue has now been fixed\n([PR](https://github.com/elastic/integrations/pull/15669)), so the tests\ncan be safely re-enabled.\n\nThe diff appears large, but the only functional change is the removal of\n`.only`. The rest comes from Prettier formatting.","sha":"1bfd3c1046ae74295d77a33d68a0aa91071ce5e5"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/239868","number":239868,"state":"MERGED","mergeCommit":{"sha":"c8d163f6133593a534b53955c7e266a6408ed8e3","message":"[9.1] [Security Solution] Unskip Related Integrations Cypress test (#239532) (#239868)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution] Unskip Related Integrations Cypress test\n(#239532)](https://github.com/elastic/kibana/pull/239532)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nikita Indik <nikita.indik@elastic.co>"}},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->