### PR TITLE
[Search] Getting started page amends

### DIFF
--- a/x-pack/solutions/search/packages/kbn-search-code-examples/src/getting-started-tutorials/curl.ts
+++ b/x-pack/solutions/search/packages/kbn-search-code-examples/src/getting-started-tutorials/curl.ts
@@ -16,7 +16,7 @@ export const CURL_INFO: CodeLanguage = {
     defaultMessage: 'cURL',
   }),
   icon: 'curl.svg',
-  codeBlockLanguage: 'shell',
+  codeBlockLanguage: 'bash',
 };
 
 const formatSampleDocs = (sampleDocuments: object[], indexName: string) => {

--- a/x-pack/solutions/search/packages/kbn-search-code-examples/src/getting-started-tutorials/javascript.ts
+++ b/x-pack/solutions/search/packages/kbn-search-code-examples/src/getting-started-tutorials/javascript.ts
@@ -103,7 +103,7 @@ const searchResult = await client.search({
 });
 
 // Log the search hits (documents that match the query)
-console.log(result.hits.hits);`;
+console.log(searchResult.hits.hits);`;
 
 export const JavascriptConnectDeploymentExample: GettingStartedCodeDefinition = {
   gettingStartedSemantic,

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/code_box.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/code_box.tsx
@@ -19,9 +19,10 @@ import { API_KEY_PLACEHOLDER } from '../../constants';
 
 interface Props {
   selectedLanguage: AvailableLanguages;
+  codeBlockLanguage: string;
 }
 
-export const CodeBox = ({ selectedLanguage }: Props) => {
+export const CodeBox = ({ selectedLanguage, codeBlockLanguage }: Props) => {
   const { cloud } = useKibana().services;
   const elasticsearchUrl = useElasticsearchUrl();
   const { apiKey } = useSearchApiKey();
@@ -44,12 +45,7 @@ export const CodeBox = ({ selectedLanguage }: Props) => {
   }, [selectedExample, codeParams]);
 
   return (
-    <EuiCodeBlock
-      isCopyable
-      fontSize="m"
-      language={selectedLanguage === 'curl' ? 'bash' : selectedLanguage}
-      overflowHeight={700}
-    >
+    <EuiCodeBlock isCopyable fontSize="m" language={codeBlockLanguage} overflowHeight={700}>
       {codeExample}
     </EuiCodeBlock>
   );

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/index.tsx
@@ -5,13 +5,14 @@
  * 2.0.
  */
 import React, { useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, useEuiTheme } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import {
   type AvailableLanguages,
   LanguageOptions,
+  Languages,
 } from '@kbn/search-code-examples/src/getting-started-tutorials';
 
 import { LanguageSelector } from './language_selector';
@@ -20,7 +21,10 @@ import { SearchGettingStartedSectionHeading } from '../section_heading';
 import { CodeBox } from './code_box';
 
 export const SearchGettingStartedConnectCode = () => {
+  const { euiTheme } = useEuiTheme();
   const [selectedLanguage, setSelectedLanguage] = useState<AvailableLanguages>('python');
+
+  const codeBlockLanguage = Languages[selectedLanguage].codeBlockLanguage;
 
   return (
     <>
@@ -38,7 +42,7 @@ export const SearchGettingStartedConnectCode = () => {
         <EuiFlexItem
           grow={false}
           css={css`
-            width: 360px;
+            width: calc(${euiTheme.size.xxxxl} * 6);
           `}
         >
           <LanguageSelector
@@ -51,7 +55,7 @@ export const SearchGettingStartedConnectCode = () => {
       <EuiSpacer size="l" />
       <InstallCommandCodeBox selectedLanguage={selectedLanguage} />
       <EuiSpacer size="m" />
-      <CodeBox selectedLanguage={selectedLanguage} />
+      <CodeBox selectedLanguage={selectedLanguage} codeBlockLanguage={codeBlockLanguage} />
     </>
   );
 };

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/install_command_code_box.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/install_command_code_box.tsx
@@ -22,7 +22,7 @@ export const InstallCommandCodeBox = ({ selectedLanguage }: Props) => {
   if (!installCommand) return null;
 
   return (
-    <EuiCodeBlock isCopyable fontSize="m" language={selectedLanguage}>
+    <EuiCodeBlock isCopyable fontSize="m" language={'bash'}>
       {installCommand}
     </EuiCodeBlock>
   );

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
@@ -34,7 +34,7 @@ export const SearchGettingStartedPage: React.FC = () => {
       <EuiPageTemplate.Section paddingSize="xl">
         <ConsoleTutorialsGroup />
       </EuiPageTemplate.Section>
-      <EuiPageTemplate.Section data-test-subj="search-getting-code-example">
+      <EuiPageTemplate.Section data-test-subj="gettingStartedCodeExamples">
         <SearchGettingStartedConnectCode />
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/section_heading/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/section_heading/index.tsx
@@ -20,7 +20,7 @@ export const SearchGettingStartedSectionHeading = ({ title, icon, description }:
         <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiPanel color="subdued" paddingSize="s" grow={false}>
-              <EuiIcon type={icon} size="m" />
+              <EuiIcon type={icon} size="m" color="subdued" />
             </EuiPanel>
           </EuiFlexItem>
           <EuiFlexItem>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
@@ -91,7 +91,7 @@ export const ConsoleTutorialsGroup = () => {
         title={i18n.translate('xpack.searchGettingStarted.consoleTutorials.label', {
           defaultMessage: 'Explore the API',
         })}
-        icon={commandLineIllustration}
+        icon={commandLineIllustration} // TODO: Replace with EUI icon when it's available
         description={i18n.translate('xpack.searchGettingStarted.consoleTutorials.description', {
           defaultMessage:
             'Choose a tutorial and use Console to quickly start interacting with the Elasticsearch API.',
@@ -112,7 +112,7 @@ export const ConsoleTutorialsGroup = () => {
                 footer={
                   <TryInConsoleButton
                     type="button"
-                    iconType={commandLineIllustration}
+                    iconType={commandLineIllustration} // TODO: Replace with EUI icon when it's available
                     color="text"
                     request={tutorial.request}
                     application={application}


### PR DESCRIPTION
## Summary

A couple of amends to the getting started page based on Michael's feedback, and a bug I spotted.

- Set the size of the `LanguageSelector` parent based on a multiple of an EUI size
-  Use a better `data-test-subj` for the code example section
- Set the `EuiCodeBlock` language in the `InstallCommandCodeBox` to `bash`
- In the Javascript code example, the console.log which returns the search result is using the wrong variable name
- Use the `codeBlockLanguage` property to set the language for the `EuiCodeBlock` in `CodeBox`
- Set the `EuiIcon` color in the heading to `subdued`
- Add a comment to replace the `commandLineIllustration` SVG with the EUI icon once it's available


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.~com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~