### PR TITLE
[Cases] Add empty state and loading indicator for case events

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/case_events/table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/case_events/table.test.tsx
@@ -7,7 +7,11 @@
 
 import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import { EventsTableForCases } from './table';
+import {
+  EMPTY_EVENTS_TABLE_FOR_CASES_ID,
+  EventsTableForCases,
+  LOADING_EVENTS_TABLE_FOR_CASES_ID,
+} from './table';
 import { TestProviders } from '../../../common/mock';
 import { useCaseEventsDataView } from './use_events_data_view';
 
@@ -60,13 +64,25 @@ describe('EventsTableForCases', () => {
       { wrapper: TestProviders }
     );
 
-    expect(screen.getByTestId('body-data-grid')).toBeInTheDocument();
+    // renders loading initially
+    expect(screen.getByTestId(LOADING_EVENTS_TABLE_FOR_CASES_ID)).toBeInTheDocument();
 
     // Check if value cells are displayed at all
     await waitFor(() => {
+      expect(screen.getByTestId('body-data-grid')).toBeInTheDocument();
+
       const cells = screen.getAllByTestId('dataGridRowCell');
 
       expect(cells.length).toBeGreaterThan(2);
+    });
+  });
+
+  it('renders empty state for no events', async () => {
+    jest.mocked(searchEvents).mockResolvedValue([]);
+    render(<EventsTableForCases events={[]} />, { wrapper: TestProviders });
+
+    await waitFor(() => {
+      expect(screen.getByTestId(EMPTY_EVENTS_TABLE_FOR_CASES_ID)).toBeInTheDocument();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/case_events/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/case_events/table.tsx
@@ -27,6 +27,7 @@ import React, { useMemo, useEffect, useContext, type FC, useState, useCallback }
 import { useDispatch, useSelector } from 'react-redux';
 
 import { ThemeContext } from 'styled-components';
+import { EuiEmptyPrompt, EuiProgress } from '@elastic/eui';
 import { SecurityCellActionsTrigger } from '../../../app/actions/constants';
 import { RowAction } from '../../../common/components/control_columns/row_action';
 import { buildBrowserFields } from '../../../data_view_manager/utils/build_browser_fields';
@@ -36,9 +37,11 @@ import { DefaultCellRenderer } from '../../../timelines/components/timeline/cell
 import type { State } from '../../../common/store/types';
 import { useGetEvents } from './use_get_events';
 import { useCaseEventsDataView } from './use_events_data_view';
-import { TABLE_UNIT } from './translations';
+import { TABLE_UNIT, NO_EVENTS_TITLE } from './translations';
 
 export const EVENTS_TABLE_FOR_CASES_ID = 'EVENTS_TABLE_FOR_CASES_ID' as const;
+export const EMPTY_EVENTS_TABLE_FOR_CASES_ID = `EMPTY_${EVENTS_TABLE_FOR_CASES_ID}` as const;
+export const LOADING_EVENTS_TABLE_FOR_CASES_ID = `LOADING_${EVENTS_TABLE_FOR_CASES_ID}` as const;
 
 const noop = () => {};
 const emptyObject = {} as const;
@@ -102,7 +105,7 @@ const EventsTableForCasesBody: FC<{ dataView: DataView } & CaseViewEventsTablePr
     );
   }, [events]);
 
-  const { data = [] } = useGetEvents(dataView, {
+  const { data = [], isFetching: isFetchingEvents } = useGetEvents(dataView, {
     eventIds,
     sort,
     pageIndex: currentPageIndex,
@@ -174,6 +177,21 @@ const EventsTableForCasesBody: FC<{ dataView: DataView } & CaseViewEventsTablePr
     (fieldName: string) => dataView.fields.getByName(fieldName)?.toSpec(),
     [dataView.fields]
   );
+
+  if (isFetchingEvents) {
+    return (
+      <EuiProgress size="xs" color="accent" data-test-subj={LOADING_EVENTS_TABLE_FOR_CASES_ID} />
+    );
+  }
+
+  if (!data.length) {
+    return (
+      <EuiEmptyPrompt
+        data-test-subj={EMPTY_EVENTS_TABLE_FOR_CASES_ID}
+        title={<h2>{NO_EVENTS_TITLE}</h2>}
+      />
+    );
+  }
 
   return (
     <DataTableComponent

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/case_events/translations.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/case_events/translations.tsx
@@ -19,6 +19,10 @@ export const EVENTS_ERROR_TITLE = i18n.translate('xpack.securitySolution.caseEve
   defaultMessage: 'Error Searching Events',
 });
 
+export const NO_EVENTS_TITLE = i18n.translate('xpack.securitySolution.caseEvents.noEvents', {
+  defaultMessage: 'No Events Found',
+});
+
 export const ADD_TO_NEW_CASE = i18n.translate('xpack.securitySolution.caseEvents.addToNewCase', {
   defaultMessage: 'Add to new case',
 });


### PR DESCRIPTION
## Summary

During the demo, I've noticed that the loading indicator is missing. Adding it & the empty state for UX.

Testing: just create new case and go to the events tab.

![events_table_loading](https://github.com/user-attachments/assets/fbc8b272-5c76-495e-bbbe-8329a3d54809)
