### PR TITLE
Skip serverless APM alerts transaction duration test suite for MKI

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
@@ -40,7 +40,10 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     groupBy: ['service.name', 'service.environment', 'transaction.type', 'transaction.name'],
   };
 
-  describe('transaction duration alert', () => {
+  describe('transaction duration alert', function () {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/241102
+    this.tags(['failsOnMKI']);
+
     let apmSynthtraceEsClient: ApmSynthtraceEsClient;
     let roleAuthc: RoleCredentials;
 


### PR DESCRIPTION
## Summary

This PR skips the serverless APM alerts transaction duration test suite for MKI runs.
Details on the failure / flakiness in #241102.

