### PR TITLE
[8.19] [dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BehaviorSubject, Subject } from 'rxjs';
+import { getSampleDashboardState } from '../mocks';
+import type { DashboardState } from '../../common';
+import { COMPARE_DEBOUNCE, initializeUnifiedSearchManager } from './unified_search_manager';
+import type { ControlGroupApi } from '@kbn/controls-plugin/public';
+
+describe('initializeUnifiedSearchManager', () => {
+  describe('startComparing$', () => {
+    test('Should return no changes when there are no changes', (done) => {
+      const lastSavedState$ = new BehaviorSubject<DashboardState>(getSampleDashboardState());
+      const unifiedSearchManager = initializeUnifiedSearchManager(
+        lastSavedState$.value,
+        new BehaviorSubject<ControlGroupApi | undefined>(undefined),
+        new BehaviorSubject<boolean>(false),
+        new Subject<void>(),
+        () => lastSavedState$.value,
+        {
+          useUnifiedSearchIntegration: false,
+        }
+      );
+      unifiedSearchManager.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
+        expect(changes).toMatchInlineSnapshot(`Object {}`);
+        done();
+      });
+    });
+
+    describe('timeRange', () => {
+      test('Should not return timeRanage change when timeRestore is false', (done) => {
+        const lastSavedState$ = new BehaviorSubject<DashboardState>(getSampleDashboardState());
+        const unifiedSearchManager = initializeUnifiedSearchManager(
+          lastSavedState$.value,
+          new BehaviorSubject<ControlGroupApi | undefined>(undefined),
+          new BehaviorSubject<boolean>(false),
+          new Subject<void>(),
+          () => lastSavedState$.value,
+          {
+            useUnifiedSearchIntegration: false,
+          }
+        );
+        unifiedSearchManager.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
+          expect(changes).toMatchInlineSnapshot(`Object {}`);
+          done();
+        });
+
+        unifiedSearchManager.api.setTimeRange({
+          to: 'now',
+          from: 'now-30m',
+        });
+      });
+
+      test('Should return timeRanage change when timeRestore is true', (done) => {
+        const lastSavedState$ = new BehaviorSubject<DashboardState>({
+          ...getSampleDashboardState(),
+          timeRestore: true,
+        });
+        const unifiedSearchManager = initializeUnifiedSearchManager(
+          lastSavedState$.value,
+          new BehaviorSubject<ControlGroupApi | undefined>(undefined),
+          new BehaviorSubject<boolean>(true),
+          new Subject<void>(),
+          () => lastSavedState$.value,
+          {
+            useUnifiedSearchIntegration: false,
+          }
+        );
+        unifiedSearchManager.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
+          expect(changes).toMatchInlineSnapshot(`
+            Object {
+              "timeRange": Object {
+                "from": "now-30m",
+                "to": "now",
+              },
+            }
+          `);
+          done();
+        });
+
+        unifiedSearchManager.api.setTimeRange({
+          to: 'now',
+          from: 'now-30m',
+        });
+      });
+
+      test('Should not return timeRanage change when timeRestore resets to false', async () => {
+        const lastSavedState$ = new BehaviorSubject<DashboardState>(getSampleDashboardState());
+        const timeRestore$ = new BehaviorSubject<boolean>(false);
+        const unifiedSearchManager = initializeUnifiedSearchManager(
+          lastSavedState$.value,
+          new BehaviorSubject<ControlGroupApi | undefined>(undefined),
+          timeRestore$,
+          new Subject<void>(),
+          () => lastSavedState$.value,
+          {
+            useUnifiedSearchIntegration: false,
+          }
+        );
+        let unsavedChanges: object | undefined;
+        unifiedSearchManager.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
+          unsavedChanges = changes;
+        });
+
+        timeRestore$.next(true);
+        unifiedSearchManager.api.setTimeRange({
+          to: 'now',
+          from: 'now-30m',
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, COMPARE_DEBOUNCE + 1));
+
+        expect(unsavedChanges).toMatchInlineSnapshot(`
+            Object {
+              "timeRange": Object {
+                "from": "now-30m",
+                "to": "now",
+              },
+            }
+          `);
+
+        // reset timeRestore to false
+        timeRestore$.next(false);
+
+        await new Promise((resolve) => setTimeout(resolve, COMPARE_DEBOUNCE + 1));
+
+        expect(unsavedChanges).toMatchInlineSnapshot(`Object {}`);
+      });
+    });
+  });
+});

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.test.ts
@@ -20,7 +20,7 @@ describe('initializeUnifiedSearchManager', () => {
       const unifiedSearchManager = initializeUnifiedSearchManager(
         lastSavedState$.value,
         new BehaviorSubject<ControlGroupApi | undefined>(undefined),
-        new BehaviorSubject<boolean>(false),
+        new BehaviorSubject<boolean | undefined>(false),
         new Subject<void>(),
         () => lastSavedState$.value,
         {
@@ -39,7 +39,7 @@ describe('initializeUnifiedSearchManager', () => {
         const unifiedSearchManager = initializeUnifiedSearchManager(
           lastSavedState$.value,
           new BehaviorSubject<ControlGroupApi | undefined>(undefined),
-          new BehaviorSubject<boolean>(false),
+          new BehaviorSubject<boolean | undefined>(false),
           new Subject<void>(),
           () => lastSavedState$.value,
           {
@@ -65,7 +65,7 @@ describe('initializeUnifiedSearchManager', () => {
         const unifiedSearchManager = initializeUnifiedSearchManager(
           lastSavedState$.value,
           new BehaviorSubject<ControlGroupApi | undefined>(undefined),
-          new BehaviorSubject<boolean>(true),
+          new BehaviorSubject<boolean | undefined>(true),
           new Subject<void>(),
           () => lastSavedState$.value,
           {
@@ -92,7 +92,7 @@ describe('initializeUnifiedSearchManager', () => {
 
       test('Should not return timeRanage change when timeRestore resets to false', async () => {
         const lastSavedState$ = new BehaviorSubject<DashboardState>(getSampleDashboardState());
-        const timeRestore$ = new BehaviorSubject<boolean>(false);
+        const timeRestore$ = new BehaviorSubject<boolean | undefined>(false);
         const unifiedSearchManager = initializeUnifiedSearchManager(
           lastSavedState$.value,
           new BehaviorSubject<ControlGroupApi | undefined>(undefined),

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.ts
@@ -53,6 +53,8 @@ import { DEFAULT_DASHBOARD_STATE } from './default_dashboard_state';
 import { DashboardCreationOptions } from './types';
 import { DashboardState } from '../../common';
 
+export const COMPARE_DEBOUNCE = 100;
+
 export function initializeUnifiedSearchManager(
   initialState: DashboardState,
   controlGroupApi$: PublishingSubject<ControlGroupApi | undefined>,
@@ -343,8 +345,14 @@ export function initializeUnifiedSearchManager(
     internalApi: {
       controlGroupReload$,
       startComparing$: (lastSavedState$: BehaviorSubject<DashboardState>) => {
-        return combineLatest([unifiedSearchFilters$, query$, refreshInterval$, timeRange$]).pipe(
-          debounceTime(100),
+        return combineLatest([
+          unifiedSearchFilters$,
+          query$,
+          refreshInterval$,
+          timeRange$,
+          timeRestore$,
+        ]).pipe(
+          debounceTime(COMPARE_DEBOUNCE),
           map(([filters, query, refreshInterval, timeRange]) => ({
             filters: filters ?? DEFAULT_DASHBOARD_STATE.filters,
             query: query ?? DEFAULT_DASHBOARD_STATE.query,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2025-10-22T14:15:37Z","message":"[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)\n\nCloses https://github.com/elastic/kibana/issues/239962\n\nThe issue was caused because `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  is used in comparators but\nwas not part of `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  subscription. The unsaved changes\nbadge would remain because `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  from unifiedSearchManager\nwould not emit after `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  was reset.\n\nIssue resolved by adding `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  to `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT \nsubscription. Now `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  emit will cause `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  to\nemit with freshly calculated values.","sha":"6a78829c23466aca4451ca2d12558a56a76def2f","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","backport:version","v9.2.0","v9.3.0","v9.1.6","v8.19.6"],"title":"[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range","number":239992,"url":"https://github.com/elastic/kibana/pull/239992","mergeCommit":{"message":"[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)\n\nCloses https://github.com/elastic/kibana/issues/239962\n\nThe issue was caused because `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  is used in comparators but\nwas not part of `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  subscription. The unsaved changes\nbadge would remain because `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  from unifiedSearchManager\nwould not emit after `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  was reset.\n\nIssue resolved by adding `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  to `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT \nsubscription. Now `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  emit will cause `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  to\nemit with freshly calculated values.","sha":"6a78829c23466aca4451ca2d12558a56a76def2f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/240112","number":240112,"state":"OPEN"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239992","number":239992,"mergeCommit":{"message":"[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)\n\nCloses https://github.com/elastic/kibana/issues/239962\n\nThe issue was caused because `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  is used in comparators but\nwas not part of `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  subscription. The unsaved changes\nbadge would remain because `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  from unifiedSearchManager\nwould not emit after `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  was reset.\n\nIssue resolved by adding `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  to `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT \nsubscription. Now `timeRestore# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  emit will cause `startComparing# Backport

This will backport the following commits from `main` to `8.19`:
{{{{raw}}}} - [[dashboard] fix unable to reset unsaved change when enabling timeRestore and setting time range (#239992)](https://github.com/elastic/kibana/pull/239992){{{{/raw}}}}

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  to\nemit with freshly calculated values.","sha":"6a78829c23466aca4451ca2d12558a56a76def2f"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/240111","number":240111,"state":"OPEN"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/240110","number":240110,"state":"OPEN"}]}] BACKPORT-->