### PR TITLE
[AgentBuilder] [Flyout] allows passing initialMessage, agentId, sessionTag and newConversation

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
@@ -18,7 +18,7 @@ import { useSendMessage } from '../../context/send_message/send_message_context'
 import { useConversationScrollActions } from '../../hooks/use_conversation_scroll_actions';
 import { useConversationStatus } from '../../hooks/use_conversation';
 import { ConversationContent } from './conversation_grid';
-import { useInitialMessage } from '../../hooks/use_initial_message';
+import { useSendPredefinedInitialMessage } from '../../hooks/use_initial_message';
 
 const fullHeightStyles = css`
   height: 100%;
@@ -36,7 +36,7 @@ export const Conversation: React.FC<{}> = () => {
   const { isFetched } = useConversationStatus();
   const shouldStickToBottom = useShouldStickToBottom();
 
-  useInitialMessage();
+  useSendPredefinedInitialMessage();
 
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
@@ -18,6 +18,7 @@ import { useSendMessage } from '../../context/send_message/send_message_context'
 import { useConversationScrollActions } from '../../hooks/use_conversation_scroll_actions';
 import { useConversationStatus } from '../../hooks/use_conversation';
 import { ConversationContent } from './conversation_grid';
+import { useInitialMessage } from '../../hooks/use_initial_message';
 
 const fullHeightStyles = css`
   height: 100%;
@@ -34,6 +35,8 @@ export const Conversation: React.FC<{}> = () => {
   const { isResponseLoading } = useSendMessage();
   const { isFetched } = useConversationStatus();
   const shouldStickToBottom = useShouldStickToBottom();
+
+  useInitialMessage();
 
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const {

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/conversation_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/conversation_context.tsx
@@ -12,6 +12,9 @@ interface ConversationContextValue {
   conversationId?: string;
   shouldStickToBottom?: boolean;
   isEmbeddedContext: boolean;
+  sessionTag?: string;
+  agentId?: string;
+  initialMessage?: string;
   setConversationId?: (conversationId: string) => void;
   conversationActions: ConversationActions;
 }

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/embeddable_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/embeddable_conversations_provider.tsx
@@ -16,6 +16,8 @@ import { SendMessageProvider } from '../send_message/send_message_context';
 import { queryKeys } from '../../query_keys';
 import { newConversationId } from '../../utils/new_conversation';
 import { useConversationActions } from './use_conversation_actions';
+import { useResolveConversationId } from '../../hooks/use_resolve_conversation_id';
+import { useSaveLastConversationId } from '../../hooks/use_save_last_conversation_id';
 
 interface EmbeddableConversationsProviderProps extends EmbeddableConversationInternalProps {
   children: React.ReactNode;
@@ -38,12 +40,26 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
     [coreStart, services.startDependencies]
   );
 
+  const { resolvedConversationId, isLoading: isResolvingConversation } = useResolveConversationId({
+    newConversation: contextProps.newConversation,
+    conversationId: contextProps.conversationId,
+    sessionTag: contextProps.sessionTag,
+    agentId: contextProps.agentId,
+  });
+
   const [conversationId, setConversationId] = useState<string | undefined>(undefined);
 
+  useSaveLastConversationId({
+    conversationId,
+    sessionTag: contextProps.sessionTag,
+    agentId: contextProps.agentId,
+  });
+
   useEffect(() => {
-    // React to conversationId changing through the flyout API
-    setConversationId(contextProps.conversationId);
-  }, [contextProps.conversationId]);
+    if (!isResolvingConversation) {
+      setConversationId(resolvedConversationId);
+    }
+  }, [resolvedConversationId, isResolvingConversation]);
 
   const queryKey = queryKeys.conversations.byId(conversationId ?? newConversationId);
 
@@ -79,12 +95,21 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
       conversationId,
       shouldStickToBottom: true,
       isEmbeddedContext: true,
+      sessionTag: contextProps.sessionTag,
+      agentId: contextProps.agentId,
+      initialMessage: contextProps.initialMessage,
       setConversationId: (id: string) => {
         setConversationId(id);
       },
       conversationActions,
     }),
-    [conversationId, conversationActions]
+    [
+      conversationId,
+      contextProps.sessionTag,
+      contextProps.agentId,
+      contextProps.initialMessage,
+      conversationActions,
+    ]
   );
 
   return (

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/embeddable_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/embeddable_conversations_provider.tsx
@@ -49,27 +49,25 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
 
   const [conversationId, setConversationId] = useState<string | undefined>(undefined);
 
+  const validateAndSetConversationId = useCallback(
+    async (id: string) => {
+      try {
+        const conversation = await services.conversationsService.get({ conversationId: id });
+        setConversationId(conversation ? id : undefined);
+      } catch {
+        setConversationId(undefined);
+      }
+    },
+    [services.conversationsService]
+  );
+
   useEffect(() => {
     if (!resolvedConversationId) {
       setConversationId(undefined);
       return;
     }
-
-    services.conversationsService
-      .get({
-        conversationId: resolvedConversationId,
-      })
-      .then((conversation) => {
-        if (conversation) {
-          setConversationId(resolvedConversationId);
-        } else {
-          setConversationId(undefined);
-        }
-      })
-      .catch(() => {
-        setConversationId(undefined);
-      });
-  }, [resolvedConversationId, contextProps.sessionTag, contextProps.agentId, services]);
+    validateAndSetConversationId(resolvedConversationId);
+  }, [resolvedConversationId, validateAndSetConversationId]);
 
   useSaveLastConversationId({
     conversationId,

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation.ts
@@ -72,12 +72,12 @@ export const useAgentId = () => {
   const isNewConversation = !conversationId;
   const getNewConversationAgentId = useGetNewConversationAgentId();
 
-  if (context.agentId) {
-    return context.agentId;
-  }
-
   if (agentId) {
     return agentId;
+  }
+
+  if (context.agentId) {
+    return context.agentId;
   }
 
   // For new conversations, agent id must be defined

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation.ts
@@ -17,6 +17,7 @@ import { useOnechatServices } from './use_onechat_service';
 import { storageKeys } from '../storage_keys';
 import { useSendMessage } from '../context/send_message/send_message_context';
 import { useValidateAgentId } from './agents/use_validate_agent_id';
+import { useConversationContext } from '../context/conversation/conversation_context';
 
 export const useConversation = () => {
   const conversationId = useConversationId();
@@ -65,10 +66,15 @@ const useGetNewConversationAgentId = () => {
 
 export const useAgentId = () => {
   const { conversation } = useConversation();
+  const context = useConversationContext();
   const agentId = conversation?.agent_id;
   const conversationId = useConversationId();
   const isNewConversation = !conversationId;
   const getNewConversationAgentId = useGetNewConversationAgentId();
+
+  if (context.agentId) {
+    return context.agentId;
+  }
 
   if (agentId) {
     return agentId;

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_initial_message.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_initial_message.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useConversationContext } from '../context/conversation/conversation_context';
+import { useConversationId } from '../context/conversation/use_conversation_id';
+import { useSendMessage } from '../context/send_message/send_message_context';
+
+export const useInitialMessage = () => {
+  const context = useConversationContext();
+  const conversationId = useConversationId();
+  const { sendMessage } = useSendMessage();
+  const hasSentInitialMessage = useRef(false);
+
+  const initialMessage = context.initialMessage;
+  const isNewConversation = !conversationId;
+
+  useEffect(() => {
+    if (initialMessage && isNewConversation && !hasSentInitialMessage.current) {
+      hasSentInitialMessage.current = true;
+      sendMessage({ message: initialMessage });
+    }
+  }, [initialMessage, isNewConversation, sendMessage]);
+
+  return {
+    hasSentInitialMessage: hasSentInitialMessage.current,
+  };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_initial_message.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_initial_message.ts
@@ -10,7 +10,7 @@ import { useConversationContext } from '../context/conversation/conversation_con
 import { useConversationId } from '../context/conversation/use_conversation_id';
 import { useSendMessage } from '../context/send_message/send_message_context';
 
-export const useInitialMessage = () => {
+export const useSendPredefinedInitialMessage = () => {
   const context = useConversationContext();
   const conversationId = useConversationId();
   const { sendMessage } = useSendMessage();

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_last_conversation_id.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_last_conversation_id.ts
@@ -20,7 +20,7 @@ export const useLastConversationId = ({
   agentId,
 }: UseLastConversationIdParams = {}) => {
   const storageKey = storageKeys.getLastConversationKey(sessionTag, agentId);
-  const [storedId] = useLocalStorage<string>(storageKey);
+  const [storedId, setStoredId] = useLocalStorage<string>(storageKey);
 
   const { conversations, isLoading } = useConversationList({ agentId });
 
@@ -28,8 +28,14 @@ export const useLastConversationId = ({
     if (storedId && conversations?.find((c) => c.id === storedId)) {
       return storedId;
     }
+
+    // Remove the stored ID if the conversation no longer exists
+    if (storedId && conversations) {
+      setStoredId(undefined);
+    }
+
     return undefined;
-  }, [storedId, conversations]);
+  }, [storedId, conversations, setStoredId]);
 
   return {
     lastConversationId,

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_last_conversation_id.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_last_conversation_id.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+import { storageKeys } from '../storage_keys';
+import { useConversationList } from './use_conversation_list';
+
+interface UseLastConversationIdParams {
+  sessionTag?: string;
+  agentId?: string;
+}
+
+export const useLastConversationId = ({
+  sessionTag,
+  agentId,
+}: UseLastConversationIdParams = {}) => {
+  const storageKey = storageKeys.getLastConversationKey(sessionTag, agentId);
+  const [storedId] = useLocalStorage<string>(storageKey);
+
+  const { conversations, isLoading } = useConversationList({ agentId });
+
+  const lastConversationId = useMemo(() => {
+    if (storedId && conversations?.find((c) => c.id === storedId)) {
+      return storedId;
+    }
+    return undefined;
+  }, [storedId, conversations]);
+
+  return {
+    lastConversationId,
+    isLoading,
+  };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_last_conversation_id.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_last_conversation_id.ts
@@ -5,10 +5,8 @@
  * 2.0.
  */
 
-import { useMemo } from 'react';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { storageKeys } from '../storage_keys';
-import { useConversationList } from './use_conversation_list';
 
 interface UseLastConversationIdParams {
   sessionTag?: string;
@@ -20,25 +18,7 @@ export const useLastConversationId = ({
   agentId,
 }: UseLastConversationIdParams = {}) => {
   const storageKey = storageKeys.getLastConversationKey(sessionTag, agentId);
-  const [storedId, setStoredId] = useLocalStorage<string>(storageKey);
+  const [storedId] = useLocalStorage<string>(storageKey);
 
-  const { conversations, isLoading } = useConversationList({ agentId });
-
-  const lastConversationId = useMemo(() => {
-    if (storedId && conversations?.find((c) => c.id === storedId)) {
-      return storedId;
-    }
-
-    // Remove the stored ID if the conversation no longer exists
-    if (storedId && conversations) {
-      setStoredId(undefined);
-    }
-
-    return undefined;
-  }, [storedId, conversations, setStoredId]);
-
-  return {
-    lastConversationId,
-    isLoading,
-  };
+  return storedId;
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_resolve_conversation_id.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_resolve_conversation_id.ts
@@ -20,27 +20,18 @@ export const useResolveConversationId = ({
   sessionTag,
   agentId,
 }: UseResolveConversationIdParams) => {
-  const { lastConversationId, isLoading } = useLastConversationId({
+  const lastConversationId = useLastConversationId({
     sessionTag,
     agentId,
   });
 
   if (newConversation === true) {
-    return {
-      resolvedConversationId: undefined,
-      isLoading: false,
-    };
+    return undefined;
   }
 
   if (conversationId) {
-    return {
-      resolvedConversationId: conversationId,
-      isLoading: false,
-    };
+    return conversationId;
   }
 
-  return {
-    resolvedConversationId: lastConversationId,
-    isLoading,
-  };
+  return lastConversationId;
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_resolve_conversation_id.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_resolve_conversation_id.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useLastConversationId } from './use_last_conversation_id';
+
+interface UseResolveConversationIdParams {
+  newConversation?: boolean;
+  conversationId?: string;
+  sessionTag?: string;
+  agentId?: string;
+}
+
+export const useResolveConversationId = ({
+  newConversation,
+  conversationId,
+  sessionTag,
+  agentId,
+}: UseResolveConversationIdParams) => {
+  const { lastConversationId, isLoading } = useLastConversationId({
+    sessionTag,
+    agentId,
+  });
+
+  if (newConversation === true) {
+    return {
+      resolvedConversationId: undefined,
+      isLoading: false,
+    };
+  }
+
+  if (conversationId) {
+    return {
+      resolvedConversationId: conversationId,
+      isLoading: false,
+    };
+  }
+
+  return {
+    resolvedConversationId: lastConversationId,
+    isLoading,
+  };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_save_last_conversation_id.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_save_last_conversation_id.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+import { storageKeys } from '../storage_keys';
+
+interface UseSaveLastConversationIdParams {
+  conversationId?: string;
+  sessionTag?: string;
+  agentId?: string;
+}
+
+export const useSaveLastConversationId = ({
+  conversationId,
+  sessionTag,
+  agentId,
+}: UseSaveLastConversationIdParams) => {
+  const storageKey = storageKeys.getLastConversationKey(sessionTag, agentId);
+  const [, setStoredId] = useLocalStorage<string>(storageKey);
+
+  const lastSavedId = useRef<string | undefined>();
+
+  const saveConversationId = useCallback(
+    (id: string) => {
+      if (id && id !== lastSavedId.current) {
+        setStoredId(id);
+        lastSavedId.current = id;
+      }
+    },
+    [setStoredId]
+  );
+
+  useEffect(() => {
+    if (conversationId) {
+      saveConversationId(conversationId);
+    }
+  }, [conversationId, saveConversationId]);
+
+  return {
+    saveConversationId,
+  };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/storage_keys.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/storage_keys.ts
@@ -8,4 +8,10 @@
 export const storageKeys = {
   agentId: 'agentBuilder.agentId',
   lastUsedConnector: 'agentBuilder.lastUsedConnector',
+
+  getLastConversationKey: (sessionTag?: string, agentId?: string): string => {
+    const tag = sessionTag || 'default';
+    const agent = agentId || 'default';
+    return `agentBuilder.lastConversation.${tag}.${agent}`;
+  },
 };

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/types.ts
@@ -15,10 +15,50 @@ export interface EmbeddableConversationDependencies {
 
 export interface EmbeddableConversationProps {
   /**
-   * Optional conversation ID to load an existing conversation.
-   * If not provided, a new conversation will be started.
+   * Explicit conversation ID to load a specific conversation.
+   * Takes priority over sessionTag/agentId-based restoration.
+   * If not provided, the flyout will attempt to restore the last conversation.
    */
   conversationId?: string;
+
+  /**
+   * Force starting a new conversation, ignoring any stored conversation IDs.
+   * When true, a fresh conversation is always created.
+   * @default false
+   */
+  newConversation?: boolean;
+
+  /**
+   * Session tag for conversation context. Used to maintain separate conversation
+   * histories for different parts of the application.
+   *
+   * Examples:
+   * - 'dashboard' - Conversations started from dashboard page
+   * - 'search' - Conversations started from search interface
+   * - 'observability' - Conversations in observability context
+   *
+   * Combined with agentId to restore the correct conversation when the flyout reopens.
+   * @default 'default'
+   */
+  sessionTag?: string;
+
+  /**
+   * Specific agent ID to use for this conversation.
+   * If not provided, uses the last selected agent from localStorage.
+   *
+   * Examples:
+   * - 'platform.core.dashboard' - Dashboard agent
+   * - 'platform.core.general' - General agent
+   */
+  agentId?: string;
+
+  /**
+   * Optional initial message to automatically send when starting a new conversation.
+   * Only applies when creating a new conversation (not when restoring existing ones).
+   *
+   * Example: 'Show me error logs from the last hour'
+   */
+  initialMessage?: string;
 }
 
 export type EmbeddableConversationInternalProps = EmbeddableConversationDependencies &


### PR DESCRIPTION
## Summary

allows passing initialMessage, agentId, sessionTag and newConversation flag to agent builder flyout

resolves https://github.com/elastic/search-team/issues/11488
resolves https://github.com/elastic/search-team/issues/11489