### PR TITLE
[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BehaviorSubject, Subject } from 'rxjs';
+import { getSampleDashboardState } from '../mocks';
+import type { DashboardState } from '../../common';
+import { COMPARE_DEBOUNCE, initializeUnifiedSearchManager } from './unified_search_manager';
+import type { ControlGroupApi } from '@kbn/controls-plugin/public';
+
+describe('initializeUnifiedSearchManager', () => {
+  describe('startComparing$', () => {
+    test('Should return no changes when there are no changes', (done) => {
+      const lastSavedState$ = new BehaviorSubject<DashboardState>(getSampleDashboardState());
+      const unifiedSearchManager = initializeUnifiedSearchManager(
+        lastSavedState$.value,
+        new BehaviorSubject<ControlGroupApi | undefined>(undefined),
+        new BehaviorSubject<boolean>(false),
+        new Subject<void>(),
+        () => lastSavedState$.value,
+        {
+          useUnifiedSearchIntegration: false,
+        }
+      );
+      unifiedSearchManager.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
+        expect(changes).toMatchInlineSnapshot(`Object {}`);
+        done();
+      });
+    });
+
+    describe('timeRange', () => {
+      test('Should not return timeRanage change when timeRestore is false', (done) => {
+        const lastSavedState$ = new BehaviorSubject<DashboardState>(getSampleDashboardState());
+        const unifiedSearchManager = initializeUnifiedSearchManager(
+          lastSavedState$.value,
+          new BehaviorSubject<ControlGroupApi | undefined>(undefined),
+          new BehaviorSubject<boolean>(false),
+          new Subject<void>(),
+          () => lastSavedState$.value,
+          {
+            useUnifiedSearchIntegration: false,
+          }
+        );
+        unifiedSearchManager.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
+          expect(changes).toMatchInlineSnapshot(`Object {}`);
+          done();
+        });
+
+        unifiedSearchManager.api.setTimeRange({
+          to: 'now',
+          from: 'now-30m',
+        });
+      });
+
+      test('Should return timeRanage change when timeRestore is true', (done) => {
+        const lastSavedState$ = new BehaviorSubject<DashboardState>({
+          ...getSampleDashboardState(),
+          timeRestore: true,
+        });
+        const unifiedSearchManager = initializeUnifiedSearchManager(
+          lastSavedState$.value,
+          new BehaviorSubject<ControlGroupApi | undefined>(undefined),
+          new BehaviorSubject<boolean>(true),
+          new Subject<void>(),
+          () => lastSavedState$.value,
+          {
+            useUnifiedSearchIntegration: false,
+          }
+        );
+        unifiedSearchManager.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
+          expect(changes).toMatchInlineSnapshot(`
+            Object {
+              "timeRange": Object {
+                "from": "now-30m",
+                "to": "now",
+              },
+            }
+          `);
+          done();
+        });
+
+        unifiedSearchManager.api.setTimeRange({
+          to: 'now',
+          from: 'now-30m',
+        });
+      });
+
+      test('Should not return timeRanage change when timeRestore resets to false', async () => {
+        const lastSavedState$ = new BehaviorSubject<DashboardState>(getSampleDashboardState());
+        const timeRestore$ = new BehaviorSubject<boolean>(false);
+        const unifiedSearchManager = initializeUnifiedSearchManager(
+          lastSavedState$.value,
+          new BehaviorSubject<ControlGroupApi | undefined>(undefined),
+          timeRestore$,
+          new Subject<void>(),
+          () => lastSavedState$.value,
+          {
+            useUnifiedSearchIntegration: false,
+          }
+        );
+        let unsavedChanges: object | undefined;
+        unifiedSearchManager.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
+          unsavedChanges = changes;
+        });
+
+        timeRestore$.next(true);
+        unifiedSearchManager.api.setTimeRange({
+          to: 'now',
+          from: 'now-30m',
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, COMPARE_DEBOUNCE + 1));
+
+        expect(unsavedChanges).toMatchInlineSnapshot(`
+            Object {
+              "timeRange": Object {
+                "from": "now-30m",
+                "to": "now",
+              },
+            }
+          `);
+
+        // reset timeRestore to false
+        timeRestore$.next(false);
+
+        await new Promise((resolve) => setTimeout(resolve, COMPARE_DEBOUNCE + 1));
+
+        expect(unsavedChanges).toMatchInlineSnapshot(`Object {}`);
+      });
+    });
+  });
+});

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.ts
@@ -41,6 +41,8 @@ import type { DashboardCreationOptions } from './types';
 import type { DashboardState } from '../../common';
 import { cleanFiltersForSerialize } from '../../common';
 
+export const COMPARE_DEBOUNCE = 100;
+
 export function initializeUnifiedSearchManager(
   initialState: DashboardState,
   controlGroupApi$: PublishingSubject<ControlGroupApi | undefined>,
@@ -322,8 +324,14 @@ export function initializeUnifiedSearchManager(
     internalApi: {
       controlGroupReload$,
       startComparing$: (lastSavedState$: BehaviorSubject<DashboardState>) => {
-        return combineLatest([unifiedSearchFilters$, query$, refreshInterval$, timeRange$]).pipe(
-          debounceTime(100),
+        return combineLatest([
+          unifiedSearchFilters$,
+          query$,
+          refreshInterval$,
+          timeRange$,
+          timeRestore$,
+        ]).pipe(
+          debounceTime(COMPARE_DEBOUNCE),
           map(([filters, query, refreshInterval, timeRange]) => ({
             filters,
             query,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/239962

The issue was caused because `timeRestore$` is used in comparators but was not part of `startComparing$` subscription. The unsaved changes badge would remain because `startComparing$` from unifiedSearchManager would not emit after `timeRestore$` was reset.

Issue resolved by adding `timeRestore$` to `startComparing$` subscription. Now `timeRestore$` emit will cause `startComparing$` to emit with freshly calculated values.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->