### PR TITLE
[One Workflow] fix: 14428 fix inefficient saving of step executions

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/integration_tests/mocks/step_execution_repository.mock.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/integration_tests/mocks/step_execution_repository.mock.ts
@@ -20,43 +20,14 @@ export class StepExecutionRepositoryMock implements Required<StepExecutionReposi
     );
   }
 
-  public createStepExecution(stepExecution: Partial<EsWorkflowStepExecution>): Promise<void> {
-    if (!stepExecution.id) {
-      throw new Error('Step execution ID is required for creation');
-    }
-
-    this.stepExecutions.set(stepExecution.id, stepExecution as EsWorkflowStepExecution);
-    return Promise.resolve();
-  }
-
-  public updateStepExecution(stepExecution: Partial<EsWorkflowStepExecution>): Promise<void> {
-    if (!stepExecution.id) {
-      throw new Error('Step execution ID is required for update');
-    }
-
-    if (!this.stepExecutions.has(stepExecution.id)) {
-      throw new Error(`Step execution with ID ${stepExecution.id} does not exist`);
-    }
-
-    this.stepExecutions.set(stepExecution.id, {
-      ...this.stepExecutions.get(stepExecution.id),
-      ...(stepExecution as EsWorkflowStepExecution),
-    });
-    return Promise.resolve();
-  }
-
-  public updateStepExecutions(stepExecutions: Partial<EsWorkflowStepExecution>[]): Promise<void> {
+  public bulkUpsert(stepExecutions: Partial<EsWorkflowStepExecution>[]): Promise<void> {
     for (const stepExecution of stepExecutions) {
       if (!stepExecution.id) {
-        throw new Error('Step execution ID is required for update');
-      }
-
-      if (!this.stepExecutions.has(stepExecution.id)) {
-        throw new Error(`Step execution with ID ${stepExecution.id} does not exist`);
+        throw new Error('Step execution ID is required for upsert');
       }
 
       this.stepExecutions.set(stepExecution.id, {
-        ...this.stepExecutions.get(stepExecution.id),
+        ...(this.stepExecutions.get(stepExecution.id) || {}),
         ...(stepExecution as EsWorkflowStepExecution),
       });
     }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.test.ts
@@ -7,12 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { ExecutionStatus } from '@kbn/workflows';
 import { StepExecutionRepository } from './step_execution_repository';
-import { WORKFLOWS_STEP_EXECUTIONS_INDEX } from '../../common';
 
 describe('StepExecutionRepository', () => {
-  let repository: StepExecutionRepository;
+  let underTest: StepExecutionRepository;
   let esClient: {
     index: jest.Mock;
     update: jest.Mock;
@@ -30,68 +28,261 @@ describe('StepExecutionRepository', () => {
         create: jest.fn().mockResolvedValue({}),
       },
     };
-    repository = new StepExecutionRepository(esClient as any);
+    underTest = new StepExecutionRepository(esClient as any);
   });
 
-  describe('createStepExecution', () => {
-    it('should create a step execution', async () => {
-      const stepExecution = { id: '1', stepId: 'test-step' };
-      await repository.createStepExecution(stepExecution);
-      expect(esClient.index).toHaveBeenCalledWith({
-        index: WORKFLOWS_STEP_EXECUTIONS_INDEX,
-        id: '1',
-        refresh: true,
-        document: stepExecution,
-      });
-    });
-
-    it('should throw an error if ID is missing during create', async () => {
-      await expect(repository.createStepExecution({})).rejects.toThrow(
-        'Step execution ID is required for creation'
-      );
-    });
-  });
-
-  describe('updateStepExecution', () => {
-    it('should update a step execution', async () => {
-      const stepExecution = { id: '1', status: ExecutionStatus.RUNNING };
-      await repository.updateStepExecution(stepExecution);
-      expect(esClient.bulk).toHaveBeenCalledWith({
-        index: WORKFLOWS_STEP_EXECUTIONS_INDEX,
-        refresh: true,
-        body: [{ update: { _id: '1' } }, { doc: { id: '1', status: ExecutionStatus.RUNNING } }],
-      });
-    });
-
-    it('should throw an error if ID is missing during update', async () => {
-      await expect(repository.updateStepExecution({})).rejects.toThrow(
-        'Step execution ID is required for update'
-      );
-    });
-  });
-
-  describe('updateStepExecutions', () => {
-    it('should update multiple step executions', async () => {
+  describe('bulkUpsert', () => {
+    it('should successfully upsert multiple step executions', async () => {
       const stepExecutions = [
-        { id: '1', status: ExecutionStatus.COMPLETED },
-        { id: '2', status: ExecutionStatus.FAILED },
+        { id: 'step-1', stepId: 'test-step-1', status: 'completed' },
+        { id: 'step-2', stepId: 'test-step-2', status: 'running' },
+        { id: 'step-3', stepId: 'test-step-3', status: 'pending' },
       ];
-      await repository.updateStepExecutions(stepExecutions);
+
+      esClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [
+          { update: { _id: 'step-1', status: 200 } },
+          { update: { _id: 'step-2', status: 200 } },
+          { update: { _id: 'step-3', status: 200 } },
+        ],
+      });
+
+      await underTest.bulkUpsert(stepExecutions as any);
+
       expect(esClient.bulk).toHaveBeenCalledWith({
-        index: WORKFLOWS_STEP_EXECUTIONS_INDEX,
         refresh: true,
+        index: expect.any(String),
         body: [
-          { update: { _id: '1' } },
-          { doc: { id: '1', status: ExecutionStatus.COMPLETED } },
-          { update: { _id: '2' } },
-          { doc: { id: '2', status: ExecutionStatus.FAILED } },
+          { update: { _id: 'step-1' } },
+          { doc: stepExecutions[0], doc_as_upsert: true },
+          { update: { _id: 'step-2' } },
+          { doc: stepExecutions[1], doc_as_upsert: true },
+          { update: { _id: 'step-3' } },
+          { doc: stepExecutions[2], doc_as_upsert: true },
         ],
       });
     });
 
-    it('should throw an error if ID is missing during bulk update', async () => {
-      await expect(repository.updateStepExecutions([{}])).rejects.toThrow(
-        'Step execution ID is required for update'
+    it('should handle empty array without making ES call', async () => {
+      await underTest.bulkUpsert([]);
+
+      expect(esClient.bulk).not.toHaveBeenCalled();
+    });
+
+    it('should throw error if step execution does not have an id', async () => {
+      const stepExecutions = [
+        { id: 'step-1', stepId: 'test-step-1' },
+        { stepId: 'test-step-2' }, // Missing id
+      ];
+
+      await expect(underTest.bulkUpsert(stepExecutions as any)).rejects.toThrow(
+        'Step execution ID is required for upsert'
+      );
+
+      expect(esClient.bulk).not.toHaveBeenCalled();
+    });
+
+    it('should throw error with details when bulk operation has errors', async () => {
+      const stepExecutions = [
+        { id: 'step-1', stepId: 'test-step-1', status: 'completed' },
+        { id: 'step-2', stepId: 'test-step-2', status: 'running' },
+        { id: 'step-3', stepId: 'test-step-3', status: 'pending' },
+      ];
+
+      esClient.bulk.mockResolvedValue({
+        errors: true,
+        items: [
+          { update: { _id: 'step-1', status: 200 } },
+          {
+            update: {
+              _id: 'step-2',
+              status: 409,
+              error: {
+                type: 'version_conflict_engine_exception',
+                reason: 'version conflict',
+              },
+            },
+          },
+          {
+            update: {
+              _id: 'step-3',
+              status: 400,
+              error: {
+                type: 'mapper_parsing_exception',
+                reason: 'failed to parse field [status]',
+              },
+            },
+          },
+        ],
+      });
+
+      await expect(underTest.bulkUpsert(stepExecutions as any)).rejects.toThrow(
+        'Failed to upsert 2 step executions'
+      );
+
+      expect(esClient.bulk).toHaveBeenCalled();
+    });
+
+    it('should include error details in exception message', async () => {
+      const stepExecutions = [{ id: 'step-1', stepId: 'test-step-1' }];
+
+      const errorDetails = {
+        type: 'mapper_parsing_exception',
+        reason: 'failed to parse field [executionTimeMs]',
+      };
+
+      esClient.bulk.mockResolvedValue({
+        errors: true,
+        items: [
+          {
+            update: {
+              _id: 'step-1',
+              status: 400,
+              error: errorDetails,
+            },
+          },
+        ],
+      });
+
+      try {
+        await underTest.bulkUpsert(stepExecutions as any);
+        fail('Should have thrown an error');
+      } catch (error: any) {
+        expect(error.message).toContain('Failed to upsert 1 step executions');
+        expect(error.message).toContain('step-1');
+        expect(error.message).toContain('mapper_parsing_exception');
+      }
+    });
+
+    it('should handle partial success by only throwing errors for failed items', async () => {
+      const stepExecutions = [
+        { id: 'step-1', stepId: 'test-step-1' },
+        { id: 'step-2', stepId: 'test-step-2' },
+        { id: 'step-3', stepId: 'test-step-3' },
+      ];
+
+      esClient.bulk.mockResolvedValue({
+        errors: true,
+        items: [
+          { update: { _id: 'step-1', status: 200 } }, // Success
+          {
+            update: {
+              _id: 'step-2',
+              status: 409,
+              error: { type: 'version_conflict_engine_exception' },
+            },
+          }, // Error
+          { update: { _id: 'step-3', status: 201 } }, // Success
+        ],
+      });
+
+      try {
+        await underTest.bulkUpsert(stepExecutions as any);
+        fail('Should have thrown an error');
+      } catch (error: any) {
+        expect(error.message).toContain('Failed to upsert 1 step executions');
+        expect(error.message).toContain('step-2');
+        expect(error.message).not.toContain('step-1');
+        expect(error.message).not.toContain('step-3');
+      }
+    });
+
+    it('should use doc_as_upsert flag for each document', async () => {
+      const stepExecutions = [{ id: 'step-1', stepId: 'test-step-1', status: 'completed' }];
+
+      esClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [{ update: { _id: 'step-1', status: 200 } }],
+      });
+
+      await underTest.bulkUpsert(stepExecutions as any);
+
+      const bulkCall = esClient.bulk.mock.calls[0][0];
+      expect(bulkCall.body[1]).toEqual({
+        doc: stepExecutions[0],
+        doc_as_upsert: true,
+      });
+    });
+
+    it('should ensure index exists before upserting', async () => {
+      const stepExecutions = [{ id: 'step-1', stepId: 'test-step-1' }];
+
+      esClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [{ update: { _id: 'step-1', status: 200 } }],
+      });
+
+      await underTest.bulkUpsert(stepExecutions as any);
+
+      expect(esClient.indices.exists).toHaveBeenCalled();
+    });
+
+    it('should handle single step execution', async () => {
+      const stepExecutions = [{ id: 'step-1', stepId: 'test-step-1', status: 'completed' }];
+
+      esClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [{ update: { _id: 'step-1', status: 200 } }],
+      });
+
+      await underTest.bulkUpsert(stepExecutions as any);
+
+      expect(esClient.bulk).toHaveBeenCalledWith({
+        refresh: true,
+        index: expect.any(String),
+        body: [{ update: { _id: 'step-1' } }, { doc: stepExecutions[0], doc_as_upsert: true }],
+      });
+    });
+
+    it('should preserve all fields in partial updates', async () => {
+      const stepExecutions = [
+        {
+          id: 'step-1',
+          stepId: 'test-step-1',
+          status: 'completed',
+          completedAt: '2025-10-28T10:00:00Z',
+          executionTimeMs: 5000,
+          output: { result: 'success' },
+        },
+      ];
+
+      esClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [{ update: { _id: 'step-1', status: 200 } }],
+      });
+
+      await underTest.bulkUpsert(stepExecutions as any);
+
+      const bulkCall = esClient.bulk.mock.calls[0][0];
+      expect(bulkCall.body[1].doc).toEqual(stepExecutions[0]);
+    });
+
+    it('should handle multiple validation errors', async () => {
+      const stepExecutions = [
+        { stepId: 'test-step-1' }, // Missing id
+        { stepId: 'test-step-2' }, // Missing id
+      ];
+
+      await expect(underTest.bulkUpsert(stepExecutions as any)).rejects.toThrow(
+        'Step execution ID is required for upsert'
+      );
+    });
+
+    it('should use refresh: true for immediate visibility', async () => {
+      const stepExecutions = [{ id: 'step-1', stepId: 'test-step-1' }];
+
+      esClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [{ update: { _id: 'step-1', status: 200 } }],
+      });
+
+      await underTest.bulkUpsert(stepExecutions as any);
+
+      expect(esClient.bulk).toHaveBeenCalledWith(
+        expect.objectContaining({
+          refresh: true,
+        })
       );
     });
   });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.ts
@@ -53,67 +53,42 @@ export class StepExecutionRepository {
     return response.hits.hits.map((hit) => hit._source as EsWorkflowStepExecution);
   }
 
-  /**
-   * Creates a new step execution document in Elasticsearch.
-   *
-   * @param stepExecution - A partial object representing the workflow step execution to be indexed.
-   * @returns A promise that resolves when the document has been successfully indexed.
-   */
-  public async createStepExecution(stepExecution: Partial<EsWorkflowStepExecution>): Promise<void> {
+  public async bulkUpsert(stepExecutions: Array<Partial<EsWorkflowStepExecution>>): Promise<void> {
     await this.ensureIndexExists();
 
-    if (!stepExecution.id) {
-      throw new Error('Step execution ID is required for creation');
+    if (stepExecutions.length === 0) {
+      return;
     }
-
-    await this.esClient.index({
-      index: this.indexName,
-      id: stepExecution.id,
-      refresh: true,
-      document: stepExecution,
-    });
-  }
-
-  /**
-   * Updates a single workflow step execution in the repository.
-   *
-   * @param stepExecution - A partial object representing the workflow step execution to update.
-   * @returns A promise that resolves when the update operation is complete.
-   */
-  public updateStepExecution(stepExecution: Partial<EsWorkflowStepExecution>): Promise<void> {
-    return this.updateStepExecutions([stepExecution]);
-  }
-
-  /**
-   * Updates multiple step executions in Elasticsearch.
-   *
-   * This method takes an array of partial `EsWorkflowStepExecution` objects,
-   * validates that each has an `id`, and performs a bulk update operation
-   * in Elasticsearch for all provided step executions.
-   *
-   * @param stepExecutions - An array of partial step execution objects to update.
-   * Each object must include an `id` property.
-   * @throws {Error} If any step execution does not have an `id`.
-   * @returns A promise that resolves when the bulk update operation completes.
-   */
-  public async updateStepExecutions(
-    stepExecutions: Array<Partial<EsWorkflowStepExecution>>
-  ): Promise<void> {
-    await this.ensureIndexExists();
 
     stepExecutions.forEach((stepExecution) => {
       if (!stepExecution.id) {
-        throw new Error('Step execution ID is required for update');
+        throw new Error('Step execution ID is required for upsert');
       }
     });
 
-    await this.esClient?.bulk({
+    const bulkResponse = await this.esClient.bulk({
       refresh: true,
       index: this.indexName,
       body: stepExecutions.flatMap((stepExecution) => [
         { update: { _id: stepExecution.id } },
-        { doc: stepExecution },
+        { doc: stepExecution, doc_as_upsert: true },
       ]),
     });
+
+    if (bulkResponse.errors) {
+      const erroredDocuments = bulkResponse.items
+        .filter((item) => item.update?.error)
+        .map((item) => ({
+          id: item.update?._id,
+          error: item.update?.error,
+          status: item.update?.status,
+        }));
+
+      throw new Error(
+        `Failed to upsert ${erroredDocuments.length} step executions: ${JSON.stringify(
+          erroredDocuments
+        )}`
+      );
+    }
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
@@ -178,7 +178,7 @@ export class WorkflowExecutionState {
       ...step,
     } as EsWorkflowStepExecution);
     this.stepChanges.set(step.id as string, {
-      ...this.stepChanges.get(step.id as string),
+      ...(this.stepChanges.get(step.id as string) || {}),
       ...step,
     });
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
@@ -138,8 +138,7 @@ export class WorkflowExecutionState {
         return acc;
       }, {});
 
-    const toCreate: Partial<EsWorkflowStepExecution>[] = [];
-    const toUpdate: Partial<EsWorkflowStepExecution>[] = [];
+    const documents: Partial<EsWorkflowStepExecution>[] = [];
 
     Object.entries(groupedStepChangesById).forEach(([objectId, changes]) => {
       const accumulated: Partial<EsWorkflowStepExecution> = changes.reduce(
@@ -150,14 +149,10 @@ export class WorkflowExecutionState {
         {}
       );
 
-      if (changes.some((change) => change.changeType === 'create')) {
-        toCreate.push(accumulated);
-      } else {
-        toUpdate.push(accumulated);
-      }
+      documents.push(accumulated);
     });
 
-    await this.workflowStepExecutionRepository.bulkUpsert(Array.from(toCreate.concat(toUpdate)));
+    await this.workflowStepExecutionRepository.bulkUpsert(documents);
     this.stepChanges = [];
   }
 


### PR DESCRIPTION
## Summary

Closes: https://github.com/elastic/security-team/issues/14428

### Performance Improvements
- **Optimized step execution persistence**: Replaced individual `createStepExecution()` calls and separate `updateStepExecutions()` operations with a single `bulkUpsert()` method, reducing Elasticsearch round trips from N+1 to 1 per flush cycle

### Bug Fixes
- **Fixed silent bulk operation failures**: Added error detection and reporting for Elasticsearch bulk API responses, ensuring failed upserts throw descriptive errors instead of silently failing
- **Fixed document creation failures**: Enabled `doc_as_upsert: true` flag to prevent `document_missing_exception` errors when upserting non-existent documents

### Breaking Changes
- **Removed `StepExecutionRepository` methods**: `createStepExecution()`, `updateStepExecution()`, and `updateStepExecutions()` replaced by `bulkUpsert()`
  - Impact: None (no external usages)

### Code Quality
- **Simplified `flushStepChanges()` logic**: Consolidated create/update separation logic into unified document collection
- **Removed optional chaining** on `esClient.bulk()` call (constructor guarantees non-null client)

### Technical Details
- `bulkUpsert()` now validates bulk response and reports errors with document IDs, error types, and status codes
- Single bulk upsert operation handles both document creation and updates atomically


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



