### PR TITLE
[8.19] [Security Solution][Timelines] Fix template id asssignment (#237992)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/helpers.test.ts
@@ -9,7 +9,9 @@ import { createMockStore, kibanaMock, mockGlobalState } from '../../../common/mo
 import { TimelineId } from '../../../../common/types/timeline';
 import { TimelineStatusEnum } from '../../../../common/api/timeline';
 import { persistTimeline } from '../../containers/api';
-import { ensureTimelineIsSaved } from './helpers';
+import { ensureTimelineIsSaved, extractTimelineIdsAndVersions } from './helpers';
+import type { TimelineModel } from '../model';
+import { parse } from 'uuid';
 
 jest.mock('../../containers/api');
 
@@ -59,6 +61,74 @@ describe('Timeline middleware helpers', () => {
 
       expect(returnedTimeline.savedObjectId).toBe(mockSavedObjectId);
       expect(returnedTimeline.status).toBe(TimelineStatusEnum.draft);
+    });
+  });
+
+  describe('extractTimelineIdsAndVersions()', () => {
+    let testTimeline: TimelineModel;
+
+    beforeEach(() => {
+      testTimeline = structuredClone(mockGlobalState.timeline.timelineById[TimelineId.test]);
+    });
+
+    describe('timelines', () => {
+      describe('when timeline has been saved already (so id exsists)', () => {
+        beforeEach(() => {
+          testTimeline.savedObjectId = 'existing-timeline-id';
+        });
+
+        it('should return exisiting so id as timeline id', () => {
+          expect(extractTimelineIdsAndVersions(testTimeline)).toMatchObject({
+            timelineId: 'existing-timeline-id',
+          });
+        });
+      });
+
+      describe('when timeline has not been saved already (no so id exsists)', () => {
+        beforeEach(() => {
+          testTimeline.savedObjectId = null;
+        });
+
+        it('should return null timeline id', () => {
+          expect(extractTimelineIdsAndVersions(testTimeline)).toMatchObject({
+            timelineId: null,
+          });
+        });
+      });
+    });
+
+    describe('templates', () => {
+      beforeEach(() => {
+        testTimeline.timelineType = 'template';
+      });
+
+      describe('when timeline template has been saved already (so id exsists)', () => {
+        beforeEach(() => {
+          testTimeline.savedObjectId = 'uuid8a7ffa2c-0d8d-4b68-800f-c4b3622bdd03';
+        });
+
+        it('should return exisiting template id', () => {
+          testTimeline.templateTimelineId = 'existing-template-id';
+
+          expect(extractTimelineIdsAndVersions(testTimeline)).toMatchObject({
+            templateTimelineId: 'existing-template-id',
+          });
+        });
+      });
+
+      describe('when timeline template has not been saved yet (we dont have the so id)', () => {
+        it('should return a new, randomly generated uuid', () => {
+          testTimeline.templateTimelineId = null;
+          testTimeline.savedObjectId = null;
+
+          const a = extractTimelineIdsAndVersions(testTimeline).templateTimelineId;
+          const b = extractTimelineIdsAndVersions(testTimeline).templateTimelineId;
+          expect(typeof a).toBe('string');
+          expect(typeof b).toBe('string');
+          expect(a).not.toEqual(b);
+          expect(parse(a!));
+        });
+      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/timeline_save.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/timeline_save.test.ts
@@ -42,7 +42,10 @@ jest.mock('../actions', () => {
   };
 });
 jest.mock('../../containers/api');
-jest.mock('./helpers');
+jest.mock('./helpers', () => ({
+  refreshTimelines: jest.fn(),
+  extractTimelineIdsAndVersions: jest.requireActual('./helpers').extractTimelineIdsAndVersions,
+}));
 
 const startTimelineSavingMock = startTimelineSaving as unknown as jest.Mock;
 const endTimelineSavingMock = endTimelineSaving as unknown as jest.Mock;

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/timeline_save.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/timeline_save.ts
@@ -45,7 +45,7 @@ import type {
 } from '../../../../common/api/timeline';
 import type { TimelineModel } from '../model';
 import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
-import { refreshTimelines } from './helpers';
+import { extractTimelineIdsAndVersions, refreshTimelines } from './helpers';
 import { SourcererScopeName } from '../../../sourcerer/store/model';
 
 function isSaveTimelineAction(action: Action): action is ReturnType<typeof saveTimeline> {
@@ -66,6 +66,7 @@ export const saveTimelineMiddleware: (kibana: CoreStart) => Middleware<{}, State
     const timeline = selectTimelineById(storeState, localTimelineId);
     const { timelineId, timelineVersion, templateTimelineId, templateTimelineVersion } =
       extractTimelineIdsAndVersions(timeline);
+
     const timelineTimeRange = inputsSelectors.timelineTimeRangeSelector(storeState);
     const selectedDataViewIdSourcerer = sourcererSelectors.sourcererScopeSelectedDataViewId(
       storeState,
@@ -340,16 +341,4 @@ function getErrorFromResponse(response: TimelineErrorResponse) {
   } else if ('statusCode' in response) {
     return { errorCode: response.statusCode, message: response.message };
   }
-}
-
-function extractTimelineIdsAndVersions(timeline: TimelineModel) {
-  // When a timeline hasn't been saved yet, its `savedObectId` is not defined.
-  // In that case, we want to overwrite all locally created properties for the
-  // timeline id, the timeline template id and the timeline template version.
-  return {
-    timelineId: timeline.savedObjectId ?? null,
-    timelineVersion: timeline.version,
-    templateTimelineId: timeline.savedObjectId ? timeline.templateTimelineId : null,
-    templateTimelineVersion: timeline.savedObjectId ? timeline.templateTimelineVersion : null,
-  };
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution][Timelines] Fix template id asssignment (#237992)](https://github.com/elastic/kibana/pull/237992)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"lgestc","email":"11671118+lgestc@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-14T11:37:33Z","message":"[Security Solution][Timelines] Fix template id asssignment (#237992)\n\n## Summary\n\nWhen duplicating timeline templates, we dont have saved object id nor\ntemplate id yet, hence the current logic for resolving them was not\nworking. Added in uuidv4 in place to handle this case. This is currently\ndone on the ui side of things, we should probably move it to the backend\nat some point (of of scope here).","sha":"b12524bc01364d970fb7f13485b412f55f2cba15","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting:Investigations","backport:version","v9.1.0","v8.19.0","v9.2.0","v9.3.0"],"title":"[Security Solution][Timelines] Fix template id asssignment","number":237992,"url":"https://github.com/elastic/kibana/pull/237992","mergeCommit":{"message":"[Security Solution][Timelines] Fix template id asssignment (#237992)\n\n## Summary\n\nWhen duplicating timeline templates, we dont have saved object id nor\ntemplate id yet, hence the current logic for resolving them was not\nworking. Added in uuidv4 in place to handle this case. This is currently\ndone on the ui side of things, we should probably move it to the backend\nat some point (of of scope here).","sha":"b12524bc01364d970fb7f13485b412f55f2cba15"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/238853","number":238853,"state":"MERGED","mergeCommit":{"sha":"5635b002a643105cd2eceb03441b0cd3aece5977","message":"[9.2] [Security Solution][Timelines] Fix template id asssignment (#237992) (#238853)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Security Solution][Timelines] Fix template id asssignment\n(#237992)](https://github.com/elastic/kibana/pull/237992)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: lgestc <11671118+lgestc@users.noreply.github.com>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237992","number":237992,"mergeCommit":{"message":"[Security Solution][Timelines] Fix template id asssignment (#237992)\n\n## Summary\n\nWhen duplicating timeline templates, we dont have saved object id nor\ntemplate id yet, hence the current logic for resolving them was not\nworking. Added in uuidv4 in place to handle this case. This is currently\ndone on the ui side of things, we should probably move it to the backend\nat some point (of of scope here).","sha":"b12524bc01364d970fb7f13485b412f55f2cba15"}}]}] BACKPORT-->