### PR TITLE
[Security Solution] remove protectionUpdatesEnabled feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -76,11 +76,6 @@ export const allowedExperimentalValues = Object.freeze({
   esqlRulesDisabled: false,
 
   /**
-   * Enables Protection Updates tab in the Endpoint Policy Details page
-   */
-  protectionUpdatesEnabled: true,
-
-  /**
    * Enables experimental Microsoft Defender for Endpoint integration data to be available in Analyzer
    */
   microsoftDefenderEndpointDataInAnalyzerEnabled: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/index.tsx
@@ -7,32 +7,28 @@
 
 import React, { memo } from 'react';
 import { Redirect } from 'react-router-dom';
-import { Routes, Route } from '@kbn/shared-ux-router';
+import { Route, Routes } from '@kbn/shared-ux-router';
 
 import { useLicense } from '../../../common/hooks/use_license';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { PolicyDetails, PolicyList } from './view';
 import {
-  MANAGEMENT_ROUTING_POLICY_DETAILS_FORM_PATH,
-  MANAGEMENT_ROUTING_POLICY_DETAILS_TRUSTED_APPS_PATH,
-  MANAGEMENT_ROUTING_POLICY_DETAILS_EVENT_FILTERS_PATH,
-  MANAGEMENT_ROUTING_POLICY_DETAILS_PATH_OLD,
-  MANAGEMENT_ROUTING_POLICY_DETAILS_HOST_ISOLATION_EXCEPTIONS_PATH,
   MANAGEMENT_ROUTING_POLICIES_PATH,
   MANAGEMENT_ROUTING_POLICY_DETAILS_BLOCKLISTS_PATH,
+  MANAGEMENT_ROUTING_POLICY_DETAILS_EVENT_FILTERS_PATH,
+  MANAGEMENT_ROUTING_POLICY_DETAILS_FORM_PATH,
+  MANAGEMENT_ROUTING_POLICY_DETAILS_HOST_ISOLATION_EXCEPTIONS_PATH,
+  MANAGEMENT_ROUTING_POLICY_DETAILS_PATH_OLD,
   MANAGEMENT_ROUTING_POLICY_DETAILS_PROTECTION_UPDATES_PATH,
+  MANAGEMENT_ROUTING_POLICY_DETAILS_TRUSTED_APPS_PATH,
   MANAGEMENT_ROUTING_POLICY_DETAILS_TRUSTED_DEVICES_PATH,
 } from '../../common/constants';
 import { NotFoundPage } from '../../../app/404';
 import { getPolicyDetailPath } from '../../common/routing';
 
 export const PolicyContainer = memo(() => {
-  const isProtectionUpdatesFeatureEnabled = useIsExperimentalFeatureEnabled(
-    'protectionUpdatesEnabled'
-  );
   const isTrustedDevicesFeatureEnabled = useIsExperimentalFeatureEnabled('trustedDevices');
   const isEnterprise = useLicense().isEnterprise();
-  const isProtectionUpdatesEnabled = isEnterprise && isProtectionUpdatesFeatureEnabled;
 
   return (
     <Routes>
@@ -46,9 +42,7 @@ export const PolicyContainer = memo(() => {
           MANAGEMENT_ROUTING_POLICY_DETAILS_EVENT_FILTERS_PATH,
           MANAGEMENT_ROUTING_POLICY_DETAILS_HOST_ISOLATION_EXCEPTIONS_PATH,
           MANAGEMENT_ROUTING_POLICY_DETAILS_BLOCKLISTS_PATH,
-          ...(isProtectionUpdatesEnabled
-            ? [MANAGEMENT_ROUTING_POLICY_DETAILS_PROTECTION_UPDATES_PATH]
-            : []),
+          ...(isEnterprise ? [MANAGEMENT_ROUTING_POLICY_DETAILS_PROTECTION_UPDATES_PATH] : []),
         ]}
         exact
         component={PolicyDetails}

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/tabs/policy_tabs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/tabs/policy_tabs.tsx
@@ -19,32 +19,32 @@ import { ProtectionUpdatesLayout } from '../protection_updates/protection_update
 import { PolicySettingsLayout } from '../policy_settings_layout';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
 import {
-  getPolicyDetailPath,
-  getPolicyEventFiltersPath,
-  getPolicyHostIsolationExceptionsPath,
-  getPolicyTrustedAppsPath,
+  getBlocklistsListPath,
   getEventFiltersListPath,
   getHostIsolationExceptionsListPath,
-  getTrustedAppsListPath,
-  getPolicyDetailsArtifactsListPath,
-  getBlocklistsListPath,
   getPolicyBlocklistsPath,
+  getPolicyDetailPath,
+  getPolicyDetailsArtifactsListPath,
+  getPolicyEventFiltersPath,
+  getPolicyHostIsolationExceptionsPath,
   getPolicyProtectionUpdatesPath,
-  getTrustedDevicesListPath,
+  getPolicyTrustedAppsPath,
   getPolicyTrustedDevicesPath,
+  getTrustedAppsListPath,
+  getTrustedDevicesListPath,
 } from '../../../../common/routing';
 import { useHttp, useToasts } from '../../../../../common/lib/kibana';
 import { ManagementPageLoader } from '../../../../components/management_page_loader';
 import {
+  isOnBlocklistsView,
   isOnHostIsolationExceptionsView,
   isOnPolicyEventFiltersView,
   isOnPolicyFormView,
   isOnPolicyTrustedAppsView,
-  isOnBlocklistsView,
+  isOnPolicyTrustedDevicesView,
+  isOnProtectionUpdatesView,
   policyDetails,
   policyIdFromParams,
-  isOnProtectionUpdatesView,
-  isOnPolicyTrustedDevicesView,
 } from '../../store/policy_details/selectors';
 import { PolicyArtifactsLayout } from '../artifacts/layout/policy_artifacts_layout';
 import { usePolicyDetailsSelector } from '../policy_hooks';
@@ -138,13 +138,9 @@ export const PolicyTabs = React.memo(() => {
   } = useUserPrivileges().endpointPrivileges;
   const { state: routeState = {} } = useLocation<PolicyDetailsRouteState>();
 
-  const isProtectionUpdatesFeatureEnabled = useIsExperimentalFeatureEnabled(
-    'protectionUpdatesEnabled'
-  );
   const isTrustedDevicesFeatureEnabled = useIsExperimentalFeatureEnabled('trustedDevices');
 
   const isEnterprise = useLicense().isEnterprise();
-  const isProtectionUpdatesEnabled = isEnterprise && isProtectionUpdatesFeatureEnabled;
   const isTrustedDevicesEnabled =
     isEnterprise && isTrustedDevicesFeatureEnabled && canReadTrustedDevices;
 
@@ -429,7 +425,7 @@ export const PolicyTabs = React.memo(() => {
           }
         : undefined,
 
-      [PolicyTabKeys.PROTECTION_UPDATES]: isProtectionUpdatesEnabled
+      [PolicyTabKeys.PROTECTION_UPDATES]: isEnterprise
         ? {
             id: PolicyTabKeys.PROTECTION_UPDATES,
             name: i18n.translate(
@@ -469,7 +465,7 @@ export const PolicyTabs = React.memo(() => {
     canReadBlocklist,
     getBlocklistsApiClientInstance,
     canWriteBlocklist,
-    isProtectionUpdatesEnabled,
+    isEnterprise,
   ]);
 
   // convert tabs object into an array EuiTabbedContent can understand

--- a/x-pack/solutions/security/plugins/security_solution/public/management/services/policies/hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/services/policies/hooks.ts
@@ -7,7 +7,7 @@
 import type { QueryObserverResult, UseQueryOptions } from '@kbn/react-query';
 import { useQuery } from '@kbn/react-query';
 import type { IHttpFetchError } from '@kbn/core-http-browser';
-import { type GetInfoResponse, type BulkGetAgentPoliciesResponse } from '@kbn/fleet-plugin/common';
+import { type BulkGetAgentPoliciesResponse, type GetInfoResponse } from '@kbn/fleet-plugin/common';
 import { firstValueFrom } from 'rxjs';
 import type { IKibanaSearchResponse } from '@kbn/search-types';
 import { ENDPOINT_PACKAGE_POLICIES_STATS_STRATEGY } from '../../../../common/endpoint/constants';
@@ -52,7 +52,7 @@ export function useGetEndpointSpecificPolicies(
   );
 }
 
-export function useEndpointPackagePoliciesStats(enabled: boolean) {
+export function useEndpointPackagePoliciesStats() {
   const { data } = useKibana().services;
   return useQuery(
     ['endpointPackagePoliciesStatsStrategy'],
@@ -64,7 +64,7 @@ export function useEndpointPackagePoliciesStats(enabled: boolean) {
         )
       );
     },
-    { select: (response) => response.rawResponse, enabled }
+    { select: (response) => response.rawResponse, enabled: true }
   );
 }
 


### PR DESCRIPTION
## Summary

This PR removes the `protectionUpdatesEnabled` feature flag and its related code. This flag was enabled in 2023.

**_As I'm unfamiliar with what this feature flag does, let me know if we actually do want to keep this code in._**

> [!IMPORTANT]
> As the feature flag has been enabled for over 2 years, no UI or behavior changes should be introduced by this PR!

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
