### PR TITLE
[kbn/failed-test-reporter] avoid creating GH issue for failed ES snapshot fetch

### DIFF
--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_failures.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_failures.ts
@@ -69,6 +69,10 @@ const isLikelyIrrelevant = (name: string, failure: string) => {
     return true;
   }
 
+  if (failure.includes('Unable to read snapshot manifest: Internal Server Error')) {
+    return true;
+  }
+
   return false;
 };
 


### PR DESCRIPTION
related to https://github.com/elastic/kibana/issues/223770

This PR should prevent from opening GH issues when our test infra fails to get the ES snapshot

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->