### PR TITLE
fix: connector and trigger type decorations slip to the next line

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/decorations/use_connector_type_decorations.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/decorations/use_connector_type_decorations.ts
@@ -10,7 +10,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import type { Document, Pair, Scalar } from 'yaml';
 import { isPair, isScalar } from 'yaml';
-import type { monaco } from '@kbn/monaco';
+import { monaco } from '@kbn/monaco';
 import { isBuiltInStepType } from '@kbn/workflows';
 import { getStepNodesWithType } from '../../../../../common/lib/yaml_utils';
 import { getCachedAllConnectorsMap } from '../../../../../common/schema';
@@ -158,6 +158,7 @@ export const useConnectorTypeDecorations = ({
               },
               options: {
                 inlineClassName: `type-inline-highlight type-${baseConnectorType}`,
+                stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
               },
             },
           ];

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/decorations/use_trigger_type_decorations.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/decorations/use_trigger_type_decorations.ts
@@ -10,7 +10,7 @@
 import { useEffect, useRef } from 'react';
 import type { Document, Pair, Scalar } from 'yaml';
 import { isPair, isScalar } from 'yaml';
-import type { monaco } from '@kbn/monaco';
+import { monaco } from '@kbn/monaco';
 import { getTriggerNodesWithType } from '../../../../../common/lib/yaml_utils';
 
 interface UseTriggerTypeDecorationsProps {
@@ -150,6 +150,7 @@ export const useTriggerTypeDecorations = ({
               },
               options: {
                 inlineClassName: `type-inline-highlight type-${className}`,
+                stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
               },
             },
           ];


### PR DESCRIPTION
## Before
Type decoration slipped to the next line for a second and then "fixed" itself. 

https://github.com/user-attachments/assets/5fcdb8a3-af8a-4d57-adbe-5cb40485c8fd

## After

Type decorations stay on the their line.

https://github.com/user-attachments/assets/adc1ed16-2784-4a0e-a62a-9040564fd041

