### PR TITLE
[9.1] [Fleet] Fix download agent policy privileges (#239729)

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -15016,7 +15016,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/download": {
       "get": {
-        "description": "Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-download",
         "parameters": [
           {
@@ -27078,7 +27078,7 @@
     },
     "/api/fleet/kubernetes": {
       "get": {
-        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-kubernetes",
         "parameters": [
           {
@@ -27164,7 +27164,7 @@
     },
     "/api/fleet/kubernetes/download": {
       "get": {
-        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-kubernetes-download",
         "parameters": [
           {

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -15016,7 +15016,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/download": {
       "get": {
-        "description": "Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-download",
         "parameters": [
           {
@@ -27078,7 +27078,7 @@
     },
     "/api/fleet/kubernetes": {
       "get": {
-        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-kubernetes",
         "parameters": [
           {
@@ -27164,7 +27164,7 @@
     },
     "/api/fleet/kubernetes/download": {
       "get": {
-        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.",
         "operationId": "get-fleet-kubernetes-download",
         "parameters": [
           {

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -19494,7 +19494,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/download:
     get:
-      description: 'Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.'
+      description: 'Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.'
       operationId: get-fleet-agent-policies-agentpolicyid-download
       parameters:
         - in: path
@@ -27731,7 +27731,7 @@ paths:
         - Fleet internals
   /api/fleet/kubernetes:
     get:
-      description: '[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.'
       operationId: get-fleet-kubernetes
       parameters:
         - in: query
@@ -27786,7 +27786,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/kubernetes/download:
     get:
-      description: '[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-setup.'
       operationId: get-fleet-kubernetes-download
       parameters:
         - in: query

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/index.ts
@@ -423,8 +423,9 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       security: {
         authz: {
           requiredPrivileges: [
-            FLEET_API_PRIVILEGES.AGENT_POLICIES.READ,
-            FLEET_API_PRIVILEGES.SETUP,
+            {
+              anyRequired: [FLEET_API_PRIVILEGES.AGENT_POLICIES.READ, FLEET_API_PRIVILEGES.SETUP],
+            },
           ],
         },
       },
@@ -463,8 +464,9 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       security: {
         authz: {
           requiredPrivileges: [
-            FLEET_API_PRIVILEGES.AGENT_POLICIES.READ,
-            FLEET_API_PRIVILEGES.SETUP,
+            {
+              anyRequired: [FLEET_API_PRIVILEGES.AGENT_POLICIES.READ, FLEET_API_PRIVILEGES.SETUP],
+            },
           ],
         },
       },
@@ -498,8 +500,9 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       security: {
         authz: {
           requiredPrivileges: [
-            FLEET_API_PRIVILEGES.AGENT_POLICIES.READ,
-            FLEET_API_PRIVILEGES.SETUP,
+            {
+              anyRequired: [FLEET_API_PRIVILEGES.AGENT_POLICIES.READ, FLEET_API_PRIVILEGES.SETUP],
+            },
           ],
         },
       },

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/privileges.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/privileges.ts
@@ -163,6 +163,27 @@ export default function (providerContext: FtrProviderContext) {
       scenarios: READ_SCENARIOS,
     },
     {
+      method: 'GET',
+      path: '/api/fleet/agent_policies/policy-test-privileges-1/download',
+      scenarios: READ_SCENARIOS.filter(
+        (scenario) => scenario.user.username !== testUsers.fleet_agents_read_only.username
+      ),
+    },
+    {
+      method: 'GET',
+      path: '/api/fleet/kubernetes',
+      scenarios: READ_SCENARIOS.filter(
+        (scenario) => scenario.user.username !== testUsers.fleet_agents_read_only.username
+      ),
+    },
+    {
+      method: 'GET',
+      path: '/api/fleet/kubernetes/download',
+      scenarios: READ_SCENARIOS.filter(
+        (scenario) => scenario.user.username !== testUsers.fleet_agents_read_only.username
+      ),
+    },
+    {
       method: 'POST',
       path: '/api/fleet/agent_policies/_bulk_get',
       scenarios: READ_SCENARIOS,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Fleet] Fix download agent policy privileges (#239729)](https://github.com/elastic/kibana/pull/239729)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-10-21T12:59:28Z","message":"[Fleet] Fix download agent policy privileges (#239729)\n\n## Summary\n\nResolve https://github.com/elastic/kibana/issues/239155\n\nWhen moving to Kibana authz privileges a typo was made, on the download\nagent policy API endpoints, requiring both setup and agent policy READ\npermissions instead of any of them. that PR fix that and add missing API\nintegration tests that would have catch that.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"acd4326d1977b2123ac223372ddeb81630eb0cb5","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.2.0","v9.3.0","v9.1.6","v8.19.6"],"title":"[Fleet] Fix download agent policy privileges","number":239729,"url":"https://github.com/elastic/kibana/pull/239729","mergeCommit":{"message":"[Fleet] Fix download agent policy privileges (#239729)\n\n## Summary\n\nResolve https://github.com/elastic/kibana/issues/239155\n\nWhen moving to Kibana authz privileges a typo was made, on the download\nagent policy API endpoints, requiring both setup and agent policy READ\npermissions instead of any of them. that PR fix that and add missing API\nintegration tests that would have catch that.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"acd4326d1977b2123ac223372ddeb81630eb0cb5"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/239914","number":239914,"state":"MERGED","mergeCommit":{"sha":"38be8e5948de594fbefad3b394dc152d7534569c","message":"[9.2] [Fleet] Fix download agent policy privileges (#239729) (#239914)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Fleet] Fix download agent policy privileges\n(#239729)](https://github.com/elastic/kibana/pull/239729)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239729","number":239729,"mergeCommit":{"message":"[Fleet] Fix download agent policy privileges (#239729)\n\n## Summary\n\nResolve https://github.com/elastic/kibana/issues/239155\n\nWhen moving to Kibana authz privileges a typo was made, on the download\nagent policy API endpoints, requiring both setup and agent policy READ\npermissions instead of any of them. that PR fix that and add missing API\nintegration tests that would have catch that.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"acd4326d1977b2123ac223372ddeb81630eb0cb5"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->