### PR TITLE
[Security Solution] remove valueListItemsModalEnabled feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -86,11 +86,6 @@ export const allowedExperimentalValues = Object.freeze({
   microsoftDefenderEndpointDataInAnalyzerEnabled: true,
 
   /**
-   * Enables the new modal for the value list items
-   */
-  valueListItemsModalEnabled: true,
-
-  /**
    * Enables the storing of gaps in the event log
    */
   storeGapsInEventLogEnabled: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/value_list/components/show_value_list_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/value_list/components/show_value_list_modal.tsx
@@ -6,9 +6,8 @@
  */
 
 import { EuiLink } from '@elastic/eui';
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useListsPrivileges } from '../../detections/containers/detection_engine/lists/use_lists_privileges';
-import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { ValueListModal } from './value_list_modal';
 import { METRIC_TYPE, TELEMETRY_EVENT, track } from '../../common/lib/telemetry';
 
@@ -23,9 +22,6 @@ export const ShowValueListModal = ({
 }) => {
   const [showModal, setShowModal] = useState(false);
   const { canWriteIndex, canReadIndex, loading } = useListsPrivileges();
-  const isValueItemsListModalEnabled = useIsExperimentalFeatureEnabled(
-    'valueListItemsModalEnabled'
-  );
 
   const onCloseModal = useCallback(() => setShowModal(false), []);
   const onShowModal = useCallback(() => {
@@ -35,7 +31,7 @@ export const ShowValueListModal = ({
 
   if (loading) return null;
 
-  if (!canReadIndex || !isValueItemsListModalEnabled) {
+  if (!canReadIndex) {
     return shouldShowContentIfModalNotAvailable ? <>{children}</> : null;
   }
 


### PR DESCRIPTION
## Summary

This PR removes the `valueListItemsModalEnabled` feature flag and its related code. This flag was enabled in early 2024.

**_As I'm unfamiliar with what this feature flag does, let me know if we actually do want to keep this code in._**

> [!IMPORTANT]
> As the feature flag has been enabled for nearly 2 years, no UI or behavior changes should be introduced by this PR!

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
