### PR TITLE
[Discover][Metrics] Prevent flyouts from overlapping

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart_section_template.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart_section_template.tsx
@@ -7,11 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import React from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import type { SerializedStyles } from '@emotion/serialize';
 import { i18n } from '@kbn/i18n';
 import { IconButtonGroup, type IconButtonGroupProps } from '@kbn/shared-ux-button-toolbar';
-import React from 'react';
+import { DiscoverFlyouts, dismissAllFlyoutsExceptFor } from '@kbn/discover-utils';
 
 export interface ChartSectionTemplateProps {
   id: string;
@@ -42,6 +43,7 @@ export const ChartSectionTemplate = ({
       alignItems="stretch"
       gutterSize="none"
       responsive={false}
+      onClick={handleClick}
     >
       <EuiFlexItem grow={false} css={toolbarCss}>
         <EuiFlexGroup
@@ -83,4 +85,12 @@ export const ChartSectionTemplate = ({
       {children}
     </EuiFlexGroup>
   );
+};
+
+const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const target = event.target as HTMLElement;
+
+  if (target.closest('[data-test-subj="embeddablePanelAction-openInspector"]')) {
+    dismissAllFlyoutsExceptFor(DiscoverFlyouts.inspectorPanel);
+  }
 };

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/flyout/metrics_insights_flyout.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/flyout/metrics_insights_flyout.tsx
@@ -72,7 +72,8 @@ export const MetricInsightsFlyout = ({
     <EuiPortal>
       <EuiFlyoutResizable
         onClose={onClose}
-        type="overlay"
+        type="push"
+        pushMinBreakpoint="xl"
         size={flyoutWidth}
         onKeyDown={onKeyDown}
         data-test-subj="metricsExperienceFlyout"

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/flyout/metrics_insights_flyout.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/flyout/metrics_insights_flyout.tsx
@@ -22,11 +22,12 @@ import {
   EuiTitle,
   EuiPortal,
 } from '@elastic/eui';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { css } from '@emotion/react';
 import type { MetricField } from '@kbn/metrics-experience-plugin/common/types';
+import { DiscoverFlyouts, dismissAllFlyoutsExceptFor } from '@kbn/discover-utils';
 import { MetricFlyoutBody } from './metrics_flyout_body';
 import { useFlyoutA11y } from './hooks/use_flyout_a11y';
 import { useFieldsMetadataContext } from '../../context/fields_metadata';
@@ -53,6 +54,10 @@ export const MetricInsightsFlyout = ({
   );
   const { a11yProps, screenReaderDescription } = useFlyoutA11y({ isXlScreen });
   const { fieldsMetadata = {} } = useFieldsMetadataContext();
+
+  useEffect(() => {
+    dismissAllFlyoutsExceptFor(DiscoverFlyouts.metricInsights);
+  }, []);
 
   const onKeyDown = useCallback(
     (ev: React.KeyboardEvent) => {

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.tsx
@@ -110,13 +110,17 @@ export const MetricsGrid = ({
   );
 
   const handleCloseFlyout = useCallback(() => {
-    if (expandedMetric) {
-      // Use requestAnimationFrame to ensure the flyout is fully closed before focusing
-      requestAnimationFrame(() => {
-        focusCell(expandedMetric.rowIndex, expandedMetric.colIndex);
-      });
+    if (!expandedMetric) {
+      return;
     }
+
+    const rowIndex = expandedMetric.rowIndex;
+    const colIndex = expandedMetric.colIndex;
     setExpandedMetric(undefined);
+    // Use requestAnimationFrame to ensure the flyout is fully closed before focusing
+    requestAnimationFrame(() => {
+      focusCell(rowIndex, colIndex);
+    });
   }, [expandedMetric, focusCell]);
 
   const getChartRefForFocus = useCallback(() => {

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/index.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/index.tsx
@@ -8,10 +8,9 @@
  */
 import { EuiFlexGrid, EuiFlexItem, EuiPanel, euiPaletteColorBlind } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { DiscoverFlyouts, dismissAllFlyoutsExceptFor } from '@kbn/discover-utils/src';
 import { useFetch } from '@kbn/unified-histogram';
 import type { ChartSectionProps, UnifiedHistogramInputMessage } from '@kbn/unified-histogram/types';
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Provider } from 'react-redux';
 import { Subject } from 'rxjs';
 import { TraceMetricsProvider } from '../../context/trace_metrics_context';
@@ -69,22 +68,6 @@ function TraceMetricsGrid({
     input$,
     beforeFetch: updateTimeRange,
   });
-
-  useEffect(() => {
-    const handleClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
-
-      if (target.closest('[data-test-subj="embeddablePanelAction-openInspector"]')) {
-        dismissAllFlyoutsExceptFor(DiscoverFlyouts.inspectorPanel);
-      }
-    };
-
-    document.addEventListener('click', handleClick);
-
-    return () => {
-      document.removeEventListener('click', handleClick);
-    };
-  }, []);
 
   const indexPattern = dataView?.getIndexPattern();
 


### PR DESCRIPTION
- Addresses https://github.com/elastic/kibana/issues/237965

## Summary

This PR closes existing flyouts when user opens Metrics Inspect or Details flyout.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->