### PR TITLE
Add searchChannels subaction for slack, expose to workflows

### DIFF
--- a/src/platform/plugins/shared/workflows_management/common/connector_sub_actions_map.ts
+++ b/src/platform/plugins/shared/workflows_management/common/connector_sub_actions_map.ts
@@ -49,6 +49,10 @@ import {
   SUB_ACTION as SENTINELONE_SUB_ACTION,
 } from '@kbn/stack-connectors-plugin/common/sentinelone/constants';
 import {
+  SLACK_API_CONNECTOR_ID,
+  SUB_ACTION as SLACK_API_SUB_ACTION,
+} from '@kbn/stack-connectors-plugin/common/slack_api/constants';
+import {
   THEHIVE_CONNECTOR_ID,
   SUB_ACTION as THEHIVE_SUB_ACTION,
 } from '@kbn/stack-connectors-plugin/common/thehive/constants';
@@ -137,6 +141,7 @@ function createSubActionsMapping() {
     },
     { id: JIRA_SERVICE_MANAGEMENT_CONNECTOR_TYPE_ID, actions: JiraServiceManagementSubActions },
     { id: OpsgenieConnectorTypeId, actions: OpsgenieSubActions },
+    { id: SLACK_API_CONNECTOR_ID, actions: SLACK_API_SUB_ACTION },
     // Legacy connectors (using older ActionType pattern)
     { id: '.jira', actions: JIRA_SUB_ACTIONS },
     { id: '.servicenow-itsm', actions: SERVICENOW_ITSM_SUB_ACTIONS },

--- a/src/platform/plugins/shared/workflows_management/common/schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/schema.ts
@@ -97,6 +97,7 @@ import {
   SlackApiPostMessageParamsSchema,
   SlackApiGetChannelsParamsSchema,
   SlackApiGetUsersParamsSchema,
+  SlackApiSearchChannelsParamsSchema,
   SlackApiResponseSchema,
   // Tines connector schemas
   TinesStoriesParamsSchema,
@@ -355,6 +356,8 @@ function getSubActionParamsSchema(actionTypeId: string, subActionName: string): 
         return SlackApiGetChannelsParamsSchema;
       case 'getUsers':
         return SlackApiGetUsersParamsSchema;
+      case 'searchChannels':
+        return SlackApiSearchChannelsParamsSchema;
     }
   }
 

--- a/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/index.ts
+++ b/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/index.ts
@@ -146,6 +146,7 @@ export {
   SlackApiPostMessageParamsSchema,
   SlackApiGetChannelsParamsSchema,
   SlackApiGetUsersParamsSchema,
+  SlackApiSearchChannelsParamsSchema,
   SlackApiResponseSchema,
 } from './slack_api';
 

--- a/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/slack_api.ts
+++ b/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/slack_api.ts
@@ -35,6 +35,12 @@ export const SlackApiGetUsersParamsSchema = z.object({
   limit: z.number().optional(),
 });
 
+export const SlackApiSearchChannelsParamsSchema = z.object({
+  query: z.string().min(1),
+  count: z.number().min(1).max(100).optional(),
+  page: z.number().min(1).optional(),
+});
+
 // Slack API connector response schema
 export const SlackApiResponseSchema = z.object({
   ok: z.boolean(),
@@ -66,6 +72,24 @@ export const SlackApiResponseSchema = z.object({
         real_name: z.string().optional(),
       })
     )
+    .optional(),
+  messages: z
+    .object({
+      matches: z.array(
+        z.object({
+          channel: z.object({
+            id: z.string(),
+            name: z.string(),
+          }),
+          text: z.string(),
+          user: z.string(),
+          username: z.string(),
+          ts: z.string(),
+          permalink: z.string(),
+        })
+      ),
+      total: z.number(),
+    })
     .optional(),
   error: z.string().optional(),
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/common/slack_api/constants.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/slack_api/constants.ts
@@ -7,3 +7,10 @@
 
 export const SLACK_API_CONNECTOR_ID = '.slack_api';
 export const SLACK_URL = 'https://slack.com/api/';
+
+export const SUB_ACTION = {
+  POST_MESSAGE: 'postMessage',
+  GET_CHANNELS: 'getChannels',
+  GET_USERS: 'getUsers',
+  SEARCH_CHANNELS: 'searchChannels',
+} as const;

--- a/x-pack/platform/plugins/shared/stack_connectors/common/slack_api/lib.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/slack_api/lib.ts
@@ -32,9 +32,38 @@ export function serviceErrorResult(
   actionId: string,
   serviceMessage?: string
 ): ConnectorTypeExecutorResult<void> {
-  const errMessage = i18n.translate('xpack.stackConnectors.slack.errorPostingErrorMessage', {
-    defaultMessage: 'error posting slack message',
-  });
+  const errMessage = serviceMessage
+    ? i18n.translate('xpack.stackConnectors.slack.errorPostingErrorMessageWithDetails', {
+        defaultMessage: 'error posting slack message: {serviceMessage}',
+        values: {
+          serviceMessage,
+        },
+      })
+    : i18n.translate('xpack.stackConnectors.slack.errorPostingErrorMessage', {
+        defaultMessage: 'error posting slack message',
+      });
+  return {
+    status: 'error',
+    message: errMessage,
+    actionId,
+    serviceMessage,
+  };
+}
+
+export function searchErrorResult(
+  actionId: string,
+  serviceMessage?: string
+): ConnectorTypeExecutorResult<void> {
+  const errMessage = serviceMessage
+    ? i18n.translate('xpack.stackConnectors.slack.errorSearchingErrorMessageWithDetails', {
+        defaultMessage: 'error searching slack messages: {serviceMessage}',
+        values: {
+          serviceMessage,
+        },
+      })
+    : i18n.translate('xpack.stackConnectors.slack.errorSearchingErrorMessage', {
+        defaultMessage: 'error searching slack messages',
+      });
   return {
     status: 'error',
     message: errMessage,

--- a/x-pack/platform/plugins/shared/stack_connectors/common/slack_api/schema.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/slack_api/schema.ts
@@ -9,6 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 export const SlackApiSecretsSchema = schema.object({
   token: schema.string({ minLength: 1 }),
+  userToken: schema.maybe(schema.string({ minLength: 1 })),
 });
 
 export const SlackApiConfigSchema = schema.object({
@@ -56,6 +57,12 @@ export const PostBlockkitSubActionParamsSchema = schema.object({
   text: schema.string({ validate: validateBlockkit }),
 });
 
+export const SearchChannelsSubActionParamsSchema = schema.object({
+  query: schema.string({ minLength: 1 }),
+  count: schema.maybe(schema.number({ min: 1, max: 100 })),
+  page: schema.maybe(schema.number({ min: 1 })),
+});
+
 export const PostMessageParamsSchema = schema.object({
   subAction: schema.literal('postMessage'),
   subActionParams: PostMessageSubActionParamsSchema,
@@ -66,8 +73,14 @@ export const PostBlockkitParamsSchema = schema.object({
   subActionParams: PostBlockkitSubActionParamsSchema,
 });
 
+export const SearchChannelsParamsSchema = schema.object({
+  subAction: schema.literal('searchChannels'),
+  subActionParams: SearchChannelsSubActionParamsSchema,
+});
+
 export const SlackApiParamsSchema = schema.oneOf([
   ValidChannelIdParamsSchema,
   PostMessageParamsSchema,
   PostBlockkitParamsSchema,
+  SearchChannelsParamsSchema,
 ]);

--- a/x-pack/platform/plugins/shared/stack_connectors/common/slack_api/types.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/slack_api/types.ts
@@ -18,6 +18,8 @@ import type {
   SlackApiParamsSchema,
   SlackApiConfigSchema,
   ValidChannelIdSubActionParamsSchema,
+  SearchChannelsSubActionParamsSchema,
+  SearchChannelsParamsSchema,
 } from './schema';
 
 export type SlackApiSecrets = TypeOf<typeof SlackApiSecretsSchema>;
@@ -28,6 +30,8 @@ export type PostMessageSubActionParams = TypeOf<typeof PostMessageSubActionParam
 export type PostBlockkitSubActionParams = TypeOf<typeof PostBlockkitSubActionParamsSchema>;
 export type PostBlockkitParams = TypeOf<typeof PostBlockkitParamsSchema>;
 export type ValidChannelIdSubActionParams = TypeOf<typeof ValidChannelIdSubActionParamsSchema>;
+export type SearchChannelsSubActionParams = TypeOf<typeof SearchChannelsSubActionParamsSchema>;
+export type SearchChannelsParams = TypeOf<typeof SearchChannelsParamsSchema>;
 export type SlackApiParams = TypeOf<typeof SlackApiParamsSchema>;
 export type SlackApiConnectorType = ConnectorType<
   SlackApiConfig,
@@ -50,7 +54,7 @@ export type SlackExecutorOptions = ConnectorTypeExecutorOptions<
 
 export type SlackApiActionParams = TypeOf<typeof SlackApiParamsSchema>;
 
-export interface SlackAPiResponse {
+export interface SlackApiResponse {
   ok: boolean;
   error?: string;
   message?: {
@@ -69,12 +73,26 @@ export interface ChannelResponse {
   is_private: boolean;
 }
 
-export interface ValidChannelResponse extends SlackAPiResponse {
+export interface ValidChannelResponse extends SlackApiResponse {
   channel?: ChannelResponse;
 }
 
-export interface PostMessageResponse extends SlackAPiResponse {
+export interface PostMessageResponse extends SlackApiResponse {
   channel?: string;
+}
+
+export interface SearchChannelsResponse extends SlackApiResponse {
+  messages?: {
+    matches: Array<{
+      channel: { id: string; name: string };
+      text: string;
+      user: string;
+      username: string;
+      ts: string;
+      permalink: string;
+    }>;
+    total: number;
+  };
 }
 
 export interface ValidChannelRouteResponse {
@@ -96,4 +114,9 @@ export interface SlackApiService {
     channelIds,
     text,
   }: PostBlockkitSubActionParams) => Promise<ConnectorTypeExecutorResult<unknown>>;
+  searchChannels: ({
+    query,
+    count,
+    page,
+  }: SearchChannelsSubActionParams) => Promise<ConnectorTypeExecutorResult<unknown>>;
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/slack_api/slack_connectors.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/slack_api/slack_connectors.tsx
@@ -34,8 +34,21 @@ const getSecretsFormSchema = (docLinks: DocLinksStart): SecretsFieldSchema[] => 
     helpText: (
       <EuiLink href={docLinks.links.alerting.slackApiAction} target="_blank">
         <FormattedMessage
-          id="xpack.stackConnectors.components.slack_api.apiKeyDocumentation"
-          defaultMessage="Create a Slack Web API token"
+          id="xpack.stackConnectors.components.slack_api.botTokenDocumentation"
+          defaultMessage="Create a Slack Bot Token (xoxb-...)"
+        />
+      </EuiLink>
+    ),
+  },
+  {
+    id: 'userToken',
+    label: i18n.USER_TOKEN_LABEL,
+    isPasswordField: true,
+    helpText: (
+      <EuiLink href={docLinks.links.alerting.slackApiAction} target="_blank">
+        <FormattedMessage
+          id="xpack.stackConnectors.components.slack_api.userTokenDocumentation"
+          defaultMessage="Create a Slack User Token (xoxp-...) for search operations. Required for searchChannels subAction."
         />
       </EuiLink>
     ),

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/slack_api/translations.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/slack_api/translations.ts
@@ -22,7 +22,13 @@ export const CHANNEL_REQUIRED = i18n.translate(
 export const TOKEN_LABEL = i18n.translate(
   'xpack.stackConnectors.components.slack_api.tokenTextFieldLabel',
   {
-    defaultMessage: 'API Token',
+    defaultMessage: 'Bot Token',
+  }
+);
+export const USER_TOKEN_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.slack_api.userTokenTextFieldLabel',
+  {
+    defaultMessage: 'User Token (optional)',
   }
 );
 export const WEB_API = i18n.translate('xpack.stackConnectors.components.slack_api.webApi', {

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/slack_api/api.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/slack_api/api.test.ts
@@ -11,24 +11,33 @@ import { api } from './api';
 const createMock = (): jest.Mocked<SlackApiService> => {
   const service = {
     postMessage: jest.fn().mockImplementation(() => ({
-      ok: true,
-      channel: 'general',
-      message: {
-        text: 'a message',
-        type: 'message',
+      status: 'ok',
+      data: {
+        ok: true,
+        channel: 'general',
+        message: {
+          text: 'a message',
+          type: 'message',
+        },
       },
+      actionId: '.slack_api',
     })),
     postBlockkit: jest.fn().mockImplementation(() => ({
-      ok: true,
-      channel: 'general',
-      message: {
-        text: 'a blockkit message',
-      },
-    })),
-    validChannelId: jest.fn().mockImplementation(() => [
-      {
+      status: 'ok',
+      data: {
         ok: true,
-        channels: {
+        channel: 'general',
+        message: {
+          text: 'a blockkit message',
+        },
+      },
+      actionId: '.slack_api',
+    })),
+    validChannelId: jest.fn().mockImplementation(() => ({
+      status: 'ok',
+      data: {
+        ok: true,
+        channel: {
           id: 'channel_id_1',
           name: 'general',
           is_channel: true,
@@ -36,7 +45,28 @@ const createMock = (): jest.Mocked<SlackApiService> => {
           is_private: true,
         },
       },
-    ]),
+      actionId: '.slack_api',
+    })),
+    searchChannels: jest.fn().mockImplementation(() => ({
+      status: 'ok',
+      data: {
+        ok: true,
+        messages: {
+          matches: [
+            {
+              channel: { id: 'C123', name: 'general' },
+              text: 'test message',
+              user: 'U123',
+              username: 'testuser',
+              ts: '1234567890.123456',
+              permalink: 'https://slack.com/archives/C123/p1234567890123456',
+            },
+          ],
+          total: 1,
+        },
+      },
+      actionId: '.slack_api',
+    })),
   };
 
   return service;
@@ -59,19 +89,20 @@ describe('api', () => {
       params: { channelId: 'channel_id_1' },
     });
 
-    expect(res).toEqual([
-      {
-        channels: {
-          id: 'channel_id_1',
-          is_archived: false,
-          is_channel: true,
-          is_private: true,
-          name: 'general',
-        },
-
+    expect(res).toEqual({
+      status: 'ok',
+      data: {
         ok: true,
+        channel: {
+          id: 'channel_id_1',
+          name: 'general',
+          is_channel: true,
+          is_archived: false,
+          is_private: true,
+        },
       },
-    ]);
+      actionId: '.slack_api',
+    });
   });
 
   test('postMessage with channels params', async () => {
@@ -81,12 +112,16 @@ describe('api', () => {
     });
 
     expect(res).toEqual({
-      channel: 'general',
-      message: {
-        text: 'a message',
-        type: 'message',
+      status: 'ok',
+      data: {
+        ok: true,
+        channel: 'general',
+        message: {
+          text: 'a message',
+          type: 'message',
+        },
       },
-      ok: true,
+      actionId: '.slack_api',
     });
   });
 
@@ -97,12 +132,16 @@ describe('api', () => {
     });
 
     expect(res).toEqual({
-      channel: 'general',
-      message: {
-        text: 'a message',
-        type: 'message',
+      status: 'ok',
+      data: {
+        ok: true,
+        channel: 'general',
+        message: {
+          text: 'a message',
+          type: 'message',
+        },
       },
-      ok: true,
+      actionId: '.slack_api',
     });
   });
 
@@ -113,11 +152,43 @@ describe('api', () => {
     });
 
     expect(res).toEqual({
-      channel: 'general',
-      message: {
-        text: 'a blockkit message',
+      status: 'ok',
+      data: {
+        ok: true,
+        channel: 'general',
+        message: {
+          text: 'a blockkit message',
+        },
       },
-      ok: true,
+      actionId: '.slack_api',
+    });
+  });
+
+  test('searchChannels', async () => {
+    const res = await api.searchChannels({
+      externalService,
+      params: { query: 'test', count: 20, page: 1 },
+    });
+
+    expect(res).toEqual({
+      status: 'ok',
+      data: {
+        ok: true,
+        messages: {
+          matches: [
+            {
+              channel: { id: 'C123', name: 'general' },
+              text: 'test message',
+              user: 'U123',
+              username: 'testuser',
+              ts: '1234567890.123456',
+              permalink: 'https://slack.com/archives/C123/p1234567890123456',
+            },
+          ],
+          total: 1,
+        },
+      },
+      actionId: '.slack_api',
     });
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/slack_api/api.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/slack_api/api.ts
@@ -10,6 +10,7 @@ import type {
   PostBlockkitSubActionParams,
   SlackApiService,
   ValidChannelIdSubActionParams,
+  SearchChannelsSubActionParams,
 } from '../../../common/slack_api/types';
 
 const validChannelIdHandler = async ({
@@ -36,8 +37,17 @@ const postBlockkitHandler = async ({
   params: PostBlockkitSubActionParams;
 }) => await externalService.postBlockkit({ channelIds, channels, text });
 
+const searchChannelsHandler = async ({
+  externalService,
+  params: { query, count, page },
+}: {
+  externalService: SlackApiService;
+  params: SearchChannelsSubActionParams;
+}) => await externalService.searchChannels({ query, count, page });
+
 export const api = {
   validChannelId: validChannelIdHandler,
   postMessage: postMessageHandler,
   postBlockkit: postBlockkitHandler,
+  searchChannels: searchChannelsHandler,
 };

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/slack_api/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/slack_api/index.ts
@@ -31,7 +31,13 @@ import { SLACK_CONNECTOR_NAME } from './translations';
 import { api } from './api';
 import { createExternalService } from './service';
 
-const supportedSubActions = ['getAllowedChannels', 'validChannelId', 'postMessage', 'postBlockkit'];
+const supportedSubActions = [
+  'getAllowedChannels',
+  'validChannelId',
+  'postMessage',
+  'postBlockkit',
+  'searchChannels',
+];
 
 export const getConnectorType = (): SlackApiConnectorType => {
   return {
@@ -149,6 +155,13 @@ const slackApiExecutor = async ({
 
   if (subAction === 'postBlockkit') {
     return await api.postBlockkit({
+      externalService,
+      params: params.subActionParams,
+    });
+  }
+
+  if (subAction === 'searchChannels') {
+    return await api.searchChannels({
       externalService,
       params: params.subActionParams,
     });


### PR DESCRIPTION
## Summary

Still a WIP, but I'm looking at adding another subAction to the Slack Connector, and then exposing it to Workflows.
The goal is to enable Search of your channels, and pass the search results on to subsequent workflow steps.

A simple workflow step looks like:
```
  - name: other_slack_search
    type: slack_api.searchChannels
    connector-id: slack_connector
    with:
      query: "{test}"
```

I haven't actually managed to test it yet, because it's remarkably difficult to get a user token for this API. I'm waiting on IT approval for my slack app. In the mean time, thought I'd put this up for visibility.


Because a new token type is needed for this type of API, I added a new (optional) config field for the connector

<img width="732" height="511" alt="Screenshot 2025-10-24 at 3 03 57 PM" src="https://github.com/user-attachments/assets/c2aa6c90-8dbd-4ac9-a188-5d3e157d64c7" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



