### PR TITLE
Update ETag hashing algorithm

### DIFF
--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/internal/fields.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/internal/fields.ts
@@ -18,7 +18,7 @@ import { parseFields, querySchema, validate } from './fields_for';
 import { DEFAULT_FIELD_CACHE_FRESHNESS } from '../../constants';
 
 export function calculateHash(srcBuffer: Buffer) {
-  const hash = createHash('sha512');
+  const hash = createHash('sha256');
   hash.update(srcBuffer);
   return hash.digest('hex');
 }

--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/internal/fields.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/internal/fields.ts
@@ -18,7 +18,7 @@ import { parseFields, querySchema, validate } from './fields_for';
 import { DEFAULT_FIELD_CACHE_FRESHNESS } from '../../constants';
 
 export function calculateHash(srcBuffer: Buffer) {
-  const hash = createHash('sha1'); // eslint-disable-line @kbn/eslint/no_unsafe_hash
+  const hash = createHash('sha512');
   hash.update(srcBuffer);
   return hash.digest('hex');
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-team/issues/2027

## Summary

Changes the ETag algorithm from sha1 to sha512 to be FIPS 140-3 compliant.
I guess the only downside to this change is that the browsers that did the requests when it was still done with sha1 will have a cache miss and will need to request again the whole response.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["8.19","9.3"]} ONMERGE-->