### PR TITLE
[ES|QL] Display Create lookup index as first suggestion

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/autocomplete.test.ts
@@ -122,7 +122,7 @@ describe('JOIN Autocomplete', () => {
         incomplete: true,
         kind: 'Issue',
         label: 'Create lookup index',
-        sortText: '1A',
+        sortText: '0',
         text: '',
       });
     });
@@ -197,7 +197,7 @@ describe('JOIN Autocomplete', () => {
           end: 37,
           start: 23,
         },
-        sortText: '1A',
+        sortText: '0',
         text: 'new_join_index',
       });
     });

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/autocomplete/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/autocomplete/helpers.ts
@@ -548,7 +548,7 @@ export function getLookupIndexCreateSuggestion(
       }
     ),
 
-    sortText: '1A',
+    sortText: '0',
 
     command: {
       id: `esql.lookup_index.create`,


### PR DESCRIPTION
## Summary
Now "Create lookup index" is displayed as first suggestion.

<img width="1153" height="432" alt="image" src="https://github.com/user-attachments/assets/b56c9f6c-3d48-418b-a878-4aa1c5e28f90" />



