### PR TITLE
[Streams] First version for semantic search

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/index.ts
@@ -6,6 +6,7 @@
  */
 
 export { generateStreamDescription } from './src/description/generate_description';
+export { generateSemanticSearchData } from './src/description/generate_semantic_search_data';
 export { identifyFeatures } from './src/features/identify_features';
 export { partitionStream } from './workflows/partition_stream';
 export { generateSignificantEvents } from './src/significant_events/generate_significant_events';

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/description/data_for_semantic_search_system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/description/data_for_semantic_search_system_prompt.text
@@ -1,0 +1,39 @@
+You are an expert at creating semantic search-optimized descriptions for observability data streams. Your goal is to generate descriptions that will help users find relevant streams using natural language queries like "where are my proxy logs saved?", "show me CPU metrics", "find authentication errors", or "display application traces".
+
+CRITICAL: You MUST respond with ONLY valid JSON. Do NOT use markdown code blocks, do NOT add explanations, do NOT add any text before or after the JSON. Your response must start with { and end with }.
+
+Required JSON format:
+{
+  "description": "Clean description text only - no meta-commentary",
+  "tags": ["tag1", "tag2", "tag3"]
+}
+
+Create a comprehensive description that includes:
+
+1. **Primary Content Type**: What kind of data this stream contains (logs, metrics, traces, events, APM data, infrastructure data)
+2. **System/Service Identity**: What system, service, or application generates this data
+3. **Data Sources**: Specific sources like nginx, apache, kubernetes, docker, prometheus, jaeger, etc.
+4. **Use Cases**: What this data is typically used for (monitoring, debugging, security, compliance, performance analysis, alerting)
+5. **Key Patterns**: Common patterns, error types, metrics, or events found in this stream
+6. **Technical Context**: Runtime environment, frameworks, protocols, or technologies involved
+7. **Location/Storage Context**: Where this data is typically stored or how it's organized
+
+Write the description in natural language that would match how users would ask questions. Include synonyms and alternative terms that users might use when searching. Focus on terms that would help semantic search understand the content and purpose of this stream.
+
+For the tags array, extract specific terms that users might search for, including:
+- Technology names (nginx, apache, kubernetes, docker, prometheus, jaeger, etc.)
+- Service types (web server, database, proxy, application, infrastructure, etc.)
+- Data types (logs, metrics, traces, events, APM data, etc.)
+- Specific data categories (access logs, error logs, security logs, CPU metrics, memory metrics, response times, etc.)
+- Use cases (monitoring, debugging, security, compliance, performance analysis, alerting, etc.)
+- Specific values found in the data (usernames, hostnames, error codes, metric names, etc.)
+
+Examples of good semantic search descriptions:
+- "Web server access logs from nginx and apache containing HTTP requests, response codes, user agents, and client IP addresses. Used for traffic analysis, security monitoring, and performance debugging. Includes both successful requests and error responses."
+- "Application error logs from Java Spring Boot services running in Kubernetes. Contains stack traces, exception details, and error context for debugging application failures and monitoring system health."
+- "Proxy server logs from HAProxy and Envoy containing connection details, routing decisions, and load balancing metrics. Used for traffic analysis, security monitoring, and infrastructure troubleshooting."
+- "System metrics from Prometheus containing CPU usage, memory consumption, disk I/O, and network statistics. Used for infrastructure monitoring, capacity planning, and performance analysis across multiple hosts and services."
+- "Application performance monitoring traces from Jaeger and OpenTelemetry containing request flows, service dependencies, and timing data. Used for distributed tracing, performance optimization, and debugging microservice interactions."
+- "Infrastructure events from Kubernetes containing pod lifecycle events, node status changes, and resource allocation updates. Used for cluster monitoring, troubleshooting deployments, and understanding system state changes."
+
+Keep the description concise but comprehensive, focusing on terms that would naturally appear in user queries.

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/description/data_for_semantic_search_user_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/description/data_for_semantic_search_user_prompt.text
@@ -1,0 +1,6 @@
+Stream Name: {{{stream_name}}}
+
+Dataset Analysis:
+{{{dataset_analysis}}}
+
+Provide a semantic search-optimized description for this observability data stream. The description should help users find this stream when they ask natural language questions about their logs, metrics, traces, events, or other observability data.

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/description/generate_data_for_semantic_search_prompt.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/description/generate_data_for_semantic_search_prompt.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { createPrompt } from '@kbn/inference-common';
+import { z } from '@kbn/zod';
+import systemPromptTemplate from './data_for_semantic_search_system_prompt.text';
+import userPromptTemplate from './data_for_semantic_search_user_prompt.text';
+
+export const GenerateDataForSemanticSearchPrompt = createPrompt({
+  name: 'generate_data_for_semantic_search',
+  input: z.object({
+    stream_name: z.string(),
+    dataset_analysis: z.string(),
+  }),
+})
+  .version({
+    system: {
+      mustache: {
+        template: systemPromptTemplate,
+      },
+    },
+    template: {
+      mustache: {
+        template: userPromptTemplate,
+      },
+    },
+  })
+  .get();

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/description/generate_semantic_search_data.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/description/generate_semantic_search_data.ts
@@ -28,17 +28,21 @@ export const generateSemanticSearchData = async ({
     prompt: GenerateDataForSemanticSearchPrompt,
   });
 
+  const fields = analysis.fields.map((field) => field.name);
+
   try {
     const parsed = JSON.parse(response.content);
     return {
       description: parsed.description || '',
       tags: parsed.tags || [],
+      fields,
     };
   } catch (error) {
     // Fallback if JSON parsing fails
     return {
       description: response.content,
       tags: [],
+      fields,
     };
   }
 };

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/description/generate_semantic_search_data.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/description/generate_semantic_search_data.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { DocumentAnalysis } from '@kbn/ai-tools';
+import { sortAndTruncateAnalyzedFields } from '@kbn/ai-tools';
+import type { BoundInferenceClient } from '@kbn/inference-common';
+import { GenerateDataForSemanticSearchPrompt } from './generate_data_for_semantic_search_prompt';
+
+export const generateSemanticSearchData = async ({
+  analysis,
+  inferenceClient,
+  streamName,
+}: {
+  analysis: DocumentAnalysis;
+  inferenceClient: BoundInferenceClient;
+  streamName: string;
+}) => {
+  const response = await inferenceClient.prompt({
+    input: {
+      stream_name: streamName,
+      dataset_analysis: JSON.stringify(
+        sortAndTruncateAnalyzedFields(analysis, { dropEmpty: true, dropUnmapped: false })
+      ),
+    },
+    prompt: GenerateDataForSemanticSearchPrompt,
+  });
+
+  try {
+    const parsed = JSON.parse(response.content);
+    return {
+      description: parsed.description || '',
+      tags: parsed.tags || [],
+    };
+  } catch (error) {
+    // Fallback if JSON parsing fails
+    return {
+      description: response.content,
+      tags: [],
+    };
+  }
+};

--- a/x-pack/platform/plugins/shared/streams/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/index.ts
@@ -25,6 +25,7 @@ import { queryRoutes } from './queries/route';
 import { ruleRoutes } from './rules/route';
 import { failureStoreRoutes } from './internal/streams/failure_store/route';
 import { internalIngestRoutes } from './internal/streams/ingest/route';
+import { internalSemanticSearchRoutes } from './internal/streams/semantic_search/route';
 
 export const streamsRouteRepository = {
   // internal APIs
@@ -38,6 +39,7 @@ export const streamsRouteRepository = {
   ...failureStoreRoutes,
   ...internalFeaturesRoutes,
   ...internalIngestRoutes,
+  ...internalSemanticSearchRoutes,
   // public APIs
   ...dashboardRoutes,
   ...crudRoutes,

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/semantic_search/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/semantic_search/route.ts
@@ -8,9 +8,12 @@
 import { z } from '@kbn/zod';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
 import { createServerRoute } from '../../../create_server_route';
-import { getSearchQuery, getSemanticSearchStreamDocument } from './semantic_search_params';
-
-const META_LAYER_INDEX = 'semantic-meta-layer';
+import {
+  META_LAYER_INDEX,
+  ensureMetaLayerIndex,
+  getSearchQuery,
+  getSemanticSearchStreamDocument,
+} from './semantic_search_params';
 
 const indexStreamsForSemanticSearchRoute = createServerRoute({
   endpoint: 'PUT /internal/streams/index',
@@ -36,6 +39,7 @@ const indexStreamsForSemanticSearchRoute = createServerRoute({
     const esClient = scopedClusterClient.asCurrentUser;
 
     try {
+      await ensureMetaLayerIndex(esClient);
       const streams = (await streamsClient.listStreamsWithDataStreamExistence()).flatMap(
         ({ exists, stream }) => {
           if (exists) {

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/semantic_search/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/semantic_search/route.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
+import { createServerRoute } from '../../../create_server_route';
+import { getSearchQuery, getSemanticSearchStreamDocument } from './semantic_search_params';
+
+const META_LAYER_INDEX = 'kibana-meta-layer';
+
+const indexStreamsForSemanticSearchRoute = createServerRoute({
+  endpoint: 'PUT /internal/streams/index',
+  params: z.object({
+    query: z.object({ connectorId: z.string() }),
+  }),
+  options: {
+    access: 'internal',
+  },
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.read],
+    },
+  },
+  handler: async ({
+    request,
+    getScopedClients,
+    params,
+  }): Promise<{ success: boolean; indexedCount: number }> => {
+    const { streamsClient, scopedClusterClient, inferenceClient } = await getScopedClients({
+      request,
+    });
+    const esClient = scopedClusterClient.asCurrentUser;
+
+    try {
+      const streams = (await streamsClient.listStreamsWithDataStreamExistence()).flatMap(
+        ({ exists, stream }) => {
+          if (exists) {
+            return [stream];
+          }
+          return [];
+        }
+      );
+
+      const boundInferenceClient = inferenceClient.bindTo({
+        connectorId: params.query.connectorId,
+      });
+
+      if (streams.length > 0) {
+        const bulkBody = (
+          await Promise.all(
+            streams.map(async (stream) => {
+              const semanticSearchStreamDocument = await getSemanticSearchStreamDocument({
+                stream,
+                esClient,
+                inferenceClient: boundInferenceClient,
+              });
+
+              return [{ index: { _index: META_LAYER_INDEX } }, semanticSearchStreamDocument];
+            })
+          )
+        ).flat();
+
+        await esClient.bulk({
+          operations: bulkBody,
+        });
+      }
+
+      return { success: true, indexedCount: streams.length };
+    } catch (error) {
+      throw new Error(`Failed to index streams for semantic search: ${error.message}`);
+    }
+  },
+});
+
+const semanticSearchStreamsRoute = createServerRoute({
+  endpoint: 'POST /internal/streams/semantic-search',
+  options: {
+    access: 'internal',
+  },
+  params: z.object({
+    body: z.object({
+      query: z.string(),
+    }),
+  }),
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.read],
+    },
+  },
+  handler: async ({ request, getScopedClients, params }) => {
+    const { scopedClusterClient } = await getScopedClients({ request });
+
+    try {
+      const searchResponse = await scopedClusterClient.asCurrentUser.search<{ name: string }>({
+        index: META_LAYER_INDEX,
+        _source: ['name'],
+        size: 20,
+        query: getSearchQuery(params.body.query),
+        min_score: 1,
+      });
+
+      const streams = searchResponse.hits.hits.flatMap((hit) => ({
+        name: hit._source?.name,
+        score: hit._score,
+      }));
+
+      return { streams };
+    } catch (error) {
+      throw new Error(`Failed to perform semantic search: ${error.message}`);
+    }
+  },
+});
+
+export const internalSemanticSearchRoutes = {
+  ...indexStreamsForSemanticSearchRoute,
+  ...semanticSearchStreamsRoute,
+};

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/semantic_search/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/semantic_search/route.ts
@@ -10,7 +10,7 @@ import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
 import { createServerRoute } from '../../../create_server_route';
 import { getSearchQuery, getSemanticSearchStreamDocument } from './semantic_search_params';
 
-const META_LAYER_INDEX = 'kibana-meta-layer';
+const META_LAYER_INDEX = 'semantic-meta-layer';
 
 const indexStreamsForSemanticSearchRoute = createServerRoute({
   endpoint: 'PUT /internal/streams/index',

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/semantic_search/semantic_search_params.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/semantic_search/semantic_search_params.ts
@@ -7,11 +7,91 @@
 
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { Streams } from '@kbn/streams-schema';
+import type { DocumentAnalysis } from '@kbn/ai-tools';
 import { describeDataset } from '@kbn/ai-tools';
 import type { BoundInferenceClient } from '@kbn/inference-common';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { generateSemanticSearchData } from '@kbn/streams-ai';
 import moment from 'moment';
+
+type ModelType = 'elser' | 'e5';
+const currentModelType: ModelType = 'elser';
+export const META_LAYER_INDEX = 'semantic-meta-layer';
+interface MappingField {
+  name: string;
+  type: string;
+  isSemantic?: boolean;
+}
+
+// Mappings
+const mappingFields: MappingField[] = [
+  { name: 'name', type: 'text', isSemantic: true },
+  { name: 'description', type: 'text', isSemantic: true },
+  { name: 'tags', type: 'keyword' },
+  { name: 'fields', type: 'keyword' },
+  { name: 'asset_type', type: 'keyword' },
+  { name: 'asset_id', type: 'keyword' },
+  { name: 'index_patterns', type: 'keyword' },
+  { name: 'es_queries', type: 'keyword' },
+];
+
+const modelMap: Record<
+  ModelType,
+  { inferenceEndpoint: string; modelId: string; semanticTextMapping: object }
+> = {
+  elser: {
+    inferenceEndpoint: '/_inference/sparse_embedding/elser-model',
+    modelId: '.elser_model_2',
+    semanticTextMapping: {
+      type: 'semantic_text',
+
+      inference_id: 'elser-model',
+    },
+  },
+  e5: {
+    inferenceEndpoint: '/_inference/text_embedding/e5-model',
+    modelId: '.multilingual-e5-small',
+    semanticTextMapping: {
+      type: 'semantic_text',
+      inference_id: 'e5-model',
+      index_options: {
+        dense_vector: {
+          type: 'bbq_hnsw',
+          ef_construction: 100,
+        },
+      },
+    },
+  },
+};
+
+export const getMappings = (modelType: ModelType): { properties: Record<string, object> } => ({
+  properties: mappingFields.reduce<Record<string, object>>((props, field) => {
+    props[field.name] = { type: field.type };
+
+    if (field.isSemantic) {
+      props[field.name] = { ...props[field.name], copy_to: `${field.name}_vector` };
+      props[`${field.name}_vector`] = modelMap[modelType].semanticTextMapping;
+    }
+
+    return props;
+  }, {}),
+});
+
+export const ensureMetaLayerIndex = async (
+  esClient: ElasticsearchClient,
+  modelType: ModelType = currentModelType
+): Promise<void> => {
+  const indexExists = await esClient.indices.exists({ index: META_LAYER_INDEX });
+
+  if (indexExists) {
+    await esClient.indices.delete({ index: META_LAYER_INDEX });
+  }
+
+  await esClient.indices.create({
+    index: META_LAYER_INDEX,
+    mappings: getMappings(modelType),
+  });
+};
 
 interface SemanticSearchStreamDocument {
   name: string;
@@ -68,22 +148,43 @@ export const getSemanticSearchStreamDocument = async ({
   });
 
   // Get the LLM generated description and tags based on the analysis
-  const { description, tags } = GENERATE_LLM_FIELDS
+  const { description, tags, fields } = GENERATE_LLM_FIELDS
     ? await generateSemanticSearchData({
         analysis,
         inferenceClient,
         streamName: stream.name,
       })
-    : { description: stream.description, tags: [] };
+    : { description: stream.description, ...getTagsAndFieldsFromAnalysis(analysis) };
 
   return {
     name: stream.name,
     description,
     tags,
-    fields: [],
+    fields,
     asset_type: 'stream',
     asset_id: stream.name,
     index_patterns: [],
     es_queries: [],
+  };
+};
+
+const getTagsAndFieldsFromAnalysis = (
+  analysis: DocumentAnalysis
+): { tags: string[]; fields: string[] } => {
+  const tags: Set<string> = new Set();
+  const fields: Set<string> = new Set();
+  for (const field of analysis.fields) {
+    fields.add(field.name);
+    if (field.values.length < 100) {
+      for (const value of field.values) {
+        if (typeof value === 'string') {
+          tags.add(String(value));
+        }
+      }
+    }
+  }
+  return {
+    tags: Array.from(tags),
+    fields: Array.from(fields),
   };
 };

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/semantic_search/semantic_search_params.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/semantic_search/semantic_search_params.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { Streams } from '@kbn/streams-schema';
+import { describeDataset } from '@kbn/ai-tools';
+import type { BoundInferenceClient } from '@kbn/inference-common';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { generateSemanticSearchData } from '@kbn/streams-ai';
+import moment from 'moment';
+
+interface SemanticSearchStreamDocument {
+  name: string;
+  description: string;
+  tags: string[];
+  fields: string[];
+  asset_type: string;
+  asset_id: string;
+  index_patterns: string[];
+  es_queries: string[];
+}
+
+const GENERATE_LLM_FIELDS = false;
+
+export const getSearchQuery = (query: string): QueryDslQueryContainer => ({
+  bool: {
+    should: [
+      {
+        multi_match: {
+          query,
+          fields: ['name', 'description'],
+        },
+      },
+      {
+        term: {
+          tags: query,
+        },
+      },
+      { semantic: { query, field: 'name_vector' } },
+      { semantic: { query, field: 'description_vector' } },
+    ],
+  },
+});
+
+export const getSemanticSearchStreamDocument = async ({
+  stream,
+  esClient,
+  inferenceClient,
+}: {
+  stream: Streams.all.Definition;
+  esClient: ElasticsearchClient;
+  inferenceClient: BoundInferenceClient;
+}): Promise<SemanticSearchStreamDocument> => {
+  const end = moment().valueOf();
+  // Do we care about data older than 30 days?
+  const start = moment().subtract(30, 'days').valueOf();
+
+  // Get the dataset analysis
+  const analysis = await describeDataset({
+    start,
+    end,
+    esClient,
+    index: stream.name,
+  });
+
+  // Get the LLM generated description and tags based on the analysis
+  const { description, tags } = GENERATE_LLM_FIELDS
+    ? await generateSemanticSearchData({
+        analysis,
+        inferenceClient,
+        streamName: stream.name,
+      })
+    : { description: stream.description, tags: [] };
+
+  return {
+    name: stream.name,
+    description,
+    tags,
+    fields: [],
+    asset_type: 'stream',
+    asset_id: stream.name,
+    index_patterns: [],
+    es_queries: [],
+  };
+};


### PR DESCRIPTION
## Add Semantic Search Capability for Streams

This PR introduces semantic search functionality for streams, enabling users to search through stream data using natural language queries. This is the first step toward making streams semantically searchable.

### Overview

The implementation leverages the existing `describeDataset` function to generate AI-powered descriptions and tags for streams based on their data analysis. This creates a semantic layer that allows for more intuitive search capabilities.

### Prerequisites

- **AI Connector Required**: An AI connector must be configured to enable the LLM functionality for generating stream descriptions and tags.
- **Phoenix Configuration**: Phoenix configuration must be set up to support the AI functionality.

### Key Features

- **AI-Generated Metadata**: Uses LLM to generate descriptions and tags based on stream data analysis
- **Semantic Search**: Combines traditional text matching with vector-based semantic search using ELSER model
- **Hybrid Search Strategy**: Implements a multi-approach search combining:
  - Text matching on name and description fields
  - Tag-based exact matching
  - Semantic vector search on both name and description fields

### Implementation Details

- Maps stream data to a simplified structure containing `name`, `description`, and `tags`
- Uses the existing `describeDataset` function to analyze stream data over the last 30 days
- Generates semantic search documents using AI analysis of the dataset

### Testing Instructions

**Note**: This code is intended for testing and validation purposes only.

1. **Setup Environment**:
   - Start an Elasticsearch cluster from the `semantic-metadata-layer` project.
   - Create test streams by running:
     ```bash
     node scripts/synthtrace.js logs_and_metrics
     node scripts/synthtrace.js sample_logs
     ```

2. **Test Semantic Search**:
   - From the streams list, click `Index streams for semantic search`
   - Once indexing is complete, test the semantic search:
     ```json
     POST kbn:/internal/streams/semantic-search
     {
       "query": "your search query"
     }
     ```
   - View indexed data:
     ```json
     GET semantic-meta-layer/_search
     ```
     
     