### PR TITLE
[SharedUX] Clean up share draft mode callout component override logic

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
@@ -12,12 +12,11 @@ import moment from 'moment';
 import type { ReactElement } from 'react';
 import React, { useState } from 'react';
 
-import { EuiCallOut, EuiCheckboxGroup } from '@elastic/eui';
+import { EuiCheckboxGroup } from '@elastic/eui';
 import type { Capabilities } from '@kbn/core/public';
 import type { QueryState } from '@kbn/data-plugin/common';
 import { DASHBOARD_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { getStateFromKbnUrl, setStateToKbnUrl, unhashUrl } from '@kbn/kibana-utils-plugin/public';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 
@@ -164,42 +163,22 @@ export function ShowShareModal({
       }),
       config: {
         link: {
-          draftModeCallOut: (
-            <EuiCallOut
-              color="warning"
-              data-test-subj="DashboardDraftModeCopyLinkCallOut"
-              title={
-                <FormattedMessage
-                  id="dashboard.share.shareModal.draftModeCallout.title"
-                  defaultMessage="Unsaved changes"
-                />
-              }
-            >
-              {hasPanelChanges
-                ? allowShortUrl
-                  ? shareModalStrings.getDraftSharePanelChangesWarning()
-                  : shareModalStrings.getSnapshotShareWarning()
-                : shareModalStrings.getDraftShareWarning('link')}
-            </EuiCallOut>
-          ),
+          draftModeCallOut: {
+            message: hasPanelChanges
+              ? allowShortUrl
+                ? shareModalStrings.getDraftSharePanelChangesWarning()
+                : shareModalStrings.getSnapshotShareWarning()
+              : shareModalStrings.getDraftShareWarning('link'),
+            'data-test-subj': 'DashboardDraftModeCopyLinkCallOut',
+          },
         },
         embed: {
-          draftModeCallOut: (
-            <EuiCallOut
-              color="warning"
-              data-test-subj="DashboardDraftModeEmbedCallOut"
-              title={
-                <FormattedMessage
-                  id="dashboard.share.shareModal.draftModeCallout.title"
-                  defaultMessage="Unsaved changes"
-                />
-              }
-            >
-              {hasPanelChanges
-                ? shareModalStrings.getEmbedSharePanelChangesWarning()
-                : shareModalStrings.getDraftShareWarning('embed')}
-            </EuiCallOut>
-          ),
+          draftModeCallOut: {
+            message: hasPanelChanges
+              ? shareModalStrings.getEmbedSharePanelChangesWarning()
+              : shareModalStrings.getDraftShareWarning('embed'),
+            'data-test-subj': 'DashboardDraftModeEmbedCallOut',
+          },
           embedUrlParamExtensions: [
             {
               paramName: 'embed',
@@ -211,42 +190,10 @@ export function ShowShareModal({
         integration: {
           export: {
             pdfReports: {
-              draftModeCallOut: (
-                <EuiCallOut
-                  color="warning"
-                  iconType="warning"
-                  title={
-                    <FormattedMessage
-                      id="dashboard.exports.pdfReports.warning.title"
-                      defaultMessage="Unsaved changes"
-                    />
-                  }
-                >
-                  <FormattedMessage
-                    id="dashboard.exports.pdfReports.postURLWatcherMessage.unsavedChanges"
-                    defaultMessage="URL may change if you upgrade Kibana."
-                  />
-                </EuiCallOut>
-              ),
+              draftModeCallOut: true,
             },
             imageReports: {
-              draftModeCallOut: (
-                <EuiCallOut
-                  color="warning"
-                  iconType="warning"
-                  title={
-                    <FormattedMessage
-                      id="dashboard.exports.imageReports.warning.title"
-                      defaultMessage="Unsaved changes"
-                    />
-                  }
-                >
-                  <FormattedMessage
-                    id="dashboard.exports.imageReports.postURLWatcherMessage.unsavedChanges"
-                    defaultMessage="URL may change if you upgrade Kibana."
-                  />
-                </EuiCallOut>
-              ),
+              draftModeCallOut: true,
             },
           },
         },

--- a/src/platform/plugins/shared/share/public/components/common/draft_mode_callout/__snapshots__/draft_mode_callout.test.tsx.snap
+++ b/src/platform/plugins/shared/share/public/components/common/draft_mode_callout/__snapshots__/draft_mode_callout.test.tsx.snap
@@ -73,11 +73,3 @@ exports[`DraftModeCallout Default case renders a default callout when custom pro
   />
 </div>
 `;
-
-exports[`DraftModeCallout Node override case renders a component override when a node prop is provided 1`] = `
-<p
-  data-test-subj="overriddenDraftModeCallOut"
->
-  Component override
-</p>
-`;

--- a/src/platform/plugins/shared/share/public/components/common/draft_mode_callout/draft_mode_callout.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/common/draft_mode_callout/draft_mode_callout.test.tsx
@@ -31,19 +31,6 @@ describe('DraftModeCallout', () => {
     });
   });
 
-  describe('Node override case', () => {
-    it('renders a component override when a node prop is provided', () => {
-      render(
-        <DraftModeCallout
-          node={<p data-test-subj="overriddenDraftModeCallOut">Component override</p>}
-        />
-      );
-      const callout = screen.getByTestId('overriddenDraftModeCallOut');
-      expect(screen.getByText('Component override')).toBeInTheDocument();
-      expect(callout).toMatchSnapshot();
-    });
-  });
-
   describe('Save button case', () => {
     it('renders a save button when onSave is present', () => {
       render(<DraftModeCallout saveButtonProps={{ onSave: jest.fn() }} />);

--- a/src/platform/plugins/shared/share/public/components/common/draft_mode_callout/draft_mode_callout.tsx
+++ b/src/platform/plugins/shared/share/public/components/common/draft_mode_callout/draft_mode_callout.tsx
@@ -7,19 +7,18 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { type ReactNode } from 'react';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
 import type { CommonProps } from '@elastic/eui';
 import { EuiButton, EuiCallOut, EuiText } from '@elastic/eui';
 
 export interface SaveButtonProps extends CommonProps {
-  onSave: () => Promise<void | object>;
+  onSave: () => Promise<void>;
   label?: string;
   isSaving?: boolean;
 }
 export interface DraftModeCalloutProps extends CommonProps {
   message?: string;
-  node?: ReactNode;
   saveButtonProps?: SaveButtonProps;
 }
 
@@ -36,14 +35,11 @@ const saveButtonText = i18n.translate('share.draftModeCallout.saveButtonText', {
  * A warning callout to indicate the user has unsaved changes.
  */
 export const DraftModeCallout = ({
-  node,
   message = defaultCalloutMessage,
   ['data-test-subj']: dataTestSubj = 'unsavedChangesDraftModeCallOut',
   saveButtonProps,
 }: DraftModeCalloutProps) => {
-  return node ? (
-    node
-  ) : (
+  return (
     <EuiCallOut
       announceOnMount
       data-test-subj={dataTestSubj}

--- a/src/platform/plugins/shared/share/public/components/context/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/context/index.tsx
@@ -47,7 +47,7 @@ export const ShareProvider = ({
   const value: IShareContext = {
     ...shareContext,
     isDirty: isStateful ? internalIsDirty : shareContext.isDirty,
-    isSaving: isStateful ? isSaving : undefined,
+    isSaving,
     onSave: isStateful ? handleSave : undefined,
   };
 

--- a/src/platform/plugins/shared/share/public/components/export_integrations/export_integrations.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_integrations/export_integrations.tsx
@@ -40,7 +40,6 @@ import {
   useShareContext,
 } from '../context';
 import type { ExportShareConfig, ExportShareDerivativesConfig } from '../../types';
-import type { DraftModeCalloutProps } from '../common/draft_mode_callout';
 import { DraftModeCallout } from '../common/draft_mode_callout';
 
 export const ExportMenu: FC<{ shareContext: IShareContext }> = ({ shareContext }) => {
@@ -71,7 +70,7 @@ interface ManagedFlyoutProps {
   shareObjectTypeMeta: ReturnType<
     typeof useShareTypeContext<'integration', 'export'>
   >['objectTypeMeta'];
-  onSave?: () => Promise<void | object>;
+  onSave?: () => Promise<void>;
   isSaving?: boolean;
 }
 
@@ -154,16 +153,7 @@ function ManagedFlyout({
   }, [exportIntegration.config, intl, onCloseFlyout, usePrintLayout]);
 
   const draftModeCallout = shareObjectTypeMeta.config?.[exportIntegration.id]?.draftModeCallOut;
-  // TODO Remove node override logic https://github.com/elastic/kibana/issues/238877
-  const isValidCalloutOverride = React.isValidElement(draftModeCallout);
-  const draftModeCalloutContent = isValidCalloutOverride
-    ? // Retro-compatible case
-      { node: draftModeCallout }
-    : typeof draftModeCallout === 'object'
-    ? // Custom content callout
-      (draftModeCallout as DraftModeCalloutProps)
-    : // Default content callout
-      {};
+  const draftModeCalloutContent = typeof draftModeCallout === 'object' ? draftModeCallout : {};
 
   return (
     <React.Fragment>

--- a/src/platform/plugins/shared/share/public/components/tabs/embed/embed_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/embed/embed_content.tsx
@@ -29,7 +29,6 @@ import type { AnonymousAccessState } from '../../../../common';
 
 import { useShareContext, type IShareContext } from '../../context';
 import type { EmbedShareConfig, EmbedShareUIConfig } from '../../../types';
-import type { DraftModeCalloutProps } from '../../common/draft_mode_callout';
 import { DraftModeCallout } from '../../common/draft_mode_callout';
 
 type EmbedProps = Pick<
@@ -84,16 +83,7 @@ export const EmbedContent = ({
     computeAnonymousCapabilities,
     embedUrlParamExtensions: urlParamExtensions,
   } = objectConfig;
-  // TODO Remove node override logic https://github.com/elastic/kibana/issues/238877
-  const isValidCalloutOverride = React.isValidElement(draftModeCallOut);
-  const draftModeCalloutContent = isValidCalloutOverride
-    ? // Retro-compatible case
-      { node: draftModeCallOut }
-    : typeof draftModeCallOut === 'object'
-    ? // Custom content callout
-      (draftModeCallOut as DraftModeCalloutProps)
-    : // Default content callout
-      {};
+  const draftModeCalloutContent = typeof draftModeCallOut === 'object' ? draftModeCallOut : {};
 
   useEffect(() => {
     if (computeAnonymousCapabilities && anonymousAccess) {

--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
@@ -23,7 +23,6 @@ import React, { useCallback, useState, useRef, useEffect } from 'react';
 import { TimeTypeSection } from './time_type_section';
 import { useShareContext, type IShareContext } from '../../context';
 import type { LinkShareConfig, LinkShareUIConfig } from '../../../types';
-import type { DraftModeCalloutProps } from '../../common/draft_mode_callout';
 import { DraftModeCallout } from '../../common/draft_mode_callout';
 
 type LinkProps = Pick<
@@ -65,16 +64,7 @@ export const LinkContent = ({
   const timeRange = shareableUrlLocatorParams?.params?.timeRange;
 
   const { delegatedShareUrlHandler, draftModeCallOut } = objectConfig;
-  // TODO Remove node override logic https://github.com/elastic/kibana/issues/238877
-  const isValidCalloutOverride = React.isValidElement(draftModeCallOut);
-  const draftModeCalloutContent = isValidCalloutOverride
-    ? // Retro-compatible case
-      { node: draftModeCallOut }
-    : typeof draftModeCallOut === 'object'
-    ? // Custom content callout
-      (draftModeCallOut as DraftModeCalloutProps)
-    : // Default content callout
-      {};
+  const draftModeCalloutContent = typeof draftModeCallOut === 'object' ? draftModeCallOut : {};
 
   const getUrlWithUpdatedParams = useCallback((tempUrl: string): string => {
     const urlWithUpdatedParams = urlParamsRef.current

--- a/src/platform/plugins/shared/share/public/types.ts
+++ b/src/platform/plugins/shared/share/public/types.ts
@@ -43,8 +43,7 @@ type ShareActionUserInputBase<E extends Record<string, unknown> = Record<string,
    *   - `message`: callout message custom content
    */
 
-  // TODO Remove ReactNode type https://github.com/elastic/kibana/issues/238877
-  draftModeCallOut?: boolean | DraftModeCalloutProps | ReactNode;
+  draftModeCallOut?: boolean | DraftModeCalloutProps;
   helpText?: ReactNode;
   CTAButtonConfig?: {
     id: string;
@@ -397,7 +396,7 @@ export interface ShowShareMenuOptions extends Omit<ShareContext, 'onClose'> {
   allowShortUrl: boolean;
   onClose?: () => void;
   publicAPIEnabled?: boolean;
-  onSave?: () => Promise<void | object>;
+  onSave?: () => Promise<void>;
 }
 
 export interface ClientConfigType {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/238877

## Summary

- Cleaned up `DraftModeCallout` component override logic which allowed for any ReactNode element to be rendered inside the share modal as part of the effort to unify the callout's UI across Kibana.
- Updated Dashboards `show_share_modal` logic to use the new types and props. These changes had originally been reviewed as part of this PR https://github.com/elastic/kibana/pull/236719 but were removed to avoid conflicts with https://github.com/elastic/kibana/pull/233552

### Testing

| Before | After |
| --- | --- |
| <img width="532" height="480" alt="Screenshot 2025-10-28 at 11 25 24" src="https://github.com/user-attachments/assets/f8c4fa36-3c49-4ec8-be01-45e0dd5e9962" /> | <img width="535" height="488" alt="Screenshot 2025-10-28 at 11 20 34" src="https://github.com/user-attachments/assets/130aa891-08bc-45e1-b950-379a27e9892f" /> |
| <img width="530" height="570" alt="Screenshot 2025-10-28 at 11 26 24" src="https://github.com/user-attachments/assets/0f23a89e-7af6-4ae1-afc0-7fdca5bbdd8b" /> | <img width="521" height="561" alt="Screenshot 2025-10-28 at 11 22 33" src="https://github.com/user-attachments/assets/e8d166a0-b789-4a15-aad0-097f4d26b590" /> | 
| <img width="502" height="759" alt="Screenshot 2025-10-28 at 11 25 46" src="https://github.com/user-attachments/assets/0bb614ba-8ce9-47bb-92e4-8b3ef10c5752" /> | <img width="510" height="792" alt="Screenshot 2025-10-28 at 11 20 51" src="https://github.com/user-attachments/assets/b6375be5-e50b-4ea1-b3af-9d951395137a" /> |
