### PR TITLE
[SharedUX][A11y] Fixes ML anomaly detection job wizard bucket span error text announcement

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/bucket_span/bucket_span.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/bucket_span/bucket_span.tsx
@@ -28,6 +28,9 @@ export const BucketSpan: FC<Props> = ({ setIsValid, hideEstimateButton = false }
   const titleId = useGeneratedHtmlId({
     prefix: 'bucketSpan',
   });
+  const errorId = useGeneratedHtmlId({
+    prefix: 'bucketSpanError',
+  });
 
   useEffect(() => {
     jobCreator.bucketSpan = bucketSpan;
@@ -51,7 +54,7 @@ export const BucketSpan: FC<Props> = ({ setIsValid, hideEstimateButton = false }
   }, [estimating]);
 
   return (
-    <Description validation={validation} titleId={titleId}>
+    <Description validation={validation} titleId={titleId} errorId={errorId}>
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem>
           <BucketSpanInput
@@ -61,6 +64,7 @@ export const BucketSpan: FC<Props> = ({ setIsValid, hideEstimateButton = false }
             bucketSpan={bucketSpan}
             isInvalid={validation.valid === false}
             disabled={estimating}
+            errorId={errorId}
           />
         </EuiFlexItem>
         {hideEstimateButton === false && (

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/bucket_span/bucket_span_input.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/bucket_span/bucket_span_input.tsx
@@ -15,6 +15,7 @@ interface Props {
   isInvalid: boolean;
   disabled: boolean;
   titleId: string;
+  errorId: string;
 }
 
 export const BucketSpanInput: FC<Props> = ({
@@ -23,6 +24,7 @@ export const BucketSpanInput: FC<Props> = ({
   isInvalid,
   disabled,
   titleId,
+  errorId,
 }) => {
   return (
     <EuiFieldText
@@ -32,6 +34,7 @@ export const BucketSpanInput: FC<Props> = ({
       isInvalid={isInvalid}
       data-test-subj="mlJobWizardInputBucketSpan"
       aria-labelledby={titleId}
+      aria-describedby={isInvalid ? errorId : undefined}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/bucket_span/description.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/bucket_span/description.tsx
@@ -9,16 +9,17 @@ import type { FC, PropsWithChildren } from 'react';
 import React, { memo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiDescribedFormGroup, EuiFormRow } from '@elastic/eui';
+import { EuiDescribedFormGroup, EuiFormErrorText, EuiFormRow } from '@elastic/eui';
 import type { Validation } from '../../../../../common/job_validator';
 
 interface Props {
   validation: Validation;
   titleId: string;
+  errorId: string;
 }
 
 export const Description: FC<PropsWithChildren<Props>> = memo(
-  ({ children, validation, titleId }) => {
+  ({ children, validation, titleId, errorId }) => {
     const title = i18n.translate('xpack.ml.newJob.wizard.pickFieldsStep.bucketSpan.title', {
       defaultMessage: 'Bucket span',
     });
@@ -32,9 +33,12 @@ export const Description: FC<PropsWithChildren<Props>> = memo(
           />
         }
       >
-        <EuiFormRow error={validation.message} isInvalid={validation.valid === false}>
+        <EuiFormRow isInvalid={validation.valid === false}>
           <>{children}</>
         </EuiFormRow>
+        {validation.valid === false && validation.message && (
+          <EuiFormErrorText id={errorId}>{validation.message}</EuiFormErrorText>
+        )}
       </EuiDescribedFormGroup>
     );
   }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/216297

## Summary
- To fix bucket span validation error being rendered but not announced, an `errorId` is now generated in `bucket_span` and passed to both `Description` and `BucketSpanInput`. `EuiFormRow` was not properly wiring the correct aria attributes due to the fragment + EuiFlexGroup/EuiFlexItem nesting so the error text is now explicitly rendered using `EuiFormErrorText`. No visual changes.

### Testing

**Windows + NVDA**
Before:
<img width="1730" height="1039" alt="Screenshot 2025-10-27 at 11 42 16" src="https://github.com/user-attachments/assets/792cd62f-786f-446e-9a3e-c852383818ad" />

After:
<img width="1724" height="1045" alt="Screenshot 2025-10-27 at 11 41 15" src="https://github.com/user-attachments/assets/c0d955aa-af5e-4946-a32e-d297eb7998ac" />

**MacOS + VO**
Before:
<img width="1225" height="820" alt="Screenshot 2025-10-27 at 11 58 38" src="https://github.com/user-attachments/assets/54424673-8df7-448f-8b77-2b6cfd17fe0e" />

After:
<img width="1211" height="784" alt="Screenshot 2025-10-27 at 11 58 05" src="https://github.com/user-attachments/assets/d3d4d3aa-3903-463b-a080-f05b9255c4cb" />



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->