### PR TITLE
[APM] Unskip integration tests and skip only the failing ones

### DIFF
--- a/x-pack/solutions/observability/test/apm_api_integration/tests/fleet/apm_package_policy.spec.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/fleet/apm_package_policy.spec.ts
@@ -108,7 +108,9 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
     return res.total as number;
   }
 
-  registry.when('APM package policy', { config: 'basic', archives: [] }, () => {
+  // Failing: See https://github.com/elastic/kibana/issues/229299
+  // Failing: See https://github.com/elastic/kibana/issues/228131
+  registry.when.skip('APM package policy', { config: 'basic', archives: [] }, () => {
     let apmPackagePolicy: PackagePolicy;
     let agentPolicyId: string;
     let packagePolicyId: string;

--- a/x-pack/solutions/observability/test/apm_api_integration/tests/fleet/migration_check.spec.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/fleet/migration_check.spec.ts
@@ -23,7 +23,8 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
   const bettertest = getBettertest(supertest);
   const apmApiClient = getService('apmApiClient');
 
-  registry.when('Fleet migration check - basic', { config: 'basic', archives: [] }, () => {
+  // Failing: See https://github.com/elastic/kibana/issues/229299
+  registry.when.skip('Fleet migration check - basic', { config: 'basic', archives: [] }, () => {
     before(async () => {
       await setupFleet(bettertest);
     });
@@ -43,7 +44,7 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
       await setupFleet(bettertest);
     });
 
-    describe('migration check properties', () => {
+    describe.skip('migration check properties', () => {
       it('should contain all expected properties', async () => {
         const { status, body } = await bettertest({
           pathname: '/internal/apm/fleet/migration_check',

--- a/x-pack/solutions/observability/test/apm_api_integration/tests/index.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/index.ts
@@ -29,8 +29,7 @@ export default function apmApiIntegrationTests({ getService, loadTestFile }: Ftr
   // DO NOT SKIP
   // Skipping here will skip the entire apm api test suite
   // Instead skip (flaky) tests individually
-  // Failing: See https://github.com/elastic/kibana/issues/229299
-  describe.skip('APM API tests', function () {
+  describe('APM API tests', function () {
     const filePattern = getGlobPattern();
     const tests = globby.sync(filePattern, { cwd });
 


### PR DESCRIPTION
## Summary

This PR unskips the APM integration tests skipped in #229299 and skips only the failing ones.



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->