### PR TITLE
[8.19] [Discover][Unified Traces] Improve Unified Traces API call latencies (#240285)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
@@ -29,7 +29,8 @@ import {
 import { asMutableArray } from '../../../common/utils/as_mutable_array';
 import type { TraceItem } from '../../../common/waterfall/unified_trace_item';
 import { MAX_ITEMS_PER_PAGE } from './get_trace_items';
-import type { UnifiedTraceErrors } from './get_unified_trace_errors';
+import { getUnifiedTraceErrors, type UnifiedTraceErrors } from './get_unified_trace_errors';
+import type { LogsClient } from '../../lib/helpers/create_es_client/create_logs_client';
 
 const fields = asMutableArray(['@timestamp', 'trace.id', 'service.name'] as const);
 
@@ -72,25 +73,33 @@ export function getErrorCountByDocId(unifiedTraceErrors: UnifiedTraceErrors) {
  */
 export async function getUnifiedTraceItems({
   apmEventClient,
+  logsClient,
   maxTraceItemsFromUrlParam,
   traceId,
   start,
   end,
   config,
-  unifiedTraceErrors,
 }: {
   apmEventClient: APMEventClient;
+  logsClient: LogsClient;
   maxTraceItemsFromUrlParam?: number;
   traceId: string;
   start: number;
   end: number;
   config: APMConfig;
-  unifiedTraceErrors: UnifiedTraceErrors;
-}): Promise<TraceItem[]> {
+}): Promise<{ traceItems: TraceItem[]; unifiedTraceErrors: UnifiedTraceErrors }> {
   const maxTraceItems = maxTraceItemsFromUrlParam ?? config.ui.maxTraceItems;
   const size = Math.min(maxTraceItems, MAX_ITEMS_PER_PAGE);
 
-  const response = await apmEventClient.search(
+  const unifiedTraceErrorsPromise = getUnifiedTraceErrors({
+    apmEventClient,
+    logsClient,
+    traceId,
+    start,
+    end,
+  });
+
+  const unifiedTracePromise = apmEventClient.search(
     'get_unified_trace_items',
     {
       apm: {
@@ -137,34 +146,42 @@ export async function getUnifiedTraceItems({
     { skipProcessorEventFilter: true }
   );
 
+  const [unifiedTraceErrors, unifiedTraceItems] = await Promise.all([
+    unifiedTraceErrorsPromise,
+    unifiedTracePromise,
+  ]);
+
   const errorCountByDocId = getErrorCountByDocId(unifiedTraceErrors);
 
-  return response.hits.hits
-    .map((hit) => {
-      const event = unflattenKnownApmEventFields(hit.fields, fields);
-      const apmDuration = event.span?.duration?.us || event.transaction?.duration?.us;
-      const id = event.span?.id || event.transaction?.id;
-      if (!id) {
-        return undefined;
-      }
+  return {
+    traceItems: unifiedTraceItems.hits.hits
+      .map((hit) => {
+        const event = unflattenKnownApmEventFields(hit.fields, fields);
+        const apmDuration = event.span?.duration?.us || event.transaction?.duration?.us;
+        const id = event.span?.id || event.transaction?.id;
+        if (!id) {
+          return undefined;
+        }
 
-      const docErrorCount = errorCountByDocId[id] || 0;
-      return {
-        id: event.span?.id ?? event.transaction?.id,
-        timestampUs: event.timestamp?.us ?? toMicroseconds(event[AT_TIMESTAMP]),
-        name: event.span?.name ?? event.transaction?.name,
-        traceId: event.trace.id,
-        duration: resolveDuration(apmDuration, event.duration),
-        hasError:
-          docErrorCount > 0 ||
-          (event.status?.code && Array.isArray(event.status.code)
-            ? event.status.code[0] === 'Error'
-            : false),
-        parentId: event.parent?.id,
-        serviceName: event.service.name,
-      } as TraceItem;
-    })
-    .filter((_) => _) as TraceItem[];
+        const docErrorCount = errorCountByDocId[id] || 0;
+        return {
+          id: event.span?.id ?? event.transaction?.id,
+          timestampUs: event.timestamp?.us ?? toMicroseconds(event[AT_TIMESTAMP]),
+          name: event.span?.name ?? event.transaction?.name,
+          traceId: event.trace.id,
+          duration: resolveDuration(apmDuration, event.duration),
+          hasError:
+            docErrorCount > 0 ||
+            (event.status?.code && Array.isArray(event.status.code)
+              ? event.status.code[0] === 'Error'
+              : false),
+          parentId: event.parent?.id,
+          serviceName: event.service.name,
+        } as TraceItem;
+      })
+      .filter((_) => _) as TraceItem[],
+    unifiedTraceErrors,
+  };
 }
 
 /**

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/route.ts
@@ -35,7 +35,6 @@ import type { TraceSamplesResponse } from './get_trace_samples_by_query';
 import { getTraceSamplesByQuery } from './get_trace_samples_by_query';
 import { getTraceSummaryCount } from './get_trace_summary_count';
 import { getUnifiedTraceItems } from './get_unified_trace_items';
-import { getUnifiedTraceErrors } from './get_unified_trace_errors';
 import { createLogsClient } from '../../lib/helpers/create_es_client/create_logs_client';
 
 const tracesRoute = createApmServerRoute({
@@ -141,29 +140,23 @@ const unifiedTracesByIdRoute = createApmServerRoute({
   ): Promise<{
     traceItems: TraceItem[];
   }> => {
-    const apmEventClient = await getApmEventClient(resources);
-    const logsClient = await createLogsClient(resources);
+    const [apmEventClient, logsClient] = await Promise.all([
+      getApmEventClient(resources),
+      createLogsClient(resources),
+    ]);
 
     const { params, config } = resources;
     const { traceId } = params.path;
     const { start, end } = params.query;
 
-    const unifiedTraceErrors = await getUnifiedTraceErrors({
+    const { traceItems } = await getUnifiedTraceItems({
       apmEventClient,
       logsClient,
       traceId,
       start,
       end,
-    });
-
-    const traceItems = await getUnifiedTraceItems({
-      apmEventClient,
-      traceId,
-      start,
-      end,
       maxTraceItemsFromUrlParam: params.query.maxTraceItems,
       config,
-      unifiedTraceErrors,
     });
 
     return {
@@ -188,29 +181,24 @@ const focusedTraceRoute = createApmServerRoute({
     traceItems?: FocusedTraceItems;
     summary: { services: number; traceEvents: number; errors: number };
   }> => {
-    const apmEventClient = await getApmEventClient(resources);
-    const logsClient = await createLogsClient(resources);
+    const [apmEventClient, logsClient] = await Promise.all([
+      getApmEventClient(resources),
+      createLogsClient(resources),
+    ]);
+
     const { params, config } = resources;
     const { traceId, docId } = params.path;
     const { start, end } = params.query;
 
-    const unifiedTraceErrors = await getUnifiedTraceErrors({
-      apmEventClient,
-      logsClient,
-      traceId,
-      start,
-      end,
-    });
-
-    const [traceItems, traceSummaryCount] = await Promise.all([
+    const [{ traceItems, unifiedTraceErrors }, traceSummaryCount] = await Promise.all([
       getUnifiedTraceItems({
         apmEventClient,
+        logsClient,
         traceId,
         start,
         end,
         maxTraceItemsFromUrlParam: params.query.maxTraceItems,
         config,
-        unifiedTraceErrors,
       }),
       getTraceSummaryCount({ apmEventClient, start, end, traceId }),
     ]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover][Unified Traces] Improve Unified Traces API call latencies (#240285)](https://github.com/elastic/kibana/pull/240285)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2025-10-23T15:32:15Z","message":"[Discover][Unified Traces] Improve Unified Traces API call latencies (#240285)\n\n## Summary\n\nIn some of the Unified Trace API calls, there are various async calls\nbeing made sequentially when they could in fact be made concurrently.\nThis PR fixes that by making these small improvements to make various\ncalls concurrent where possible and thus avoiding the added latency.\n\nThese changes were benchmarked and for the unified trace call, it has\nthe following profile: the first time is the elapsed time for getting\nthe APM and Logs clients, and the second time is the total time elapsed\nwith the full response returned:\n\nBEFORE:\n```\nclients: 648.295ms\nresponse: 1.165s\n\nclients: 653.911ms\nresponse: 1.166s\n\nclients: 649.343ms\nresponse: 1.328s\n```\n\nAFTER:\n```\nclients: 335.631ms\nresponse: 836.463ms\n\nclients: 332.548ms\nresponse: 669.448ms\n\nclients: 325.188ms\nresponse: 820.929ms\n```\n\n## How to test\n\n- Go to Discover page in Observability mode, select a trace index in\neither classic or ES|QL mode\n- Going to a trace overview, the focused trace waterfall and the full\ntrace waterfall views should not regress in functionality or error\nunexpectedly.","sha":"ca9eb7c8fc8e5a01bf8601573b3da66bb821307c","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.2.0","v9.3.0","v9.1.6","v8.19.6","v9.0.9"],"title":"[Discover][Unified Traces] Improve Unified Traces API call latencies","number":240285,"url":"https://github.com/elastic/kibana/pull/240285","mergeCommit":{"message":"[Discover][Unified Traces] Improve Unified Traces API call latencies (#240285)\n\n## Summary\n\nIn some of the Unified Trace API calls, there are various async calls\nbeing made sequentially when they could in fact be made concurrently.\nThis PR fixes that by making these small improvements to make various\ncalls concurrent where possible and thus avoiding the added latency.\n\nThese changes were benchmarked and for the unified trace call, it has\nthe following profile: the first time is the elapsed time for getting\nthe APM and Logs clients, and the second time is the total time elapsed\nwith the full response returned:\n\nBEFORE:\n```\nclients: 648.295ms\nresponse: 1.165s\n\nclients: 653.911ms\nresponse: 1.166s\n\nclients: 649.343ms\nresponse: 1.328s\n```\n\nAFTER:\n```\nclients: 335.631ms\nresponse: 836.463ms\n\nclients: 332.548ms\nresponse: 669.448ms\n\nclients: 325.188ms\nresponse: 820.929ms\n```\n\n## How to test\n\n- Go to Discover page in Observability mode, select a trace index in\neither classic or ES|QL mode\n- Going to a trace overview, the focused trace waterfall and the full\ntrace waterfall views should not regress in functionality or error\nunexpectedly.","sha":"ca9eb7c8fc8e5a01bf8601573b3da66bb821307c"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19","9.0"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/240329","number":240329,"state":"OPEN"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/240285","number":240285,"mergeCommit":{"message":"[Discover][Unified Traces] Improve Unified Traces API call latencies (#240285)\n\n## Summary\n\nIn some of the Unified Trace API calls, there are various async calls\nbeing made sequentially when they could in fact be made concurrently.\nThis PR fixes that by making these small improvements to make various\ncalls concurrent where possible and thus avoiding the added latency.\n\nThese changes were benchmarked and for the unified trace call, it has\nthe following profile: the first time is the elapsed time for getting\nthe APM and Logs clients, and the second time is the total time elapsed\nwith the full response returned:\n\nBEFORE:\n```\nclients: 648.295ms\nresponse: 1.165s\n\nclients: 653.911ms\nresponse: 1.166s\n\nclients: 649.343ms\nresponse: 1.328s\n```\n\nAFTER:\n```\nclients: 335.631ms\nresponse: 836.463ms\n\nclients: 332.548ms\nresponse: 669.448ms\n\nclients: 325.188ms\nresponse: 820.929ms\n```\n\n## How to test\n\n- Go to Discover page in Observability mode, select a trace index in\neither classic or ES|QL mode\n- Going to a trace overview, the focused trace waterfall and the full\ntrace waterfall views should not regress in functionality or error\nunexpectedly.","sha":"ca9eb7c8fc8e5a01bf8601573b3da66bb821307c"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->