### PR TITLE
[8.19] [Security Solution] Make prebuilt rules bootstrap errors visible (#239521)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/oom_testing/install_prebuilt_rules/install_prebuilt_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/oom_testing/install_prebuilt_rules/install_prebuilt_rules.ts
@@ -59,10 +59,10 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     it('install prebuilt rules from a package', async () => {
-      const { body: bootstrapPrebuiltRulesResponse } = await detectionsApi
-        .bootstrapPrebuiltRules()
-        .expect(200);
+      const { statusCode: bootstrapPrebuiltRulesStatusCode, body: bootstrapPrebuiltRulesResponse } =
+        await detectionsApi.bootstrapPrebuiltRules();
 
+      // Assert body first to be able to see error messages in case of failure
       expect(bootstrapPrebuiltRulesResponse).toMatchObject({
         packages: expect.arrayContaining([
           expect.objectContaining({
@@ -73,6 +73,7 @@ export default ({ getService }: FtrProviderContext): void => {
           }),
         ]),
       });
+      expect(bootstrapPrebuiltRulesStatusCode).toBe(200);
 
       const { body: reviewPrebuiltRulesForInstallationResponse } = await supertest
         .post(REVIEW_RULE_INSTALLATION_URL)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Make prebuilt rules bootstrap errors visible (#239521)](https://github.com/elastic/kibana/pull/239521)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2025-10-21T11:32:11Z","message":"[Security Solution] Make prebuilt rules bootstrap errors visible (#239521)\n\n**Partially addresses:** https://github.com/elastic/kibana/issues/188090\n\n## Summary\n\nPrebuilt Rules bootstrap API endpoint may fail on a fresh deployment in Elastic Cloud. This PR rearranges assertions to provide an ability to view the error message.","sha":"9b8ef8299d59fd31e29c91797ad4237eeba78604","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:version","v9.2.0","v9.1.3","v9.3.0","v8.19.6"],"title":"[Security Solution] Make prebuilt rules bootstrap errors visible","number":239521,"url":"https://github.com/elastic/kibana/pull/239521","mergeCommit":{"message":"[Security Solution] Make prebuilt rules bootstrap errors visible (#239521)\n\n**Partially addresses:** https://github.com/elastic/kibana/issues/188090\n\n## Summary\n\nPrebuilt Rules bootstrap API endpoint may fail on a fresh deployment in Elastic Cloud. This PR rearranges assertions to provide an ability to view the error message.","sha":"9b8ef8299d59fd31e29c91797ad4237eeba78604"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.1","8.19"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239521","number":239521,"mergeCommit":{"message":"[Security Solution] Make prebuilt rules bootstrap errors visible (#239521)\n\n**Partially addresses:** https://github.com/elastic/kibana/issues/188090\n\n## Summary\n\nPrebuilt Rules bootstrap API endpoint may fail on a fresh deployment in Elastic Cloud. This PR rearranges assertions to provide an ability to view the error message.","sha":"9b8ef8299d59fd31e29c91797ad4237eeba78604"}},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->