### PR TITLE
[8.19] [APM] Hide non-trace services in service map (#240104)

### DIFF
--- a/x-pack/solutions/observability/test/apm_api_integration/tests/service_maps/service_maps.spec.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/service_maps/service_maps.spec.ts
@@ -91,7 +91,6 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
         ).sort();
         expectSnapshot(serviceNames).toMatchInline(`
               Array [
-                "auditbeat",
                 "opbeans-dotnet",
                 "opbeans-go",
                 "opbeans-java",

--- a/x-pack/solutions/observability/test/apm_api_integration/tests/service_maps/service_maps.spec.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/service_maps/service_maps.spec.ts
@@ -82,14 +82,25 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
         expect(getElements(response).length).to.be.greaterThan(0);
       });
 
-      it('returns serviceNames equal empty array if services have no traces', () => {
+      it('returns the correct data', () => {
         const elements: Array<{ data: Record<string, any> }> = getElements(response);
         const serviceNames = uniq(
           elements
             .filter((element) => element.data['service.name'] !== undefined)
             .map((element) => element.data['service.name'])
         ).sort();
-        expect(serviceNames.length).to.be.equal(0);
+        expectSnapshot(serviceNames).toMatchInline(`
+              Array [
+                "auditbeat",
+                "opbeans-dotnet",
+                "opbeans-go",
+                "opbeans-java",
+                "opbeans-node",
+                "opbeans-python",
+                "opbeans-ruby",
+                "opbeans-rum",
+              ]
+            `);
 
         const externalDestinations = uniq(
           elements

--- a/x-pack/solutions/observability/test/apm_api_integration/tests/service_maps/service_maps.spec.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/service_maps/service_maps.spec.ts
@@ -82,25 +82,14 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
         expect(getElements(response).length).to.be.greaterThan(0);
       });
 
-      it('returns the correct data', () => {
+      it('returns serviceNames equal empty array if services have no traces', () => {
         const elements: Array<{ data: Record<string, any> }> = getElements(response);
         const serviceNames = uniq(
           elements
             .filter((element) => element.data['service.name'] !== undefined)
             .map((element) => element.data['service.name'])
         ).sort();
-        expectSnapshot(serviceNames).toMatchInline(`
-              Array [
-                "auditbeat",
-                "opbeans-dotnet",
-                "opbeans-go",
-                "opbeans-java",
-                "opbeans-node",
-                "opbeans-python",
-                "opbeans-ruby",
-                "opbeans-rum",
-              ]
-            `);
+        expect(serviceNames.length).to.be.equal(0);
 
         const externalDestinations = uniq(
           elements


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM] Hide non-trace services in service map (#240104)](https://github.com/elastic/kibana/pull/240104)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-10-28T19:50:58Z","message":"[APM] Hide non-trace services in service map (#240104)\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b713d606db4bb72eb4d4357215ef6aab53ab96b3","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","apm:service-maps","ci:project-deploy-observability","Team:obs-ux-infra_services","backport:version","v9.2.0","v9.3.0","v9.1.6","v8.19.6","v9.2.1"],"title":"[APM] Hide non-trace services in service map","number":240104,"url":"https://github.com/elastic/kibana/pull/240104","mergeCommit":{"message":"[APM] Hide non-trace services in service map (#240104)\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b713d606db4bb72eb4d4357215ef6aab53ab96b3"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241032","number":241032,"state":"MERGED","mergeCommit":{"sha":"eb5ed9961b1dbdb872749753112c76fe4cf18381","message":"[9.2] [APM] Hide non-trace services in service map (#240104) (#241032)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[APM] Hide non-trace services in service map\n(#240104)](https://github.com/elastic/kibana/pull/240104)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/240104","number":240104,"mergeCommit":{"message":"[APM] Hide non-trace services in service map (#240104)\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b713d606db4bb72eb4d4357215ef6aab53ab96b3"}},{"branch":"9.1","label":"v9.1.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->