### PR TITLE
fix(dashboard): use EuiTitle for panel title with description

### DIFF
--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
@@ -11,6 +11,7 @@ import {
   EuiIcon,
   EuiLink,
   EuiScreenReaderOnly,
+  EuiTitle,
   EuiToolTip,
   euiTextTruncate,
   useEuiTheme,
@@ -112,28 +113,31 @@ export const PresentationPanelTitle = ({
           tabIndex={0}
         >
           {!hideTitle ? (
-            <h2
+            <EuiTitle
+              size="xs"
               // styles necessary for applying ellipsis and showing the info icon if description is present
               css={css`
                 overflow: hidden;
               `}
             >
-              <EuiScreenReaderOnly>
-                <span id={headerId}>
-                  {panelTitle
-                    ? i18n.translate('presentationPanel.ariaLabel', {
-                        defaultMessage: 'Panel: {title}',
-                        values: {
-                          title: panelTitle,
-                        },
-                      })
-                    : i18n.translate('presentationPanel.untitledPanelAriaLabel', {
-                        defaultMessage: 'Untitled panel',
-                      })}
-                </span>
-              </EuiScreenReaderOnly>
-              {panelTitleElement}
-            </h2>
+              <>
+                <EuiScreenReaderOnly>
+                  <span id={headerId}>
+                    {panelTitle
+                      ? i18n.translate('presentationPanel.ariaLabel', {
+                          defaultMessage: 'Panel: {title}',
+                          values: {
+                            title: panelTitle,
+                          },
+                        })
+                      : i18n.translate('presentationPanel.untitledPanelAriaLabel', {
+                          defaultMessage: 'Untitled panel',
+                        })}
+                  </span>
+                </EuiScreenReaderOnly>
+                {panelTitleElement}
+              </>
+            </EuiTitle>
           ) : null}
           <EuiIcon
             type="info"


### PR DESCRIPTION
## Summary

This PR fixes issue [#239708](https://github.com/elastic/kibana/issues/239708), where dashboard panel titles were rendered with an unstyled `<h2>` tag when a description was present. This could lead to inconsistent font sizes if global `h2` styles were applied, as shown in the issue's screenshot.

This fix replaces the `<h2>` tag with EUI's `<EuiTitle size="xs">` component. This ensures the panel title has a consistent, theme-aligned appearance, regardless of whether a description is present, and prevents it from being affected by broad, inherited styles.

**Before:**
A panel title with a description used a raw `<h2>` tag, making it susceptible to style overrides.

**After:**
The panel title now uses `<EuiTitle>`, ensuring consistent styling with other titles in the application.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### For the reviewer

Apply the following labels:
`release_note:fix`
`backport:8.x`
`backport:9.x`

### Identify risks

- **Risk:** Minimal.
- **Severity:** Low.
- **Mitigation:** This change is a low-risk visual fix that replaces a standard HTML element with its equivalent EUI component (`EuiTitle`). The change is self-contained within the `PresentationPanelTitle` component and has no impact on functionality, data, or performance. The `EuiTitle` component is a well-tested and standard part of the Elastic UI library.



