### PR TITLE
[Security Solution] remove riskScoringRoutesEnabled feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -61,11 +61,6 @@ export const allowedExperimentalValues = Object.freeze({
   newUserDetailsFlyoutManagedUser: false,
 
   /**
-   * Enables experimental Entity Analytics HTTP endpoints
-   */
-  riskScoringRoutesEnabled: true,
-
-  /**
    * Disables ESQL-based risk scoring
    */
   disableESQLRiskScoring: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/index.ts
@@ -11,9 +11,9 @@ import { routes } from './routes';
 export class EntityAnalytics {
   public setup() {}
 
-  public start(isEnabled = false): SecuritySubPlugin {
+  public start(): SecuritySubPlugin {
     return {
-      routes: isEnabled ? routes : [],
+      routes,
     };
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/links.ts
@@ -15,6 +15,7 @@ import {
 } from '../../common/endpoint/service/authz';
 import {
   BLOCKLIST_PATH,
+  ENDPOINT_EXCEPTIONS_PATH,
   ENDPOINTS_PATH,
   ENTITY_ANALYTICS_ENTITY_STORE_MANAGEMENT_PATH,
   ENTITY_ANALYTICS_MANAGEMENT_PATH,
@@ -23,15 +24,17 @@ import {
   MANAGE_PATH,
   POLICIES_PATH,
   RESPONSE_ACTIONS_HISTORY_PATH,
-  SecurityPageName,
   SECURITY_FEATURE_ID,
+  SecurityPageName,
   TRUSTED_APPS_PATH,
-  ENDPOINT_EXCEPTIONS_PATH,
   TRUSTED_DEVICES_PATH,
 } from '../../common/constants';
 import {
   BLOCKLIST,
+  ENDPOINT_EXCEPTIONS,
   ENDPOINTS,
+  ENTITY_ANALYTICS_RISK_SCORE,
+  ENTITY_STORE,
   EVENT_FILTERS,
   HOST_ISOLATION_EXCEPTIONS,
   MANAGE,
@@ -39,9 +42,6 @@ import {
   RESPONSE_ACTIONS_HISTORY,
   TRUSTED_APPLICATIONS,
   TRUSTED_DEVICES,
-  ENTITY_ANALYTICS_RISK_SCORE,
-  ENTITY_STORE,
-  ENDPOINT_EXCEPTIONS,
 } from '../app/translations';
 import { licenseService } from '../common/hooks/use_license';
 import type { LinkItem } from '../common/links/types';
@@ -218,7 +218,6 @@ export const links: LinkItem = {
       skipUrlState: true,
       hideTimeline: true,
       capabilities: [`${SECURITY_FEATURE_ID}.entity-analytics`],
-      experimentalKey: 'riskScoringRoutesEnabled',
       licenseType: 'platinum',
     },
     {

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -7,15 +7,15 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { BehaviorSubject, Subject, combineLatestWith } from 'rxjs';
+import { BehaviorSubject, combineLatestWith, Subject } from 'rxjs';
 import type * as H from 'history';
 import type {
   AppMountParameters,
   AppUpdater,
   CoreSetup,
   CoreStart,
-  PluginInitializerContext,
   Plugin as IPlugin,
+  PluginInitializerContext,
 } from '@kbn/core/public';
 import { AppStatus, DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
@@ -30,20 +30,20 @@ import type {
   PluginSetup,
   PluginStart,
   SetupPlugins,
+  StartedSubPlugins,
   StartPlugins,
+  StartPluginsDependencies,
   StartServices,
   SubPlugins,
-  StartedSubPlugins,
-  StartPluginsDependencies,
 } from './types';
-import { SOLUTION_NAME, ASSISTANT_MANAGEMENT_TITLE } from './common/translations';
+import { ASSISTANT_MANAGEMENT_TITLE, SOLUTION_NAME } from './common/translations';
 
-import { APP_ID, APP_UI_ID, APP_PATH, APP_ICON_SOLUTION } from '../common/constants';
+import { APP_ICON_SOLUTION, APP_ID, APP_PATH, APP_UI_ID } from '../common/constants';
 
 import type { AppLinkItems } from './common/links';
 import {
-  applicationLinksUpdater,
   type ApplicationLinksUpdateParams,
+  applicationLinksUpdater,
 } from './app/links/application_links_updater';
 import type { FleetUiExtensionGetterOptions, SecuritySolutionUiConfigType } from './common/types';
 
@@ -344,9 +344,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       rules: subPlugins.rules.start(storage),
       threatIntelligence: subPlugins.threatIntelligence.start(),
       timelines: subPlugins.timelines.start(),
-      entityAnalytics: subPlugins.entityAnalytics.start(
-        this.experimentalFeatures.riskScoringRoutesEnabled
-      ),
+      entityAnalytics: subPlugins.entityAnalytics.start(),
       siemMigrations: subPlugins.siemMigrations.start(this.experimentalFeatures),
       siemReadiness: subPlugins.siemReadiness.start(),
       configurations: subPlugins.configurations.start(),

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/ess/config.base.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/ess/config.base.ts
@@ -108,7 +108,6 @@ export function createTestConfig(options: CreateTestConfigOptions, testFiles?: s
           '--xpack.ruleRegistry.unsafe.legacyMultiTenancy.enabled=true',
           `--xpack.securitySolution.enableExperimental=${JSON.stringify([
             'previewTelemetryUrlEnabled',
-            'riskScoringRoutesEnabled',
             'bulkEditAlertSuppressionEnabled',
             'doesNotMatchForIndicatorMatchRuleEnabled',
             'endpointExceptionsMovedUnderManagement',


### PR DESCRIPTION
## Summary

This PR removes the `riskScoringRoutesEnabled` feature flag. This feature flag was enabled back in 2023 .

**_Feel free to close this PR if our intention is to keep the feature flag around!_**

> [!IMPORTANT]
> As the feature flag has been eanbled for a while,, no UI or behavior changes should be introduced by this PR!

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
