### PR TITLE
[One Workflow] fix: do not register workflows connector type if the FF is not enabled

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/public/plugin.ts
@@ -40,46 +40,50 @@ export class WorkflowsPlugin
     core: CoreSetup<WorkflowsPublicPluginStartDependencies, WorkflowsPublicPluginStart>,
     plugins: WorkflowsPublicPluginSetupDependencies
   ): WorkflowsPublicPluginSetup {
+    // Check if workflows UI is enabled
+    const isWorkflowsUiEnabled = core.uiSettings.get<boolean>(WORKFLOWS_UI_SETTING_ID, false);
+
+    /* **************************************************************************************************************************** */
+    /* WARNING: DO NOT ADD ANYTHING ABOVE THIS LINE, which can expose workflows UI to users who don't have the feature flag enabled */
+    /* **************************************************************************************************************************** */
+    // Return early if workflows UI is not enabled, do not register the connector type and UI
+    if (!isWorkflowsUiEnabled) {
+      return {};
+    }
+
     // Register workflows connector UI component lazily to reduce main bundle size
     const registerConnectorType = async () => {
       const { getWorkflowsConnectorType } = await import('./connectors/workflows');
       plugins.triggersActionsUi.actionTypeRegistry.register(getWorkflowsConnectorType());
     };
 
-    // Register the connector type immediately but load it lazily
     registerConnectorType();
 
-    // Check if workflows UI is enabled
-    const isWorkflowsUiEnabled = core.uiSettings.get<boolean>(WORKFLOWS_UI_SETTING_ID, false);
+    core.application.register({
+      id: PLUGIN_ID,
+      title: PLUGIN_NAME,
+      appRoute: '/app/workflows',
+      euiIconType: 'workflowsApp',
+      visibleIn: ['globalSearch', 'home', 'kibanaOverview', 'sideNav'],
+      category: DEFAULT_APP_CATEGORIES.management,
+      order: 9015,
+      mount: async (params: AppMountParameters) => {
+        // Load application bundle
+        const { renderApp } = await import('./application');
+        const services = await this.createWorkflowsStartServices(core);
 
-    if (isWorkflowsUiEnabled) {
-      core.application.register({
-        id: PLUGIN_ID,
-        title: PLUGIN_NAME,
-        appRoute: '/app/workflows',
-        euiIconType: 'workflowsApp',
-        visibleIn: ['globalSearch', 'home', 'kibanaOverview', 'sideNav'],
-        category: DEFAULT_APP_CATEGORIES.management,
-        order: 9015,
-        mount: async (params: AppMountParameters) => {
-          // Load application bundle
-          const { renderApp } = await import('./application');
-          const services = await this.createWorkflowsStartServices(core);
+        // Set badge for classic navbar
+        services.chrome.setBadge({
+          text: 'Technical preview',
+          tooltip:
+            'This functionality is in technical preview. It may change or be removed in a future release.',
+          iconType: 'beaker',
+        });
 
-          // Set badge for classic navbar
-          services.chrome.setBadge({
-            text: 'Technical preview',
-            tooltip:
-              'This functionality is in technical preview. It may change or be removed in a future release.',
-            iconType: 'beaker',
-          });
+        return renderApp(services, params);
+      },
+    });
 
-          return renderApp(services, params);
-        },
-      });
-    }
-
-    // Return methods that should be available to other plugins
     return {};
   }
 


### PR DESCRIPTION
```yaml
# kibana.yml or uisettings via devtools
uiSettings.overrides:
  workflows:ui:enabled: false # or not set
```

## Before

<img width="1624" height="1056" alt="Screenshot 2025-10-24 at 10 13 02" src="https://github.com/user-attachments/assets/f1f89d1f-febd-4629-be57-c13e68fe16a6" />

## After

<img width="1624" height="1056" alt="Screenshot 2025-10-24 at 10 13 15" src="https://github.com/user-attachments/assets/51692631-0def-4a16-b401-107c3979e2d0" />

https://github.com/user-attachments/assets/79a289ee-dd3f-40e0-98e6-6350c4fd31a5

