### PR TITLE
[Agent Builder] Fix llm connector selection when connector removed

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/connector_selector/connector_selector.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/connector_selector/connector_selector.tsx
@@ -76,14 +76,22 @@ export const ConnectorSelector: React.FC<ConnectorSelectorProps> = ({
     defaultConnectorId,
   });
 
-  // If no user preference is set, initialize with reasonable default connector
-  useEffect(() => {
-    if (!selectedConnectorId && !isLoading && initialConnectorId) {
-      onSelectConnector(initialConnectorId);
-    }
-  }, [selectedConnectorId, isLoading, initialConnectorId, onSelectConnector]);
-
   const selectedConnector = connectors.find((c) => c.id === selectedConnectorId);
+
+  useEffect(() => {
+    if (!isLoading && initialConnectorId) {
+      // No user preference set
+      if (!selectedConnectorId) {
+        onSelectConnector(initialConnectorId);
+      }
+      // User preference is set but connector is not available in the list.
+      // Scenario: the connector was deleted or admin changed GenAI settings
+      else if (selectedConnectorId && !selectedConnector) {
+        onSelectConnector(initialConnectorId);
+      }
+    }
+  }, [selectedConnectorId, selectedConnector, isLoading, initialConnectorId, onSelectConnector]);
+
   const selectedConnectorName = selectedConnector?.name || selectedConnectorId;
 
   const buttonLabel =


### PR DESCRIPTION
## Summary

Improvement to handle 2 edge cases gracefully:
- user preference connector removed (doesn't exist in list anymore)
- admin restricts connectors in gen ai settings

In both cases the saved connector id won't be in the list of `connectors`. Handle this gracefully and change selection to a reasonable default.

## Testing


https://github.com/user-attachments/assets/89e905b1-1b91-4bb4-8fb9-7f15ef2d73c1

