### PR TITLE
[Write restricted SOs] Simplify integration and unit tests

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/saved_objects/access_control_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/saved_objects/access_control_service.ts
@@ -48,13 +48,20 @@ export class AccessControlService {
 
     const { accessControl } = object;
     if (!accessControl) {
+      // Always check if we are introducing access control for an unowned object
+      if (
+        actions.has(SecurityAction.CHANGE_OWNERSHIP) ||
+        actions.has(SecurityAction.CHANGE_ACCESS_MODE)
+      ) {
+        return true;
+      }
       return false;
     }
 
     // Note: We will ultimately have to check privileges even if there is no
     // current user because we will need to support actions via HTTP APIs,
     // like import
-    if (!accessControl.owner || !currentUser) {
+    if (!accessControl?.owner || !currentUser) {
       return false;
     }
 

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/config.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/config.ts
@@ -23,7 +23,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   );
 
   return {
-    testFiles: [resolve(__dirname, './apis/spaces/access_control_objects.ts')],
+    testFiles: [resolve(__dirname, './tests/index.ts')],
     services: {
       ...kibanaAPITestsConfig.get('services'),
       ...xPackAPITestsConfig.get('services'),

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/access_control_objects.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/access_control_objects.ts
@@ -13,7 +13,7 @@ import {
 import expect from '@kbn/expect';
 import { adminTestUser } from '@kbn/test';
 
-import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const es = getService('es');

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/bulk_create.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/bulk_create.ts
@@ -1,0 +1,286 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { parse as parseCookie } from 'tough-cookie';
+
+import { ACCESS_CONTROL_TYPE } from '@kbn/access-control-test-plugin/server';
+import expect from '@kbn/expect';
+import { adminTestUser } from '@kbn/test';
+
+import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  const login = async (username: string, password: string | undefined) => {
+    const response = await supertestWithoutAuth
+      .post('/internal/security/login')
+      .set('kbn-xsrf', 'xxx')
+      .send({
+        providerType: 'basic',
+        providerName: 'basic',
+        currentURL: '/',
+        params: { username, password },
+      })
+      .expect(200);
+    const cookie = parseCookie(response.headers['set-cookie'][0])!;
+    const profileUidResponse = await supertestWithoutAuth
+      .get('/internal/security/me')
+      .set('Cookie', cookie.cookieString())
+      .expect(200);
+    return {
+      cookie,
+      profileUid: profileUidResponse.body.profile_uid,
+    };
+  };
+
+  const loginAsKibanaAdmin = () => login(adminTestUser.username, adminTestUser.password);
+
+  const loginAsObjectOwner = (username: string, password: string) => login(username, password);
+
+  const loginAsNotObjectOwner = (username: string, password: string) => login(username, password);
+
+  describe('#bulk_create', () => {
+    it('should create write-restricted objects', async () => {
+      const { cookie: objectOwnerCookie, profileUid: objectOwnerProfileUid } =
+        await loginAsObjectOwner('test_user', 'changeme');
+
+      const bulkCreateResponse = await supertestWithoutAuth
+        .post('/access_control_objects/bulk_create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({
+          objects: [
+            { type: ACCESS_CONTROL_TYPE, isWriteRestricted: true },
+            { type: ACCESS_CONTROL_TYPE, isWriteRestricted: true },
+          ],
+        });
+      expect(bulkCreateResponse.body.saved_objects).to.have.length(2);
+      for (const { accessControl } of bulkCreateResponse.body.saved_objects) {
+        expect(accessControl).to.have.property('owner', objectOwnerProfileUid);
+        expect(accessControl).to.have.property('accessMode', 'write_restricted');
+      }
+    });
+
+    it('should allow overwriting objects owned by current user', async () => {
+      const { cookie: objectOwnerCookie, profileUid: objectOwnerProfileUid } =
+        await loginAsObjectOwner('test_user', 'changeme');
+      const firstObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId1, type: type1 } = firstObject.body;
+      expect(firstObject.body.accessControl).to.have.property('owner', objectOwnerProfileUid);
+
+      const secondObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId2, type: type2 } = secondObject.body;
+      expect(secondObject.body.accessControl).to.have.property('owner', objectOwnerProfileUid);
+
+      const objects = [
+        {
+          id: objectId1,
+          type: type1,
+        },
+        {
+          id: objectId2,
+          type: type2,
+        },
+      ];
+
+      const res = await supertestWithoutAuth
+        .post('/access_control_objects/bulk_create?overwrite=true')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({
+          objects,
+        })
+        .expect(200);
+      for (const { id, accessControl } of res.body.saved_objects) {
+        const object = objects.find((obj) => obj.id === id);
+        expect(object).to.not.be(undefined);
+        expect(accessControl).to.have.property('owner', objectOwnerProfileUid);
+        expect(accessControl).to.have.property('accessMode', 'write_restricted');
+      }
+    });
+
+    it('should allow overwriting objects owned by another user if admin', async () => {
+      const { cookie: objectOwnerCookie, profileUid: objectOwnerProfileUid } =
+        await loginAsObjectOwner('test_user', 'changeme');
+      const firstObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId1, type: type1 } = firstObject.body;
+      expect(firstObject.body.accessControl).to.have.property('owner', objectOwnerProfileUid);
+
+      const secondObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId2, type: type2 } = secondObject.body;
+      expect(secondObject.body.accessControl).to.have.property('owner', objectOwnerProfileUid);
+
+      const objects = [
+        {
+          id: objectId1,
+          type: type1,
+        },
+        {
+          id: objectId2,
+          type: type2,
+        },
+      ];
+
+      const { cookie: adminCookie } = await loginAsKibanaAdmin();
+
+      const res = await supertestWithoutAuth
+        .post('/access_control_objects/bulk_create?overwrite=true')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({
+          objects,
+        })
+        .expect(200);
+      for (const { id, accessControl } of res.body.saved_objects) {
+        const object = objects.find((obj) => obj.id === id);
+        expect(object).to.not.be(undefined);
+        expect(accessControl).to.have.property('owner', objectOwnerProfileUid);
+        expect(accessControl).to.have.property('accessMode', 'write_restricted');
+      }
+    });
+
+    it('should allow overwriting objects owned by another user if in default mode', async () => {
+      const { cookie: adminCookie, profileUid: adminProfileUid } = await loginAsKibanaAdmin();
+
+      const firstObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: false })
+        .expect(200);
+      const { id: objectId1, type: type1 } = firstObject.body;
+      expect(firstObject.body.accessControl).to.have.property('owner', adminProfileUid);
+
+      const secondObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: false })
+        .expect(200);
+      const { id: objectId2, type: type2 } = secondObject.body;
+      expect(secondObject.body.accessControl).to.have.property('owner', adminProfileUid);
+
+      const objects = [
+        {
+          id: objectId1,
+          type: type1,
+        },
+        {
+          id: objectId2,
+          type: type2,
+        },
+      ];
+
+      const { cookie: notObjectOwnerCookieCookie } = await loginAsNotObjectOwner(
+        'test_user',
+        'changeme'
+      );
+
+      const res = await supertestWithoutAuth
+        .post('/access_control_objects/bulk_create?overwrite=true')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', notObjectOwnerCookieCookie.cookieString())
+        .send({
+          objects,
+        })
+        .expect(200);
+
+      expect(res.body.saved_objects.length).to.be(2);
+      expect(res.body.saved_objects[0].accessControl).to.have.property('owner', adminProfileUid);
+      expect(res.body.saved_objects[0].accessControl).to.have.property('accessMode', 'default');
+      expect(res.body.saved_objects[1].accessControl).to.have.property('owner', adminProfileUid);
+      expect(res.body.saved_objects[1].accessControl).to.have.property('accessMode', 'default');
+    });
+
+    it('should reject when attempting to overwrite objects owned by another user if not admin', async () => {
+      const { cookie: adminCookie, profileUid: adminProfileUid } = await loginAsKibanaAdmin();
+
+      const firstObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId1, type: type1 } = firstObject.body;
+      expect(firstObject.body.accessControl).to.have.property('owner', adminProfileUid);
+
+      const secondObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId2, type: type2 } = secondObject.body;
+      expect(secondObject.body.accessControl).to.have.property('owner', adminProfileUid);
+
+      const objects = [
+        {
+          id: objectId1,
+          type: type1,
+        },
+        {
+          id: objectId2,
+          type: type2,
+        },
+      ];
+
+      const { cookie: notObjectOwnerCookieCookie } = await loginAsNotObjectOwner(
+        'test_user',
+        'changeme'
+      );
+
+      const res = await supertestWithoutAuth
+        .post('/access_control_objects/bulk_create?overwrite=true')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', notObjectOwnerCookieCookie.cookieString())
+        .send({
+          objects,
+        })
+        .expect(403);
+
+      expect(res.body).to.have.property('error', 'Forbidden');
+      expect(res.body).to.have.property('message', `Unable to bulk_create ${ACCESS_CONTROL_TYPE}`);
+
+      // ToDo: read back objects and confirm the owner has not changed
+      const getResponse = await supertestWithoutAuth
+        .get(`/access_control_objects/${objectId1}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .expect(200);
+      expect(getResponse.body.accessControl).to.have.property('owner', adminProfileUid);
+      expect(getResponse.body.accessControl).to.have.property('accessMode', 'write_restricted');
+
+      const getResponse2 = await supertestWithoutAuth
+        .get(`/access_control_objects/${objectId2}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .expect(200);
+      expect(getResponse2.body.accessControl).to.have.property('owner', adminProfileUid);
+      expect(getResponse2.body.accessControl).to.have.property('accessMode', 'write_restricted');
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/bulk_delete.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/bulk_delete.ts
@@ -1,0 +1,397 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { parse as parseCookie } from 'tough-cookie';
+
+import { ACCESS_CONTROL_TYPE } from '@kbn/access-control-test-plugin/server';
+import expect from '@kbn/expect';
+import { adminTestUser } from '@kbn/test';
+
+import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const es = getService('es');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  const createSimpleUser = async (roles: string[] = ['viewer']) => {
+    await es.security.putUser({
+      username: 'simple_user',
+      refresh: 'wait_for',
+      password: 'changeme',
+      roles,
+    });
+  };
+
+  const login = async (username: string, password: string | undefined) => {
+    const response = await supertestWithoutAuth
+      .post('/internal/security/login')
+      .set('kbn-xsrf', 'xxx')
+      .send({
+        providerType: 'basic',
+        providerName: 'basic',
+        currentURL: '/',
+        params: { username, password },
+      })
+      .expect(200);
+    const cookie = parseCookie(response.headers['set-cookie'][0])!;
+    const profileUidResponse = await supertestWithoutAuth
+      .get('/internal/security/me')
+      .set('Cookie', cookie.cookieString())
+      .expect(200);
+    return {
+      cookie,
+      profileUid: profileUidResponse.body.profile_uid,
+    };
+  };
+
+  const loginAsKibanaAdmin = () => login(adminTestUser.username, adminTestUser.password);
+
+  const loginAsObjectOwner = (username: string, password: string) => login(username, password);
+
+  const loginAsNotObjectOwner = (username: string, password: string) => login(username, password);
+
+  const activateSimpleUserProfile = async () => {
+    const response = await es.security.activateUserProfile({
+      username: 'simple_user',
+      password: 'changeme',
+      grant_type: 'password',
+    });
+
+    return {
+      profileUid: response.uid,
+    };
+  };
+
+  describe('#bulk_delete', () => {
+    describe('bulk delete ownable objects', () => {
+      it('allow owner to bulk delete objects marked as write-restricted', async () => {
+        const { cookie: objectOwnerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+        const firstObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId1, type: type1 } = firstObject.body;
+
+        const secondObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId2, type: type2 } = secondObject.body;
+
+        const objects = [
+          {
+            id: objectId1,
+            type: type1,
+          },
+          {
+            id: objectId2,
+            type: type2,
+          },
+        ];
+
+        const res = await supertestWithoutAuth
+          .post('/access_control_objects/bulk_delete')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({
+            objects,
+          })
+          .expect(200);
+
+        for (const { id, success } of res.body.statuses) {
+          const object = objects.find((obj) => obj.id === id);
+          expect(object).to.not.be(undefined);
+          expect(success).to.be(true);
+        }
+      });
+
+      it('allow admin to bulk delete objects marked as write-restricted', async () => {
+        const { cookie: objectOwnerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+        const firstObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId1, type: type1 } = firstObject.body;
+
+        const secondObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId2, type: type2 } = secondObject.body;
+
+        const { cookie: adminCookie } = await loginAsKibanaAdmin();
+
+        const objects = [
+          {
+            id: objectId1,
+            type: type1,
+          },
+          {
+            id: objectId2,
+            type: type2,
+          },
+        ];
+
+        const res = await supertestWithoutAuth
+          .post('/access_control_objects/bulk_delete')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', adminCookie.cookieString())
+          .send({
+            objects,
+          })
+          .expect(200);
+        for (const { id, success } of res.body.statuses) {
+          const object = objects.find((obj) => obj.id === id);
+          expect(object).to.not.be(undefined);
+          expect(success).to.be(true);
+        }
+      });
+
+      it('does not allow non-owner to bulk delete objects marked as write-restricted', async () => {
+        await activateSimpleUserProfile();
+        const { cookie: objectOwnerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+        const firstObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId1, type: type1 } = firstObject.body;
+
+        const secondObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId2, type: type2 } = secondObject.body;
+
+        const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('simple_user', 'changeme');
+
+        const objects = [
+          {
+            id: objectId1,
+            type: type1,
+          },
+          {
+            id: objectId2,
+            type: type2,
+          },
+        ];
+
+        const res = await supertestWithoutAuth
+          .post('/access_control_objects/bulk_delete')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', notOwnerCookie.cookieString())
+          .send({
+            objects,
+          })
+          .expect(403);
+        expect(res.body).to.have.property('message');
+        expect(res.body.message).to.equal(`Unable to bulk_delete ${ACCESS_CONTROL_TYPE}`);
+      });
+
+      it('allows non-owner non-admin to bulk delete objects in default mode', async () => {
+        const { cookie: objectOwnerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+
+        const firstObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE })
+          .expect(200);
+        const { id: objectId1, type: type1 } = firstObject.body;
+
+        const secondObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE })
+          .expect(200);
+        const { id: objectId2, type: type2 } = secondObject.body;
+
+        const objects = [
+          {
+            id: objectId1,
+            type: type1,
+          },
+          {
+            id: objectId2,
+            type: type2,
+          },
+        ];
+        await createSimpleUser(['kibana_savedobjects_editor']);
+        const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('simple_user', 'changeme');
+
+        await supertestWithoutAuth
+          .post('/access_control_objects/bulk_delete')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', notOwnerCookie.cookieString())
+          .send({ objects })
+          .expect(200);
+
+        await supertestWithoutAuth
+          .get(`/access_control_objects/${objectId1}`)
+          .set('kbn-xsrf', 'true')
+          .set('cookie', notOwnerCookie.cookieString())
+          .expect(404);
+
+        await supertestWithoutAuth
+          .get(`/access_control_objects/${objectId2}`)
+          .set('kbn-xsrf', 'true')
+          .set('cookie', notOwnerCookie.cookieString())
+          .expect(404);
+      });
+    });
+
+    describe('force bulk delete ownable objects', () => {
+      it('allow owner to bulk delete objects marked as write-restricted', async () => {
+        const { cookie: objectOwnerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+        const firstObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId1, type: type1 } = firstObject.body;
+
+        const secondObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId2, type: type2 } = secondObject.body;
+
+        const objects = [
+          {
+            id: objectId1,
+            type: type1,
+          },
+          {
+            id: objectId2,
+            type: type2,
+          },
+        ];
+
+        const res = await supertestWithoutAuth
+          .post('/access_control_objects/bulk_delete')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({
+            objects,
+            force: true,
+          })
+          .expect(200);
+
+        for (const { id, success } of res.body.statuses) {
+          const object = objects.find((obj) => obj.id === id);
+          expect(object).to.not.be(undefined);
+          expect(success).to.be(true);
+        }
+      });
+
+      it('allow admin to bulk delete objects marked as write-restricted', async () => {
+        const { cookie: objectOwnerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+        const firstObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId1, type: type1 } = firstObject.body;
+
+        const secondObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId2, type: type2 } = secondObject.body;
+
+        const { cookie: adminCookie } = await loginAsKibanaAdmin();
+
+        const objects = [
+          {
+            id: objectId1,
+            type: type1,
+          },
+          {
+            id: objectId2,
+            type: type2,
+          },
+        ];
+
+        const res = await supertestWithoutAuth
+          .post('/access_control_objects/bulk_delete')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', adminCookie.cookieString())
+          .send({
+            objects,
+            force: true,
+          })
+          .expect(200);
+        for (const { id, success } of res.body.statuses) {
+          const object = objects.find((obj) => obj.id === id);
+          expect(object).to.not.be(undefined);
+          expect(success).to.be(true);
+        }
+      });
+      it('does not allow non-owner to bulk delete objects marked as write-restricted', async () => {
+        await activateSimpleUserProfile();
+        const { cookie: objectOwnerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+        const firstObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId1, type: type1 } = firstObject.body;
+
+        const secondObject = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', objectOwnerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const { id: objectId2, type: type2 } = secondObject.body;
+
+        const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('simple_user', 'changeme');
+
+        const objects = [
+          {
+            id: objectId1,
+            type: type1,
+          },
+          {
+            id: objectId2,
+            type: type2,
+          },
+        ];
+
+        const res = await supertestWithoutAuth
+          .post('/access_control_objects/bulk_delete')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', notOwnerCookie.cookieString())
+          .send({
+            objects,
+            force: true,
+          })
+          .expect(403);
+        expect(res.body).to.have.property('message');
+        expect(res.body.message).to.equal(`Unable to bulk_delete ${ACCESS_CONTROL_TYPE}`);
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/bulk_update.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/bulk_update.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { parse as parseCookie } from 'tough-cookie';
+
+import { ACCESS_CONTROL_TYPE } from '@kbn/access-control-test-plugin/server';
+import expect from '@kbn/expect';
+import { adminTestUser } from '@kbn/test';
+
+import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const es = getService('es');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  const createSimpleUser = async (roles: string[] = ['viewer']) => {
+    await es.security.putUser({
+      username: 'simple_user',
+      refresh: 'wait_for',
+      password: 'changeme',
+      roles,
+    });
+  };
+
+  const login = async (username: string, password: string | undefined) => {
+    const response = await supertestWithoutAuth
+      .post('/internal/security/login')
+      .set('kbn-xsrf', 'xxx')
+      .send({
+        providerType: 'basic',
+        providerName: 'basic',
+        currentURL: '/',
+        params: { username, password },
+      })
+      .expect(200);
+    const cookie = parseCookie(response.headers['set-cookie'][0])!;
+    const profileUidResponse = await supertestWithoutAuth
+      .get('/internal/security/me')
+      .set('Cookie', cookie.cookieString())
+      .expect(200);
+    return {
+      cookie,
+      profileUid: profileUidResponse.body.profile_uid,
+    };
+  };
+
+  const loginAsKibanaAdmin = () => login(adminTestUser.username, adminTestUser.password);
+
+  const loginAsObjectOwner = (username: string, password: string) => login(username, password);
+
+  const loginAsNotObjectOwner = (username: string, password: string) => login(username, password);
+
+  const activateSimpleUserProfile = async () => {
+    const response = await es.security.activateUserProfile({
+      username: 'simple_user',
+      password: 'changeme',
+      grant_type: 'password',
+    });
+
+    return {
+      profileUid: response.uid,
+    };
+  };
+
+  describe('#bulk_update', () => {
+    it('allow owner to bulk update objects marked as write-restricted', async () => {
+      const { cookie: objectOwnerCookie, profileUid: objectOwnerProfileUid } =
+        await loginAsObjectOwner('test_user', 'changeme');
+      const firstObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId1, type: type1 } = firstObject.body;
+
+      const secondObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId2, type: type2 } = secondObject.body;
+
+      const objects = [
+        {
+          id: objectId1,
+          type: type1,
+        },
+        {
+          id: objectId2,
+          type: type2,
+        },
+      ];
+
+      const res = await supertestWithoutAuth
+        .post('/access_control_objects/bulk_update')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({
+          objects,
+        })
+        .expect(200);
+      for (const { id, attributes, accessControl } of res.body.saved_objects) {
+        const object = objects.find((obj) => obj.id === id);
+        expect(object).to.not.be(undefined);
+        expect(attributes).to.have.property('description', 'updated description');
+        expect(accessControl).to.have.property('owner', objectOwnerProfileUid);
+        expect(accessControl).to.have.property('accessMode', 'write_restricted');
+      }
+    });
+
+    it('allow admin to bulk update objects marked as write-restricted', async () => {
+      const { cookie: objectOwnerCookie, profileUid: objectOwnerProfileUid } =
+        await loginAsObjectOwner('test_user', 'changeme');
+      const firstObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId1, type: type1 } = firstObject.body;
+
+      const secondObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId2, type: type2 } = secondObject.body;
+
+      const objects = [
+        {
+          id: objectId1,
+          type: type1,
+        },
+        {
+          id: objectId2,
+          type: type2,
+        },
+      ];
+      const { cookie: adminCookie } = await loginAsKibanaAdmin();
+      const res = await supertestWithoutAuth
+        .post('/access_control_objects/bulk_update')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({
+          objects,
+        })
+        .expect(200);
+      for (const { id, attributes, accessControl } of res.body.saved_objects) {
+        const object = objects.find((obj) => obj.id === id);
+        expect(object).to.not.be(undefined);
+        expect(attributes).to.have.property('description', 'updated description');
+        expect(accessControl).to.have.property('owner', objectOwnerProfileUid);
+        expect(accessControl).to.have.property('accessMode', 'write_restricted');
+      }
+    });
+
+    it('does not allow non-owner to bulk update objects marked as write-restricted if not admin', async () => {
+      await activateSimpleUserProfile();
+      const { cookie: objectOwnerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+      const firstObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId1, type: type1 } = firstObject.body;
+
+      const secondObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const { id: objectId2, type: type2 } = secondObject.body;
+
+      const objects = [
+        {
+          id: objectId1,
+          type: type1,
+        },
+        {
+          id: objectId2,
+          type: type2,
+        },
+      ];
+      const { cookie: nonOwnerCookie } = await loginAsNotObjectOwner('simple_user', 'changeme');
+      const res = await supertestWithoutAuth
+        .post('/access_control_objects/bulk_update')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', nonOwnerCookie.cookieString())
+        .send({
+          objects,
+        })
+        .expect(403);
+      expect(res.body).to.have.property('message');
+      expect(res.body.message).to.contain(`Unable to bulk_update ${ACCESS_CONTROL_TYPE}`);
+    });
+
+    it('allows non-owner non-admin to bulk update objects in default mode ', async () => {
+      const { cookie: objectOwnerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+      const firstObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE })
+        .expect(200);
+      const { id: objectId1, type: type1 } = firstObject.body;
+
+      const secondObject = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE })
+        .expect(200);
+      const { id: objectId2, type: type2 } = secondObject.body;
+
+      const objects = [
+        {
+          id: objectId1,
+          type: type1,
+        },
+        {
+          id: objectId2,
+          type: type2,
+        },
+      ];
+
+      await createSimpleUser(['kibana_savedobjects_editor']);
+      const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('simple_user', 'changeme');
+
+      const res = await supertestWithoutAuth
+        .post('/access_control_objects/bulk_update')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', notOwnerCookie.cookieString())
+        .send({
+          objects,
+        })
+        .expect(200);
+      for (const { id, attributes, accessControl } of res.body.saved_objects) {
+        const object = objects.find((obj) => obj.id === id);
+        expect(object).to.not.be(undefined);
+        expect(attributes).to.have.property('description', 'updated description');
+        expect(accessControl).to.have.property('accessMode', 'default');
+      }
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/change_access_mode.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/change_access_mode.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { parse as parseCookie } from 'tough-cookie';
+
+import { ACCESS_CONTROL_TYPE } from '@kbn/access-control-test-plugin/server';
+import expect from '@kbn/expect';
+import { adminTestUser } from '@kbn/test';
+
+import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const es = getService('es');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  const createSimpleUser = async (roles: string[] = ['viewer']) => {
+    await es.security.putUser({
+      username: 'simple_user',
+      refresh: 'wait_for',
+      password: 'changeme',
+      roles,
+    });
+  };
+
+  const login = async (username: string, password: string | undefined) => {
+    const response = await supertestWithoutAuth
+      .post('/internal/security/login')
+      .set('kbn-xsrf', 'xxx')
+      .send({
+        providerType: 'basic',
+        providerName: 'basic',
+        currentURL: '/',
+        params: { username, password },
+      })
+      .expect(200);
+    const cookie = parseCookie(response.headers['set-cookie'][0])!;
+    const profileUidResponse = await supertestWithoutAuth
+      .get('/internal/security/me')
+      .set('Cookie', cookie.cookieString())
+      .expect(200);
+    return {
+      cookie,
+      profileUid: profileUidResponse.body.profile_uid,
+    };
+  };
+
+  const loginAsKibanaAdmin = () => login(adminTestUser.username, adminTestUser.password);
+
+  const loginAsObjectOwner = (username: string, password: string) => login(username, password);
+
+  const loginAsNotObjectOwner = (username: string, password: string) => login(username, password);
+
+  const activateSimpleUserProfile = async () => {
+    const response = await es.security.activateUserProfile({
+      username: 'simple_user',
+      password: 'changeme',
+      grant_type: 'password',
+    });
+
+    return {
+      profileUid: response.uid,
+    };
+  };
+
+  describe('#change_access_mode', () => {
+    it('should allow admins to change access mode of any object', async () => {
+      const { cookie: ownerCookie, profileUid } = await loginAsObjectOwner('test_user', 'changeme');
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: false })
+        .expect(200);
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+
+      const { cookie: adminCookie } = await loginAsKibanaAdmin();
+      const response = await supertestWithoutAuth
+        .put('/access_control_objects/change_access_mode')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({
+          objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
+          newAccessMode: 'write_restricted',
+        })
+        .expect(200);
+      expect(response.body.objects).to.have.length(1);
+      expect(response.body.objects[0].id).to.eql(objectId);
+      expect(response.body.objects[0].type).to.eql(ACCESS_CONTROL_TYPE);
+
+      const getResponse = await supertestWithoutAuth
+        .get(`/access_control_objects/${objectId}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .expect(200);
+
+      expect(getResponse.body.accessControl).to.have.property('accessMode', 'write_restricted');
+    });
+
+    it('allow owner to update object data after access mode change', async () => {
+      const { cookie: ownerCookie, profileUid } = await loginAsObjectOwner('test_user', 'changeme');
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: false })
+        .expect(200);
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+
+      const { cookie: adminCookie } = await loginAsKibanaAdmin();
+      const response = await supertestWithoutAuth
+        .put('/access_control_objects/change_access_mode')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({
+          objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
+          newAccessMode: 'write_restricted',
+        })
+        .expect(200);
+      expect(response.body.objects).to.have.length(1);
+      expect(response.body.objects[0].id).to.eql(objectId);
+      expect(response.body.objects[0].type).to.eql(ACCESS_CONTROL_TYPE);
+
+      const getResponse = await supertestWithoutAuth
+        .get(`/access_control_objects/${objectId}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .expect(200);
+
+      expect(getResponse.body.accessControl).to.have.property('accessMode', 'write_restricted');
+
+      const updateResponse = await supertestWithoutAuth
+        .put('/access_control_objects/update')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({ objectId, type: ACCESS_CONTROL_TYPE })
+        .expect(200);
+      expect(updateResponse.body.id).to.eql(objectId);
+      expect(updateResponse.body.attributes).to.have.property('description', 'updated description');
+    });
+
+    it('should throw when trying to change access mode on locked objects when not owner', async () => {
+      const { cookie: ownerCookie, profileUid } = await loginAsObjectOwner('test_user', 'changeme');
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+
+      await activateSimpleUserProfile();
+      const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('simple_user', 'changeme');
+      const updateResponse = await supertestWithoutAuth
+        .put('/access_control_objects/change_access_mode')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', notOwnerCookie.cookieString())
+        .send({
+          objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
+          newAccessMode: 'write_restricted',
+        })
+        .expect(403);
+      expect(updateResponse.body).to.have.property('message');
+      expect(updateResponse.body.message).to.contain(
+        `Access denied: Unable to manage access control for ${ACCESS_CONTROL_TYPE}`
+      );
+    });
+
+    it('allows updates by non-owner after removing write-restricted access mode', async () => {
+      const { cookie: ownerCookie, profileUid } = await loginAsObjectOwner('test_user', 'changeme');
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+
+      await supertestWithoutAuth
+        .put('/access_control_objects/change_access_mode')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({
+          objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
+          newAccessMode: 'default',
+        })
+        .expect(200);
+
+      await createSimpleUser(['kibana_savedobjects_editor']);
+      const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('simple_user', 'changeme');
+
+      const updateResponse = await supertestWithoutAuth
+        .put('/access_control_objects/update')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', notOwnerCookie.cookieString())
+        .send({ objectId, type: ACCESS_CONTROL_TYPE })
+        .expect(200);
+      expect(updateResponse.body.id).to.eql(objectId);
+      expect(updateResponse.body.attributes).to.have.property('description', 'updated description');
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/change_ownership.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/change_ownership.ts
@@ -1,0 +1,289 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { parse as parseCookie } from 'tough-cookie';
+
+import {
+  ACCESS_CONTROL_TYPE,
+  NON_ACCESS_CONTROL_TYPE,
+} from '@kbn/access-control-test-plugin/server';
+import expect from '@kbn/expect';
+import { adminTestUser } from '@kbn/test';
+
+import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const es = getService('es');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+  const security = getService('security');
+
+  const createSimpleUser = async (roles: string[] = ['viewer']) => {
+    await es.security.putUser({
+      username: 'simple_user',
+      refresh: 'wait_for',
+      password: 'changeme',
+      roles,
+    });
+  };
+
+  const login = async (username: string, password: string | undefined) => {
+    const response = await supertestWithoutAuth
+      .post('/internal/security/login')
+      .set('kbn-xsrf', 'xxx')
+      .send({
+        providerType: 'basic',
+        providerName: 'basic',
+        currentURL: '/',
+        params: { username, password },
+      })
+      .expect(200);
+    const cookie = parseCookie(response.headers['set-cookie'][0])!;
+    const profileUidResponse = await supertestWithoutAuth
+      .get('/internal/security/me')
+      .set('Cookie', cookie.cookieString())
+      .expect(200);
+    return {
+      cookie,
+      profileUid: profileUidResponse.body.profile_uid,
+    };
+  };
+
+  const loginAsKibanaAdmin = () => login(adminTestUser.username, adminTestUser.password);
+
+  const loginAsObjectOwner = (username: string, password: string) => login(username, password);
+
+  const loginAsNotObjectOwner = (username: string, password: string) => login(username, password);
+
+  const activateSimpleUserProfile = async () => {
+    const response = await es.security.activateUserProfile({
+      username: 'simple_user',
+      password: 'changeme',
+      grant_type: 'password',
+    });
+
+    return {
+      profileUid: response.uid,
+    };
+  };
+
+  describe('access control saved objects', () => {
+    before(async () => {
+      await security.testUser.setRoles(['kibana_savedobjects_editor']);
+      await createSimpleUser();
+    });
+    after(async () => {
+      await security.testUser.restoreDefaults();
+    });
+
+    describe('#change_ownership', () => {
+      it('should transfer ownership of write-restricted objects by owner', async () => {
+        const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
+
+        const { cookie: ownerCookie, profileUid } = await loginAsObjectOwner(
+          'test_user',
+          'changeme'
+        );
+
+        const createResponse = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', ownerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const objectId = createResponse.body.id;
+        expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+
+        await supertestWithoutAuth
+          .put('/access_control_objects/change_owner')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', ownerCookie.cookieString())
+          .send({
+            objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
+            newOwnerProfileUid: simpleUserProfileUid,
+          })
+          .expect(200);
+
+        const getResponse = await supertestWithoutAuth
+          .get(`/access_control_objects/${objectId}`)
+          .set('kbn-xsrf', 'true')
+          .set('cookie', ownerCookie.cookieString())
+          .expect(200);
+        expect(getResponse.body).to.have.property('accessControl');
+        expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
+      });
+
+      it('should throw when transferring ownership of object owned by a different user and not admin', async () => {
+        const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
+        const { cookie: adminCookie, profileUid: adminProfileUid } = await loginAsKibanaAdmin();
+        const createResponse = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', adminCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const objectId = createResponse.body.id;
+
+        expect(createResponse.body.accessControl).to.have.property('owner', adminProfileUid);
+
+        const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('test_user', 'changeme');
+        const transferResponse = await supertestWithoutAuth
+          .put('/access_control_objects/change_owner')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', notOwnerCookie.cookieString())
+          .send({
+            objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
+            newOwnerProfileUid: simpleUserProfileUid,
+          })
+          .expect(403);
+
+        expect(transferResponse.body).to.have.property('message');
+        expect(transferResponse.body.message).to.contain(
+          `Access denied: Unable to manage access control for ${ACCESS_CONTROL_TYPE}`
+        );
+      });
+
+      it('should allow admins to transfer ownership of any object', async () => {
+        const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
+        const { cookie: ownerCookie, profileUid } = await loginAsObjectOwner(
+          'test_user',
+          'changeme'
+        );
+        const createResponse = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', ownerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const objectId = createResponse.body.id;
+
+        expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+
+        const { cookie: adminCookie } = await loginAsKibanaAdmin();
+        await supertestWithoutAuth
+          .put('/access_control_objects/change_owner')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', adminCookie.cookieString())
+          .send({
+            objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
+            newOwnerProfileUid: simpleUserProfileUid,
+          })
+          .expect(200);
+
+        const getResponse = await supertestWithoutAuth
+          .get(`/access_control_objects/${objectId}`)
+          .set('kbn-xsrf', 'true')
+          .set('cookie', adminCookie.cookieString())
+          .expect(200);
+
+        expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
+      });
+
+      it('should allow bulk transfer ownership of allowed objects', async () => {
+        const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
+        const { cookie: ownerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+        const { cookie: adminCookie } = await loginAsKibanaAdmin();
+        const firstCreate = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', ownerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const firstObjectId = firstCreate.body.id;
+
+        const secondCreate = await supertestWithoutAuth
+          .post('/access_control_objects/create')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', ownerCookie.cookieString())
+          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .expect(200);
+        const secondObjectId = secondCreate.body.id;
+
+        await supertestWithoutAuth
+          .put('/access_control_objects/change_owner')
+          .set('kbn-xsrf', 'true')
+          .set('cookie', ownerCookie.cookieString())
+          .send({
+            objects: [
+              { id: firstObjectId, type: firstCreate.body.type },
+              { id: secondObjectId, type: secondCreate.body.type },
+            ],
+            newOwnerProfileUid: simpleUserProfileUid,
+          })
+          .expect(200);
+        {
+          const getResponse = await supertestWithoutAuth
+            .get(`/access_control_objects/${firstObjectId}`)
+            .set('kbn-xsrf', 'true')
+            .set('cookie', adminCookie.cookieString())
+            .expect(200);
+
+          expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
+        }
+        {
+          const getResponse = await supertestWithoutAuth
+            .get(`/access_control_objects/${secondObjectId}`)
+            .set('kbn-xsrf', 'true')
+            .set('cookie', adminCookie.cookieString())
+            .expect(200);
+          expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
+        }
+      });
+
+      describe('partial bulk change ownership', () => {
+        it('should allow bulk transfer ownership of allowed objects', async () => {
+          const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
+          const { cookie: ownerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+          const firstCreate = await supertestWithoutAuth
+            .post('/access_control_objects/create')
+            .set('kbn-xsrf', 'true')
+            .set('cookie', ownerCookie.cookieString())
+            .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+            .expect(200);
+          const firstObjectId = firstCreate.body.id;
+
+          const secondCreate = await supertestWithoutAuth
+            .post('/access_control_objects/create')
+            .set('kbn-xsrf', 'true')
+            .set('cookie', ownerCookie.cookieString())
+            .send({ type: NON_ACCESS_CONTROL_TYPE })
+            .expect(200);
+          const secondObjectId = secondCreate.body.id;
+
+          const transferResponse = await supertestWithoutAuth
+            .put('/access_control_objects/change_owner')
+            .set('kbn-xsrf', 'true')
+            .set('cookie', ownerCookie.cookieString())
+            .send({
+              objects: [
+                { id: firstObjectId, type: firstCreate.body.type },
+                { id: secondObjectId, type: secondCreate.body.type },
+              ],
+              newOwnerProfileUid: simpleUserProfileUid,
+            })
+            .expect(200);
+          expect(transferResponse.body.objects).to.have.length(2);
+          transferResponse.body.objects.forEach(
+            (object: { id: string; type: string; error?: any }) => {
+              if (object.type === ACCESS_CONTROL_TYPE) {
+                expect(object).to.have.property('id', firstObjectId);
+              }
+              if (object.type === NON_ACCESS_CONTROL_TYPE) {
+                expect(object).to.have.property('id', secondObjectId);
+                expect(object).to.have.property('error');
+                expect(object.error).to.have.property('output');
+                expect(object.error.output).to.have.property('payload');
+                expect(object.error.output.payload).to.have.property('message');
+                expect(object.error.output.payload.message).to.contain(
+                  `The type ${NON_ACCESS_CONTROL_TYPE} does not support access control: Bad Request`
+                );
+              }
+            }
+          );
+        });
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/change_ownership.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/change_ownership.ts
@@ -14,20 +14,12 @@ import expect from '@kbn/expect';
 import { adminTestUser } from '@kbn/test';
 
 import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
+import { X_ELASTIC_INTERNAL_ORIGIN_REQUEST } from '@kbn/core/packages/http/common';
 
 export default function ({ getService }: FtrProviderContext) {
   const es = getService('es');
+  const supertest = getService('supertest');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
-  const security = getService('security');
-
-  const createSimpleUser = async (roles: string[] = ['viewer']) => {
-    await es.security.putUser({
-      username: 'simple_user',
-      refresh: 'wait_for',
-      password: 'changeme',
-      roles,
-    });
-  };
 
   const login = async (username: string, password: string | undefined) => {
     const response = await supertestWithoutAuth
@@ -69,122 +61,207 @@ export default function ({ getService }: FtrProviderContext) {
     };
   };
 
-  describe('access control saved objects', () => {
-    before(async () => {
-      await security.testUser.setRoles(['kibana_savedobjects_editor']);
-      await createSimpleUser();
-    });
+  const unownedObjectId = 'unowned_object_id';
+
+  const createUnownedAccessControlObject = async () => {
+    // Note: Using deprecated SO API to create an unowned object
+    const res = await supertest
+      .post(`/api/saved_objects/${ACCESS_CONTROL_TYPE}/${unownedObjectId}`)
+      .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+      .set('kbn-xsrf', 'xxx')
+      .send({ attributes: {} })
+      .expect(200);
+    return res.body.id;
+  };
+
+  const deleteUnownedAccessControlObject = async () => {
+    await supertest
+      .delete(`/api/saved_objects/${ACCESS_CONTROL_TYPE}/${unownedObjectId}`)
+      .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+      .set('kbn-xsrf', 'xxx')
+      .expect(200);
+  };
+
+  describe('#change_ownership', () => {
     after(async () => {
-      await security.testUser.restoreDefaults();
+      await deleteUnownedAccessControlObject();
+    });
+    it('should transfer ownership of write-restricted objects by owner', async () => {
+      const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
+
+      const { cookie: ownerCookie, profileUid } = await loginAsObjectOwner('test_user', 'changeme');
+
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+
+      await supertestWithoutAuth
+        .put('/access_control_objects/change_owner')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({
+          objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
+          newOwnerProfileUid: simpleUserProfileUid,
+        })
+        .expect(200);
+
+      const getResponse = await supertestWithoutAuth
+        .get(`/access_control_objects/${objectId}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .expect(200);
+      expect(getResponse.body).to.have.property('accessControl');
+      expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
     });
 
-    describe('#change_ownership', () => {
-      it('should transfer ownership of write-restricted objects by owner', async () => {
-        const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
+    it('should throw when transferring ownership of object owned by a different user and not admin', async () => {
+      const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
+      const { cookie: adminCookie, profileUid: adminProfileUid } = await loginAsKibanaAdmin();
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const objectId = createResponse.body.id;
 
-        const { cookie: ownerCookie, profileUid } = await loginAsObjectOwner(
-          'test_user',
-          'changeme'
-        );
+      expect(createResponse.body.accessControl).to.have.property('owner', adminProfileUid);
 
-        const createResponse = await supertestWithoutAuth
-          .post('/access_control_objects/create')
-          .set('kbn-xsrf', 'true')
-          .set('cookie', ownerCookie.cookieString())
-          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
-          .expect(200);
-        const objectId = createResponse.body.id;
-        expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+      const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('test_user', 'changeme');
+      const transferResponse = await supertestWithoutAuth
+        .put('/access_control_objects/change_owner')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', notOwnerCookie.cookieString())
+        .send({
+          objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
+          newOwnerProfileUid: simpleUserProfileUid,
+        })
+        .expect(403);
 
-        await supertestWithoutAuth
-          .put('/access_control_objects/change_owner')
-          .set('kbn-xsrf', 'true')
-          .set('cookie', ownerCookie.cookieString())
-          .send({
-            objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
-            newOwnerProfileUid: simpleUserProfileUid,
-          })
-          .expect(200);
+      expect(transferResponse.body).to.have.property('message');
+      expect(transferResponse.body.message).to.contain(
+        `Access denied: Unable to manage access control for ${ACCESS_CONTROL_TYPE}`
+      );
+    });
 
+    it('should allow admins to transfer ownership of any object', async () => {
+      const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
+      const { cookie: ownerCookie, profileUid } = await loginAsObjectOwner('test_user', 'changeme');
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const objectId = createResponse.body.id;
+
+      expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+
+      const { cookie: adminCookie } = await loginAsKibanaAdmin();
+      await supertestWithoutAuth
+        .put('/access_control_objects/change_owner')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({
+          objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
+          newOwnerProfileUid: simpleUserProfileUid,
+        })
+        .expect(200);
+
+      const getResponse = await supertestWithoutAuth
+        .get(`/access_control_objects/${objectId}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .expect(200);
+
+      expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
+    });
+
+    it('should allow bulk transfer ownership of allowed objects', async () => {
+      const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
+      const { cookie: ownerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+      const { cookie: adminCookie } = await loginAsKibanaAdmin();
+      const firstCreate = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const firstObjectId = firstCreate.body.id;
+
+      const secondCreate = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const secondObjectId = secondCreate.body.id;
+
+      await supertestWithoutAuth
+        .put('/access_control_objects/change_owner')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({
+          objects: [
+            { id: firstObjectId, type: firstCreate.body.type },
+            { id: secondObjectId, type: secondCreate.body.type },
+          ],
+          newOwnerProfileUid: simpleUserProfileUid,
+        })
+        .expect(200);
+      {
         const getResponse = await supertestWithoutAuth
-          .get(`/access_control_objects/${objectId}`)
+          .get(`/access_control_objects/${firstObjectId}`)
           .set('kbn-xsrf', 'true')
-          .set('cookie', ownerCookie.cookieString())
+          .set('cookie', adminCookie.cookieString())
           .expect(200);
-        expect(getResponse.body).to.have.property('accessControl');
+
         expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
-      });
-
-      it('should throw when transferring ownership of object owned by a different user and not admin', async () => {
-        const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
-        const { cookie: adminCookie, profileUid: adminProfileUid } = await loginAsKibanaAdmin();
-        const createResponse = await supertestWithoutAuth
-          .post('/access_control_objects/create')
-          .set('kbn-xsrf', 'true')
-          .set('cookie', adminCookie.cookieString())
-          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
-          .expect(200);
-        const objectId = createResponse.body.id;
-
-        expect(createResponse.body.accessControl).to.have.property('owner', adminProfileUid);
-
-        const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('test_user', 'changeme');
-        const transferResponse = await supertestWithoutAuth
-          .put('/access_control_objects/change_owner')
-          .set('kbn-xsrf', 'true')
-          .set('cookie', notOwnerCookie.cookieString())
-          .send({
-            objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
-            newOwnerProfileUid: simpleUserProfileUid,
-          })
-          .expect(403);
-
-        expect(transferResponse.body).to.have.property('message');
-        expect(transferResponse.body.message).to.contain(
-          `Access denied: Unable to manage access control for ${ACCESS_CONTROL_TYPE}`
-        );
-      });
-
-      it('should allow admins to transfer ownership of any object', async () => {
-        const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
-        const { cookie: ownerCookie, profileUid } = await loginAsObjectOwner(
-          'test_user',
-          'changeme'
-        );
-        const createResponse = await supertestWithoutAuth
-          .post('/access_control_objects/create')
-          .set('kbn-xsrf', 'true')
-          .set('cookie', ownerCookie.cookieString())
-          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
-          .expect(200);
-        const objectId = createResponse.body.id;
-
-        expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
-
-        const { cookie: adminCookie } = await loginAsKibanaAdmin();
-        await supertestWithoutAuth
-          .put('/access_control_objects/change_owner')
-          .set('kbn-xsrf', 'true')
-          .set('cookie', adminCookie.cookieString())
-          .send({
-            objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
-            newOwnerProfileUid: simpleUserProfileUid,
-          })
-          .expect(200);
-
+      }
+      {
         const getResponse = await supertestWithoutAuth
-          .get(`/access_control_objects/${objectId}`)
+          .get(`/access_control_objects/${secondObjectId}`)
           .set('kbn-xsrf', 'true')
           .set('cookie', adminCookie.cookieString())
           .expect(200);
-
         expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
-      });
+      }
+    });
 
+    it('should allow admin to assign ownership of an unowned object', async () => {
+      const { cookie: adminCookie } = await loginAsKibanaAdmin();
+      const objectId = await createUnownedAccessControlObject();
+
+      const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
+      const transferResponse = await supertestWithoutAuth
+        .put('/access_control_objects/change_owner')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({
+          objects: [{ id: objectId, type: ACCESS_CONTROL_TYPE }],
+          newOwnerProfileUid: simpleUserProfileUid,
+        })
+        .expect(200);
+      expect(transferResponse.body.objects).to.have.length(1);
+
+      const getResponse = await supertestWithoutAuth
+        .get(`/access_control_objects/${objectId}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .expect(200);
+
+      expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
+    });
+
+    describe('partial bulk change ownership', () => {
       it('should allow bulk transfer ownership of allowed objects', async () => {
         const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
         const { cookie: ownerCookie } = await loginAsObjectOwner('test_user', 'changeme');
-        const { cookie: adminCookie } = await loginAsKibanaAdmin();
         const firstCreate = await supertestWithoutAuth
           .post('/access_control_objects/create')
           .set('kbn-xsrf', 'true')
@@ -197,11 +274,11 @@ export default function ({ getService }: FtrProviderContext) {
           .post('/access_control_objects/create')
           .set('kbn-xsrf', 'true')
           .set('cookie', ownerCookie.cookieString())
-          .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+          .send({ type: NON_ACCESS_CONTROL_TYPE })
           .expect(200);
         const secondObjectId = secondCreate.body.id;
 
-        await supertestWithoutAuth
+        const transferResponse = await supertestWithoutAuth
           .put('/access_control_objects/change_owner')
           .set('kbn-xsrf', 'true')
           .set('cookie', ownerCookie.cookieString())
@@ -213,76 +290,24 @@ export default function ({ getService }: FtrProviderContext) {
             newOwnerProfileUid: simpleUserProfileUid,
           })
           .expect(200);
-        {
-          const getResponse = await supertestWithoutAuth
-            .get(`/access_control_objects/${firstObjectId}`)
-            .set('kbn-xsrf', 'true')
-            .set('cookie', adminCookie.cookieString())
-            .expect(200);
-
-          expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
-        }
-        {
-          const getResponse = await supertestWithoutAuth
-            .get(`/access_control_objects/${secondObjectId}`)
-            .set('kbn-xsrf', 'true')
-            .set('cookie', adminCookie.cookieString())
-            .expect(200);
-          expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
-        }
-      });
-
-      describe('partial bulk change ownership', () => {
-        it('should allow bulk transfer ownership of allowed objects', async () => {
-          const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
-          const { cookie: ownerCookie } = await loginAsObjectOwner('test_user', 'changeme');
-          const firstCreate = await supertestWithoutAuth
-            .post('/access_control_objects/create')
-            .set('kbn-xsrf', 'true')
-            .set('cookie', ownerCookie.cookieString())
-            .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
-            .expect(200);
-          const firstObjectId = firstCreate.body.id;
-
-          const secondCreate = await supertestWithoutAuth
-            .post('/access_control_objects/create')
-            .set('kbn-xsrf', 'true')
-            .set('cookie', ownerCookie.cookieString())
-            .send({ type: NON_ACCESS_CONTROL_TYPE })
-            .expect(200);
-          const secondObjectId = secondCreate.body.id;
-
-          const transferResponse = await supertestWithoutAuth
-            .put('/access_control_objects/change_owner')
-            .set('kbn-xsrf', 'true')
-            .set('cookie', ownerCookie.cookieString())
-            .send({
-              objects: [
-                { id: firstObjectId, type: firstCreate.body.type },
-                { id: secondObjectId, type: secondCreate.body.type },
-              ],
-              newOwnerProfileUid: simpleUserProfileUid,
-            })
-            .expect(200);
-          expect(transferResponse.body.objects).to.have.length(2);
-          transferResponse.body.objects.forEach(
-            (object: { id: string; type: string; error?: any }) => {
-              if (object.type === ACCESS_CONTROL_TYPE) {
-                expect(object).to.have.property('id', firstObjectId);
-              }
-              if (object.type === NON_ACCESS_CONTROL_TYPE) {
-                expect(object).to.have.property('id', secondObjectId);
-                expect(object).to.have.property('error');
-                expect(object.error).to.have.property('output');
-                expect(object.error.output).to.have.property('payload');
-                expect(object.error.output.payload).to.have.property('message');
-                expect(object.error.output.payload.message).to.contain(
-                  `The type ${NON_ACCESS_CONTROL_TYPE} does not support access control: Bad Request`
-                );
-              }
+        expect(transferResponse.body.objects).to.have.length(2);
+        transferResponse.body.objects.forEach(
+          (object: { id: string; type: string; error?: any }) => {
+            if (object.type === ACCESS_CONTROL_TYPE) {
+              expect(object).to.have.property('id', firstObjectId);
             }
-          );
-        });
+            if (object.type === NON_ACCESS_CONTROL_TYPE) {
+              expect(object).to.have.property('id', secondObjectId);
+              expect(object).to.have.property('error');
+              expect(object.error).to.have.property('output');
+              expect(object.error.output).to.have.property('payload');
+              expect(object.error.output.payload).to.have.property('message');
+              expect(object.error.output.payload.message).to.contain(
+                `The type ${NON_ACCESS_CONTROL_TYPE} does not support access control: Bad Request`
+              );
+            }
+          }
+        );
       });
     });
   });

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/create.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/create.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { parse as parseCookie } from 'tough-cookie';
+
+import { ACCESS_CONTROL_TYPE } from '@kbn/access-control-test-plugin/server';
+import expect from '@kbn/expect';
+import { adminTestUser } from '@kbn/test';
+
+import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  const login = async (username: string, password: string | undefined) => {
+    const response = await supertestWithoutAuth
+      .post('/internal/security/login')
+      .set('kbn-xsrf', 'xxx')
+      .send({
+        providerType: 'basic',
+        providerName: 'basic',
+        currentURL: '/',
+        params: { username, password },
+      })
+      .expect(200);
+    const cookie = parseCookie(response.headers['set-cookie'][0])!;
+    const profileUidResponse = await supertestWithoutAuth
+      .get('/internal/security/me')
+      .set('Cookie', cookie.cookieString())
+      .expect(200);
+    return {
+      cookie,
+      profileUid: profileUidResponse.body.profile_uid,
+    };
+  };
+
+  const loginAsKibanaAdmin = () => login(adminTestUser.username, adminTestUser.password);
+
+  const loginAsObjectOwner = (username: string, password: string) => login(username, password);
+
+  const loginAsNotObjectOwner = (username: string, password: string) => login(username, password);
+
+  describe('#create', () => {
+    it('should create a write-restricted object', async () => {
+      const { cookie: adminCookie, profileUid } = await loginAsKibanaAdmin();
+      const response = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+
+      expect(response.body.type).to.eql(ACCESS_CONTROL_TYPE);
+      expect(response.body).to.have.property('accessControl');
+
+      const { accessControl } = response.body;
+      expect(accessControl).to.have.property('accessMode');
+      expect(accessControl).to.have.property('owner');
+
+      const { owner, accessMode } = accessControl;
+      expect(accessMode).to.be('write_restricted');
+      expect(owner).to.be(profileUid);
+    });
+
+    it('creates objects that support access control without metadata when there is no active user profile', async () => {
+      const response = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'xxxxx')
+        .set(
+          'Authorization',
+          `Basic ${Buffer.from(`${adminTestUser.username}:${adminTestUser.password}`).toString(
+            'base64'
+          )}`
+        )
+        .send({ type: ACCESS_CONTROL_TYPE })
+        .expect(200);
+      expect(response.body).not.to.have.property('accessControl');
+      expect(response.body).to.have.property('type');
+      const { type } = response.body;
+      expect(type).to.be(ACCESS_CONTROL_TYPE);
+    });
+
+    it('should throw when trying to create an access control object with no user', async () => {
+      const response = await supertest
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(400);
+      expect(response.body).to.have.property('message');
+      expect(response.body.message).to.contain(
+        `Unable to create "write_restricted" "${ACCESS_CONTROL_TYPE}" saved object. User profile ID not found.: Bad Request`
+      );
+    });
+
+    it('should allow overwriting an object owned by current user', async () => {
+      const { cookie: objectOwnerCookie, profileUid } = await loginAsObjectOwner(
+        'test_user',
+        'changeme'
+      );
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.attributes).to.have.property('description', 'test');
+      {
+        expect(createResponse.body).to.have.property('accessControl');
+
+        const { accessControl } = createResponse.body;
+        expect(accessControl).to.have.property('accessMode');
+        expect(accessControl).to.have.property('owner');
+
+        const { owner, accessMode } = accessControl;
+        expect(accessMode).to.be('write_restricted');
+        expect(owner).to.be(profileUid);
+      }
+
+      const overwriteResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create?overwrite=true')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ id: objectId, type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+
+      const overwriteId = overwriteResponse.body.id;
+      expect(createResponse.body).to.have.property('id', overwriteId);
+      expect(createResponse.body.accessControl).to.have.property('accessMode', 'write_restricted');
+      expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+    });
+
+    it('should allow overwriting an object owned by another user if admin', async () => {
+      const { cookie: objectOwnerCookie, profileUid: objectOnwerProfileUid } =
+        await loginAsObjectOwner('test_user', 'changeme');
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.attributes).to.have.property('description', 'test');
+      expect(createResponse.body.accessControl).to.have.property('accessMode', 'write_restricted');
+      expect(createResponse.body.accessControl).to.have.property('owner', objectOnwerProfileUid);
+
+      const { cookie: adminCookie } = await loginAsKibanaAdmin();
+
+      const overwriteResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create?overwrite=true')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ id: objectId, type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+
+      const overwriteId = overwriteResponse.body.id;
+      expect(createResponse.body).to.have.property('id', overwriteId);
+      expect(createResponse.body.accessControl).to.have.property('accessMode', 'write_restricted');
+      expect(createResponse.body.accessControl).to.have.property('owner', objectOnwerProfileUid);
+    });
+
+    it('should allow overwriting an object owned by another user if in default mode', async () => {
+      const { cookie: adminCookie, profileUid: adminUid } = await loginAsKibanaAdmin();
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: false })
+        .expect(200);
+
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.attributes).to.have.property('description', 'test');
+      expect(createResponse.body.accessControl).to.have.property('accessMode', 'default');
+      expect(createResponse.body.accessControl).to.have.property('owner', adminUid);
+
+      const { cookie: otherUserCookie } = await loginAsNotObjectOwner('test_user', 'changeme');
+
+      const overwriteResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create?overwrite=true')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', otherUserCookie.cookieString())
+        .send({
+          id: objectId,
+          type: ACCESS_CONTROL_TYPE,
+          isWriteRestricted: true,
+          // description: 'overwritten', ToDo: support this in test plugin
+        })
+        .expect(200);
+
+      const overwriteId = overwriteResponse.body.id;
+      expect(createResponse.body).to.have.property('id', overwriteId);
+      // expect(createResponse.body.attributes).to.have.property('description', 'test');
+      expect(createResponse.body.accessControl).to.have.property('accessMode', 'default'); // cannot overwrite mode
+      expect(createResponse.body.accessControl).to.have.property('owner', adminUid);
+    });
+
+    it('should reject when attempting to overwrite an object owned by another user if not admin', async () => {
+      const { cookie: objectOwnerCookie, profileUid: adminUid } = await loginAsKibanaAdmin();
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.attributes).to.have.property('description', 'test');
+      expect(createResponse.body.accessControl).to.have.property('accessMode', 'write_restricted');
+      expect(createResponse.body.accessControl).to.have.property('owner', adminUid);
+
+      const { cookie: otherOwnerCookie } = await loginAsNotObjectOwner('test_user', 'changeme');
+
+      const overwriteResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create?overwrite=true')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', otherOwnerCookie.cookieString())
+        .send({ id: objectId, type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(403);
+
+      expect(overwriteResponse.body).to.have.property('error', 'Forbidden');
+      expect(overwriteResponse.body).to.have.property(
+        'message',
+        `Unable to create ${ACCESS_CONTROL_TYPE}`
+      );
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/create.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/create.ts
@@ -4,45 +4,19 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { parse as parseCookie } from 'tough-cookie';
 
 import { ACCESS_CONTROL_TYPE } from '@kbn/access-control-test-plugin/server';
 import expect from '@kbn/expect';
 import { adminTestUser } from '@kbn/test';
 
+import { utils } from './utils';
 import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  const login = async (username: string, password: string | undefined) => {
-    const response = await supertestWithoutAuth
-      .post('/internal/security/login')
-      .set('kbn-xsrf', 'xxx')
-      .send({
-        providerType: 'basic',
-        providerName: 'basic',
-        currentURL: '/',
-        params: { username, password },
-      })
-      .expect(200);
-    const cookie = parseCookie(response.headers['set-cookie'][0])!;
-    const profileUidResponse = await supertestWithoutAuth
-      .get('/internal/security/me')
-      .set('Cookie', cookie.cookieString())
-      .expect(200);
-    return {
-      cookie,
-      profileUid: profileUidResponse.body.profile_uid,
-    };
-  };
-
-  const loginAsKibanaAdmin = () => login(adminTestUser.username, adminTestUser.password);
-
-  const loginAsObjectOwner = (username: string, password: string) => login(username, password);
-
-  const loginAsNotObjectOwner = (username: string, password: string) => login(username, password);
+  const { loginAsKibanaAdmin, loginAsObjectOwner, loginAsNotObjectOwner } = utils(getService);
 
   describe('#create', () => {
     it('should create a write-restricted object', async () => {

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/default.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/default.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { parse as parseCookie } from 'tough-cookie';
+
+import { ACCESS_CONTROL_TYPE } from '@kbn/access-control-test-plugin/server';
+import expect from '@kbn/expect';
+import { adminTestUser } from '@kbn/test';
+
+import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  const login = async (username: string, password: string | undefined) => {
+    const response = await supertestWithoutAuth
+      .post('/internal/security/login')
+      .set('kbn-xsrf', 'xxx')
+      .send({
+        providerType: 'basic',
+        providerName: 'basic',
+        currentURL: '/',
+        params: { username, password },
+      })
+      .expect(200);
+    const cookie = parseCookie(response.headers['set-cookie'][0])!;
+    const profileUidResponse = await supertestWithoutAuth
+      .get('/internal/security/me')
+      .set('Cookie', cookie.cookieString())
+      .expect(200);
+    return {
+      cookie,
+      profileUid: profileUidResponse.body.profile_uid,
+    };
+  };
+
+  const loginAsKibanaAdmin = () => login(adminTestUser.username, adminTestUser.password);
+
+  describe('default state of access control objects', () => {
+    it('types supporting access control are created with default access mode when not specified', async () => {
+      const { cookie: adminCookie, profileUid } = await loginAsKibanaAdmin();
+      const response = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE })
+        .expect(200);
+      expect(response.body).to.have.property('accessControl');
+      expect(response.body.accessControl).to.have.property('accessMode', 'default');
+      expect(response.body.accessControl).to.have.property('owner', profileUid);
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/delete.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/delete.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { parse as parseCookie } from 'tough-cookie';
+
+import { ACCESS_CONTROL_TYPE } from '@kbn/access-control-test-plugin/server';
+import expect from '@kbn/expect';
+import { adminTestUser } from '@kbn/test';
+
+import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  const login = async (username: string, password: string | undefined) => {
+    const response = await supertestWithoutAuth
+      .post('/internal/security/login')
+      .set('kbn-xsrf', 'xxx')
+      .send({
+        providerType: 'basic',
+        providerName: 'basic',
+        currentURL: '/',
+        params: { username, password },
+      })
+      .expect(200);
+    const cookie = parseCookie(response.headers['set-cookie'][0])!;
+    const profileUidResponse = await supertestWithoutAuth
+      .get('/internal/security/me')
+      .set('Cookie', cookie.cookieString())
+      .expect(200);
+    return {
+      cookie,
+      profileUid: profileUidResponse.body.profile_uid,
+    };
+  };
+
+  const loginAsKibanaAdmin = () => login(adminTestUser.username, adminTestUser.password);
+
+  const loginAsObjectOwner = (username: string, password: string) => login(username, password);
+
+  const loginAsNotObjectOwner = (username: string, password: string) => login(username, password);
+
+  describe('#delete', () => {
+    it('allow owner to delete object marked as write-restricted', async () => {
+      const { cookie: objectOwnerCookie, profileUid } = await loginAsObjectOwner(
+        'test_user',
+        'changeme'
+      );
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+
+      await supertestWithoutAuth
+        .delete(`/access_control_objects/${objectId}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .expect(200);
+    });
+
+    it('allows admin to delete object marked as write-restricted', async () => {
+      const { cookie: objectOwnerCookie, profileUid } = await loginAsObjectOwner(
+        'test_user',
+        'changeme'
+      );
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+
+      const { cookie: adminCookie } = await loginAsKibanaAdmin();
+      await supertestWithoutAuth
+        .delete(`/access_control_objects/${objectId}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .expect(200);
+
+      const getResponse = await supertestWithoutAuth
+        .get(`/access_control_objects/${objectId}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .expect(404);
+      expect(getResponse.body).to.have.property('message');
+      expect(getResponse.body.message).to.contain(
+        `Saved object [${ACCESS_CONTROL_TYPE}/${objectId}] not found`
+      );
+    });
+
+    it('throws when trying to delete write-restricted object owned by a different user when not admin', async () => {
+      const { cookie: adminCookie, profileUid: adminProfileUid } = await loginAsKibanaAdmin();
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.accessControl).to.have.property('owner', adminProfileUid);
+
+      const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('test_user', 'changeme');
+      const deleteResponse = await supertestWithoutAuth
+        .delete(`/access_control_objects/${objectId}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', notOwnerCookie.cookieString())
+        .expect(403);
+      expect(deleteResponse.body).to.have.property('message');
+      expect(deleteResponse.body.message).to.contain(`Unable to delete ${ACCESS_CONTROL_TYPE}`);
+    });
+
+    it('allows non-owner to delete object in default mode', async () => {
+      const { cookie: ownerCookie } = await loginAsKibanaAdmin();
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE })
+        .expect(200);
+
+      const objectId = createResponse.body.id;
+      const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('test_user', 'changeme');
+
+      await supertestWithoutAuth
+        .delete(`/access_control_objects/${objectId}`)
+        .set('kbn-xsrf', 'true')
+        .set('cookie', notOwnerCookie.cookieString())
+        .expect(200);
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/update.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/update.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { parse as parseCookie } from 'tough-cookie';
+
+import { ACCESS_CONTROL_TYPE } from '@kbn/access-control-test-plugin/server';
+import expect from '@kbn/expect';
+import { adminTestUser } from '@kbn/test';
+
+import type { FtrProviderContext } from '../../../../functional/ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const es = getService('es');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  const createSimpleUser = async (roles: string[] = ['viewer']) => {
+    await es.security.putUser({
+      username: 'simple_user',
+      refresh: 'wait_for',
+      password: 'changeme',
+      roles,
+    });
+  };
+
+  const login = async (username: string, password: string | undefined) => {
+    const response = await supertestWithoutAuth
+      .post('/internal/security/login')
+      .set('kbn-xsrf', 'xxx')
+      .send({
+        providerType: 'basic',
+        providerName: 'basic',
+        currentURL: '/',
+        params: { username, password },
+      })
+      .expect(200);
+    const cookie = parseCookie(response.headers['set-cookie'][0])!;
+    const profileUidResponse = await supertestWithoutAuth
+      .get('/internal/security/me')
+      .set('Cookie', cookie.cookieString())
+      .expect(200);
+    return {
+      cookie,
+      profileUid: profileUidResponse.body.profile_uid,
+    };
+  };
+
+  const loginAsKibanaAdmin = () => login(adminTestUser.username, adminTestUser.password);
+
+  const loginAsObjectOwner = (username: string, password: string) => login(username, password);
+
+  const loginAsNotObjectOwner = (username: string, password: string) => login(username, password);
+
+  describe('#update', () => {
+    it('should update write-restricted objects owned by the same user', async () => {
+      const { cookie: objectOwnerCookie, profileUid } = await loginAsObjectOwner(
+        'test_user',
+        'changeme'
+      );
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.attributes).to.have.property('description', 'test');
+      expect(createResponse.body.accessControl).to.have.property('accessMode', 'write_restricted');
+      expect(createResponse.body.accessControl).to.have.property('owner', profileUid);
+
+      const updateResponse = await supertestWithoutAuth
+        .put('/access_control_objects/update')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', objectOwnerCookie.cookieString())
+        .send({ objectId, type: ACCESS_CONTROL_TYPE })
+        .expect(200);
+
+      expect(updateResponse.body.id).to.eql(objectId);
+      expect(updateResponse.body.attributes).to.have.property('description', 'updated description');
+    });
+
+    it('should throw when updating write-restricted objects owned by a different user when not admin', async () => {
+      const { cookie: adminCookie, profileUid: adminProfileUid } = await loginAsKibanaAdmin();
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const objectId = createResponse.body.id;
+      expect(createResponse.body.attributes).to.have.property('description', 'test');
+      expect(createResponse.body.accessControl).to.have.property('accessMode', 'write_restricted');
+      expect(createResponse.body.accessControl).to.have.property('owner', adminProfileUid);
+
+      const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('test_user', 'changeme');
+      const updateResponse = await supertestWithoutAuth
+        .put('/access_control_objects/update')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', notOwnerCookie.cookieString())
+        .send({ objectId, type: ACCESS_CONTROL_TYPE })
+        .expect(403);
+      expect(updateResponse.body).to.have.property('message');
+      expect(updateResponse.body.message).to.contain(`Unable to update ${ACCESS_CONTROL_TYPE}`);
+    });
+
+    it('objects with default accessMode can be modified by non-owners', async () => {
+      const { cookie: adminCookie } = await loginAsKibanaAdmin();
+      const response = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE })
+        .expect(200);
+      const objectId = response.body.id;
+
+      await createSimpleUser(['kibana_savedobjects_editor']);
+      const { cookie: notOwnerCookie } = await loginAsNotObjectOwner('simple_user', 'changeme');
+      const updateResponse = await supertestWithoutAuth
+        .put('/access_control_objects/update')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', notOwnerCookie.cookieString())
+        .send({ objectId, type: ACCESS_CONTROL_TYPE });
+
+      expect(updateResponse.body.id).to.eql(objectId);
+      expect(updateResponse.body.attributes).to.have.property('description', 'updated description');
+    });
+
+    it('allows admin to update objects owned by different user', async () => {
+      const { cookie: ownerCookie } = await loginAsObjectOwner('test_user', 'changeme');
+      const createResponse = await supertestWithoutAuth
+        .post('/access_control_objects/create')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', ownerCookie.cookieString())
+        .send({ type: ACCESS_CONTROL_TYPE, isWriteRestricted: true })
+        .expect(200);
+      const objectId = createResponse.body.id;
+
+      const { cookie: adminCookie } = await loginAsKibanaAdmin();
+      const updateResponse = await supertestWithoutAuth
+        .put('/access_control_objects/update')
+        .set('kbn-xsrf', 'true')
+        .set('cookie', adminCookie.cookieString())
+        .send({ objectId, type: ACCESS_CONTROL_TYPE })
+        .expect(200);
+
+      expect(updateResponse.body.id).to.eql(objectId);
+      expect(updateResponse.body.attributes).to.have.property('description', 'updated description');
+    });
+  });
+}

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/utils/index.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/apis/utils/index.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { parse as parseCookie } from 'tough-cookie';
+
+import { adminTestUser } from '@kbn/test';
+
+import type { FtrProviderContext } from '../../../../../functional/ftr_provider_context';
+
+export const utils = (getService: FtrProviderContext['getService']) => {
+  const es = getService('es');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  const createSimpleUser = async (roles: string[] = ['viewer']) => {
+    await es.security.putUser({
+      username: 'simple_user',
+      refresh: 'wait_for',
+      password: 'changeme',
+      roles,
+    });
+  };
+
+  const login = async (username: string, password: string | undefined) => {
+    const response = await supertestWithoutAuth
+      .post('/internal/security/login')
+      .set('kbn-xsrf', 'xxx')
+      .send({
+        providerType: 'basic',
+        providerName: 'basic',
+        currentURL: '/',
+        params: { username, password },
+      })
+      .expect(200);
+    const cookie = parseCookie(response.headers['set-cookie'][0])!;
+    const profileUidResponse = await supertestWithoutAuth
+      .get('/internal/security/me')
+      .set('Cookie', cookie.cookieString())
+      .expect(200);
+    return {
+      cookie,
+      profileUid: profileUidResponse.body.profile_uid,
+    };
+  };
+
+  const loginAsKibanaAdmin = () => login(adminTestUser.username, adminTestUser.password);
+
+  const loginAsObjectOwner = (username: string, password: string) => login(username, password);
+
+  const loginAsNotObjectOwner = (username: string, password: string) => login(username, password);
+
+  const activateSimpleUserProfile = async () => {
+    const response = await es.security.activateUserProfile({
+      username: 'simple_user',
+      password: 'changeme',
+      grant_type: 'password',
+    });
+
+    return {
+      profileUid: response.uid,
+    };
+  };
+
+  return {
+    createSimpleUser,
+    login,
+    loginAsKibanaAdmin,
+    loginAsObjectOwner,
+    loginAsNotObjectOwner,
+    activateSimpleUserProfile,
+  };
+};

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/index.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/tests/index.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
+
+export default function ({ loadTestFile, getService }: FtrProviderContext) {
+  const es = getService('es');
+  const security = getService('security');
+
+  const createSimpleUser = async (roles: string[] = ['viewer']) => {
+    await es.security.putUser({
+      username: 'simple_user',
+      refresh: 'wait_for',
+      password: 'changeme',
+      roles,
+    });
+  };
+
+  describe('Platform Security - Access Control Objects', function () {
+    before(async () => {
+      await security.testUser.setRoles(['kibana_savedobjects_editor']);
+      await createSimpleUser();
+    });
+    after(async () => {
+      await security.testUser.restoreDefaults();
+    });
+
+    loadTestFile(require.resolve('./apis/create.ts'));
+    loadTestFile(require.resolve('./apis/bulk_create.ts'));
+
+    loadTestFile(require.resolve('./apis/update.ts'));
+    loadTestFile(require.resolve('./apis/bulk_update.ts'));
+
+    loadTestFile(require.resolve('./apis/delete.ts'));
+    loadTestFile(require.resolve('./apis/bulk_delete.ts'));
+
+    loadTestFile(require.resolve('./apis/change_access_mode.ts'));
+    loadTestFile(require.resolve('./apis/change_ownership.ts'));
+
+    loadTestFile(require.resolve('./apis/default.ts'));
+  });
+}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/237819

## Summary

No functional changes to Write restricted objects. Changes only to integration tests

- [ ] Move to deployment agnostic setup
- [x]  Split each operation tests into individual test files and add to config: https://github.com/elastic/kibana/pull/224411#discussion_r2413200605
- [ ]  Add unit tests for change access mode and change owner to confirm calling of changeAccessControl
- [ ] Add 'allows creating an object supporting access control with no access control metadata when there is no active user profile and no access mode is provided' to [src/core/packages/saved-objects/api-server-internal/src/lib/apis/create.test.ts](https://github.com/elastic/kibana/pull/224411/files/2c96ed58ad18a1c323e63c8d4738d42d81e2773b#diff-22b326216a60f8a87284c1372405b5d6da2db9d58ed2960d7570eb5594adfecc)
- [x]  Add specific test for allowing unowned ownable objects to be assigned an owner by an admin



