### PR TITLE
[DOCS][8.19.x][Release notes]: Turning flapping off prevents alerts to be generated when alert delay is set to more than 1 

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -115,7 +115,7 @@ include::upgrade-notes.asciidoc[]
 [[release-notes-8.19.5]]
 == {kib} 8.19.5
 
-The 8.19.5 release includes the following fixes.
+The 8.19.5 release includes the following known issues and fixes.
 
 IMPORTANT: This release contains fixes for potential security vulnerabilities. Check our link:https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
 
@@ -168,7 +168,7 @@ Management::
 [[release-notes-8.19.4]]
 == {kib} 8.19.4
 
-The 8.19.4 release includes the following fixes.
+The 8.19.4 release includes the following known issues, enhancements, and fixes.
 
 [float]
 [[known-issues-8.19.4]]
@@ -198,7 +198,7 @@ Observability solution::
 [[release-notes-8.19.3]]
 == {kib} 8.19.3
 
-The 8.19.3 release includes the following fixes.
+The 8.19.3 release includes the following known issues and fixes.
 
 [float]
 [[known-issues-8.19.3]]
@@ -228,7 +228,7 @@ Kibana platform::
 [[release-notes-8.19.2]]
 == {kib} 8.19.2
 
-The 8.19.2 release includes the following fixes.
+The 8.19.2 release includes the following known issues, enhancements, and fixes.
 
 [float]
 [[known-issues-8.19.2]]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -120,6 +120,11 @@ The 8.19.5 release includes the following fixes.
 IMPORTANT: This release contains fixes for potential security vulnerabilities. Check our link:https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
 
 [float]
+[[known-issues-8.19.5]]
+=== Known issues
+include::CHANGELOG.asciidoc[tag=known-issue-3610]
+
+[float]
 [[fixes-v8.19.5]]
 === Fixes
 Alerting::
@@ -166,6 +171,11 @@ Management::
 The 8.19.4 release includes the following fixes.
 
 [float]
+[[known-issues-8.19.4]]
+=== Known issues
+include::CHANGELOG.asciidoc[tag=known-issue-3610]
+
+[float]
 [[enhancement-v8.19.4]]
 === Enhancements
 Stack management::
@@ -191,6 +201,11 @@ Observability solution::
 The 8.19.3 release includes the following fixes.
 
 [float]
+[[known-issues-8.19.3]]
+=== Known issues
+include::CHANGELOG.asciidoc[tag=known-issue-3610]
+
+[float]
 [[fixes-v8.19.3]]
 === Fixes
 Alerting::
@@ -214,6 +229,11 @@ Kibana platform::
 == {kib} 8.19.2
 
 The 8.19.2 release includes the following fixes.
+
+[float]
+[[known-issues-8.19.2]]
+=== Known issues
+include::CHANGELOG.asciidoc[tag=known-issue-3610]
 
 [float]
 [[enhancement-v8.19.2]]
@@ -242,6 +262,7 @@ The 8.19.1 release includes the following known issues and fixes.
 === Known issues
 include::CHANGELOG.asciidoc[tag=known-issue-230275]
 include::CHANGELOG.asciidoc[tag=known-issue-2462]
+include::CHANGELOG.asciidoc[tag=known-issue-3610]
 
 [float]
 [[fixes-v8.19.1]]
@@ -295,6 +316,20 @@ After creating a report in a non-default {kib} space, the document exists in the
 This issue is resolved in 8.19.0, 8.19.2, 9.1.0, and 9.1.2.
 ====
 // end::known-issue-2462[]
+
+// tag::known-issue-3610[]
+.Alerts aren't generated for rules with alert flapping off and an alert delay higher than 1.
+[%collapsible]
+====
+*Details* +
+
+Alerts aren't generated for rules that have **Alert flapping detection** turned off and the alert delay set to a value higher than 1.
+
+*Workaround* +
+Set the alert delay value to 1 or turn on **Alert flapping detection**.
+
+====
+// end::known-issue-3610[]
 
 [float]
 [[breaking-changes-8.19.0]]


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-content/issues/3610

Preview