### PR TITLE
[9.1] [Discover][APM] Check for undefined data from useFetcher in TraceWaterfallEmbeddable  (#240843)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/focused_trace_waterfall_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/focused_trace_waterfall_embeddable.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiText } from '@elastic/eui';
+import { EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { FocusedTraceWaterfall } from '../../components/shared/focused_trace_waterfall';
@@ -35,12 +35,15 @@ export function FocusedTraceWaterfallEmbeddable({
 
   if (data === undefined) {
     return (
-      <EuiText>
-        {i18n.translate(
-          'xpack.apm.focusedTraceWaterfallEmbeddable.traceWaterfallCouldNotTextLabel',
-          { defaultMessage: 'Trace waterfall could not be loaded' }
-        )}
-      </EuiText>
+      <EuiCallOut
+        announceOnMount
+        data-test-subj="FocusedTraceWaterfallEmbeddableNoData"
+        color="danger"
+        size="s"
+        title={i18n.translate('xpack.apm.focusedTraceWaterfallEmbeddable.noDataCalloutLabel', {
+          defaultMessage: 'Trace waterfall could not be loaded.',
+        })}
+      />
     );
   }
 

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/focused_trace_waterfall_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/focused_trace_waterfall_embeddable.tsx
@@ -36,7 +36,6 @@ export function FocusedTraceWaterfallEmbeddable({
   if (data === undefined) {
     return (
       <EuiCallOut
-        announceOnMount
         data-test-subj="FocusedTraceWaterfallEmbeddableNoData"
         color="danger"
         size="s"

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/trace_waterfall_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/trace_waterfall_embeddable.tsx
@@ -6,13 +6,15 @@
  */
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React from 'react';
-import { WaterfallLegends } from '../../components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_legends';
+import { EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { isPending, useFetcher } from '../../hooks/use_fetcher';
 import { Loading } from './loading';
 import type { ApmTraceWaterfallEmbeddableEntryProps } from './react_embeddable_factory';
 import { TraceWaterfall } from '../../components/shared/trace_waterfall';
 import { getServiceLegends } from '../../components/shared/trace_waterfall/use_trace_waterfall';
 import { WaterfallLegendType } from '../../components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers';
+import { WaterfallLegends } from '../../components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_legends';
 
 export function TraceWaterfallEmbeddable({
   serviceName,
@@ -41,6 +43,19 @@ export function TraceWaterfallEmbeddable({
 
   if (isPending(status)) {
     return <Loading />;
+  }
+
+  if (data === undefined) {
+    return (
+      <EuiCallOut
+        data-test-subj="TraceWaterfallEmbeddableNoData"
+        color="danger"
+        size="s"
+        title={i18n.translate('xpack.apm.traceWaterfallEmbeddable.noDataCalloutLabel', {
+          defaultMessage: 'Trace waterfall could not be loaded.',
+        })}
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Discover][APM] Add fallback to traceItems when calling useTraceWaterfall  (#240843)](https://github.com/elastic/kibana/pull/240843)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Irene Blanco","email":"irene.blanco@elastic.co"},"sourceCommit":{"committedDate":"2025-10-29T08:51:15Z","message":"[Discover][APM] Add fallback to traceItems when calling useTraceWaterfall  (#240843)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/238405\n\nSince we upgraded the error handling strategy to catch Fatal React\nErrors, we’ve started seeing `TypeError: Cannot read properties of\nundefined (reading 'map')` in versions 8.19.x and 9.1.x.\n\n<img width=\"809\" height=\"121\" alt=\"Screenshot 2025-10-27 at 16 03 48\"\nsrc=\"https://github.com/user-attachments/assets/042a4118-8294-4701-8d0b-590321a2bde8\"\n/>\n\nAfter reviewing the error stack, we found that this occurs because\n`traceItems` is occasionally arrive as `undefined`. Although TS enforces\nthat it should always be defined, a potential API malfunction may cause\nthis scenario.\n\nTo prevent users from encountering an uncontrolled error, this PR adds a\ncheck for `undefined` for `data` coming from the `useFetcher` (more\ndetails in [this\ncomment](https://github.com/elastic/kibana/pull/240843#discussion_r2469707226)).\n\nThis ensures that the UI behaves safely even if `traceItems` is\nunexpectedly `undefined`.\n\n|Before|After|\n|-|-|\n|![Screen Recording 2025-10-27 at 15 33\n39](https://github.com/user-attachments/assets/6753ed8c-1e37-4117-8ba0-112d996e2066)|<img\nwidth=\"1405\" height=\"968\" alt=\"Screenshot 2025-10-28 at 14 26 04\"\nsrc=\"https://github.com/user-attachments/assets/1d4453df-25b5-4573-b29f-0da76f42b064\"\n/>|\n\nI also took the chance to update the UI, so the error message is more\nvisible:\n|Before|After|\n|-|-|\n|<img width=\"1405\" height=\"968\" alt=\"Screenshot 2025-10-28 at 14 26 04\"\nsrc=\"https://github.com/user-attachments/assets/1d4453df-25b5-4573-b29f-0da76f42b064\"\n/>|<img width=\"1405\" height=\"966\" alt=\"Screenshot 2025-10-28 at 14 24\n51\"\nsrc=\"https://github.com/user-attachments/assets/3426defd-58fc-4ea8-950c-1163bb11cb20\"\n/>|\n\nThe same error has been now added to the `TraceWaterfallEmbeddable`:\n<img width=\"1387\" height=\"135\" alt=\"Screenshot 2025-10-28 at 14 27 31\"\nsrc=\"https://github.com/user-attachments/assets/3bd01cb3-b716-4216-82de-ec02d7f01bdf\"\n/>","sha":"7d2975b2ece67ff9b1c99be7d98bb422099065e1","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:obs-ux-infra_services","backport:version","v9.3.0","v8.19.7","v9.1.7","v9.2.1"],"title":"[Discover][APM] Add fallback to traceItems when calling useTraceWaterfall ","number":240843,"url":"https://github.com/elastic/kibana/pull/240843","mergeCommit":{"message":"[Discover][APM] Add fallback to traceItems when calling useTraceWaterfall  (#240843)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/238405\n\nSince we upgraded the error handling strategy to catch Fatal React\nErrors, we’ve started seeing `TypeError: Cannot read properties of\nundefined (reading 'map')` in versions 8.19.x and 9.1.x.\n\n<img width=\"809\" height=\"121\" alt=\"Screenshot 2025-10-27 at 16 03 48\"\nsrc=\"https://github.com/user-attachments/assets/042a4118-8294-4701-8d0b-590321a2bde8\"\n/>\n\nAfter reviewing the error stack, we found that this occurs because\n`traceItems` is occasionally arrive as `undefined`. Although TS enforces\nthat it should always be defined, a potential API malfunction may cause\nthis scenario.\n\nTo prevent users from encountering an uncontrolled error, this PR adds a\ncheck for `undefined` for `data` coming from the `useFetcher` (more\ndetails in [this\ncomment](https://github.com/elastic/kibana/pull/240843#discussion_r2469707226)).\n\nThis ensures that the UI behaves safely even if `traceItems` is\nunexpectedly `undefined`.\n\n|Before|After|\n|-|-|\n|![Screen Recording 2025-10-27 at 15 33\n39](https://github.com/user-attachments/assets/6753ed8c-1e37-4117-8ba0-112d996e2066)|<img\nwidth=\"1405\" height=\"968\" alt=\"Screenshot 2025-10-28 at 14 26 04\"\nsrc=\"https://github.com/user-attachments/assets/1d4453df-25b5-4573-b29f-0da76f42b064\"\n/>|\n\nI also took the chance to update the UI, so the error message is more\nvisible:\n|Before|After|\n|-|-|\n|<img width=\"1405\" height=\"968\" alt=\"Screenshot 2025-10-28 at 14 26 04\"\nsrc=\"https://github.com/user-attachments/assets/1d4453df-25b5-4573-b29f-0da76f42b064\"\n/>|<img width=\"1405\" height=\"966\" alt=\"Screenshot 2025-10-28 at 14 24\n51\"\nsrc=\"https://github.com/user-attachments/assets/3426defd-58fc-4ea8-950c-1163bb11cb20\"\n/>|\n\nThe same error has been now added to the `TraceWaterfallEmbeddable`:\n<img width=\"1387\" height=\"135\" alt=\"Screenshot 2025-10-28 at 14 27 31\"\nsrc=\"https://github.com/user-attachments/assets/3bd01cb3-b716-4216-82de-ec02d7f01bdf\"\n/>","sha":"7d2975b2ece67ff9b1c99be7d98bb422099065e1"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/240843","number":240843,"mergeCommit":{"message":"[Discover][APM] Add fallback to traceItems when calling useTraceWaterfall  (#240843)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/238405\n\nSince we upgraded the error handling strategy to catch Fatal React\nErrors, we’ve started seeing `TypeError: Cannot read properties of\nundefined (reading 'map')` in versions 8.19.x and 9.1.x.\n\n<img width=\"809\" height=\"121\" alt=\"Screenshot 2025-10-27 at 16 03 48\"\nsrc=\"https://github.com/user-attachments/assets/042a4118-8294-4701-8d0b-590321a2bde8\"\n/>\n\nAfter reviewing the error stack, we found that this occurs because\n`traceItems` is occasionally arrive as `undefined`. Although TS enforces\nthat it should always be defined, a potential API malfunction may cause\nthis scenario.\n\nTo prevent users from encountering an uncontrolled error, this PR adds a\ncheck for `undefined` for `data` coming from the `useFetcher` (more\ndetails in [this\ncomment](https://github.com/elastic/kibana/pull/240843#discussion_r2469707226)).\n\nThis ensures that the UI behaves safely even if `traceItems` is\nunexpectedly `undefined`.\n\n|Before|After|\n|-|-|\n|![Screen Recording 2025-10-27 at 15 33\n39](https://github.com/user-attachments/assets/6753ed8c-1e37-4117-8ba0-112d996e2066)|<img\nwidth=\"1405\" height=\"968\" alt=\"Screenshot 2025-10-28 at 14 26 04\"\nsrc=\"https://github.com/user-attachments/assets/1d4453df-25b5-4573-b29f-0da76f42b064\"\n/>|\n\nI also took the chance to update the UI, so the error message is more\nvisible:\n|Before|After|\n|-|-|\n|<img width=\"1405\" height=\"968\" alt=\"Screenshot 2025-10-28 at 14 26 04\"\nsrc=\"https://github.com/user-attachments/assets/1d4453df-25b5-4573-b29f-0da76f42b064\"\n/>|<img width=\"1405\" height=\"966\" alt=\"Screenshot 2025-10-28 at 14 24\n51\"\nsrc=\"https://github.com/user-attachments/assets/3426defd-58fc-4ea8-950c-1163bb11cb20\"\n/>|\n\nThe same error has been now added to the `TraceWaterfallEmbeddable`:\n<img width=\"1387\" height=\"135\" alt=\"Screenshot 2025-10-28 at 14 27 31\"\nsrc=\"https://github.com/user-attachments/assets/3bd01cb3-b716-4216-82de-ec02d7f01bdf\"\n/>","sha":"7d2975b2ece67ff9b1c99be7d98bb422099065e1"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241079","number":241079,"state":"OPEN"}]}] BACKPORT-->