### PR TITLE
[Cloud Security] Fix AWS cloud connector showing on non AWS cloud hosts

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/hooks/use_cloud_setup_context.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/hooks/use_cloud_setup_context.test.tsx
@@ -264,4 +264,265 @@ describe('useCloudSetup', () => {
       ])
     );
   });
+
+  describe('Cloud Connector Enablement', () => {
+    const mockConfigWithCloudConnectors: CloudSetupConfig = {
+      ...mockConfig,
+      providers: {
+        aws: {
+          ...mockConfig.providers.aws,
+          cloudConnectorEnabledVersion: '1.0.0',
+        },
+        gcp: {
+          ...mockConfig.providers.gcp,
+          cloudConnectorEnabledVersion: '1.0.0',
+        },
+        azure: {
+          ...mockConfig.providers.azure,
+          cloudConnectorEnabledVersion: '1.0.0',
+        },
+      },
+    };
+
+    beforeEach(() => {
+      // Enable cloud connectors feature
+      mockCore.uiSettings.get.mockReturnValue(true);
+    });
+
+    it('enables AWS cloud connector only on AWS host', () => {
+      mockCloud.cloudHost = 'us-east-1.aws.elastic-cloud.com';
+
+      const customWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+        <CloudSetupContext.Provider
+          value={{
+            config: mockConfigWithCloudConnectors,
+            uiSettings: mockCore.uiSettings,
+            cloud: mockCloud,
+            packageInfo,
+            packagePolicy,
+          }}
+        >
+          {children}
+        </CloudSetupContext.Provider>
+      );
+
+      const { result } = renderHook(() => useCloudSetup(), { wrapper: customWrapper });
+      expect(result.current.isAwsCloudConnectorEnabled).toBe(true);
+    });
+
+    it('disables AWS cloud connector on Azure host', () => {
+      mockCloud.cloudHost = 'westeurope.azure.elastic-cloud.com';
+
+      const customWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+        <CloudSetupContext.Provider
+          value={{
+            config: mockConfigWithCloudConnectors,
+            uiSettings: mockCore.uiSettings,
+            cloud: mockCloud,
+            packageInfo,
+            packagePolicy,
+          }}
+        >
+          {children}
+        </CloudSetupContext.Provider>
+      );
+
+      const { result } = renderHook(() => useCloudSetup(), { wrapper: customWrapper });
+      expect(result.current.isAwsCloudConnectorEnabled).toBe(false);
+    });
+
+    it('disables AWS cloud connector on GCP host', () => {
+      mockCloud.cloudHost = 'us-central1.gcp.elastic-cloud.com';
+
+      const customWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+        <CloudSetupContext.Provider
+          value={{
+            config: mockConfigWithCloudConnectors,
+            uiSettings: mockCore.uiSettings,
+            cloud: mockCloud,
+            packageInfo,
+            packagePolicy,
+          }}
+        >
+          {children}
+        </CloudSetupContext.Provider>
+      );
+
+      const { result } = renderHook(() => useCloudSetup(), { wrapper: customWrapper });
+      expect(result.current.isAwsCloudConnectorEnabled).toBe(false);
+    });
+
+    it('disables GCP cloud connector (not enabled yet) on GCP host', () => {
+      mockCloud.cloudHost = 'us-central1.gcp.elastic-cloud.com';
+
+      const customWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+        <CloudSetupContext.Provider
+          value={{
+            config: mockConfigWithCloudConnectors,
+            uiSettings: mockCore.uiSettings,
+            cloud: mockCloud,
+            packageInfo,
+            packagePolicy,
+          }}
+        >
+          {children}
+        </CloudSetupContext.Provider>
+      );
+
+      const { result } = renderHook(() => useCloudSetup(), { wrapper: customWrapper });
+      expect(result.current.isGcpCloudConnectorEnabled).toBe(false);
+    });
+
+    it('disables GCP cloud connector (not enabled yet) on Azure host', () => {
+      mockCloud.cloudHost = 'westeurope.azure.elastic-cloud.com';
+
+      const customWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+        <CloudSetupContext.Provider
+          value={{
+            config: mockConfigWithCloudConnectors,
+            uiSettings: mockCore.uiSettings,
+            cloud: mockCloud,
+            packageInfo,
+            packagePolicy,
+          }}
+        >
+          {children}
+        </CloudSetupContext.Provider>
+      );
+
+      const { result } = renderHook(() => useCloudSetup(), { wrapper: customWrapper });
+      expect(result.current.isGcpCloudConnectorEnabled).toBe(false);
+    });
+
+    it('disables GCP cloud connector (not enabled yet) on AWS host', () => {
+      mockCloud.cloudHost = 'us-east-1.aws.elastic-cloud.com';
+
+      const customWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+        <CloudSetupContext.Provider
+          value={{
+            config: mockConfigWithCloudConnectors,
+            uiSettings: mockCore.uiSettings,
+            cloud: mockCloud,
+            packageInfo,
+            packagePolicy,
+          }}
+        >
+          {children}
+        </CloudSetupContext.Provider>
+      );
+
+      const { result } = renderHook(() => useCloudSetup(), { wrapper: customWrapper });
+      expect(result.current.isGcpCloudConnectorEnabled).toBe(false);
+    });
+
+    it('enables Azure cloud connector on Azure host', () => {
+      mockCloud.cloudHost = 'westeurope.azure.elastic-cloud.com';
+
+      const customWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+        <CloudSetupContext.Provider
+          value={{
+            config: mockConfigWithCloudConnectors,
+            uiSettings: mockCore.uiSettings,
+            cloud: mockCloud,
+            packageInfo,
+            packagePolicy,
+          }}
+        >
+          {children}
+        </CloudSetupContext.Provider>
+      );
+
+      const { result } = renderHook(() => useCloudSetup(), { wrapper: customWrapper });
+      expect(result.current.isAzureCloudConnectorEnabled).toBe(true);
+    });
+
+    it('enables Azure cloud connector on AWS host', () => {
+      mockCloud.cloudHost = 'us-east-1.aws.elastic-cloud.com';
+
+      const customWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+        <CloudSetupContext.Provider
+          value={{
+            config: mockConfigWithCloudConnectors,
+            uiSettings: mockCore.uiSettings,
+            cloud: mockCloud,
+            packageInfo,
+            packagePolicy,
+          }}
+        >
+          {children}
+        </CloudSetupContext.Provider>
+      );
+
+      const { result } = renderHook(() => useCloudSetup(), { wrapper: customWrapper });
+      expect(result.current.isAzureCloudConnectorEnabled).toBe(true);
+    });
+
+    it('enables Azure cloud connector on GCP host', () => {
+      mockCloud.cloudHost = 'us-central1.gcp.elastic-cloud.com';
+
+      const customWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+        <CloudSetupContext.Provider
+          value={{
+            config: mockConfigWithCloudConnectors,
+            uiSettings: mockCore.uiSettings,
+            cloud: mockCloud,
+            packageInfo,
+            packagePolicy,
+          }}
+        >
+          {children}
+        </CloudSetupContext.Provider>
+      );
+
+      const { result } = renderHook(() => useCloudSetup(), { wrapper: customWrapper });
+      expect(result.current.isAzureCloudConnectorEnabled).toBe(true);
+    });
+
+    it('disables all cloud connectors when feature flag is off', () => {
+      mockCore.uiSettings.get.mockReturnValue(false);
+      mockCloud.cloudHost = 'us-east-1.aws.elastic-cloud.com';
+
+      const customWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+        <CloudSetupContext.Provider
+          value={{
+            config: mockConfigWithCloudConnectors,
+            uiSettings: mockCore.uiSettings,
+            cloud: mockCloud,
+            packageInfo,
+            packagePolicy,
+          }}
+        >
+          {children}
+        </CloudSetupContext.Provider>
+      );
+
+      const { result } = renderHook(() => useCloudSetup(), { wrapper: customWrapper });
+      expect(result.current.isAwsCloudConnectorEnabled).toBe(false);
+      expect(result.current.isGcpCloudConnectorEnabled).toBe(false);
+      expect(result.current.isAzureCloudConnectorEnabled).toBe(false);
+    });
+
+    it('disables cloud connectors when cloudHost is not set', () => {
+      mockCloud.cloudHost = undefined;
+
+      const customWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+        <CloudSetupContext.Provider
+          value={{
+            config: mockConfigWithCloudConnectors,
+            uiSettings: mockCore.uiSettings,
+            cloud: mockCloud,
+            packageInfo,
+            packagePolicy,
+          }}
+        >
+          {children}
+        </CloudSetupContext.Provider>
+      );
+
+      const { result } = renderHook(() => useCloudSetup(), { wrapper: customWrapper });
+      expect(result.current.isAwsCloudConnectorEnabled).toBe(false);
+      expect(result.current.isGcpCloudConnectorEnabled).toBe(false);
+      expect(result.current.isAzureCloudConnectorEnabled).toBe(false);
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
@@ -1673,7 +1673,7 @@ describe('<CspPolicyTemplateForm />', () => {
       }
     });
 
-    it.skip('should render setup technology selector for AWS and allow to select cloud connectors in ess aws environment', async () => {
+    it('should render setup technology selector for AWS and allow to select cloud connectors in ess aws environment', async () => {
       const newPackagePolicy = getMockPolicyAWS();
 
       jest.spyOn(KibanaHook, 'useKibana').mockReturnValue({
@@ -1768,10 +1768,11 @@ describe('<CspPolicyTemplateForm />', () => {
       const optionValues = options.map((option) => option.value);
 
       await waitFor(() => {
-        expect(options).toHaveLength(3);
+        expect(options).toHaveLength(2);
         expect(optionValues).toEqual(
-          expect.arrayContaining(['cloud_connectors', 'direct_access_keys', 'temporary_keys'])
+          expect.arrayContaining(['direct_access_keys', 'temporary_keys'])
         );
+        expect(optionValues).not.toContain('cloud_connectors');
       });
     });
 
@@ -1817,10 +1818,11 @@ describe('<CspPolicyTemplateForm />', () => {
       const optionValues = options.map((option) => option.value);
 
       await waitFor(() => {
-        expect(options).toHaveLength(3);
+        expect(options).toHaveLength(2);
         expect(optionValues).toEqual(
-          expect.arrayContaining(['cloud_connectors', 'direct_access_keys', 'temporary_keys'])
+          expect.arrayContaining(['direct_access_keys', 'temporary_keys'])
         );
+        expect(optionValues).not.toContain('cloud_connectors');
       });
     });
 
@@ -1921,10 +1923,11 @@ describe('<CspPolicyTemplateForm />', () => {
       const optionValues = options.map((option) => option.value);
 
       await waitFor(() => {
-        expect(options).toHaveLength(3);
+        expect(options).toHaveLength(2);
         expect(optionValues).toEqual(
-          expect.arrayContaining(['cloud_connectors', 'direct_access_keys', 'temporary_keys'])
+          expect.arrayContaining(['direct_access_keys', 'temporary_keys'])
         );
+        expect(optionValues).not.toContain('cloud_connectors');
       });
     });
 
@@ -1973,10 +1976,11 @@ describe('<CspPolicyTemplateForm />', () => {
       const optionValues = options.map((option) => option.value);
 
       await waitFor(() => {
-        expect(options).toHaveLength(3);
+        expect(options).toHaveLength(2);
         expect(optionValues).toEqual(
-          expect.arrayContaining(['cloud_connectors', 'direct_access_keys', 'temporary_keys'])
+          expect.arrayContaining(['direct_access_keys', 'temporary_keys'])
         );
+        expect(optionValues).not.toContain('cloud_connectors');
       });
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/policy_template_form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/policy_template_form.test.tsx
@@ -1068,7 +1068,7 @@ describe('<CloudAssetinventoryPolicyTemplateForm />', () => {
       });
     });
 
-    it.skip('should render setup technology selector for AWS and allow to select cloud connector in ess  aws environnement', async () => {
+    it('should render setup technology selector for AWS and allow to select cloud connector in ess aws environment', async () => {
       const newPackagePolicy = getMockPolicyAWS();
       (useKibana as jest.Mock).mockReturnValue({
         services: {
@@ -1125,7 +1125,7 @@ describe('<CloudAssetinventoryPolicyTemplateForm />', () => {
       });
     });
 
-    it('should render setup technology selector for AWS and allow to select cloud connector in cloud GCP environment', async () => {
+    it('should render setup technology selector for AWS and hide cloud connectors in cloud GCP environment', async () => {
       const newPackagePolicy = getMockPolicyAWS();
       (useKibana as jest.Mock).mockReturnValue({
         services: {
@@ -1175,10 +1175,11 @@ describe('<CloudAssetinventoryPolicyTemplateForm />', () => {
       const optionValues = options.map((option) => option.value);
 
       await waitFor(() => {
-        expect(options).toHaveLength(3);
+        expect(options).toHaveLength(2);
         expect(optionValues).toEqual(
-          expect.arrayContaining(['cloud_connectors', 'direct_access_keys', 'temporary_keys'])
+          expect.arrayContaining(['direct_access_keys', 'temporary_keys'])
         );
+        expect(optionValues).not.toContain('cloud_connectors');
       });
     });
     it('should render setup technology selector for AWS and allow to select cloud connectors in serverless aws environment', async () => {
@@ -1296,10 +1297,11 @@ describe('<CloudAssetinventoryPolicyTemplateForm />', () => {
       const optionValues = options.map((option) => option.value);
 
       await waitFor(() => {
-        expect(options).toHaveLength(3);
+        expect(options).toHaveLength(2);
         expect(optionValues).toEqual(
-          expect.arrayContaining(['cloud_connectors', 'direct_access_keys', 'temporary_keys'])
+          expect.arrayContaining(['direct_access_keys', 'temporary_keys'])
         );
+        expect(optionValues).not.toContain('cloud_connectors');
       });
     });
 
@@ -1357,10 +1359,11 @@ describe('<CloudAssetinventoryPolicyTemplateForm />', () => {
       const optionValues = options.map((option) => option.value);
 
       await waitFor(() => {
-        expect(options).toHaveLength(3);
+        expect(options).toHaveLength(2);
         expect(optionValues).toEqual(
-          expect.arrayContaining(['cloud_connectors', 'direct_access_keys', 'temporary_keys'])
+          expect.arrayContaining(['direct_access_keys', 'temporary_keys'])
         );
+        expect(optionValues).not.toContain('cloud_connectors');
       });
     });
   });


### PR DESCRIPTION
## Summary

- Fixes AWS Cloud Connector option showing in non-AWS cloud hosts
- Adds comprehensive tests to verify the enablement rules for AWS, GCP, and Azure cloud connectors. 


Testing (local):
In serverless.dev.yml,  switch between these settings to set the cloud host from AWS to Azure
```
// serverless.dev.yml
# AWS Cloud Host
xpack.cloud.id: 'cloud_connector_cspm:dXMtZWFzdC0xLmF3cy5zdGFnaW5nLmZvdW5kaXQubm86NDQzJDYyMjExNzI5MDhjZTQ0YmE5YWNkOGFmN2NlYmUyYmVjJGZmYmUyNDc2NGFkNTQwODJhZTkyYjU1NDQ0ZDI3NzA5'
# GCP Cloud Host
# xpack.cloud.id: 'test:d2VzdGV1cm9wZS5henVyZS5lbGFzdGljLWNsb3VkLmNvbSQxMjM0NTY3ODkwYWJjZGVmMTIzNDU2Nzg5MGFiY2RlZiRhYmNkZWYxMjM0NTY3ODkwYWJjZGVmMTIzNDU2Nzg5MA=='
```

```
yarn serverless-security

// different terminal window
yarn es --serverless=security
```


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
