### PR TITLE
[9.2] [ML][AI Connector] Ensures all auth fields show up correctly (#240913)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/authentication_form_items.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/authentication_form_items.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { AuthenticationFormItems } from './authentication_form_items';
+import { render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import type { ConfigEntryView } from '../../types/types';
+
+describe('AuthenticationFormItems', () => {
+  const mockRequiredAuthItems = [
+    {
+      key: 'secret_key',
+      isValid: true,
+      validationErrors: [],
+      value: null,
+      default_value: null,
+      description: 'A valid AWS secret key that is paired with the access_key.',
+      label: 'Secret Key',
+      required: true,
+      sensitive: true,
+      updatable: true,
+      type: 'str',
+      supported_task_types: ['text_embedding', 'completion'],
+    },
+    {
+      key: 'access_key',
+      isValid: true,
+      validationErrors: [],
+      value: null,
+      default_value: null,
+      description: 'A valid AWS access key that has permissions to use Amazon Bedrock.',
+      label: 'Access Key',
+      required: true,
+      sensitive: true,
+      updatable: true,
+      type: 'str',
+      supported_task_types: ['text_embedding', 'completion'],
+    },
+  ];
+  const mockOptionalAuthItems = [
+    {
+      key: 'api_key',
+      isValid: true,
+      validationErrors: [],
+      value: null,
+      default_value: null,
+      description: 'You must provide either an API key or an Entra ID.',
+      label: 'API Key',
+      required: false,
+      sensitive: true,
+      updatable: true,
+      type: 'str',
+      supported_task_types: ['text_embedding', 'completion'],
+    },
+    {
+      key: 'entra_id',
+      isValid: true,
+      validationErrors: [],
+      value: null,
+      default_value: null,
+      description: 'You must provide either an API key or an Entra ID.',
+      label: 'Entra ID',
+      required: false,
+      sensitive: true,
+      updatable: true,
+      type: 'str',
+      supported_task_types: ['text_embedding', 'completion'],
+    },
+  ];
+
+  const defaultProps = {
+    isLoading: false,
+    setConfigEntry: jest.fn(),
+    reenterSecretsOnEdit: true,
+  };
+
+  it('should render all required auth fields without auth type selector', () => {
+    render(
+      <IntlProvider>
+        <AuthenticationFormItems
+          {...defaultProps}
+          items={mockRequiredAuthItems as ConfigEntryView[]}
+        />
+      </IntlProvider>
+    );
+    expect(screen.getByTestId('authentication-label')).toBeInTheDocument();
+    expect(screen.queryByTestId('authTypeSelect')).not.toBeInTheDocument();
+    expect(screen.getByTestId('configuration-formrow-secret_key')).toBeInTheDocument();
+    expect(screen.getByTestId('configuration-formrow-access_key')).toBeInTheDocument();
+  });
+
+  it('should render single required auth field without auth type selector', () => {
+    render(
+      <IntlProvider>
+        <AuthenticationFormItems
+          {...defaultProps}
+          items={[mockRequiredAuthItems[0]] as ConfigEntryView[]}
+        />
+      </IntlProvider>
+    );
+    expect(screen.getByTestId('authentication-label')).toBeInTheDocument();
+    expect(screen.queryByTestId('authTypeSelect')).not.toBeInTheDocument();
+    expect(screen.getByTestId('configuration-formrow-secret_key')).toBeInTheDocument();
+  });
+
+  it('should allow selection of auth type field when multiple optional fields present', () => {
+    render(
+      <IntlProvider>
+        <AuthenticationFormItems
+          {...defaultProps}
+          items={mockOptionalAuthItems as ConfigEntryView[]}
+        />
+      </IntlProvider>
+    );
+    expect(screen.getByTestId('authentication-label')).toBeInTheDocument();
+    expect(screen.getByTestId('authTypeSelect')).toBeInTheDocument();
+    expect(screen.getByTestId('configuration-formrow-api_key')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/authentication_form_items.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/authentication_form_items.test.tsx
@@ -76,7 +76,6 @@ describe('AuthenticationFormItems', () => {
   const defaultProps = {
     isLoading: false,
     setConfigEntry: jest.fn(),
-    reenterSecretsOnEdit: true,
   };
 
   it('should render all required auth fields without auth type selector', () => {

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/authentication_form_items.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/authentication_form_items.tsx
@@ -40,7 +40,7 @@ export const AuthenticationFormItems: React.FC<AuthenticationFormItemsProps> = (
       })),
     [items]
   );
-  const configEntry = useMemo(
+  const selectedConfigEntry = useMemo(
     () => items.find((item) => item.key === authType) || items[0],
     [authType, items]
   );
@@ -58,27 +58,42 @@ export const AuthenticationFormItems: React.FC<AuthenticationFormItemsProps> = (
         </EuiTitle>
       </EuiFlexItem>
       {isMultiAuthType ? (
-        <EuiFlexItem grow={false}>
-          <EuiButtonGroup
-            isDisabled={isLoading}
-            data-test-subj="authTypeSelect"
-            legend="Authentication type"
-            defaultValue={authType}
-            idSelected={authType}
-            onChange={(id) => setAuthType(id)}
-            options={authTypeOptions}
-            color="text"
-            type="single"
+        <>
+          <EuiFlexItem grow={false}>
+            <EuiButtonGroup
+              isDisabled={isLoading}
+              data-test-subj="authTypeSelect"
+              legend="Authentication type"
+              defaultValue={authType}
+              idSelected={authType}
+              onChange={(id) => setAuthType(id)}
+              options={authTypeOptions}
+              color="text"
+              type="single"
+            />
+          </EuiFlexItem>
+          <ItemFormRow
+            configEntry={selectedConfigEntry}
+            isPreconfigured={isPreconfigured}
+            isEdit={isEdit}
+            isLoading={isLoading}
+            setConfigEntry={setConfigEntry}
           />
-        </EuiFlexItem>
+        </>
       ) : null}
-      <ItemFormRow
-        configEntry={configEntry}
-        isPreconfigured={isPreconfigured}
-        isEdit={isEdit}
-        isLoading={isLoading}
-        setConfigEntry={setConfigEntry}
-      />
+      {isMultiAuthType === false
+        ? items.map((configEntry) => {
+            return (
+              <ItemFormRow
+                configEntry={configEntry}
+                isPreconfigured={isPreconfigured}
+                isEdit={isEdit}
+                isLoading={isLoading}
+                setConfigEntry={setConfigEntry}
+              />
+            );
+          })
+        : null}
     </EuiFlexGroup>
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ML][AI Connector] Ensures all auth fields show up correctly (#240913)](https://github.com/elastic/kibana/pull/240913)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Melissa Alvarez","email":"melissa.alvarez@elastic.co"},"sourceCommit":{"committedDate":"2025-10-28T18:44:22Z","message":"[ML][AI Connector] Ensures all auth fields show up correctly (#240913)\n\n## Summary\nThis PR handles the case of multiple required auth fields as well as\nmultiple fields where only one is required.\n \nBedrock requires multiple auth fields:\n\n<img width=\"590\" height=\"783\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/43c485a5-f0db-42a9-a3d0-29af480ddcbf\"\n/>\n\nAzure OpenAI requires only one auth field but allows the user to choose\nwhich:\n\n<img width=\"600\" height=\"850\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3d18b64d-c9b3-402d-90f1-f5add0e77a60\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"083daa3bc42e886c2d290de9625cde1451b12585","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","backport:version","Feature:Inference UI","v9.3.0","Feature: AI Infra","v9.2.1"],"title":"[ML][AI Connector] Ensures all auth fields show up correctly","number":240913,"url":"https://github.com/elastic/kibana/pull/240913","mergeCommit":{"message":"[ML][AI Connector] Ensures all auth fields show up correctly (#240913)\n\n## Summary\nThis PR handles the case of multiple required auth fields as well as\nmultiple fields where only one is required.\n \nBedrock requires multiple auth fields:\n\n<img width=\"590\" height=\"783\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/43c485a5-f0db-42a9-a3d0-29af480ddcbf\"\n/>\n\nAzure OpenAI requires only one auth field but allows the user to choose\nwhich:\n\n<img width=\"600\" height=\"850\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3d18b64d-c9b3-402d-90f1-f5add0e77a60\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"083daa3bc42e886c2d290de9625cde1451b12585"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/240913","number":240913,"mergeCommit":{"message":"[ML][AI Connector] Ensures all auth fields show up correctly (#240913)\n\n## Summary\nThis PR handles the case of multiple required auth fields as well as\nmultiple fields where only one is required.\n \nBedrock requires multiple auth fields:\n\n<img width=\"590\" height=\"783\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/43c485a5-f0db-42a9-a3d0-29af480ddcbf\"\n/>\n\nAzure OpenAI requires only one auth field but allows the user to choose\nwhich:\n\n<img width=\"600\" height=\"850\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/3d18b64d-c9b3-402d-90f1-f5add0e77a60\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"083daa3bc42e886c2d290de9625cde1451b12585"}},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->