### PR TITLE
[ResponseOps] Use @kbn/react-query 

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.test.tsx
@@ -31,7 +31,7 @@ import {
 import { useKibana } from '../../../../common/lib/kibana';
 import { ruleTypeRegistryMock } from '../../../rule_type_registry.mock';
 import { createMockConnectorType } from '@kbn/actions-plugin/server/application/connector/mocks';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/use_rule_description_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/use_rule_description_fields.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { AsyncField, createPrebuildFields } from './use_rule_description_fields';
 import { screen, render } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import type { HttpSetup } from '@kbn/core/public';
 import { RULE_PREBUILD_DESCRIPTION_FIELDS } from './rule_detail_description_type';
 

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/use_rule_description_fields.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/use_rule_description_fields.tsx
@@ -8,7 +8,7 @@
 import React, { Suspense, useMemo } from 'react';
 import { EuiBadge, EuiCodeBlock, EuiFlexGroup, EuiLoadingSpinner, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery } from '@kbn/react-query';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { HttpResponse, HttpSetup } from '@kbn/core/public';
 import { RULE_PREBUILD_DESCRIPTION_FIELDS } from './rule_detail_description_type';


### PR DESCRIPTION
## Summary

This PR is to update recently added react-query import to use our abstraction

Some files weren't updated between merging https://github.com/elastic/kibana/commit/61e143e3da0c654a4954cbe52dd8b7b560e4e7e6 and https://github.com/elastic/kibana/commit/3aa6761a4e9ba8ed2b2ad55b5276b4f8154a6764
