### PR TITLE
[ML][AI Connector] Ensures all auth fields show up correctly

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/authentication_form_items.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/authentication_form_items.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { AuthenticationFormItems } from './authentication_form_items';
+import { render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import type { ConfigEntryView } from '../../types/types';
+
+describe('AuthenticationFormItems', () => {
+  const mockRequiredAuthItems = [
+    {
+      key: 'secret_key',
+      isValid: true,
+      validationErrors: [],
+      value: null,
+      default_value: null,
+      description: 'A valid AWS secret key that is paired with the access_key.',
+      label: 'Secret Key',
+      required: true,
+      sensitive: true,
+      updatable: true,
+      type: 'str',
+      supported_task_types: ['text_embedding', 'completion'],
+    },
+    {
+      key: 'access_key',
+      isValid: true,
+      validationErrors: [],
+      value: null,
+      default_value: null,
+      description: 'A valid AWS access key that has permissions to use Amazon Bedrock.',
+      label: 'Access Key',
+      required: true,
+      sensitive: true,
+      updatable: true,
+      type: 'str',
+      supported_task_types: ['text_embedding', 'completion'],
+    },
+  ];
+  const mockOptionalAuthItems = [
+    {
+      key: 'api_key',
+      isValid: true,
+      validationErrors: [],
+      value: null,
+      default_value: null,
+      description: 'You must provide either an API key or an Entra ID.',
+      label: 'API Key',
+      required: false,
+      sensitive: true,
+      updatable: true,
+      type: 'str',
+      supported_task_types: ['text_embedding', 'completion'],
+    },
+    {
+      key: 'entra_id',
+      isValid: true,
+      validationErrors: [],
+      value: null,
+      default_value: null,
+      description: 'You must provide either an API key or an Entra ID.',
+      label: 'Entra ID',
+      required: false,
+      sensitive: true,
+      updatable: true,
+      type: 'str',
+      supported_task_types: ['text_embedding', 'completion'],
+    },
+  ];
+
+  const defaultProps = {
+    isLoading: false,
+    setConfigEntry: jest.fn(),
+    reenterSecretsOnEdit: true,
+  };
+
+  it('should render all required auth fields without auth type selector', () => {
+    render(
+      <IntlProvider>
+        <AuthenticationFormItems
+          {...defaultProps}
+          items={mockRequiredAuthItems as ConfigEntryView[]}
+        />
+      </IntlProvider>
+    );
+    expect(screen.getByTestId('authentication-label')).toBeInTheDocument();
+    expect(screen.queryByTestId('authTypeSelect')).not.toBeInTheDocument();
+    expect(screen.getByTestId('configuration-formrow-secret_key')).toBeInTheDocument();
+    expect(screen.getByTestId('configuration-formrow-access_key')).toBeInTheDocument();
+  });
+
+  it('should render single required auth field without auth type selector', () => {
+    render(
+      <IntlProvider>
+        <AuthenticationFormItems
+          {...defaultProps}
+          items={[mockRequiredAuthItems[0]] as ConfigEntryView[]}
+        />
+      </IntlProvider>
+    );
+    expect(screen.getByTestId('authentication-label')).toBeInTheDocument();
+    expect(screen.queryByTestId('authTypeSelect')).not.toBeInTheDocument();
+    expect(screen.getByTestId('configuration-formrow-secret_key')).toBeInTheDocument();
+  });
+
+  it('should allow selection of auth type field when multiple optional fields present', () => {
+    render(
+      <IntlProvider>
+        <AuthenticationFormItems
+          {...defaultProps}
+          items={mockOptionalAuthItems as ConfigEntryView[]}
+        />
+      </IntlProvider>
+    );
+    expect(screen.getByTestId('authentication-label')).toBeInTheDocument();
+    expect(screen.getByTestId('authTypeSelect')).toBeInTheDocument();
+    expect(screen.getByTestId('configuration-formrow-api_key')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/authentication_form_items.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/authentication_form_items.tsx
@@ -42,7 +42,7 @@ export const AuthenticationFormItems: React.FC<AuthenticationFormItemsProps> = (
       })),
     [items]
   );
-  const configEntry = useMemo(
+  const selectedConfigEntry = useMemo(
     () => items.find((item) => item.key === authType) || items[0],
     [authType, items]
   );
@@ -60,28 +60,44 @@ export const AuthenticationFormItems: React.FC<AuthenticationFormItemsProps> = (
         </EuiTitle>
       </EuiFlexItem>
       {isMultiAuthType ? (
-        <EuiFlexItem grow={false}>
-          <EuiButtonGroup
-            isDisabled={isLoading}
-            data-test-subj="authTypeSelect"
-            legend="Authentication type"
-            defaultValue={authType}
-            idSelected={authType}
-            onChange={(id) => setAuthType(id)}
-            options={authTypeOptions}
-            color="text"
-            type="single"
+        <>
+          <EuiFlexItem grow={false}>
+            <EuiButtonGroup
+              isDisabled={isLoading}
+              data-test-subj="authTypeSelect"
+              legend="Authentication type"
+              defaultValue={authType}
+              idSelected={authType}
+              onChange={(id) => setAuthType(id)}
+              options={authTypeOptions}
+              color="text"
+              type="single"
+            />
+          </EuiFlexItem>
+          <ItemFormRow
+            configEntry={selectedConfigEntry}
+            isPreconfigured={isPreconfigured}
+            isEdit={isEdit}
+            isLoading={isLoading}
+            setConfigEntry={setConfigEntry}
+            reenterSecretsOnEdit={reenterSecretsOnEdit}
           />
-        </EuiFlexItem>
+        </>
       ) : null}
-      <ItemFormRow
-        configEntry={configEntry}
-        isPreconfigured={isPreconfigured}
-        isEdit={isEdit}
-        isLoading={isLoading}
-        setConfigEntry={setConfigEntry}
-        reenterSecretsOnEdit={reenterSecretsOnEdit}
-      />
+      {isMultiAuthType === false
+        ? items.map((configEntry) => {
+            return (
+              <ItemFormRow
+                configEntry={configEntry}
+                isPreconfigured={isPreconfigured}
+                isEdit={isEdit}
+                isLoading={isLoading}
+                setConfigEntry={setConfigEntry}
+                reenterSecretsOnEdit={reenterSecretsOnEdit}
+              />
+            );
+          })
+        : null}
     </EuiFlexGroup>
   );
 };


### PR DESCRIPTION
## Summary
This PR handles the case of multiple required auth fields as well as multiple fields where only one is required.
 
Bedrock requires multiple auth fields:

<img width="590" height="783" alt="image" src="https://github.com/user-attachments/assets/43c485a5-f0db-42a9-a3d0-29af480ddcbf" />

Azure OpenAI requires only one auth field but allows the user to choose which:

<img width="600" height="850" alt="image" src="https://github.com/user-attachments/assets/3d18b64d-c9b3-402d-90f1-f5add0e77a60" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->