### PR TITLE
[Security Solution] Fixes react-query id collision

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/hooks/use_integrations.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/hooks/use_integrations.test.tsx
@@ -20,7 +20,7 @@ const createWrapper = (): FC<PropsWithChildren<{}>> => {
 };
 
 const renderUseQuery = (result: { items: unknown[] }) =>
-  renderHook(() => useQuery(['integrations'], () => result), {
+  renderHook(() => useQuery(['integrations-threat-intel'], () => result), {
     wrapper: createWrapper(),
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/hooks/use_integrations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/hooks/use_integrations.ts
@@ -26,7 +26,7 @@ export interface Integration {
   status: IntegrationInstallStatus;
 }
 
-const queryKey = ['integrations'];
+const queryKey = ['integrations-threat-intel'];
 
 /**
  * Retrieves integrations from the Fleet plugin endpoint /api/fleet/epm/packages.


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/security-team/issues/14369 (internal)

Updates one of the two places we use the react query key "integrations" to be something different so it doesn't use the incorrect cache when reading. This was causing page failures when going from a page that used one integrations query to one that used another. We fetch integrations 2 separate ways in these queries and they should not share their key.

The other file that uses the `integrations` key label is `x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/components/related_integrations/use_integrations.tsx`. I just changed the most recent file between the two.

### Testing steps
1. Have an instance with prebuilt rules installed that contain related integrations (installing all prebuilt rules will do this)
2. Go to the `Intellegence` page in the security app
3. Navigate to the `Detection Rules` page under the `Rules` tab in the navigation sidebar
4. See that the page loads without error

### Videos

https://github.com/user-attachments/assets/9245a569-8686-4c11-bb11-a0512764722f


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->