### PR TITLE
[Data Views] Add edit action to data views table

### DIFF
--- a/src/platform/plugins/shared/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -100,7 +100,7 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
   const [selectedRelationships, setSelectedRelationships] = useState<
     Record<string, SavedObjectRelation[]>
   >({});
-  const [deleteFlyoutOpen, setDeleteFlyoutOpen] = useState<boolean>(false);
+  const [deleteFlyoutOpen, setDeleteFlyoutOpen] = useState(false);
   const [dataViewController] = useState(
     () =>
       new DataViewTableController({

--- a/src/platform/plugins/shared/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -30,7 +30,11 @@ import type { SavedObjectRelation } from '@kbn/saved-objects-management-plugin/c
 import { reactRouterNavigate, useKibana } from '@kbn/kibana-react-plugin/public';
 import { NoDataViewsPromptComponent, useOnTryESQL } from '@kbn/shared-ux-prompt-no-data-views';
 import type { SpacesContextProps } from '@kbn/spaces-plugin/public';
-import { DATA_VIEW_SAVED_OBJECT_TYPE, DataViewType } from '@kbn/data-views-plugin/public';
+import {
+  DATA_VIEW_SAVED_OBJECT_TYPE,
+  DataViewType,
+  type DataView,
+} from '@kbn/data-views-plugin/public';
 import { RollupDeprecationTooltip } from '@kbn/rollup';
 import { useEuiTablePersist } from '@kbn/shared-ux-table-persist';
 
@@ -85,16 +89,19 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
     spaces,
     docLinks,
     noDataPage,
+    IndexPatternEditor,
     savedObjectsManagement,
   } = useKibana<IndexPatternManagmentContext>().services;
 
   const [query, setQuery] = useState('');
   const [selectedItems, setSelectedItems] = useState<RemoveDataViewProps[]>([]);
   const [selectedDataView, setSelectedDataView] = useState<RemoveDataViewProps>();
+  const [editDataView, setEditDataView] = useState<DataView>();
   const [selectedRelationships, setSelectedRelationships] = useState<
     Record<string, SavedObjectRelation[]>
   >({});
-  const [flyoutOpen, setFlyoutOpen] = React.useState(false);
+  const [deleteFlyoutOpen, setDeleteFlyoutOpen] = useState<boolean>(false);
+  const [editFlyoutOpen, setEditFlyoutOpen] = useState<boolean>(false);
   const [dataViewController] = useState(
     () =>
       new DataViewTableController({
@@ -133,11 +140,16 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
     }
   };
 
-  const onFlyoutClose = () => {
-    setFlyoutOpen(false);
+  const onDeleteFlyoutClose = () => {
+    setDeleteFlyoutOpen(false);
     setSelectedItems([]);
     setSelectedDataView(undefined);
     setSelectedRelationships({});
+  };
+
+  const onEditFlyoutClose = () => {
+    setEditFlyoutOpen(false);
+    setEditDataView(undefined);
   };
 
   const dataViewArray = useMemo(() => {
@@ -187,7 +199,7 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
               SavedObjectRelation[]
             >) || {};
           setSelectedRelationships(relationships);
-          setFlyoutOpen(true);
+          setDeleteFlyoutOpen(true);
         }}
       >
         <FormattedMessage
@@ -231,6 +243,23 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
     width: '10%',
     actions: [
       {
+        name: i18n.translate('indexPatternManagement.dataViewTable.columnEdit', {
+          defaultMessage: 'Edit',
+        }),
+        description: i18n.translate('indexPatternManagement.dataViewTable.columnEditDescription', {
+          defaultMessage: 'Edit this data view',
+        }),
+        icon: 'pencil',
+        color: 'primary',
+        type: 'icon',
+        onClick: async (dataView: RemoveDataViewProps) => {
+          const fullDataView = await dataViews.get(dataView.id);
+          setEditDataView(fullDataView);
+          setEditFlyoutOpen(true);
+        },
+        'data-test-subj': 'action-edit',
+      },
+      {
         name: i18n.translate('indexPatternManagement.dataViewTable.columnDelete', {
           defaultMessage: 'Delete',
         }),
@@ -250,7 +279,7 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
           >;
           setSelectedDataView(dataView);
           setSelectedRelationships(relationships);
-          setFlyoutOpen(true);
+          setDeleteFlyoutOpen(true);
         },
         isPrimary: true,
         'data-test-subj': 'action-delete',
@@ -394,7 +423,7 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
           selection={dataViews.getCanSaveSync() ? selection : undefined}
         />
       </ContextWrapper>
-      {flyoutOpen && (
+      {deleteFlyoutOpen && (
         <DeleteDataViewFlyout
           dataViews={dataViews}
           dataViewArray={dataViewArray}
@@ -402,9 +431,19 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
           hasSpaces={!!spaces}
           onDelete={async () => {
             dataViewController.loadDataViews();
-            onFlyoutClose();
+            onDeleteFlyoutClose();
           }}
-          onClose={onFlyoutClose}
+          onClose={onDeleteFlyoutClose}
+        />
+      )}
+      {editFlyoutOpen && (
+        <IndexPatternEditor
+          onSave={() => {
+            dataViewController.loadDataViews();
+            onEditFlyoutClose();
+          }}
+          onCancel={onEditFlyoutClose}
+          editData={editDataView}
         />
       )}
     </>

--- a/src/platform/plugins/shared/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -101,7 +101,6 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
     Record<string, SavedObjectRelation[]>
   >({});
   const [deleteFlyoutOpen, setDeleteFlyoutOpen] = useState<boolean>(false);
-  const [editFlyoutOpen, setEditFlyoutOpen] = useState<boolean>(false);
   const [dataViewController] = useState(
     () =>
       new DataViewTableController({
@@ -148,7 +147,6 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
   };
 
   const onEditFlyoutClose = () => {
-    setEditFlyoutOpen(false);
     setEditDataView(undefined);
   };
 
@@ -255,7 +253,6 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
         onClick: async (dataView: RemoveDataViewProps) => {
           const fullDataView = await dataViews.get(dataView.id);
           setEditDataView(fullDataView);
-          setEditFlyoutOpen(true);
         },
         'data-test-subj': 'action-edit',
       },
@@ -436,7 +433,7 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
           onClose={onDeleteFlyoutClose}
         />
       )}
-      {editFlyoutOpen && (
+      {!!editDataView && (
         <IndexPatternEditor
           onSave={() => {
             dataViewController.loadDataViews();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/233300

This PR adds edit action to data views table.

| Before | After |
| -------- | ------- |
| <img width="1917" height="956" alt="Screenshot 2025-10-24 at 09 24 17" src="https://github.com/user-attachments/assets/9ecc7d3b-c1f0-4f57-aa56-d36af2314303" /> | <img width="1915" height="958" alt="Screenshot 2025-10-24 at 09 24 40" src="https://github.com/user-attachments/assets/f7b1c1be-f212-4338-aead-9c0ae2f0c62b" /> |
|  | <img width="1915" height="959" alt="Screenshot 2025-10-24 at 09 23 51" src="https://github.com/user-attachments/assets/61f9d0a9-78e2-4e01-bb71-7edd45f75159" /> |

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.