### PR TITLE
[Fleet] fix flaky privilege level change test

### DIFF
--- a/x-pack/platform/test/fleet_api_integration/apis/agents/privilege_level_change.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/privilege_level_change.ts
@@ -25,8 +25,7 @@ export default function (providerContext: FtrProviderContext) {
     expect(actionStatus.nbAgentsActioned).to.eql(agentCount);
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/238933
-  describe.skip('fleet_agents_change_privilege_level', () => {
+  describe('fleet_agents_change_privilege_level', () => {
     before(async () => {
       // Not strictly necessary, but allows automatic cleanup.
       await esArchiver.load('x-pack/platform/test/fixtures/es_archives/fleet/agents');
@@ -426,12 +425,14 @@ export default function (providerContext: FtrProviderContext) {
         expect(actionStatus.nbAgentsActionCreated).to.eql(1);
         expect(actionStatus.nbAgentsFailed).to.eql(2);
         expect(actionStatus.latestErrors.length).to.eql(2);
-        expect(actionStatus.latestErrors[0].agentId).to.eql('agent5');
-        expect(actionStatus.latestErrors[0].error).to.eql(
+        expect(
+          actionStatus.latestErrors.find((error: any) => error.agentId === 'agent5').error
+        ).to.eql(
           'Cannot remove root privilege. Privilege level change is supported from version 9.3.0.'
         );
-        expect(actionStatus.latestErrors[1].agentId).to.eql('agent6');
-        expect(actionStatus.latestErrors[1].error).to.eql(
+        expect(
+          actionStatus.latestErrors.find((error: any) => error.agentId === 'agent6').error
+        ).to.eql(
           `Agent agent6 is on policy ${policy2.id}, which contains integrations that require root privilege: system`
         );
       });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/238933

Fix flaky test, made the verification independent of the order.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


