### PR TITLE
[8.19] [Index Management] Don't default index mode to standard and add set index mode toggle in template form (#238883)

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_clone.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_clone.test.tsx
@@ -103,10 +103,10 @@ describe('<TemplateClone />', () => {
           body: JSON.stringify({
             name: `${templateToClone.name}-copy`,
             indexPatterns: DEFAULT_INDEX_PATTERNS,
-            indexMode,
             priority,
             version,
             allowAutoCreate,
+            indexMode,
             _kbnMeta,
             template,
           }),

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_create.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_create.test.tsx
@@ -490,9 +490,8 @@ describe('<TemplateCreate />', () => {
           body: JSON.stringify({
             name: 'my_logs_template',
             indexPatterns: ['logs-*-*'],
-            indexMode: 'logsdb',
             allowAutoCreate: 'NO_OVERWRITE',
-            dataStream: {},
+            indexMode: 'logsdb',
             _kbnMeta: {
               type: 'default',
               hasDatastream: false,
@@ -636,9 +635,9 @@ describe('<TemplateCreate />', () => {
           body: JSON.stringify({
             name: TEMPLATE_NAME,
             indexPatterns: DEFAULT_INDEX_PATTERNS,
-            indexMode: 'time_series',
             allowAutoCreate: 'TRUE',
             dataStream: {},
+            indexMode: 'time_series',
             _kbnMeta: {
               type: 'default',
               hasDatastream: false,

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_edit.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_edit.test.tsx
@@ -167,13 +167,13 @@ describe('<TemplateEdit />', () => {
           body: JSON.stringify({
             name: 'test',
             indexPatterns: ['myPattern*'],
-            indexMode: 'standard',
             version: 1,
             allowAutoCreate: 'NO_OVERWRITE',
             dataStream: {
               hidden: true,
               anyUnknownKey: 'should_be_kept',
             },
+            indexMode: 'standard',
             _kbnMeta: {
               type: 'default',
               hasDatastream: true,
@@ -287,10 +287,10 @@ describe('<TemplateEdit />', () => {
             body: JSON.stringify({
               name: TEMPLATE_NAME,
               indexPatterns: UPDATED_INDEX_PATTERN,
-              indexMode: 'standard',
               priority: 3,
               version: templateToEdit.version,
               allowAutoCreate: 'TRUE',
+              indexMode: 'standard',
               _kbnMeta: {
                 type: 'default',
                 hasDatastream: false,
@@ -387,9 +387,9 @@ describe('<TemplateEdit />', () => {
           body: JSON.stringify({
             name: TEMPLATE_NAME,
             indexPatterns: INDEX_PATTERNS,
-            indexMode: templateToEdit.indexMode,
             version: templateToEdit.version,
             allowAutoCreate: templateToEdit.allowAutoCreate,
+            indexMode: templateToEdit.indexMode,
             _kbnMeta: templateToEdit._kbnMeta,
             composedOf: [NONEXISTENT_COMPONENT_TEMPLATE.name],
             template: {},

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_form.helpers.ts
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_form.helpers.ts
@@ -207,6 +207,7 @@ export const formSetup = async (initTestBed: SetupFunc<TestSubjects>) => {
       }
 
       if (indexMode) {
+        form.toggleEuiSwitch('toggleIndexMode');
         form.setSelectValue('indexModeField', indexMode);
       }
     });
@@ -393,6 +394,7 @@ export type TestSubjects =
   | 'templateForm'
   | 'templateFormContainer'
   | 'testingEditor'
+  | 'toggleIndexMode'
   | 'versionField'
   | 'aliasesEditor'
   | 'settingsEditor'

--- a/x-pack/platform/plugins/shared/index_management/common/constants/index_modes.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/constants/index_modes.ts
@@ -9,3 +9,10 @@ export const STANDARD_INDEX_MODE = 'standard';
 export const LOGSDB_INDEX_MODE = 'logsdb';
 export const TIME_SERIES_MODE = 'time_series';
 export const LOOKUP_INDEX_MODE = 'lookup';
+
+export const IndexMode = {
+  standard: STANDARD_INDEX_MODE,
+  logsdb: LOGSDB_INDEX_MODE,
+  time_series: TIME_SERIES_MODE,
+  lookup: LOOKUP_INDEX_MODE,
+} as const;

--- a/x-pack/platform/plugins/shared/index_management/common/lib/template_serialization.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/lib/template_serialization.test.ts
@@ -59,7 +59,7 @@ describe('Template serialization', () => {
                 },
               },
             })
-          ).toHaveProperty('indexMode', value ?? STANDARD_INDEX_MODE);
+          ).toHaveProperty('indexMode', value);
         });
       });
 
@@ -78,7 +78,7 @@ describe('Template serialization', () => {
           ).toHaveProperty('indexMode', LOGSDB_INDEX_MODE);
         });
 
-        test('deserializes to standard index mode when logsdb is disabled', () => {
+        test('deserializes index mode to undefined when logsdb is disabled', () => {
           expect(
             deserializeTemplate(
               {
@@ -89,7 +89,7 @@ describe('Template serialization', () => {
               undefined,
               false
             )
-          ).toHaveProperty('indexMode', STANDARD_INDEX_MODE);
+          ).toHaveProperty('indexMode', undefined);
         });
       });
     });
@@ -117,6 +117,63 @@ describe('Template serialization', () => {
           ).toHaveProperty('template.settings.index.mode', value);
         });
       });
+
+      test(`does not create empty index object when indexMode is undefined`, () => {
+        const result = serializeTemplate({
+          ...defaultDeserializedTemplate,
+          indexMode: undefined,
+        });
+        // Should not have settings.index at all when indexMode is undefined and no other index settings exist
+        expect(result.template?.settings?.index).toBeUndefined();
+      });
+
+      test(`does not create empty settings object when no settings are provided`, () => {
+        const result = serializeTemplate({
+          ...defaultDeserializedTemplate,
+          indexMode: undefined,
+          template: {},
+        });
+        // Should not have settings at all when there are no settings to include
+        expect(result.template?.settings).toBeUndefined();
+      });
+
+      test(`preserves existing index settings when indexMode is undefined`, () => {
+        const result = serializeTemplate({
+          ...defaultDeserializedTemplate,
+          indexMode: undefined,
+          template: {
+            settings: {
+              index: {
+                number_of_shards: 3,
+              },
+            },
+          },
+        });
+        // Should keep existing index settings
+        expect(result.template?.settings?.index).toEqual({
+          number_of_shards: 3,
+        });
+      });
+
+      test(`adds indexMode to existing index settings`, () => {
+        const result = serializeTemplate({
+          ...defaultDeserializedTemplate,
+          indexMode: LOGSDB_INDEX_MODE,
+          template: {
+            settings: {
+              index: {
+                number_of_shards: 3,
+              },
+            },
+          },
+        });
+        // Should merge indexMode with existing index settings
+        expect(result.template?.settings?.index).toEqual({
+          number_of_shards: 3,
+          mode: LOGSDB_INDEX_MODE,
+        });
+      });
+
       test(`correctly serializes data_stream_options`, () => {
         expect(
           serializeTemplate(defaultDeserializedTemplate, { failure_store: { enabled: true } })

--- a/x-pack/platform/plugins/shared/index_management/common/lib/template_serialization.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/lib/template_serialization.ts
@@ -17,10 +17,10 @@ import { deserializeESLifecycle } from './data_stream_utils';
 import {
   allowAutoCreateRadioValues,
   allowAutoCreateRadioIds,
-  STANDARD_INDEX_MODE,
   LOGSDB_INDEX_MODE,
 } from '../constants';
-import { DataStreamOptions } from '../types/data_streams';
+import type { DataStreamOptions } from '../types/data_streams';
+import { buildTemplateSettings } from './utils';
 
 const hasEntries = (data: object = {}) => Object.entries(data).length > 0;
 
@@ -42,22 +42,31 @@ export function serializeTemplate(
     deprecated,
   } = templateDeserialized;
 
+  // Build settings object, properly handling index mode
+  const settings = buildTemplateSettings(template, indexMode);
+
+  // Separate settings and lifecycle from other template properties so we can rebuild template cleanly
+  const { settings: _templateSettings, lifecycle, ...otherTemplateProperties } = template || {};
+
+  const showTemplateOptions =
+    Object.keys(otherTemplateProperties).length > 0 ||
+    (settings && Object.keys(settings).length > 0) ||
+    (lifecycle && Object.keys(lifecycle).length > 0) ||
+    dataStreamOptions;
+
+  const templateOptions = {
+    ...otherTemplateProperties,
+    ...(settings && { settings }),
+    ...(lifecycle && { lifecycle }),
+    // If the existing template contains data stream options, we need to persist them.
+    // Otherwise, they will be lost when the template is updated.
+    ...(dataStreamOptions && { data_stream_options: dataStreamOptions }),
+  };
+
   return {
     version,
     priority,
-    template: {
-      ...template,
-      settings: {
-        ...template?.settings,
-        index: {
-          ...template?.settings?.index,
-          mode: indexMode,
-        },
-      },
-      // If the existing template contains data stream options, we need to persist them.
-      // Otherwise, they will be lost when the template is updated.
-      ...(dataStreamOptions && { data_stream_options: dataStreamOptions }),
-    },
+    ...(showTemplateOptions && { template: templateOptions }),
     index_patterns: indexPatterns,
     data_stream: dataStream,
     composed_of: composedOf,
@@ -102,7 +111,7 @@ export function deserializeTemplate(
   const indexMode = (settings?.index?.mode ??
     (isLogsdbEnabled && indexPatterns.some((pattern) => pattern === 'logs-*-*')
       ? LOGSDB_INDEX_MODE
-      : STANDARD_INDEX_MODE)) as IndexMode;
+      : undefined)) as IndexMode | undefined;
 
   const deserializedTemplate: TemplateDeserialized = {
     name,

--- a/x-pack/platform/plugins/shared/index_management/common/lib/utils.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/lib/utils.test.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { LegacyTemplateSerialized, TemplateSerialized } from '../types';
-import { isLegacyTemplate } from './utils';
+import type { LegacyTemplateSerialized, TemplateSerialized } from '../types';
+import { IndexMode } from '../constants';
+import { isLegacyTemplate, buildTemplateSettings } from './utils';
 
 describe('utils', () => {
   describe('isLegacyTemplate', () => {
@@ -32,6 +33,166 @@ describe('utils', () => {
         },
       };
       expect(isLegacyTemplate(template as TemplateSerialized)).toBe(false);
+    });
+  });
+
+  describe('buildTemplateSettings', () => {
+    test('should return undefined when template is undefined and no indexMode', () => {
+      const result = buildTemplateSettings(undefined, undefined);
+      expect(result).toBeUndefined();
+    });
+
+    test('should return undefined when template has no settings and no indexMode', () => {
+      const result = buildTemplateSettings({}, undefined);
+      expect(result).toBeUndefined();
+    });
+
+    test('should include indexMode when provided', () => {
+      const result = buildTemplateSettings({}, IndexMode.logsdb);
+      expect(result).toEqual({
+        index: {
+          mode: IndexMode.logsdb,
+        },
+      });
+    });
+
+    test('should remove existing mode and add new indexMode', () => {
+      const template = {
+        settings: {
+          index: {
+            mode: IndexMode.standard,
+            number_of_shards: 3,
+          },
+        },
+      };
+      const result = buildTemplateSettings(template, IndexMode.time_series);
+      expect(result).toEqual({
+        index: {
+          number_of_shards: 3,
+          mode: IndexMode.time_series,
+        },
+      });
+    });
+
+    test('should remove existing mode when indexMode is undefined', () => {
+      const template = {
+        settings: {
+          index: {
+            mode: IndexMode.standard,
+            number_of_shards: 3,
+          },
+        },
+      };
+      const result = buildTemplateSettings(template, undefined);
+      expect(result).toEqual({
+        index: {
+          number_of_shards: 3,
+        },
+      });
+    });
+
+    test('should preserve other index settings when adding mode', () => {
+      const template = {
+        settings: {
+          index: {
+            number_of_shards: 5,
+            number_of_replicas: 2,
+            refresh_interval: '1s',
+          },
+        },
+      };
+      const result = buildTemplateSettings(template, IndexMode.logsdb);
+      expect(result).toEqual({
+        index: {
+          number_of_shards: 5,
+          number_of_replicas: 2,
+          refresh_interval: '1s',
+          mode: IndexMode.logsdb,
+        },
+      });
+    });
+
+    test('should preserve other settings outside of index', () => {
+      const template = {
+        settings: {
+          number_of_shards: 3,
+          other_setting: 10000,
+        },
+      };
+      const result = buildTemplateSettings(template, IndexMode.time_series);
+      expect(result).toEqual({
+        number_of_shards: 3,
+        other_setting: 10000,
+        index: {
+          mode: IndexMode.time_series,
+        },
+      });
+    });
+
+    test('should return only non-index settings when no indexMode and no index settings', () => {
+      const template = {
+        settings: {
+          number_of_shards: 3,
+          other_setting: 10000,
+        },
+      };
+      const result = buildTemplateSettings(template, undefined);
+      expect(result).toEqual({
+        number_of_shards: 3,
+        other_setting: 10000,
+      });
+    });
+
+    test('should return undefined when only mode exists and indexMode is undefined', () => {
+      const template = {
+        settings: {
+          index: {
+            mode: IndexMode.standard,
+          },
+        },
+      };
+      const result = buildTemplateSettings(template, undefined);
+      expect(result).toBeUndefined();
+    });
+
+    test('should handle complex nested settings', () => {
+      const template = {
+        settings: {
+          analysis: {
+            analyzer: {
+              my_analyzer: {
+                type: 'standard',
+                tokenizer: 'standard',
+              },
+            },
+          },
+          index: {
+            mode: IndexMode.standard,
+            number_of_shards: 1,
+            lifecycle: {
+              name: 'my_policy',
+            },
+          },
+        },
+      };
+      const result = buildTemplateSettings(template, IndexMode.logsdb);
+      expect(result).toEqual({
+        analysis: {
+          analyzer: {
+            my_analyzer: {
+              type: 'standard',
+              tokenizer: 'standard',
+            },
+          },
+        },
+        index: {
+          number_of_shards: 1,
+          lifecycle: {
+            name: 'my_policy',
+          },
+          mode: IndexMode.logsdb,
+        },
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/index_management/common/lib/utils.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/lib/utils.ts
@@ -5,7 +5,57 @@
  * 2.0.
  */
 
-import { TemplateDeserialized, LegacyTemplateSerialized, TemplateSerialized } from '../types';
+import type {
+  TemplateDeserialized,
+  LegacyTemplateSerialized,
+  TemplateSerialized,
+  IndexMode,
+  IndexSettings,
+} from '../types';
+
+/**
+ * Builds template settings object, properly handling index mode.
+ * This function:
+ * - Removes any existing mode from template.settings.index
+ * - Only includes the mode if indexMode parameter is provided
+ * - Preserves all other settings
+ * - Returns undefined if there are no settings to include
+ *
+ * @param template The template object containing settings
+ * @param indexMode The index mode to set (if any)
+ * @returns The rebuilt settings object or undefined if empty
+ */
+export const buildTemplateSettings = (
+  template?: TemplateDeserialized['template'],
+  indexMode?: IndexMode
+): IndexSettings | undefined => {
+  // Extract existing settings, separating index settings from other settings
+  const { index: existingIndexSettings, ...otherSettings } = template?.settings || {};
+
+  // Remove mode from existing index settings as we'll set it from indexMode parameter
+  const { mode: _existingMode, ...otherIndexSettings } = existingIndexSettings || {};
+
+  // Build index settings: include if we have indexMode to set or other index settings to preserve
+  const hasIndexMode = indexMode !== undefined;
+  const hasOtherIndexSettings = Object.keys(otherIndexSettings).length > 0;
+
+  const indexSettings =
+    hasIndexMode || hasOtherIndexSettings
+      ? {
+          ...otherIndexSettings,
+          ...(hasIndexMode && { mode: indexMode }),
+        }
+      : undefined;
+
+  // Build settings object: only include if we have index settings or other settings
+  const settings = {
+    ...otherSettings,
+    ...(indexSettings && { index: indexSettings }),
+  };
+
+  // Return undefined if settings object is empty
+  return Object.keys(settings).length > 0 ? settings : undefined;
+};
 
 /**
  * Helper to know if a template has the legacy format or not

--- a/x-pack/platform/plugins/shared/index_management/common/types/data_streams.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/types/data_streams.ts
@@ -13,6 +13,7 @@ import {
   IndicesDataStreamIndex,
   IndicesDataStreamLifecycleWithRollover,
 } from '@elastic/elasticsearch/lib/api/types';
+import type { IndexMode } from '../constants/index_modes';
 
 interface TimestampFieldFromEs {
   name: string;
@@ -34,7 +35,7 @@ export type DataStreamIndexFromEs = IndicesDataStreamIndex;
 
 export type Health = 'green' | 'yellow' | 'red';
 
-export type IndexMode = 'standard' | 'logsdb' | 'time_series' | 'lookup';
+export type IndexMode = (typeof IndexMode)[keyof typeof IndexMode];
 
 export interface EnhancedDataStreamFromEs extends IndicesDataStream {
   global_max_retention?: string;

--- a/x-pack/platform/plugins/shared/index_management/common/types/templates.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/types/templates.ts
@@ -44,6 +44,7 @@ export interface TemplateDeserialized {
     aliases?: Aliases;
     mappings?: Mappings;
     data_stream_options?: DataStreamOptions;
+    lifecycle?: DataStream['lifecycle'];
   };
   lifecycle?: DataRetention;
   composedOf?: string[]; // Composable template only

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/template_form/steps/step_logistics.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/template_form/steps/step_logistics.tsx
@@ -30,6 +30,7 @@ import {
   JsonEditorField,
   NumericField,
   RadioGroupField,
+  ToggleField,
 } from '../../../../shared_imports';
 import { UnitField, timeUnits } from '../../shared';
 import { DataRetention } from '../../../../../common';
@@ -229,6 +230,7 @@ interface LogisticsForm {
 interface LogisticsFormInternal extends LogisticsForm {
   addMeta: boolean;
   doCreateDataStream: boolean;
+  setIndexMode: boolean;
 }
 
 interface Props {
@@ -243,14 +245,22 @@ function formDeserializer(formData: LogisticsForm): LogisticsFormInternal {
     ...formData,
     addMeta: Boolean(formData._meta && Object.keys(formData._meta).length),
     doCreateDataStream: Boolean(formData.dataStream),
+    setIndexMode: Boolean(formData.indexMode),
   };
 }
 
 function getformSerializer(initialTemplateData: LogisticsForm = {}) {
   return (formData: LogisticsFormInternal): LogisticsForm => {
-    const { addMeta, doCreateDataStream, ...rest } = formData;
+    const {
+      addMeta,
+      doCreateDataStream,
+      setIndexMode,
+      indexMode: indexModeValue,
+      ...rest
+    } = formData;
     const dataStream = doCreateDataStream ? initialTemplateData.dataStream ?? {} : undefined;
-    return { ...rest, dataStream };
+    const indexMode = setIndexMode ? indexModeValue : undefined;
+    return { ...rest, dataStream, indexMode };
   };
 }
 
@@ -271,24 +281,36 @@ export const StepLogistics: React.FunctionComponent<Props> = React.memo(
       getErrors: getFormErrors,
       getFormData,
       setFieldValue,
+      updateFieldValues,
     } = form;
 
-    const [{ addMeta, doCreateDataStream, lifecycle, indexPatterns: indexPatternsField }] =
-      useFormData<{
-        addMeta: boolean;
-        lifecycle: DataRetention;
-        doCreateDataStream: boolean;
-        indexPatterns: string[];
-      }>({
-        form,
-        watch: [
-          'addMeta',
-          'lifecycle.enabled',
-          'lifecycle.infiniteDataRetention',
-          'doCreateDataStream',
-          'indexPatterns',
-        ],
-      });
+    const [
+      { addMeta, doCreateDataStream, lifecycle, indexPatterns: indexPatternsField, setIndexMode },
+    ] = useFormData<{
+      addMeta: boolean;
+      lifecycle: DataRetention;
+      doCreateDataStream: boolean;
+      indexPatterns: string[];
+      indexMode: string;
+      setIndexMode: boolean;
+    }>({
+      form,
+      watch: [
+        'addMeta',
+        'lifecycle.enabled',
+        'lifecycle.infiniteDataRetention',
+        'doCreateDataStream',
+        'indexPatterns',
+        'indexMode',
+        'setIndexMode',
+      ],
+    });
+
+    useEffect(() => {
+      if (!setIndexMode) {
+        setFieldValue('indexMode', null);
+      }
+    }, [setIndexMode, setFieldValue]);
 
     useEffect(() => {
       if (
@@ -298,9 +320,12 @@ export const StepLogistics: React.FunctionComponent<Props> = React.memo(
         // Only set index mode if index pattern was changed
         defaultValue.indexPatterns !== indexPatternsField
       ) {
-        setFieldValue('indexMode', LOGSDB_INDEX_MODE);
+        updateFieldValues({
+          setIndexMode: true,
+          indexMode: LOGSDB_INDEX_MODE,
+        });
       }
-    }, [defaultValue.indexPatterns, indexPatternsField, setFieldValue]);
+    }, [defaultValue.indexPatterns, indexPatternsField, updateFieldValues]);
 
     /**
      * When the consumer call validate() on this step, we submit the form so it enters the "isSubmitted" state
@@ -457,17 +482,42 @@ export const StepLogistics: React.FunctionComponent<Props> = React.memo(
           )}
 
           {/* Index mode */}
-          <FormRow title={indexMode.title} description={indexMode.description}>
-            <UseField
-              path="indexMode"
-              componentProps={{
-                euiFieldProps: {
-                  hasDividers: true,
-                  'data-test-subj': indexMode.testSubject,
-                  options: indexMode.options,
-                },
-              }}
-            />
+          <FormRow
+            title={indexMode.title}
+            description={
+              <>
+                {indexMode.description}
+                <EuiSpacer size="m" />
+                <UseField
+                  path="setIndexMode"
+                  component={ToggleField}
+                  componentProps={{
+                    'data-test-subj': 'toggleIndexMode',
+                    euiFieldProps: {
+                      label: i18n.translate(
+                        'xpack.idxMgmt.templateForm.stepLogistics.toggleIndexModeLabel',
+                        {
+                          defaultMessage: 'Set index mode',
+                        }
+                      ),
+                    },
+                  }}
+                />
+              </>
+            }
+          >
+            {setIndexMode && (
+              <UseField
+                path="indexMode"
+                componentProps={{
+                  euiFieldProps: {
+                    hasDividers: true,
+                    'data-test-subj': indexMode.testSubject,
+                    options: indexMode.options,
+                  },
+                }}
+              />
+            )}
           </FormRow>
 
           {/* Order */}

--- a/x-pack/platform/test/api_integration/apis/management/index_management/templates.ts
+++ b/x-pack/platform/test/api_integration/apis/management/index_management/templates.ts
@@ -360,13 +360,12 @@ export default function ({ getService }: FtrProviderContext) {
           { enabled: false, prior_logs_usage: true, indexMode: undefined },
           // In stateful Kibana, if prior_logs_usage is set to true, the cluster.logsdb.enabled setting is false by default, so index mode is undefined
           { enabled: null, prior_logs_usage: true, indexMode: undefined },
-          // In stateful Kibana, when cluster.logsb.enabled setting is not set, the index mode is always standard
           // For versions 9.0+, if prior_logs_usage is set to false, the cluster.logsdb.enabled setting is true by default, so logsdb index mode
-          { enabled: null, prior_logs_usage: true, indexMode: 'standard' },
+          // Otherwise, index mode is undefined
           {
             enabled: null,
             prior_logs_usage: false,
-            indexMode: esVersion.matchRange('>=9.0.0') ? 'logsdb' : 'standard',
+            indexMode: esVersion.matchRange('>=9.0.0') ? 'logsdb' : undefined,
           },
         ];
 

--- a/x-pack/platform/test/api_integration/apis/management/index_management/templates.ts
+++ b/x-pack/platform/test/api_integration/apis/management/index_management/templates.ts
@@ -7,8 +7,9 @@
 
 import expect from '@kbn/expect';
 
-import { TemplateDeserialized } from '@kbn/index-management-plugin/common';
-import { FtrProviderContext } from '../../../ftr_provider_context';
+import type { TemplateDeserialized } from '@kbn/index-management-plugin/common';
+import { IndexMode } from '@kbn/index-management-plugin/common/constants';
+import type { FtrProviderContext } from '../../../ftr_provider_context';
 import { templatesApi } from './lib/templates.api';
 import { templatesHelpers } from './lib/templates.helpers';
 import { getRandomString } from './lib/random';
@@ -68,6 +69,13 @@ export default function ({ getService }: FtrProviderContext) {
           },
         },
       };
+      const tmpTemplate3 = getTemplatePayload(`template-${getRandomString()}`, [getRandomString()]);
+      const indexTemplateWithIndexMode = {
+        ...tmpTemplate3,
+        // For composable templates, only the top-level indexMode is needed.
+        // During serialization, serializeTemplate() will automatically set template.settings.index.mode from this value.
+        indexMode: IndexMode.standard,
+      };
 
       beforeEach(async () => {
         try {
@@ -75,6 +83,7 @@ export default function ({ getService }: FtrProviderContext) {
           await createTemplate(legacyTemplate);
           await createTemplate(indexTemplateWithDSL);
           await createTemplate(indexTemplateWithILM);
+          await createTemplate(indexTemplateWithIndexMode);
         } catch (err) {
           log.debug('[Setup error] Error creating index template');
           throw err;
@@ -94,7 +103,6 @@ export default function ({ getService }: FtrProviderContext) {
         const expectedKeys = [
           'name',
           'indexPatterns',
-          'indexMode',
           'hasSettings',
           'hasAliases',
           'hasMappings',
@@ -118,7 +126,6 @@ export default function ({ getService }: FtrProviderContext) {
         const expectedLegacyKeys = [
           'name',
           'indexPatterns',
-          'indexMode',
           'hasSettings',
           'hasAliases',
           'hasMappings',
@@ -142,7 +149,6 @@ export default function ({ getService }: FtrProviderContext) {
         const expectedWithDSLKeys = [
           'name',
           'indexPatterns',
-          'indexMode',
           'lifecycle',
           'hasSettings',
           'hasAliases',
@@ -168,7 +174,6 @@ export default function ({ getService }: FtrProviderContext) {
         const expectedWithILMKeys = [
           'name',
           'indexPatterns',
-          'indexMode',
           'ilmPolicy',
           'hasSettings',
           'hasAliases',
@@ -182,6 +187,30 @@ export default function ({ getService }: FtrProviderContext) {
         ].sort();
 
         expect(Object.keys(templateWithILM).sort()).to.eql(expectedWithILMKeys);
+
+        // Index template with Index Mode
+        const templateWithIndexMode = allTemplates.templates.find(
+          (template: TemplateDeserialized) => template.name === indexTemplateWithIndexMode.name
+        );
+
+        expect(templateWithIndexMode).to.be.ok();
+
+        const expectedWithIndexModeKeys = [
+          'name',
+          'indexPatterns',
+          'indexMode',
+          'hasSettings',
+          'hasAliases',
+          'hasMappings',
+          'priority',
+          'composedOf',
+          'ignoreMissingComponentTemplates',
+          'version',
+          '_kbnMeta',
+          'allowAutoCreate',
+        ].sort();
+
+        expect(Object.keys(templateWithIndexMode).sort()).to.eql(expectedWithIndexModeKeys);
       });
     });
 
@@ -196,7 +225,6 @@ export default function ({ getService }: FtrProviderContext) {
         const expectedKeys = [
           'name',
           'indexPatterns',
-          'indexMode',
           'template',
           'composedOf',
           'ignoreMissingComponentTemplates',
@@ -220,7 +248,6 @@ export default function ({ getService }: FtrProviderContext) {
         const expectedKeys = [
           'name',
           'indexPatterns',
-          'indexMode',
           'template',
           'order',
           'version',
@@ -234,6 +261,82 @@ export default function ({ getService }: FtrProviderContext) {
         expect(body.name).to.equal(templateName);
         expect(Object.keys(body).sort()).to.eql(expectedKeys);
         expect(Object.keys(body.template).sort()).to.eql(expectedTemplateKeys);
+      });
+
+      describe('with index mode', () => {
+        const indexModeTemplateName = `template-${getRandomString()}`;
+
+        it('should return an index template with the expected parameters', async () => {
+          const template = getTemplatePayload(indexModeTemplateName, [getRandomString()]);
+          const templateWithIndexMode = {
+            ...template,
+            // For composable templates, only the top-level indexMode is needed.
+            // During serialization, serializeTemplate() will automatically set template.settings.index.mode from this value.
+            indexMode: IndexMode.standard,
+          };
+
+          await createTemplate(templateWithIndexMode).expect(200);
+
+          const { body } = await getOneTemplate(indexModeTemplateName).expect(200);
+          const expectedKeys = [
+            'name',
+            'indexPatterns',
+            'indexMode',
+            'template',
+            'composedOf',
+            'ignoreMissingComponentTemplates',
+            'priority',
+            'version',
+            '_kbnMeta',
+            'allowAutoCreate',
+          ].sort();
+          const expectedTemplateKeys = ['aliases', 'mappings', 'settings'].sort();
+
+          expect(body.name).to.equal(indexModeTemplateName);
+          expect(Object.keys(body).sort()).to.eql(expectedKeys);
+          expect(Object.keys(body.template).sort()).to.eql(expectedTemplateKeys);
+        });
+
+        it('should return a legacy index template with the expected parameters', async () => {
+          const legacyTemplate = getTemplatePayload(
+            indexModeTemplateName,
+            [getRandomString()],
+            true
+          );
+          const legacyTemplateWithIndexMode = {
+            ...legacyTemplate,
+            template: {
+              ...legacyTemplate.template,
+              settings: {
+                ...legacyTemplate.template?.settings,
+                index: {
+                  mode: IndexMode.standard,
+                },
+              },
+            },
+          };
+
+          await createTemplate(legacyTemplateWithIndexMode).expect(200);
+
+          const { body } = await getOneTemplate(indexModeTemplateName, true).expect(200);
+          const expectedKeys = [
+            'name',
+            'indexPatterns',
+            'indexMode',
+            'template',
+            'order',
+            'version',
+            '_kbnMeta',
+            'allowAutoCreate',
+            'composedOf',
+            'ignoreMissingComponentTemplates',
+          ].sort();
+          const expectedTemplateKeys = ['aliases', 'mappings', 'settings'].sort();
+
+          expect(body.name).to.equal(indexModeTemplateName);
+          expect(Object.keys(body).sort()).to.eql(expectedKeys);
+          expect(Object.keys(body.template).sort()).to.eql(expectedTemplateKeys);
+        });
       });
 
       describe('with logs-*-* index pattern', () => {
@@ -250,10 +353,13 @@ export default function ({ getService }: FtrProviderContext) {
         const logsdbSettings: Array<{
           enabled: boolean | null;
           prior_logs_usage: boolean;
-          indexMode: string;
+          indexMode?: string;
         }> = [
           { enabled: true, prior_logs_usage: true, indexMode: 'logsdb' },
-          { enabled: false, prior_logs_usage: true, indexMode: 'standard' },
+          // If the the cluster.logsdb.enabled setting is false, and the settings.index.mode is not set, index mode is undefined
+          { enabled: false, prior_logs_usage: true, indexMode: undefined },
+          // In stateful Kibana, if prior_logs_usage is set to true, the cluster.logsdb.enabled setting is false by default, so index mode is undefined
+          { enabled: null, prior_logs_usage: true, indexMode: undefined },
           // In stateful Kibana, when cluster.logsb.enabled setting is not set, the index mode is always standard
           // For versions 9.0+, if prior_logs_usage is set to false, the cluster.logsdb.enabled setting is true by default, so logsdb index mode
           { enabled: null, prior_logs_usage: true, indexMode: 'standard' },

--- a/x-pack/platform/test/serverless/api_integration/test_suites/index_management/index_templates.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/index_management/index_templates.ts
@@ -6,7 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../ftr_provider_context';
+import { IndexMode } from '@kbn/index-management-plugin/common/constants';
+import type { FtrProviderContext } from '../../ftr_provider_context';
 import type { InternalRequestHeader, RoleCredentials } from '../../../shared/services';
 
 const API_BASE_PATH = '/api/index_management';
@@ -40,20 +41,38 @@ export default function ({ getService }: FtrProviderContext) {
 
     describe('get', () => {
       let templateName: string;
+      let templateWithIndexModeName: string;
 
       before(async () => {
         templateName = `template-${getRandomString()}`;
         const indexTemplate = {
           name: templateName,
           body: {
-            index_patterns: ['test*'],
+            index_patterns: ['a-test*'],
           },
         };
-        // Create a new index template to test against
+
+        templateWithIndexModeName = `template-${getRandomString()}`;
+        const indexTemplateWithIndexMode = {
+          name: templateWithIndexModeName,
+          body: {
+            index_patterns: ['b-test*'],
+          },
+          template: {
+            settings: {
+              index: {
+                mode: IndexMode.standard,
+              },
+            },
+          },
+        };
+
+        // Create a new index templates to test against
         try {
           await es.indices.putIndexTemplate(indexTemplate);
+          await es.indices.putIndexTemplate(indexTemplateWithIndexMode);
         } catch (err) {
-          log.debug('[Setup error] Error creating index template');
+          log.debug('[Setup error] Error creating index templates');
           throw err;
         }
       });
@@ -64,8 +83,11 @@ export default function ({ getService }: FtrProviderContext) {
           await es.indices.deleteIndexTemplate({
             name: templateName,
           });
+          await es.indices.deleteIndexTemplate({
+            name: templateWithIndexModeName,
+          });
         } catch (err) {
-          log.debug('[Cleanup error] Error deleting index template');
+          log.debug('[Cleanup error] Error deleting index templates');
           throw err;
         }
       });
@@ -90,7 +112,6 @@ export default function ({ getService }: FtrProviderContext) {
           const expectedKeys = [
             'name',
             'indexPatterns',
-            'indexMode',
             'hasSettings',
             'hasAliases',
             'hasMappings',
@@ -101,6 +122,40 @@ export default function ({ getService }: FtrProviderContext) {
           ].sort();
 
           expect(Object.keys(indexTemplateFound).sort()).to.eql(expectedKeys);
+        });
+
+        describe('with index mode', () => {
+          it('should list all the index templates with the expected parameters', async () => {
+            const { status, body: allTemplates } = await supertestWithoutAuth
+              .get(`${API_BASE_PATH}/index_templates`)
+              .set(internalReqHeader)
+              .set(roleAuthc.apiKeyHeader);
+            expect(status).to.eql(200);
+
+            // Legacy templates are not applicable on serverless
+            expect(allTemplates.legacyTemplates.length).to.eql(0);
+
+            const indexTemplateFound = allTemplates.templates.find(
+              (template: { name: string }) => template.name === templateWithIndexModeName
+            );
+
+            expect(indexTemplateFound).to.be.ok();
+
+            const expectedKeys = [
+              'name',
+              'indexPatterns',
+              'indexMode',
+              'hasSettings',
+              'hasAliases',
+              'hasMappings',
+              '_kbnMeta',
+              'allowAutoCreate',
+              'composedOf',
+              'ignoreMissingComponentTemplates',
+            ].sort();
+
+            expect(Object.keys(indexTemplateFound).sort()).to.eql(expectedKeys);
+          });
         });
       });
 
@@ -115,7 +170,6 @@ export default function ({ getService }: FtrProviderContext) {
           const expectedKeys = [
             'name',
             'indexPatterns',
-            'indexMode',
             'template',
             '_kbnMeta',
             'allowAutoCreate',
@@ -143,9 +197,9 @@ export default function ({ getService }: FtrProviderContext) {
             await svlTemplatesApi.deleteTemplates([{ name: logsdbTemplateName }], roleAuthc);
           });
 
-          const logsdbSettings: Array<{ enabled: boolean | null; indexMode: string }> = [
+          const logsdbSettings: Array<{ enabled: boolean | null; indexMode?: string }> = [
             { enabled: true, indexMode: 'logsdb' },
-            { enabled: false, indexMode: 'standard' },
+            { enabled: false, indexMode: undefined }, // If the the cluster.logsdb.enabled setting is false, and the settings.index.mode is not set, index mode is undefined
             { enabled: null, indexMode: 'logsdb' }, // In serverless Kibana, the cluster.logsdb.enabled setting is true by default, so logsdb index mode
           ];
 
@@ -170,6 +224,30 @@ export default function ({ getService }: FtrProviderContext) {
               expect(status).to.eql(200);
               expect(body.indexMode).to.equal(indexMode);
             });
+          });
+        });
+
+        describe('with index mode', () => {
+          it('should return an index template with the expected parameters', async () => {
+            const { body, status } = await supertestWithoutAuth
+              .get(`${API_BASE_PATH}/index_templates/${templateWithIndexModeName}`)
+              .set(internalReqHeader)
+              .set(roleAuthc.apiKeyHeader);
+            expect(status).to.eql(200);
+
+            const expectedKeys = [
+              'name',
+              'indexPatterns',
+              'indexMode',
+              'template',
+              '_kbnMeta',
+              'allowAutoCreate',
+              'composedOf',
+              'ignoreMissingComponentTemplates',
+            ].sort();
+
+            expect(body.name).to.eql(templateWithIndexModeName);
+            expect(Object.keys(body).sort()).to.eql(expectedKeys);
           });
         });
       });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Index Management] Don't default index mode to standard and add set index mode toggle in template form (#238883)](https://github.com/elastic/kibana/pull/238883)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Damian Polewski","email":"125268832+damian-polewski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-23T11:10:09Z","message":"[Index Management] Don't default index mode to standard and add set index mode toggle in template form (#238883)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/229990\n\nThis PR:\n\n- Changed the deserialization logic - when\n`template.settings.index.mode` is missing in the index template\ndefinition (+ logdb is disabled or index pattern is not matching\n`logs-*-*`) instead of setting index mode to `standard` we leave it as\n`undefined`.\n- Added a toggle to conditionally show the indexMode field (toggled off\nwhen `indexMode` is `undefined`).","sha":"566e41baa4b9a779368dfb68e61ea7efe8b4fd81","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Index Management","Team:Kibana Management","release_note:skip","backport:all-open","v9.3.0"],"title":"[Index Management] Don't default index mode to standard and add set index mode toggle in template form","number":238883,"url":"https://github.com/elastic/kibana/pull/238883","mergeCommit":{"message":"[Index Management] Don't default index mode to standard and add set index mode toggle in template form (#238883)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/229990\n\nThis PR:\n\n- Changed the deserialization logic - when\n`template.settings.index.mode` is missing in the index template\ndefinition (+ logdb is disabled or index pattern is not matching\n`logs-*-*`) instead of setting index mode to `standard` we leave it as\n`undefined`.\n- Added a toggle to conditionally show the indexMode field (toggled off\nwhen `indexMode` is `undefined`).","sha":"566e41baa4b9a779368dfb68e61ea7efe8b4fd81"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238883","number":238883,"mergeCommit":{"message":"[Index Management] Don't default index mode to standard and add set index mode toggle in template form (#238883)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/229990\n\nThis PR:\n\n- Changed the deserialization logic - when\n`template.settings.index.mode` is missing in the index template\ndefinition (+ logdb is disabled or index pattern is not matching\n`logs-*-*`) instead of setting index mode to `standard` we leave it as\n`undefined`.\n- Added a toggle to conditionally show the indexMode field (toggled off\nwhen `indexMode` is `undefined`).","sha":"566e41baa4b9a779368dfb68e61ea7efe8b4fd81"}},{"url":"https://github.com/elastic/kibana/pull/240261","number":240261,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->