### PR TITLE
[Agent Builder] Gracefully handle deleted tools in agent edit

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/agents/use_agent_edit.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/agents/use_agent_edit.ts
@@ -15,6 +15,7 @@ import { useToolsService } from '../tools/use_tools';
 import { queryKeys } from '../../query_keys';
 import { duplicateName } from '../../utils/duplicate_name';
 import { searchParamNames } from '../../search_param_names';
+import { cleanInvalidToolReferences } from '../../utils/tool_selection_utils';
 
 export type AgentEditState = Omit<AgentDefinition, 'type' | 'readonly'>;
 
@@ -101,14 +102,16 @@ export function useAgentEdit({
 
   const submit = useCallback(
     async (data: AgentEditState) => {
+      const cleanedData = cleanInvalidToolReferences(data, tools);
+
       if (editingAgentId) {
-        const { id, ...updatedAgent } = data;
+        const { id, ...updatedAgent } = cleanedData;
         await updateMutation.mutateAsync(updatedAgent);
       } else {
-        await createMutation.mutateAsync(data);
+        await createMutation.mutateAsync(cleanedData);
       }
     },
-    [editingAgentId, createMutation, updateMutation]
+    [editingAgentId, createMutation, updateMutation, tools]
   );
 
   const isLoading = agentId ? agentLoading || toolsLoading : false;

--- a/x-pack/platform/plugins/shared/onechat/public/application/utils/tool_selection_utils.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/utils/tool_selection_utils.ts
@@ -5,8 +5,13 @@
  * 2.0.
  */
 
-import type { ToolSelection, ToolSelectionRelevantFields } from '@kbn/onechat-common';
+import type {
+  ToolDefinition,
+  ToolSelection,
+  ToolSelectionRelevantFields,
+} from '@kbn/onechat-common';
 import { allToolsSelectionWildcard, toolMatchSelection } from '@kbn/onechat-common';
+import type { AgentEditState } from '../hooks/agents/use_agent_edit';
 
 /**
  * Check if a specific tool is selected based on the current tool selections.
@@ -87,3 +92,29 @@ export const toggleToolSelection = (
     }
   }
 };
+
+/**
+ * Removes invalid tool references from the agent configuration.
+ * Filters out tool IDs that don't exist in the available tools list,
+ * while preserving wildcard selections and removing empty selections.
+ */
+export function cleanInvalidToolReferences(
+  data: AgentEditState,
+  availableTools: ToolDefinition[]
+): AgentEditState {
+  const validToolIds = new Set(availableTools.map((tool) => tool.id));
+  const cleanedTools = data.configuration.tools
+    .map((selection) => ({
+      ...selection,
+      tool_ids: selection.tool_ids.filter((id) => id === '*' || validToolIds.has(id)),
+    }))
+    .filter((selection) => selection.tool_ids.length > 0);
+
+  return {
+    ...data,
+    configuration: {
+      ...data.configuration,
+      tools: cleanedTools,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Exclude referenced tools that no longeer exist from payload when saving an agent.

Adding this to client only, we still want to have strict validation on server side. Backporting to 9.2

### Validation

https://github.com/user-attachments/assets/2c82c2ff-9986-47f1-8abb-570198286576



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->