### PR TITLE
🌊 Streams: Fix streams header layout on small screens with doc flyout

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
@@ -136,10 +136,11 @@ export function Wrapper({
           <EuiFlexGroup
             direction="row"
             gutterSize="s"
-            alignItems="center"
+            alignItems="baseline"
             justifyContent="spaceBetween"
+            wrap
           >
-            <EuiFlexGroup gutterSize="s" alignItems="baseline">
+            <EuiFlexGroup gutterSize="s" alignItems="baseline" wrap>
               {streamId}
               <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" wrap>
                 <EuiFlexItem grow={true}>


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/240738

<img width="950" height="222" alt="Screenshot 2025-10-27 at 10 03 00" src="https://github.com/user-attachments/assets/e49cf786-62e7-4c60-be30-a7b8d83bc416" />
<img width="667" height="211" alt="Screenshot 2025-10-27 at 10 03 09" src="https://github.com/user-attachments/assets/83d78bac-497c-4c62-a622-6243246558f2" />
<img width="630" height="351" alt="Screenshot 2025-10-27 at 10 03 16" src="https://github.com/user-attachments/assets/e7ba315c-4250-4081-bd9c-087ba69b814b" />

Really small screen flyout changes from push layout to overlay:
<img width="992" height="383" alt="Screenshot 2025-10-27 at 10 03 28" src="https://github.com/user-attachments/assets/55d616b8-10b8-478a-bf6a-131de86dfcec" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->