### PR TITLE
[Discover][Unified Traces] Improve Unified Traces API call latencies

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/route.ts
@@ -137,29 +137,23 @@ const unifiedTracesByIdRoute = createApmServerRoute({
   ): Promise<{
     traceItems: TraceItem[];
   }> => {
-    const apmEventClient = await getApmEventClient(resources);
-    const logsClient = await createLogsClient(resources);
+    const [apmEventClient, logsClient] = await Promise.all([
+      getApmEventClient(resources),
+      createLogsClient(resources),
+    ]);
 
     const { params, config } = resources;
     const { traceId } = params.path;
     const { start, end } = params.query;
 
-    const unifiedTraceErrors = await getUnifiedTraceErrors({
+    const { traceItems } = await getUnifiedTraceItems({
       apmEventClient,
       logsClient,
       traceId,
       start,
       end,
-    });
-
-    const traceItems = await getUnifiedTraceItems({
-      apmEventClient,
-      traceId,
-      start,
-      end,
       maxTraceItemsFromUrlParam: params.query.maxTraceItems,
       config,
-      unifiedTraceErrors,
     });
 
     return {
@@ -183,30 +177,24 @@ const unifiedTracesByIdSummaryRoute = createApmServerRoute({
     traceItems?: FocusedTraceItems;
     summary: { services: number; traceEvents: number; errors: number };
   }> => {
-    const apmEventClient = await getApmEventClient(resources);
-    const logsClient = await createLogsClient(resources);
+    const [apmEventClient, logsClient] = await Promise.all([
+      getApmEventClient(resources),
+      createLogsClient(resources),
+    ]);
 
     const { params, config } = resources;
     const { traceId } = params.path;
     const { start, end, docId } = params.query;
 
-    const unifiedTraceErrors = await getUnifiedTraceErrors({
-      apmEventClient,
-      logsClient,
-      traceId,
-      start,
-      end,
-    });
-
-    const [traceItems, traceSummaryCount] = await Promise.all([
+    const [{ traceItems, unifiedTraceErrors }, traceSummaryCount] = await Promise.all([
       getUnifiedTraceItems({
         apmEventClient,
+        logsClient,
         traceId,
         start,
         end,
         maxTraceItemsFromUrlParam: params.query.maxTraceItems,
         config,
-        unifiedTraceErrors,
       }),
       getTraceSummaryCount({ apmEventClient, start, end, traceId }),
     ]);
@@ -233,8 +221,10 @@ const unifiedTracesByIdErrorsRoute = createApmServerRoute({
   }),
   security: { authz: { requiredPrivileges: ['apm'] } },
   handler: async (resources): Promise<ErrorsByTraceId> => {
-    const apmEventClient = await getApmEventClient(resources);
-    const logsClient = await createLogsClient(resources);
+    const [apmEventClient, logsClient] = await Promise.all([
+      getApmEventClient(resources),
+      createLogsClient(resources),
+    ]);
 
     const { params } = resources;
     const { traceId } = params.path;


### PR DESCRIPTION
## Summary

In some of the Unified Trace API calls, there are various async calls being made sequentially when they could in fact be made concurrently. This PR fixes that by making these small improvements to make various calls concurrent where possible and thus avoiding the added latency.

These changes were benchmarked and for the unified trace call, it has the following profile: the first time is the elapsed time for getting the APM and Logs clients, and the second time is the total time elapsed with the full response returned:

BEFORE:
```
clients: 648.295ms
response: 1.165s

clients: 653.911ms
response: 1.166s

clients: 649.343ms
response: 1.328s
```

AFTER:
```
clients: 335.631ms
response: 836.463ms

clients: 332.548ms
response: 669.448ms

clients: 325.188ms
response: 820.929ms
```

## How to test

- Go to Discover page in Observability mode, select a trace index in either classic or ES|QL mode
- Going to a trace overview, the focused trace waterfall and the full trace waterfall views should not regress in functionality or error unexpectedly.



<!--ONMERGE {"backportTargets":["8.19","9.0","9.1","9.2"]} ONMERGE-->