### PR TITLE
[Security Solution] remove unnecessary kbnServerArgs when the feature flags are already true

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/rbac/endpoint_role_rbac.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/rbac/endpoint_role_rbac.cy.ts
@@ -16,71 +16,58 @@ import { closeAllToasts } from '../../tasks/toasts';
 import { login, ROLE } from '../../tasks/login';
 import { SECURITY_FEATURE_ID } from '../../../../../common/constants';
 
-describe(
-  'When defining a kibana role for Endpoint security access',
-  {
-    tags: '@ess',
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify(['trustedDevices'])}`,
-        ],
-      },
-    },
-  },
-  () => {
-    const getAllSubFeatureRows = (): Cypress.Chainable<JQuery<HTMLElement>> => {
-      return cy
-        .get(`#featurePrivilegeControls_${SECURITY_FEATURE_ID}`)
-        .findByTestSubj('mutexSubFeaturePrivilegeControl')
-        .closest('.euiFlexGroup');
-    };
+describe('When defining a kibana role for Endpoint security access', { tags: '@ess' }, () => {
+  const getAllSubFeatureRows = (): Cypress.Chainable<JQuery<HTMLElement>> => {
+    return cy
+      .get(`#featurePrivilegeControls_${SECURITY_FEATURE_ID}`)
+      .findByTestSubj('mutexSubFeaturePrivilegeControl')
+      .closest('.euiFlexGroup');
+  };
 
-    beforeEach(() => {
-      login(ROLE.system_indices_superuser);
-      navigateToRolePage();
-      closeAllToasts();
+  beforeEach(() => {
+    login(ROLE.system_indices_superuser);
+    navigateToRolePage();
+    closeAllToasts();
 
-      openKibanaFeaturePrivilegesFlyout();
-      setKibanaPrivilegeSpace('default');
-      expandSecuritySolutionCategoryKibanaPrivileges();
-      expandEndpointSecurityFeaturePrivileges();
-    });
+    openKibanaFeaturePrivilegesFlyout();
+    setKibanaPrivilegeSpace('default');
+    expandSecuritySolutionCategoryKibanaPrivileges();
+    expandEndpointSecurityFeaturePrivileges();
+  });
 
-    it('should display RBAC entries with expected controls', () => {
-      getAllSubFeatureRows()
-        .then(($subFeatures) => {
-          const featureRows: string[] = [];
-          $subFeatures.each((_, $subFeature) => {
-            featureRows.push($subFeature.textContent ?? '');
-          });
+  it('should display RBAC entries with expected controls', () => {
+    getAllSubFeatureRows()
+      .then(($subFeatures) => {
+        const featureRows: string[] = [];
+        $subFeatures.each((_, $subFeature) => {
+          featureRows.push($subFeature.textContent ?? '');
+        });
 
-          return featureRows;
-        })
-        .should('deep.equal', [
-          'Endpoint List Displays all hosts running Elastic Defend and their relevant integration details.Endpoint List sub-feature privilegeAllReadNone',
-          'Automatic Troubleshooting Access to the automatic troubleshooting.Automatic Troubleshooting sub-feature privilegeAllReadNone',
-          'Global Artifact Management Manage global assignment of endpoint artifacts (e.g., Trusted Applications, Event Filters) across all policies. This privilege controls global assignment rights only; privileges for each artifact type are required for full artifact management.Global Artifact Management sub-feature privilegeAllNone',
-          'Trusted Applications Helps mitigate conflicts with other software, usually other antivirus or endpoint security applications.Trusted Applications sub-feature privilegeAllReadNone',
-          'Trusted Devices Manage security exceptions for USB and external devices.Trusted Devices sub-feature privilegeAllReadNone',
-          'Host Isolation Exceptions Add specific IP addresses that isolated hosts are still allowed to communicate with, even when isolated from the rest of the network.Host Isolation Exceptions sub-feature privilegeAllReadNone',
-          'Blocklist Extend Elastic Defend’s protection against malicious processes and protect against potentially harmful applications.Blocklist sub-feature privilegeAllReadNone',
-          'Event Filters Filter out endpoint events that you do not need or want stored in Elasticsearch.Event Filters sub-feature privilegeAllReadNone',
-          'Endpoint Exceptions Reduce false positive alerts, and keep Elastic Defend from blocking standard processes.Endpoint Exceptions sub-feature privilegeAllReadNone',
-          'Elastic Defend Policy Management Access the Elastic Defend integration policy to configure protections, event collection, and advanced policy features.Elastic Defend Policy Management sub-feature privilegeAllReadNone',
-          'Response Actions History Access the history of response actions performed on endpoints.Response Actions History sub-feature privilegeAllReadNone',
-          'Host Isolation Perform the "isolate" and "release" response actions.Host Isolation sub-feature privilegeAllNone',
-          'Process Operations Perform process-related response actions in the response console.Process Operations sub-feature privilegeAllNone',
-          'File Operations Perform file-related response actions in the response console.File Operations sub-feature privilegeAllNone',
-          'Execute Operations Perform script execution response actions in the response console.Execute Operations sub-feature privilegeAllNone',
-          'Scan Operations Perform folder scan response actions in the response console.Scan Operations sub-feature privilegeAllNone',
-        ]);
-    });
+        return featureRows;
+      })
+      .should('deep.equal', [
+        'Endpoint List Displays all hosts running Elastic Defend and their relevant integration details.Endpoint List sub-feature privilegeAllReadNone',
+        'Automatic Troubleshooting Access to the automatic troubleshooting.Automatic Troubleshooting sub-feature privilegeAllReadNone',
+        'Global Artifact Management Manage global assignment of endpoint artifacts (e.g., Trusted Applications, Event Filters) across all policies. This privilege controls global assignment rights only; privileges for each artifact type are required for full artifact management.Global Artifact Management sub-feature privilegeAllNone',
+        'Trusted Applications Helps mitigate conflicts with other software, usually other antivirus or endpoint security applications.Trusted Applications sub-feature privilegeAllReadNone',
+        'Trusted Devices Manage security exceptions for USB and external devices.Trusted Devices sub-feature privilegeAllReadNone',
+        'Host Isolation Exceptions Add specific IP addresses that isolated hosts are still allowed to communicate with, even when isolated from the rest of the network.Host Isolation Exceptions sub-feature privilegeAllReadNone',
+        'Blocklist Extend Elastic Defend’s protection against malicious processes and protect against potentially harmful applications.Blocklist sub-feature privilegeAllReadNone',
+        'Event Filters Filter out endpoint events that you do not need or want stored in Elasticsearch.Event Filters sub-feature privilegeAllReadNone',
+        'Endpoint Exceptions Reduce false positive alerts, and keep Elastic Defend from blocking standard processes.Endpoint Exceptions sub-feature privilegeAllReadNone',
+        'Elastic Defend Policy Management Access the Elastic Defend integration policy to configure protections, event collection, and advanced policy features.Elastic Defend Policy Management sub-feature privilegeAllReadNone',
+        'Response Actions History Access the history of response actions performed on endpoints.Response Actions History sub-feature privilegeAllReadNone',
+        'Host Isolation Perform the "isolate" and "release" response actions.Host Isolation sub-feature privilegeAllNone',
+        'Process Operations Perform process-related response actions in the response console.Process Operations sub-feature privilegeAllNone',
+        'File Operations Perform file-related response actions in the response console.File Operations sub-feature privilegeAllNone',
+        'Execute Operations Perform script execution response actions in the response console.Execute Operations sub-feature privilegeAllNone',
+        'Scan Operations Perform folder scan response actions in the response console.Scan Operations sub-feature privilegeAllNone',
+      ]);
+  });
 
-    it('should display all RBAC entries set to None by default', () => {
-      getAllSubFeatureRows()
-        .findByTestSubj('none')
-        .should('have.class', 'euiButtonGroupButton-isSelected');
-    });
-  }
-);
+  it('should display all RBAC entries set to None by default', () => {
+    getAllSubFeatureRows()
+      .findByTestSubj('none')
+      .should('have.class', 'euiButtonGroupButton-isSelected');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/rbac/endpoint_role_rbac_with_space_awareness.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/rbac/endpoint_role_rbac_with_space_awareness.cy.ts
@@ -35,9 +35,6 @@ describe(
           { product_line: 'security', product_tier: 'complete' },
           { product_line: 'endpoint', product_tier: 'complete' },
         ],
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify(['trustedDevices'])}`,
-        ],
       },
     },
   },

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/rbac/navigation.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/rbac/navigation.cy.ts
@@ -12,166 +12,152 @@ import { loadPage } from '../../tasks/common';
 import type { SiemVersion } from '../../common/constants';
 import { SIEM_VERSIONS } from '../../common/constants';
 
-describe(
-  'Navigation RBAC',
-  {
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify(['trustedDevices'])}`,
-        ],
-      },
+describe('Navigation RBAC', () => {
+  const isServerless = Cypress.env('IS_SERVERLESS');
+
+  const Selectors = isServerless ? ServerlessHeaders : EssHeaders;
+  const MenuButtonSelector = isServerless
+    ? ServerlessHeaders.ASSETS_PANEL_BTN
+    : EssHeaders.SETTINGS_PANEL_BTN;
+
+  const allPages = [
+    {
+      name: 'Endpoints',
+      privilegePrefix: 'endpoint_list_',
+      selector: Selectors.ENDPOINTS,
     },
-  },
-  () => {
-    const isServerless = Cypress.env('IS_SERVERLESS');
+    {
+      name: 'Policies',
+      privilegePrefix: 'policy_management_',
+      selector: Selectors.POLICIES,
+    },
+    {
+      name: 'Trusted applications',
+      privilegePrefix: 'trusted_applications_',
+      selector: Selectors.TRUSTED_APPS,
+    },
+    {
+      name: 'Trusted devices',
+      privilegePrefix: 'trusted_devices_',
+      selector: Selectors.TRUSTED_DEVICES,
+      siemVersions: ['siemV3', 'siemV4'], // Only available starting siemV3
+    },
+    {
+      name: 'Event filters',
+      privilegePrefix: 'event_filters_',
+      selector: Selectors.EVENT_FILTERS,
+    },
+    {
+      name: 'Blocklist',
+      privilegePrefix: 'blocklist_',
+      selector: Selectors.BLOCKLIST,
+    },
+    {
+      name: 'Host isolation exceptions',
+      privilegePrefix: 'host_isolation_exceptions_',
+      selector: Selectors.HOST_ISOLATION_EXCEPTIONS,
+    },
+    {
+      name: 'Response actions history',
+      privilegePrefix: 'actions_log_management_',
+      selector: Selectors.RESPONSE_ACTIONS_HISTORY,
+    },
+  ];
 
-    const Selectors = isServerless ? ServerlessHeaders : EssHeaders;
-    const MenuButtonSelector = isServerless
-      ? ServerlessHeaders.ASSETS_PANEL_BTN
-      : EssHeaders.SETTINGS_PANEL_BTN;
+  const getPagesForSiemVersion = (siemVersion: SiemVersion) => {
+    return allPages.filter((page) => !page.siemVersions || page.siemVersions.includes(siemVersion));
+  };
 
-    const allPages = [
-      {
-        name: 'Endpoints',
-        privilegePrefix: 'endpoint_list_',
-        selector: Selectors.ENDPOINTS,
-      },
-      {
-        name: 'Policies',
-        privilegePrefix: 'policy_management_',
-        selector: Selectors.POLICIES,
-      },
-      {
-        name: 'Trusted applications',
-        privilegePrefix: 'trusted_applications_',
-        selector: Selectors.TRUSTED_APPS,
-      },
-      {
-        name: 'Trusted devices',
-        privilegePrefix: 'trusted_devices_',
-        selector: Selectors.TRUSTED_DEVICES,
-        siemVersions: ['siemV3', 'siemV4'], // Only available starting siemV3
-      },
-      {
-        name: 'Event filters',
-        privilegePrefix: 'event_filters_',
-        selector: Selectors.EVENT_FILTERS,
-      },
-      {
-        name: 'Blocklist',
-        privilegePrefix: 'blocklist_',
-        selector: Selectors.BLOCKLIST,
-      },
-      {
-        name: 'Host isolation exceptions',
-        privilegePrefix: 'host_isolation_exceptions_',
-        selector: Selectors.HOST_ISOLATION_EXCEPTIONS,
-      },
-      {
-        name: 'Response actions history',
-        privilegePrefix: 'actions_log_management_',
-        selector: Selectors.RESPONSE_ACTIONS_HISTORY,
-      },
-    ];
+  describe('ESS - using custom roles', { tags: ['@ess'] }, () => {
+    for (const siemVersion of SIEM_VERSIONS) {
+      describe(siemVersion, () => {
+        const pages = getPagesForSiemVersion(siemVersion);
 
-    const getPagesForSiemVersion = (siemVersion: SiemVersion) => {
-      return allPages.filter(
-        (page) => !page.siemVersions || page.siemVersions.includes(siemVersion)
-      );
-    };
-
-    describe('ESS - using custom roles', { tags: ['@ess'] }, () => {
-      for (const siemVersion of SIEM_VERSIONS) {
-        describe(siemVersion, () => {
-          const pages = getPagesForSiemVersion(siemVersion);
-
-          describe('NONE access', () => {
-            beforeEach(() => {
-              login.withCustomKibanaPrivileges({ [siemVersion]: ['all'] });
-            });
-
-            it(`none of the links should be visible in navigation bar`, () => {
-              loadPage('/app/security');
-              cy.get(MenuButtonSelector).click();
-
-              for (const page of pages) {
-                cy.get(page.selector).should('not.exist');
-              }
-            });
-
-            it(`none of the cards should be visible on Management page`, () => {
-              loadPage('/app/security/manage');
-
-              for (const page of pages) {
-                cy.getByTestSubj('LandingItem').should('not.contain.text', page.name);
-              }
-            });
+        describe('NONE access', () => {
+          beforeEach(() => {
+            login.withCustomKibanaPrivileges({ [siemVersion]: ['all'] });
           });
 
-          for (const access of ['read', 'all']) {
+          it(`none of the links should be visible in navigation bar`, () => {
+            loadPage('/app/security');
+            cy.get(MenuButtonSelector).click();
+
             for (const page of pages) {
-              describe(`${access.toUpperCase()} access only to ${page.name}`, () => {
-                beforeEach(() => {
-                  login.withCustomKibanaPrivileges({
-                    [siemVersion]: ['read', `${page.privilegePrefix}${access}`],
-                  });
-                });
+              cy.get(page.selector).should('not.exist');
+            }
+          });
 
-                it(`only ${page.name} link should be displayed in navigation bar`, () => {
-                  loadPage('/app/security');
-                  cy.get(MenuButtonSelector).click();
+          it(`none of the cards should be visible on Management page`, () => {
+            loadPage('/app/security/manage');
 
-                  cy.get(page.selector);
-                  pages
-                    .filter((iterator) => iterator.name !== page.name)
-                    .forEach((otherPage) => cy.get(otherPage.selector).should('not.exist'));
-                });
+            for (const page of pages) {
+              cy.getByTestSubj('LandingItem').should('not.contain.text', page.name);
+            }
+          });
+        });
 
-                it(`only ${page.name} card should be displayed on Management page`, () => {
-                  loadPage('/app/security/manage');
-
-                  cy.contains(page.name);
-                  pages
-                    .filter((iterator) => iterator.name !== page.name)
-                    .forEach((otherPage) =>
-                      cy.getByTestSubj('LandingItem').should('not.contain.text', otherPage.name)
-                    );
+        for (const access of ['read', 'all']) {
+          for (const page of pages) {
+            describe(`${access.toUpperCase()} access only to ${page.name}`, () => {
+              beforeEach(() => {
+                login.withCustomKibanaPrivileges({
+                  [siemVersion]: ['read', `${page.privilegePrefix}${access}`],
                 });
               });
-            }
+
+              it(`only ${page.name} link should be displayed in navigation bar`, () => {
+                loadPage('/app/security');
+                cy.get(MenuButtonSelector).click();
+
+                cy.get(page.selector);
+                pages
+                  .filter((iterator) => iterator.name !== page.name)
+                  .forEach((otherPage) => cy.get(otherPage.selector).should('not.exist'));
+              });
+
+              it(`only ${page.name} card should be displayed on Management page`, () => {
+                loadPage('/app/security/manage');
+
+                cy.contains(page.name);
+                pages
+                  .filter((iterator) => iterator.name !== page.name)
+                  .forEach((otherPage) =>
+                    cy.getByTestSubj('LandingItem').should('not.contain.text', otherPage.name)
+                  );
+              });
+            });
           }
-        });
+        }
+      });
+    }
+  });
+
+  describe('Serverless - using prebuilt roles (for now)', { tags: ['@serverless'] }, () => {
+    it('without access to any of the subpages, none of those should be displayed', () => {
+      login(ROLE.detections_admin);
+      loadPage('/app/security');
+      // assets should be missing, checking that assets link and more button is missing
+      cy.get(ServerlessHeaders.MORE_MENU_BTN).should('not.exist');
+      cy.get(MenuButtonSelector).should('not.exist');
+
+      for (const page of allPages) {
+        cy.get(page.selector).should('not.exist');
       }
     });
 
-    describe('Serverless - using prebuilt roles (for now)', { tags: ['@serverless'] }, () => {
-      it('without access to any of the subpages, none of those should be displayed', () => {
-        login(ROLE.detections_admin);
-        loadPage('/app/security');
-        // assets should be missing, checking that assets link and more button is missing
-        cy.get(ServerlessHeaders.MORE_MENU_BTN).should('not.exist');
-        cy.get(MenuButtonSelector).should('not.exist');
+    it('with access to all of the subpages, all of those should be displayed', () => {
+      login(ROLE.soc_manager);
+      loadPage('/app/security');
+      ServerlessHeaders.showMoreItems();
+      cy.get(MenuButtonSelector).click(); // click "Assets" to open the menu
+      cy.get(allPages[0].selector).click(); // open the Assets anv panel by clicking the first item in more>assets popover
 
-        for (const page of allPages) {
-          cy.get(page.selector).should('not.exist');
+      for (const page of allPages) {
+        if (page.selector !== Selectors.TRUSTED_DEVICES) {
+          // Skip Trusted Devices for now — soc_manager does not yet have the required privilege in controller (MKI would fail otherwise).
+          cy.get(page.selector);
         }
-      });
-
-      it('with access to all of the subpages, all of those should be displayed', () => {
-        login(ROLE.soc_manager);
-        loadPage('/app/security');
-        ServerlessHeaders.showMoreItems();
-        cy.get(MenuButtonSelector).click(); // click "Assets" to open the menu
-        cy.get(allPages[0].selector).click(); // open the Assets anv panel by clicking the first item in more>assets popover
-
-        for (const page of allPages) {
-          if (page.selector !== Selectors.TRUSTED_DEVICES) {
-            // Skip Trusted Devices for now — soc_manager does not yet have the required privilege in controller (MKI would fail otherwise).
-            cy.get(page.selector);
-          }
-        }
-      });
+      }
     });
-  }
-);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/serverless/roles/essentials_with_endpoint.roles.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/serverless/roles/essentials_with_endpoint.roles.cy.ts
@@ -10,17 +10,17 @@ import { indexEndpointHosts } from '../../../tasks/index_endpoint_hosts';
 import { login, ROLE } from '../../../tasks/login';
 import type { EndpointArtifactPageId } from '../../../screens';
 import {
-  getNoPrivilegesPage,
-  getArtifactListEmptyStateAddButton,
-  getEndpointManagementPageMap,
-  getEndpointManagementPageList,
   ensureArtifactPageAuthzAccess,
   ensureEndpointListPageAuthzAccess,
-  ensurePolicyListPageAuthzAccess,
   ensureFleetPermissionDeniedScreen,
-  getFleetAgentListTable,
-  visitFleetAgentList,
   ensurePolicyDetailsPageAuthzAccess,
+  ensurePolicyListPageAuthzAccess,
+  getArtifactListEmptyStateAddButton,
+  getEndpointManagementPageList,
+  getEndpointManagementPageMap,
+  getFleetAgentListTable,
+  getNoPrivilegesPage,
+  visitFleetAgentList,
 } from '../../../screens';
 
 // FLAKY: https://github.com/elastic/kibana/issues/170985
@@ -33,9 +33,6 @@ describe.skip(
         productTypes: [
           { product_line: 'security', product_tier: 'essentials' },
           { product_line: 'endpoint', product_tier: 'essentials' },
-        ],
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify(['trustedDevices'])}`,
         ],
       },
     },

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/eql_sequence_rule.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/eql_sequence_rule.cy.ts
@@ -12,110 +12,101 @@ import { getDetails } from '../../../../tasks/rule_details';
 import { CREATE_RULE_URL } from '../../../../urls/navigation';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import {
-  fillAlertSuppressionFields,
-  fillAboutRuleMinimumAndContinue,
-  createRuleWithoutEnabling,
-  skipScheduleRuleAction,
   continueFromDefineStep,
-  selectAlertSuppressionPerInterval,
-  setAlertSuppressionDuration,
-  selectDoNotSuppressForMissingFields,
+  createRuleWithoutEnabling,
+  fillAboutRuleMinimumAndContinue,
+  fillAlertSuppressionFields,
   fillDefineEqlRule,
+  selectAlertSuppressionPerInterval,
+  selectDoNotSuppressForMissingFields,
   selectEqlRuleType,
+  setAlertSuppressionDuration,
+  skipScheduleRuleAction,
 } from '../../../../tasks/create_new_rule';
 
 import {
   DEFINITION_DETAILS,
-  SUPPRESS_FOR_DETAILS,
   SUPPRESS_BY_DETAILS,
+  SUPPRESS_FOR_DETAILS,
   SUPPRESS_MISSING_FIELD,
 } from '../../../../screens/rule_details';
 
 const SUPPRESS_BY_FIELDS = ['agent.type'];
 
-describe(
-  'EQL Rules - Alert suppression',
-  {
-    tags: ['@ess', '@serverless'],
-    env: {
-      kbnServerArgs: [],
-    },
-  },
-  () => {
-    describe('with sequence queries ', () => {
-      const rule = getEqlSequenceRule();
+describe('EQL Rules - Alert suppression', { tags: ['@ess', '@serverless'] }, () => {
+  describe('with sequence queries ', () => {
+    const rule = getEqlSequenceRule();
 
-      beforeEach(() => {
-        deleteAlertsAndRules();
-        login();
-        visit(CREATE_RULE_URL);
+    beforeEach(() => {
+      deleteAlertsAndRules();
+      login();
+      visit(CREATE_RULE_URL);
 
-        selectEqlRuleType();
-        fillDefineEqlRule(rule);
+      selectEqlRuleType();
+      fillDefineEqlRule(rule);
+    });
+
+    it('creates a rule with a "per rule execution" suppression duration', () => {
+      // selecting only suppression fields, the rest options would be default
+      fillAlertSuppressionFields(SUPPRESS_BY_FIELDS);
+      continueFromDefineStep();
+
+      // ensures details preview works correctly
+      cy.get(DEFINITION_DETAILS).within(() => {
+        getDetails(SUPPRESS_BY_DETAILS).should('have.text', SUPPRESS_BY_FIELDS.join(''));
+        getDetails(SUPPRESS_FOR_DETAILS).should('have.text', 'One rule execution');
+        getDetails(SUPPRESS_MISSING_FIELD).should(
+          'have.text',
+          'Suppress and group alerts for events with missing fields'
+        );
       });
 
-      it('creates a rule with a "per rule execution" suppression duration', () => {
-        // selecting only suppression fields, the rest options would be default
-        fillAlertSuppressionFields(SUPPRESS_BY_FIELDS);
-        continueFromDefineStep();
+      fillAboutRuleMinimumAndContinue(rule);
+      skipScheduleRuleAction();
+      createRuleWithoutEnabling();
 
-        // ensures details preview works correctly
-        cy.get(DEFINITION_DETAILS).within(() => {
-          getDetails(SUPPRESS_BY_DETAILS).should('have.text', SUPPRESS_BY_FIELDS.join(''));
-          getDetails(SUPPRESS_FOR_DETAILS).should('have.text', 'One rule execution');
-          getDetails(SUPPRESS_MISSING_FIELD).should(
-            'have.text',
-            'Suppress and group alerts for events with missing fields'
-          );
-        });
-
-        fillAboutRuleMinimumAndContinue(rule);
-        skipScheduleRuleAction();
-        createRuleWithoutEnabling();
-
-        cy.get(DEFINITION_DETAILS).within(() => {
-          getDetails(SUPPRESS_BY_DETAILS).should('have.text', SUPPRESS_BY_FIELDS.join(''));
-          getDetails(SUPPRESS_FOR_DETAILS).should('have.text', 'One rule execution');
-          getDetails(SUPPRESS_MISSING_FIELD).should(
-            'have.text',
-            'Suppress and group alerts for events with missing fields'
-          );
-        });
-      });
-
-      it('creates a rule with a "per time interval" suppression duration', () => {
-        const expectedSuppressByFields = SUPPRESS_BY_FIELDS.slice(0, 1);
-
-        // fill suppress by fields and select non-default suppression options
-        fillAlertSuppressionFields(expectedSuppressByFields);
-        selectAlertSuppressionPerInterval();
-        setAlertSuppressionDuration(45, 'm');
-        selectDoNotSuppressForMissingFields();
-        continueFromDefineStep();
-
-        // ensures details preview works correctly
-        cy.get(DEFINITION_DETAILS).within(() => {
-          getDetails(SUPPRESS_BY_DETAILS).should('have.text', expectedSuppressByFields.join(''));
-          getDetails(SUPPRESS_FOR_DETAILS).should('have.text', '45m');
-          getDetails(SUPPRESS_MISSING_FIELD).should(
-            'have.text',
-            'Do not suppress alerts for events with missing fields'
-          );
-        });
-
-        fillAboutRuleMinimumAndContinue(rule);
-        skipScheduleRuleAction();
-        createRuleWithoutEnabling();
-
-        cy.get(DEFINITION_DETAILS).within(() => {
-          getDetails(SUPPRESS_BY_DETAILS).should('have.text', expectedSuppressByFields.join(''));
-          getDetails(SUPPRESS_FOR_DETAILS).should('have.text', '45m');
-          getDetails(SUPPRESS_MISSING_FIELD).should(
-            'have.text',
-            'Do not suppress alerts for events with missing fields'
-          );
-        });
+      cy.get(DEFINITION_DETAILS).within(() => {
+        getDetails(SUPPRESS_BY_DETAILS).should('have.text', SUPPRESS_BY_FIELDS.join(''));
+        getDetails(SUPPRESS_FOR_DETAILS).should('have.text', 'One rule execution');
+        getDetails(SUPPRESS_MISSING_FIELD).should(
+          'have.text',
+          'Suppress and group alerts for events with missing fields'
+        );
       });
     });
-  }
-);
+
+    it('creates a rule with a "per time interval" suppression duration', () => {
+      const expectedSuppressByFields = SUPPRESS_BY_FIELDS.slice(0, 1);
+
+      // fill suppress by fields and select non-default suppression options
+      fillAlertSuppressionFields(expectedSuppressByFields);
+      selectAlertSuppressionPerInterval();
+      setAlertSuppressionDuration(45, 'm');
+      selectDoNotSuppressForMissingFields();
+      continueFromDefineStep();
+
+      // ensures details preview works correctly
+      cy.get(DEFINITION_DETAILS).within(() => {
+        getDetails(SUPPRESS_BY_DETAILS).should('have.text', expectedSuppressByFields.join(''));
+        getDetails(SUPPRESS_FOR_DETAILS).should('have.text', '45m');
+        getDetails(SUPPRESS_MISSING_FIELD).should(
+          'have.text',
+          'Do not suppress alerts for events with missing fields'
+        );
+      });
+
+      fillAboutRuleMinimumAndContinue(rule);
+      skipScheduleRuleAction();
+      createRuleWithoutEnabling();
+
+      cy.get(DEFINITION_DETAILS).within(() => {
+        getDetails(SUPPRESS_BY_DETAILS).should('have.text', expectedSuppressByFields.join(''));
+        getDetails(SUPPRESS_FOR_DETAILS).should('have.text', '45m');
+        getDetails(SUPPRESS_MISSING_FIELD).should(
+          'have.text',
+          'Do not suppress alerts for events with missing fields'
+        );
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_gaps/bulk_fill_rule_gaps.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_gaps/bulk_fill_rule_gaps.cy.ts
@@ -18,159 +18,134 @@ import { createRule } from '../../../../tasks/api_calls/rules';
 import { login } from '../../../../tasks/login';
 import { interceptBulkFillRulesGaps } from '../../../../tasks/api_calls/gaps';
 
-describe(
-  'bulk fill rule gaps',
-  {
-    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'storeGapsInEventLogEnabled',
-            'bulkFillRuleGapsEnabled',
-          ])}`,
+describe('bulk fill rule gaps', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  beforeEach(() => {
+    login();
+    deleteAlertsAndRules();
+
+    Array.from({ length: 5 }).forEach((_, idx) => {
+      const ruleId = String(idx + 1);
+      createRule(
+        getNewRule({
+          rule_id: ruleId,
+          name: `Rule ${ruleId}`,
+          enabled: true,
+          interval: '1m',
+          from: 'now-1m',
+        })
+      );
+    });
+    visitRulesManagementTable();
+  });
+
+  it('schedule gap fills for enabled rules', () => {
+    const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
+    interceptBulkFillRulesGaps({ succeeded: 3, failed: 0, skipped: 0 });
+    selectRulesByName(enabledRules);
+
+    const enabledCount = enabledRules.length;
+    const disabledCount = 0;
+    scheduleBulkFillGapsForSelectedRules(enabledCount, disabledCount);
+    cy.wait('@bulkFillRulesGaps');
+
+    cy.contains(TOASTER_BODY, `You've successfully scheduled gap fills for ${enabledCount} rules`);
+  });
+
+  it('schedule gap fills for enabled rules and show warning about disabled rules', () => {
+    const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
+    const disabledRules = ['Rule 3', 'Rule 5'] as const;
+
+    interceptBulkFillRulesGaps({ succeeded: 3, failed: 0, skipped: 0 });
+
+    selectRulesByName(disabledRules);
+    disableSelectedRules();
+
+    selectRulesByName([...enabledRules, ...disabledRules]);
+
+    const enabledCount = enabledRules.length;
+    const disabledCount = disabledRules.length;
+    scheduleBulkFillGapsForSelectedRules(enabledCount, disabledCount);
+    cy.wait('@bulkFillRulesGaps');
+
+    cy.contains(TOASTER_BODY, `You've successfully scheduled gap fills for ${enabledCount} rules`);
+  });
+
+  it('handle gap fills result with skipped rules', () => {
+    const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
+    interceptBulkFillRulesGaps({ succeeded: 2, failed: 0, skipped: 1 });
+    selectRulesByName(enabledRules);
+
+    scheduleBulkFillGapsForSelectedRules(enabledRules.length, 0);
+    cy.wait('@bulkFillRulesGaps');
+
+    cy.contains(
+      TOASTER_BODY,
+      `You've successfully scheduled gap fills for 2 rules. 1 rule was excluded from the bulk schedule gap fill action.`
+    );
+  });
+
+  it('handle gap fills result when all rules are skipped', () => {
+    const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
+    interceptBulkFillRulesGaps({ succeeded: 0, failed: 0, skipped: 3 });
+    selectRulesByName(enabledRules);
+
+    const enabledCount = enabledRules.length;
+    scheduleBulkFillGapsForSelectedRules(enabledCount, 0);
+    cy.wait('@bulkFillRulesGaps');
+
+    cy.contains(TOASTER_BODY, 'No gaps were detected for the selected time range.');
+  });
+
+  it('handle the case when the request is slow', () => {
+    const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
+    interceptBulkFillRulesGaps({ succeeded: 3, failed: 0, skipped: 0, delay: 6000 });
+    selectRulesByName(enabledRules);
+
+    const enabledCount = enabledRules.length;
+    scheduleBulkFillGapsForSelectedRules(enabledCount, 0);
+    cy.contains(TOASTER_BODY, `Scheduling gap fills for ${enabledCount} rules`);
+    cy.wait('@bulkFillRulesGaps');
+
+    cy.contains(TOASTER_BODY, `You've successfully scheduled gap fills for ${enabledCount} rules`);
+  });
+
+  it('schedule gap fills for enabled rules and show partial error for errored rules when all rules are selected', () => {
+    const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
+    const errors = [
+      {
+        message: 'SCHEDULING - some error 1',
+        status_code: 500,
+        rules: [
+          {
+            id: '2d4b54da-3a6d-4508-b4f0-aaeb25859e11',
+            name: 'Rule 1',
+          },
         ],
       },
-    },
-  },
-  () => {
-    beforeEach(() => {
-      login();
-      deleteAlertsAndRules();
+      {
+        message: 'SCHEDULING - some error 2',
+        status_code: 500,
+        rules: [
+          {
+            id: '2d4b54da-3a6d-4508-b4f0-aaeb25859e11',
+            name: 'Rule 2',
+          },
+        ],
+      },
+    ];
+    interceptBulkFillRulesGaps({ succeeded: 1, failed: 2, skipped: 0, errorsArray: errors });
+    selectRulesByName(enabledRules);
 
-      Array.from({ length: 5 }).forEach((_, idx) => {
-        const ruleId = String(idx + 1);
-        createRule(
-          getNewRule({
-            rule_id: ruleId,
-            name: `Rule ${ruleId}`,
-            enabled: true,
-            interval: '1m',
-            from: 'now-1m',
-          })
-        );
-      });
-      visitRulesManagementTable();
+    const enabledCount = enabledRules.length;
+    scheduleBulkFillGapsForSelectedRules(enabledCount, 0);
+    cy.wait('@bulkFillRulesGaps');
+
+    cy.contains(TOASTER_BODY, `Unable to schedule gap fills for 2 rules`);
+
+    clickErrorToastBtn();
+
+    errors.forEach((error) => {
+      cy.contains(MODAL_ERROR_BODY, error.message);
     });
-
-    it('schedule gap fills for enabled rules', () => {
-      const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
-      interceptBulkFillRulesGaps({ succeeded: 3, failed: 0, skipped: 0 });
-      selectRulesByName(enabledRules);
-
-      const enabledCount = enabledRules.length;
-      const disabledCount = 0;
-      scheduleBulkFillGapsForSelectedRules(enabledCount, disabledCount);
-      cy.wait('@bulkFillRulesGaps');
-
-      cy.contains(
-        TOASTER_BODY,
-        `You've successfully scheduled gap fills for ${enabledCount} rules`
-      );
-    });
-
-    it('schedule gap fills for enabled rules and show warning about disabled rules', () => {
-      const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
-      const disabledRules = ['Rule 3', 'Rule 5'] as const;
-
-      interceptBulkFillRulesGaps({ succeeded: 3, failed: 0, skipped: 0 });
-
-      selectRulesByName(disabledRules);
-      disableSelectedRules();
-
-      selectRulesByName([...enabledRules, ...disabledRules]);
-
-      const enabledCount = enabledRules.length;
-      const disabledCount = disabledRules.length;
-      scheduleBulkFillGapsForSelectedRules(enabledCount, disabledCount);
-      cy.wait('@bulkFillRulesGaps');
-
-      cy.contains(
-        TOASTER_BODY,
-        `You've successfully scheduled gap fills for ${enabledCount} rules`
-      );
-    });
-
-    it('handle gap fills result with skipped rules', () => {
-      const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
-      interceptBulkFillRulesGaps({ succeeded: 2, failed: 0, skipped: 1 });
-      selectRulesByName(enabledRules);
-
-      scheduleBulkFillGapsForSelectedRules(enabledRules.length, 0);
-      cy.wait('@bulkFillRulesGaps');
-
-      cy.contains(
-        TOASTER_BODY,
-        `You've successfully scheduled gap fills for 2 rules. 1 rule was excluded from the bulk schedule gap fill action.`
-      );
-    });
-
-    it('handle gap fills result when all rules are skipped', () => {
-      const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
-      interceptBulkFillRulesGaps({ succeeded: 0, failed: 0, skipped: 3 });
-      selectRulesByName(enabledRules);
-
-      const enabledCount = enabledRules.length;
-      scheduleBulkFillGapsForSelectedRules(enabledCount, 0);
-      cy.wait('@bulkFillRulesGaps');
-
-      cy.contains(TOASTER_BODY, 'No gaps were detected for the selected time range.');
-    });
-
-    it('handle the case when the request is slow', () => {
-      const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
-      interceptBulkFillRulesGaps({ succeeded: 3, failed: 0, skipped: 0, delay: 6000 });
-      selectRulesByName(enabledRules);
-
-      const enabledCount = enabledRules.length;
-      scheduleBulkFillGapsForSelectedRules(enabledCount, 0);
-      cy.contains(TOASTER_BODY, `Scheduling gap fills for ${enabledCount} rules`);
-      cy.wait('@bulkFillRulesGaps');
-
-      cy.contains(
-        TOASTER_BODY,
-        `You've successfully scheduled gap fills for ${enabledCount} rules`
-      );
-    });
-
-    it('schedule gap fills for enabled rules and show partial error for errored rules when all rules are selected', () => {
-      const enabledRules = ['Rule 1', 'Rule 2', 'Rule 4'] as const;
-      const errors = [
-        {
-          message: 'SCHEDULING - some error 1',
-          status_code: 500,
-          rules: [
-            {
-              id: '2d4b54da-3a6d-4508-b4f0-aaeb25859e11',
-              name: 'Rule 1',
-            },
-          ],
-        },
-        {
-          message: 'SCHEDULING - some error 2',
-          status_code: 500,
-          rules: [
-            {
-              id: '2d4b54da-3a6d-4508-b4f0-aaeb25859e11',
-              name: 'Rule 2',
-            },
-          ],
-        },
-      ];
-      interceptBulkFillRulesGaps({ succeeded: 1, failed: 2, skipped: 0, errorsArray: errors });
-      selectRulesByName(enabledRules);
-
-      const enabledCount = enabledRules.length;
-      scheduleBulkFillGapsForSelectedRules(enabledCount, 0);
-      cy.wait('@bulkFillRulesGaps');
-
-      cy.contains(TOASTER_BODY, `Unable to schedule gap fills for 2 rules`);
-
-      clickErrorToastBtn();
-
-      errors.forEach((error) => {
-        cy.contains(MODAL_ERROR_BODY, error.message);
-      });
-    });
-  }
-);
+  });
+});

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_gaps/fill_all_rule_gaps.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_gaps/fill_all_rule_gaps.cy.ts
@@ -21,189 +21,173 @@ import { visit } from '../../../../tasks/navigation';
 import { ruleDetailsUrl } from '../../../../urls/rule_details';
 import { goToExecutionLogTab } from '../../../../tasks/rule_details';
 
-describe(
-  'bulk fill rule gaps',
-  {
-    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'storeGapsInEventLogEnabled',
-            'bulkFillRuleGapsEnabled',
-          ])}`,
+describe('bulk fill rule gaps', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  beforeEach(() => {
+    login();
+    deleteAlertsAndRules();
+
+    createRule(
+      getNewRule({ rule_id: '1', name: `Rule 1`, enabled: true, interval: '1m', from: 'now-1m' })
+    ).then((response) => {
+      cy.wrap(response.body.id).as('ruleId');
+    });
+  });
+
+  it('schedule gap fills for the rule when it is enabled', function () {
+    interceptBulkFillRulesGaps({ succeeded: 1, failed: 0, skipped: 0 });
+    interceptGetRuleGaps();
+    interceptGetManualRuns(this.ruleId);
+
+    // Visit rule details and go to execution log tab
+    visit(ruleDetailsUrl(this.ruleId));
+    goToExecutionLogTab();
+
+    // the gaps and manual runs are fetched when navigating to the execution log tab
+    cy.wait('@getRuleGaps');
+    cy.wait('@getRuleManualRuns');
+
+    interceptGetRuleGaps();
+    interceptGetManualRuns(this.ruleId);
+
+    // Schedule the backfill
+    cy.get(RULE_FILL_ALL_GAPS_BUTTON).click();
+    cy.get(MODAL_CONFIRMATION_BTN).click();
+    cy.wait('@bulkFillRulesGaps');
+
+    // After scheduling the backfill, the gaps and manual runs are refreshed
+    cy.wait('@getRuleGaps');
+    cy.wait('@getRuleManualRuns');
+
+    cy.contains(TOASTER_BODY, `You've successfully scheduled gap fills for 1 rule.`);
+  });
+
+  it('handle the case when the rule is disabled', function () {
+    interceptGetRuleGaps();
+    interceptGetManualRuns(this.ruleId);
+
+    // Visit rule details and go to execution log tab
+    visit(ruleDetailsUrl(this.ruleId));
+    goToExecutionLogTab();
+
+    // the gaps and manual runs are fetched when navigating to the execution log tab
+    cy.wait('@getRuleGaps');
+    cy.wait('@getRuleManualRuns');
+
+    // Disable the rule
+    cy.get('[data-test-subj="ruleSwitch"]').click();
+
+    cy.waitUntil(() =>
+      cy
+        .get('[data-test-subj="ruleSwitch"]')
+        .invoke('attr', 'aria-checked')
+        .then((checked) => checked === 'false')
+    );
+
+    // Attempt to schedule the backfill
+    cy.get(RULE_FILL_ALL_GAPS_BUTTON).click();
+
+    // Verify that an error modal is displayed
+    cy.get('[data-test-subj="bulkActionRejectModal"]').should(
+      'have.text',
+      `Unable to schedule gap fills for a disabled ruleEnable the rule to schedule gap fills.CloseYou are in a modal dialog. Press Escape or tap/click outside the dialog on the shadowed overlay to close.`
+    );
+
+    cy.get(MODAL_CONFIRMATION_BTN).click();
+  });
+
+  it('handle gap fills result when the rule is skipped', function () {
+    interceptBulkFillRulesGaps({ succeeded: 0, failed: 0, skipped: 1 });
+    interceptGetRuleGaps();
+    interceptGetManualRuns(this.ruleId);
+
+    // Visit rule details and go to execution log tab
+    visit(ruleDetailsUrl(this.ruleId));
+    goToExecutionLogTab();
+
+    // the gaps and manual runs are fetched when navigating to the execution log tab
+    cy.wait('@getRuleGaps');
+    cy.wait('@getRuleManualRuns');
+
+    interceptGetRuleGaps();
+    interceptGetManualRuns(this.ruleId);
+
+    // Schedule the backfill
+    cy.get(RULE_FILL_ALL_GAPS_BUTTON).click();
+    cy.get(MODAL_CONFIRMATION_BTN).click();
+    cy.wait('@bulkFillRulesGaps');
+
+    // After scheduling the backfill, the gaps and manual runs are refreshed
+    cy.wait('@getRuleGaps');
+    cy.wait('@getRuleManualRuns');
+
+    cy.contains(TOASTER_BODY, 'No gaps were detected for the selected time range.');
+  });
+
+  it('handle the case when the request is slow', function () {
+    interceptBulkFillRulesGaps({ succeeded: 1, failed: 0, skipped: 0, delay: 6000 });
+    interceptGetRuleGaps();
+    interceptGetManualRuns(this.ruleId);
+
+    // Visit rule details and go to execution log tab
+    visit(ruleDetailsUrl(this.ruleId));
+    goToExecutionLogTab();
+
+    // the gaps and manual runs are fetched when navigating to the execution log tab
+    cy.wait('@getRuleGaps');
+    cy.wait('@getRuleManualRuns');
+
+    interceptGetRuleGaps();
+    interceptGetManualRuns(this.ruleId);
+
+    // Schedule the backfill
+    cy.get(RULE_FILL_ALL_GAPS_BUTTON).click();
+    cy.get(MODAL_CONFIRMATION_BTN).click();
+    cy.contains(TOASTER_BODY, `Scheduling gap fills for 1 rule`);
+    cy.wait('@bulkFillRulesGaps');
+
+    // After scheduling the backfill, the gaps and manual runs are refreshed
+    cy.wait('@getRuleGaps');
+    cy.wait('@getRuleManualRuns');
+
+    cy.contains(TOASTER_BODY, `You've successfully scheduled gap fills for 1 rule.`);
+  });
+
+  it('handle the case when the request to fill gaps errors', function () {
+    const errors = [
+      {
+        message: 'SCHEDULING - some error 1',
+        status_code: 500,
+        rules: [
+          {
+            id: '2d4b54da-3a6d-4508-b4f0-aaeb25859e11',
+            name: 'Rule 1',
+          },
         ],
       },
-    },
-  },
-  () => {
-    beforeEach(() => {
-      login();
-      deleteAlertsAndRules();
+    ];
+    interceptBulkFillRulesGaps({ succeeded: 0, failed: 1, skipped: 0, errorsArray: errors });
+    interceptGetRuleGaps();
+    interceptGetManualRuns(this.ruleId);
 
-      createRule(
-        getNewRule({ rule_id: '1', name: `Rule 1`, enabled: true, interval: '1m', from: 'now-1m' })
-      ).then((response) => {
-        cy.wrap(response.body.id).as('ruleId');
-      });
+    // Visit rule details and go to execution log tab
+    visit(ruleDetailsUrl(this.ruleId));
+    goToExecutionLogTab();
+
+    // the gaps and manual runs are fetched when navigating to the execution log tab
+    cy.wait('@getRuleGaps');
+    cy.wait('@getRuleManualRuns');
+
+    // Schedule the backfill
+    cy.get(RULE_FILL_ALL_GAPS_BUTTON).click();
+    cy.get(MODAL_CONFIRMATION_BTN).click();
+    cy.wait('@bulkFillRulesGaps');
+
+    cy.contains(TOASTER_BODY, `Unable to schedule gap fills for 1 rule`);
+
+    clickErrorToastBtn();
+
+    errors.forEach((error) => {
+      cy.contains(MODAL_ERROR_BODY, error.message);
     });
-
-    it('schedule gap fills for the rule when it is enabled', function () {
-      interceptBulkFillRulesGaps({ succeeded: 1, failed: 0, skipped: 0 });
-      interceptGetRuleGaps();
-      interceptGetManualRuns(this.ruleId);
-
-      // Visit rule details and go to execution log tab
-      visit(ruleDetailsUrl(this.ruleId));
-      goToExecutionLogTab();
-
-      // the gaps and manual runs are fetched when navigating to the execution log tab
-      cy.wait('@getRuleGaps');
-      cy.wait('@getRuleManualRuns');
-
-      interceptGetRuleGaps();
-      interceptGetManualRuns(this.ruleId);
-
-      // Schedule the backfill
-      cy.get(RULE_FILL_ALL_GAPS_BUTTON).click();
-      cy.get(MODAL_CONFIRMATION_BTN).click();
-      cy.wait('@bulkFillRulesGaps');
-
-      // After scheduling the backfill, the gaps and manual runs are refreshed
-      cy.wait('@getRuleGaps');
-      cy.wait('@getRuleManualRuns');
-
-      cy.contains(TOASTER_BODY, `You've successfully scheduled gap fills for 1 rule.`);
-    });
-
-    it('handle the case when the rule is disabled', function () {
-      interceptGetRuleGaps();
-      interceptGetManualRuns(this.ruleId);
-
-      // Visit rule details and go to execution log tab
-      visit(ruleDetailsUrl(this.ruleId));
-      goToExecutionLogTab();
-
-      // the gaps and manual runs are fetched when navigating to the execution log tab
-      cy.wait('@getRuleGaps');
-      cy.wait('@getRuleManualRuns');
-
-      // Disable the rule
-      cy.get('[data-test-subj="ruleSwitch"]').click();
-
-      cy.waitUntil(() =>
-        cy
-          .get('[data-test-subj="ruleSwitch"]')
-          .invoke('attr', 'aria-checked')
-          .then((checked) => checked === 'false')
-      );
-
-      // Attempt to schedule the backfill
-      cy.get(RULE_FILL_ALL_GAPS_BUTTON).click();
-
-      // Verify that an error modal is displayed
-      cy.get('[data-test-subj="bulkActionRejectModal"]').should(
-        'have.text',
-        `Unable to schedule gap fills for a disabled ruleEnable the rule to schedule gap fills.CloseYou are in a modal dialog. Press Escape or tap/click outside the dialog on the shadowed overlay to close.`
-      );
-
-      cy.get(MODAL_CONFIRMATION_BTN).click();
-    });
-
-    it('handle gap fills result when the rule is skipped', function () {
-      interceptBulkFillRulesGaps({ succeeded: 0, failed: 0, skipped: 1 });
-      interceptGetRuleGaps();
-      interceptGetManualRuns(this.ruleId);
-
-      // Visit rule details and go to execution log tab
-      visit(ruleDetailsUrl(this.ruleId));
-      goToExecutionLogTab();
-
-      // the gaps and manual runs are fetched when navigating to the execution log tab
-      cy.wait('@getRuleGaps');
-      cy.wait('@getRuleManualRuns');
-
-      interceptGetRuleGaps();
-      interceptGetManualRuns(this.ruleId);
-
-      // Schedule the backfill
-      cy.get(RULE_FILL_ALL_GAPS_BUTTON).click();
-      cy.get(MODAL_CONFIRMATION_BTN).click();
-      cy.wait('@bulkFillRulesGaps');
-
-      // After scheduling the backfill, the gaps and manual runs are refreshed
-      cy.wait('@getRuleGaps');
-      cy.wait('@getRuleManualRuns');
-
-      cy.contains(TOASTER_BODY, 'No gaps were detected for the selected time range.');
-    });
-
-    it('handle the case when the request is slow', function () {
-      interceptBulkFillRulesGaps({ succeeded: 1, failed: 0, skipped: 0, delay: 6000 });
-      interceptGetRuleGaps();
-      interceptGetManualRuns(this.ruleId);
-
-      // Visit rule details and go to execution log tab
-      visit(ruleDetailsUrl(this.ruleId));
-      goToExecutionLogTab();
-
-      // the gaps and manual runs are fetched when navigating to the execution log tab
-      cy.wait('@getRuleGaps');
-      cy.wait('@getRuleManualRuns');
-
-      interceptGetRuleGaps();
-      interceptGetManualRuns(this.ruleId);
-
-      // Schedule the backfill
-      cy.get(RULE_FILL_ALL_GAPS_BUTTON).click();
-      cy.get(MODAL_CONFIRMATION_BTN).click();
-      cy.contains(TOASTER_BODY, `Scheduling gap fills for 1 rule`);
-      cy.wait('@bulkFillRulesGaps');
-
-      // After scheduling the backfill, the gaps and manual runs are refreshed
-      cy.wait('@getRuleGaps');
-      cy.wait('@getRuleManualRuns');
-
-      cy.contains(TOASTER_BODY, `You've successfully scheduled gap fills for 1 rule.`);
-    });
-
-    it('handle the case when the request to fill gaps errors', function () {
-      const errors = [
-        {
-          message: 'SCHEDULING - some error 1',
-          status_code: 500,
-          rules: [
-            {
-              id: '2d4b54da-3a6d-4508-b4f0-aaeb25859e11',
-              name: 'Rule 1',
-            },
-          ],
-        },
-      ];
-      interceptBulkFillRulesGaps({ succeeded: 0, failed: 1, skipped: 0, errorsArray: errors });
-      interceptGetRuleGaps();
-      interceptGetManualRuns(this.ruleId);
-
-      // Visit rule details and go to execution log tab
-      visit(ruleDetailsUrl(this.ruleId));
-      goToExecutionLogTab();
-
-      // the gaps and manual runs are fetched when navigating to the execution log tab
-      cy.wait('@getRuleGaps');
-      cy.wait('@getRuleManualRuns');
-
-      // Schedule the backfill
-      cy.get(RULE_FILL_ALL_GAPS_BUTTON).click();
-      cy.get(MODAL_CONFIRMATION_BTN).click();
-      cy.wait('@bulkFillRulesGaps');
-
-      cy.contains(TOASTER_BODY, `Unable to schedule gap fills for 1 rule`);
-
-      clickErrorToastBtn();
-
-      errors.forEach((error) => {
-        cy.contains(MODAL_ERROR_BODY, error.message);
-      });
-    });
-  }
-);
+  });
+});

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/siem_migrations/dashboards/onboarding.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/siem_migrations/dashboards/onboarding.cy.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 import {
-  DASHBOARD_MIGRATIONS_GROUP_PANEL,
   DASHBOARD_MIGRATION_PROGRESS_BAR,
+  DASHBOARD_MIGRATIONS_GROUP_PANEL,
   MIGRATION_PANEL_NAME,
   ONBOARDING_SIEM_MIGRATIONS_LIST,
   ONBOARDING_TRANSLATIONS_RESULT_TABLE,
@@ -16,13 +16,13 @@ import { createBedrockConnector } from '../../../../tasks/api_calls/connectors';
 import { cleanDashboardsMigrationData } from '../../../../tasks/api_calls/siem_migrations';
 import { visit } from '../../../../tasks/navigation';
 import {
-  selectMigrationConnector,
-  saveDefaultMigrationName,
-  renameMigration,
   openUploadDashboardsFlyout,
+  renameMigration,
+  saveDefaultMigrationName,
+  selectMigrationConnector,
+  startDashboardMigrationFromFlyout,
   toggleMigrateDashboardsCard,
   uploadDashboards,
-  startDashboardMigrationFromFlyout,
 } from '../../../../tasks/siem_migrations';
 import { GET_STARTED_URL } from '../../../../urls/navigation';
 import { role } from '../common/role';
@@ -78,18 +78,7 @@ let bedrockConnectorId: string | null = null;
 // TODO: https://github.com/elastic/kibana/issues/228940 remove @skipInServerlessMKI tag when privileges issue is fixed
 describe(
   'Dashboards Migrations - Basic Workflow',
-  {
-    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'automaticDashboardsMigration',
-          ])}`,
-        ],
-      },
-    },
-  },
+  { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
 
   () => {
     before(() => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/siem_migrations/dashboards/translated_dashboards_page.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/siem_migrations/dashboards/translated_dashboards_page.cy.ts
@@ -18,10 +18,10 @@ import { deleteConnectors } from '../../../../tasks/api_calls/common';
 import { createBedrockConnector } from '../../../../tasks/api_calls/connectors';
 import { visit } from '../../../../tasks/navigation';
 import {
-  selectMigrationConnector,
   goToTranslatedDashboardsPageFromOnboarding,
   openReprocessDialog,
   reprocessDashboards,
+  selectMigrationConnector,
 } from '../../../../tasks/siem_migrations';
 import { GET_STARTED_URL } from '../../../../urls/navigation';
 import { role } from '../common/role';
@@ -31,18 +31,7 @@ let bedrockConnectorId: string | null = null;
 // TODO: https://github.com/elastic/kibana/issues/228940 remove @skipInServerlessMKI tag when privileges issue is fixed
 describe(
   'Dashboard Migrations - Translated Dashboards Page',
-  {
-    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'automaticDashboardsMigration',
-          ])}`,
-        ],
-      },
-    },
-  },
+  { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
 
   () => {
     before(() => {


### PR DESCRIPTION
## Summary

This PR makes a super small cleanup to a few Cypress files that are using some feature flags via the `kbnServerArgs` option when it is no longer necessary as the feature flags are already turned on by default. These are the feature flag that are `true` by default:
- automaticDashboardsMigration
- bulkFillRuleGapsEnabled
- endpointManagementSpaceAwarenessEnabled
- protectionUpdatesEnabled
- storeGapsInEventLogEnabled
- trustedDevices

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
