### PR TITLE
[9.1][Fleet] Show prerelease upgrade versions in Install integrations UI (#240317)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -113,7 +113,9 @@ export const EPMHomePage: React.FC = () => {
       <Route path={INTEGRATIONS_ROUTING_PATHS.integrations_installed}>
         <DefaultLayout section="manage" notificationsBySection={notificationsBySection}>
           {installedIntegrationsTabularUI ? (
-            <InstalledIntegrationsPage />
+            <InstalledIntegrationsPage
+              prereleaseIntegrationsEnabled={prereleaseIntegrationsEnabled}
+            />
           ) : (
             <InstalledPackages installedPackages={installedPackages} isLoading={isLoading} />
           )}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/hooks/use_installed_integrations.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/hooks/use_installed_integrations.tsx
@@ -53,10 +53,12 @@ export function useInstalledIntegrations(
   filters: InstalledIntegrationsFilter,
   pagination: Pagination,
   upgradingIntegrations?: InstalledPackageUIPackageListItem[],
-  uninstallingIntegrations?: InstalledPackageUIPackageListItem[]
+  uninstallingIntegrations?: InstalledPackageUIPackageListItem[],
+  prereleaseIntegrationsEnabled?: boolean
 ) {
   const { data, isInitialLoading, isLoading } = useGetPackagesQuery({
     withPackagePoliciesCount: true,
+    prerelease: prereleaseIntegrationsEnabled,
   });
 
   const internalInstalledPackages: InstalledPackageUIPackageListItem[] = useMemo(

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/index.tsx
@@ -21,7 +21,9 @@ import { useInstalledIntegrationsActions } from './hooks/use_installed_integrati
 import { BulkActionContextProvider } from './hooks/use_bulk_actions_context';
 import { PackagePoliciesPanel } from './components/package_policies_panel';
 
-const InstalledIntegrationsPageContent: React.FunctionComponent = () => {
+const InstalledIntegrationsPageContent: React.FunctionComponent<{
+  prereleaseIntegrationsEnabled: boolean;
+}> = ({ prereleaseIntegrationsEnabled }) => {
   // State management
   const filters = useUrlFilters();
   const { selectedPackageViewPolicies } = useViewPolicies();
@@ -38,7 +40,8 @@ const InstalledIntegrationsPageContent: React.FunctionComponent = () => {
     filters,
     pagination.pagination,
     upgradingIntegrations,
-    uninstallingIntegrations
+    uninstallingIntegrations,
+    prereleaseIntegrationsEnabled
   );
 
   const [selectedItems, setSelectedItems] = useState<InstalledPackageUIPackageListItem[]>([]);
@@ -85,10 +88,14 @@ const InstalledIntegrationsPageContent: React.FunctionComponent = () => {
   );
 };
 
-export const InstalledIntegrationsPage: React.FunctionComponent = () => {
+export const InstalledIntegrationsPage: React.FunctionComponent<{
+  prereleaseIntegrationsEnabled: boolean;
+}> = ({ prereleaseIntegrationsEnabled }) => {
   return (
     <BulkActionContextProvider>
-      <InstalledIntegrationsPageContent />
+      <InstalledIntegrationsPageContent
+        prereleaseIntegrationsEnabled={prereleaseIntegrationsEnabled}
+      />
     </BulkActionContextProvider>
   );
 };


### PR DESCRIPTION
Backport https://github.com/elastic/kibana/pull/240317 to 9.1

