### PR TITLE
[8.19] Fix: Add styling to handle the text overflow (#239768)

### DIFF
--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/rich_result_header.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/rich_result_header.tsx
@@ -22,11 +22,14 @@ import {
   EuiTextColor,
   EuiTitle,
   useEuiTheme,
+  EuiToolTip,
+  copyToClipboard,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
-import { MetaDataProps } from './result_types';
+import type { MetaDataProps } from './result_types';
+import { definitionStyle } from './styles';
 
 interface Props {
   metaData: MetaDataProps;
@@ -50,9 +53,58 @@ const Term: React.FC<TermDef> = ({ label }) => (
 
 const Definition: React.FC<TermDef> = ({ label }) => (
   <EuiFlexItem>
-    <EuiTextColor color="subdued">{label}</EuiTextColor>
+    <EuiToolTip position="top" content={label}>
+      <EuiTextColor component="div" css={definitionStyle} color="subdued">
+        {label}
+      </EuiTextColor>
+    </EuiToolTip>
   </EuiFlexItem>
 );
+const CopyButton: React.FC<{ textToCopy: string }> = ({ textToCopy }) => {
+  const [isTextCopied, setTextCopied] = useState(false);
+
+  const onClick = () => {
+    copyToClipboard(textToCopy);
+    setTextCopied(true);
+  };
+  const onBlur = () => {
+    setTextCopied(false);
+  };
+  return (
+    <EuiToolTip
+      content={
+        isTextCopied
+          ? i18n.translate(
+              'xpack.searchIndexDocuments.result.header.compactCard.metadata.copiedTextToClipboard',
+              {
+                defaultMessage: 'Copied to clipboard',
+              }
+            )
+          : i18n.translate(
+              'xpack.searchIndexDocuments.result.header.compactCard.metadata.copyTextToClipboard',
+              {
+                defaultMessage: 'Copy text to clipboard',
+              }
+            )
+      }
+      data-test-subj="copyTextToClipboardButtonTooltip"
+    >
+      <EuiButtonIcon
+        aria-label={i18n.translate(
+          'xpack.searchIndexDocuments.result.header.compactCard.metadata.copyTextToClipboard',
+          {
+            defaultMessage: 'Copy text to clipboard',
+          }
+        )}
+        data-test-subj="copyTextToClipboardButton"
+        color="text"
+        iconType="copy"
+        onClick={onClick}
+        onBlur={onBlur}
+      />
+    </EuiToolTip>
+  );
+};
 const MetadataPopover: React.FC<MetaDataProps> = ({
   id,
   onDocumentDelete,
@@ -95,9 +147,10 @@ const MetadataPopover: React.FC<MetaDataProps> = ({
         `}
       >
         <EuiFlexItem>
-          <EuiFlexGroup justifyContent="spaceBetween" gutterSize="s">
+          <EuiFlexGroup justifyContent="spaceBetween" gutterSize="s" alignItems="center">
             <Term label="ID" />
             <Definition label={id} />
+            <CopyButton textToCopy={id} />
           </EuiFlexGroup>
         </EuiFlexItem>
 

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/styles.ts
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/styles.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { type EuiThemeComputed } from '@elastic/eui';
+
+export const resultField = (euiTheme: EuiThemeComputed<{}>) =>
+  css({
+    padding: 0,
+    borderBottom: `1px solid ${euiTheme.colors.lightShade}`,
+    position: 'relative',
+
+    '&:last-child': {
+      borderBottom: 'none',
+    },
+
+    '> .euiTableRow:hover': {
+      backgroundColor: euiTheme.colors.emptyShade,
+    },
+
+    '> .euiTableRowCell': {
+      borderTop: 'none',
+      borderBottom: 'none',
+
+      '> .euiTableCellContent': {
+        padding: euiTheme.size.s,
+        fontFamily: euiTheme.font.familyCode,
+        color: euiTheme.colors.mediumShade,
+      },
+    },
+
+    '.denseVectorFieldValue': {
+      position: 'absolute',
+      right: 0,
+      top: euiTheme.size.s, // replaced $euiSizeS
+      backgroundColor: euiTheme.colors.emptyShade, // replaced $euiColorEmptyShade
+      padding: `0 ${euiTheme.size.s}`,
+    },
+  });
+
+export const ResultHeader = styled.div<{ euiTheme: EuiThemeComputed<{}> }>`
+  padding: ${({ euiTheme }) => `0 ${euiTheme.size.s} ${euiTheme.size.xs} 0`};
+`;
+
+export const definitionStyle = css({
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+  maxWidth: '16rem',
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix: Add styling to handle the text overflow (#239768)](https://github.com/elastic/kibana/pull/239768)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Efe Gürkan YALAMAN","email":"efeguerkan.yalaman@elastic.co"},"sourceCommit":{"committedDate":"2025-10-22T10:51:19Z","message":"Fix: Add styling to handle the text overflow (#239768)\n\n## Summary\n\nThis fixes a case where having too long id not wrapping and overflowing\nthe popout by truncating the text and adding a copy button with tooltip\nto show whole ID.\n\nBefore\n<img width=\"3192\" height=\"954\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/84eb8772-a4ab-4310-b6f3-c1973b91948d\"\n/>\n\nAfter\n<img width=\"341\" height=\"218\" alt=\"Screenshot 2025-10-16 at 20 15 19\"\nsrc=\"https://github.com/user-attachments/assets/b1dad5d6-3123-4710-baf6-3c362cfa2580\"\n/>\n<img width=\"367\" height=\"234\" alt=\"Screenshot 2025-10-16 at 20 15 23\"\nsrc=\"https://github.com/user-attachments/assets/44606124-57b1-4a86-8071-89bca85860b9\"\n/>\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n\n## Release Note:\nFixed data preview metadata popup visual issues when ID is too long.\nAdded a tooltip and copy button to improve user experience.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"32972ca0ca2409a6b1c0a1dd7c0a499dbfae9401","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Search","backport:version","v9.2.0","v9.3.0","v9.1.6","v8.19.6"],"title":"Fix: Add styling to handle the text overflow","number":239768,"url":"https://github.com/elastic/kibana/pull/239768","mergeCommit":{"message":"Fix: Add styling to handle the text overflow (#239768)\n\n## Summary\n\nThis fixes a case where having too long id not wrapping and overflowing\nthe popout by truncating the text and adding a copy button with tooltip\nto show whole ID.\n\nBefore\n<img width=\"3192\" height=\"954\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/84eb8772-a4ab-4310-b6f3-c1973b91948d\"\n/>\n\nAfter\n<img width=\"341\" height=\"218\" alt=\"Screenshot 2025-10-16 at 20 15 19\"\nsrc=\"https://github.com/user-attachments/assets/b1dad5d6-3123-4710-baf6-3c362cfa2580\"\n/>\n<img width=\"367\" height=\"234\" alt=\"Screenshot 2025-10-16 at 20 15 23\"\nsrc=\"https://github.com/user-attachments/assets/44606124-57b1-4a86-8071-89bca85860b9\"\n/>\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n\n## Release Note:\nFixed data preview metadata popup visual issues when ID is too long.\nAdded a tooltip and copy button to improve user experience.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"32972ca0ca2409a6b1c0a1dd7c0a499dbfae9401"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/240058","number":240058,"state":"OPEN"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239768","number":239768,"mergeCommit":{"message":"Fix: Add styling to handle the text overflow (#239768)\n\n## Summary\n\nThis fixes a case where having too long id not wrapping and overflowing\nthe popout by truncating the text and adding a copy button with tooltip\nto show whole ID.\n\nBefore\n<img width=\"3192\" height=\"954\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/84eb8772-a4ab-4310-b6f3-c1973b91948d\"\n/>\n\nAfter\n<img width=\"341\" height=\"218\" alt=\"Screenshot 2025-10-16 at 20 15 19\"\nsrc=\"https://github.com/user-attachments/assets/b1dad5d6-3123-4710-baf6-3c362cfa2580\"\n/>\n<img width=\"367\" height=\"234\" alt=\"Screenshot 2025-10-16 at 20 15 23\"\nsrc=\"https://github.com/user-attachments/assets/44606124-57b1-4a86-8071-89bca85860b9\"\n/>\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n\n## Release Note:\nFixed data preview metadata popup visual issues when ID is too long.\nAdded a tooltip and copy button to improve user experience.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"32972ca0ca2409a6b1c0a1dd7c0a499dbfae9401"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->