### PR TITLE
[tests] Increase package registry timeout

### DIFF
--- a/src/platform/packages/private/kbn-journeys/journey/journey_ftr_config.ts
+++ b/src/platform/packages/private/kbn-journeys/journey/journey_ftr_config.ts
@@ -86,7 +86,7 @@ export function makeFtrConfigProvider(
           port: dockerRegistryPort,
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes
         },
       }),
 

--- a/src/platform/packages/shared/kbn-scout/src/config/serverless/serverless.base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/config/serverless/serverless.base.config.ts
@@ -62,7 +62,7 @@ export const defaultConfig: ScoutServerConfig = {
       port: dockerRegistryPort,
       args: dockerArgs,
       waitForLogLine: 'package manifests loaded',
-      waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+      waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes
     },
   }),
   esTestCluster: {

--- a/src/platform/packages/shared/kbn-scout/src/config/stateful/base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/config/stateful/base.config.ts
@@ -67,7 +67,7 @@ export const defaultConfig: ScoutServerConfig = {
       port: dockerRegistryPort,
       args: dockerArgs,
       waitForLogLine: 'package manifests loaded',
-      waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+      waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes
     },
   }),
   esTestCluster: {

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/helpers/docker_registry_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/helpers/docker_registry_helper.ts
@@ -17,7 +17,7 @@ import pRetry from 'p-retry';
 
 const BEFORE_SETUP_TIMEOUT = 30 * 60 * 1000; // 30 minutes;
 
-const DOCKER_START_TIMEOUT = 5 * 60 * 1000; // 5 minutes
+const DOCKER_START_TIMEOUT = 6 * 60 * 1000; // 6 minutes
 // This image comes from the latest successful build of https://buildkite.com/elastic/kibana-package-registry-promote
 // which is promoted after acceptance tests succeed against docker.elastic.co/package-registry/distribution:lite
 const DOCKER_IMAGE =

--- a/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/feature_flag.serverless.config.base.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/feature_flag.serverless.config.base.ts
@@ -94,7 +94,7 @@ export function createServerlessFeatureFlagTestConfig<T extends DeploymentAgnost
           port: dockerRegistryPort,
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes
         },
       }),
       esTestCluster: {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/feature_flag.stateful.config.base.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/feature_flag.stateful.config.base.ts
@@ -98,7 +98,7 @@ export function createStatefulFeatureFlagTestConfig<T extends DeploymentAgnostic
           port: dockerRegistryPort,
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes
         },
       }),
       testFiles: options.testFiles,

--- a/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/serverless.config.base.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/serverless.config.base.ts
@@ -96,7 +96,7 @@ export function createServerlessTestConfig<T extends DeploymentAgnosticCommonSer
           port: dockerRegistryPort,
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes
         },
       }),
       esTestCluster: {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/stateful.config.base.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/stateful.config.base.ts
@@ -99,7 +99,7 @@ export function createStatefulTestConfig<T extends DeploymentAgnosticCommonServi
           port: dockerRegistryPort,
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes
         },
       }),
       testFiles: options.testFiles,

--- a/x-pack/platform/test/fleet_api_integration/config.base.ts
+++ b/x-pack/platform/test/fleet_api_integration/config.base.ts
@@ -49,7 +49,7 @@ export default async function ({ readConfigFile, log }: FtrConfigProviderContext
           port: registryPort,
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes
         },
       })
     : undefined;

--- a/x-pack/platform/test/serverless/shared/config.base.ts
+++ b/x-pack/platform/test/serverless/shared/config.base.ts
@@ -66,7 +66,7 @@ export default async () => {
         port: dockerRegistryPort,
         args: dockerArgs,
         waitForLogLine: 'package manifests loaded',
-        waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+        waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes
       },
     }),
     browser: {

--- a/x-pack/solutions/observability/test/apm_api_integration/common/config.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/common/config.ts
@@ -120,7 +120,7 @@ export function createTestConfig(
           port: dockerRegistryPort,
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes
         },
       }),
       testFiles: [require.resolve('../tests')],

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/services/common/endpoint_registry_helpers.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/services/common/endpoint_registry_helpers.ts
@@ -70,7 +70,7 @@ export function SecuritySolutionEndpointRegistryHelpers() {
           port: dockerRegistryPort,
           args,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 6 minutes,
+          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes,
         },
       });
     },

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/services/common/endpoint_registry_helpers.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/services/common/endpoint_registry_helpers.ts
@@ -70,7 +70,7 @@ export function SecuritySolutionEndpointRegistryHelpers() {
           port: dockerRegistryPort,
           args,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes,
+          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 6 minutes,
         },
       });
     },

--- a/x-pack/solutions/security/test/security_solution_endpoint/services/endpoint_registry_helpers.ts
+++ b/x-pack/solutions/security/test/security_solution_endpoint/services/endpoint_registry_helpers.ts
@@ -70,7 +70,7 @@ export function SecuritySolutionEndpointRegistryHelpers() {
           port: dockerRegistryPort,
           args,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes,
+          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes,
         },
       });
     },


### PR DESCRIPTION
Increases the timeout from 4 minutes to 6 minutes.  We're seeing timeouts waiting for the package manifests to load.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->