### PR TITLE
[Search] Redirect to getting started page on first visit

### DIFF
--- a/x-pack/solutions/search/packages/shared-ui/src/constants.ts
+++ b/x-pack/solutions/search/packages/shared-ui/src/constants.ts
@@ -9,6 +9,7 @@ export const WORKFLOW_LOCALSTORAGE_KEY = 'search_onboarding_workflow';
 export const GLOBAL_EMPTY_STATE_SKIP_KEY = 'search_onboarding_global_empty_state_skip';
 export const ELASTIC_LLM_COST_TOUR_SKIP_KEY = 'search_elastic_llm_cost_info_skip';
 export const ELASTICSEARCH_URL_PLACEHOLDER = 'https://your_deployment_url';
+export const GETTING_STARTED_LOCALSTORAGE_KEY = 'gettingStartedVisited';
 
 // Feature Flags
 // `searchSolution.homepage.ingestionCTA` FF is deprecated

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
@@ -7,6 +7,7 @@
 
 import React, { useEffect } from 'react';
 import { EuiPageTemplate } from '@elastic/eui';
+import { GETTING_STARTED_LOCALSTORAGE_KEY } from '@kbn/search-shared-ui';
 import { useUsageTracker } from '../contexts/usage_tracker_context';
 import { AnalyticsEvents } from '../../common';
 import { SearchGettingStartedPageTemplate } from '../layout/page_template';
@@ -19,6 +20,7 @@ export const SearchGettingStartedPage: React.FC = () => {
   const usageTracker = useUsageTracker();
   useEffect(() => {
     usageTracker.load(AnalyticsEvents.gettingStartedLoaded);
+    localStorage.setItem(GETTING_STARTED_LOCALSTORAGE_KEY, 'true');
   }, [usageTracker]);
 
   return (

--- a/x-pack/solutions/search/plugins/search_homepage/public/application.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/application.tsx
@@ -17,6 +17,7 @@ import { QueryClientProvider } from '@kbn/react-query';
 import type { SearchHomepageServicesContextDeps } from './types';
 import { HomepageRouter } from './router';
 import { UsageTrackerContextProvider } from './contexts/usage_tracker_context';
+import { GettingStartedRedirectGate } from './components/getting_started_redirect_gate';
 
 export const renderApp = async (
   core: CoreStart,
@@ -30,9 +31,11 @@ export const renderApp = async (
         <UsageTrackerContextProvider usageCollection={services.usageCollection}>
           <QueryClientProvider client={queryClient}>
             <I18nProvider>
-              <Router history={services.history}>
-                <HomepageRouter />
-              </Router>
+              <GettingStartedRedirectGate coreStart={core}>
+                <Router history={services.history}>
+                  <HomepageRouter />
+                </Router>
+              </GettingStartedRedirectGate>
             </I18nProvider>
           </QueryClientProvider>
         </UsageTrackerContextProvider>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/getting_started_redirect_gate.test.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/getting_started_redirect_gate.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { GettingStartedRedirectGate } from './getting_started_redirect_gate';
+import { GETTING_STARTED_LOCALSTORAGE_KEY } from '@kbn/search-shared-ui';
+import { useSearchGettingStartedFeatureFlag } from '../hooks/use_search_getting_started_feature_flag';
+
+jest.mock('@kbn/search-shared-ui', () => ({
+  GETTING_STARTED_LOCALSTORAGE_KEY: 'search.gettingStarted.visited',
+}));
+
+jest.mock('../hooks/use_search_getting_started_feature_flag', () => ({
+  useSearchGettingStartedFeatureFlag: jest.fn(),
+}));
+
+describe('GettingStartedRedirectGate', () => {
+  const navigateToApp = jest.fn();
+  const coreStartMock = {
+    application: {
+      navigateToApp,
+    },
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  const renderGate = () =>
+    render(
+      <GettingStartedRedirectGate coreStart={coreStartMock}>
+        <div data-test-subj="child">Child content</div>
+      </GettingStartedRedirectGate>
+    );
+
+  it('renders children', () => {
+    (useSearchGettingStartedFeatureFlag as jest.Mock).mockReturnValue(true);
+    const { getByTestId } = renderGate();
+    expect(getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('navigates if feature is enabled and localStorage key is missing', () => {
+    (useSearchGettingStartedFeatureFlag as jest.Mock).mockReturnValue(true);
+    renderGate();
+    expect(navigateToApp).toHaveBeenCalledWith('searchGettingStarted');
+  });
+
+  it('navigates if feature is enabled and key is "false"', () => {
+    (useSearchGettingStartedFeatureFlag as jest.Mock).mockReturnValue(true);
+    localStorage.setItem(GETTING_STARTED_LOCALSTORAGE_KEY, 'false');
+    renderGate();
+    expect(navigateToApp).toHaveBeenCalledWith('searchGettingStarted');
+  });
+
+  it('does not navigate if key is "true"', () => {
+    (useSearchGettingStartedFeatureFlag as jest.Mock).mockReturnValue(true);
+    localStorage.setItem(GETTING_STARTED_LOCALSTORAGE_KEY, 'true');
+    renderGate();
+    expect(navigateToApp).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate when feature flag is disabled', () => {
+    (useSearchGettingStartedFeatureFlag as jest.Mock).mockReturnValue(false);
+    renderGate();
+    expect(navigateToApp).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/getting_started_redirect_gate.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/getting_started_redirect_gate.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+import type { CoreStart } from '@kbn/core/public';
+import { GETTING_STARTED_LOCALSTORAGE_KEY } from '@kbn/search-shared-ui';
+
+interface Props {
+  coreStart: CoreStart;
+  children: React.ReactNode;
+}
+
+export const GettingStartedRedirectGate = ({ coreStart, children }: Props) => {
+  useEffect(() => {
+    const visited = localStorage.getItem(GETTING_STARTED_LOCALSTORAGE_KEY);
+    if (!visited || visited === 'false') {
+      coreStart.application.navigateToApp('searchGettingStarted');
+    }
+  }, [coreStart]);
+
+  return <>{children}</>;
+};

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/getting_started_redirect_gate.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/getting_started_redirect_gate.tsx
@@ -8,6 +8,7 @@
 import React, { useEffect } from 'react';
 import type { CoreStart } from '@kbn/core/public';
 import { GETTING_STARTED_LOCALSTORAGE_KEY } from '@kbn/search-shared-ui';
+import { useSearchGettingStartedFeatureFlag } from '../hooks/use_search_getting_started_feature_flag';
 
 interface Props {
   coreStart: CoreStart;
@@ -15,12 +16,13 @@ interface Props {
 }
 
 export const GettingStartedRedirectGate = ({ coreStart, children }: Props) => {
+  const isGettingStartedEnabled = useSearchGettingStartedFeatureFlag();
   useEffect(() => {
     const visited = localStorage.getItem(GETTING_STARTED_LOCALSTORAGE_KEY);
-    if (!visited || visited === 'false') {
+    if (isGettingStartedEnabled && (!visited || visited === 'false')) {
       coreStart.application.navigateToApp('searchGettingStarted');
     }
-  }, [coreStart]);
+  }, [coreStart, isGettingStartedEnabled]);
 
   return <>{children}</>;
 };


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/11472

## Summary

This PR uses a redirect gate to check for a `gettingStartedVisited` local storage key and the value of `isGettingStartedEnabled` which is based on the feature flag.

If the local storage key value doesn't exist or is false, and `isGettingStartedEnabled` is true, the user is redirected to the Getting Started page. If the local storage key value is true or `isGettingStartedEnabled` is false they are sent to the Home page.

### Testing

The plugin is disabled behind kibana config. To test locally: `xpack.searchGettingStarted.enabled: true`

Start up the app. If this is your first visit, you should not have the `gettingStartedVisited` local storage key, and you should be redirected to the Getting Started page. On subsequent visits you should be sent to the home page. This should be the flow on serverless and hosted.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~

