### PR TITLE
[9.2] [Metrics][Discover] Grid using date picker stale state fix (#239849)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_chart_layers.ts
@@ -67,5 +67,5 @@ export const useChartLayers = ({
           : undefined,
       },
     ];
-  }, [dimensions, metric, color]);
+  }, [color, dimensions, metric.instrument, metric.name, metric.unit]);
 };

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
@@ -10,22 +10,28 @@
 import type { LensAttributes, LensConfig } from '@kbn/lens-embeddable-utils/config_builder';
 import { LensConfigBuilder, type LensSeriesLayer } from '@kbn/lens-embeddable-utils/config_builder';
 import type { ChartSectionProps, UnifiedHistogramInputMessage } from '@kbn/unified-histogram/types';
-import useAsync from 'react-use/lib/useAsync';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { EmbeddableComponentProps } from '@kbn/lens-plugin/public';
+import useLatest from 'react-use/lib/useLatest';
 import { useStableCallback } from '@kbn/unified-histogram';
 import {
-  BehaviorSubject,
-  debounceTime,
   filter,
-  merge,
-  withLatestFrom,
-  startWith,
   Observable,
   distinctUntilChanged,
+  from,
+  merge,
+  shareReplay,
+  BehaviorSubject,
+  switchMap,
+  combineLatest,
+  map,
 } from 'rxjs';
 import type { TimeRange } from '@kbn/data-plugin/common';
 import { useEuiTheme } from '@elastic/eui';
+import type {
+  LensYBoundsConfig,
+  LensESQLDataset,
+} from '@kbn/lens-embeddable-utils/config_builder/types';
 export type LensProps = Pick<
   EmbeddableComponentProps,
   | 'id'
@@ -56,66 +62,44 @@ export const useLensProps = ({
   chartLayers: LensSeriesLayer[];
 } & Pick<ChartSectionProps, 'services' | 'searchSessionId'>) => {
   const { euiTheme } = useEuiTheme();
-  const attributes$ = useRef(new BehaviorSubject<LensAttributes | undefined>(undefined));
-  const lensParams = useMemo<LensConfig | undefined>(
-    () =>
-      chartLayers.length > 0
-        ? {
-            chartType: 'xy',
-            dataset: {
-              esql: query,
-            },
-            title,
-            legend: {
-              show: false,
-            },
-            axisTitleVisibility: {
-              showXAxisTitle: false,
-              showYAxisTitle: false,
-              showYRightAxisTitle: false,
-            },
-            layers: chartLayers,
-            fittingFunction: 'Linear',
-          }
-        : undefined,
-    [query, title, chartLayers]
-  );
-
-  useAsync(async () => {
-    if (!lensParams) {
-      attributes$.current.next(undefined);
-      return;
-    }
-
-    const builder = new LensConfigBuilder(services.dataViews);
-
-    attributes$.current.next(
-      (await builder.build(lensParams, {
-        query: {
-          esql: query,
-        },
-      })) as LensAttributes
-    );
-  }, [lensParams, query, services.dataViews]);
-
-  const buildLensProps = useCallback(() => {
-    if (!attributes$.current.value) {
-      return;
-    }
-
-    return getLensProps({
-      searchSessionId,
-      getTimeRange,
-      attributes: attributes$.current.value,
-    });
-  }, [searchSessionId, getTimeRange]);
-
-  const [lensPropsContext, setLensPropsContext] = useState<ReturnType<typeof buildLensProps>>();
-  const updateLensPropsContext = useStableCallback(() => setLensPropsContext(buildLensProps()));
+  const chartConfigUpdates$ = useRef<BehaviorSubject<void>>(new BehaviorSubject<void>(undefined));
 
   useEffect(() => {
-    const attributesCurrent = attributes$.current;
+    chartConfigUpdates$.current.next(void 0);
+  }, [query, title, chartLayers]);
+
+  // creates a stable function that builds the Lens attributes
+  const buildAttributesFn = useLatest(async () => {
+    const lensParams = buildLensParams({ query, title, chartLayers });
+    const builder = new LensConfigBuilder(services.dataViews);
+
+    const result = (await builder.build(lensParams, {
+      query: {
+        esql: (lensParams.dataset as LensESQLDataset).esql,
+      },
+    })) as LensAttributes;
+    return result;
+  });
+
+  const buildLensProps = useCallback(
+    (attributes: LensAttributes) => {
+      return getLensProps({
+        searchSessionId,
+        getTimeRange,
+        attributes,
+      });
+    },
+    [searchSessionId, getTimeRange]
+  );
+
+  const [lensPropsContext, setLensPropsContext] = useState<ReturnType<typeof buildLensProps>>();
+  const updateLensPropsContext = useStableCallback((attributes: LensAttributes) =>
+    setLensPropsContext(buildLensProps(attributes))
+  );
+
+  useEffect(() => {
     const chartRefCurrent = chartRef?.current;
+    const configUpdates$ = chartConfigUpdates$.current;
 
     // progressively load Lens when the chart becomes visible
     const intersecting$ = new Observable<boolean>((subscriber) => {
@@ -132,32 +116,67 @@ export const useLensProps = ({
       }
 
       return () => observer.disconnect();
-    }).pipe(startWith(!!chartRefCurrent), distinctUntilChanged());
+    }).pipe(distinctUntilChanged(), shareReplay(1));
 
-    const subscription = merge(
-      discoverFetch$,
-      // Emit the current attributes value immediately to handle cases where
-      // attributes are already set but discoverFetch$ emitted before this hook mounted.
-      // This ensures we don't miss an update that occurred between unmount and mount.
-      attributesCurrent.pipe(startWith(attributesCurrent.value)),
-      intersecting$
-    )
+    // load lens props when any trigger emits;
+    const triggers$ = merge(
+      // dependencies that change the chart configuration
+      configUpdates$,
+      // discover state update
+      discoverFetch$
+    ).pipe(
+      // any new emission cancels previous load to avoid race conditions
+      switchMap(() => from(buildAttributesFn.current()))
+    );
+
+    // Update Lens props when new attributes load AND chart is visible
+    // OR when chart becomes visible (using latest attributes)
+    const subscription = combineLatest([triggers$, intersecting$])
       .pipe(
-        // prevent rapid successive updates
-        debounceTime(100),
-        withLatestFrom(attributesCurrent, intersecting$),
-        filter(([, attr, isIntersecting]) => {
-          return !!attr && isIntersecting;
-        })
+        filter(([, isIntersecting]) => isIntersecting),
+        map(([attributes]) => attributes)
       )
-      .subscribe(() => updateLensPropsContext());
+      .subscribe((attributes) => {
+        updateLensPropsContext(attributes);
+      });
 
     return () => {
       subscription.unsubscribe();
     };
-  }, [discoverFetch$, updateLensPropsContext, chartRef, euiTheme.size.base]);
+  }, [discoverFetch$, buildAttributesFn, updateLensPropsContext, chartRef, euiTheme.size.base]);
 
   return lensPropsContext;
+};
+
+const buildLensParams = ({
+  query,
+  title,
+  chartLayers,
+  yBounds,
+}: {
+  query: string;
+  title: string;
+  chartLayers: LensSeriesLayer[];
+  yBounds?: LensYBoundsConfig;
+}): LensConfig => {
+  return {
+    chartType: 'xy',
+    dataset: {
+      esql: query,
+    },
+    title,
+    legend: {
+      show: false,
+    },
+    axisTitleVisibility: {
+      showXAxisTitle: false,
+      showYAxisTitle: false,
+      showYRightAxisTitle: false,
+    },
+    layers: chartLayers,
+    fittingFunction: 'Linear',
+    yBounds,
+  };
 };
 
 const getLensProps = ({

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import '@testing-library/jest-dom';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { MetricsExperienceGrid } from './metrics_experience_grid';
 import * as hooks from '../hooks';
 import { FIELD_VALUE_SEPARATOR } from '../common/constants';
@@ -30,9 +30,27 @@ jest.mock('./chart', () => ({
   Chart: jest.fn(() => <div data-test-subj="metric-chart" />),
 }));
 
+/**
+ * Mock EuiDelayRender to render immediately in tests.
+ *
+ * WITHOUT THIS MOCK: "renders the loading state when fields API is fetching" takes 521ms
+ * WITH THIS MOCK: Same test takes ~15ms
+ *
+ * The EmptyState component uses EuiDelayRender with a 500ms delay to avoid
+ * flashing loading states. In tests, this just slows things down.
+ */
+jest.mock('@elastic/eui', () => {
+  const actual = jest.requireActual('@elastic/eui');
+  return {
+    ...actual,
+    EuiDelayRender: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
 const useMetricsGridStateMock = hooks.useMetricsGridState as jest.MockedFunction<
   typeof hooks.useMetricsGridState
 >;
+
 const useMetricFieldsQueryMock = hooks.useMetricFieldsQuery as jest.MockedFunction<
   typeof hooks.useMetricFieldsQuery
 >;
@@ -49,8 +67,6 @@ const useFullScreenStylesMock = hooks.useFullScreenStyles as jest.MockedFunction
 const usePaginatedFieldsMock = hooks.usePaginatedFields as jest.MockedFunction<
   typeof hooks.usePaginatedFields
 >;
-
-const input$ = new Subject<UnifiedHistogramInputMessage>();
 
 const dimensions: Dimension[] = [
   { name: 'foo', type: ES_FIELD_TYPES.KEYWORD },
@@ -74,28 +90,34 @@ const allFields: MetricField[] = [
 ];
 
 describe('MetricsExperienceGrid', () => {
-  const defaultProps: ChartSectionProps = {
-    dataView: { getIndexPattern: () => 'metrics-*' } as ChartSectionProps['dataView'],
-    renderToggleActions: () => <div data-test-subj="toggleActions" />,
-    chartToolbarCss: { name: '', styles: '' },
-    histogramCss: { name: '', styles: '' },
-    requestParams: {
-      getTimeRange: () => ({ from: 'now-15m', to: 'now' }),
-      filters: [],
-      query: { esql: 'FROM metrics-*' },
-      esqlVariables: [],
-      relativeTimeRange: { from: 'now-15m', to: 'now' },
-      updateTimeRange: () => {},
-    },
-    services: {
-      fieldsMetadata: fieldsMetadataPluginPublicMock.createStartContract(),
-    } as unknown as UnifiedHistogramServices,
-    input$,
-    isComponentVisible: true,
-  };
+  let input$: Subject<UnifiedHistogramInputMessage>;
+  let defaultProps: ChartSectionProps;
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // Create new Subject for each test to prevent memory leaks
+    input$ = new Subject<UnifiedHistogramInputMessage>();
+
+    defaultProps = {
+      dataView: { getIndexPattern: () => 'metrics-*' } as ChartSectionProps['dataView'],
+      renderToggleActions: () => <div data-test-subj="toggleActions" />,
+      chartToolbarCss: { name: '', styles: '' },
+      histogramCss: { name: '', styles: '' },
+      requestParams: {
+        getTimeRange: () => ({ from: 'now-15m', to: 'now' }),
+        filters: [],
+        query: { esql: 'FROM metrics-*' },
+        esqlVariables: [],
+        relativeTimeRange: { from: 'now-15m', to: 'now' },
+        updateTimeRange: () => {},
+      },
+      services: {
+        fieldsMetadata: fieldsMetadataPluginPublicMock.createStartContract(),
+      } as unknown as UnifiedHistogramServices,
+      input$,
+      isComponentVisible: true,
+    };
 
     useMetricsGridStateMock.mockReturnValue({
       currentPage: 0,
@@ -141,15 +163,20 @@ describe('MetricsExperienceGrid', () => {
     });
   });
 
-  it('renders the <MetricsGrid />', async () => {
+  afterEach(() => {
+    // Complete the Subject to prevent memory leaks and hanging tests
+    input$.complete();
+  });
+
+  it('renders the <MetricsGrid />', () => {
     const { getByTestId } = render(<MetricsExperienceGrid {...defaultProps} />, {
       wrapper: IntlProvider,
     });
 
-    await waitFor(() => expect(getByTestId('unifiedMetricsExperienceGrid')).toBeInTheDocument());
+    expect(getByTestId('unifiedMetricsExperienceGrid')).toBeInTheDocument();
   });
 
-  it('renders the loading state when fields API is fetching', async () => {
+  it('renders the loading state when fields API is fetching', () => {
     useMetricFieldsQueryMock.mockReturnValue({
       data: [],
       status: 'loading',
@@ -160,17 +187,17 @@ describe('MetricsExperienceGrid', () => {
       wrapper: IntlProvider,
     });
 
-    await waitFor(() => expect(getByTestId('metricsExperienceProgressBar')).toBeInTheDocument());
+    expect(getByTestId('metricsExperienceProgressBar')).toBeInTheDocument();
   });
 
-  it('renders the loading state when Discover is reloading', async () => {
+  it('renders the loading state when Discover is reloading', () => {
     const props = { ...defaultProps, isChartLoading: true };
 
     const { getByTestId } = render(<MetricsExperienceGrid {...props} />, {
       wrapper: IntlProvider,
     });
 
-    await waitFor(() => expect(getByTestId('metricsExperienceProgressBar')).toBeInTheDocument());
+    expect(getByTestId('metricsExperienceProgressBar')).toBeInTheDocument();
   });
 
   it('renders the no data state covering the entire container when Fields API returns no data', () => {
@@ -188,7 +215,7 @@ describe('MetricsExperienceGrid', () => {
     expect(getByTestId('metricsExperienceNoData')).toBeInTheDocument();
   });
 
-  it('renders the no data state covering only the grid section when paginated fields returns no fields', async () => {
+  it('renders the no data state covering only the grid section when paginated fields returns no fields', () => {
     usePaginatedFieldsMock.mockReturnValue({
       totalPages: 0,
       currentPageFields: [],
@@ -199,11 +226,9 @@ describe('MetricsExperienceGrid', () => {
       wrapper: IntlProvider,
     });
 
-    await waitFor(() => {
-      expect(getByTestId('toggleActions')).toBeInTheDocument();
-      expect(getByTestId('metricsExperienceBreakdownSelectorButton')).toBeInTheDocument();
-      expect(getByTestId('metricsExperienceNoData')).toBeInTheDocument();
-    });
+    expect(getByTestId('toggleActions')).toBeInTheDocument();
+    expect(getByTestId('metricsExperienceBreakdownSelectorButton')).toBeInTheDocument();
+    expect(getByTestId('metricsExperienceNoData')).toBeInTheDocument();
   });
 
   it('renders the toolbar', () => {
@@ -218,7 +243,7 @@ describe('MetricsExperienceGrid', () => {
     expect(queryByTestId('metricsExperienceValuesSelectorButton')).not.toBeInTheDocument();
   });
 
-  it('render <ValuesSelector /> when dimensions are selected', async () => {
+  it('render <ValuesSelector /> when dimensions are selected', () => {
     useMetricsGridStateMock.mockReturnValue({
       currentPage: 0,
       dimensions: ['foo'],
@@ -239,12 +264,12 @@ describe('MetricsExperienceGrid', () => {
       wrapper: IntlProvider,
     });
 
-    await waitFor(() =>
-      expect(getByTestId('metricsExperienceValuesSelectorButton')).toBeInTheDocument()
-    );
+    expect(getByTestId('metricsExperienceValuesSelectorButton')).toBeInTheDocument();
   });
 
-  it('shows and updates the search input when the search button is clicked', async () => {
+  it('shows and updates the search input when the search button is clicked', () => {
+    jest.useFakeTimers();
+
     const onSearchTermChange = jest.fn();
 
     useMetricsGridStateMock.mockReturnValue({
@@ -267,17 +292,11 @@ describe('MetricsExperienceGrid', () => {
       wrapper: IntlProvider,
     });
 
-    await waitFor(() => {
-      expect(getByTestId('metricsExperienceToolbarSearch')).toBeInTheDocument();
-    });
-
     const inputButton = getByTestId('metricsExperienceToolbarSearch');
 
-    await act(async () => {
+    act(() => {
       inputButton.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
     });
-
     const input = getByTestId('metricsExperienceGridToolbarSearch');
     expect(input).toBeInTheDocument();
 
@@ -290,9 +309,11 @@ describe('MetricsExperienceGrid', () => {
     });
 
     expect(onSearchTermChange).toHaveBeenCalledWith('cpu');
+
+    jest.useRealTimers();
   });
 
-  it('toggles fullscreen mode when the fullscreen button is clicked', async () => {
+  it('toggles fullscreen mode when the fullscreen button is clicked', () => {
     const onToggleFullscreen = jest.fn();
     const isFullscreen = false;
 
@@ -316,9 +337,7 @@ describe('MetricsExperienceGrid', () => {
       wrapper: IntlProvider,
     });
 
-    await waitFor(() => {
-      expect(getByTestId('metricsExperienceToolbarFullScreen')).toBeInTheDocument();
-    });
+    expect(getByTestId('metricsExperienceToolbarFullScreen')).toBeInTheDocument();
 
     const fullscreenButton = getByTestId('metricsExperienceToolbarFullScreen');
 
@@ -329,7 +348,7 @@ describe('MetricsExperienceGrid', () => {
     expect(onToggleFullscreen).toHaveBeenCalled();
   });
 
-  it('filters fields by search term and respects page size', async () => {
+  it('filters fields by search term and respects page size', () => {
     const onSearchTermChange = jest.fn();
 
     // 20 fields, 10 with "cpu" in the name

--- a/src/platform/plugins/shared/metrics_experience/server/lib/fields/deduplicate_fields.test.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/lib/fields/deduplicate_fields.test.ts
@@ -89,4 +89,16 @@ describe('deduplicateFields', () => {
       { ...baseField, name: 'disk.io' },
     ]);
   });
+
+  it('should handle fields with the same name but different indices', () => {
+    const fields: MetricField[] = [
+      { ...baseField, name: 'cpu', index: 'test-index-1' },
+      { ...baseField, name: 'cpu', index: 'test-index-2' },
+    ];
+    const result = deduplicateFields(fields);
+    expect(result).toEqual([
+      { ...baseField, name: 'cpu', index: 'test-index-1' },
+      { ...baseField, name: 'cpu', index: 'test-index-2' },
+    ]);
+  });
 });

--- a/src/platform/plugins/shared/metrics_experience/server/lib/fields/deduplicate_fields.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/lib/fields/deduplicate_fields.ts
@@ -8,6 +8,7 @@
  */
 
 import type { MetricField } from '../../../common/types';
+import { generateMapKey } from './enrich_metric_fields';
 
 const BASE_FIELD_NAME = 'metrics.';
 export function deduplicateFields(fields: MetricField[]): MetricField[] {
@@ -18,7 +19,7 @@ export function deduplicateFields(fields: MetricField[]): MetricField[] {
     const base = isMetricsPrefixed ? field.name.slice(BASE_FIELD_NAME.length) : field.name;
 
     if (!map.has(base) || !isMetricsPrefixed) {
-      map.set(base, { ...field, name: base });
+      map.set(generateMapKey(field.index, base), { ...field, name: base });
     }
   }
 

--- a/src/platform/plugins/shared/metrics_experience/server/lib/fields/enrich_metric_fields.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/lib/fields/enrich_metric_fields.ts
@@ -29,8 +29,8 @@ function isErrorResponseBase(subject: unknown): subject is ErrorResponseBase {
   return typeof subject === 'object' && subject !== null && 'error' in subject;
 }
 
-function generateMapKey(indexName: string, fieldName: string) {
-  return `${indexName}>${fieldName}`;
+export function generateMapKey(indexName: string, fieldName: string) {
+  return `${fieldName}>${indexName}`;
 }
 
 function buildMetricMetadataMap(

--- a/src/platform/plugins/shared/metrics_experience/server/routes/fields/get_metric_fields.test.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/routes/fields/get_metric_fields.test.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import type { TracedElasticsearchClient } from '@kbn/traced-es-client';
+import type { FieldCapsFieldCapability } from '@elastic/elasticsearch/lib/api/types';
+import type { EpochTimeRange } from '../../types';
+import type { MetricField } from '../../../common/types';
+import { getMetricFields } from './get_metric_fields';
+import { retrieveFieldCaps } from '../../lib/fields/retrieve_fieldcaps';
+import { applyPagination } from '../../lib/pagination/apply_pagination';
+
+jest.mock('../../lib/fields/retrieve_fieldcaps');
+jest.mock('../../lib/pagination/apply_pagination');
+
+const mockRetrieveFieldCaps = retrieveFieldCaps as jest.MockedFunction<typeof retrieveFieldCaps>;
+const mockApplyPagination = applyPagination as jest.MockedFunction<typeof applyPagination>;
+
+describe('getMetricFields', () => {
+  let logger: Logger;
+  let mockEsClient: TracedElasticsearchClient;
+  let timerange: EpochTimeRange;
+
+  // Test data constants - complete field definitions
+  const TEST_FIELDS = {
+    METRIC_A_INDEX_A: {
+      name: 'metric.a',
+      type: 'long',
+      index: 'metrics-a-default',
+      instrument: 'counter',
+    },
+    METRIC_Z_INDEX_A: {
+      name: 'metric.z',
+      type: 'long',
+      index: 'metrics-a-default',
+      instrument: 'counter',
+    },
+    METRIC_Z_INDEX_B: {
+      name: 'metric.z',
+      type: 'double',
+      index: 'metrics-b-default',
+      instrument: 'gauge',
+    },
+  } as const;
+
+  const createMockFieldCapability = (
+    type: string,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    time_series_metric?: 'gauge' | 'counter'
+  ): FieldCapsFieldCapability => ({
+    type,
+    searchable: true,
+    aggregatable: true,
+    time_series_metric,
+  });
+
+  const createMockField = (
+    name: string,
+    index: string,
+    type: string,
+    instrument?: 'counter' | 'gauge'
+  ): MetricField => ({
+    name,
+    index,
+    dimensions: [],
+    type,
+    instrument,
+  });
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    mockEsClient = { client: {} as any } as TracedElasticsearchClient;
+    timerange = { from: 1234567890, to: 1234567900 };
+    jest.clearAllMocks();
+  });
+
+  it('should sort fields alphabetically by index and name', async () => {
+    const mockDataStreamFieldCapsMap = new Map<
+      string,
+      Record<string, Record<string, FieldCapsFieldCapability>>
+    >([
+      [
+        TEST_FIELDS.METRIC_Z_INDEX_B.index,
+        {
+          [TEST_FIELDS.METRIC_Z_INDEX_B.name]: {
+            [TEST_FIELDS.METRIC_Z_INDEX_B.type]: createMockFieldCapability(
+              TEST_FIELDS.METRIC_Z_INDEX_B.type,
+              TEST_FIELDS.METRIC_Z_INDEX_B.instrument
+            ),
+          },
+        },
+      ],
+      [
+        TEST_FIELDS.METRIC_A_INDEX_A.index,
+        {
+          [TEST_FIELDS.METRIC_Z_INDEX_A.name]: {
+            [TEST_FIELDS.METRIC_Z_INDEX_A.type]: createMockFieldCapability(
+              TEST_FIELDS.METRIC_Z_INDEX_A.type,
+              TEST_FIELDS.METRIC_Z_INDEX_A.instrument
+            ),
+          },
+          [TEST_FIELDS.METRIC_A_INDEX_A.name]: {
+            [TEST_FIELDS.METRIC_A_INDEX_A.type]: createMockFieldCapability(
+              TEST_FIELDS.METRIC_A_INDEX_A.type,
+              TEST_FIELDS.METRIC_A_INDEX_A.instrument
+            ),
+          },
+        },
+      ],
+    ]);
+
+    const field1 = createMockField(
+      TEST_FIELDS.METRIC_A_INDEX_A.name,
+      TEST_FIELDS.METRIC_A_INDEX_A.index,
+      TEST_FIELDS.METRIC_A_INDEX_A.type,
+      TEST_FIELDS.METRIC_A_INDEX_A.instrument
+    );
+    const field2 = createMockField(
+      TEST_FIELDS.METRIC_Z_INDEX_A.name,
+      TEST_FIELDS.METRIC_Z_INDEX_A.index,
+      TEST_FIELDS.METRIC_Z_INDEX_A.type,
+      TEST_FIELDS.METRIC_Z_INDEX_A.instrument
+    );
+    const field3 = createMockField(
+      TEST_FIELDS.METRIC_Z_INDEX_B.name,
+      TEST_FIELDS.METRIC_Z_INDEX_B.index,
+      TEST_FIELDS.METRIC_Z_INDEX_B.type,
+      TEST_FIELDS.METRIC_Z_INDEX_B.instrument
+    );
+
+    mockRetrieveFieldCaps.mockResolvedValue(mockDataStreamFieldCapsMap);
+    mockApplyPagination.mockReturnValue([field1, field2, field3]);
+
+    const result = await getMetricFields({
+      esClient: mockEsClient,
+      indexPattern: 'metrics-*',
+      timerange,
+      page: 1,
+      size: 10,
+      logger,
+    });
+
+    expect(mockApplyPagination).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metricFields: [field1, field2, field3],
+      })
+    );
+
+    expect(result.fields).toEqual([
+      expect.objectContaining(field1),
+      expect.objectContaining(field2),
+      expect.objectContaining(field3),
+    ]);
+  });
+});

--- a/src/platform/plugins/shared/metrics_experience/server/routes/fields/get_metric_fields.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/routes/fields/get_metric_fields.ts
@@ -14,7 +14,7 @@ import type { TracedElasticsearchClient } from '@kbn/traced-es-client';
 import type { MetricField, MetricFieldsResponse } from '../../../common/types';
 import { deduplicateFields } from '../../lib/fields/deduplicate_fields';
 import { extractMetricFields } from '../../lib/fields/extract_metric_fields';
-import { enrichMetricFields } from '../../lib/fields/enrich_metric_fields';
+import { enrichMetricFields, generateMapKey } from '../../lib/fields/enrich_metric_fields';
 import { extractDimensions } from '../../lib/dimensions/extract_dimensions';
 import { buildMetricField } from '../../lib/fields/build_metric_field';
 import { retrieveFieldCaps } from '../../lib/fields/retrieve_fieldcaps';
@@ -53,6 +53,7 @@ export async function getMetricFields({
     if (Object.keys(fieldCaps).length === 0) continue;
 
     const metricFields = extractMetricFields(fieldCaps);
+
     const allDimensions = extractDimensions(fieldCaps);
 
     const initialFields = metricFields.map(({ fieldName, type, typeInfo }) =>
@@ -69,7 +70,9 @@ export async function getMetricFields({
     allMetricFields.push(...deduped);
   }
 
-  allMetricFields.sort((a, b) => a.name.localeCompare(b.name));
+  allMetricFields.sort((a, b) =>
+    generateMapKey(a.index, a.name).localeCompare(generateMapKey(b.index, b.name))
+  );
 
   const enrichedMetricFields = await enrichMetricFields({
     esClient,


### PR DESCRIPTION
# Backport


>[!NOTE]
>This backport had to be cherry-picked because the `metrics_grid.tsx` changes could not be backported

This will backport the following commits from `main` to `9.2`:
 - [[Metrics][Discover] Grid using date picker stale state fix (#239849)](https://github.com/elastic/kibana/pull/239849)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-28T19:56:45Z","message":"[Metrics][Discover] Grid using date picker stale state fix (#239849)\n\nfixes [#239846](https://github.com/elastic/kibana/issues/239846)\n\n\n## Summary\n\nThis PR fixes a problem with the grid passing a stale date picker state\nto Lens visualizations\n\n\n\n![date_picker_grid_fix](https://github.com/user-attachments/assets/df69bade-5612-4e28-a5ba-8108d7e24a05)\n\n### Investigation Summary\n\nThere were a couple of things contributing to the problem.\n\n---\n\n#### **1. Fields API returning an unstable list of fields**\n\nThis issue occurred when [sorting the\nfields](https://github.com/crespocarlos/kibana/blob/main/src/platform/plugins/shared/metrics_experience/server/routes/fields/get_metric_fields.ts#L72).\n\nWhen the same field name appeared in multiple indices, the sorting logic\ndidn’t take the index name into account.\nAs a result, entries like:\n\n```json\n{ \"name\": \"a\", \"index\": \"index-a\" }\n{ \"name\": \"a\", \"index\": \"index-b\" }\n```\n\ncould sometimes be returned in a different order by the API:\n\n```json\n{ \"name\": \"a\", \"index\": \"index-b\" }\n{ \"name\": \"a\", \"index\": \"index-a\" }\n```\n\nThis caused the API response to be non-deterministic. Components\nconsuming this list detected changes even when no apparent field\ndifferences existed (since the UI displays the list sorted by field\nname), leading to unnecessary re-renders and downstream state updates.\n\nWhich leads to the second problem\n\n#### **2. Race condition when loading Lens props**\n\n\n[`useLensProps`](https://github.com/main/kibana/blob/main/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts#L42)\nrelies on observables to sync chart attribute updates with Discover’s\nstate updates.\n\nA few things were triggering the `useAsync` call **before** the\n`discoverFetch# Backport

This will backport the following commits from `main` to `9.2`:
{{{{raw}}}} - [[Metrics][Discover] Grid using date picker stale state fix (#239849)](https://github.com/elastic/kibana/pull/239849){{{{/raw}}}}
