### PR TITLE
[9.2] [Discover] Fix ES|QL extra fetches (#239646)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.test.tsx
@@ -94,6 +94,7 @@ async function mountComponent({
           query: '',
         },
     filters: [],
+    esqlVariables: [],
     relativeTimeRange: { from: '2020-05-14T11:05:13.590', to: '2020-05-14T11:20:13.590' },
     getTimeRange: () => ({ from: '2020-05-14T11:05:13.590', to: '2020-05-14T11:20:13.590' }),
     updateTimeRange: () => {},

--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.tsx
@@ -28,7 +28,6 @@ import type { DataView, DataViewField } from '@kbn/data-views-plugin/public';
 import type { TimeRange } from '@kbn/es-query';
 import type { PublishingSubject } from '@kbn/presentation-publishing';
 import type { RequestStatus } from '@kbn/inspector-plugin/public';
-import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { IKibanaSearchResponse } from '@kbn/search-types';
 import type { estypes } from '@elastic/elasticsearch';
 import { Histogram } from './histogram';
@@ -91,7 +90,6 @@ export interface UnifiedHistogramChartProps {
   onBrushEnd?: LensEmbeddableInput['onBrushEnd'];
   withDefaultActions?: EmbeddableComponentProps['withDefaultActions'];
   columns?: DatatableColumn[];
-  esqlVariables?: ESQLControlVariable[];
 }
 
 const RequestStatusError: typeof RequestStatus.ERROR = 2;
@@ -143,7 +141,8 @@ export function UnifiedHistogramChart({
     [originalInput$]
   );
 
-  const { filters, query, getTimeRange, updateTimeRange, relativeTimeRange } = requestParams;
+  const { filters, query, esqlVariables, getTimeRange, updateTimeRange, relativeTimeRange } =
+    requestParams;
 
   const fetch$ = useFetch({
     input$,
@@ -218,6 +217,7 @@ export function UnifiedHistogramChart({
     getTimeRange,
     fetch$,
     visContext,
+    esqlVariables,
     onLoad,
   });
 

--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/histogram.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/histogram.tsx
@@ -12,7 +12,6 @@ import { css } from '@emotion/react';
 import React from 'react';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { TimeRange } from '@kbn/es-query';
-import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { EmbeddableComponentProps, LensEmbeddableInput } from '@kbn/lens-plugin/public';
 import type {
   UnifiedHistogramBucketInterval,
@@ -39,7 +38,6 @@ export interface HistogramProps {
   onFilter?: LensEmbeddableInput['onFilter'];
   onBrushEnd?: LensEmbeddableInput['onBrushEnd'];
   withDefaultActions?: EmbeddableComponentProps['withDefaultActions'];
-  esqlVariables?: ESQLControlVariable[];
 }
 
 export function Histogram({
@@ -58,7 +56,6 @@ export function Histogram({
   onBrushEnd,
   withDefaultActions,
   abortController,
-  esqlVariables,
 }: HistogramProps) {
   const { timeRangeText, timeRangeDisplay } = useTimeRange({
     uiSettings,
@@ -121,7 +118,6 @@ export function Histogram({
           onFilter={onFilter}
           onBrushEnd={onBrushEnd}
           withDefaultActions={withDefaultActions}
-          esqlVariables={esqlVariables}
         />
       </div>
       {timeRangeDisplay}

--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/hooks/use_lens_props.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/hooks/use_lens_props.ts
@@ -12,6 +12,7 @@ import type { DefaultInspectorAdapters } from '@kbn/expressions-plugin/common';
 import type { EmbeddableComponentProps, TypedLensByValueInput } from '@kbn/lens-plugin/public';
 import { useCallback, useEffect, useState } from 'react';
 import type { Observable } from 'rxjs';
+import type { ESQLControlVariable } from '@kbn/esql-types';
 import type {
   UnifiedHistogramInputMessage,
   UnifiedHistogramRequestContext,
@@ -25,6 +26,7 @@ export type LensProps = Pick<
   | 'viewMode'
   | 'timeRange'
   | 'attributes'
+  | 'esqlVariables'
   | 'noPadding'
   | 'searchSessionId'
   | 'executionContext'
@@ -36,12 +38,14 @@ export const useLensProps = ({
   getTimeRange,
   fetch$,
   visContext,
+  esqlVariables,
   onLoad,
 }: {
   request?: UnifiedHistogramRequestContext;
   getTimeRange: () => TimeRange;
   fetch$: Observable<UnifiedHistogramInputMessage>;
   visContext?: UnifiedHistogramVisContext;
+  esqlVariables?: ESQLControlVariable[];
   onLoad: (isLoading: boolean, adapters: Partial<DefaultInspectorAdapters> | undefined) => void;
 }) => {
   const buildLensProps = useCallback(() => {
@@ -57,10 +61,11 @@ export const useLensProps = ({
         searchSessionId: request?.searchSessionId,
         getTimeRange,
         attributes,
+        esqlVariables,
         onLoad,
       }),
     };
-  }, [visContext, getTimeRange, onLoad, request?.searchSessionId]);
+  }, [visContext, request?.searchSessionId, getTimeRange, esqlVariables, onLoad]);
 
   // Initialize with undefined to avoid rendering Lens until a fetch has been triggered
   const [lensPropsContext, setLensPropsContext] = useState<ReturnType<typeof buildLensProps>>();
@@ -78,17 +83,20 @@ export const getLensProps = ({
   searchSessionId,
   getTimeRange,
   attributes,
+  esqlVariables,
   onLoad,
 }: {
   searchSessionId?: string;
   getTimeRange: () => TimeRange;
   attributes: TypedLensByValueInput['attributes'];
+  esqlVariables?: ESQLControlVariable[];
   onLoad: (isLoading: boolean, adapters: Partial<DefaultInspectorAdapters> | undefined) => void;
 }): LensProps => ({
   id: 'unifiedHistogramLensComponent',
   viewMode: 'view',
   timeRange: getTimeRange(),
   attributes,
+  esqlVariables,
   noPadding: true,
   searchSessionId,
   executionContext: {

--- a/src/platform/packages/shared/kbn-unified-histogram/hooks/use_request_params.test.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/hooks/use_request_params.test.ts
@@ -35,6 +35,7 @@ describe('useRequestParams', () => {
         query: '',
         language: 'kuery',
       },
+      esqlVariables: [],
     };
     const hook = renderHook((props) => useRequestParams(props), {
       initialProps: originalProps,

--- a/src/platform/packages/shared/kbn-unified-histogram/hooks/use_request_params.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/hooks/use_request_params.tsx
@@ -10,12 +10,14 @@
 import { getAbsoluteTimeRange } from '@kbn/data-plugin/common';
 import type { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
 import { useCallback, useMemo, useRef } from 'react';
+import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { UnifiedHistogramServices } from '../types';
 import { useStableCallback } from './use_stable_callback';
 
 export interface UseRequestParamsResult {
   query: Query | AggregateQuery;
   filters: Filter[];
+  esqlVariables: ESQLControlVariable[];
   relativeTimeRange: TimeRange;
   getTimeRange: () => TimeRange;
   updateTimeRange: () => void;
@@ -25,12 +27,14 @@ export const useRequestParams = ({
   services,
   query: originalQuery,
   filters: originalFilters,
+  esqlVariables: originalEsqlVariables,
   timeRange: originalTimeRange,
 }: {
   services: UnifiedHistogramServices;
-  query?: Query | AggregateQuery;
-  filters?: Filter[];
-  timeRange?: TimeRange;
+  query: Query | AggregateQuery | undefined;
+  filters: Filter[] | undefined;
+  esqlVariables: ESQLControlVariable[] | undefined;
+  timeRange: TimeRange | undefined;
 }): UseRequestParamsResult => {
   const { data } = services;
 
@@ -40,6 +44,10 @@ export const useRequestParams = ({
     () => originalQuery ?? data.query.queryString.getDefaultQuery(),
     [data.query.queryString, originalQuery]
   );
+
+  const esqlVariables = useMemo(() => {
+    return originalEsqlVariables ?? [];
+  }, [originalEsqlVariables]);
 
   const relativeTimeRange = useMemo(
     () => originalTimeRange ?? data.query.timefilter.timefilter.getTimeDefaults(),
@@ -52,5 +60,5 @@ export const useRequestParams = ({
     timeRange.current = getAbsoluteTimeRange(relativeTimeRange);
   });
 
-  return { filters, query, getTimeRange, updateTimeRange, relativeTimeRange };
+  return { filters, query, esqlVariables, getTimeRange, updateTimeRange, relativeTimeRange };
 };

--- a/src/platform/packages/shared/kbn-unified-histogram/hooks/use_services_bootstrap.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/hooks/use_services_bootstrap.ts
@@ -53,6 +53,7 @@ export const useServicesBootstrap = (props: UseUnifiedHistogramProps) => {
     localStorageKeyPrefix,
     filters,
     timeRange,
+    esqlVariables,
   } = props;
 
   const initialBreakdownField = useMemo(
@@ -81,6 +82,7 @@ export const useServicesBootstrap = (props: UseUnifiedHistogramProps) => {
     services,
     query,
     filters,
+    esqlVariables,
     timeRange,
   });
 

--- a/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.test.tsx
@@ -45,7 +45,7 @@ describe('useUnifiedHistogram', () => {
     });
     expect(hook.result.current.api).toBeDefined();
     expect(hook.result.current.chartProps?.chart?.timeInterval).toBe('42s');
-    expect(hook.result.current.chartProps?.esqlVariables).toEqual([
+    expect(hook.result.current.chartProps?.requestParams.esqlVariables).toEqual([
       {
         key: 'agent_keyword',
         value: 'Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1',

--- a/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.ts
@@ -177,16 +177,8 @@ export const useUnifiedHistogram = (props: UseUnifiedHistogramProps): UseUnified
     setLensVisService(new LensVisService({ services, lensSuggestionsApi: apiHelper.suggestions }));
   });
 
-  const {
-    services,
-    dataView,
-    columns,
-    isChartLoading,
-    timeRange,
-    table,
-    externalVisContext,
-    esqlVariables,
-  } = props;
+  const { services, dataView, columns, isChartLoading, timeRange, table, externalVisContext } =
+    props;
 
   const columnsMap = useMemo(() => {
     return columns?.reduce<Record<string, DatatableColumn>>((acc, column) => {
@@ -259,7 +251,6 @@ export const useUnifiedHistogram = (props: UseUnifiedHistogramProps): UseUnified
       ? {
           ...props,
           ...stateProps,
-          esqlVariables,
           input$,
           chart,
           isChartAvailable,
@@ -267,16 +258,7 @@ export const useUnifiedHistogram = (props: UseUnifiedHistogramProps): UseUnified
           lensVisService,
         }
       : undefined;
-  }, [
-    chart,
-    input$,
-    isChartAvailable,
-    lensVisService,
-    props,
-    requestParams,
-    stateProps,
-    esqlVariables,
-  ]);
+  }, [chart, input$, isChartAvailable, lensVisService, props, requestParams, stateProps]);
   const layoutProps = useMemo<UnifiedHistogramPartialLayoutProps>(
     () => ({
       chart,

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.test.tsx
@@ -83,6 +83,7 @@ describe('MetricsExperienceGrid', () => {
       getTimeRange: () => ({ from: 'now-15m', to: 'now' }),
       filters: [],
       query: { esql: 'FROM metrics-*' },
+      esqlVariables: [],
       relativeTimeRange: { from: 'now-15m', to: 'now' },
       updateTimeRange: () => {},
     },

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_grid.test.tsx
@@ -29,6 +29,7 @@ describe('MetricsGrid', () => {
     query: {
       esql: 'FROM metrics-*',
     },
+    esqlVariables: [],
     relativeTimeRange: { from: 'now-1h', to: 'now' },
     updateTimeRange: () => {},
   };

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_esql_variables.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_esql_variables.test.tsx
@@ -9,7 +9,7 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import type { ControlPanelsState, ControlGroupRendererApi } from '@kbn/controls-plugin/public';
 import type { SavedSearch } from '@kbn/saved-search-plugin/public';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, skip } from 'rxjs';
 import { DiscoverTestProvider } from '../../../../__mocks__/test_provider';
 import { getDiscoverStateMock } from '../../../../__mocks__/discover_state.mock';
 import { mockControlState } from '../../../../__mocks__/esql_controls';
@@ -37,7 +37,7 @@ class MockControlGroupRendererApi {
   }
 
   getInput$() {
-    return this.inputSubject.asObservable();
+    return this.inputSubject.asObservable().pipe(skip(1));
   }
 
   // Method to simulate new input coming from the API
@@ -274,6 +274,16 @@ describe('useESQLVariables', () => {
           },
         },
       });
+      expect(mockOnTextLangQueryChange).not.toHaveBeenCalled();
+
+      act(() => {
+        mockControlGroupAPI.simulateInput({
+          initialChildControlState: {
+            '123': { type: 'esqlControl' },
+          } as unknown as ControlPanelsState<ESQLControlState>,
+        });
+      });
+
       expect(mockOnTextLangQueryChange).toHaveBeenCalledTimes(1);
       expect(mockOnTextLangQueryChange).toHaveBeenCalledWith(mockUpdatedQuery);
     });

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_esql_variables.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_esql_variables.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { isEqual } from 'lodash';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { ControlPanelsState, ControlGroupRendererApi } from '@kbn/controls-plugin/public';
 import { ESQL_CONTROL } from '@kbn/controls-constants';
 import type { ESQLControlState, ESQLControlVariable } from '@kbn/esql-types';
@@ -59,8 +59,8 @@ export const useESQLVariables = ({
   const setControlGroupState = useCurrentTabAction(internalStateActions.setControlGroupState);
   const setEsqlVariables = useCurrentTabAction(internalStateActions.setEsqlVariables);
   const currentControlGroupState = useCurrentTabSelector((tab) => tab.controlGroupState);
-
   const savedSearchState = useSavedSearch();
+  const pendingQueryUpdate = useRef<string>();
 
   useEffect(() => {
     // Only proceed if in ESQL mode and controlGroupApi is available
@@ -69,7 +69,7 @@ export const useESQLVariables = ({
     }
 
     // Handling the reset unsaved changes badge
-    const savedSearchResetSubsciption = stateContainer.savedSearchState
+    const savedSearchResetSubscription = stateContainer.savedSearchState
       .getInitial$()
       .pipe(skip(1)) // Skip the initial emission since it's a BehaviorSubject
       .subscribe((initialSavedSearch) => {
@@ -78,36 +78,37 @@ export const useESQLVariables = ({
       });
 
     const inputSubscription = controlGroupApi.getInput$().subscribe((input) => {
-      if (input && input.initialChildControlState) {
-        const currentTabControlState =
-          input.initialChildControlState as ControlPanelsState<ESQLControlState>;
+      const controlGroupState =
+        input.initialChildControlState as ControlPanelsState<ESQLControlState>;
 
-        stateContainer.savedSearchState.updateControlState({
-          nextControlState: currentTabControlState,
-        });
-        dispatch(
-          setControlGroupState({
-            controlGroupState: currentTabControlState,
-          })
-        );
-        const newVariables = extractEsqlVariables(currentTabControlState);
-        if (!isEqual(newVariables, currentEsqlVariables)) {
-          // Update the ESQL variables in the internal state
-          dispatch(setEsqlVariables({ esqlVariables: newVariables }));
-          stateContainer.dataState.fetch();
-        }
+      stateContainer.savedSearchState.updateControlState({
+        nextControlState: controlGroupState,
+      });
+      dispatch(setControlGroupState({ controlGroupState }));
+
+      if (pendingQueryUpdate.current) {
+        onUpdateESQLQuery(pendingQueryUpdate.current);
+        pendingQueryUpdate.current = undefined;
+      }
+
+      const newVariables = extractEsqlVariables(controlGroupState);
+      if (!isEqual(newVariables, currentEsqlVariables)) {
+        // Update the ESQL variables in the internal state
+        dispatch(setEsqlVariables({ esqlVariables: newVariables }));
+        stateContainer.dataState.fetch();
       }
     });
 
     return () => {
       inputSubscription.unsubscribe();
-      savedSearchResetSubsciption.unsubscribe();
+      savedSearchResetSubscription.unsubscribe();
     };
   }, [
     controlGroupApi,
     currentEsqlVariables,
     dispatch,
     isEsqlMode,
+    onUpdateESQLQuery,
     setControlGroupState,
     setEsqlVariables,
     stateContainer.dataState,
@@ -121,8 +122,12 @@ export const useESQLVariables = ({
         console.error('controlGroupApi is not available when attempting to save control.');
         return;
       }
+
+      // update the query
+      pendingQueryUpdate.current = updatedQuery;
+
       // add a new control
-      controlGroupApi.addNewPanel({
+      await controlGroupApi.addNewPanel({
         panelType: ESQL_CONTROL,
         serializedState: {
           rawState: {
@@ -130,13 +135,8 @@ export const useESQLVariables = ({
           },
         },
       });
-
-      // update the query
-      if (updatedQuery) {
-        onUpdateESQLQuery(updatedQuery);
-      }
     },
-    [controlGroupApi, onUpdateESQLQuery]
+    [controlGroupApi]
   );
 
   // Getter function to retrieve the currently active control panels state for the current tab


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Discover] Fix ES|QL extra fetches (#239646)](https://github.com/elastic/kibana/pull/239646)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2025-10-23T12:34:37Z","message":"[Discover] Fix ES|QL extra fetches (#239646)\n\n## Summary\n\nThis PR fixes 2 of the scenarios where extra ES|QL fetches occur:\n1. When the ES|QL variables change, the corresponding Lens prop was\nupdated, which triggered an extra fetch on top of the manually triggered\none. Now `esqlVariables` is part of the memoized Lens props in Unified\nHistogram, and only gets updated when a manual fetch is triggered.\n2. When a new ES|QL control was added, we first updated the query with\nthe modified query including the new variable name. We then added a new\npanel, which is an async operation that also triggered a fetch when it\ncompleted, since it modified the ES|QL variables. Now we defer updating\nthe ES|QL query until the same time the variables are updated, so\ntogether they only trigger a single fetch when a new control is added.\n\nThere's still at least one other scenario I encountered where an extra\nES|QL fetch is triggered, but it's proven pretty tricky to fix so far,\nso I figured it's best to merge these two for now while we continue\ninvestigating.\n\nResolves #235300.\nResolves #234565.\nResolves #235607.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"6296da66777493e59f5d5613c7e21daa341498bc","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:version","v9.2.0","v9.3.0"],"title":"[Discover] Fix ES|QL extra fetches","number":239646,"url":"https://github.com/elastic/kibana/pull/239646","mergeCommit":{"message":"[Discover] Fix ES|QL extra fetches (#239646)\n\n## Summary\n\nThis PR fixes 2 of the scenarios where extra ES|QL fetches occur:\n1. When the ES|QL variables change, the corresponding Lens prop was\nupdated, which triggered an extra fetch on top of the manually triggered\none. Now `esqlVariables` is part of the memoized Lens props in Unified\nHistogram, and only gets updated when a manual fetch is triggered.\n2. When a new ES|QL control was added, we first updated the query with\nthe modified query including the new variable name. We then added a new\npanel, which is an async operation that also triggered a fetch when it\ncompleted, since it modified the ES|QL variables. Now we defer updating\nthe ES|QL query until the same time the variables are updated, so\ntogether they only trigger a single fetch when a new control is added.\n\nThere's still at least one other scenario I encountered where an extra\nES|QL fetch is triggered, but it's proven pretty tricky to fix so far,\nso I figured it's best to merge these two for now while we continue\ninvestigating.\n\nResolves #235300.\nResolves #234565.\nResolves #235607.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"6296da66777493e59f5d5613c7e21daa341498bc"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239646","number":239646,"mergeCommit":{"message":"[Discover] Fix ES|QL extra fetches (#239646)\n\n## Summary\n\nThis PR fixes 2 of the scenarios where extra ES|QL fetches occur:\n1. When the ES|QL variables change, the corresponding Lens prop was\nupdated, which triggered an extra fetch on top of the manually triggered\none. Now `esqlVariables` is part of the memoized Lens props in Unified\nHistogram, and only gets updated when a manual fetch is triggered.\n2. When a new ES|QL control was added, we first updated the query with\nthe modified query including the new variable name. We then added a new\npanel, which is an async operation that also triggered a fetch when it\ncompleted, since it modified the ES|QL variables. Now we defer updating\nthe ES|QL query until the same time the variables are updated, so\ntogether they only trigger a single fetch when a new control is added.\n\nThere's still at least one other scenario I encountered where an extra\nES|QL fetch is triggered, but it's proven pretty tricky to fix so far,\nso I figured it's best to merge these two for now while we continue\ninvestigating.\n\nResolves #235300.\nResolves #234565.\nResolves #235607.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"6296da66777493e59f5d5613c7e21daa341498bc"}}]}] BACKPORT-->