### PR TITLE
Remove entityID path parameter

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -16125,6 +16125,50 @@ paths:
         - content: Kibana, Elastic Cloud Serverless
           name: product_name
   /api/entity_store/entities/{entityType}:
+    delete:
+      description: |
+        Delete a single entity in Entity Store.
+        The entity will be immediately deleted from the latest index.  It will remain available in historical snapshots if it has been snapshotted.  The delete operation does not prevent the entity from being recreated if it is observed again in the future. 
+      operationId: DeleteSingleEntity
+      parameters:
+        - in: path
+          name: entityType
+          required: true
+          schema:
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  description: Identifier of the entity to be deleted, commonly entity.id value.
+                  type: string
+              required:
+                - id
+        description: Schema for the deleting entity
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+          description: Successful response. Entity deleted.
+        '404':
+          description: Entity Not Found. No entity with this ID and Type exists.
+        '503':
+          description: Operation on an uninitialized Engine or in a cluster without CRUD API Enabled
+      summary: Delete an entity in Entity Store
+      tags:
+        - Security Entity Analytics API
+      x-metaTags:
+        - content: Kibana, Elastic Cloud Serverless
+          name: product_name
     put:
       description: |
         Update or create an entity in Entity Store.
@@ -16165,51 +16209,6 @@ paths:
         '503':
           description: Operation on an uninitialized Engine or in a cluster without CRUD API Enabled
       summary: Upsert an entity in Entity Store
-      tags:
-        - Security Entity Analytics API
-      x-metaTags:
-        - content: Kibana, Elastic Cloud Serverless
-          name: product_name
-  /api/entity_store/entities/{entityType}/{entityId}:
-    delete:
-      description: |
-        Delete a single entity in Entity Store.
-        The entity will be immediately deleted from the latest index.  It will remain available in historical snapshots if it has been snapshotted.  The delete operation does not prevent the entity from being recreated if it is observed again in the future. 
-      operationId: DeleteSingleEntity
-      parameters:
-        - in: path
-          name: entityType
-          required: true
-          schema:
-            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  description: Identifier of the entity to be deleted, commonly entity.id value.
-                  type: string
-              required:
-                - id
-        description: Schema for the deleting entity
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  deleted:
-                    type: boolean
-          description: Successful response. Entity deleted.
-        '404':
-          description: Entity Not Found. No entity with this ID and Type exists.
-        '503':
-          description: Operation on an uninitialized Engine or in a cluster without CRUD API Enabled
-      summary: Delete an entity in Entity Store
       tags:
         - Security Entity Analytics API
       x-metaTags:

--- a/x-pack/solutions/security/packages/test-api-clients/supertest/entity_analytics.gen.ts
+++ b/x-pack/solutions/security/packages/test-api-clients/supertest/entity_analytics.gen.ts
@@ -254,7 +254,7 @@ The entity will be immediately deleted from the latest index.  It will remain av
       return supertest
         .delete(
           getRouteUrlForSpace(
-            replaceParams('/api/entity_store/entities/{entityType}/{entityId}', props.params),
+            replaceParams('/api/entity_store/entities/{entityType}', props.params),
             kibanaSpace
           )
         )

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/delete_entity.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/delete_entity.schema.yaml
@@ -3,7 +3,7 @@ info:
   version: '2023-10-31'
   title: Entity Store - Delete Single Entity
 paths:
-  /api/entity_store/entities/{entityType}/{entityId}:
+  /api/entity_store/entities/{entityType}:
     delete:
       x-labels: [ess, serverless]
       x-codegen-enabled: true

--- a/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
@@ -1085,7 +1085,7 @@ The entity will be immediately deleted from the latest index.  It will remain av
     this.log.info(`${new Date().toISOString()} Calling API DeleteSingleEntity`);
     return this.kbnClient
       .request<DeleteSingleEntityResponse>({
-        path: replaceParams('/api/entity_store/entities/{entityType}/{entityId}', props.params),
+        path: replaceParams('/api/entity_store/entities/{entityType}', props.params),
         headers: {
           [ELASTIC_HTTP_VERSION_HEADER]: '2023-10-31',
         },

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -984,6 +984,55 @@ paths:
       tags:
         - Security Entity Analytics API
   /api/entity_store/entities/{entityType}:
+    delete:
+      description: >
+        Delete a single entity in Entity Store.
+
+        The entity will be immediately deleted from the latest index.  It will
+        remain available in historical snapshots if it has been snapshotted. 
+        The delete operation does not prevent the entity from being recreated if
+        it is observed again in the future. 
+      operationId: DeleteSingleEntity
+      parameters:
+        - in: path
+          name: entityType
+          required: true
+          schema:
+            $ref: '#/components/schemas/EntityType'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  description: >-
+                    Identifier of the entity to be deleted, commonly entity.id
+                    value.
+                  type: string
+              required:
+                - id
+        description: Schema for the deleting entity
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+          description: Successful response. Entity deleted.
+        '404':
+          description: Entity Not Found. No entity with this ID and Type exists.
+        '503':
+          description: >-
+            Operation on an uninitialized Engine or in a cluster without CRUD
+            API Enabled
+      summary: Delete an entity in Entity Store
+      tags:
+        - Security Entity Analytics API
     put:
       description: >
         Update or create an entity in Entity Store.
@@ -1040,56 +1089,6 @@ paths:
             Operation on an uninitialized Engine or in a cluster without CRUD
             API Enabled
       summary: Upsert an entity in Entity Store
-      tags:
-        - Security Entity Analytics API
-  /api/entity_store/entities/{entityType}/{entityId}:
-    delete:
-      description: >
-        Delete a single entity in Entity Store.
-
-        The entity will be immediately deleted from the latest index.  It will
-        remain available in historical snapshots if it has been snapshotted. 
-        The delete operation does not prevent the entity from being recreated if
-        it is observed again in the future. 
-      operationId: DeleteSingleEntity
-      parameters:
-        - in: path
-          name: entityType
-          required: true
-          schema:
-            $ref: '#/components/schemas/EntityType'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  description: >-
-                    Identifier of the entity to be deleted, commonly entity.id
-                    value.
-                  type: string
-              required:
-                - id
-        description: Schema for the deleting entity
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  deleted:
-                    type: boolean
-          description: Successful response. Entity deleted.
-        '404':
-          description: Entity Not Found. No entity with this ID and Type exists.
-        '503':
-          description: >-
-            Operation on an uninitialized Engine or in a cluster without CRUD
-            API Enabled
-      summary: Delete an entity in Entity Store
       tags:
         - Security Entity Analytics API
   /api/entity_store/entities/bulk:

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -984,6 +984,55 @@ paths:
       tags:
         - Security Entity Analytics API
   /api/entity_store/entities/{entityType}:
+    delete:
+      description: >
+        Delete a single entity in Entity Store.
+
+        The entity will be immediately deleted from the latest index.  It will
+        remain available in historical snapshots if it has been snapshotted. 
+        The delete operation does not prevent the entity from being recreated if
+        it is observed again in the future. 
+      operationId: DeleteSingleEntity
+      parameters:
+        - in: path
+          name: entityType
+          required: true
+          schema:
+            $ref: '#/components/schemas/EntityType'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  description: >-
+                    Identifier of the entity to be deleted, commonly entity.id
+                    value.
+                  type: string
+              required:
+                - id
+        description: Schema for the deleting entity
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+          description: Successful response. Entity deleted.
+        '404':
+          description: Entity Not Found. No entity with this ID and Type exists.
+        '503':
+          description: >-
+            Operation on an uninitialized Engine or in a cluster without CRUD
+            API Enabled
+      summary: Delete an entity in Entity Store
+      tags:
+        - Security Entity Analytics API
     put:
       description: >
         Update or create an entity in Entity Store.
@@ -1040,56 +1089,6 @@ paths:
             Operation on an uninitialized Engine or in a cluster without CRUD
             API Enabled
       summary: Upsert an entity in Entity Store
-      tags:
-        - Security Entity Analytics API
-  /api/entity_store/entities/{entityType}/{entityId}:
-    delete:
-      description: >
-        Delete a single entity in Entity Store.
-
-        The entity will be immediately deleted from the latest index.  It will
-        remain available in historical snapshots if it has been snapshotted. 
-        The delete operation does not prevent the entity from being recreated if
-        it is observed again in the future. 
-      operationId: DeleteSingleEntity
-      parameters:
-        - in: path
-          name: entityType
-          required: true
-          schema:
-            $ref: '#/components/schemas/EntityType'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  description: >-
-                    Identifier of the entity to be deleted, commonly entity.id
-                    value.
-                  type: string
-              required:
-                - id
-        description: Schema for the deleting entity
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  deleted:
-                    type: boolean
-          description: Successful response. Entity deleted.
-        '404':
-          description: Entity Not Found. No entity with this ID and Type exists.
-        '503':
-          description: >-
-            Operation on an uninitialized Engine or in a cluster without CRUD
-            API Enabled
-      summary: Delete an entity in Entity Store
       tags:
         - Security Entity Analytics API
   /api/entity_store/entities/bulk:


### PR DESCRIPTION
## Summary

From https://github.com/elastic/kibana/pull/239314#discussion_r2454858613 the `entityID` is expected to be supplied in the request body, but the path parameter was only partially removed. This results in an invalid API specification which breaks [client generation](https://github.com/elastic/terraform-provider-elasticstack/pull/1402#issuecomment-3450994632). 


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
