### PR TITLE
[8.19] Allow fleet-setup retries for all environments (#240342)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -226,7 +226,7 @@ export const config: PluginConfigDescriptor = {
               min: 0,
             })
           ),
-          retrySetupOnBoot: schema.boolean({ defaultValue: false }),
+          retrySetupOnBoot: schema.boolean({ defaultValue: true }),
           registry: schema.object(
             {
               kibanaVersionCheckEnabled: schema.boolean({ defaultValue: true }),

--- a/x-pack/platform/plugins/shared/fleet/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/plugin.ts
@@ -735,7 +735,6 @@ export class FleetPlugin
 
     this.policyWatcher.start(licenseService);
 
-    // We only retry when this feature flag is enabled (Serverless)
     const setupAttempts = this.configInitialValue.internal?.retrySetupOnBoot ? 25 : 1;
 
     const fleetSetupPromise = (async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Allow fleet-setup retries for all environments (#240342)](https://github.com/elastic/kibana/pull/240342)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michel Losier","email":"michel.losier@elastic.co"},"sourceCommit":{"committedDate":"2025-10-24T17:00:34Z","message":"Allow fleet-setup retries for all environments (#240342)\n\nnon-serverless environments relied on integrations-server triggering\nfleet setup retries externally. This change allows fleet setup retries\nin all environments","sha":"a82601e16417e028a9c4534a51a5a8473171846f","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:version","v9.3.0","v9.1.6","v8.19.6","v9.1.7","v9.2.1"],"title":"Allow fleet-setup retries for all environments","number":240342,"url":"https://github.com/elastic/kibana/pull/240342","mergeCommit":{"message":"Allow fleet-setup retries for all environments (#240342)\n\nnon-serverless environments relied on integrations-server triggering\nfleet setup retries externally. This change allows fleet setup retries\nin all environments","sha":"a82601e16417e028a9c4534a51a5a8473171846f"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/240342","number":240342,"mergeCommit":{"message":"Allow fleet-setup retries for all environments (#240342)\n\nnon-serverless environments relied on integrations-server triggering\nfleet setup retries externally. This change allows fleet setup retries\nin all environments","sha":"a82601e16417e028a9c4534a51a5a8473171846f"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/240486","number":240486,"state":"MERGED","mergeCommit":{"sha":"196623300e67308011d8bffa5c0dfa7782d48401","message":"[9.1] Allow fleet-setup retries for all environments (#240342) (#240486)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [Allow fleet-setup retries for all environments\n(#240342)](https://github.com/elastic/kibana/pull/240342)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Michel Losier <michel.losier@elastic.co>"}},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/240487","number":240487,"state":"MERGED","mergeCommit":{"sha":"0d770422df00dc37c4175de20b386517575245bd","message":"[9.2] Allow fleet-setup retries for all environments (#240342) (#240487)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [Allow fleet-setup retries for all environments\n(#240342)](https://github.com/elastic/kibana/pull/240342)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Michel Losier <michel.losier@elastic.co>"}}]}] BACKPORT-->