### PR TITLE
[streams][lifecycle] delete duplicated Storage size value

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/cards/storage_size_card.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/cards/storage_size_card.tsx
@@ -33,7 +33,6 @@ export const StorageSizeCard = ({
             { defaultMessage: 'storageSize' }
           )}
         >
-          {stats?.sizeBytes}
           {statsError || !stats || stats.sizeBytes === undefined
             ? '-'
             : formatBytes(stats.sizeBytes)}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/240737

We print the raw size bytes and the formatted size, resulting in bizarre values





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->