### PR TITLE
[9.2] [dashboard as code] fix references for the links panel are passed when updating a dashboard (#239804)

### DIFF
--- a/src/platform/plugins/private/links/common/embeddable/transforms/transforms.ts
+++ b/src/platform/plugins/private/links/common/embeddable/transforms/transforms.ts
@@ -11,6 +11,7 @@ import { transformIn } from './transform_in';
 import { transformOut } from './transform_out';
 
 export const transforms = {
+  transformOutInjectsReferences: true,
   transformIn,
   transformOut,
 };

--- a/src/platform/plugins/shared/dashboard/common/reference_utils.ts
+++ b/src/platform/plugins/shared/dashboard/common/reference_utils.ts
@@ -11,6 +11,11 @@ import type { Reference } from '@kbn/content-management-utils';
 
 const controlGroupReferencePrefix = 'controlGroup_';
 
+export const getPanelIdFromReference = (reference: Reference) => {
+  const splits = reference.name.split(':', 1);
+  return splits.length ? splits[0] : undefined;
+};
+
 export const getReferencesForPanelId = (id: string, references: Reference[]): Reference[] => {
   const prefix = `${id}:`;
   const filteredReferences = references

--- a/src/platform/plugins/shared/dashboard/server/content_management/v1/transform_utils.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v1/transform_utils.ts
@@ -63,7 +63,7 @@ export function savedObjectToItem(
   try {
     const dashboardState = transformDashboardOut(attributes, savedObject.references);
 
-    const references = transformReferencesOut(savedObject.references ?? []);
+    const references = transformReferencesOut(savedObject.references ?? [], dashboardState.panels);
 
     return {
       item: {

--- a/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_references_out.test.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_references_out.test.ts
@@ -75,7 +75,7 @@ describe('transformReferencesOut', () => {
         transformReferencesOut(references, [
           {
             config: {},
-            grid: { x: 0, y: 0, w: 24, h: 15 },
+            grid: { x: 0, y: 0, w: 24, h: 15, i: 'panel1' },
             uid: 'panel1',
             type: 'someType',
           },
@@ -100,7 +100,7 @@ describe('transformReferencesOut', () => {
         transformReferencesOut(references, [
           {
             config: {},
-            grid: { x: 0, y: 0, w: 24, h: 15 },
+            grid: { x: 0, y: 0, w: 24, h: 15, i: 'panel1' },
             uid: 'panel1',
             type: 'someType',
           },

--- a/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_references_out.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_references_out.ts
@@ -29,7 +29,9 @@ export function transformReferencesOut(
   }
   (panels ?? []).forEach((panel) => {
     if (isDashboardSection(panel)) {
-      panel.panels.forEach((panelInSection) => setDropRefsForPanel(panelInSection));
+      panel.panels.forEach((panelInSection) =>
+        setDropRefsForPanel(panelInSection as DashboardPanel)
+      );
     } else {
       setDropRefsForPanel(panel);
     }

--- a/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_references_out.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_references_out.ts
@@ -8,11 +8,44 @@
  */
 
 import type { SavedObjectReference } from '@kbn/core/server';
+import type { DashboardAttributes, DashboardPanel } from '../../types';
+import { isDashboardSection } from '../../../../../common';
+import { embeddableService } from '../../../../kibana_services';
+import { getPanelIdFromReference } from '../../../../../common/reference_utils';
 
-export function transformReferencesOut(references: SavedObjectReference[]): SavedObjectReference[] {
-  return references.map((ref) => {
-    return isLegacySavedObjectRef(ref) ? transformLegacySavedObjectRef(ref) : ref;
+export function transformReferencesOut(
+  references: SavedObjectReference[],
+  panels?: DashboardAttributes['panels']
+): SavedObjectReference[] {
+  // key: panel uid
+  // value: boolean indicating to drop references for panel
+  // because transformOut injected references serverside
+  // TODO - remove when all references are handled on server
+  const dropRefsForPanel: Record<string, boolean> = {};
+  function setDropRefsForPanel(panel: DashboardPanel) {
+    if (!panel.uid) return;
+    const { transformOutInjectsReferences } = embeddableService?.getTransforms(panel.type) ?? {};
+    dropRefsForPanel[panel.uid] = Boolean(transformOutInjectsReferences);
+  }
+  (panels ?? []).forEach((panel) => {
+    if (isDashboardSection(panel)) {
+      panel.panels.forEach((panelInSection) => setDropRefsForPanel(panelInSection));
+    } else {
+      setDropRefsForPanel(panel);
+    }
   });
+
+  return references
+    .map((ref) => {
+      return isLegacySavedObjectRef(ref) ? transformLegacySavedObjectRef(ref) : ref;
+    })
+    .filter((ref) => {
+      const panelId = getPanelIdFromReference(ref);
+      return panelId && dropRefsForPanel[panelId]
+        ? // drop references for panels that inject references on server
+          false
+        : true;
+    });
 }
 
 // < 9.2 legach saved object ref name shape `${panelId}:panel_${panelId}`

--- a/src/platform/plugins/shared/embeddable/common/types.ts
+++ b/src/platform/plugins/shared/embeddable/common/types.ts
@@ -14,6 +14,12 @@ export type EmbeddableTransforms<
   EmbeddableState extends object = object
 > = {
   /**
+   * Temporary flag indicating transformOut injects references
+   * When true, container REST API responses will drop references for panels that use transformOut
+   * TODO: remove once all reference injection is done in server
+   */
+  transformOutInjectsReferences?: boolean;
+  /**
    * Converts StoredEmbeddableState and injects references into EmbeddableState
    */
   transformOut?: (storedState: StoredEmbeddableState, references?: Reference[]) => EmbeddableState;

--- a/src/platform/plugins/shared/visualizations/common/embeddable/transforms/get_transforms.ts
+++ b/src/platform/plugins/shared/visualizations/common/embeddable/transforms/get_transforms.ts
@@ -16,6 +16,7 @@ export function getTransforms(
   transformEnhancementsOut: EnhancementsRegistry['transformOut']
 ) {
   return {
+    transformOutInjectsReferences: true,
     transformIn: getTransformIn(transformEnhancementsIn),
     transformOut: getTransformOut(transformEnhancementsOut),
   };

--- a/x-pack/platform/plugins/shared/maps/common/embeddable/transforms/get_transforms.ts
+++ b/x-pack/platform/plugins/shared/maps/common/embeddable/transforms/get_transforms.ts
@@ -14,6 +14,7 @@ export function getTransforms(
   transformEnhancementsOut: EnhancementsRegistry['transformOut']
 ) {
   return {
+    transformOutInjectsReferences: true,
     transformIn: getTransformIn(transformEnhancementsIn),
     transformOut: getTransformOut(transformEnhancementsOut),
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[dashboard as code] fix references for the links panel are passed when updating a dashboard (#239804)](https://github.com/elastic/kibana/pull/239804)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2025-10-23T13:19:04Z","message":"[dashboard as code] fix references for the links panel are passed when updating a dashboard (#239804)\n\nCloses https://github.com/elastic/kibana/issues/239367\n\nIssue caused because server returns references for all panels. Then,\nwhen dashboard is saved, panel state provided by server is returned.\nThis caused the references to be passed back to the server. The reason\nclient passes back panel state provided by the server is that client can\nnot call embeddableApi.serializeState when serializing a dashboard since\nembeddableApi does not exist for embeddables in collapsed sections.\n`embeddableApi.serializeState` is only called when an embeddable reports\nunsaved changes.\n\nResolves issue by dropping references for panels that inject references\nserver side. This way, references are never passed to the client.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7fdb0b22b5dd58935e3e2b9a36462ec7d52e2bad","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Embedding","Team:Presentation","release_note:skip","backport:version","Project:Dashboards API","v9.2.0","v9.3.0"],"title":"[dashboard as code] fix references for the links panel are passed when updating a dashboard","number":239804,"url":"https://github.com/elastic/kibana/pull/239804","mergeCommit":{"message":"[dashboard as code] fix references for the links panel are passed when updating a dashboard (#239804)\n\nCloses https://github.com/elastic/kibana/issues/239367\n\nIssue caused because server returns references for all panels. Then,\nwhen dashboard is saved, panel state provided by server is returned.\nThis caused the references to be passed back to the server. The reason\nclient passes back panel state provided by the server is that client can\nnot call embeddableApi.serializeState when serializing a dashboard since\nembeddableApi does not exist for embeddables in collapsed sections.\n`embeddableApi.serializeState` is only called when an embeddable reports\nunsaved changes.\n\nResolves issue by dropping references for panels that inject references\nserver side. This way, references are never passed to the client.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7fdb0b22b5dd58935e3e2b9a36462ec7d52e2bad"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/240292","number":240292,"state":"OPEN"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239804","number":239804,"mergeCommit":{"message":"[dashboard as code] fix references for the links panel are passed when updating a dashboard (#239804)\n\nCloses https://github.com/elastic/kibana/issues/239367\n\nIssue caused because server returns references for all panels. Then,\nwhen dashboard is saved, panel state provided by server is returned.\nThis caused the references to be passed back to the server. The reason\nclient passes back panel state provided by the server is that client can\nnot call embeddableApi.serializeState when serializing a dashboard since\nembeddableApi does not exist for embeddables in collapsed sections.\n`embeddableApi.serializeState` is only called when an embeddable reports\nunsaved changes.\n\nResolves issue by dropping references for panels that inject references\nserver side. This way, references are never passed to the client.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7fdb0b22b5dd58935e3e2b9a36462ec7d52e2bad"}}]}] BACKPORT-->