### PR TITLE
[Controls Anywhere] Fix errors with changing control types

### DIFF
--- a/src/platform/plugins/shared/controls/public/actions/edit_control_display_settings/control_display_settings_popover.tsx
+++ b/src/platform/plugins/shared/controls/public/actions/edit_control_display_settings/control_display_settings_popover.tsx
@@ -43,15 +43,10 @@ export const ControlDisplaySettingsPopover: React.FC<Props> = ({ api, displayNam
 
   const layoutState = api.parentApi.layout$.value;
   const layoutEntry = useMemo(() => layoutState.controls[api.uuid], [layoutState, api.uuid]);
-  const isToRightOfGrowControl = useMemo(() => {
-    if (layoutEntry.order === 0) return false;
-    const nextLowestOrder = layoutEntry.order - 1;
-    const nextLowestOrderControl = Object.values(layoutState.controls).reduce((a, b) =>
-      b.order - nextLowestOrder < a.order - nextLowestOrder ? b : a
-    );
-    if (nextLowestOrderControl.order === layoutEntry.order) return false;
-    return nextLowestOrderControl.grow;
-  }, [layoutEntry.order, layoutState.controls]);
+  const isToRightOfGrowControl = useMemo(
+    () => layoutEntry.order > 0 && Object.values(layoutState.controls)[layoutEntry.order - 1].grow,
+    [layoutEntry.order, layoutState.controls]
+  );
 
   const grow = useMemo(() => layoutEntry.grow ?? DEFAULT_CONTROL_GROW, [layoutEntry]);
   const width = useMemo(() => layoutEntry.width ?? DEFAULT_CONTROL_WIDTH, [layoutEntry]);

--- a/src/platform/plugins/shared/controls/public/actions/edit_control_display_settings/control_display_settings_popover.tsx
+++ b/src/platform/plugins/shared/controls/public/actions/edit_control_display_settings/control_display_settings_popover.tsx
@@ -43,10 +43,15 @@ export const ControlDisplaySettingsPopover: React.FC<Props> = ({ api, displayNam
 
   const layoutState = api.parentApi.layout$.value;
   const layoutEntry = useMemo(() => layoutState.controls[api.uuid], [layoutState, api.uuid]);
-  const isToRightOfGrowControl = useMemo(
-    () => layoutEntry.order > 0 && Object.values(layoutState.controls)[layoutEntry.order - 1].grow,
-    [layoutEntry.order, layoutState.controls]
-  );
+  const isToRightOfGrowControl = useMemo(() => {
+    if (layoutEntry.order === 0) return false;
+    const nextLowestOrder = layoutEntry.order - 1;
+    const nextLowestOrderControl = Object.values(layoutState.controls).reduce((a, b) =>
+      b.order - nextLowestOrder < a.order - nextLowestOrder ? b : a
+    );
+    if (nextLowestOrderControl.order === layoutEntry.order) return false;
+    return nextLowestOrderControl.grow;
+  }, [layoutEntry.order, layoutState.controls]);
 
   const grow = useMemo(() => layoutEntry.grow ?? DEFAULT_CONTROL_GROW, [layoutEntry]);
   const width = useMemo(() => layoutEntry.width ?? DEFAULT_CONTROL_WIDTH, [layoutEntry]);

--- a/src/platform/plugins/shared/controls/public/actions/edit_control_display_settings/edit_control_display_settings.tsx
+++ b/src/platform/plugins/shared/controls/public/actions/edit_control_display_settings/edit_control_display_settings.tsx
@@ -19,7 +19,7 @@ import {
   type EmbeddableApiContext,
 } from '@kbn/presentation-publishing';
 import type { FrequentCompatibilityChangeAction } from '@kbn/ui-actions-plugin/public';
-import { IncompatibleActionError, type Action } from '@kbn/ui-actions-plugin/public';
+import { type Action } from '@kbn/ui-actions-plugin/public';
 
 import { ACTION_EDIT_CONTROL_DISPLAY_SETTINGS } from '../constants';
 import { apiIsPinnableControlApi } from './types';
@@ -36,7 +36,7 @@ export class EditControlDisplaySettingsAction
 
   public readonly MenuItem = ({ context }: { context: EmbeddableApiContext }) => {
     const { embeddable } = context;
-    if (!apiIsPinnableControlApi(embeddable)) throw new IncompatibleActionError();
+    if (!apiIsPinnableControlApi(embeddable)) return null;
 
     return (
       <ControlDisplaySettingsPopover

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/types.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/types.ts
@@ -28,6 +28,7 @@ export interface DashboardPinnableControl {
   type: DashboardPanel['type'];
   grow?: boolean;
   width?: ControlWidth;
+  order?: number;
 }
 
 export interface DashboardLayout {


### PR DESCRIPTION
## Summary

Fixes #240190

- Fixes the `Panel not found` error when changing a pinned control from one type to another, e.g. Options List to Range Slider
- ~Fixes a runtime error related to the display settings popover when deleting multiple controls~
