### PR TITLE
[Search] Getting started page footer section

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -202,6 +202,10 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       customerEngineerRequestForm: `${ELASTIC_WEBSITE_URL}contact/ce-help`,
       elasticCommunity: `${ELASTIC_WEBSITE_URL}community/`,
     },
+    searchGettingStarted: {
+      visitSearchLabs: `${ELASTIC_WEBSITE_URL}search-labs`,
+      notebooksExamples: `${ELASTIC_WEBSITE_URL}search-labs/tutorials/examples`,
+    },
     metricbeat: {
       base: `${ELASTIC_DOCS}reference/beats/metricbeat`,
       configure: `${ELASTIC_DOCS}reference/beats/metricbeat/configuring-howto-metricbeat`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -88,6 +88,10 @@ export interface DocLinks {
     readonly customerEngineerRequestForm: string;
     readonly elasticCommunity: string;
   };
+  readonly searchGettingStarted: {
+    readonly visitSearchLabs: string;
+    readonly notebooksExamples: string;
+  };
   readonly metricbeat: {
     readonly base: string;
     readonly configure: string;

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React, { useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
@@ -25,22 +25,16 @@ export const SearchGettingStartedConnectCode = () => {
   return (
     <>
       <EuiFlexGroup alignItems="center">
-        <EuiFlexItem>
-          <SearchGettingStartedSectionHeading
-            icon="plugs"
-            title={i18n.translate('xpack.search.gettingStarted.page.codeExample.title', {
-              defaultMessage: 'Connect to your application',
-            })}
-          />
-          <EuiSpacer size="s" />
-          <EuiText size="s" color="subdued" grow={false}>
-            <p>
-              {i18n.translate('xpack.search.gettingStarted.page.codeExample.description', {
-                defaultMessage: 'Choose a language client and connect your application.',
-              })}
-            </p>
-          </EuiText>
-        </EuiFlexItem>
+        <SearchGettingStartedSectionHeading
+          icon="plugs"
+          title={i18n.translate('xpack.search.gettingStarted.page.codeExample.title', {
+            defaultMessage: 'Connect to your application',
+          })}
+          description={i18n.translate('xpack.search.gettingStarted.page.codeExample.description', {
+            defaultMessage: 'Choose a language client and connect your application.',
+          })}
+        />
+
         <EuiFlexItem
           grow={false}
           css={css`

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/doc_callouts.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/doc_callouts.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButtonEmpty, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import React from 'react';
+
+export interface DocCalloutsProps {
+  title: string;
+  description: string;
+  buttonHref: string;
+  buttonLabel: string;
+  dataTestSubj: string;
+}
+
+export const DocCallouts: React.FC<DocCalloutsProps> = ({
+  title,
+  description,
+  buttonHref,
+  buttonLabel,
+  dataTestSubj,
+}) => {
+  return (
+    <>
+      <EuiTitle size="xxs">
+        <h4>{title}</h4>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued">
+        <p>{description}</p>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <span>
+        <EuiButtonEmpty
+          href={buttonHref}
+          iconType="popout"
+          iconSide="right"
+          flush="left"
+          data-test-subj={dataTestSubj}
+          aria-label={buttonLabel}
+        >
+          {buttonLabel}
+        </EuiButtonEmpty>
+      </span>
+    </>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/doc_links.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/doc_links.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DocLinks } from '@kbn/doc-links';
+
+class ESDocLinks {
+  public visitSearchLabs: string = '';
+  public notebooksExamples: string = '';
+  public elasticsearchDocs: string = '';
+
+  constructor() {}
+
+  setDocLinks(newDocLinks: DocLinks) {
+    this.elasticsearchDocs = newDocLinks.elasticsearch.gettingStarted;
+    this.visitSearchLabs = newDocLinks.searchGettingStarted.visitSearchLabs;
+    this.notebooksExamples = newDocLinks.searchGettingStarted.notebooksExamples;
+  }
+}
+
+export const docLinks = new ESDocLinks();

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/footer_links.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/footer_links.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { docLinks } from './doc_links';
+
+export interface DocLinkItem {
+  id: string;
+  title: string;
+  description: string;
+  buttonLabel: string;
+  buttonHref: string;
+  dataTestSubj: string;
+}
+
+export const footerLinks: DocLinkItem[] = [
+  {
+    id: 'searchLabs',
+    title: i18n.translate('xpack.gettingStarted.searchLabs.title', {
+      defaultMessage: 'Search Labs',
+    }),
+    description: i18n.translate('xpack.gettingStarted.searchLabs.description', {
+      defaultMessage:
+        'Explore the latest articles and tutorials on using Elasticsearch for AI/ML-powered search experiences.',
+    }),
+    buttonLabel: i18n.translate('xpack.gettingStarted.searchLabs.buttonText', {
+      defaultMessage: 'Visit Elasticsearch Labs',
+    }),
+    buttonHref: docLinks.visitSearchLabs,
+    dataTestSubj: 'gettingStartedSearchLabsButton',
+  },
+  {
+    id: 'pythonNotebooks',
+    title: i18n.translate('xpack.gettingStarted.pythonNotebooks.title', {
+      defaultMessage: 'Python notebooks',
+    }),
+    description: i18n.translate('xpack.gettingStarted.pythonNotebooks.description', {
+      defaultMessage:
+        'A range of executable Python notebooks available to easily test features in a virtual environment.',
+    }),
+    buttonLabel: i18n.translate('xpack.gettingStarted.pythonNotebooks.buttonText', {
+      defaultMessage: 'Browse our notebooks',
+    }),
+    buttonHref: docLinks.notebooksExamples,
+    dataTestSubj: 'gettingStartedOpenNotebooksButton',
+  },
+  {
+    id: 'elasticsearchDocs',
+    title: i18n.translate('xpack.gettingStarted.elasticsearchDocs.title', {
+      defaultMessage: 'Elasticsearch documentation',
+    }),
+    description: i18n.translate('xpack.gettingStarted.elasticsearchDocumentation.description', {
+      defaultMessage:
+        'Comprehensive reference material to help you learn, build, and deploy search solutions with Elasticsearch.',
+    }),
+    buttonLabel: i18n.translate('xpack.gettingStarted.elasticsearchDocumentation.buttonText', {
+      defaultMessage: 'View documentation',
+    }),
+    buttonHref: docLinks.elasticsearchDocs,
+    dataTestSubj: 'gettingStartedViewDocumentationButton',
+  },
+];

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/index.tsx
@@ -35,6 +35,7 @@ export const GettingStartedFooter = () => {
           </EuiFlexItem>
         ))}
       </EuiFlexGroup>
+      <EuiSpacer size="xxl" />
     </>
   );
 };

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/index.tsx
@@ -28,7 +28,7 @@ export const GettingStartedFooter = () => {
       <EuiFlexGroup direction={'column'} justifyContent="spaceBetween" gutterSize="l">
         <SearchGettingStartedSectionHeading
           title={i18n.translate('xpack.searchGettingStarted.footer.label', {
-            defaultMessage: 'Dive Deeper with Elasticsearch',
+            defaultMessage: 'Dive deeper with Elasticsearch',
           })}
           icon="documentation"
           description={i18n.translate('xpack.searchGettingStarted.footer.description', {

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/index.tsx
@@ -13,42 +13,27 @@ import {
   EuiSpacer,
   useCurrentEuiBreakpoint,
 } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { DocCallouts } from './doc_callouts';
-import { SearchGettingStartedSectionHeading } from '../section_heading';
 import { footerLinks } from './footer_links';
 
 export const GettingStartedFooter = () => {
   const currentBreakpoint = useCurrentEuiBreakpoint();
   return (
     <>
-      <EuiSpacer size="xxl" />
       <EuiHorizontalRule />
       <EuiSpacer size="xxl" />
-      <EuiFlexGroup direction={'column'} justifyContent="spaceBetween" gutterSize="l">
-        <SearchGettingStartedSectionHeading
-          title={i18n.translate('xpack.searchGettingStarted.footer.label', {
-            defaultMessage: 'Dive deeper with Elasticsearch',
-          })}
-          icon="documentation"
-          description={i18n.translate('xpack.searchGettingStarted.footer.description', {
-            defaultMessage:
-              'Explore our resources to expand your knowledge and build advanced search solutions.',
-          })}
-        />
-        <EuiFlexGroup direction={currentBreakpoint === 'xl' ? 'row' : 'column'}>
-          {footerLinks.map((item) => (
-            <EuiFlexItem key={item.id} data-test-subj={`${item.id}Section`}>
-              <DocCallouts
-                title={item.title}
-                description={item.description}
-                buttonHref={item.buttonHref}
-                buttonLabel={item.buttonLabel}
-                dataTestSubj={item.dataTestSubj}
-              />
-            </EuiFlexItem>
-          ))}
-        </EuiFlexGroup>
+      <EuiFlexGroup direction={currentBreakpoint === 'xl' ? 'row' : 'column'}>
+        {footerLinks.map((item) => (
+          <EuiFlexItem key={item.id} data-test-subj={`${item.id}Section`}>
+            <DocCallouts
+              title={item.title}
+              description={item.description}
+              buttonHref={item.buttonHref}
+              buttonLabel={item.buttonLabel}
+              dataTestSubj={item.dataTestSubj}
+            />
+          </EuiFlexItem>
+        ))}
       </EuiFlexGroup>
     </>
   );

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/index.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiSpacer,
+  useCurrentEuiBreakpoint,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { DocCallouts } from './doc_callouts';
+import { SearchGettingStartedSectionHeading } from '../section_heading';
+import { footerLinks } from './footer_links';
+
+export const GettingStartedFooter = () => {
+  const currentBreakpoint = useCurrentEuiBreakpoint();
+  return (
+    <>
+      <EuiSpacer size="xxl" />
+      <EuiHorizontalRule />
+      <EuiSpacer size="xxl" />
+      <EuiFlexGroup direction={'column'} justifyContent="spaceBetween" gutterSize="l">
+        <SearchGettingStartedSectionHeading
+          title={i18n.translate('xpack.searchGettingStarted.footer.label', {
+            defaultMessage: 'Dive Deeper with Elasticsearch',
+          })}
+          icon="documentation"
+          description={i18n.translate('xpack.searchGettingStarted.footer.description', {
+            defaultMessage:
+              'Explore our resources to expand your knowledge and build advanced search solutions.',
+          })}
+        />
+        <EuiFlexGroup direction={currentBreakpoint === 'xl' ? 'row' : 'column'}>
+          {footerLinks.map((item) => (
+            <EuiFlexItem key={item.id} data-test-subj={`${item.id}Section`}>
+              <DocCallouts
+                title={item.title}
+                description={item.description}
+                buttonHref={item.buttonHref}
+                buttonLabel={item.buttonLabel}
+                dataTestSubj={item.dataTestSubj}
+              />
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
+      </EuiFlexGroup>
+    </>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
@@ -14,6 +14,7 @@ import { useUsageTracker } from '../contexts/usage_tracker_context';
 import { SearchGettingStartedPageTemplate } from '../layout/page_template';
 import { ConsoleTutorialsGroup } from './tutorials/console_tutorials_group';
 import { SearchGettingStartedConnectCode } from './connect_code';
+import { GettingStartedFooter } from './footer';
 
 export const SearchGettingStartedPage: React.FC = () => {
   const usageTracker = useUsageTracker();
@@ -35,6 +36,9 @@ export const SearchGettingStartedPage: React.FC = () => {
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section data-test-subj="search-getting-code-example">
         <SearchGettingStartedConnectCode />
+      </EuiPageTemplate.Section>
+      <EuiPageTemplate.Section paddingSize="xl">
+        <GettingStartedFooter />
       </EuiPageTemplate.Section>
     </SearchGettingStartedPageTemplate>
   );

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
@@ -37,7 +37,7 @@ export const SearchGettingStartedPage: React.FC = () => {
       <EuiPageTemplate.Section data-test-subj="search-getting-code-example">
         <SearchGettingStartedConnectCode />
       </EuiPageTemplate.Section>
-      <EuiPageTemplate.Section paddingSize="xl">
+      <EuiPageTemplate.Section>
         <GettingStartedFooter />
       </EuiPageTemplate.Section>
     </SearchGettingStartedPageTemplate>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/section_heading/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/section_heading/index.tsx
@@ -5,25 +5,35 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiTitle, EuiIcon } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiTitle, EuiIcon, EuiText } from '@elastic/eui';
 
 interface Props {
   title: string;
   icon: string;
+  description: string;
 }
 
-export const SearchGettingStartedSectionHeading = ({ title, icon }: Props) => {
+export const SearchGettingStartedSectionHeading = ({ title, icon, description }: Props) => {
   return (
-    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+    <EuiFlexGroup gutterSize="xs" direction={'column'} justifyContent="spaceBetween">
       <EuiFlexItem grow={false}>
-        <EuiPanel color="subdued" paddingSize="s" grow={false}>
-          <EuiIcon type={icon} size="m" />
-        </EuiPanel>
+        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiPanel color="subdued" paddingSize="s" grow={false}>
+              <EuiIcon type={icon} size="m" />
+            </EuiPanel>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiTitle size="xs">
+              <h2>{title}</h2>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiTitle size="xs">
-          <h2>{title}</h2>
-        </EuiTitle>
+      <EuiFlexItem grow={false}>
+        <EuiText size="s" color="subdued" grow={false}>
+          <p>{description}</p>
+        </EuiText>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
@@ -94,7 +94,7 @@ export const ConsoleTutorialsGroup = () => {
         icon={commandLineIllustration}
         description={i18n.translate('xpack.searchGettingStarted.consoleTutorials.description', {
           defaultMessage:
-            'Choose a tutorial and use Console to quickly start interacting with the elasticsearch API.',
+            'Choose a tutorial and use Console to quickly start interacting with the Elasticsearch API.',
         })}
       />
       <EuiFlexItem grow={false}>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
@@ -87,24 +87,16 @@ export const ConsoleTutorialsGroup = () => {
 
   return (
     <EuiFlexGroup gutterSize="l" direction={'column'} justifyContent="spaceBetween">
-      <EuiFlexGroup gutterSize="xs" direction={'column'} justifyContent="spaceBetween">
-        <EuiFlexItem grow={false}>
-          <SearchGettingStartedSectionHeading
-            title={i18n.translate('xpack.searchGettingStarted.consoleTutorials.label', {
-              defaultMessage: 'Explore the API',
-            })}
-            icon={commandLineIllustration}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiText color="subdued" size="s">
-            <FormattedMessage
-              id="xpack.searchGettingStarted.consoleTutorials.description"
-              defaultMessage="Choose a tutorial and use Console to quickly start interacting with the elasticsearch API."
-            />
-          </EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <SearchGettingStartedSectionHeading
+        title={i18n.translate('xpack.searchGettingStarted.consoleTutorials.label', {
+          defaultMessage: 'Explore the API',
+        })}
+        icon={commandLineIllustration}
+        description={i18n.translate('xpack.searchGettingStarted.consoleTutorials.description', {
+          defaultMessage:
+            'Choose a tutorial and use Console to quickly start interacting with the elasticsearch API.',
+        })}
+      />
       <EuiFlexItem grow={false}>
         <EuiFlexGroup gutterSize="l" justifyContent="spaceBetween">
           {tutorials.map((tutorial) => (

--- a/x-pack/solutions/search/plugins/search_getting_started/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_getting_started/tsconfig.json
@@ -30,6 +30,7 @@
     "@kbn/search-shared-ui",
     "@kbn/search-code-examples",
     "@kbn/search-api-keys-components",
+    "@kbn/doc-links",
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/11474

## Summary

This PR adds the footer section for the Getting Started page, the section titled "Dive Deeper with Elasticsearch". 
**NOTE**: Spacing to be fixed once all the sections are put together.

The `SearchGettingStartedSectionHeading` component has also been updated to take a description, as this code was being repeated for each section it was used in.

The plugin is disabled behind kibana config. To test locally: `xpack.searchGettingStarted.enabled: true`

Designs: https://www.figma.com/design/CDZUrXVD7gplkfitcJIqjM/FY26-Onboarding-Updates---11462-?node-id=5622-59911&m=dev

<img width="1508" height="782" alt="Screenshot 2025-10-24 at 10 42 00" src="https://github.com/user-attachments/assets/dbd0542c-24be-4c05-b564-532de49dc574" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~
