### PR TITLE
[One Workflow] Fix: Elasticsearch actions now execute with user credentials instead of `kibana_system` user

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
+import { cloudMock } from '@kbn/cloud-plugin/server/mocks';
+import type { CoreStart, ElasticsearchClient, KibanaRequest, Logger } from '@kbn/core/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import { setupDependencies } from './setup_dependencies';
+import type { WorkflowsExecutionEngineConfig } from '../config';
+import { ConnectorExecutor } from '../connector_executor';
+import { UrlValidator } from '../lib/url_validator';
+import type { LogsRepository } from '../repositories/logs_repository/logs_repository';
+import type { StepExecutionRepository } from '../repositories/step_execution_repository';
+import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import { NodesFactory } from '../step/nodes_factory';
+import { StepExecutionRuntimeFactory } from '../workflow_context_manager/step_execution_runtime_factory';
+import type { ContextDependencies } from '../workflow_context_manager/types';
+import { WorkflowExecutionRuntimeManager } from '../workflow_context_manager/workflow_execution_runtime_manager';
+import { WorkflowExecutionState } from '../workflow_context_manager/workflow_execution_state';
+import { WorkflowEventLogger } from '../workflow_event_logger/workflow_event_logger';
+import { WorkflowTaskManager } from '../workflow_task_manager/workflow_task_manager';
+
+jest.mock('../connector_executor');
+jest.mock('../lib/url_validator');
+jest.mock('../step/nodes_factory');
+jest.mock('../workflow_context_manager/step_execution_runtime_factory');
+jest.mock('../workflow_context_manager/workflow_execution_runtime_manager');
+jest.mock('../workflow_context_manager/workflow_execution_state');
+jest.mock('../workflow_event_logger/workflow_event_logger');
+jest.mock('../workflow_task_manager/workflow_task_manager');
+
+describe('setupDependencies', () => {
+  const workflowRunId = 'test-workflow-run-id';
+  const spaceId = 'default';
+
+  const mockWorkflowExecution = {
+    id: workflowRunId,
+    workflowId: 'test-workflow',
+    workflowDefinition: {
+      name: 'Test Workflow',
+      steps: [],
+    },
+    spaceId,
+    status: 'running',
+    startedAt: Date.now(),
+  };
+
+  const mockActionsPlugin = {
+    getUnsecuredActionsClient: jest.fn().mockResolvedValue({}),
+  } as unknown as ActionsPluginStartContract;
+
+  const mockTaskManager = {} as TaskManagerStartContract;
+
+  const mockEsClient = {
+    search: jest.fn(),
+    index: jest.fn(),
+  } as unknown as ElasticsearchClient;
+
+  const mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as Logger;
+
+  const mockConfig = {
+    logging: {
+      console: true,
+    },
+    http: {
+      allowedHosts: ['*'],
+    },
+  } as WorkflowsExecutionEngineConfig;
+
+  const mockWorkflowExecutionRepository = {
+    getWorkflowExecutionById: jest.fn().mockResolvedValue(mockWorkflowExecution),
+  } as unknown as WorkflowExecutionRepository;
+
+  const mockStepExecutionRepository = {} as StepExecutionRepository;
+  const mockLogsRepository = {} as LogsRepository;
+
+  const cloudSetupMock = cloudMock.createSetup();
+  const mockDependencies: ContextDependencies = {
+    cloudSetup: cloudSetupMock,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (ConnectorExecutor as jest.Mock).mockImplementation(() => ({}));
+    (UrlValidator as jest.Mock).mockImplementation(() => ({}));
+    (NodesFactory as jest.Mock).mockImplementation(() => ({}));
+    (StepExecutionRuntimeFactory as jest.Mock).mockImplementation(() => ({}));
+    (WorkflowExecutionRuntimeManager as jest.Mock).mockImplementation(() => ({}));
+    (WorkflowExecutionState as jest.Mock).mockImplementation(() => ({
+      getWorkflowExecution: () => mockWorkflowExecution,
+    }));
+    (WorkflowEventLogger as jest.Mock).mockImplementation(() => ({
+      logInfo: jest.fn(),
+      logError: jest.fn(),
+      createStepLogger: jest.fn(),
+    }));
+    (WorkflowTaskManager as jest.Mock).mockImplementation(() => ({}));
+  });
+
+  it('should use original esClient when fakeRequest is not provided', async () => {
+    const result = await setupDependencies(
+      workflowRunId,
+      spaceId,
+      mockActionsPlugin,
+      mockTaskManager,
+      mockEsClient,
+      mockLogger,
+      mockConfig,
+      mockWorkflowExecutionRepository,
+      mockStepExecutionRepository,
+      mockLogsRepository,
+      {} as CoreStart,
+      mockDependencies
+    );
+
+    expect(result.clientToUse).toBe(mockEsClient);
+  });
+
+  it('should use user-scoped ES client when fakeRequest and coreStart are provided', async () => {
+    const mockScopedClient = {
+      search: jest.fn(),
+      index: jest.fn(),
+    } as unknown as ElasticsearchClient;
+
+    const mockAsCurrentUser = mockScopedClient;
+    const mockAsScoped = jest.fn().mockReturnValue({
+      asCurrentUser: mockAsCurrentUser,
+    });
+
+    const mockCoreStart = {
+      elasticsearch: {
+        client: {
+          asScoped: mockAsScoped,
+        },
+      },
+    } as unknown as CoreStart;
+
+    const mockFakeRequest = {
+      headers: {},
+    } as KibanaRequest;
+
+    const result = await setupDependencies(
+      workflowRunId,
+      spaceId,
+      mockActionsPlugin,
+      mockTaskManager,
+      mockEsClient,
+      mockLogger,
+      mockConfig,
+      mockWorkflowExecutionRepository,
+      mockStepExecutionRepository,
+      mockLogsRepository,
+      mockCoreStart,
+      mockDependencies,
+      mockFakeRequest
+    );
+
+    expect(mockAsScoped).toHaveBeenCalledWith(mockFakeRequest);
+    expect(result.clientToUse).toBe(mockAsCurrentUser);
+    expect(result.clientToUse).not.toBe(mockEsClient);
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.ts
@@ -109,7 +109,7 @@ export async function setupDependencies(
     workflowExecutionGraph,
     workflowExecutionState,
     workflowLogger,
-    esClient,
+    esClient: clientToUse,
     fakeRequest,
     coreStart,
     dependencies,


### PR DESCRIPTION
_LLM generated description_

### Problem
Elasticsearch internal actions were executing with the kibana_system user credentials instead of the actual user's credentials, causing authorization errors even when the user had sufficient permissions (e.g., superuser role).
Error example:
### Root Cause
In setup_dependencies.ts, we correctly created a user-scoped ES client using coreStart.elasticsearch.client.asScoped(fakeRequest).asCurrentUser and stored it in clientToUse. However, we were passing the original unscoped esClient (which uses kibana_system credentials) to the StepExecutionRuntimeFactory instead of the user-scoped clientToUse.
### Solution
Changed line 112 in setup_dependencies.ts to pass clientToUse instead of esClient to the StepExecutionRuntimeFactory. This ensures that the user-scoped client flows through to the WorkflowContextManager and is used by elasticsearch action steps.
### Impact

- Elasticsearch actions now execute with the actual user's permissions
- Users can perform operations based on their assigned roles
- Maintains proper security boundaries and audit trails