### PR TITLE
[DOCS] Add synthetic API response descriptions

### DIFF
--- a/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
+++ b/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
@@ -1,4 +1,4 @@
 {
-  "./oas_docs/output/kibana.yaml": 1523,
+  "./oas_docs/output/kibana.yaml": 1521,
   "./oas_docs/output/kibana.serverless.yaml": 1469
 }

--- a/x-pack/solutions/observability/plugins/synthetics/docs/openapi/synthetic_apis.yaml
+++ b/x-pack/solutions/observability/plugins/synthetics/docs/openapi/synthetic_apis.yaml
@@ -295,6 +295,7 @@ paths:
             type: string
       responses:
         '200':
+          description: A successful response.
           content:
             application/json:
               schema:
@@ -475,6 +476,7 @@ paths:
                   }
       responses:
         '200':
+          description: A successful response.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/233419, https://github.com/elastic/kibana/issues/228077

This PR addresses a couple of errors related to missing response descriptions that are returned by `node scripts/validate_oas_docs.js`

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~~
~~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
~~- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
~~- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~
~~- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~~
~~- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~~

### Identify risks

N/A


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->