### PR TITLE
Revert "[Fleet] remove beta integrations switch (#240035)"

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -46303,7 +46303,6 @@
                           "type": "array"
                         },
                         "prerelease_integrations_enabled": {
-                          "deprecated": true,
                           "type": "boolean"
                         },
                         "secret_storage_requirements_met": {
@@ -46451,7 +46450,6 @@
                     "type": "array"
                   },
                   "prerelease_integrations_enabled": {
-                    "deprecated": true,
                     "type": "boolean"
                   }
                 },
@@ -46508,7 +46506,6 @@
                           "type": "array"
                         },
                         "prerelease_integrations_enabled": {
-                          "deprecated": true,
                           "type": "boolean"
                         },
                         "secret_storage_requirements_met": {

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -45827,7 +45827,6 @@
                           "type": "array"
                         },
                         "prerelease_integrations_enabled": {
-                          "deprecated": true,
                           "type": "boolean"
                         },
                         "secret_storage_requirements_met": {
@@ -45975,7 +45974,6 @@
                     "type": "array"
                   },
                   "prerelease_integrations_enabled": {
-                    "deprecated": true,
                     "type": "boolean"
                   }
                 },
@@ -46032,7 +46030,6 @@
                           "type": "array"
                         },
                         "prerelease_integrations_enabled": {
-                          "deprecated": true,
                           "type": "boolean"
                         },
                         "secret_storage_requirements_met": {

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -43446,7 +43446,6 @@ paths:
                           type: string
                         type: array
                       prerelease_integrations_enabled:
-                        deprecated: true
                         type: boolean
                       secret_storage_requirements_met:
                         type: boolean
@@ -43547,7 +43546,6 @@ paths:
                     type: string
                   type: array
                 prerelease_integrations_enabled:
-                  deprecated: true
                   type: boolean
       responses:
         '200':
@@ -43587,7 +43585,6 @@ paths:
                           type: string
                         type: array
                       prerelease_integrations_enabled:
-                        deprecated: true
                         type: boolean
                       secret_storage_requirements_met:
                         type: boolean

--- a/packages/kbn-babel-preset/styled_components_files.js
+++ b/packages/kbn-babel-preset/styled_components_files.js
@@ -80,6 +80,7 @@ module.exports = {
     /x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]fleet[\/\\]public[\/\\]applications[\/\\]fleet[\/\\]sections[\/\\]settings[\/\\]components[\/\\]multi_row_input[\/\\]index.tsx/,
     /x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]fleet[\/\\]public[\/\\]applications[\/\\]fleet[\/\\]sections[\/\\]settings[\/\\]components[\/\\]outputs_table[\/\\]index.tsx/,
     /x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]fleet[\/\\]public[\/\\]applications[\/\\]fleet[\/\\]sections[\/\\]settings[\/\\]components[\/\\]outputs_table[\/\\]integration_sync_flyout.test.tsx/,
+    /x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]fleet[\/\\]public[\/\\]applications[\/\\]integrations[\/\\]sections[\/\\]epm[\/\\]components[\/\\]integration_preference.tsx/,
     /x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]fleet[\/\\]public[\/\\]applications[\/\\]integrations[\/\\]sections[\/\\]epm[\/\\]components[\/\\]package_list_grid[\/\\]controls.tsx/,
     /x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]fleet[\/\\]public[\/\\]applications[\/\\]integrations[\/\\]sections[\/\\]epm[\/\\]components[\/\\]package_list_grid[\/\\]index.tsx/,
     /x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]fleet[\/\\]public[\/\\]applications[\/\\]integrations[\/\\]sections[\/\\]epm[\/\\]components[\/\\]requirements.tsx/,

--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
@@ -92,7 +92,7 @@ export const isOnlyAgentlessIntegration = (
 export const isOnlyAgentlessPolicyTemplate = (policyTemplate: RegistryPolicyTemplate) => {
   return Boolean(
     policyTemplate.deployment_modes &&
-      policyTemplate.deployment_modes.agentless.enabled === true &&
+      policyTemplate.deployment_modes.agentless?.enabled === true &&
       (!policyTemplate.deployment_modes.default ||
         policyTemplate.deployment_modes.default.enabled === false)
   );

--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
@@ -92,7 +92,7 @@ export const isOnlyAgentlessIntegration = (
 export const isOnlyAgentlessPolicyTemplate = (policyTemplate: RegistryPolicyTemplate) => {
   return Boolean(
     policyTemplate.deployment_modes &&
-      policyTemplate.deployment_modes.agentless?.enabled === true &&
+      policyTemplate.deployment_modes.agentless.enabled === true &&
       (!policyTemplate.deployment_modes.default ||
         policyTemplate.deployment_modes.default.enabled === false)
   );

--- a/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/agentless.md
+++ b/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/agentless.md
@@ -23,4 +23,4 @@ xpack.fleet.agentless.api.tls.ca: './config/ca.crt'
 
 ## Which integrations to test with?
 
-At the time of writing, the Elastic Connectors integration is [agentless only](https://github.com/elastic/integrations/blob/2ebdf0cada6faed352e71a82cf71487672f27bf2/packages/elastic_connectors/manifest.yml#L35-L39) and the Cloud Security Posture Management (CSPM) integration offers both agent-based and agentless deployment modes.
+At the time of writing, the Elastic Connectors integration is [agentless only](https://github.com/elastic/integrations/blob/2ebdf0cada6faed352e71a82cf71487672f27bf2/packages/elastic_connectors/manifest.yml#L35-L39) and the Cloud Security Posture Management (CSPM) integration offers both agent-based and agentless deployment modes. These are still in technical preview, so "Display beta integrations" should be checked.

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
@@ -4,9 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useMemo } from 'react';
 import { useLocation, useRouteMatch } from 'react-router-dom';
+
+import { useGetSettings } from '../../../hooks';
 
 import { splitPkgKey } from '../../../../../../common/services';
 
@@ -24,8 +26,21 @@ export const CreatePackagePolicyPage: React.FC<{}> = () => {
     () => queryParams.get('policyId') ?? undefined,
     [queryParams]
   );
-
+  const [prerelease, setPrerelease] = React.useState<boolean>(false);
   const { pkgName, pkgVersion } = splitPkgKey(params.pkgkey);
+
+  const { data: settings } = useGetSettings();
+
+  const queryParamPrerelease = useMemo(() => Boolean(queryParams.get('prerelease')), [queryParams]);
+
+  useEffect(() => {
+    const isEnabled =
+      Boolean(settings?.item.prerelease_integrations_enabled) || queryParamPrerelease;
+
+    if (settings?.item) {
+      setPrerelease(isEnabled);
+    }
+  }, [queryParamPrerelease, settings?.item]);
 
   /**
    * Please note: policyId can come from one of two sources. The URL param (in the URL path) or
@@ -44,7 +59,7 @@ export const CreatePackagePolicyPage: React.FC<{}> = () => {
   const pageParams = {
     from,
     queryParamsPolicyId,
-    prerelease: true,
+    prerelease,
     pkgName,
     pkgVersion,
     integration: params.integration,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -38,7 +38,6 @@ import {
   checkIntegrationFipsLooseCompatibility,
   getInheritedNamespace,
   getRootPrivilegedDataStreams,
-  isPackagePrerelease,
   isRootPrivilegesRequired,
 } from '../../../../../../../common/services';
 import type { NewAgentPolicy, PackagePolicyEditExtensionComponentProps } from '../../../../types';
@@ -78,8 +77,6 @@ import { generateNewAgentPolicyWithDefaults } from '../../../../../../../common/
 import { packageHasAtLeastOneSecret } from '../utils';
 
 import { SetupTechnologySelector } from '../../../../../../services/setup_technology_selector';
-
-import { PrereleaseCallout } from '../../../../../integrations/sections/epm/screens/detail/overview/prerelease_callout';
 
 import {
   AddIntegrationFlyoutConfigureHeader,
@@ -671,15 +668,6 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
           <EuiSpacer size="m" />
         </>
       )}
-      {isAddIntegrationFlyout &&
-        packageInfo?.version &&
-        isPackagePrerelease(packageInfo.version) && (
-          <>
-            <PrereleaseCallout packageInfo={packageInfo} />
-
-            <EuiSpacer size="m" />
-          </>
-        )}
       <StepsWithLessPadding steps={steps} />
     </>
   );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/add_integration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/add_integration_flyout.tsx
@@ -24,13 +24,14 @@ import {
   EuiTitle,
   useGeneratedHtmlId,
 } from '@elastic/eui';
-import React, { Suspense, useCallback, useMemo, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { i18n } from '@kbn/i18n';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { Loading } from '../../../../agents/components';
+import { useGetSettings } from '../../../../../hooks';
 import type { AgentPolicy } from '../../../../../../../../common';
 import { CreatePackagePolicySinglePage } from '../../../create_package_policy_page/single_page_layout';
 import { useAvailablePackages } from '../../../../../../integrations/sections/epm/screens/home/hooks/use_available_packages';
@@ -42,7 +43,19 @@ export const AddIntegrationFlyout: React.FunctionComponent<{
 }> = ({ onClose, agentPolicy }) => {
   const modalTitleId = useGeneratedHtmlId();
 
-  const { filteredCards, isLoading } = useAvailablePackages();
+  const [prerelease, setPrerelease] = React.useState<boolean>(false);
+  const { data: settings } = useGetSettings();
+
+  useEffect(() => {
+    const isEnabled = Boolean(settings?.item.prerelease_integrations_enabled);
+    if (settings?.item) {
+      setPrerelease(isEnabled);
+    }
+  }, [settings?.item]);
+
+  const { filteredCards, isLoading } = useAvailablePackages({
+    prereleaseIntegrationsEnabled: prerelease,
+  });
 
   const options = useMemo(() => {
     return filteredCards
@@ -165,7 +178,7 @@ export const AddIntegrationFlyout: React.FunctionComponent<{
               <CreatePackagePolicySinglePage
                 from="policy"
                 queryParamsPolicyId={agentPolicy.id}
-                prerelease={true}
+                prerelease={prerelease}
                 pkgLabel={selectedOptions[0]?.label}
                 pkgName={selectedOptions[0]?.value}
                 integration={selectedOptions[0]?.integration}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -18,6 +18,7 @@ import {
   sendBulkGetAgentPolicies,
   sendGetOnePackagePolicy,
   sendGetPackageInfoByKey,
+  sendGetSettings,
   sendUpdatePackagePolicy,
   sendUpgradePackagePolicyDryRun,
 } from '../../../../hooks';
@@ -53,6 +54,12 @@ function mergeVars(
 
     return acc;
   }, {} as PackagePolicyConfigRecord);
+}
+
+async function isPreleaseEnabled() {
+  const { data: settings } = await sendGetSettings();
+
+  return Boolean(settings?.item.prerelease_integrations_enabled);
 }
 
 export function usePackagePolicyWithRelatedData(
@@ -163,6 +170,8 @@ export function usePackagePolicyWithRelatedData(
       setIsLoadingData(true);
       setLoadingError(undefined);
       try {
+        const prerelease = await isPreleaseEnabled();
+
         const { data: packagePolicyData, error: packagePolicyError } =
           await sendGetOnePackagePolicy(packagePolicyId);
 
@@ -301,7 +310,7 @@ export function usePackagePolicyWithRelatedData(
             const { data: packageData } = await sendGetPackageInfoByKey(
               _packageInfo!.name,
               _packageInfo!.version,
-              { prerelease: true, full: true }
+              { prerelease, full: true }
             );
 
             if (packageData?.item) {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/integration_preference.stories.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/integration_preference.stories.tsx
@@ -32,5 +32,11 @@ export default {
 } as Meta;
 
 export const IntegrationPreference = () => {
-  return <Component initialType="agent" onChange={action('onChange')} />;
+  return (
+    <Component
+      initialType="agent"
+      onChange={action('onChange')}
+      prereleaseIntegrationsEnabled={false}
+    />
+  );
 };

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/components/edit_integration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/components/edit_integration_flyout.tsx
@@ -68,7 +68,7 @@ export const EditIntegrationFlyout: React.FunctionComponent<{
 
   // Get all the possible categories
   const { data: categoriesData } = useGetCategoriesQuery({
-    prerelease: true,
+    prerelease: false,
   });
   // We only need the parent categories for now, filter out any with parent_id fields to only leave the parents
   const parentCategories = categoriesData?.items.filter((item) => item.parent_id === undefined);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
@@ -102,6 +102,9 @@ describe.skip('When on integration detail', () => {
 
   describe('and the package is not installed and prerelease enabled', () => {
     beforeEach(async () => {
+      mockedApi.responseProvider.getSettings.mockReturnValue({
+        item: { prerelease_integrations_enabled: true, id: '' },
+      });
       mockGAAndPrereleaseVersions('1.0.0-beta');
       await render();
       await act(() => mockedApi.waitForApi());
@@ -119,13 +122,13 @@ describe.skip('When on integration detail', () => {
       expect(renderResult.queryByTestId('tab-policies')).toBeNull();
     });
 
-    it('should display version select if prererelase version available', async () => {
+    it('should display version select if prerelease setting enabled and prererelase version available', async () => {
       const versionSelect = renderResult.queryByTestId('versionSelect');
       expect(versionSelect?.textContent).toEqual('1.0.0-beta1.0.0');
       expect((versionSelect as any)?.value).toEqual('1.0.0-beta');
     });
 
-    it('should display prerelease callout if prerelease version available', async () => {
+    it('should display prerelease callout if prerelease setting enabled and prerelease version available', async () => {
       const calloutTitle = renderResult.getByTestId('prereleaseCallout');
       expect(calloutTitle).toBeInTheDocument();
       const calloutGABtn = renderResult.getByTestId('switchToGABtn');
@@ -135,8 +138,39 @@ describe.skip('When on integration detail', () => {
     });
   });
 
+  describe('and the package is not installed and prerelease disabled', () => {
+    beforeEach(async () => {
+      mockGAAndPrereleaseVersions('1.0.0');
+      mockedApi.responseProvider.getSettings.mockReturnValue({
+        item: { prerelease_integrations_enabled: false, id: '' },
+      });
+      await render();
+      await act(() => mockedApi.waitForApi());
+      // All those waitForApi call are needed to avoid flakyness because details conditionnaly refetch multiple time
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+    }, TESTS_TIMEOUT);
+
+    it('should NOT display policy usage count', async () => {
+      expect(renderResult.queryByTestId('policyCount')).toBeNull();
+    });
+
+    it('should NOT display the Policies tab', async () => {
+      expect(renderResult.queryByTestId('tab-policies')).toBeNull();
+    });
+
+    it('should display version text and no callout if prerelease setting disabled', async () => {
+      expect((renderResult.queryByTestId('versionText') as any)?.textContent).toEqual('1.0.0');
+      expect(renderResult.queryByTestId('prereleaseCallout')).toBeNull();
+    });
+  });
+
   describe('and a custom UI extension is NOT registered', () => {
     beforeEach(async () => {
+      mockedApi.responseProvider.getSettings.mockReturnValue({
+        item: { prerelease_integrations_enabled: false, id: '' },
+      });
       await render();
       await act(() => mockedApi.waitForApi());
       // All those waitForApi call are needed to avoid flakyness because details conditionnaly refetch multiple time
@@ -173,6 +207,9 @@ describe.skip('When on integration detail', () => {
 
     beforeEach(async () => {
       let setWasRendered: () => void;
+      mockedApi.responseProvider.getSettings.mockReturnValue({
+        item: { prerelease_integrations_enabled: false, id: '' },
+      });
       lazyComponentWasRendered = new Promise((resolve) => {
         setWasRendered = resolve;
       });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -90,11 +90,10 @@ interface Props {
   packageMetadata?: PackageMetadata;
   startServices: Pick<FleetStartServices, 'analytics' | 'i18n' | 'theme'>;
   isCustomPackage: boolean;
-  latestGAVersion?: string;
 }
 
 export const SettingsPage: React.FC<Props> = memo(
-  ({ packageInfo, packageMetadata, startServices, isCustomPackage, latestGAVersion }: Props) => {
+  ({ packageInfo, packageMetadata, startServices, isCustomPackage }: Props) => {
     const authz = useAuthz();
     const { name, title, latestVersion, version, keepPoliciesUpToDate } = packageInfo;
     const [isUpgradingPackagePolicies, setIsUpgradingPackagePolicies] = useState<boolean>(false);
@@ -217,11 +216,8 @@ export const SettingsPage: React.FC<Props> = memo(
     const isViewingOldPackage = version < latestVersion;
     // hide install/remove options if the user has version of the package is installed
     // and this package is out of date or if they do have a version installed but it's not this one
-    // allow to install the latest GA version if the latest version is prerelease
     const hideInstallOptions =
-      (installationStatus === InstallStatus.notInstalled &&
-        isViewingOldPackage &&
-        latestGAVersion !== version) ||
+      (installationStatus === InstallStatus.notInstalled && isViewingOldPackage) ||
       (installationStatus === InstallStatus.installed && installedVersion !== version);
 
     const isUpdating = installationStatus === InstallStatus.installing && installedVersion;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -98,7 +98,9 @@ function OnPremLink() {
   );
 }
 
-export const AvailablePackages: React.FC<{}> = () => {
+export const AvailablePackages: React.FC<{ prereleaseIntegrationsEnabled: boolean }> = ({
+  prereleaseIntegrationsEnabled,
+}) => {
   useBreadcrumbs('integrations_all');
 
   const {
@@ -126,7 +128,7 @@ export const AvailablePackages: React.FC<{}> = () => {
     availableSubCategories,
     selectedSubCategory,
     setSelectedSubCategory,
-  } = useAvailablePackages();
+  } = useAvailablePackages({ prereleaseIntegrationsEnabled });
 
   const onCategoryChange = useCallback(
     ({ id }: { id: string }) => {
@@ -184,7 +186,11 @@ export const AvailablePackages: React.FC<{}> = () => {
           <EuiSpacer size="m" />
         </>
       )}
-      <IntegrationPreference initialType={preference} onChange={setPreference} />
+      <IntegrationPreference
+        initialType={preference}
+        prereleaseIntegrationsEnabled={prereleaseIntegrationsEnabled}
+        onChange={setPreference}
+      />
     </EuiFlexItem>,
   ];
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/hooks/use_available_packages.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/hooks/use_available_packages.tsx
@@ -142,11 +142,11 @@ const filterPackageListDeploymentModes = (packages: PackageList, isAgentlessEnab
 
 export type AvailablePackagesHookType = typeof useAvailablePackages;
 
-export const useAvailablePackages = (
-  { prereleaseIntegrationsEnabled }: { prereleaseIntegrationsEnabled: boolean } = {
-    prereleaseIntegrationsEnabled: true,
-  }
-) => {
+export const useAvailablePackages = ({
+  prereleaseIntegrationsEnabled,
+}: {
+  prereleaseIntegrationsEnabled: boolean;
+}) => {
   const [preference, setPreference] = useState<IntegrationPreferenceType>('agent');
 
   const { isAgentlessEnabled } = useAgentless();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -66,18 +66,19 @@ export const EPMHomePage: React.FC = () => {
 
   const authz = useAuthz();
   const isAuthorizedToFetchSettings = authz.fleet.readSettings;
-  const { isFetchedAfterMount: isSettingsFetched } = useGetSettingsQuery({
+  const { data: settings, isFetchedAfterMount: isSettingsFetched } = useGetSettingsQuery({
     enabled: isAuthorizedToFetchSettings,
   });
 
   const installedIntegrationsTabularUI =
     ExperimentalFeaturesService.get()?.installedIntegrationsTabularUI ?? false;
 
+  const prereleaseIntegrationsEnabled = settings?.item.prerelease_integrations_enabled ?? false;
   const shouldFetchPackages = !isAuthorizedToFetchSettings || isSettingsFetched;
   // loading packages to find installed ones
   const { data: allPackages, isLoading } = useGetPackagesQuery(
     {
-      prerelease: true,
+      prerelease: prereleaseIntegrationsEnabled,
     },
     {
       enabled: shouldFetchPackages,
@@ -130,7 +131,7 @@ export const EPMHomePage: React.FC = () => {
       </Route>
       <Route path={INTEGRATIONS_ROUTING_PATHS.integrations_all}>
         <DefaultLayout section="browse" notificationsBySection={notificationsBySection}>
-          <AvailablePackages />
+          <AvailablePackages prereleaseIntegrationsEnabled={prereleaseIntegrationsEnabled} />
         </DefaultLayout>
       </Route>
     </Routes>

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
@@ -34,6 +34,9 @@ jest.mock('../services/epm/registry');
 jest.mock('../services/epm/packages', () => ({
   getInstalledPackages: jest.fn(),
 }));
+jest.mock('../services/epm/packages/get_prerelease_setting', () => ({
+  getPrereleaseFromSettings: jest.fn().mockReturnValue(false),
+}));
 
 const MockRegistry = jest.mocked(Registry);
 

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/settings.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/settings.ts
@@ -52,13 +52,7 @@ export const PutSettingsRequestSchema = {
         },
       })
     ),
-    prerelease_integrations_enabled: schema.maybe(
-      schema.boolean({
-        meta: {
-          deprecated: true,
-        },
-      })
-    ),
+    prerelease_integrations_enabled: schema.maybe(schema.boolean()),
     delete_unenrolled_agents: schema.maybe(
       schema.object({
         enabled: schema.boolean(),
@@ -80,13 +74,7 @@ export const SpaceSettingsResponseSchema = schema.object({
 export const SettingsResponseSchema = schema.object({
   item: schema.object({
     has_seen_add_data_notice: schema.maybe(schema.boolean()),
-    prerelease_integrations_enabled: schema.maybe(
-      schema.boolean({
-        meta: {
-          deprecated: true,
-        },
-      })
-    ),
+    prerelease_integrations_enabled: schema.maybe(schema.boolean()),
     id: schema.string(),
     version: schema.maybe(schema.string()),
     preconfigured_fields: schema.maybe(schema.arrayOf(schema.literal('fleet_server_hosts'))),


### PR DESCRIPTION
This reverts commit b1b8d549a101ac6186120ce9d5ef9ddd0ff04d4b.

Reverting the changes for now as we are still discussing the concern of showing prerelease integrations newer than GA versions mentioned in the issue here https://github.com/elastic/ingest-dev/issues/4790.