### PR TITLE
[9.2] [EDR Workflows][Device Control] Add suggestions support (#238265)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/suggestions/get_suggestions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/suggestions/get_suggestions.ts
@@ -20,6 +20,7 @@ export const EndpointSuggestionsSchema = {
       schema.literal('eventFilters'),
       schema.literal('endpoints'),
       schema.literal('trustedApps'),
+      schema.literal('trustedDevices'),
     ]),
   }),
 };

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/constants.ts
@@ -19,6 +19,7 @@ export const ENDPOINT_ACTION_RESPONSES_INDEX_PATTERN = `${ENDPOINT_ACTION_RESPON
 
 export const eventsIndexPattern = 'logs-endpoint.events.*';
 export const FILE_EVENTS_INDEX_PATTERN = 'logs-endpoint.events.file-*';
+export const DEVICE_EVENTS_INDEX_PATTERN = 'logs-endpoint.events.device-*';
 export const alertsIndexPattern = 'logs-endpoint.alerts-*';
 
 // metadata datastream

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/index_device_events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/index_device_events.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import { usageTracker } from './usage_tracker';
+import type { EndpointDocGenerator, Event, TreeOptions } from '../generate_data';
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export const indexDeviceEvents = usageTracker.track(
+  'indexDeviceEvents',
+  async ({
+    client,
+    deviceIndex,
+    generator,
+    numDeviceEvents,
+    options = {},
+  }: {
+    client: Client;
+    deviceIndex: string;
+    generator: EndpointDocGenerator;
+    numDeviceEvents: number;
+    options: TreeOptions;
+  }) => {
+    const deviceEventsGenerator = generator.deviceEventsGenerator(
+      numDeviceEvents,
+      options.eventsDataStream
+    );
+
+    let result = deviceEventsGenerator.next();
+    const deviceEventDocs: Event[] = [];
+
+    while (!result.done) {
+      deviceEventDocs.push(result.value);
+      result = deviceEventsGenerator.next();
+    }
+
+    if (deviceEventDocs.length > 0) {
+      const body = deviceEventDocs.flatMap((doc) => [{ create: { _index: deviceIndex } }, doc]);
+
+      await client.bulk({ body, refresh: 'wait_for' });
+    }
+
+    await client.indices.refresh({
+      index: deviceIndex,
+    });
+
+    await delay(5000);
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/generate_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/generate_data.test.ts
@@ -164,6 +164,57 @@ describe('data generator', () => {
     expect(processEvent.process?.name).not.toBeNull();
   });
 
+  it('creates device event documents', () => {
+    const deviceEvents = [...generator.deviceEventsGenerator(1)];
+    expect(deviceEvents.length).toEqual(1);
+
+    const deviceEvent = deviceEvents[0];
+    expect(deviceEvent['@timestamp']).not.toBeNull();
+    expect(deviceEvent.event?.category).toEqual(['host']);
+    expect(deviceEvent.event?.kind).toEqual('event');
+    expect(deviceEvent.event?.type).toEqual(['denied', 'device']);
+    expect(deviceEvent.agent).not.toBeNull();
+    expect(deviceEvent.host).not.toBeNull();
+    expect(deviceEvent.device?.serial_number).not.toBeNull();
+    expect(deviceEvent.device?.vendor?.id).not.toBeNull();
+    expect(deviceEvent.device?.vendor?.name).not.toBeNull();
+    expect(deviceEvent.device?.product?.id).not.toBeNull();
+    expect(deviceEvent.device?.product?.name).not.toBeNull();
+    expect(deviceEvent.device?.type).not.toBeNull();
+  });
+
+  it('creates multiple device events via generator', () => {
+    const numEvents = 5;
+    const deviceEvents = [...generator.deviceEventsGenerator(numEvents)];
+    expect(deviceEvents.length).toEqual(numEvents);
+
+    deviceEvents.forEach((event) => {
+      expect(event.event?.category).toEqual(['host']);
+      expect(event.event?.kind).toEqual('event');
+      expect(event.event?.type).toEqual(['denied', 'device']);
+      expect(event.device?.serial_number).not.toBeNull();
+      expect(event.device?.vendor?.id).not.toBeNull();
+      expect(event.device?.product?.id).not.toBeNull();
+    });
+
+    // Verify each event has unique serial numbers (randomness)
+    const serialNumbers = deviceEvents.map((event) => event.device?.serial_number);
+    const uniqueSerialNumbers = new Set(serialNumbers);
+    expect(uniqueSerialNumbers.size).toBeGreaterThan(1);
+  });
+
+  it('creates device events with custom data stream', () => {
+    const customDataStream = { type: 'custom', dataset: 'custom.device', namespace: 'test' };
+    const deviceEvents = [...generator.deviceEventsGenerator(3, customDataStream)];
+
+    deviceEvents.forEach((event) => {
+      expect(event.data_stream).toEqual({
+        ...customDataStream,
+        dataset: 'endpoint.events.device',
+      });
+    });
+  });
+
   describe('creates events with an empty ancestry array', () => {
     let tree: Tree;
     beforeEach(() => {

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/index_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/index_data.ts
@@ -23,6 +23,7 @@ import {
 } from './data_loaders/index_endpoint_hosts';
 import { enableFleetServerIfNecessary } from './data_loaders/index_fleet_server';
 import { indexAlerts } from './data_loaders/index_alerts';
+import { indexDeviceEvents } from './data_loaders/index_device_events';
 import { setupFleetForEndpoint } from './data_loaders/setup_fleet_for_endpoint';
 import { createToolingLogger, mergeAndAppendArrays } from './data_loaders/utils';
 import {
@@ -67,6 +68,7 @@ export const indexHostsAndAlerts = usageTracker.track(
     policyResponseIndex: string,
     eventIndex: string,
     alertIndex: string,
+    deviceIndex: string,
     alertsPerHost: number,
     fleet: boolean,
     options: TreeOptions = {},
@@ -142,6 +144,16 @@ export const indexHostsAndAlerts = usageTracker.track(
           alertIndex,
           generator,
           numAlerts: alertsPerHost,
+          options,
+        });
+      }
+
+      if (options.deviceEvents && options.deviceEvents > 0) {
+        await indexDeviceEvents({
+          client,
+          deviceIndex,
+          generator,
+          numDeviceEvents: options.deviceEvents,
           options,
         });
       }

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/index.ts
@@ -816,6 +816,18 @@ export type SafeEndpointEvent = Partial<{
   }>;
   file: Partial<{ path: ECSField<string> }>;
   registry: Partial<{ path: ECSField<string>; key: ECSField<string> }>;
+  device: Partial<{
+    serial_number: ECSField<string>;
+    vendor: Partial<{
+      name: ECSField<string>;
+      id: ECSField<string>;
+    }>;
+    product: Partial<{
+      name: ECSField<string>;
+      id: ECSField<string>;
+    }>;
+    type: ECSField<string>;
+  }>;
 }>;
 
 export interface SafeLegacyEndpointEvent {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/support/plugin_handlers/endpoint_data_loader.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/support/plugin_handlers/endpoint_data_loader.ts
@@ -20,6 +20,7 @@ import { STARTED_TRANSFORM_STATES } from '../../../../../common/constants';
 import {
   ENDPOINT_ALERTS_INDEX,
   ENDPOINT_EVENTS_INDEX,
+  ENDPOINT_DEVICE_INDEX,
 } from '../../../../../scripts/endpoint/common/constants';
 import {
   METADATA_DATASTREAM,
@@ -120,6 +121,7 @@ export const cyLoadEndpointDataHandler = async (
     POLICY_RESPONSE_INDEX,
     ENDPOINT_EVENTS_INDEX,
     ENDPOINT_ALERTS_INDEX,
+    ENDPOINT_DEVICE_INDEX,
     alertsPerHost,
     enableFleetIntegration,
     undefined,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/artifacts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/artifacts.ts
@@ -257,8 +257,13 @@ export const trustedDevicesFormSelectors = {
   },
 
   fillValue: (value: string) => {
-    cy.getByTestSubj('trustedDevices-form-valueField').clear();
-    cy.getByTestSubj('trustedDevices-form-valueField').type(value);
+    cy.getByTestSubj('trustedDevices-form-valueField').within(() => {
+      cy.get('input[role="combobox"]').click();
+      cy.get('input[role="combobox"]').should('be.focused');
+      cy.get('input[role="combobox"]').type(`{selectall}{backspace}`);
+      cy.get('input[role="combobox"]').should('have.value', '');
+      cy.get('input[role="combobox"]').type(`${value}{enter}`);
+    });
   },
 
   fillOutTrustedDevicesFlyout: (name = 'Test Trusted Device', description = 'Test Description') => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/perform_user_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/perform_user_actions.ts
@@ -31,8 +31,27 @@ const performAction = (action: FormAction) => {
   if (action.type === 'click') {
     element.click();
   } else if (action.type === 'input') {
-    element.type(action.value || '');
+    // Check if this is a combobox field - if so, interact with the input inside it
+    element.then(($el) => {
+      const comboboxInput = $el.find('input[role="combobox"]');
+      if (comboboxInput.length > 0) {
+        cy.wrap(comboboxInput).click();
+        cy.wrap(comboboxInput).type(`{selectall}{backspace}`);
+        cy.wrap(comboboxInput).type(`${action.value || ''}{enter}`);
+      } else {
+        element.type(action.value || '');
+      }
+    });
   } else if (action.type === 'clear') {
-    element.clear();
+    // Check if this is a combobox field - if so, clear the input inside it
+    element.then(($el) => {
+      const comboboxInput = $el.find('input[role="combobox"]');
+      if (comboboxInput.length > 0) {
+        cy.wrap(comboboxInput).click();
+        cy.wrap(comboboxInput).type('{selectall}{backspace}');
+      } else {
+        element.clear();
+      }
+    });
   }
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactQueryHookRenderer } from '../../../../common/mock/endpoint';
+import { createAppRootMockRenderer } from '../../../../common/mock/endpoint';
+import { useQuery as _useQuery } from '@kbn/react-query';
+import { useGetTrustedDeviceSuggestions } from './use_get_trusted_device_suggestions';
+import { TrustedDevicesApiClient } from '../service/api_client';
+
+jest.mock('@kbn/react-query', () => {
+  const actualReactQueryModule = jest.requireActual('@kbn/react-query');
+  return {
+    ...actualReactQueryModule,
+    useQuery: jest.fn((...args) => actualReactQueryModule.useQuery(...args)),
+  };
+});
+
+jest.mock('../service/api_client');
+
+const useQueryMock = _useQuery as jest.Mock;
+
+describe('useGetTrustedDeviceSuggestions', () => {
+  let renderReactQueryHook: ReactQueryHookRenderer<
+    Parameters<typeof useGetTrustedDeviceSuggestions>,
+    ReturnType<typeof useGetTrustedDeviceSuggestions>
+  >;
+  let apiClientMock: jest.Mocked<TrustedDevicesApiClient>;
+
+  beforeEach(() => {
+    const testContext = createAppRootMockRenderer();
+
+    renderReactQueryHook = testContext.renderReactQueryHook as typeof renderReactQueryHook;
+
+    apiClientMock = {
+      getSuggestions: jest.fn(),
+    } as unknown as jest.Mocked<TrustedDevicesApiClient>;
+
+    (TrustedDevicesApiClient as unknown as jest.Mock).mockImplementation(() => apiClientMock);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call useQuery with correct parameters', async () => {
+    const field = 'device.serial_number';
+    const query = 'test';
+
+    apiClientMock.getSuggestions.mockResolvedValue([]);
+
+    await renderReactQueryHook(() =>
+      useGetTrustedDeviceSuggestions({
+        field,
+        query,
+        enabled: true,
+      })
+    );
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['trustedDevices', 'suggestions', field, query],
+        enabled: true,
+      })
+    );
+  });
+
+  it('should be disabled when field is empty', async () => {
+    apiClientMock.getSuggestions.mockResolvedValue([]);
+
+    await renderReactQueryHook(
+      () =>
+        useGetTrustedDeviceSuggestions({
+          field: '',
+          enabled: true,
+        }),
+      false
+    );
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+      })
+    );
+  });
+
+  it('should be disabled when enabled is false', async () => {
+    apiClientMock.getSuggestions.mockResolvedValue([]);
+
+    await renderReactQueryHook(
+      () =>
+        useGetTrustedDeviceSuggestions({
+          field: 'device.serial_number',
+          enabled: false,
+        }),
+      false
+    );
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+      })
+    );
+  });
+
+  it('should use empty string as default query', async () => {
+    const field = 'device.vendor.id';
+
+    apiClientMock.getSuggestions.mockResolvedValue([]);
+
+    await renderReactQueryHook(() =>
+      useGetTrustedDeviceSuggestions({
+        field,
+      })
+    );
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['trustedDevices', 'suggestions', field, ''],
+      })
+    );
+  });
+
+  it('should call API client with correct parameters when queryFn is executed', async () => {
+    const field = 'device.product.name';
+    const query = 'USB';
+    const mockSuggestions = ['USB Device 1', 'USB Device 2'];
+
+    apiClientMock.getSuggestions.mockResolvedValue(mockSuggestions);
+
+    const result = await renderReactQueryHook(() =>
+      useGetTrustedDeviceSuggestions({
+        field,
+        query,
+      })
+    );
+
+    expect(apiClientMock.getSuggestions).toHaveBeenCalledWith({
+      field,
+      query,
+    });
+    expect(result.data).toEqual(mockSuggestions);
+  });
+
+  it('should handle API errors gracefully', async () => {
+    const field = 'device.serial_number';
+    const error = new Error('API Error');
+
+    apiClientMock.getSuggestions.mockRejectedValue(error);
+
+    const result = await renderReactQueryHook(
+      () =>
+        useGetTrustedDeviceSuggestions({
+          field,
+        }),
+      'isError'
+    );
+
+    expect(result.error).toBeTruthy();
+  });
+
+  it('should update query key when field changes', async () => {
+    const initialField = 'device.serial_number';
+
+    apiClientMock.getSuggestions.mockResolvedValue([]);
+
+    await renderReactQueryHook(() => useGetTrustedDeviceSuggestions({ field: initialField }));
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['trustedDevices', 'suggestions', initialField, ''],
+      })
+    );
+
+    const updatedField = 'device.vendor.id';
+
+    await renderReactQueryHook(() => useGetTrustedDeviceSuggestions({ field: updatedField }));
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['trustedDevices', 'suggestions', updatedField, ''],
+      })
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.test.ts
@@ -7,7 +7,7 @@
 
 import type { ReactQueryHookRenderer } from '../../../../common/mock/endpoint';
 import { createAppRootMockRenderer } from '../../../../common/mock/endpoint';
-import { useQuery as _useQuery } from '@kbn/react-query';
+import { useQuery as _useQuery } from '@tanstack/react-query';
 import { useGetTrustedDeviceSuggestions } from './use_get_trusted_device_suggestions';
 import { TrustedDevicesApiClient } from '../service/api_client';
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.test.ts
@@ -11,8 +11,8 @@ import { useQuery as _useQuery } from '@tanstack/react-query';
 import { useGetTrustedDeviceSuggestions } from './use_get_trusted_device_suggestions';
 import { TrustedDevicesApiClient } from '../service/api_client';
 
-jest.mock('@kbn/react-query', () => {
-  const actualReactQueryModule = jest.requireActual('@kbn/react-query');
+jest.mock('@tanstack/react-query', () => {
+  const actualReactQueryModule = jest.requireActual('@tanstack/react-query');
   return {
     ...actualReactQueryModule,
     useQuery: jest.fn((...args) => actualReactQueryModule.useQuery(...args)),

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseQueryOptions, UseQueryResult } from '@kbn/react-query';
+import type { IHttpFetchError } from '@kbn/core-http-browser';
+import { useQuery } from '@kbn/react-query';
+import { useHttp } from '../../../../common/lib/kibana/hooks';
+import { TrustedDevicesApiClient } from '../service/api_client';
+
+export interface UseGetTrustedDeviceSuggestionsOptions {
+  field: string;
+  query?: string;
+  enabled?: boolean;
+}
+
+/**
+ * Hook to fetch autocomplete suggestions for trusted device fields
+ * Uses React Query to handle race conditions when field changes rapidly
+ */
+export const useGetTrustedDeviceSuggestions = (
+  { field, query = '', enabled = true }: UseGetTrustedDeviceSuggestionsOptions,
+  options: UseQueryOptions<string[], IHttpFetchError> = {}
+): UseQueryResult<string[], IHttpFetchError> => {
+  const http = useHttp();
+
+  return useQuery<string[], IHttpFetchError>({
+    queryKey: ['trustedDevices', 'suggestions', field, query],
+    ...options,
+    queryFn: async () => {
+      const apiClient = new TrustedDevicesApiClient(http);
+      return apiClient.getSuggestions({ field, query });
+    },
+    enabled: !!field && enabled,
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.ts
@@ -6,9 +6,10 @@
  */
 
 import type { IHttpFetchError } from '@kbn/core-http-browser';
+import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useHttp } from '../../../../common/lib/kibana/hooks';
 import { TrustedDevicesApiClient } from '../service/api_client';
-import { useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 
 export interface UseGetTrustedDeviceSuggestionsOptions {
   field: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/hooks/use_get_trusted_device_suggestions.ts
@@ -5,11 +5,10 @@
  * 2.0.
  */
 
-import type { UseQueryOptions, UseQueryResult } from '@kbn/react-query';
 import type { IHttpFetchError } from '@kbn/core-http-browser';
-import { useQuery } from '@kbn/react-query';
 import { useHttp } from '../../../../common/lib/kibana/hooks';
 import { TrustedDevicesApiClient } from '../service/api_client';
+import { useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 
 export interface UseGetTrustedDeviceSuggestionsOptions {
   field: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/service/api_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/service/api_client.ts
@@ -7,6 +7,9 @@
 
 import type { HttpStart } from '@kbn/core/public';
 import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
+import type { EndpointSuggestionsBody } from '../../../../../common/api/endpoint';
+import { SUGGESTIONS_INTERNAL_ROUTE } from '../../../../../common/endpoint/constants';
+import { resolvePathVariables } from '../../../../common/utils/resolve_path_variables';
 import { ExceptionsListApiClient } from '../../../services/exceptions_list/exceptions_list_api_client';
 import { TRUSTED_DEVICES_EXCEPTION_LIST_DEFINITION } from '../constants';
 import { readTransform, writeTransform } from './transforms';
@@ -35,5 +38,20 @@ export class TrustedDevicesApiClient extends ExceptionsListApiClient {
       readTransform,
       writeTransform
     );
+  }
+
+  /**
+   * Returns suggestions for given field
+   */
+  async getSuggestions(body: EndpointSuggestionsBody): Promise<string[]> {
+    const result: string[] = await this.getHttp().post(
+      resolvePathVariables(SUGGESTIONS_INTERNAL_ROUTE, { suggestion_type: 'trustedDevices' }),
+      {
+        version: '1',
+        body: JSON.stringify(body),
+      }
+    );
+
+    return result;
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/view/components/form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/view/components/form.tsx
@@ -35,6 +35,7 @@ import type { ArtifactFormComponentProps } from '../../../../components/artifact
 import { FormattedError } from '../../../../components/formatted_error';
 import { useTestIdGenerator } from '../../../../hooks/use_test_id_generator';
 import { useCanAssignArtifactPerPolicy } from '../../../../hooks/artifacts';
+import { useGetTrustedDeviceSuggestions } from '../../hooks/use_get_trusted_device_suggestions';
 import type { EffectedPolicySelectProps } from '../../../../components/effected_policy_select';
 import { EffectedPolicySelect } from '../../../../components/effected_policy_select';
 import { OPERATING_SYSTEM_WINDOWS_AND_MAC, OS_TITLES } from '../../../../common/translations';
@@ -170,7 +171,7 @@ const ConditionsSection = memo<{
   currentEntry: ExceptionListItemSchema['entries'][0];
   handleFieldChange: (value: string) => void;
   handleOperatorChange: (value: string) => void;
-  handleValueChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleValueChange: (options: Array<EuiComboBoxOptionOption<string>>) => void;
   handleValueBlur: () => void;
   disabled: boolean;
   visitedFields: Record<string, boolean>;
@@ -193,6 +194,13 @@ const ConditionsSection = memo<{
     const availableFieldOptions = useMemo(() => {
       return getFieldOptionsForOs(selectedOs);
     }, [selectedOs]);
+
+    // Load suggestions when field changes - useQuery handles race conditions automatically
+    const { data: suggestions = [], isLoading: isLoadingSuggestions } =
+      useGetTrustedDeviceSuggestions({
+        field: currentEntry.field || '',
+        enabled: !disabled,
+      });
 
     return (
       <>
@@ -266,12 +274,24 @@ const ConditionsSection = memo<{
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiFormRow label="Value">
-                <EuiFieldText
-                  value={('value' in currentEntry ? currentEntry.value : '') || ''}
+                <EuiComboBox
+                  placeholder="Enter or select value"
+                  singleSelection={{ asPlainText: true }}
+                  options={suggestions.map((suggestion) => ({ label: suggestion }))}
+                  selectedOptions={
+                    'value' in currentEntry && currentEntry.value
+                      ? [{ label: String(currentEntry.value) }]
+                      : []
+                  }
                   onChange={handleValueChange}
                   onBlur={handleValueBlur}
+                  onCreateOption={(searchValue) => {
+                    handleValueChange([{ label: searchValue }]);
+                  }}
+                  isLoading={isLoadingSuggestions}
                   data-test-subj={getTestId('valueField')}
-                  disabled={disabled}
+                  isDisabled={disabled}
+                  isClearable={false}
                 />
               </EuiFormRow>
             </EuiFlexItem>
@@ -546,8 +566,9 @@ export const TrustedDevicesForm = memo<ArtifactFormComponentProps>(
     );
 
     const handleValueChange = useCallback(
-      (event: React.ChangeEvent<HTMLInputElement>) => {
-        updateConditionField({ value: event.target.value });
+      (options: Array<EuiComboBoxOptionOption<string>>) => {
+        const value = options.length > 0 ? options[0].label : '';
+        updateConditionField({ value });
       },
       [updateConditionField]
     );

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/constants.ts
@@ -11,6 +11,8 @@ export const ENDPOINT_EVENTS_INDEX = 'logs-endpoint.events.process-default';
 
 export const ENDPOINT_ALERTS_INDEX = 'logs-endpoint.alerts-default';
 
+export const ENDPOINT_DEVICE_INDEX = 'logs-endpoint.events.device-default';
+
 export const COMMON_API_HEADERS = Object.freeze({
   'kbn-xsrf': 'security-solution',
   'x-elastic-internal-origin': 'security-solution',

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/resolver_generator_script.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/resolver_generator_script.ts
@@ -22,7 +22,11 @@ import { EndpointMetadataGenerator } from '../../common/endpoint/data_generators
 import { indexHostsAndAlerts } from '../../common/endpoint/index_data';
 import { ANCESTRY_LIMIT, EndpointDocGenerator } from '../../common/endpoint/generate_data';
 import { fetchStackVersion } from './common/stack_services';
-import { ENDPOINT_ALERTS_INDEX, ENDPOINT_EVENTS_INDEX } from './common/constants';
+import {
+  ENDPOINT_ALERTS_INDEX,
+  ENDPOINT_EVENTS_INDEX,
+  ENDPOINT_DEVICE_INDEX,
+} from './common/constants';
 
 main();
 
@@ -147,6 +151,12 @@ async function main() {
       default: ENDPOINT_ALERTS_INDEX,
       type: 'string',
     },
+    deviceIndex: {
+      alias: 'di',
+      describe: 'index to store device events in',
+      default: ENDPOINT_DEVICE_INDEX,
+      type: 'string',
+    },
     metadataIndex: {
       alias: 'mi',
       describe: 'index to store host metadata in',
@@ -231,6 +241,12 @@ async function main() {
       describe: 'number of resolver trees to make for each host',
       type: 'number',
       default: 1,
+    },
+    deviceEvents: {
+      alias: 'dev',
+      describe: 'number of device events to create per host',
+      type: 'number',
+      default: 5,
     },
     delete: {
       alias: 'd',
@@ -413,6 +429,7 @@ async function main() {
     argv.policyIndex,
     argv.eventIndex,
     argv.alertIndex,
+    argv.deviceIndex,
     argv.alertsPerHost,
     argv.fleet,
     {
@@ -427,6 +444,7 @@ async function main() {
       ancestryArraySize: argv.ancestryArraySize,
       eventsDataStream: EndpointDocGenerator.createDataStreamFromIndex(argv.eventIndex),
       alertsDataStream: EndpointDocGenerator.createDataStreamFromIndex(argv.alertIndex),
+      deviceEvents: argv.deviceEvents,
     },
     DocGenerator
   );

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/suggestions/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/suggestions/index.test.ts
@@ -38,6 +38,7 @@ import { EndpointActionGenerator } from '../../../../common/endpoint/data_genera
 import { getEndpointAuthzInitialStateMock } from '../../../../common/endpoint/service/authz/mocks';
 import {
   eventsIndexPattern,
+  DEVICE_EVENTS_INDEX_PATTERN,
   SUGGESTIONS_INTERNAL_ROUTE,
   METADATA_UNITED_INDEX,
 } from '../../../../common/endpoint/constants';
@@ -910,6 +911,81 @@ describe('when calling the Suggestions route handler', () => {
       });
     });
 
+    describe('when suggestion_type is trustedDevices', () => {
+      beforeEach(() => {
+        mockEndpointContext.experimentalFeatures = {
+          ...mockEndpointContext.experimentalFeatures,
+        };
+        suggestionsRouteHandler = getEndpointSuggestionsRequestHandler(
+          config$,
+          mockEndpointContext
+        );
+      });
+
+      it('should use space-aware device events index pattern', async () => {
+        const spaceId = 'custom-space';
+        const mockIntegrationNamespaces = { endpoint: ['custom-namespace'] };
+        const mockIndexPattern = 'logs-endpoint.events.device-*-custom-namespace';
+
+        applyActionsEsSearchMock(mockScopedEsClient.asInternalUser);
+
+        const mockContext = requestContextMock.convertContext(
+          createRouteHandlerContext(mockScopedEsClient, mockSavedObjectClient)
+        );
+
+        ((await mockContext.securitySolution).getSpaceId as jest.Mock).mockReturnValue(spaceId);
+
+        const mockFleetServices = {
+          getIntegrationNamespaces: jest.fn().mockResolvedValue(mockIntegrationNamespaces),
+        };
+        mockEndpointContext.service.getInternalFleetServices = jest
+          .fn()
+          .mockReturnValue(mockFleetServices);
+
+        buildIndexNameWithNamespaceMock.mockReturnValue(mockIndexPattern);
+
+        const fieldName = 'device.manufacturer';
+        const mockRequest = httpServerMock.createKibanaRequest<
+          TypeOf<typeof EndpointSuggestionsSchema.params>,
+          never,
+          never
+        >({
+          params: { suggestion_type: 'trustedDevices' },
+          body: {
+            field: fieldName,
+            query: 'test-query',
+            filters: [{ term: { 'test.field': 'test-value' } }],
+            fieldMeta: 'test-field-meta',
+          },
+        });
+
+        await suggestionsRouteHandler(mockContext, mockRequest, mockResponse);
+
+        expect((await mockContext.securitySolution).getSpaceId as jest.Mock).toHaveBeenCalled();
+        expect(mockEndpointContext.service.getInternalFleetServices).toHaveBeenCalledWith(spaceId);
+        expect(mockFleetServices.getIntegrationNamespaces).toHaveBeenCalledWith(['endpoint']);
+        expect(buildIndexNameWithNamespaceMock).toHaveBeenCalledWith(
+          DEVICE_EVENTS_INDEX_PATTERN,
+          'custom-namespace',
+          { preserveWildcard: true }
+        );
+        expect(termsEnumSuggestionsMock).toHaveBeenNthCalledWith(
+          1,
+          expect.any(Object),
+          expect.any(Object),
+          expect.any(Object),
+          mockIndexPattern,
+          fieldName,
+          'test-query',
+          [{ term: { 'test.field': 'test-value' } }],
+          'test-field-meta',
+          expect.any(Object)
+        );
+
+        expect(mockResponse.ok).toHaveBeenCalled();
+      });
+    });
+
     it('should respond with bad request if wrong suggestion type', async () => {
       // Set up context without space awareness for this test
       mockEndpointContext.experimentalFeatures = {
@@ -991,6 +1067,7 @@ describe('when calling the Suggestions route handler', () => {
             canWriteEventFilters: false,
             canReadTrustedApplications: true,
             canWriteTrustedApplications: false,
+            canWriteTrustedDevices: false,
           },
         });
 
@@ -1004,6 +1081,22 @@ describe('when calling the Suggestions route handler', () => {
             canWriteEventFilters: false,
             canReadTrustedApplications: true,
             canWriteTrustedApplications: false,
+            canWriteTrustedDevices: false,
+          },
+        });
+
+        expect(mockResponse.forbidden).toBeCalled();
+      });
+      it('should respond with forbidden for trusted devices', async () => {
+        await callRoute(SUGGESTIONS_INTERNAL_ROUTE, {
+          params: { suggestion_type: 'trustedDevices' },
+          authz: {
+            canReadEventFilters: true,
+            canWriteEventFilters: false,
+            canReadTrustedApplications: true,
+            canWriteTrustedApplications: false,
+            canReadTrustedDevices: true,
+            canWriteTrustedDevices: false,
           },
         });
 

--- a/x-pack/solutions/security/test/security_solution_endpoint/services/endpoint.ts
+++ b/x-pack/solutions/security/test/security_solution_endpoint/services/endpoint.ts
@@ -175,6 +175,7 @@ export function EndpointTestResourcesProvider({ getService }: FtrProviderContext
             'metrics-endpoint.policy-default',
             'logs-endpoint.events.process-default',
             'logs-endpoint.alerts-default',
+            'logs-endpoint.events.device-default',
             alertsPerHost,
             enableFleetIntegration,
             undefined,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[EDR Workflows][Device Control] Add suggestions support (#238265)](https://github.com/elastic/kibana/pull/238265)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Szwarc","email":"konrad.szwarc@elastic.co"},"sourceCommit":{"committedDate":"2025-10-28T16:27:59Z","message":"[EDR Workflows][Device Control] Add suggestions support (#238265)\n\nExtends the existing suggestions API to support Trusted Devices by\nadding `trustedDevices` as a new suggestion type. This enables field\nvalue autocomplete functionality for Trusted Devices forms by querying\nthe `logs-endpoint.events.device-*` index pattern.\n\nThe implementation follows the established patterns from Event Filters\nand Trusted Applications, sharing the same route handler logic.\n\nAdditionally, updates the resolver generator script to support\ngenerating device events data for local development and testing. The\nscript now accepts `--deviceEvents` and `--deviceIndex` options to\npopulate the device events index with sample data.\n\n\n\nhttps://github.com/user-attachments/assets/c21c3ba0-15ce-4ad2-b790-384ab8c7cc12\n\n\nhttps://github.com/user-attachments/assets/527708a1-01d0-4b4c-8545-2d8485aa4c25","sha":"3a0777f7c64d205a394b45ab4988335f445ecc6e","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","backport:version","v9.2.0","v9.3.0"],"title":"[EDR Workflows][Device Control] Add suggestions support","number":238265,"url":"https://github.com/elastic/kibana/pull/238265","mergeCommit":{"message":"[EDR Workflows][Device Control] Add suggestions support (#238265)\n\nExtends the existing suggestions API to support Trusted Devices by\nadding `trustedDevices` as a new suggestion type. This enables field\nvalue autocomplete functionality for Trusted Devices forms by querying\nthe `logs-endpoint.events.device-*` index pattern.\n\nThe implementation follows the established patterns from Event Filters\nand Trusted Applications, sharing the same route handler logic.\n\nAdditionally, updates the resolver generator script to support\ngenerating device events data for local development and testing. The\nscript now accepts `--deviceEvents` and `--deviceIndex` options to\npopulate the device events index with sample data.\n\n\n\nhttps://github.com/user-attachments/assets/c21c3ba0-15ce-4ad2-b790-384ab8c7cc12\n\n\nhttps://github.com/user-attachments/assets/527708a1-01d0-4b4c-8545-2d8485aa4c25","sha":"3a0777f7c64d205a394b45ab4988335f445ecc6e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241018","number":241018,"state":"OPEN"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238265","number":238265,"mergeCommit":{"message":"[EDR Workflows][Device Control] Add suggestions support (#238265)\n\nExtends the existing suggestions API to support Trusted Devices by\nadding `trustedDevices` as a new suggestion type. This enables field\nvalue autocomplete functionality for Trusted Devices forms by querying\nthe `logs-endpoint.events.device-*` index pattern.\n\nThe implementation follows the established patterns from Event Filters\nand Trusted Applications, sharing the same route handler logic.\n\nAdditionally, updates the resolver generator script to support\ngenerating device events data for local development and testing. The\nscript now accepts `--deviceEvents` and `--deviceIndex` options to\npopulate the device events index with sample data.\n\n\n\nhttps://github.com/user-attachments/assets/c21c3ba0-15ce-4ad2-b790-384ab8c7cc12\n\n\nhttps://github.com/user-attachments/assets/527708a1-01d0-4b4c-8545-2d8485aa4c25","sha":"3a0777f7c64d205a394b45ab4988335f445ecc6e"}}]}] BACKPORT-->