### PR TITLE
[Security Solution] [AI assistant] remove extra spacing in footer of assistant message

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/get_comments/stream/index.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/get_comments/stream/index.tsx
@@ -127,8 +127,8 @@ export const StreamComment = ({
     );
   }, [isAnythingLoading, isControlsEnabled, reader, regenerateMessage, stopStream]);
 
-  const footer = (
-    interruptValue && <InterruptFactory
+  const footer = interruptValue && (
+    <InterruptFactory
       interruptValue={interruptValue}
       resumeGraph={resumeGraph}
       interruptResumeValue={interruptResumeValue}

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/get_comments/stream/index.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/get_comments/stream/index.tsx
@@ -128,7 +128,7 @@ export const StreamComment = ({
   }, [isAnythingLoading, isControlsEnabled, reader, regenerateMessage, stopStream]);
 
   const footer = (
-    <InterruptFactory
+    interruptValue && <InterruptFactory
       interruptValue={interruptValue}
       resumeGraph={resumeGraph}
       interruptResumeValue={interruptResumeValue}

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/get_comments/typed_interrupt/index.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/get_comments/typed_interrupt/index.tsx
@@ -29,7 +29,6 @@ export const InterruptFactory = ({
   interruptResumeValue: resumedValue,
   isLastInConversation,
 }: Props<InterruptType>) => {
-
   switch (interrupt.type) {
     case 'SELECT_OPTION':
       return (

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/get_comments/typed_interrupt/index.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/get_comments/typed_interrupt/index.tsx
@@ -17,7 +17,7 @@ import { SelectOption } from './typed_interrupts/select_option';
 import { InputText } from './typed_interrupts/input_text';
 
 interface Props<T extends InterruptType> {
-  interruptValue?: { type: T } & InterruptValue;
+  interruptValue: { type: T } & InterruptValue;
   resumeGraph: (threadId: string, resumeValue: { type: T } & InterruptResumeValue) => void;
   interruptResumeValue?: { type: T } & InterruptResumeValue;
   isLastInConversation: boolean;
@@ -29,9 +29,6 @@ export const InterruptFactory = ({
   interruptResumeValue: resumedValue,
   isLastInConversation,
 }: Props<InterruptType>) => {
-  if (!interrupt) {
-    return;
-  }
 
   switch (interrupt.type) {
     case 'SELECT_OPTION':


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

Fixes UI issue where there was extra spacing at the footer of the Security assistant messages.

## Before:
<img width="1254" height="759" alt="image" src="https://github.com/user-attachments/assets/f7292a67-00fa-4418-be88-7041e5c3ac8b" />


## After:
<img width="863" height="395" alt="image" src="https://github.com/user-attachments/assets/09f1ccc2-f39a-484f-8cfa-1f96dd8acc52" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [X] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [X] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [X] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [X] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [X] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [X] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



