### PR TITLE
[SharedUX][A11y] Fix ingest pipelines file picker announcement

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_create_from_csv/pipelines_csv_uploader.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_create_from_csv/pipelines_csv_uploader.tsx
@@ -54,27 +54,29 @@ export const PipelinesCsvUploader: FC<Props> = ({
 
   const options = getOptions(actionOptions);
 
+  const filePickerTitle = i18n.translate(
+    'xpack.ingestPipelines.createFromCsv.fileUpload.filePickerTitle',
+    {
+      defaultMessage: 'Upload file (up to {maxFileSize})',
+      values: { maxFileSize },
+    }
+  );
+
+  const filePickerDescription = i18n.translate(
+    'xpack.ingestPipelines.createFromCsv.fileUpload.selectOrDragAndDropFileDescription',
+    {
+      defaultMessage: 'Select or drag and drop a CSV file',
+    }
+  );
+
   return (
     <>
-      <EuiFormRow
-        fullWidth
-        label={
-          <FormattedMessage
-            id="xpack.ingestPipelines.createFromCsv.fileUpload.filePickerTitle"
-            defaultMessage="Upload file (up to {maxFileSize})"
-            values={{ maxFileSize }}
-          />
-        }
-      >
+      <EuiFormRow fullWidth label={filePickerTitle}>
         <EuiFilePicker
           id="filePicker"
           data-test-subj="csvFilePicker"
-          initialPromptText={i18n.translate(
-            'xpack.ingestPipelines.createFromCsv.fileUpload.selectOrDragAndDropFileDescription',
-            {
-              defaultMessage: 'Select or drag and drop a CSV file',
-            }
-          )}
+          initialPromptText={filePickerDescription}
+          aria-label={`${filePickerTitle}. ${filePickerDescription}`}
           onChange={onFilePickerChange}
           accept=".csv"
         />


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/218081

## Summary

- Explicitly added a composed `aria-label` to the `EuiFilePicker` which is the focusable element so screen readers announce both the row label and the file picker description. Before, only the row label was being announced.
- Also tried other approaches such as the use of `aria-describedby` and `EuiScreenReaderOnly` but they wouldn't work or became too complicated for such a small fix.

### Testing

Windows + NVDA:

<img width="799" height="604" alt="Screenshot 2025-10-22 at 09 48 48" src="https://github.com/user-attachments/assets/46c8d9f1-21bf-41fd-9971-25f9221386e6" />

MacOS + VO:

<img width="1176" height="587" alt="Screenshot 2025-10-22 at 10 09 23" src="https://github.com/user-attachments/assets/449d1139-0daf-485c-89d1-13a34941fd46" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->