### PR TITLE
[ES|QL] special filtering handling for ES|QL queries in cascade layout

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -52,6 +52,7 @@ export {
   getESQLStatsQueryMeta,
   constructCascadeQuery,
   mutateQueryStatsGrouping,
+  appendFilteringWhereClauseForCascadeLayout,
 } from './src';
 
 export { ENABLE_ESQL, FEEDBACK_LINK } from './constants';

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -59,4 +59,5 @@ export {
   getESQLStatsQueryMeta,
   constructCascadeQuery,
   mutateQueryStatsGrouping,
+  appendFilteringWhereClauseForCascadeLayout,
 } from './utils/cascaded_documents_helpers';

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query.test.ts
@@ -37,7 +37,7 @@ describe('appendToQuery', () => {
         appendWhereClauseToESQLQuery('from logstash-* // meow', 'dest', 'tada!', '+', 'string')
       ).toBe(
         `from logstash-* // meow
-| WHERE \`dest\`=="tada!"`
+| WHERE \`dest\` == "tada!"`
       );
     });
     it('appends a filter out where clause in an existing query', () => {
@@ -45,7 +45,7 @@ describe('appendToQuery', () => {
         appendWhereClauseToESQLQuery('from logstash-* // meow', 'dest', 'tada!', '-', 'string')
       ).toBe(
         `from logstash-* // meow
-| WHERE \`dest\`!="tada!"`
+| WHERE \`dest\` != "tada!"`
       );
     });
 
@@ -54,14 +54,14 @@ describe('appendToQuery', () => {
         appendWhereClauseToESQLQuery('from logstash-* // meow', 'ip_field', 'tada!', '-', 'ip')
       ).toBe(
         `from logstash-* // meow
-| WHERE \`ip_field\`!="tada!"`
+| WHERE \`ip_field\` != "tada!"`
       );
     });
 
     it('appends a where clause in an existing query with casting to string when the type is not given', () => {
       expect(appendWhereClauseToESQLQuery('from logstash-* // meow', 'dest', 'tada!', '-')).toBe(
         `from logstash-* // meow
-| WHERE \`dest\`::string!="tada!"`
+| WHERE \`dest\`::string != "tada!"`
       );
     });
 
@@ -106,7 +106,7 @@ describe('appendToQuery', () => {
         )
       ).toBe(
         `from logstash-* | where country == "GR"
-AND \`dest\`=="Crete"`
+AND \`dest\` == "Crete"`
       );
     });
 
@@ -169,7 +169,7 @@ AND \`dest\`=="Crete"`
         )
       ).toBe(
         `from logstash-* | where CIDR_MATCH(ip1, "127.0.0.2/32", "127.0.0.3/32")
-and \`ip\`!="127.0.0.2/32"`
+and \`ip\` != "127.0.0.2/32"`
       );
     });
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query.ts
@@ -7,10 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { parse, mutate, BasicPrettyPrinter } from '@kbn/esql-ast';
+import { BasicPrettyPrinter, EsqlQuery, parse, mutate } from '@kbn/esql-ast';
+import type { BinaryExpressionComparisonOperator } from '@kbn/esql-ast/src/types';
 import { sanitazeESQLInput } from './sanitaze_input';
 
-const PARAM_TYPES_NO_NEED_IMPLICIT_STRING_CASTING = [
+export const PARAM_TYPES_NO_NEED_IMPLICIT_STRING_CASTING = [
   'date',
   'date_nanos',
   'version',
@@ -20,11 +21,46 @@ const PARAM_TYPES_NO_NEED_IMPLICIT_STRING_CASTING = [
   'string',
 ];
 
+export type SupportedOperators =
+  | Extract<BinaryExpressionComparisonOperator, '==' | '!='>
+  | 'is not null'
+  | 'is null';
+
 // Append in a new line the appended text to take care of the case where the user adds a comment at the end of the query
 // in these cases a base query such as "from index // comment" will result in errors or wrong data if we don't append in a new line
 export function appendToESQLQuery(baseESQLQuery: string, appendedText: string): string {
   return `${baseESQLQuery}\n${appendedText}`;
 }
+
+/**
+ * Gets the operator and expression type for the given operation
+ */
+export const getOperator = (
+  operation: '+' | '-' | 'is_not_null' | 'is_null'
+): { operator: SupportedOperators; expressionType: 'postfix-unary' | 'binary' } => {
+  switch (operation) {
+    case 'is_not_null':
+      return {
+        operator: 'is not null',
+        expressionType: 'postfix-unary',
+      };
+    case 'is_null':
+      return {
+        operator: 'is null',
+        expressionType: 'postfix-unary',
+      };
+    case '-':
+      return {
+        operator: '!=',
+        expressionType: 'binary',
+      };
+    default:
+      return {
+        operator: '==',
+        expressionType: 'binary',
+      };
+  }
+};
 
 export function appendWhereClauseToESQLQuery(
   baseESQLQuery: string,
@@ -37,20 +73,13 @@ export function appendWhereClauseToESQLQuery(
   if (Array.isArray(value)) {
     return undefined;
   }
-  let operator;
-  switch (operation) {
-    case 'is_not_null':
-      operator = ' is not null';
-      break;
-    case 'is_null':
-      operator = ' is null';
-      break;
-    case '-':
-      operator = '!=';
-      break;
-    default:
-      operator = '==';
-  }
+
+  const ESQLQuery = EsqlQuery.fromSrc(baseESQLQuery);
+
+  const whereCommands = Array.from(mutate.commands.where.list(ESQLQuery.ast));
+
+  const { operator } = getOperator(operation);
+
   let filterValue =
     typeof value === 'string' ? `"${value.replace(/\\/g, '\\\\').replace(/\"/g, '\\"')}"` : value;
   // Adding the backticks here are they are needed for special char fields
@@ -69,16 +98,14 @@ export function appendWhereClauseToESQLQuery(
     filterValue = '';
   }
 
-  const { ast } = parse(baseESQLQuery);
-
-  const lastCommandIsWhere = ast[ast.length - 1].name === 'where';
   // if where command already exists in the end of the query:
-  // - we need to append with and if the filter doesnt't exist
+  // - we need to append with and if the filter doesn't exist
   // - we need to change the filter operator if the filter exists with different operator
   // - we do nothing if the filter exists with the same operator
-  if (lastCommandIsWhere) {
-    const whereCommand = ast[ast.length - 1];
-    const whereAstText = whereCommand.text;
+  if (Boolean(whereCommands.length)) {
+    const lastWhereCommand = whereCommands[whereCommands.length - 1];
+
+    const whereAstText = lastWhereCommand.text;
     // the filter already exists in the where clause
     if (whereAstText.includes(field) && whereAstText.includes(String(filterValue))) {
       const pipesArray = baseESQLQuery.split('|');
@@ -88,7 +115,10 @@ export function appendWhereClauseToESQLQuery(
       if (matches) {
         const existingOperator = matches[1]?.trim().replace('`', '').toLowerCase();
         if (!['==', '!=', 'is not null', 'is null'].includes(existingOperator.trim())) {
-          return appendToESQLQuery(baseESQLQuery, `and ${fieldName}${operator}${filterValue}`);
+          return appendToESQLQuery(
+            baseESQLQuery,
+            `and ${fieldName} ${operator} ${filterValue}`.trim()
+          );
         }
         // the filter is the same
         if (existingOperator === operator.trim()) {
@@ -101,11 +131,13 @@ export function appendWhereClauseToESQLQuery(
         }
       }
     }
+
     // filter does not exist in the where clause
-    const whereClause = `AND ${fieldName}${operator}${filterValue}`;
+    const whereClause = `AND ${fieldName} ${operator} ${filterValue}`.trim();
     return appendToESQLQuery(baseESQLQuery, whereClause);
   }
-  const whereClause = `| WHERE ${fieldName}${operator}${filterValue}`;
+
+  const whereClause = `| WHERE ${fieldName} ${operator} ${filterValue}`.trim();
   return appendToESQLQuery(baseESQLQuery, whereClause);
 }
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers.ts
@@ -22,12 +22,19 @@ import {
   type ESQLAstItem,
   type ESQLCommandOption,
   type ESQLColumn,
+  isBinaryExpression,
 } from '@kbn/esql-ast';
 import type {
   StatsCommandSummary,
   StatsFieldSummary,
 } from '@kbn/esql-ast/src/mutate/commands/stats';
+import type {
+  BinaryExpressionComparisonOperator,
+  BinaryExpressionWhereOperator,
+  ESQLBinaryExpression,
+} from '@kbn/esql-ast/src/types';
 import { extractCategorizeTokens } from './extract_categorize_tokens';
+import { getOperator, PARAM_TYPES_NO_NEED_IMPLICIT_STRING_CASTING } from './append_to_query';
 
 type NodeType = 'group' | 'leaf';
 
@@ -51,8 +58,27 @@ export type SupportedStatsFunction = (typeof SUPPORTED_STATS_COMMAND_OPTION_FUNC
 const isSupportedStatsFunction = (fnName: string): fnName is SupportedStatsFunction =>
   SUPPORTED_STATS_COMMAND_OPTION_FUNCTIONS.includes(fnName as SupportedStatsFunction);
 
+export type SupportedFieldTypes = Exclude<
+  keyof typeof Builder.expression.literal,
+  'nil' | 'numeric' | 'timespan'
+>;
+
+export type FieldValue<T extends SupportedFieldTypes> =
+  | Parameters<(typeof Builder.expression.literal)[T]>[0]
+  | unknown;
+
 // helper for removing backticks from field names of function names
 const removeBackticks = (str: string) => str.replace(/`/g, '');
+
+/**
+ * constrains the field value type to be one of the supported field value types, else we process as a string literal when building the expression
+ */
+export const isSupportedFieldType = (fieldType: unknown): fieldType is SupportedFieldTypes => {
+  return (
+    PARAM_TYPES_NO_NEED_IMPLICIT_STRING_CASTING.includes(fieldType as SupportedFieldTypes) &&
+    Object.keys(Builder.expression.literal).includes(fieldType as SupportedFieldTypes)
+  );
+};
 
 function getStatsCommandToOperateOn(esqlQuery: EsqlQuery): StatsCommandSummary | null {
   if (esqlQuery.errors.length) {
@@ -497,3 +523,153 @@ export function mutateQueryStatsGrouping(query: AggregateQuery, pick: string[]):
     esql: BasicPrettyPrinter.print(EditorESQLQuery.ast),
   };
 }
+
+/**
+ * Handles the computation and appending of a filtering where clause,
+ * for ES|QL query containing a stats command in the cascade layout experience
+ */
+export const appendFilteringWhereClauseForCascadeLayout = <
+  T extends SupportedFieldTypes | string = SupportedFieldTypes | string
+>(
+  query: string,
+  fieldName: string,
+  value: T extends SupportedFieldTypes ? FieldValue<T> : unknown,
+  operation: '+' | '-' | 'is_not_null' | 'is_null',
+  fieldType?: T extends SupportedFieldTypes ? T : string
+) => {
+  const ESQLQuery = EsqlQuery.fromSrc(query);
+
+  const { ast } = ESQLQuery;
+
+  const queryRuntimeFields = Array.from(mutate.commands.stats.summarize(ESQLQuery)).map(
+    (command) => command.newFields
+  );
+
+  const fieldDeclarationCommandIndex = queryRuntimeFields.findIndex((field) =>
+    field.has(fieldName)
+  );
+
+  const fieldIsRuntimeDeclared = fieldDeclarationCommandIndex >= 0;
+
+  let fieldDeclarationCommand: ESQLCommand<'stats'> | null = null;
+
+  // if the field that's being filtered on is a new field created by some stats command in the query,
+  // then we want to find the command that created it
+  if (fieldIsRuntimeDeclared) {
+    fieldDeclarationCommand = mutate.commands.stats.byIndex(
+      ast,
+      fieldDeclarationCommandIndex
+    ) as ESQLCommand<'stats'>;
+  }
+
+  const datasourceCommand = getESQLQueryDataSourceCommand(ESQLQuery);
+
+  const insertionAnchorCommand = fieldDeclarationCommand ?? datasourceCommand;
+
+  if (!insertionAnchorCommand) {
+    throw new Error('No insertion anchor command found, nothing to do');
+  }
+
+  const insertionAnchorCommandIndex = ast.commands.findIndex(
+    (cmd) => cmd.text === insertionAnchorCommand.text
+  );
+
+  // we would always want to insert our new query right after the insertion anchor command
+  const filterInsertionIndex = insertionAnchorCommandIndex + 1;
+
+  // since we can't anticipate the nature of the query we could be dealing with
+  // we simply select the commands that exist from start of the query including the insertion anchor command
+  const commandsBeforeInsertionAnchor = ast.commands.slice(0, filterInsertionIndex + 1);
+
+  const filteringWhereCommandIndex = commandsBeforeInsertionAnchor.findLastIndex(
+    (cmd) => cmd.name === 'where'
+  );
+
+  const { operator, expressionType } = getOperator(operation);
+
+  // This is the computed expression for the filter operation that has been requested by the user
+  const computedFilteringExpression =
+    expressionType === 'postfix-unary'
+      ? Builder.expression.func.postfix(operator, [Builder.identifier({ name: fieldName! })])
+      : Builder.expression.func.binary(operator as BinaryExpressionComparisonOperator, [
+          Builder.identifier({ name: fieldName! }),
+          fieldType && isSupportedFieldType(fieldType)
+            ? // @ts-expect-error - this works but needs more type improvements
+              Builder.expression.literal[fieldType].call(
+                null,
+                value as FieldValue<typeof fieldType>
+              )
+            : // when fieldType is not provided or supported, we default to string
+              Builder.expression.literal.string(value as string),
+        ]);
+
+  if (filteringWhereCommandIndex < 0) {
+    const filteringWhereCommand = Builder.command({
+      name: 'where',
+      args: [computedFilteringExpression],
+    });
+
+    mutate.generic.commands.insert(ast, filteringWhereCommand, filterInsertionIndex);
+
+    return BasicPrettyPrinter.print(ast);
+  }
+
+  const filteringWhereCommand = commandsBeforeInsertionAnchor[filteringWhereCommandIndex];
+
+  let modifiedFilteringWhereCommand: ESQLCommand<'where'> | null = null;
+
+  // the where command itself typically only accepts a single expression as its argument
+  // if it's not a named "and" binary expression, we'll treat it as a command that has only one expression,
+  // hence we only need to either replace it with a new one or append a new one
+  if (
+    isBinaryExpression(filteringWhereCommand.args[0]) &&
+    filteringWhereCommand.args[0].name !== 'and'
+  ) {
+    const binaryExpression = filteringWhereCommand
+      .args[0] as ESQLBinaryExpression<BinaryExpressionWhereOperator>;
+    const [left] = binaryExpression.args;
+
+    modifiedFilteringWhereCommand = Builder.command({
+      name: 'where',
+      args:
+        (left as ESQLColumn).name !== fieldName
+          ? [
+              Builder.expression.func.binary('and', [
+                computedFilteringExpression,
+                synth.exp(BasicPrettyPrinter.print(binaryExpression), {
+                  withFormatting: false,
+                }),
+              ]),
+            ]
+          : [
+              // when the expression's left hand's value matches the target field we're trying to filter on, we simply replace it with the new expression
+              computedFilteringExpression,
+            ],
+    });
+  } else if (
+    isBinaryExpression(filteringWhereCommand.args[0]) &&
+    filteringWhereCommand.args[0].name === 'and'
+  ) {
+    modifiedFilteringWhereCommand = Builder.command({
+      name: 'where',
+      args: [
+        Builder.expression.func.binary('and', [
+          computedFilteringExpression,
+          // we select the arguments text from the current where command as is to avoid parsing,
+          // else we'll need to treat it's arguments as an infinitely nested case and handle it accordingly
+          synth.exp(BasicPrettyPrinter.print(filteringWhereCommand.args[0]), {
+            withFormatting: false,
+          }),
+        ]),
+      ],
+    });
+  }
+
+  // if we where able to create a new filtering where command, we need to add it in and remove the old one
+  if (modifiedFilteringWhereCommand) {
+    mutate.generic.commands.insert(ast, modifiedFilteringWhereCommand, filteringWhereCommandIndex);
+    mutate.generic.commands.remove(ast, filteringWhereCommand);
+  }
+
+  return BasicPrettyPrinter.print(ast);
+};

--- a/src/platform/plugins/shared/data/public/actions/filters/create_filters_from_value_click.test.ts
+++ b/src/platform/plugins/shared/data/public/actions/filters/create_filters_from_value_click.test.ts
@@ -271,8 +271,8 @@ describe('createFiltersFromClickEvent', () => {
         query: { esql: 'from meow' },
       });
       expect(queryString).toEqual(`from meow
-| WHERE \`columnA\`=="2048"
-AND \`columnB\`=="2048"`);
+| WHERE \`columnA\` == "2048"
+AND \`columnB\` == "2048"`);
     });
 
     test('should return null if no aggregate query is present', async () => {
@@ -304,7 +304,7 @@ AND \`columnB\`=="2048"`);
       });
 
       expect(queryString).toEqual(`from meow
-| WHERE \`columnA\`=="2048"`);
+| WHERE \`columnA\` == "2048"`);
     });
 
     test('should return the update query string for negated action', async () => {
@@ -322,7 +322,7 @@ AND \`columnB\`=="2048"`);
       });
 
       expect(queryString).toEqual(`from meow
-| WHERE \`columnA\`!="2048"`);
+| WHERE \`columnA\` != "2048"`);
     });
   });
 });

--- a/src/platform/test/functional/apps/discover/esql/_esql_view.ts
+++ b/src/platform/test/functional/apps/discover/esql/_esql_view.ts
@@ -814,7 +814,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         const editorValue = await monacoEditor.getCodeEditorValue();
         expect(editorValue).to.eql(
-          `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB\n| WHERE \`geo.dest\`=="BT"`
+          `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB\n| WHERE \`geo.dest\` == "BT"`
         );
 
         // negate
@@ -825,7 +825,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         const newValue = await monacoEditor.getCodeEditorValue();
         expect(newValue).to.eql(
-          `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB\n| WHERE \`geo.dest\`!="BT"`
+          `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB\n| WHERE \`geo.dest\`!= "BT"`
         );
       });
 
@@ -846,7 +846,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         const editorValue = await monacoEditor.getCodeEditorValue();
         expect(editorValue).to.eql(
-          `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB | where countB > 0\nAND \`geo.dest\`=="BT"`
+          `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB | where countB > 0\nAND \`geo.dest\` == "BT"`
         );
       });
 
@@ -875,7 +875,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         const editorValue = await monacoEditor.getCodeEditorValue();
         expect(editorValue).to.eql(
-          `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB\n| WHERE \`geo.dest\`=="BT"`
+          `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB\n| WHERE \`geo.dest\` == "BT"`
         );
 
         // check that the type is still line
@@ -920,7 +920,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         const editorValue = await monacoEditor.getCodeEditorValue();
         expect(editorValue).to.eql(
-          `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB\n| WHERE \`geo.dest\`=="BT"`
+          `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB\n| WHERE \`geo.dest\` == "BT"`
         );
 
         // check that the type is still line
@@ -972,7 +972,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await unifiedFieldList.waitUntilSidebarHasLoaded();
 
         const editorValue = await monacoEditor.getCodeEditorValue();
-        expect(editorValue).to.eql(`from logstash-*\n| WHERE \`extension\`=="png"`);
+        expect(editorValue).to.eql(`from logstash-*\n| WHERE \`extension\` == "png"`);
       });
 
       it('should save breakdown field in saved search', async () => {


### PR DESCRIPTION
## Summary
Culled from https://github.com/elastic/kibana/pull/220119

The cascade layout in discover provides functionality such that the grouping functions specified on a query are rendered to the user as expandable rows, when these rows are expanded, we would request the documents that match the value of said row which is quite different from what we currently have.

That been said the current filtering implementation doesn't quite work well with this model; for context from the expanded row, the user has the ability to view all the field on a document and as such can apply filters that include/exclude any specified field, it's approach is to append new filtering commands to the already existing query, this doesn't quite work very well with STATS commands which the cascade layout experience is built around

Consider the query;

```
  FROM kibana_sample_data_logs
  | STATS count_per_day=COUNT(*) BY category=CATEGORIZE(message), @timestamp=BUCKET(@timestamp, 1 day)
  | STATS count = SUM(count_per_day), Trend=VALUES(count_per_day) BY category
  | KEEP category, count
  | STATS sample= SAMPLE(count, 10) BY category
```

Despite the fact that the user would in the cascade experience have rows grouped by the field `category`, on expanding any row that is presented to the user they might opt to filter for example by some column named `clientip`, with our current implementation this would result in the following query; 

```
  FROM kibana_sample_data_logs
  | STATS count_per_day=COUNT(*) BY category=CATEGORIZE(message), @timestamp=BUCKET(@timestamp, 1 day)
  | STATS count = SUM(count_per_day), Trend=VALUES(count_per_day) BY category
  | KEEP category, count
  | STATS sample= SAMPLE(count, 10) BY category
  | WHERE clientip == "147.107.162.98"
```

This would be an invalid query, because first off the `KEEP` command has filtered out all the other columns that the index `kibana_sample_data_logs` has, if some user was actually writing this query they would know that the query shown above wouldn't work.

To account for cases as defined before and many other unknown cases this PR introduces a function that intended to be used for the cascade experience so that such filtering commands would be placed right after the data source command, hence we'd have a correct query which would be;

```
FROM kibana_sample_data_logs
  | WHERE clientip == "147.107.162.98"
  | STATS count_per_day = COUNT(*) BY category = CATEGORIZE(message), @timestamp = BUCKET(@timestamp, 1 day)
  | STATS count = SUM(count_per_day), Trend = VALUES(count_per_day) BY category
  | KEEP category, count
  | STATS `sample` = SAMPLE(count, 10)  BY category
```

it also takes into consideration an extra scenario where a runtime field is being filtered, say for instance for the currently supported grouping function `CATEGORIZE`, and the user opts to filter on the row level, a filtering where  command would be placed right after it's declaration.

<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->

