### PR TITLE
[9.1] [Security Solution] Allow partial matches on rule name when searching installed rules. (#237496)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_engine/rule_management/rule_filtering.test.ts
@@ -15,8 +15,20 @@ describe('convertRulesFilterToKQL', () => {
     tags: [],
   };
 
-  it('returns empty string if filter options are empty', () => {
+  it('returns empty string if filter is an empty string', () => {
     const kql = convertRulesFilterToKQL(filterOptions);
+
+    expect(kql).toBe('');
+  });
+
+  it('returns empty string if filter contains only whitespace', () => {
+    const kql = convertRulesFilterToKQL({ ...filterOptions, filter: ' \n\t' });
+
+    expect(kql).toBe('');
+  });
+
+  it('returns empty string if filter is undefined', () => {
+    const kql = convertRulesFilterToKQL({ ...filterOptions, filter: undefined });
 
     expect(kql).toBe('');
   });
@@ -25,16 +37,77 @@ describe('convertRulesFilterToKQL', () => {
     const kql = convertRulesFilterToKQL({ ...filterOptions, filter: 'foo' });
 
     expect(kql).toBe(
-      '(alert.attributes.name: "foo" OR alert.attributes.params.index: "foo" OR alert.attributes.params.threat.tactic.id: "foo" OR alert.attributes.params.threat.tactic.name: "foo" OR alert.attributes.params.threat.technique.id: "foo" OR alert.attributes.params.threat.technique.name: "foo" OR alert.attributes.params.threat.technique.subtechnique.id: "foo" OR alert.attributes.params.threat.technique.subtechnique.name: "foo")'
+      '(' +
+        'alert.attributes.name.keyword: *foo* ' +
+        'OR alert.attributes.params.index: "foo" ' +
+        'OR alert.attributes.params.threat.tactic.id: "foo" ' +
+        'OR alert.attributes.params.threat.tactic.name: "foo" ' +
+        'OR alert.attributes.params.threat.technique.id: "foo" ' +
+        'OR alert.attributes.params.threat.technique.name: "foo" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.id: "foo" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.name: "foo"' +
+        ')'
     );
   });
 
-  it('escapes "filter" value properly', () => {
-    const kql = convertRulesFilterToKQL({ ...filterOptions, filter: '" OR (foo: bar)' });
+  it('escapes "filter" value for single term searches', () => {
+    const kql = convertRulesFilterToKQL({
+      ...filterOptions,
+      filter: '"a<detection\\-rule*with)a<surprise:',
+    });
 
     expect(kql).toBe(
-      '(alert.attributes.name: "\\" OR (foo: bar)" OR alert.attributes.params.index: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo: bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo: bar)")'
+      '(' +
+        'alert.attributes.name.keyword: *\\"a\\<detection\\\\-rule\\*with\\)a\\<surprise\\:* ' +
+        'OR alert.attributes.params.index: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.name: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.name: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.id: "\\"a<detection\\\\-rule*with)a<surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.name: "\\"a<detection\\\\-rule*with)a<surprise:"' +
+        ')'
     );
+  });
+
+  it('allows partial name matches for single term searches', () => {
+    const kql = convertRulesFilterToKQL({
+      ...filterOptions,
+      filter: 'sql',
+    });
+
+    expect(kql.startsWith('(alert.attributes.name.keyword: *sql*')).toBe(true);
+    expect(kql).not.toContain('alert.attributes.name: "sql"');
+  });
+
+  it('escapes "filter" value for multiple term searches', () => {
+    const kql = convertRulesFilterToKQL({
+      ...filterOptions,
+      filter: '"a <detection rule with)\\a< surprise:',
+    });
+
+    expect(kql).toBe(
+      '(' +
+        'alert.attributes.name: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.index: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.id: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.tactic.name: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.id: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.name: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.id: "\\"a <detection rule with)\\\\a< surprise:" ' +
+        'OR alert.attributes.params.threat.technique.subtechnique.name: "\\"a <detection rule with)\\\\a< surprise:"' +
+        ')'
+    );
+  });
+
+  it('allows only exact matching for multi-term searches', () => {
+    const kql = convertRulesFilterToKQL({
+      ...filterOptions,
+      filter: 'sql server',
+    });
+
+    expect(kql.startsWith('(alert.attributes.name: "sql server"')).toBe(true);
+    expect(kql).not.toContain('alert.attributes.name.keyword: *sql server*');
   });
 
   it('handles presence of "showCustomRules" properly', () => {
@@ -74,7 +147,19 @@ describe('convertRulesFilterToKQL', () => {
     });
 
     expect(kql).toBe(
-      `(alert.attributes.name: "foo" OR alert.attributes.params.index: "foo" OR alert.attributes.params.threat.tactic.id: "foo" OR alert.attributes.params.threat.tactic.name: "foo" OR alert.attributes.params.threat.technique.id: "foo" OR alert.attributes.params.threat.technique.name: "foo" OR alert.attributes.params.threat.technique.subtechnique.id: "foo" OR alert.attributes.params.threat.technique.subtechnique.name: "foo") AND alert.attributes.params.immutable: true AND alert.attributes.tags:(\"tag1\" AND \"tag2\")`
+      `(` +
+        `alert.attributes.name.keyword: *foo* OR ` +
+        `alert.attributes.params.index: "foo" OR ` +
+        `alert.attributes.params.threat.tactic.id: "foo" OR ` +
+        `alert.attributes.params.threat.tactic.name: "foo" OR ` +
+        `alert.attributes.params.threat.technique.id: "foo" OR ` +
+        `alert.attributes.params.threat.technique.name: "foo" OR ` +
+        `alert.attributes.params.threat.technique.subtechnique.id: "foo" OR ` +
+        `alert.attributes.params.threat.technique.subtechnique.name: "foo")` +
+        ` AND ` +
+        `alert.attributes.params.immutable: true` +
+        ` AND ` +
+        `alert.attributes.tags:(\"tag1\" AND \"tag2\")`
     );
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/utils/kql.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/utils/kql.ts
@@ -33,23 +33,58 @@ export function prepareKQLStringParam(value: string): string {
 }
 
 /**
- * Escapes string param intended to be passed to KQL. As official docs
- * [here](https://www.elastic.co/guide/en/kibana/current/kuery-query.html) say
- * `Certain characters must be escaped by a backslash (unless surrounded by quotes).` and
- * `You must escape following characters: \():<>"*`.
+ * Partially escapes string param intended to be passed to KQL.
  *
- * This function assumes the value is surrounded by quotes so it escapes quotes, tabs and new line symbols.
+ * This is intended to be used for KQL search terms surrounded by quotes.
+ * It escapes quotes, backslashes, tabs and new line symbols.
  *
  * @param param a string param value intended to be passed to KQL
- * @returns an escaped string param value
+ * @returns a partially escaped KQL string param
  */
 export function escapeKQLStringParam(value = ''): string {
-  return escapeStringValue(value);
+  return partiallyEscapeStringValue(value);
 }
 
 const escapeQuotes = (val: string) => val.replace(/["]/g, '\\$&'); // $& means the whole matched string
 
+const escapeBackslash = (val: string) => val.replace(/\\/g, '\\$&');
+
 const escapeTabs = (val: string) =>
   val.replace(/\t/g, '\\t').replace(/\r/g, '\\r').replace(/\n/g, '\\n');
 
-const escapeStringValue = flow(escapeQuotes, escapeTabs);
+const partiallyEscapeStringValue = flow(escapeBackslash, escapeQuotes, escapeTabs);
+
+/**
+ * Fully escapes special characters to improve matching on KQL.
+ *
+ * As per official docs [here](https://www.elastic.co/guide/en/kibana/current/kuery-query.html)
+ * `Certain characters must be escaped by a backslash (unless surrounded by quotes).` and
+ * `You must escape following characters: \():<>"*`.
+ *
+ * This is intended to be used on KQL search terms WITHOUT quotes.
+ *
+ * @example "a \"user-agent+ \t }with \n a *\:(surprise!) " => "a \\\\"user-agent+ \\}with a \\*\\\\:\\(surprise!\\)"
+ *
+ * @see https://www.elastic.co/docs/reference/query-languages/kql
+ *
+ * @param param a string param value intended to be passed to KQL
+ * @returns a fully escaped KQL string value
+ */
+export function fullyEscapeKQLStringParam(value = ''): string {
+  return fullyEscapeStringValue(value);
+}
+
+const SPECIAL_KQL_CHARACTERS = '\\(){}:<>"*';
+const SPECIAL_KQL_CHARACTERS_REGEX = new RegExp(
+  `[${SPECIAL_KQL_CHARACTERS.split('').join('\\')}]`,
+  'g'
+);
+
+const escapeSpecialKQLCharacters = (val: string) =>
+  val.replace(SPECIAL_KQL_CHARACTERS_REGEX, '\\$&');
+
+const simplifyWhitespace = (val: string) => val.replace(/\s+/g, ' ');
+
+const trim = (val: string) => val.trim();
+
+const fullyEscapeStringValue = flow(escapeSpecialKQLCharacters, simplifyWhitespace, trim);

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { buildEsQuery } from '@kbn/es-query';
+import { fromKueryExpression } from '@kbn/es-query';
 import { KibanaServices } from '../../../common/lib/kibana';
 
 import { DETECTION_ENGINE_RULES_EXCEPTIONS_REFERENCE_URL } from '../../../../common/api/detection_engine/rule_exceptions';
@@ -179,7 +179,16 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: "hello world" OR alert.attributes.params.index: "hello world" OR alert.attributes.params.threat.tactic.id: "hello world" OR alert.attributes.params.threat.tactic.name: "hello world" OR alert.attributes.params.threat.technique.id: "hello world" OR alert.attributes.params.threat.technique.name: "hello world" OR alert.attributes.params.threat.technique.subtechnique.id: "hello world" OR alert.attributes.params.threat.technique.subtechnique.name: "hello world")',
+              '(' +
+              'alert.attributes.name: "hello world" ' +
+              'OR alert.attributes.params.index: "hello world" ' +
+              'OR alert.attributes.params.threat.tactic.id: "hello world" ' +
+              'OR alert.attributes.params.threat.tactic.name: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.id: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.name: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "hello world" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "hello world"' +
+              ')',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',
@@ -189,7 +198,46 @@ describe('Detections Rules API', () => {
       );
     });
 
-    test('check parameter url, query with a filter get escaped correctly', async () => {
+    test('check parameter url, query with a filter get escaped correctly (single term)', async () => {
+      await fetchRules({
+        filterOptions: {
+          filter: '"user\\-agent*with)a<surprise:',
+          showCustomRules: false,
+          showElasticRules: false,
+          tags: [],
+        },
+        sortingOptions: {
+          field: 'enabled',
+          order: 'desc',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_find',
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            filter:
+              '(' +
+              'alert.attributes.name.keyword: *\\"user\\\\-agent\\*with\\)a\\<surprise\\:* ' +
+              'OR alert.attributes.params.index: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.tactic.id: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.tactic.name: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.id: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.name: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "\\"user\\\\-agent*with)a<surprise:" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "\\"user\\\\-agent*with)a<surprise:"' +
+              ')',
+            page: 1,
+            per_page: 20,
+            sort_field: 'enabled',
+            sort_order: 'desc',
+          },
+        })
+      );
+    });
+
+    test('check parameter url, query with a filter get escaped correctly (multiple terms)', async () => {
       await fetchRules({
         filterOptions: {
           filter: '" OR (foo:bar)',
@@ -209,7 +257,16 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: "\\" OR (foo:bar)" OR alert.attributes.params.index: "\\" OR (foo:bar)" OR alert.attributes.params.threat.tactic.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.tactic.name: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.name: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo:bar)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo:bar)")',
+              '(' +
+              'alert.attributes.name: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.index: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.tactic.id: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.tactic.name: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.id: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.name: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "\\" OR (foo:bar)" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "\\" OR (foo:bar)"' +
+              ')',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',
@@ -352,7 +409,7 @@ describe('Detections Rules API', () => {
           },
         ],
       ] = fetchMock.mock.calls;
-      expect(() => buildEsQuery(undefined, { query: filter, language: 'kuery' }, [])).not.toThrow();
+      expect(() => fromKueryExpression(filter)).not.toThrow();
     });
 
     test('query KQL parses without errors when filter contains characters such as double quotes', async () => {
@@ -376,7 +433,7 @@ describe('Detections Rules API', () => {
           },
         ],
       ] = fetchMock.mock.calls;
-      expect(() => buildEsQuery(undefined, { query: filter, language: 'kuery' }, [])).not.toThrow();
+      expect(() => fromKueryExpression(filter)).not.toThrow();
     });
 
     test('query KQL parses without errors when tags contains characters such as double quotes', async () => {
@@ -400,7 +457,7 @@ describe('Detections Rules API', () => {
           },
         ],
       ] = fetchMock.mock.calls;
-      expect(() => buildEsQuery(undefined, { query: filter, language: 'kuery' }, [])).not.toThrow();
+      expect(() => fromKueryExpression(filter)).not.toThrow();
     });
 
     test('check parameter url, query with all options', async () => {
@@ -422,7 +479,16 @@ describe('Detections Rules API', () => {
           method: 'GET',
           query: {
             filter:
-              '(alert.attributes.name: "ruleName" OR alert.attributes.params.index: "ruleName" OR alert.attributes.params.threat.tactic.id: "ruleName" OR alert.attributes.params.threat.tactic.name: "ruleName" OR alert.attributes.params.threat.technique.id: "ruleName" OR alert.attributes.params.threat.technique.name: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.id: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.name: "ruleName") AND alert.attributes.tags:("hello" AND "world")',
+              '(' +
+              'alert.attributes.name.keyword: *ruleName* ' +
+              'OR alert.attributes.params.index: "ruleName" ' +
+              'OR alert.attributes.params.threat.tactic.id: "ruleName" ' +
+              'OR alert.attributes.params.threat.tactic.name: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.id: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.name: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.id: "ruleName" ' +
+              'OR alert.attributes.params.threat.technique.subtechnique.name: "ruleName") ' +
+              'AND alert.attributes.tags:("hello" AND "world")',
             page: 1,
             per_page: 20,
             sort_field: 'enabled',

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/filters_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/filters_panel.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
-  EuiSearchBar,
+  EuiFieldSearch,
 } from '@elastic/eui';
 import React, { memo, useCallback } from 'react';
 import { css } from '@emotion/css';
@@ -36,8 +36,8 @@ const CoverageOverviewFiltersPanelComponent = () => {
   const handleCollapseCellsFilterClick = () => setShowExpandedCells(false);
 
   const handleRuleSearchOnChange = useCallback(
-    ({ queryText }: { queryText: string }) => {
-      setRuleSearchFilter(queryText);
+    (queryText: string) => {
+      setRuleSearchFilter(queryText?.trim());
     },
     [setRuleSearchFilter]
   );
@@ -64,12 +64,12 @@ const CoverageOverviewFiltersPanelComponent = () => {
           </EuiFlexGroup>
           <EuiFlexGroup alignItems="center">
             <EuiFlexItem>
-              <EuiSearchBar
-                box={{
-                  placeholder: i18n.CoverageOverviewSearchBarPlaceholder,
-                  'data-test-subj': 'coverageOverviewFilterSearchBar',
-                }}
-                onChange={handleRuleSearchOnChange}
+              <EuiFieldSearch
+                fullWidth
+                incremental={false}
+                data-test-subj="coverageOverviewFilterSearchBar"
+                placeholder={i18n.CoverageOverviewSearchBarPlaceholder}
+                onSearch={handleRuleSearchOnChange}
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/translations.ts
@@ -152,7 +152,7 @@ export const CoverageOverviewSearchBarPlaceholder = i18n.translate(
   'xpack.securitySolution.coverageOverviewDashboard.searchBarPlaceholder',
   {
     defaultMessage:
-      'Search for the tactic, technique (e.g.,"defense evasion" or "TA0005") or rule name',
+      'Search for the tactic, technique (e.g.,"Defense Evasion" or "TA0005") or rule name',
   }
 );
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/basic_license_essentials_tier/coverage_overview.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/basic_license_essentials_tier/coverage_overview.ts
@@ -249,6 +249,169 @@ export default ({ getService }: FtrProviderContext): void => {
             });
           });
 
+          it('returns partial matches on rule name (when using a single term)', async () => {
+            const expectedRule1 = await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({
+                rule_id: 'rule-1',
+                name: 'Linux SMP aarch64 GNU/Linux',
+              })
+            );
+            const expectedRule2 = await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({ rule_id: 'rule-2', name: 'Windows 10 x64:IA32-e' })
+            );
+            const expectedRule3 = await createRule(
+              supertest,
+              log,
+              // here
+              getCustomQueryRuleParams({ rule_id: 'rule-3', name: 'iOS Darwin x64:IA32-e' })
+            );
+
+            const body1 = await getCoverageOverview(supertest, {
+              search_term: 'win',
+            });
+
+            expect(body1).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule2.id, expectedRule3.id],
+              rules_data: {
+                [expectedRule2.id]: {
+                  activity: 'disabled',
+                  name: 'Windows 10 x64:IA32-e',
+                },
+                [expectedRule3.id]: {
+                  activity: 'disabled',
+                  name: 'iOS Darwin x64:IA32-e',
+                },
+              },
+            });
+
+            const body2 = await getCoverageOverview(supertest, {
+              search_term: '64:IA',
+            });
+
+            expect(body2).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule2.id, expectedRule3.id],
+              rules_data: {
+                [expectedRule2.id]: {
+                  activity: 'disabled',
+                  name: 'Windows 10 x64:IA32-e',
+                },
+                [expectedRule3.id]: {
+                  activity: 'disabled',
+                  name: 'iOS Darwin x64:IA32-e',
+                },
+              },
+            });
+
+            const body3 = await getCoverageOverview(supertest, {
+              search_term: 'GNU/Linux',
+            });
+
+            expect(body3).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule1.id],
+              rules_data: {
+                [expectedRule1.id]: {
+                  activity: 'disabled',
+                  name: 'Linux SMP aarch64 GNU/Linux',
+                },
+              },
+            });
+          });
+
+          it('returns exact term matches on rule name (when using multiple terms)', async () => {
+            const expectedRule1 = await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({
+                rule_id: 'rule-1',
+                name: 'User-Agent rule1',
+              })
+            );
+
+            const expectedRule2 = await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({
+                rule_id: 'rule-2',
+                name: 'User Agent rule2',
+              })
+            );
+
+            const body1 = await getCoverageOverview(supertest, {
+              search_term: 'User-Agent rule1',
+            });
+
+            expect(body1).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule1.id],
+              rules_data: {
+                [expectedRule1.id]: {
+                  activity: 'disabled',
+                  name: 'User-Agent rule1',
+                },
+              },
+            });
+
+            const body2 = await getCoverageOverview(supertest, {
+              search_term: 'User Agent rule2',
+            });
+
+            expect(body2).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule2.id],
+              rules_data: {
+                [expectedRule2.id]: {
+                  activity: 'disabled',
+                  name: 'User Agent rule2',
+                },
+              },
+            });
+
+            const body3 = await getCoverageOverview(supertest, {
+              search_term: 'User Agent rule',
+            });
+
+            expect(body3).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [],
+              rules_data: {},
+            });
+          });
+
+          it('returns special character matches on rule name', async () => {
+            await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({ rule_id: 'rule-1', name: 'Rule name without backslash' })
+            );
+            const expectedRule = await createRule(
+              supertest,
+              log,
+              getCustomQueryRuleParams({ rule_id: 'rule-2', name: 'Rule name with backslash(\\)' })
+            );
+
+            const body = await getCoverageOverview(supertest, {
+              search_term: 'backslash(\\)',
+            });
+
+            expect(body).to.eql({
+              coverage: {},
+              unmapped_rule_ids: [expectedRule.id],
+              rules_data: {
+                [expectedRule.id]: {
+                  activity: 'disabled',
+                  name: 'Rule name with backslash(\\)',
+                },
+              },
+            });
+          });
+
           it('returns response filtered by index pattern', async () => {
             await createRule(
               supertest,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution] Allow partial matches on rule name when searching installed rules. (#237496)](https://github.com/elastic/kibana/pull/237496)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Steven de Salas","email":"sdesalas@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-28T08:25:18Z","message":"[Security Solution] Allow partial matches on rule name when searching installed rules. (#237496)\n\n**Fixes: #237278**\n**Fixes: #97094**\n**Fixes: #194066**\n\n## Summary\n\nWhen a user navigates to `Rules` > `Detection Rules (SIEM)` and wishes\nto find all rules matching a partial string on the rule name (like `win`\nto get all rules about `Windows`) they receive 0 matches. This is in\ncontrast to the behavior they experience when searching available\nprebuilt \"Elastic Rules\", where partial name searches are available.\n\nThis PR fixes this UX inconsistency by modifying the KQL output\ngenerated by the search query.\n\nWhereas previously a search for `\"win\"` would have generated the\nfollowing KQL:\n\n```sql\n(alert.attributes.name: \"win\" OR\n  alert.attributes.params.index: \"win\" OR\n  alert.attributes.params.threat.tactic.id: \"win\" OR\n  ...\n```\n\nIt now treats the `alert.attributes.name` differently, allowing it to\nmatch on partial terms (ie `*win*` instead of `\"win\"`) and using\n`.keyword` index for better special character support.\n\n```sql\n(alert.attributes.name.keyword: *win* OR      # <-- here\n  alert.attributes.params.index: \"win\" OR \n  alert.attributes.params.threat.tactic.id: \"win\" OR \n  ...\n```\n\n### 🕵️ BUT! .. We only do this for single term searches!\n\nPlease note that this approach only applies to single term searches. For\nmultiple term searches we maintain the \"old\" way of searching with\nquotations `\"windows 10 patch\"` instead of `*windows 10 patch*` or even\n`*windows* *10* *patch*`.\n\nThe reasoning here is that since search results are NOT sorted by score,\nwe want to avoid returning too many matches (wildcard searches match on\n_any_ combination of the terms, ie those with `windows` or `10` or\n`patch`) which would confuse the user just as they are trying to narrow\ndown their search results!! (ie 🤔 why am I getting `Linux patch` rules\nwhen I'm asking for `windows 10 patch`??).\n\n## How to test:\n\nTo test this PR please checkout the relevant branch and run an instance\nof kibana/elasticsearch locally.\n\n1. `Security App` > `Rules` > `Detection Rules (SIEM)` \n2. A table of installed rules should appear. Remove all installed\nElastic rules.\n3. `Elastic Rules` (filter) > Tick to select all > `Select all X Rules`\n> `Bulk actions` > `Delete` > `Delete`\n4. Go to `Add Elastic Rules`\n5. `Search rules by name` > `win` > `Enter`\n6. You should see 5 pages of results (~84 rules)\n7. `Install All`\n8. All Elastic rules have been installed > `Go back to installed Elastic\nrules`\n9. Search by rule name > `win` > `Enter`\n10. You should see 5 pages of results (~84 rules - same as in Step 6.)\n\nPlease feel free to try some additional search queries. \n\n<details>\n<summary>\n\n### 👉 Click for additional testing ideas\n\n</summary>\n\nHere are some single term searches:\n  - `goog`\n  - `proc`\n  - `sql` (should include `Postgresql` and `MSSQL`)\n  - `shell` (should include `Powershell`)\n  - `inject` (should include `injection`)\n  - `git` (should include `GitHub`)\n  - `.exe`\n  - `pub/sub` (exact matches only)\n  - `user-agent` (exact matches only)\n  - `/bin`\n  - `CVE-2025` (should include partial matches)\n  - `-` (should return matches with dash in the name like `user-agent`)\n- `_` (should return matches with dash in the name like `CAP_SYS_ADMIN`)\n  - `|` (should return no matches - no elastic rules with this)\n\nAnd behavior for multiple term searches:\n- `AWS` (check the count), then `AWS IAM` (there should be less results\nfor `AWS IAM`)\n- `pub/sub topic` (should be less than for `pub/sub`, note that `pub/sub\ntop` partial match has no matches!)\n- `root` then `root cert` then `root certificate` (the second has no\nresults, `root certificate` should only return exact matches)\n- `proc`, then `process`, then `process injection`, then `potential\nprocess injection` (each should return less results)\n\n\n</details>\n\n## Screenshots\n\n\n\n![497230260-e8badac1-85dd-41ff-b905-1a0a3d4bc53d](https://github.com/user-attachments/assets/69e39370-c31c-4f24-84d5-a84386929612)\n\n\n## Special character support\n\nNote that by switching to wildcard searches (ie `*win*`) on the\n`.keyword` index and fully escaping special characters in KQL we'll\n**_ALSO_** be allowing special character searches on single search\nterms.\n\nFor example, searching by `user-agent` will return results that only\nmatch `User-Agent` but not `user` or `agent` individually.\n\nSome other useful example of these approach are searches for: `Pub/Sub`,\n`CVE-2025`, `/bin`, `_`, `.exe`.\n\nThis support, in addition for escaping the backslash `\\` character will\nallow us to close the next TWO ISSUES in this epic 🥳 wohoo!!\n\n👉  #97094 (special chars in rule name) and,\n👉  #194066 (special chars in tags)\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5411d8e8-b3f7-4a3f-9863-c64cc2a7df2c\"\n/>\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c3589add-9f80-4646-807a-3f0c8a2ec5a7\"\n/>\n\n\n\n### Testing special character support.\n\nIn addition to the steps above (installing all elastic rules), we can:\n\n1. Create a rule with special characters: ie `Rule with special chars\n(&, *, #, $, ?, >, @, \\, /, \", ‘, {, [, ;)`\n2. Try some single term matches:\n  - `@`\n  - `&` (additional elastic rules with this term should appear).\n  - `*` \n  - `\"`\n  - `:`\n  - `>`\n  - `{`\n  - `\\` (backslash, this used to break the search under #97094)\n\n## Risks\n\nThese are some of the risks that could be identified by using this\napproach.\n\n### 1. Dependencies that reuse query logic\n\nNote that the `searchTerm -> KQL` conversion for searching for rules is\nused a few places.\n\n- Installed Rules\n- Rule Monitoring\n- Bulk actions\n\n**Note**: All these paths are tested manually, and form part of the\nautomated tests.\n\n### 2. Performance (ie `allowLeadingWildcards`)\n\nWe're using wildcard searches before and after the search term (ie\n`*win*`) in order to replicate the behavior across both 'prebuilt' and\n'installed' rules tables. The wildcard AFTER the term (`win*` =>\nmatching terms like `Windows`) is no problem but the one BEFORE (`*win`\n=> matching terms like `Darwin`) could create an issue.\n\nOur [KQL\ndocumentation](https://www.elastic.co/docs/reference/query-languages/kql#_filter_for_documents_using_wildcards)\nwarns that Kibana UI Advanced Settings have\n`query:allowLeadingWildcards` turned off by default. This is for\nperformance reasons as a leading wildcard can have a large impact when\nsearching indexes that have millions of terms associated with them.\n\n<img width=\"2784\" height=\"2120\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9e0a754c-c30b-453e-a3ae-60a104b13fde\"\n/>\n\n> By default, leading wildcards are not allowed for performance reasons.\nYou can modify this with the\n[query:allowLeadingWildcards](https://www.elastic.co/docs/reference/kibana/advanced-settings#query-allowleadingwildcards)\nadvanced setting.\n\nPlease note that the [Query DSL docs also\nwarn](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard)\nabout avoiding this approach.\n\nThere is also more info and additional warnings under [Lucene API\ndocs](https://lucene.apache.org/core/9_12_3/core/org/apache/lucene/search/WildcardQuery.html).\n\nThe risk here is two pronged:\n\n1. Users with a lot (millions?) of detection rules will likely have a\ndegraded search experience as queries will take longer to execute.\n\n2. Leading wildcards appear to be working by default (in contrast to\nwhat is stated in the documentation). But the mere _existence_ of\nvarious settings to avoid them\n([`allowLeadingWildcards`](https://www.elastic.co/docs/reference/kibana/advanced-settings#query-allowleadingwildcards),\n[`allow_leading_wildcard`](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard),\n[`analyze_wildcards`](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard))\nis a risk, because some users may have a special setup we've not been\nable to anticipate in our testing, leading to potential issues like this\none: https://github.com/elastic/kibana/issues/57828\n\n### Mitigating factors:\n\n1. Please note that in the case of security detection rules, the\nprebuilt rules package is _only ~1500 rules_! Users do not manage\nmillions of rules, they generally manage low thousands or even hundreds.\nWe've tested 100K rules successfully and there was [_no perceivable\ndifference in terms of search\nperformance_](https://github.com/elastic/kibana/pull/237496#issuecomment-3389956730).\nAnd this seems to be a realistic test when checking actual usage stats\n(our 10 largest users in Sep'25 had between 60-160K installed). Also,\ndue to current limits on pagination and bulk action logic we would\nlikely hit different kinds of problems here _before_ search performance\nbecomes an issue.\n\n2. We've tested all the documented ways to disable leading wildcards,\nincluding disabling them manually (under `Server Management > Advanced\nSettings`) and explicitly in the `kibana.yml`. None of them seemed to\naffect searches carried out on Saved Objects. This is because our\nsolution uses the\n[`alerting`](http://github.com/elastic/kibana/tree/main/x-pack/platform/plugins/shared/alerting)\nplugin under the hood which [converts the filter to KQL without\nreferring to any UI Advanced\nSettings](https://github.com/elastic/kibana/blob/91cab0e1369473846dc2712aa7dfe38b8580a9a5/x-pack/platform/plugins/shared/alerting/server/rules_client/common/build_kuery_node_filter.ts#L23).\nAnd since there is no explicit setting for `allowLeadingWildcards` the\ndefault setting of `true` gets applied instead [inside the\n`grammar.peggy`\nfile](https://github.com/elastic/kibana/blob/91cab0e1369473846dc2712aa7dfe38b8580a9a5/src/platform/packages/shared/kbn-es-query/src/kuery/grammar/grammar.peggy#L12).\n\n### Risks that were found acceptable\n\nIn the search for any possible settings that might affect the rollout of\nchanges under this PR [we did find a\nsetting](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-wildcard-query#_allow_expensive_queries_7)\ninside `elasticsearch.yml` that causes problems with the proposed\nsolution.\n\n**TL/DR** 👉 `search.allow_expensive_queries=false` breaks the search.💥🤯\n\n<img width=\"600\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/8d523d15-f832-4488-8c78-4ed60c474d44\"\n/>\n\nHowever we also found bigger problems, _this setting also prevents the\ninstallation of prebuilt rules_ (see below), which are a cornerstone of\nour security solution.\n\n<img width=\"600\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/2b8d91e8-29b9-4f06-9f76-6b1edb999fd1\"\n/>\n\nIn other words, the setting `search.allow_expensive_queries=true` has\nbecome _a de-facto requirement of Detection Rules_, that has not yet\nbeen documented. Hence we including it to the\n[documentation](https://www.elastic.co/docs/solutions/security/detect-and-alert/detections-requirements)\nas part of this PR.\n\nNote also that the errors here are not limited to detection rules.\n\nWe found that the setting _also compromised or outright broke a lot of\nfunctionality in Kibana_ 💥🤯 (including Fleet, API Keys, Timelines, Saved\nObject search, Tags, Server Monitoring etc). More about this is\n[documented in this internal\ndocument](https://docs.google.com/document/d/1HLOXQZFcm1-KBj9DHTqwcF3wDdLOE6CcgUzqzZA2CAg/edit?tab=t.0).\nAnd in this [internal slack\nthread](https://elastic.slack.com/archives/C02HA9E8221/p1760694975799469).\nSo we're assuming that most if not all of our users will have it set to\n`true`.\n\n## Checklist\n\nCheck the PR satisfies following conditions. \n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Follow the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n- [x] Changes have been socialized with the PM and rest of the team.\n- [x] All identified Risks have been properly documented and\ninvestigated. ([internal\ninvestigation](https://docs.google.com/document/d/1HLOXQZFcm1-KBj9DHTqwcF3wDdLOE6CcgUzqzZA2CAg/edit?tab=t.0))\n- [x] New requirements added to the technical docs (PR\n[#3543](https://github.com/elastic/docs-content/pull/3543), see\n[here](https://www.elastic.co/docs/solutions/security/detect-and-alert/detections-requirements))","sha":"433902b9b40c9fb3f4db5346008a61efaed3df31","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Detections and Resp","Team: SecuritySolution","Feature:Rule Management","Team:Detection Rule Management","ci:cloud-deploy","ci:project-deploy-security","backport:version","v9.3.0","v8.19.7","v9.1.7","v9.2.1"],"title":"[Security Solution] Allow partial matches on rule name when searching installed rules.","number":237496,"url":"https://github.com/elastic/kibana/pull/237496","mergeCommit":{"message":"[Security Solution] Allow partial matches on rule name when searching installed rules. (#237496)\n\n**Fixes: #237278**\n**Fixes: #97094**\n**Fixes: #194066**\n\n## Summary\n\nWhen a user navigates to `Rules` > `Detection Rules (SIEM)` and wishes\nto find all rules matching a partial string on the rule name (like `win`\nto get all rules about `Windows`) they receive 0 matches. This is in\ncontrast to the behavior they experience when searching available\nprebuilt \"Elastic Rules\", where partial name searches are available.\n\nThis PR fixes this UX inconsistency by modifying the KQL output\ngenerated by the search query.\n\nWhereas previously a search for `\"win\"` would have generated the\nfollowing KQL:\n\n```sql\n(alert.attributes.name: \"win\" OR\n  alert.attributes.params.index: \"win\" OR\n  alert.attributes.params.threat.tactic.id: \"win\" OR\n  ...\n```\n\nIt now treats the `alert.attributes.name` differently, allowing it to\nmatch on partial terms (ie `*win*` instead of `\"win\"`) and using\n`.keyword` index for better special character support.\n\n```sql\n(alert.attributes.name.keyword: *win* OR      # <-- here\n  alert.attributes.params.index: \"win\" OR \n  alert.attributes.params.threat.tactic.id: \"win\" OR \n  ...\n```\n\n### 🕵️ BUT! .. We only do this for single term searches!\n\nPlease note that this approach only applies to single term searches. For\nmultiple term searches we maintain the \"old\" way of searching with\nquotations `\"windows 10 patch\"` instead of `*windows 10 patch*` or even\n`*windows* *10* *patch*`.\n\nThe reasoning here is that since search results are NOT sorted by score,\nwe want to avoid returning too many matches (wildcard searches match on\n_any_ combination of the terms, ie those with `windows` or `10` or\n`patch`) which would confuse the user just as they are trying to narrow\ndown their search results!! (ie 🤔 why am I getting `Linux patch` rules\nwhen I'm asking for `windows 10 patch`??).\n\n## How to test:\n\nTo test this PR please checkout the relevant branch and run an instance\nof kibana/elasticsearch locally.\n\n1. `Security App` > `Rules` > `Detection Rules (SIEM)` \n2. A table of installed rules should appear. Remove all installed\nElastic rules.\n3. `Elastic Rules` (filter) > Tick to select all > `Select all X Rules`\n> `Bulk actions` > `Delete` > `Delete`\n4. Go to `Add Elastic Rules`\n5. `Search rules by name` > `win` > `Enter`\n6. You should see 5 pages of results (~84 rules)\n7. `Install All`\n8. All Elastic rules have been installed > `Go back to installed Elastic\nrules`\n9. Search by rule name > `win` > `Enter`\n10. You should see 5 pages of results (~84 rules - same as in Step 6.)\n\nPlease feel free to try some additional search queries. \n\n<details>\n<summary>\n\n### 👉 Click for additional testing ideas\n\n</summary>\n\nHere are some single term searches:\n  - `goog`\n  - `proc`\n  - `sql` (should include `Postgresql` and `MSSQL`)\n  - `shell` (should include `Powershell`)\n  - `inject` (should include `injection`)\n  - `git` (should include `GitHub`)\n  - `.exe`\n  - `pub/sub` (exact matches only)\n  - `user-agent` (exact matches only)\n  - `/bin`\n  - `CVE-2025` (should include partial matches)\n  - `-` (should return matches with dash in the name like `user-agent`)\n- `_` (should return matches with dash in the name like `CAP_SYS_ADMIN`)\n  - `|` (should return no matches - no elastic rules with this)\n\nAnd behavior for multiple term searches:\n- `AWS` (check the count), then `AWS IAM` (there should be less results\nfor `AWS IAM`)\n- `pub/sub topic` (should be less than for `pub/sub`, note that `pub/sub\ntop` partial match has no matches!)\n- `root` then `root cert` then `root certificate` (the second has no\nresults, `root certificate` should only return exact matches)\n- `proc`, then `process`, then `process injection`, then `potential\nprocess injection` (each should return less results)\n\n\n</details>\n\n## Screenshots\n\n\n\n![497230260-e8badac1-85dd-41ff-b905-1a0a3d4bc53d](https://github.com/user-attachments/assets/69e39370-c31c-4f24-84d5-a84386929612)\n\n\n## Special character support\n\nNote that by switching to wildcard searches (ie `*win*`) on the\n`.keyword` index and fully escaping special characters in KQL we'll\n**_ALSO_** be allowing special character searches on single search\nterms.\n\nFor example, searching by `user-agent` will return results that only\nmatch `User-Agent` but not `user` or `agent` individually.\n\nSome other useful example of these approach are searches for: `Pub/Sub`,\n`CVE-2025`, `/bin`, `_`, `.exe`.\n\nThis support, in addition for escaping the backslash `\\` character will\nallow us to close the next TWO ISSUES in this epic 🥳 wohoo!!\n\n👉  #97094 (special chars in rule name) and,\n👉  #194066 (special chars in tags)\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5411d8e8-b3f7-4a3f-9863-c64cc2a7df2c\"\n/>\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c3589add-9f80-4646-807a-3f0c8a2ec5a7\"\n/>\n\n\n\n### Testing special character support.\n\nIn addition to the steps above (installing all elastic rules), we can:\n\n1. Create a rule with special characters: ie `Rule with special chars\n(&, *, #, $, ?, >, @, \\, /, \", ‘, {, [, ;)`\n2. Try some single term matches:\n  - `@`\n  - `&` (additional elastic rules with this term should appear).\n  - `*` \n  - `\"`\n  - `:`\n  - `>`\n  - `{`\n  - `\\` (backslash, this used to break the search under #97094)\n\n## Risks\n\nThese are some of the risks that could be identified by using this\napproach.\n\n### 1. Dependencies that reuse query logic\n\nNote that the `searchTerm -> KQL` conversion for searching for rules is\nused a few places.\n\n- Installed Rules\n- Rule Monitoring\n- Bulk actions\n\n**Note**: All these paths are tested manually, and form part of the\nautomated tests.\n\n### 2. Performance (ie `allowLeadingWildcards`)\n\nWe're using wildcard searches before and after the search term (ie\n`*win*`) in order to replicate the behavior across both 'prebuilt' and\n'installed' rules tables. The wildcard AFTER the term (`win*` =>\nmatching terms like `Windows`) is no problem but the one BEFORE (`*win`\n=> matching terms like `Darwin`) could create an issue.\n\nOur [KQL\ndocumentation](https://www.elastic.co/docs/reference/query-languages/kql#_filter_for_documents_using_wildcards)\nwarns that Kibana UI Advanced Settings have\n`query:allowLeadingWildcards` turned off by default. This is for\nperformance reasons as a leading wildcard can have a large impact when\nsearching indexes that have millions of terms associated with them.\n\n<img width=\"2784\" height=\"2120\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9e0a754c-c30b-453e-a3ae-60a104b13fde\"\n/>\n\n> By default, leading wildcards are not allowed for performance reasons.\nYou can modify this with the\n[query:allowLeadingWildcards](https://www.elastic.co/docs/reference/kibana/advanced-settings#query-allowleadingwildcards)\nadvanced setting.\n\nPlease note that the [Query DSL docs also\nwarn](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard)\nabout avoiding this approach.\n\nThere is also more info and additional warnings under [Lucene API\ndocs](https://lucene.apache.org/core/9_12_3/core/org/apache/lucene/search/WildcardQuery.html).\n\nThe risk here is two pronged:\n\n1. Users with a lot (millions?) of detection rules will likely have a\ndegraded search experience as queries will take longer to execute.\n\n2. Leading wildcards appear to be working by default (in contrast to\nwhat is stated in the documentation). But the mere _existence_ of\nvarious settings to avoid them\n([`allowLeadingWildcards`](https://www.elastic.co/docs/reference/kibana/advanced-settings#query-allowleadingwildcards),\n[`allow_leading_wildcard`](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard),\n[`analyze_wildcards`](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard))\nis a risk, because some users may have a special setup we've not been\nable to anticipate in our testing, leading to potential issues like this\none: https://github.com/elastic/kibana/issues/57828\n\n### Mitigating factors:\n\n1. Please note that in the case of security detection rules, the\nprebuilt rules package is _only ~1500 rules_! Users do not manage\nmillions of rules, they generally manage low thousands or even hundreds.\nWe've tested 100K rules successfully and there was [_no perceivable\ndifference in terms of search\nperformance_](https://github.com/elastic/kibana/pull/237496#issuecomment-3389956730).\nAnd this seems to be a realistic test when checking actual usage stats\n(our 10 largest users in Sep'25 had between 60-160K installed). Also,\ndue to current limits on pagination and bulk action logic we would\nlikely hit different kinds of problems here _before_ search performance\nbecomes an issue.\n\n2. We've tested all the documented ways to disable leading wildcards,\nincluding disabling them manually (under `Server Management > Advanced\nSettings`) and explicitly in the `kibana.yml`. None of them seemed to\naffect searches carried out on Saved Objects. This is because our\nsolution uses the\n[`alerting`](http://github.com/elastic/kibana/tree/main/x-pack/platform/plugins/shared/alerting)\nplugin under the hood which [converts the filter to KQL without\nreferring to any UI Advanced\nSettings](https://github.com/elastic/kibana/blob/91cab0e1369473846dc2712aa7dfe38b8580a9a5/x-pack/platform/plugins/shared/alerting/server/rules_client/common/build_kuery_node_filter.ts#L23).\nAnd since there is no explicit setting for `allowLeadingWildcards` the\ndefault setting of `true` gets applied instead [inside the\n`grammar.peggy`\nfile](https://github.com/elastic/kibana/blob/91cab0e1369473846dc2712aa7dfe38b8580a9a5/src/platform/packages/shared/kbn-es-query/src/kuery/grammar/grammar.peggy#L12).\n\n### Risks that were found acceptable\n\nIn the search for any possible settings that might affect the rollout of\nchanges under this PR [we did find a\nsetting](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-wildcard-query#_allow_expensive_queries_7)\ninside `elasticsearch.yml` that causes problems with the proposed\nsolution.\n\n**TL/DR** 👉 `search.allow_expensive_queries=false` breaks the search.💥🤯\n\n<img width=\"600\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/8d523d15-f832-4488-8c78-4ed60c474d44\"\n/>\n\nHowever we also found bigger problems, _this setting also prevents the\ninstallation of prebuilt rules_ (see below), which are a cornerstone of\nour security solution.\n\n<img width=\"600\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/2b8d91e8-29b9-4f06-9f76-6b1edb999fd1\"\n/>\n\nIn other words, the setting `search.allow_expensive_queries=true` has\nbecome _a de-facto requirement of Detection Rules_, that has not yet\nbeen documented. Hence we including it to the\n[documentation](https://www.elastic.co/docs/solutions/security/detect-and-alert/detections-requirements)\nas part of this PR.\n\nNote also that the errors here are not limited to detection rules.\n\nWe found that the setting _also compromised or outright broke a lot of\nfunctionality in Kibana_ 💥🤯 (including Fleet, API Keys, Timelines, Saved\nObject search, Tags, Server Monitoring etc). More about this is\n[documented in this internal\ndocument](https://docs.google.com/document/d/1HLOXQZFcm1-KBj9DHTqwcF3wDdLOE6CcgUzqzZA2CAg/edit?tab=t.0).\nAnd in this [internal slack\nthread](https://elastic.slack.com/archives/C02HA9E8221/p1760694975799469).\nSo we're assuming that most if not all of our users will have it set to\n`true`.\n\n## Checklist\n\nCheck the PR satisfies following conditions. \n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Follow the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n- [x] Changes have been socialized with the PM and rest of the team.\n- [x] All identified Risks have been properly documented and\ninvestigated. ([internal\ninvestigation](https://docs.google.com/document/d/1HLOXQZFcm1-KBj9DHTqwcF3wDdLOE6CcgUzqzZA2CAg/edit?tab=t.0))\n- [x] New requirements added to the technical docs (PR\n[#3543](https://github.com/elastic/docs-content/pull/3543), see\n[here](https://www.elastic.co/docs/solutions/security/detect-and-alert/detections-requirements))","sha":"433902b9b40c9fb3f4db5346008a61efaed3df31"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/237496","number":237496,"mergeCommit":{"message":"[Security Solution] Allow partial matches on rule name when searching installed rules. (#237496)\n\n**Fixes: #237278**\n**Fixes: #97094**\n**Fixes: #194066**\n\n## Summary\n\nWhen a user navigates to `Rules` > `Detection Rules (SIEM)` and wishes\nto find all rules matching a partial string on the rule name (like `win`\nto get all rules about `Windows`) they receive 0 matches. This is in\ncontrast to the behavior they experience when searching available\nprebuilt \"Elastic Rules\", where partial name searches are available.\n\nThis PR fixes this UX inconsistency by modifying the KQL output\ngenerated by the search query.\n\nWhereas previously a search for `\"win\"` would have generated the\nfollowing KQL:\n\n```sql\n(alert.attributes.name: \"win\" OR\n  alert.attributes.params.index: \"win\" OR\n  alert.attributes.params.threat.tactic.id: \"win\" OR\n  ...\n```\n\nIt now treats the `alert.attributes.name` differently, allowing it to\nmatch on partial terms (ie `*win*` instead of `\"win\"`) and using\n`.keyword` index for better special character support.\n\n```sql\n(alert.attributes.name.keyword: *win* OR      # <-- here\n  alert.attributes.params.index: \"win\" OR \n  alert.attributes.params.threat.tactic.id: \"win\" OR \n  ...\n```\n\n### 🕵️ BUT! .. We only do this for single term searches!\n\nPlease note that this approach only applies to single term searches. For\nmultiple term searches we maintain the \"old\" way of searching with\nquotations `\"windows 10 patch\"` instead of `*windows 10 patch*` or even\n`*windows* *10* *patch*`.\n\nThe reasoning here is that since search results are NOT sorted by score,\nwe want to avoid returning too many matches (wildcard searches match on\n_any_ combination of the terms, ie those with `windows` or `10` or\n`patch`) which would confuse the user just as they are trying to narrow\ndown their search results!! (ie 🤔 why am I getting `Linux patch` rules\nwhen I'm asking for `windows 10 patch`??).\n\n## How to test:\n\nTo test this PR please checkout the relevant branch and run an instance\nof kibana/elasticsearch locally.\n\n1. `Security App` > `Rules` > `Detection Rules (SIEM)` \n2. A table of installed rules should appear. Remove all installed\nElastic rules.\n3. `Elastic Rules` (filter) > Tick to select all > `Select all X Rules`\n> `Bulk actions` > `Delete` > `Delete`\n4. Go to `Add Elastic Rules`\n5. `Search rules by name` > `win` > `Enter`\n6. You should see 5 pages of results (~84 rules)\n7. `Install All`\n8. All Elastic rules have been installed > `Go back to installed Elastic\nrules`\n9. Search by rule name > `win` > `Enter`\n10. You should see 5 pages of results (~84 rules - same as in Step 6.)\n\nPlease feel free to try some additional search queries. \n\n<details>\n<summary>\n\n### 👉 Click for additional testing ideas\n\n</summary>\n\nHere are some single term searches:\n  - `goog`\n  - `proc`\n  - `sql` (should include `Postgresql` and `MSSQL`)\n  - `shell` (should include `Powershell`)\n  - `inject` (should include `injection`)\n  - `git` (should include `GitHub`)\n  - `.exe`\n  - `pub/sub` (exact matches only)\n  - `user-agent` (exact matches only)\n  - `/bin`\n  - `CVE-2025` (should include partial matches)\n  - `-` (should return matches with dash in the name like `user-agent`)\n- `_` (should return matches with dash in the name like `CAP_SYS_ADMIN`)\n  - `|` (should return no matches - no elastic rules with this)\n\nAnd behavior for multiple term searches:\n- `AWS` (check the count), then `AWS IAM` (there should be less results\nfor `AWS IAM`)\n- `pub/sub topic` (should be less than for `pub/sub`, note that `pub/sub\ntop` partial match has no matches!)\n- `root` then `root cert` then `root certificate` (the second has no\nresults, `root certificate` should only return exact matches)\n- `proc`, then `process`, then `process injection`, then `potential\nprocess injection` (each should return less results)\n\n\n</details>\n\n## Screenshots\n\n\n\n![497230260-e8badac1-85dd-41ff-b905-1a0a3d4bc53d](https://github.com/user-attachments/assets/69e39370-c31c-4f24-84d5-a84386929612)\n\n\n## Special character support\n\nNote that by switching to wildcard searches (ie `*win*`) on the\n`.keyword` index and fully escaping special characters in KQL we'll\n**_ALSO_** be allowing special character searches on single search\nterms.\n\nFor example, searching by `user-agent` will return results that only\nmatch `User-Agent` but not `user` or `agent` individually.\n\nSome other useful example of these approach are searches for: `Pub/Sub`,\n`CVE-2025`, `/bin`, `_`, `.exe`.\n\nThis support, in addition for escaping the backslash `\\` character will\nallow us to close the next TWO ISSUES in this epic 🥳 wohoo!!\n\n👉  #97094 (special chars in rule name) and,\n👉  #194066 (special chars in tags)\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5411d8e8-b3f7-4a3f-9863-c64cc2a7df2c\"\n/>\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c3589add-9f80-4646-807a-3f0c8a2ec5a7\"\n/>\n\n\n\n### Testing special character support.\n\nIn addition to the steps above (installing all elastic rules), we can:\n\n1. Create a rule with special characters: ie `Rule with special chars\n(&, *, #, $, ?, >, @, \\, /, \", ‘, {, [, ;)`\n2. Try some single term matches:\n  - `@`\n  - `&` (additional elastic rules with this term should appear).\n  - `*` \n  - `\"`\n  - `:`\n  - `>`\n  - `{`\n  - `\\` (backslash, this used to break the search under #97094)\n\n## Risks\n\nThese are some of the risks that could be identified by using this\napproach.\n\n### 1. Dependencies that reuse query logic\n\nNote that the `searchTerm -> KQL` conversion for searching for rules is\nused a few places.\n\n- Installed Rules\n- Rule Monitoring\n- Bulk actions\n\n**Note**: All these paths are tested manually, and form part of the\nautomated tests.\n\n### 2. Performance (ie `allowLeadingWildcards`)\n\nWe're using wildcard searches before and after the search term (ie\n`*win*`) in order to replicate the behavior across both 'prebuilt' and\n'installed' rules tables. The wildcard AFTER the term (`win*` =>\nmatching terms like `Windows`) is no problem but the one BEFORE (`*win`\n=> matching terms like `Darwin`) could create an issue.\n\nOur [KQL\ndocumentation](https://www.elastic.co/docs/reference/query-languages/kql#_filter_for_documents_using_wildcards)\nwarns that Kibana UI Advanced Settings have\n`query:allowLeadingWildcards` turned off by default. This is for\nperformance reasons as a leading wildcard can have a large impact when\nsearching indexes that have millions of terms associated with them.\n\n<img width=\"2784\" height=\"2120\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9e0a754c-c30b-453e-a3ae-60a104b13fde\"\n/>\n\n> By default, leading wildcards are not allowed for performance reasons.\nYou can modify this with the\n[query:allowLeadingWildcards](https://www.elastic.co/docs/reference/kibana/advanced-settings#query-allowleadingwildcards)\nadvanced setting.\n\nPlease note that the [Query DSL docs also\nwarn](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard)\nabout avoiding this approach.\n\nThere is also more info and additional warnings under [Lucene API\ndocs](https://lucene.apache.org/core/9_12_3/core/org/apache/lucene/search/WildcardQuery.html).\n\nThe risk here is two pronged:\n\n1. Users with a lot (millions?) of detection rules will likely have a\ndegraded search experience as queries will take longer to execute.\n\n2. Leading wildcards appear to be working by default (in contrast to\nwhat is stated in the documentation). But the mere _existence_ of\nvarious settings to avoid them\n([`allowLeadingWildcards`](https://www.elastic.co/docs/reference/kibana/advanced-settings#query-allowleadingwildcards),\n[`allow_leading_wildcard`](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard),\n[`analyze_wildcards`](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#query-string-wildcard))\nis a risk, because some users may have a special setup we've not been\nable to anticipate in our testing, leading to potential issues like this\none: https://github.com/elastic/kibana/issues/57828\n\n### Mitigating factors:\n\n1. Please note that in the case of security detection rules, the\nprebuilt rules package is _only ~1500 rules_! Users do not manage\nmillions of rules, they generally manage low thousands or even hundreds.\nWe've tested 100K rules successfully and there was [_no perceivable\ndifference in terms of search\nperformance_](https://github.com/elastic/kibana/pull/237496#issuecomment-3389956730).\nAnd this seems to be a realistic test when checking actual usage stats\n(our 10 largest users in Sep'25 had between 60-160K installed). Also,\ndue to current limits on pagination and bulk action logic we would\nlikely hit different kinds of problems here _before_ search performance\nbecomes an issue.\n\n2. We've tested all the documented ways to disable leading wildcards,\nincluding disabling them manually (under `Server Management > Advanced\nSettings`) and explicitly in the `kibana.yml`. None of them seemed to\naffect searches carried out on Saved Objects. This is because our\nsolution uses the\n[`alerting`](http://github.com/elastic/kibana/tree/main/x-pack/platform/plugins/shared/alerting)\nplugin under the hood which [converts the filter to KQL without\nreferring to any UI Advanced\nSettings](https://github.com/elastic/kibana/blob/91cab0e1369473846dc2712aa7dfe38b8580a9a5/x-pack/platform/plugins/shared/alerting/server/rules_client/common/build_kuery_node_filter.ts#L23).\nAnd since there is no explicit setting for `allowLeadingWildcards` the\ndefault setting of `true` gets applied instead [inside the\n`grammar.peggy`\nfile](https://github.com/elastic/kibana/blob/91cab0e1369473846dc2712aa7dfe38b8580a9a5/src/platform/packages/shared/kbn-es-query/src/kuery/grammar/grammar.peggy#L12).\n\n### Risks that were found acceptable\n\nIn the search for any possible settings that might affect the rollout of\nchanges under this PR [we did find a\nsetting](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-wildcard-query#_allow_expensive_queries_7)\ninside `elasticsearch.yml` that causes problems with the proposed\nsolution.\n\n**TL/DR** 👉 `search.allow_expensive_queries=false` breaks the search.💥🤯\n\n<img width=\"600\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/8d523d15-f832-4488-8c78-4ed60c474d44\"\n/>\n\nHowever we also found bigger problems, _this setting also prevents the\ninstallation of prebuilt rules_ (see below), which are a cornerstone of\nour security solution.\n\n<img width=\"600\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/2b8d91e8-29b9-4f06-9f76-6b1edb999fd1\"\n/>\n\nIn other words, the setting `search.allow_expensive_queries=true` has\nbecome _a de-facto requirement of Detection Rules_, that has not yet\nbeen documented. Hence we including it to the\n[documentation](https://www.elastic.co/docs/solutions/security/detect-and-alert/detections-requirements)\nas part of this PR.\n\nNote also that the errors here are not limited to detection rules.\n\nWe found that the setting _also compromised or outright broke a lot of\nfunctionality in Kibana_ 💥🤯 (including Fleet, API Keys, Timelines, Saved\nObject search, Tags, Server Monitoring etc). More about this is\n[documented in this internal\ndocument](https://docs.google.com/document/d/1HLOXQZFcm1-KBj9DHTqwcF3wDdLOE6CcgUzqzZA2CAg/edit?tab=t.0).\nAnd in this [internal slack\nthread](https://elastic.slack.com/archives/C02HA9E8221/p1760694975799469).\nSo we're assuming that most if not all of our users will have it set to\n`true`.\n\n## Checklist\n\nCheck the PR satisfies following conditions. \n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Follow the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n- [x] Changes have been socialized with the PM and rest of the team.\n- [x] All identified Risks have been properly documented and\ninvestigated. ([internal\ninvestigation](https://docs.google.com/document/d/1HLOXQZFcm1-KBj9DHTqwcF3wDdLOE6CcgUzqzZA2CAg/edit?tab=t.0))\n- [x] New requirements added to the technical docs (PR\n[#3543](https://github.com/elastic/docs-content/pull/3543), see\n[here](https://www.elastic.co/docs/solutions/security/detect-and-alert/detections-requirements))","sha":"433902b9b40c9fb3f4db5346008a61efaed3df31"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/240940","number":240940,"state":"OPEN"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/240942","number":240942,"state":"MERGED","mergeCommit":{"sha":"77646b96df933fa7f97cf140578c6de3ef852dc6","message":"[9.2] [Security Solution] Allow partial matches on rule name when searching installed rules. (#237496) (#240942)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Security Solution] Allow partial matches on rule name when searching\ninstalled rules.\n(#237496)](https://github.com/elastic/kibana/pull/237496)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Steven de Salas <sdesalas@users.noreply.github.com>"}}]}] BACKPORT-->