### PR TITLE
[Streams] Wrap "create partition" buttons on small screens

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/child_stream_list.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/child_stream_list.tsx
@@ -106,6 +106,7 @@ export function ChildStreamList({ availableStreams }: { availableStreams: string
             flex-grow: 1;
             min-height: 80px;
           `}
+          wrap
         >
           {aiFeatures && aiFeatures.enabled && (
             <EuiFlexItem grow={false}>


### PR DESCRIPTION
Tiny PR ensuring create partition buttons get wrapped on small screens

## Before

<img width="1406" height="1103" alt="Screenshot 2025-10-28 at 10 27 31" src="https://github.com/user-attachments/assets/0a3e9a99-f396-42fc-98a2-5e7ffdb116e3" />

## After

<img width="1409" height="1105" alt="Screenshot 2025-10-28 at 10 27 50" src="https://github.com/user-attachments/assets/72cf281e-e27f-44b9-88e3-b3e5f436ab52" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->