### PR TITLE
[Controls Anywhere] Fix reordering controls on delete

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
@@ -303,8 +303,10 @@ export function initializeLayoutManager(
       // Recompute the order of the remaining controls
       const nextControls: typeof controls = Object.entries(controls)
         .sort(([, a], [, b]) => a.order - b.order)
-        .map(([key, value], i) => [key, { ...value, order: i }])
-        .reduce((result, [key, value]) => ({ ...result, [key as string]: value }), {});
+        .reduce(
+          (result, [key, value], i) => ({ ...result, [key as string]: { ...value, order: i } }),
+          {}
+        );
       layout$.next({ ...layout$.value, controls: nextControls });
     }
 

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
@@ -300,7 +300,12 @@ export function initializeLayoutManager(
       layout$.next({ ...layout$.value, panels });
     } else if (controls[uuid]) {
       delete controls[uuid];
-      layout$.next({ ...layout$.value, controls });
+      // Recompute the order of the remaining controls
+      const nextControls: typeof controls = Object.entries(controls)
+        .sort(([, a], [, b]) => a.order - b.order)
+        .map(([key, value], i) => [key, { ...value, order: i }])
+        .reduce((result, [key, value]) => ({ ...result, [key as string]: value }), {});
+      layout$.next({ ...layout$.value, controls: nextControls });
     }
 
     const children = { ...children$.value };


### PR DESCRIPTION
## Summary

Prevents a Kibana-crashing runtime error that can occur when deleting multiple controls.

From `control_display_settings_popover.tsx`:

```ts
 const isToRightOfGrowControl = useMemo(
    () => layoutEntry.order > 0 && Object.values(layoutState.controls)[layoutEntry.order - 1].grow,
    [layoutEntry.order, layoutState.controls]
  );
```

This can lead to a situation where `layoutEntry.order - 1` might return undefined, and then throw a Kibana-crashing type error when `undefined.grow` didn't exist.

This is because when you delete controls, the remaining controls' order property doesn't get updated. So we could get into a situation where there are 3 controls, one of them has an order of 2, and if we delete controls 0 and 1, the sole existing control still has order: 2. It then tries to look up control at index 1, gets undefined, and errors out.

This PR recomputes control order when a control is deleted, preventing this error and any future situations that might arise from trying to look up controls based on their `order`

