### PR TITLE
[Agent Builder] [Flyout] allow to provide flyout configuration async

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/mocks.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/mocks.ts
@@ -15,6 +15,8 @@ const createSetupContractMock = (): jest.Mocked<OnechatPluginSetup> => {
 const createStartContractMock = (): jest.Mocked<OnechatPluginStart> => {
   return {
     tools: {} as any,
+    setConversationFlyoutActiveConfig: jest.fn(),
+    clearConversationFlyoutActiveConfig: jest.fn(),
     openConversationFlyout: jest
       .fn()
       .mockImplementation((options: OpenConversationFlyoutOptions) => {

--- a/x-pack/platform/plugins/shared/onechat/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/plugin.tsx
@@ -35,6 +35,7 @@ import type {
   OnechatStartDependencies,
 } from './types';
 import { openConversationFlyout } from './flyout/open_conversation_flyout';
+import type { EmbeddableConversationProps } from './embeddable/types';
 
 export class OnechatPlugin
   implements
@@ -46,6 +47,7 @@ export class OnechatPlugin
     >
 {
   logger: Logger;
+  private conversationFlyoutActiveConfig: EmbeddableConversationProps = {};
   private internalServices?: OnechatInternalService;
   private setupServices?: {
     navigationService: NavigationService;
@@ -130,11 +132,19 @@ export class OnechatPlugin
 
     return {
       tools: createPublicToolContract({ toolsService }),
-      openConversationFlyout: (options) =>
-        openConversationFlyout(options, {
+      setConversationFlyoutActiveConfig: (config: EmbeddableConversationProps) => {
+        this.conversationFlyoutActiveConfig = config;
+      },
+      clearConversationFlyoutActiveConfig: () => {
+        this.conversationFlyoutActiveConfig = {};
+      },
+      openConversationFlyout: (options) => {
+        const config = options ?? this.conversationFlyoutActiveConfig;
+        return openConversationFlyout(config, {
           coreStart: core,
           services: internalServices,
-        }),
+        });
+      },
     };
   }
 }

--- a/x-pack/platform/plugins/shared/onechat/public/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/types.ts
@@ -18,6 +18,7 @@ import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { InferencePublicStart } from '@kbn/inference-plugin/public';
 import type { UiActionsSetup, UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { LicenseManagementUIPluginSetup } from '@kbn/license-management-plugin/public';
+import type { EmbeddableConversationProps } from './embeddable/types';
 import type { OpenConversationFlyoutOptions } from './flyout/types';
 
 export interface ConversationFlyoutRef {

--- a/x-pack/platform/plugins/shared/onechat/public/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/types.ts
@@ -78,5 +78,7 @@ export interface OnechatPluginStart {
    * flyoutRef.close();
    * ```
    */
-  openConversationFlyout: (options: OpenConversationFlyoutOptions) => OpenConversationFlyoutReturn;
+  openConversationFlyout: (options?: OpenConversationFlyoutOptions) => OpenConversationFlyoutReturn;
+  setConversationFlyoutActiveConfig: (config: EmbeddableConversationProps) => void;
+  clearConversationFlyoutActiveConfig: () => void;
 }


### PR DESCRIPTION
## Summary

Allows to pass flyout configuration on application load/ before user actually clicks the button.

This will enable us to add a global button to the top bar, which applications can still control.

example flow:
1. applications should call:
`onechat.setConversationFlyoutActiveConfig({ agentId: 'dashboard' })`

2. user can now click top bar button, which will call:
`onechat.openConversationFlyout()`

3. application MUST call the following when unmounting:
`onechat.clearConversationFlyoutActiveConfig()`
