### PR TITLE
[Fleet] omit system properties when syncing ingest pipelines

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
@@ -7,6 +7,8 @@
 
 import type { estypes } from '@elastic/elasticsearch';
 
+import type { IngestPipeline } from '@elastic/elasticsearch/lib/api/types';
+
 import type {
   ASSETS_SAVED_OBJECT_TYPE,
   agentAssetTypes,
@@ -791,6 +793,15 @@ export interface IndexTemplate {
   ignore_missing_component_templates?: string[];
   _meta: object;
 
+  // These properties are returned on ES read operations and
+  // not allowed to be set on ES write operations
+  created_date?: number;
+  created_date_millis?: number;
+  modified_date?: number;
+  modified_date_millis?: number;
+}
+
+export interface IngestPipelineWithDateFields extends IngestPipeline {
   // These properties are returned on ES read operations and
   // not allowed to be set on ES write operations
   created_date?: number;

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.test.ts
@@ -702,6 +702,11 @@ describe('custom assets', () => {
               },
             ],
             version: 1,
+            description: 'description pipeline',
+            created_date: '2024-01-01T12:00:00.000Z',
+            created_date_millis: 1704110400000,
+            modified_date: '2025-01-01T12:00:00.000Z',
+            modified_date_millis: 1735732800000,
           },
           type: 'ingest_pipeline',
         },
@@ -721,6 +726,7 @@ describe('custom assets', () => {
             },
           ],
           version: 1,
+          description: 'description pipeline',
         },
         expect.anything()
       );

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
@@ -18,6 +18,8 @@ import { retryTransientEsErrors } from '../../services/epm/elasticsearch/retry';
 import { packagePolicyService } from '../../services';
 import { SO_SEARCH_LIMIT } from '../../constants';
 
+import type { IngestPipelineWithDateFields } from '../../../common/types';
+
 import type { CustomAssetsData, IntegrationsData, SyncIntegrationsData } from './model';
 
 const DELETED_ASSET_TTL = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -297,14 +299,22 @@ async function updateIngestPipeline(
 
   if (shouldUpdatePipeline) {
     logger.debug(`Updating ingest pipeline: ${customAsset.name}`);
+
+    // Remove system-managed properties (dates) that cannot be set during create/update of ingest pipelines
+    const {
+      created_date: createdDate,
+      created_date_millis: createdDateMillis,
+      modified_date: modifiedDate,
+      modified_date_millis: modifiedDateMillis,
+      ...ingestPipeline
+    } = customAsset.pipeline as IngestPipelineWithDateFields;
+    const updatedIngestPipeline = ingestPipeline;
     return retryTransientEsErrors(
       () =>
         esClient.ingest.putPipeline(
           {
             id: customAsset.name,
-            description: customAsset.pipeline.description,
-            version: customAsset.pipeline.version,
-            processors: customAsset.pipeline.processors,
+            ...updatedIngestPipeline,
           },
           {
             signal: abortController.signal,

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
@@ -302,7 +302,9 @@ async function updateIngestPipeline(
         esClient.ingest.putPipeline(
           {
             id: customAsset.name,
-            ...customAsset.pipeline,
+            description: customAsset.pipeline.description,
+            version: customAsset.pipeline.version,
+            processors: customAsset.pipeline.processors,
           },
           {
             signal: abortController.signal,

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
@@ -306,9 +306,8 @@ async function updateIngestPipeline(
       created_date_millis: createdDateMillis,
       modified_date: modifiedDate,
       modified_date_millis: modifiedDateMillis,
-      ...ingestPipeline
+      ...updatedIngestPipeline
     } = customAsset.pipeline as IngestPipelineWithDateFields;
-    const updatedIngestPipeline = ingestPipeline;
     return retryTransientEsErrors(
       () =>
         esClient.ingest.putPipeline(


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/230188

Omit system properties when creating ingest pipelines on remote clusters.
Currently pipelines syncing fails with the error
```
[2025-10-29T10:50:06.429+01:00][ERROR][plugins.fleet.fleet:sync-integrations-task:1.0.5] Failed to install ingest_pipeline logs-system.auth@custom, error: ResponseError: parse_exception
        Root causes:
                parse_exception: Provided a pipeline property which is managed by the system: created_date_millis.
```
It seems the new fields were introduced by elasticsearch in 9.2 https://github.com/elastic/elasticsearch/pull/130847

To verify:
- Start 2 clusters and set up syncing between them https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/remote_clusters_ccr.md
- Create a custom ingest pipeline e.g. `logs-system.auth@custom`
- Wait for sync to run
- Verify that the sync is successful

```
# example pipeline
{
  description: 'description',
  processors: [ { set: [Object] } ],
  version: 2,
  created_date_millis: 1761731006028,
  modified_date_millis: 1761732134830
}
[2025-10-29T11:03:38.922+01:00][DEBUG][plugins.fleet.fleet:sync-integrations-task:1.0.5] Updating ingest pipeline: logs-system.auth@custom
[2025-10-29T11:11:36.343+01:00][INFO ][plugins.fleet.fleet:sync-integrations-task:1.0.5] [SyncIntegrationsTask] runTask ended: success
```



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->