### PR TITLE
[Streams] Minor UI improvement when collapsing nested conditions

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/use_steps_processing_summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/use_steps_processing_summary.tsx
@@ -21,7 +21,8 @@ type StepProcessingStatus =
   | 'successful'
   | 'disabled.processorBeforePersisted'
   | 'skipped.followsProcessorBeingEdited'
-  | 'skipped.createdInPreviousSimulation';
+  | 'skipped.createdInPreviousSimulation'
+  | 'condition';
 
 export const useStepsProcessingSummary = () => {
   const stepsContext = useStreamEnrichmentSelector((state) => {
@@ -77,6 +78,8 @@ export const useStepsProcessingSummary = () => {
         } else {
           summaryMap.set(stepId, 'successful');
         }
+      } else {
+        summaryMap.set(stepId, 'condition');
       }
     });
     return summaryMap;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/where/utils.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/where/utils.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getNestedMessage } from './utils';
+
+describe('getNestedMessage', () => {
+  it('should return singular message for steps only', () => {
+    const statusCounts = { skipped: 1 };
+    const stepsCount = 1;
+    const conditionsCount = 0;
+    const msg = getNestedMessage(statusCounts, stepsCount, conditionsCount);
+    expect(msg).toEqual('1 skipped step');
+  });
+
+  it('should return plural message for steps only', () => {
+    const statusCounts = { pending: 1, successful: 2 };
+    const stepsCount = 3;
+    const conditionsCount = 0;
+    const msg = getNestedMessage(statusCounts, stepsCount, conditionsCount);
+    expect(msg).toEqual('1 pending, 2 successful steps');
+  });
+
+  it('should return singular message for conditions only', () => {
+    const statusCounts = {};
+    const stepsCount = 0;
+    const conditionsCount = 1;
+    const msg = getNestedMessage(statusCounts, stepsCount, conditionsCount);
+    expect(msg).toEqual('1 nested condition');
+  });
+
+  it('should return plural message for conditions only', () => {
+    const statusCounts = {};
+    const stepsCount = 0;
+    const conditionsCount = 2;
+    const msg = getNestedMessage(statusCounts, stepsCount, conditionsCount);
+    expect(msg).toEqual('2 nested conditions');
+  });
+
+  it('should return singular message for steps and conditions', () => {
+    const statusCounts = { running: 1 };
+    const stepsCount = 1;
+    const conditionsCount = 1;
+    const msg = getNestedMessage(statusCounts, stepsCount, conditionsCount);
+
+    expect(msg).toEqual('1 running step and 1 nested condition');
+  });
+
+  it('should return plural message for steps and conditions', () => {
+    const statusCounts = { running: 5 };
+    const stepsCount = 5;
+    const conditionsCount = 2;
+    const msg = getNestedMessage(statusCounts, stepsCount, conditionsCount);
+    expect(msg).toEqual('5 running steps and 2 nested conditions');
+  });
+
+  it('should return singular message for steps and plural message for conditions', () => {
+    const statusCounts = { running: 1 };
+    const stepsCount = 1;
+    const conditionsCount = 2;
+    const msg = getNestedMessage(statusCounts, stepsCount, conditionsCount);
+    expect(msg).toEqual('1 running step and 2 nested conditions');
+  });
+
+  it('should return plural message for steps and singular message for conditions', () => {
+    const statusCounts = { running: 5 };
+    const stepsCount = 5;
+    const conditionsCount = 1;
+    const msg = getNestedMessage(statusCounts, stepsCount, conditionsCount);
+    expect(msg).toEqual('5 running steps and 1 nested condition');
+  });
+
+  it('should return empty string if no steps and no conditions', () => {
+    const statusCounts = {};
+    const stepsCount = 0;
+    const conditionsCount = 0;
+    expect(getNestedMessage(statusCounts, stepsCount, conditionsCount)).toEqual('');
+  });
+
+  it('should fallback to status key if status label is missing', () => {
+    const statusCounts = { foo: 7 };
+    const stepsCount = 7;
+    const conditionsCount = 0;
+    const msg = getNestedMessage(statusCounts, stepsCount, conditionsCount);
+    expect(msg).toContain('foo');
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/where/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/where/utils.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+const statusLabels: Record<string, string> = {
+  pending: i18n.translate('xpack.streams.nestedChildrenProcessingSummary.pending', {
+    defaultMessage: 'pending',
+  }),
+  running: i18n.translate('xpack.streams.nestedChildrenProcessingSummary.running', {
+    defaultMessage: 'running',
+  }),
+  failed: i18n.translate('xpack.streams.nestedChildrenProcessingSummary.failed', {
+    defaultMessage: 'failed',
+  }),
+  successful: i18n.translate('xpack.streams.nestedChildrenProcessingSummary.successful', {
+    defaultMessage: 'successful',
+  }),
+  disabled: i18n.translate('xpack.streams.nestedChildrenProcessingSummary.disabled', {
+    defaultMessage: 'disabled',
+  }),
+  skipped: i18n.translate('xpack.streams.nestedChildrenProcessingSummary.skipped', {
+    defaultMessage: 'skipped',
+  }),
+};
+
+export const getNestedMessage = (
+  statusCounts: Record<string, number>,
+  stepsCount: number,
+  conditionsCount: number
+) => {
+  const hasSteps = stepsCount > 0;
+  const hasConditions = conditionsCount > 0;
+
+  let message = '';
+
+  if (hasSteps && !hasConditions) {
+    const statusSummary = Object.entries(statusCounts)
+      .map(([status, count]) => `${count} ${statusLabels[status] || status}`)
+      .join(', ');
+
+    const stepsLabel = i18n.translate('xpack.streams.nestedChildrenProcessingSummary.stepsLabel', {
+      defaultMessage: '{count, plural, one {step} other {steps}}',
+      values: { count: stepsCount },
+    });
+    message = `${statusSummary} ${stepsLabel}`;
+  } else if (!hasSteps && hasConditions) {
+    const conditionLabel = i18n.translate(
+      'xpack.streams.nestedChildrenProcessingSummary.conditionStepsLabel',
+      {
+        defaultMessage: '{count, plural, one {nested condition} other {nested conditions}}',
+        values: { count: conditionsCount },
+      }
+    );
+    message = `${conditionsCount} ${conditionLabel}`;
+  } else if (hasSteps && hasConditions) {
+    const statusSummary = Object.entries(statusCounts)
+      .map(([status, count]) => `${count} ${statusLabels[status] || status}`)
+      .join(', ');
+
+    const stepsLabel = i18n.translate('xpack.streams.nestedChildrenProcessingSummary.stepsLabel', {
+      defaultMessage: '{count, plural, one {step} other {steps}}',
+      values: { count: stepsCount },
+    });
+
+    const andLabel = i18n.translate('xpack.streams.nestedChildrenProcessingSummary.and', {
+      defaultMessage: 'and',
+    });
+
+    const conditionLabel = i18n.translate(
+      'xpack.streams.nestedChildrenProcessingSummary.conditionStepsLabel',
+      {
+        defaultMessage: '{count, plural, one {nested condition} other {nested conditions}}',
+        values: { count: conditionsCount },
+      }
+    );
+
+    message = `${statusSummary} ${stepsLabel} ${andLabel} ${conditionsCount} ${conditionLabel}`;
+  }
+
+  return message;
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/where/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/where/utils.ts
@@ -32,55 +32,50 @@ export const getNestedMessage = (
   statusCounts: Record<string, number>,
   stepsCount: number,
   conditionsCount: number
-) => {
+): string => {
   const hasSteps = stepsCount > 0;
   const hasConditions = conditionsCount > 0;
 
-  let message = '';
+  // Build strings conditionally (only what's needed)
+  const statusSummary = hasSteps
+    ? Object.entries(statusCounts)
+        .map(([status, count]) => `${count} ${statusLabels[status] || status}`)
+        .join(', ')
+    : '';
 
+  const stepsLabel = hasSteps
+    ? i18n.translate('xpack.streams.nestedChildrenProcessingSummary.stepsLabel', {
+        defaultMessage: '{count, plural, one {step} other {steps}}',
+        values: { count: stepsCount },
+      })
+    : '';
+
+  const conditionLabel = hasConditions
+    ? i18n.translate('xpack.streams.nestedChildrenProcessingSummary.conditionStepsLabel', {
+        defaultMessage: '{count, plural, one {nested condition} other {nested conditions}}',
+        values: { count: conditionsCount },
+      })
+    : '';
+
+  const andLabel =
+    hasSteps && hasConditions
+      ? i18n.translate('xpack.streams.nestedChildrenProcessingSummary.and', {
+          defaultMessage: 'and',
+        })
+      : '';
+
+  // Compose and return based on what's present
   if (hasSteps && !hasConditions) {
-    const statusSummary = Object.entries(statusCounts)
-      .map(([status, count]) => `${count} ${statusLabels[status] || status}`)
-      .join(', ');
-
-    const stepsLabel = i18n.translate('xpack.streams.nestedChildrenProcessingSummary.stepsLabel', {
-      defaultMessage: '{count, plural, one {step} other {steps}}',
-      values: { count: stepsCount },
-    });
-    message = `${statusSummary} ${stepsLabel}`;
-  } else if (!hasSteps && hasConditions) {
-    const conditionLabel = i18n.translate(
-      'xpack.streams.nestedChildrenProcessingSummary.conditionStepsLabel',
-      {
-        defaultMessage: '{count, plural, one {nested condition} other {nested conditions}}',
-        values: { count: conditionsCount },
-      }
-    );
-    message = `${conditionsCount} ${conditionLabel}`;
-  } else if (hasSteps && hasConditions) {
-    const statusSummary = Object.entries(statusCounts)
-      .map(([status, count]) => `${count} ${statusLabels[status] || status}`)
-      .join(', ');
-
-    const stepsLabel = i18n.translate('xpack.streams.nestedChildrenProcessingSummary.stepsLabel', {
-      defaultMessage: '{count, plural, one {step} other {steps}}',
-      values: { count: stepsCount },
-    });
-
-    const andLabel = i18n.translate('xpack.streams.nestedChildrenProcessingSummary.and', {
-      defaultMessage: 'and',
-    });
-
-    const conditionLabel = i18n.translate(
-      'xpack.streams.nestedChildrenProcessingSummary.conditionStepsLabel',
-      {
-        defaultMessage: '{count, plural, one {nested condition} other {nested conditions}}',
-        values: { count: conditionsCount },
-      }
-    );
-
-    message = `${statusSummary} ${stepsLabel} ${andLabel} ${conditionsCount} ${conditionLabel}`;
+    return `${statusSummary} ${stepsLabel}`;
   }
 
-  return message;
+  if (!hasSteps && hasConditions) {
+    return `${conditionsCount} ${conditionLabel}`;
+  }
+
+  if (hasSteps && hasConditions) {
+    return `${statusSummary} ${stepsLabel} ${andLabel} ${conditionsCount} ${conditionLabel}`;
+  }
+
+  return '';
 };


### PR DESCRIPTION
Closes #237454 

## Summary

Minor improvement to the message shown when collapsing nested conditions. We were only building the message taking into account the processors and were ignoring the conditions, which was causing some problems that were fixed:

### If there was 1 processor and 1 or more conditions

The step string would be plural because we were taking into account the total of childs and not just the total of processors.

### If there was no processors and 1 or more conditions

There would appear a blank line like in the picture below.

<img width="1232" height="418" alt="Image" src="https://github.com/user-attachments/assets/0af1e82f-7a20-449b-8bcb-461f492e2d58" />


To fix this issues we now take into account also the conditions and the string is built by parts and the singular/plural is also built according to the total of processors and conditions for each of the parts.

### UI

After the fixes, we now handle all Processor/Condition combination cases, some are shown in the image below.

<img width="1110" height="798" alt="image" src="https://github.com/user-attachments/assets/5724f652-5aa1-4511-ad50-d4e342af0a23" />


## Release note

Provides a better message feedback into the collapsed Processors/Conditions for the user