### PR TITLE
[scout] increase timeout for histogram rendered indicator

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
@@ -45,6 +45,9 @@ export class DiscoverApp {
   }
 
   async waitForHistogramRendered() {
-    await this.page.testSubj.waitForSelector('unifiedHistogramRendered');
+    await this.page.testSubj.waitForSelector('unifiedHistogramRendered', {
+      state: 'visible',
+      timeout: 20_000,
+    });
   }
 }


### PR DESCRIPTION
## Summary

Increasing timeout for histogram rendering in discover saved search test.