### PR TITLE
[APM] Fix integration ML job test

### DIFF
--- a/x-pack/solutions/observability/test/apm_api_integration/tests/settings/anomaly_detection/update_to_v3.spec.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/settings/anomaly_detection/update_to_v3.spec.ts
@@ -69,6 +69,7 @@ export default function apiTest({ getService }: FtrProviderContext) {
 
     describe('when there are only v2 jobs', () => {
       before(async () => {
+        await ml.cleanMlIndices();
         await createV2Jobs(['production', 'development']);
       });
       it('creates a new job for each environment that has a v2 job', async () => {
@@ -91,6 +92,7 @@ export default function apiTest({ getService }: FtrProviderContext) {
 
     describe('when there are both v2 and v3 jobs', () => {
       before(async () => {
+        await ml.cleanMlIndices();
         await createV2Jobs(['production', 'development']);
         await createV3Jobs(['production']);
       });


### PR DESCRIPTION
Closes #237133 

## Summary

There was an error regarding the data we tried to create in the `before` block: 
```json
{"statusCode":500,"error":"Internal Server Error","message":"An error occurred while creating ML jobs: [{\"id\":\"apm-production-3aa3-apm_tx_metrics\",\"error\":{\"error\":{\"root_cause\":[{\"type\":\"resource_already_exists_exception\",\"reason\":\"The job cannot be created with the Id 'apm-production-3aa3-apm_tx_metrics'. The Id is already used.\"}],\"type\":\"resource_already_exists_exception\",\"reason\":\"The job cannot be created with the Id 'apm-production-3aa3-apm_tx_metrics'. The Id is already used.\"},\"status\":400}}]","attributes":{"data":{},"_inspect":[]}}

```
To make it more stable, I added a cleanup before we start the creation. This way, we should first clean the dat,a and the error should not happen again.


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->