### PR TITLE
[ES|QL][Discover] Replaces logs sample data saved session with ES|QL

### DIFF
--- a/src/platform/plugins/shared/home/server/services/sample_data/data_sets/logs/saved_objects.ts
+++ b/src/platform/plugins/shared/home/server/services/sample_data/data_sets/logs/saved_objects.ts
@@ -424,7 +424,7 @@ export const getSavedObjects = (): SavedObject[] => [
       hits: 0,
       kibanaSavedObjectMeta: {
         searchSourceJSON:
-          '{"query":{"esql":"FROM kibana_sample_data_logs  | SORT @timestamp desc | LIMIT 10000"},"filter":[]}',
+          '{"query":{"esql":"FROM kibana_sample_data_logs | SORT @timestamp desc | LIMIT 10000"},"filter":[]}',
       },
       sort: [['timestamp', 'desc']],
       version: 1,

--- a/src/platform/plugins/shared/home/server/services/sample_data/data_sets/logs/saved_objects.ts
+++ b/src/platform/plugins/shared/home/server/services/sample_data/data_sets/logs/saved_objects.ts
@@ -418,21 +418,17 @@ export const getSavedObjects = (): SavedObject[] => [
         defaultMessage: '[Logs] Visits',
       }),
       description: '',
-      columns: ['response', 'url', 'clientip', 'machine.os', 'tags'],
+      columns: ['@timestamp', 'response', 'url', 'clientip', 'machine.os', 'tags'],
+      isTextBasedQuery: true,
+      timeRestore: false,
       hits: 0,
       kibanaSavedObjectMeta: {
         searchSourceJSON:
-          '{"query":{"query":"","language":"kuery"},"filter":[],"indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index"}',
+          '{"query":{"esql":"FROM kibana_sample_data_logs  | SORT @timestamp desc | LIMIT 10000"},"filter":[]}',
       },
       sort: [['timestamp', 'desc']],
       version: 1,
     },
-    references: [
-      {
-        id: '90943e30-9a47-11e8-b64d-95841ca0b247',
-        name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
-        type: 'index-pattern',
-      },
-    ],
+    references: [],
   },
 ];


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/189034

Replaces the [Logs] Visits session to use ES|QL instead of _search

<img width="1519" height="1080" alt="image" src="https://github.com/user-attachments/assets/d6493721-7db5-4a4d-9352-6ed1406624f7" />




