### PR TITLE
[Case] Improve all cases table loading to prevent flashing

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/all_cases_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/all_cases_list.tsx
@@ -192,24 +192,23 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       filterOptions
     );
 
+    const cssStyling = useMemo(
+      () =>
+        isLoading || isLoadingCases || isLoadingColumns
+          ? css`
+              top: ${euiTheme.size.xxs};
+              border-radius: ${euiTheme.border.radius};
+              z-index: ${euiTheme.levels.header};
+            `
+          : css`
+              display: none;
+            `,
+      [isLoading, isLoadingCases, isLoadingColumns, euiTheme]
+    );
+
     return (
       <>
-        <EuiProgress
-          size="xs"
-          color="accent"
-          className="essentialAnimation"
-          css={
-            isLoading || isLoadingCases || isLoadingColumns
-              ? css`
-                  top: ${euiTheme.size.xxs};
-                  border-radius: ${euiTheme.border.radius};
-                  z-index: ${euiTheme.levels.header};
-                `
-              : css`
-                  display: none;
-                `
-          }
-        />
+        <EuiProgress size="xs" color="accent" className="essentialAnimation" css={cssStyling} />
 
         {!isSelectorView ? <CasesMetrics /> : null}
         <CasesTableFilters

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/table.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/table.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FunctionComponent, MutableRefObject } from 'react';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { css } from '@emotion/react';
 import type { EuiTableSelectionType, EuiBasicTableProps, Pagination } from '@elastic/eui';
 import { EuiEmptyPrompt, EuiSkeletonText, EuiBasicTable, useEuiTheme } from '@elastic/eui';
@@ -70,7 +70,17 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
     [goToCreateCase, navigateToCreateCase]
   );
 
-  return (isCasesLoading && isDataEmpty) || isLoadingColumns ? (
+  const isInitialLoading = useMemo(
+    () => (isCasesLoading && isDataEmpty) || (isLoadingColumns && columns.length === 0),
+    [isCasesLoading, isDataEmpty, isLoadingColumns, columns]
+  );
+
+  const isLoading = useMemo(
+    () => isCasesLoading || isLoadingColumns || isCommentUpdating,
+    [isCasesLoading, isLoadingColumns, isCommentUpdating]
+  );
+
+  return isInitialLoading ? (
     <div
       css={css`
         margin-top: ${euiTheme.size.m};
@@ -87,7 +97,7 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
         data-test-subj="cases-table"
         itemId="id"
         items={data.cases}
-        loading={isCommentUpdating}
+        loading={isLoading}
         noItemsMessage={
           <EuiEmptyPrompt
             title={<h3>{i18n.NO_CASES}</h3>}

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
@@ -91,7 +91,7 @@ export const useCasesColumns = ({
   const {
     data: { customFields },
     isFetching: isLoadingColumns,
-  } = useGetCaseConfiguration();
+  } = useGetCaseConfiguration({ keepPreviousData: true });
 
   const assignCaseAction = useCallback(
     async (theCase: CaseUI) => {

--- a/x-pack/platform/plugins/shared/cases/public/containers/configure/use_get_case_configuration.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/configure/use_get_case_configuration.tsx
@@ -9,12 +9,15 @@ import type { CasesConfigurationUI } from '../types';
 import { useGetCaseConfigurationsQuery } from './use_get_case_configurations_query';
 import { getConfigurationByOwner } from './utils';
 
-export const useGetCaseConfiguration = () => {
+export const useGetCaseConfiguration = ({
+  keepPreviousData,
+}: { keepPreviousData?: boolean } = {}) => {
   const { owner } = useCasesContext();
 
   return useGetCaseConfigurationsQuery<CasesConfigurationUI>({
     select: (data: CasesConfigurationUI[] | null) =>
       getConfigurationByOwner({ configurations: data, owner: owner[0] }),
+    keepPreviousData,
   });
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/containers/configure/use_get_case_configurations_query.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/configure/use_get_case_configurations_query.tsx
@@ -16,8 +16,10 @@ import { initialConfiguration } from './utils';
 
 export const useGetCaseConfigurationsQuery = <T,>({
   select,
+  keepPreviousData,
 }: {
   select: (data: CasesConfigurationUI[] | null) => T;
+  keepPreviousData?: boolean;
 }) => {
   const { showErrorToast } = useCasesToast();
 
@@ -30,6 +32,7 @@ export const useGetCaseConfigurationsQuery = <T,>({
         showErrorToast(error, { title: i18n.ERROR_TITLE });
       },
       initialData: [initialConfiguration],
+      keepPreviousData: Boolean(keepPreviousData),
     }
   );
 };


### PR DESCRIPTION
## Summary

QOL improvement to not show the skeleton text when user switch between tabs. The skeleton text can create a flashing effect when user switch tabs and come back to cases. This is more obvious in slower instances with many cases. 

Before
Skeleton text is shown despite there is data in the table

https://github.com/user-attachments/assets/1357828d-ddc4-4a4f-9541-4c0384ffc0ea


After
Skeleton text is only shown when the page first loads (first action), subsequent tab switch shows progress bar in the table (second action)


https://github.com/user-attachments/assets/3d99c3d6-7edc-4d52-a189-96049bbe7b88



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->