### PR TITLE
[Docs] Indicate default for allowNoIndex parameter of data views APIs

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -67506,7 +67506,7 @@ components:
           example: 404
           type: integer
     Data_views_allownoindex:
-      description: Allows the data view saved object to exist before the data is available.
+      description: Allows the data view saved object to exist before the data is available. Defaults to `false`.
       type: boolean
     Data_views_create_data_view_request_object:
       title: Create data view request

--- a/src/platform/plugins/shared/data_views/docs/openapi/bundled.json
+++ b/src/platform/plugins/shared/data_views/docs/openapi/bundled.json
@@ -2788,7 +2788,7 @@
       },
       "allownoindex": {
         "type": "boolean",
-        "description": "Allows the data view saved object to exist before the data is available."
+        "description": "Allows the data view saved object to exist before the data is available. Defaults to `false`."
       },
       "fieldattrs": {
         "type": "object",

--- a/src/platform/plugins/shared/data_views/docs/openapi/bundled.yaml
+++ b/src/platform/plugins/shared/data_views/docs/openapi/bundled.yaml
@@ -2064,7 +2064,7 @@ components:
           type: string
     allownoindex:
       type: boolean
-      description: Allows the data view saved object to exist before the data is available.
+      description: Allows the data view saved object to exist before the data is available. Defaults to `false`.
     fieldattrs:
       type: object
       description: A map of field attributes by field name.

--- a/src/platform/plugins/shared/data_views/docs/openapi/components/schemas/allownoindex.yaml
+++ b/src/platform/plugins/shared/data_views/docs/openapi/components/schemas/allownoindex.yaml
@@ -1,2 +1,2 @@
 type: boolean
-description: Allows the data view saved object to exist before the data is available.
+description: Allows the data view saved object to exist before the data is available. Defaults to `false`.


### PR DESCRIPTION
Tested without specifying the parameter in Console

```
POST kbn:api/data_views/data_view
{
    "data_view":{
        "name":"My Logstash data view",
        "title":"logstash-*",
        "runtimeFieldMap":{
            "runtime_shape_name":{
                "type":"keyword",
                "script":{
                    "source":"emit(doc['shape_name'].value)"
                    }
                }
            }
        }
}
```

Response contains: `"allowNoIndex": false,`

Closes: https://github.com/elastic/docs-content/issues/2642