### PR TITLE
[Controls Anywhere] Make "Use global filters" setting ignore control selections

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/fetch_and_validate.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/fetch_and_validate.tsx
@@ -97,7 +97,6 @@ export function fetchAndValidate$({
 
         /** Fetch the suggestions list + perform validation */
         api.loadingSuggestions$.next(true);
-        fetchContext.filters = getFetchContextFilters(fetchContext, useGlobalFilters);
 
         const request = {
           sort,
@@ -111,6 +110,7 @@ export function fetchAndValidate$({
 
           ignoreValidations,
           ...fetchContext,
+          filters: getFetchContextFilters(fetchContext, useGlobalFilters),
 
           // TODO: get expensive queries setting
           allowExpensiveQueries: true,

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/has_no_results.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/has_no_results.ts
@@ -45,7 +45,6 @@ export function hasNoResults$({
       if (!dataView || !rangeFilter || ignoreValidations) {
         return false;
       }
-      controlFetchContext.filters = getFetchContextFilters(controlFetchContext, useGlobalFilters);
 
       try {
         setIsLoading(true);
@@ -56,6 +55,7 @@ export function hasNoResults$({
           dataView,
           rangeFilter,
           ...controlFetchContext,
+          filters: getFetchContextFilters(controlFetchContext, useGlobalFilters),
         });
       } catch (error) {
         // Ignore error, validation is not required for control to function properly

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/min_max.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/min_max.ts
@@ -47,7 +47,6 @@ export function minMax$({
       if (!dataView || !dataViewField) {
         return { max: undefined, min: undefined };
       }
-      controlFetchContext.filters = getFetchContextFilters(controlFetchContext, useGlobalFilters);
 
       try {
         setIsLoading(true);
@@ -58,6 +57,7 @@ export function minMax$({
           dataView,
           field: dataViewField,
           ...controlFetchContext,
+          filters: getFetchContextFilters(controlFetchContext, useGlobalFilters),
         });
       } catch (error) {
         return { error, max: undefined, min: undefined };

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/utils/filter_utils.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/utils/filter_utils.ts
@@ -11,9 +11,7 @@ import type { FetchContext } from '@kbn/presentation-publishing';
 
 export const getFetchContextFilters = (fetchContext: FetchContext, useGlobalFilters?: boolean) => {
   if (!useGlobalFilters) {
-    return fetchContext.filters?.filter(
-      (currentFilter) => Boolean(currentFilter.meta.controlledBy) // filters without `controlledBy` are coming from unified search
-    );
+    return [];
   }
   return fetchContext.filters;
 };

--- a/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_control_group_out.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_control_group_out.ts
@@ -29,6 +29,9 @@ export function transformControlGroupOut(
   const legacyControlGroupOptions: StoredControlGroupInput['ignoreParentSettings'] | undefined =
     ignoreParentSettingsJSON ? JSON.parse(ignoreParentSettingsJSON) : undefined;
   if (legacyControlGroupOptions) {
+    // Ignore filters if the legacy control group option is set to ignore filters, or if the legacy chaining system
+    // is set to NONE. Including the chaining system check inside this if block is okay to do, because we don't expect
+    // a legacy chaining system to be defined without legacyControlGroupOptions also being defined
     const ignoreFilters =
       controlGroupInput.chainingSystem === 'NONE' ||
       legacyControlGroupOptions.ignoreFilters ||

--- a/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_control_group_out.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_control_group_out.ts
@@ -30,7 +30,9 @@ export function transformControlGroupOut(
     ignoreParentSettingsJSON ? JSON.parse(ignoreParentSettingsJSON) : undefined;
   if (legacyControlGroupOptions) {
     const ignoreFilters =
-      legacyControlGroupOptions.ignoreFilters || legacyControlGroupOptions.ignoreQuery;
+      controlGroupInput.chainingSystem === 'NONE' ||
+      legacyControlGroupOptions.ignoreFilters ||
+      legacyControlGroupOptions.ignoreQuery;
     controls = controls.reduce((prev, control) => {
       return [
         ...prev,
@@ -44,3 +46,4 @@ export function transformControlGroupOut(
   }
   return { controls };
 }
+``;

--- a/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_control_group_out.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/out/transform_control_group_out.ts
@@ -46,4 +46,3 @@ export function transformControlGroupOut(
   }
   return { controls };
 }
-``;


### PR DESCRIPTION
## Summary

Closes #237887 

When setting "Use global filters" on a control, it will now pass a set of empty filters to the `fetchContext` when fetching new data, instead of keeping filters from all the other controls on the dashboard.

