### PR TITLE
[ES|QL] Operators incorrectly marked as not allowed in stats in STATS WHERE with previous validation errors

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/location.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/location.ts
@@ -82,12 +82,18 @@ export function getLocationInfo(
   }
 
   // If not in an option node, try to find a function that defines a location
-  const func = Walker.find(
+  // We need to find ALL functions containing the position, then check if any have a location config
+  const funcs = Walker.findAll(
     parentCommand,
     (node) => isFunctionExpression(node) && within(position, node)
   );
 
-  if (func && isFunctionExpression(func)) {
+  // Iterate through all matching functions to find one with a location config
+  for (const func of funcs) {
+    if (!isFunctionExpression(func)) {
+      continue;
+    }
+
     const locationConfig = functionBasedLocations[parentCommand.name]?.[func.name];
 
     if (locationConfig) {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/functions.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/functions.test.ts
@@ -1072,6 +1072,16 @@ describe('function validation', () => {
           ['Unknown column "WrongField"']
         );
       });
+
+      describe('operators in STATS WHERE context', () => {
+        it('should allow IS NOT NULL operator in STATS WHERE clause when validation is applied', async () => {
+          const { expectErrors } = await setup();
+
+          await expectErrors('FROM index | STATS COUNT() WHERE unknownField IS NOT NULL', [
+            'Unknown column "unknownField"',
+          ]);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
We need to refine the logic of the last bugfix https://github.com/elastic/kibana/pull/239681 to understand the context.

There are some edge cases where, if you’re inside the WHERE clause of a STATS statement and a validation error occurs, other tokens may be incorrectly affected due to an invalid location mapping. This is also directly related to how the grammar tells us to form the AST for WHERE as a function i.e. takes all

For example, in the query STATS ... WHERE unknownColumn IS NOT NULL, the token unknownColumn is correctly marked as invalid — but the operator IS NOT NULL is also incorrectly flagged as invalid for the STATS location (even though we’re actually in STATS_WHERE).

**Problem**
```javascript
STATS {
  args: [
    where { ← function "where"
      args: [
        COUNT(), ← arg[0]
        is_not_null { ← arg[1]: the IS NOT NULL operator
          args: [@timestamp]
        }
      ]
    }
  ]
}
```
**Bug Flow**
1. When validating the `is_not_null` operator node, `getLocationInfo` was called
2. The code used `Walker.find()` to find the **first** function containing the node
3. `Walker.find()` would find `is_not_null` itself (since it contains itself) **before** finding the parent `where` function
4. No configuration exists for `stats.is_not_null` in `functionBasedLocations`
5. The code would fall back to returning `Location.STATS` instead of `Location.STATS_WHERE`
6. The validator would check if `is_not_null` is allowed in `Location.STATS` → **NO** → error

**Solution**
Changed `Walker.find()` to `Walker.findAll()` to get **all** parent functions, then iterate through them to find one that has a location configuration in `functionBasedLocations`

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->