### PR TITLE
[9.1] `@kbn/storage-adapter`: do not update settings when updating mappings (#232840)

### DIFF
--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
@@ -244,13 +244,6 @@ export class StorageIndexAdapter<
       name: getBackingIndexName(this.storage.name, 999999),
     });
 
-    if (simulateIndexTemplateResponse.template.settings) {
-      await this.esClient.indices.putSettings({
-        index: name,
-        settings: simulateIndexTemplateResponse.template.settings,
-      });
-    }
-
     if (simulateIndexTemplateResponse.template.mappings) {
       await this.esClient.indices.putMapping({
         index: name,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [`@kbn/storage-adapter`: do not update settings when updating mappings (#232840)](https://github.com/elastic/kibana/pull/232840)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pierre Gayvallet","email":"pierre.gayvallet@elastic.co"},"sourceCommit":{"committedDate":"2025-08-26T11:30:51Z","message":"`@kbn/storage-adapter`: do not update settings when updating mappings (#232840)\n\n## Summary\n\nFix a bug causing a mapping update of a `index-storage` to cause an\nerror during `updateMappingsOfExistingIndex`.\n\nDuring that phase, we were trying to update the index's settings in\naddition to its mappings. However, the `simulateIndexTemplate` API\nreturns the full set of settings, and not only the ones which can be\nupdated, so the following `putSettings` call was failing with errors\nsuch as:\n\n```\n Root causes:\n                illegal_argument_exception: can not update private setting [index.allocation.existing_shards_allocator]; this setting is managed by Elasticsearch\n```\n\nGiven there is apparently no proper way to identify which setting(s) are\nprivate vs which ones can be updated, this PR simply fully disables the\nsetting update part, as discussed with @elastic/kibana-core.","sha":"55c1587eca63d9a62415363a353a9746793703ef","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.2.0"],"title":"`@kbn/storage-adapter`: do not update settings when updating mappings","number":232840,"url":"https://github.com/elastic/kibana/pull/232840","mergeCommit":{"message":"`@kbn/storage-adapter`: do not update settings when updating mappings (#232840)\n\n## Summary\n\nFix a bug causing a mapping update of a `index-storage` to cause an\nerror during `updateMappingsOfExistingIndex`.\n\nDuring that phase, we were trying to update the index's settings in\naddition to its mappings. However, the `simulateIndexTemplate` API\nreturns the full set of settings, and not only the ones which can be\nupdated, so the following `putSettings` call was failing with errors\nsuch as:\n\n```\n Root causes:\n                illegal_argument_exception: can not update private setting [index.allocation.existing_shards_allocator]; this setting is managed by Elasticsearch\n```\n\nGiven there is apparently no proper way to identify which setting(s) are\nprivate vs which ones can be updated, this PR simply fully disables the\nsetting update part, as discussed with @elastic/kibana-core.","sha":"55c1587eca63d9a62415363a353a9746793703ef"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/232840","number":232840,"mergeCommit":{"message":"`@kbn/storage-adapter`: do not update settings when updating mappings (#232840)\n\n## Summary\n\nFix a bug causing a mapping update of a `index-storage` to cause an\nerror during `updateMappingsOfExistingIndex`.\n\nDuring that phase, we were trying to update the index's settings in\naddition to its mappings. However, the `simulateIndexTemplate` API\nreturns the full set of settings, and not only the ones which can be\nupdated, so the following `putSettings` call was failing with errors\nsuch as:\n\n```\n Root causes:\n                illegal_argument_exception: can not update private setting [index.allocation.existing_shards_allocator]; this setting is managed by Elasticsearch\n```\n\nGiven there is apparently no proper way to identify which setting(s) are\nprivate vs which ones can be updated, this PR simply fully disables the\nsetting update part, as discussed with @elastic/kibana-core.","sha":"55c1587eca63d9a62415363a353a9746793703ef"}}]}] BACKPORT-->