### PR TITLE
[ES|QL] Index editor fix header alignment

### DIFF
--- a/src/platform/packages/private/kbn-index-editor/src/components/data_grid.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/data_grid.tsx
@@ -257,6 +257,9 @@ const DataGrid: React.FC<ESQLDataGridProps> = (props) => {
               width: 100%;
               display: block;
             }
+            .unifiedDataTable__headerCell {
+              align-items: center !important;
+            }
             .euiDataGridHeaderCell {
               align-items: center;
               display: flex;


### PR DESCRIPTION
## Summary
Fixes a miss alignment in the headers.

An`!imporant` style has been [added](https://github.com/sddonne/kibana/blob/main/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx#L1456) in `UnifiedDataTable` last week that breaks the index-editor styling, we need to overwrite it.

### Before
<img width="1260" height="331" alt="image" src="https://github.com/user-attachments/assets/c8b0dea5-0140-489b-ab6e-79c10242bf61" />


### After
<img width="1428" height="358" alt="image" src="https://github.com/user-attachments/assets/f18fd9ba-29f6-4815-86e0-42773eefd083" />




