### PR TITLE
[Unified Tabs] Tweaks mocks and `useChromeStyle`

### DIFF
--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
@@ -80,7 +80,7 @@ const createStartContractMock = () => {
     setHeaderBanner: jest.fn(),
     hasHeaderBanner$: jest.fn().mockReturnValue(new BehaviorSubject(false)),
     getBodyClasses$: jest.fn().mockReturnValue(new BehaviorSubject([])),
-    getChromeStyle$: jest.fn(),
+    getChromeStyle$: jest.fn().mockReturnValue(new BehaviorSubject('classic')),
     setChromeStyle: jest.fn(),
     getActiveSolutionNavId$: jest.fn(),
     project: lazyObject({

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_visual_glue_to_header/use_chrome_style.ts
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_visual_glue_to_header/use_chrome_style.ts
@@ -7,23 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useEffect, useState } from 'react';
-import type { ChromeStyle } from '@kbn/core-chrome-browser';
+import { useMemo } from 'react';
+import useObservable from 'react-use/lib/useObservable';
+import { of } from 'rxjs';
 import type { TabsServices } from '../../types';
 
 export const useChromeStyle = (services: TabsServices) => {
   const chrome = services.core?.chrome;
-
-  const [chromeStyle, setChromeStyle] = useState<ChromeStyle | undefined>(undefined);
-
-  useEffect(() => {
-    if (!chrome?.getChromeStyle$) {
-      return;
-    }
-
-    const subscription = chrome.getChromeStyle$().subscribe(setChromeStyle);
-    return () => subscription.unsubscribe();
-  }, [chrome]);
+  const chromeStyle$ = useMemo(() => chrome?.getChromeStyle$?.() ?? of(undefined), [chrome]);
+  const chromeStyle = useObservable(chromeStyle$);
 
   return {
     isProjectChromeStyle: chromeStyle === 'project',

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_visual_glue_to_header/use_chrome_style.ts
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_visual_glue_to_header/use_chrome_style.ts
@@ -17,7 +17,7 @@ export const useChromeStyle = (services: TabsServices) => {
   const [chromeStyle, setChromeStyle] = useState<ChromeStyle | undefined>(undefined);
 
   useEffect(() => {
-    if (!chrome) {
+    if (!chrome?.getChromeStyle$) {
       return;
     }
 

--- a/src/platform/packages/shared/kbn-unified-tabs/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-tabs/tsconfig.json
@@ -5,5 +5,5 @@
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["target/**/*"],
-  "kbn_references": ["@kbn/i18n", "@kbn/es-query", "@kbn/core-chrome-browser", "@kbn/core"]
+  "kbn_references": ["@kbn/i18n", "@kbn/es-query","@kbn/core"]
 }


### PR DESCRIPTION
## Summary

While working on #235372 I ran into an issue with how mocks are set up and used with `useChromeStyle` in `@kbn/unified-tabs`.

The `@kbn/unified-tabs` package uses its own mock that defines `chrome` just as `{}`. The way the hook is set up and checks against just `services.chrome` being set let's the tests pass.

The mocks in the `browser-mocks` package define  `chrome` including `getChromeStyle$` but it's just `jest.fn()` and not returning an observable.

So I hit an issue when I used unified tabs within other tests that were using the `browser-mocks` mocks. `useChromeStyle` would not return the `if (!chrome) ...` check and fail when then trying to get the observable.

This PR does 2 things to avoid this:

- `getChromeStyle$: jest.fn().mockReturnValue(new BehaviorSubject('classic'))` extends the mock in `browser-mocks` to return an observable.
- `useChromeStyle` now checks against `chrome?.getChromeStyle$?.()` instead of just `chrome` being set. On top of that I refactored the hook to use `useObservable` instead of the custom implementation.

Note either fix would have solved the current problem in the other PR but this way we're safe both ways.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
