### PR TITLE
[ResponseOps][POC] YAML connectors

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -720,6 +720,92 @@
         ]
       }
     },
+    "/api/actions/connector/{id}/_axios_test": {
+      "post": {
+        "description": "Foobar",
+        "operationId": "post-actions-connector-id-axios-test",
+        "parameters": [
+          {
+            "description": "A required header to protect against CSRF attacks",
+            "in": "header",
+            "name": "kbn-xsrf",
+            "required": true,
+            "schema": {
+              "example": "true",
+              "type": "string"
+            }
+          },
+          {
+            "description": "An identifier for the connector.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "config": {
+                      "additionalProperties": {},
+                      "type": "object"
+                    },
+                    "connector_type_id": {
+                      "description": "The connector type identifier.",
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "The identifier for the connector.",
+                      "type": "string"
+                    },
+                    "is_deprecated": {
+                      "description": "Indicates whether the connector is deprecated.",
+                      "type": "boolean"
+                    },
+                    "is_missing_secrets": {
+                      "description": "Indicates whether the connector is missing secrets.",
+                      "type": "boolean"
+                    },
+                    "is_preconfigured": {
+                      "description": "Indicates whether the connector is preconfigured. If true, the `config` and `is_missing_secrets` properties are omitted from the response. ",
+                      "type": "boolean"
+                    },
+                    "is_system_action": {
+                      "description": "Indicates whether the connector is used for system actions.",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "description": " The name of the rule.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "connector_type_id",
+                    "is_preconfigured",
+                    "is_deprecated",
+                    "is_system_action"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Indicates a successful call."
+          }
+        },
+        "summary": "Foobar",
+        "tags": [
+          "connectors"
+        ]
+      }
+    },
     "/api/actions/connector/{id}/_execute": {
       "post": {
         "description": "You can use this API to test an action that involves interaction with Kibana services or integrations with third-party systems.",

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -720,6 +720,92 @@
         ]
       }
     },
+    "/api/actions/connector/{id}/_axios_test": {
+      "post": {
+        "description": "Foobar",
+        "operationId": "post-actions-connector-id-axios-test",
+        "parameters": [
+          {
+            "description": "A required header to protect against CSRF attacks",
+            "in": "header",
+            "name": "kbn-xsrf",
+            "required": true,
+            "schema": {
+              "example": "true",
+              "type": "string"
+            }
+          },
+          {
+            "description": "An identifier for the connector.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "config": {
+                      "additionalProperties": {},
+                      "type": "object"
+                    },
+                    "connector_type_id": {
+                      "description": "The connector type identifier.",
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "The identifier for the connector.",
+                      "type": "string"
+                    },
+                    "is_deprecated": {
+                      "description": "Indicates whether the connector is deprecated.",
+                      "type": "boolean"
+                    },
+                    "is_missing_secrets": {
+                      "description": "Indicates whether the connector is missing secrets.",
+                      "type": "boolean"
+                    },
+                    "is_preconfigured": {
+                      "description": "Indicates whether the connector is preconfigured. If true, the `config` and `is_missing_secrets` properties are omitted from the response. ",
+                      "type": "boolean"
+                    },
+                    "is_system_action": {
+                      "description": "Indicates whether the connector is used for system actions.",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "description": " The name of the rule.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "connector_type_id",
+                    "is_preconfigured",
+                    "is_deprecated",
+                    "is_system_action"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Indicates a successful call."
+          }
+        },
+        "summary": "Foobar",
+        "tags": [
+          "connectors"
+        ]
+      }
+    },
     "/api/actions/connector/{id}/_execute": {
       "post": {
         "description": "You can use this API to test an action that involves interaction with Kibana services or integrations with third-party systems.",

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/types/action_types.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/types/action_types.ts
@@ -114,13 +114,13 @@ export interface ActionTypeModel<ActionConfig = any, ActionSecrets = any, Action
   selectMessage: string;
   selectMessagePreconfigured?: string;
   actionTypeTitle?: string;
-  validateParams: (
+  validateParams?: (
     actionParams: ActionParams
   ) => Promise<GenericValidationResult<Partial<ActionParams> | unknown>>;
-  actionConnectorFields: React.LazyExoticComponent<
+  actionConnectorFields?: React.LazyExoticComponent<
     ComponentType<ActionConnectorFieldsProps>
   > | null;
-  actionParamsFields: React.LazyExoticComponent<ComponentType<ActionParamsProps<ActionParams>>>;
+  actionParamsFields?: React.LazyExoticComponent<ComponentType<ActionParamsProps<ActionParams>>>;
   actionReadOnlyExtraComponent?: React.LazyExoticComponent<
     ComponentType<ActionReadOnlyElementProps>
   >;

--- a/x-pack/platform/plugins/shared/actions/server/action_type_registry.ts
+++ b/x-pack/platform/plugins/shared/actions/server/action_type_registry.ts
@@ -274,6 +274,7 @@ export class ActionTypeRegistry {
             }
           : {}),
         isDeprecated: !!actionType.isDeprecated,
+        uiFields: actionType.uiFields,
       }));
   }
 

--- a/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.mock.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.mock.ts
@@ -29,6 +29,7 @@ const createActionsClientMock = () => {
     isSystemAction: jest.fn(),
     getGlobalExecutionKpiWithAuth: jest.fn(),
     getGlobalExecutionLogWithAuth: jest.fn(),
+    getAxiosInstance: jest.fn(),
   };
   return mocked;
 };

--- a/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.ts
@@ -20,6 +20,7 @@ import type {
 import type { AuditLogger } from '@kbn/security-plugin/server';
 import type { IEventLogClient } from '@kbn/event-log-plugin/server';
 import type { KueryNode } from '@kbn/es-query';
+import type { AxiosInstance } from 'axios';
 import type { Connector, ConnectorWithExtraFindData } from '../application/connector/types';
 import type { ConnectorType } from '../application/connector/types';
 import { get } from '../application/connector/methods/get';
@@ -81,6 +82,7 @@ import { isPreconfigured } from '../lib/is_preconfigured';
 import { isSystemAction } from '../lib/is_system_action';
 import type { ConnectorExecuteParams } from '../application/connector/methods/execute/types';
 import { connectorFromInMemoryConnector } from '../application/connector/lib/connector_from_in_memory_connector';
+import { getAxiosInstance } from '../application/connector/methods/get_axios_instance';
 
 export interface ConstructorOptions {
   logger: Logger;
@@ -497,6 +499,12 @@ export class ActionsClient {
     connectorExecuteParams: ConnectorExecuteParams
   ): Promise<ActionTypeExecutorResult<unknown>> {
     return execute(this.context, connectorExecuteParams);
+  }
+
+  public async getAxiosInstance(
+    connectorExecuteParams: ConnectorExecuteParams
+  ): Promise<AxiosInstance> {
+    return getAxiosInstance(this.context, connectorExecuteParams);
   }
 
   public async bulkEnqueueExecution(

--- a/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.ts
@@ -83,6 +83,7 @@ import { isSystemAction } from '../lib/is_system_action';
 import type { ConnectorExecuteParams } from '../application/connector/methods/execute/types';
 import { connectorFromInMemoryConnector } from '../application/connector/lib/connector_from_in_memory_connector';
 import { getAxiosInstance } from '../application/connector/methods/get_axios_instance';
+import type { GetAxiosParams } from '../lib/action_executor';
 
 export interface ConstructorOptions {
   logger: Logger;
@@ -501,10 +502,8 @@ export class ActionsClient {
     return execute(this.context, connectorExecuteParams);
   }
 
-  public async getAxiosInstance(
-    connectorExecuteParams: ConnectorExecuteParams
-  ): Promise<AxiosInstance> {
-    return getAxiosInstance(this.context, connectorExecuteParams);
+  public async getAxiosInstance(getAxiosParams: GetAxiosParams): Promise<AxiosInstance> {
+    return getAxiosInstance(this.context, getAxiosParams);
   }
 
   public async bulkEnqueueExecution(

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_axios_instance/get_axios_instance.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_axios_instance/get_axios_instance.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { AxiosInstance } from 'axios';
+import type { RawAction } from '../../../../types';
+import { ACTION_SAVED_OBJECT_TYPE } from '../../../../constants/saved_objects';
+import type { ActionsClientContext } from '../../../../actions_client';
+import type { ConnectorExecuteParams } from '../execute/types';
+
+export async function getAxiosInstance(
+  context: ActionsClientContext,
+  connectorExecuteParams: ConnectorExecuteParams
+): Promise<AxiosInstance> {
+  const log = context.logger;
+  const { actionId, params, source, relatedSavedObjects } = connectorExecuteParams;
+  let actionTypeId: string | undefined;
+
+  try {
+    const { attributes } = await context.unsecuredSavedObjectsClient.get<RawAction>(
+      ACTION_SAVED_OBJECT_TYPE,
+      actionId
+    );
+
+    actionTypeId = attributes.actionTypeId;
+  } catch (err) {
+    log.debug(`Failed to retrieve actionTypeId for action [${actionId}]`, err);
+  }
+
+  // No authorization atm
+  return context.actionExecutor.getAxiosInstance({
+    actionId,
+    params,
+    source,
+    request: context.request,
+    relatedSavedObjects,
+    actionExecutionId: uuidv4(),
+  });
+}

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_axios_instance/get_axios_instance.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_axios_instance/get_axios_instance.ts
@@ -5,39 +5,18 @@
  * 2.0.
  */
 
-import { v4 as uuidv4 } from 'uuid';
 import type { AxiosInstance } from 'axios';
-import type { RawAction } from '../../../../types';
-import { ACTION_SAVED_OBJECT_TYPE } from '../../../../constants/saved_objects';
+import type { GetAxiosParams } from '../../../../lib/action_executor';
 import type { ActionsClientContext } from '../../../../actions_client';
-import type { ConnectorExecuteParams } from '../execute/types';
 
 export async function getAxiosInstance(
   context: ActionsClientContext,
-  connectorExecuteParams: ConnectorExecuteParams
+  getAxiosParams: GetAxiosParams
 ): Promise<AxiosInstance> {
-  const log = context.logger;
-  const { actionId, params, source, relatedSavedObjects } = connectorExecuteParams;
-  let actionTypeId: string | undefined;
+  const { actionId } = getAxiosParams;
 
-  try {
-    const { attributes } = await context.unsecuredSavedObjectsClient.get<RawAction>(
-      ACTION_SAVED_OBJECT_TYPE,
-      actionId
-    );
-
-    actionTypeId = attributes.actionTypeId;
-  } catch (err) {
-    log.debug(`Failed to retrieve actionTypeId for action [${actionId}]`, err);
-  }
-
-  // No authorization atm
   return context.actionExecutor.getAxiosInstance({
     actionId,
-    params,
-    source,
     request: context.request,
-    relatedSavedObjects,
-    actionExecutionId: uuidv4(),
   });
 }

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_axios_instance/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_axios_instance/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getAxiosInstance } from './get_axios_instance';

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.mock.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.mock.ts
@@ -13,6 +13,7 @@ const createActionExecutorMock = () => {
     execute: jest.fn().mockResolvedValue({ status: 'ok', actionId: '' }),
     executeUnsecured: jest.fn().mockResolvedValue({ status: 'ok', actionId: '' }),
     logCancellation: jest.fn(),
+    getAxiosInstance: jest.fn(),
   };
   return mocked;
 };

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
@@ -4,6 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
+// @ts-nocheck
+
 import type { KibanaRequest } from '@kbn/core/server';
 import { z } from '@kbn/zod';
 import { ActionExecutor } from './action_executor';

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
@@ -21,6 +21,8 @@ import type { IEventLogger } from '@kbn/event-log-plugin/server';
 import { SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import { getErrorSource } from '@kbn/task-manager-plugin/server/task_running';
+import type { AxiosInstance } from 'axios';
+import axios from 'axios';
 import { GEN_AI_TOKEN_COUNT_EVENT } from './event_based_telemetry';
 import { ConnectorUsageCollector } from '../usage/connector_usage_collector';
 import {
@@ -134,6 +136,65 @@ export class ActionExecutor {
     }
     this.isInitialized = true;
     this.actionExecutorContext = actionExecutorContext;
+  }
+
+  public async getAxiosInstance({
+    actionId,
+    request,
+    params,
+    taskInfo,
+  }: ExecuteOptions): Promise<AxiosInstance> {
+    const { actionTypeRegistry, spaces } = this.actionExecutorContext!;
+
+    const spaceId = spaces && spaces.getSpaceId(request);
+    const namespace = spaceId && spaceId !== 'default' ? { namespace: spaceId } : {};
+    const actionInfo = await this.getActionInfoInternal(actionId, namespace.namespace);
+
+    const { actionTypeId, config, secrets } = actionInfo;
+
+    const loggerId = actionTypeId.startsWith('.') ? actionTypeId.substring(1) : actionTypeId;
+    const logger = this.actionExecutorContext!.logger.get(loggerId);
+    const actionType = actionTypeRegistry.get(actionTypeId);
+    const configurationUtilities = actionTypeRegistry.getUtils();
+    let validatedConfig;
+    let validatedSecrets;
+    try {
+      const validationResult = validateAction(
+        {
+          actionId,
+          actionType,
+          params,
+          config,
+          secrets,
+          taskInfo,
+        },
+        { configurationUtilities }
+      );
+      validatedConfig = validationResult.validatedConfig;
+      validatedSecrets = validationResult.validatedSecrets;
+    } catch (err) {
+      return err.result;
+    }
+
+    try {
+      logger.debug('validated config and secret');
+      let auth;
+      if (validatedConfig.hasAuth) {
+        auth = {
+          username: validatedSecrets.username as unknown as string,
+          password: validatedSecrets.password as unknown as string,
+        };
+      }
+      return axios.create({
+        baseURL: validatedConfig.url as unknown as string,
+        method: validatedConfig.method as unknown as string,
+        auth,
+      });
+    } catch (error) {
+      logger.error(`${error}`);
+    }
+
+    return axios.create();
   }
 
   public async execute({
@@ -522,6 +583,7 @@ export class ActionExecutor {
             await checkCanExecuteFn(actionTypeId);
           }
 
+          // @ts-ignore
           rawResult = await actionType.executor({
             actionId,
             services,

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
@@ -93,6 +93,10 @@ export interface ExecuteOptions<Source = unknown> {
   taskInfo?: TaskInfo;
 }
 
+export interface GetAxiosParams {
+  actionId: string;
+}
+
 type ExecuteHelperOptions<Source = unknown> = Omit<ExecuteOptions<Source>, 'request'> & {
   currentUser?: AuthenticatedUser | null;
   checkCanExecuteFn?: (connectorTypeId: string) => Promise<void>;
@@ -141,9 +145,7 @@ export class ActionExecutor {
   public async getAxiosInstance({
     actionId,
     request,
-    params,
-    taskInfo,
-  }: ExecuteOptions): Promise<AxiosInstance> {
+  }: GetAxiosParams & { request: KibanaRequest }): Promise<AxiosInstance> {
     const { actionTypeRegistry, spaces } = this.actionExecutorContext!;
 
     const spaceId = spaces && spaces.getSpaceId(request);
@@ -163,10 +165,9 @@ export class ActionExecutor {
         {
           actionId,
           actionType,
-          params,
+          params: {},
           config,
           secrets,
-          taskInfo,
         },
         { configurationUtilities }
       );

--- a/x-pack/platform/plugins/shared/actions/server/routes/connector/axios_test/axios_test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/routes/connector/axios_test/axios_test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IRouter } from '@kbn/core/server';
+import type { ILicenseState } from '../../../lib';
+
+import type { ActionsRequestHandlerContext } from '../../../types';
+import { BASE_ACTION_API_PATH } from '../../../../common';
+import { asHttpRequestExecutionSource } from '../../../lib/action_execution_source';
+import { verifyAccessAndContext } from '../../verify_access_and_context';
+import { connectorResponseSchemaV1 } from '../../../../common/routes/connector/response';
+import type { ExecuteConnectorRequestParamsV1 } from '../../../../common/routes/connector/apis/execute';
+import { executeConnectorRequestParamsSchemaV1 } from '../../../../common/routes/connector/apis/execute';
+import { DEFAULT_ACTION_ROUTE_SECURITY } from '../../constants';
+
+export const axiosTestRoute = (
+  router: IRouter<ActionsRequestHandlerContext>,
+  licenseState: ILicenseState
+) => {
+  router.post(
+    {
+      path: `${BASE_ACTION_API_PATH}/connector/{id}/_axios_test`,
+      security: DEFAULT_ACTION_ROUTE_SECURITY,
+      options: {
+        access: 'public',
+        summary: `Foobar`,
+        description: 'Foobar',
+        tags: ['oas-tag:connectors'],
+      },
+      validate: {
+        request: {
+          params: executeConnectorRequestParamsSchemaV1,
+        },
+        response: {
+          204: {
+            description: 'Indicates a successful call.',
+            body: () => connectorResponseSchemaV1,
+          },
+        },
+      },
+    },
+    router.handleLegacyErrors(
+      verifyAccessAndContext(licenseState, async function (context, req, res) {
+        const actionsClient = (await context.actions).getActionsClient();
+        const { id }: ExecuteConnectorRequestParamsV1 = req.params;
+
+        if (actionsClient.isSystemAction(id)) {
+          return res.badRequest({ body: 'Execution of system action is not allowed' });
+        }
+        try {
+          const axiosInstance = await actionsClient.getAxiosInstance({
+            params: {},
+            actionId: id,
+            source: asHttpRequestExecutionSource(req),
+            relatedSavedObjects: [],
+          });
+
+          // @ts-ignore
+          await axiosInstance();
+
+          return res.noContent();
+        } catch (error) {
+          return error;
+        }
+      })
+    )
+  );
+};

--- a/x-pack/platform/plugins/shared/actions/server/routes/connector/axios_test/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/routes/connector/axios_test/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { axiosTestRoute } from './axios_test';

--- a/x-pack/platform/plugins/shared/actions/server/routes/connector/list_types/transforms/transform_list_types_response/v2.ts
+++ b/x-pack/platform/plugins/shared/actions/server/routes/connector/list_types/transforms/transform_list_types_response/v2.ts
@@ -23,6 +23,7 @@ export const transformListTypesResponse = (
       isSystemActionType,
       subFeature,
       isDeprecated,
+      uiFields,
     }) => ({
       id,
       name,
@@ -34,6 +35,7 @@ export const transformListTypesResponse = (
       is_system_action_type: isSystemActionType,
       sub_feature: subFeature,
       is_deprecated: isDeprecated,
+      ui_fields: uiFields,
     })
   );
 };

--- a/x-pack/platform/plugins/shared/actions/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/routes/index.ts
@@ -22,6 +22,7 @@ import { getOAuthAccessToken } from './get_oauth_access_token';
 import type { ActionsConfigurationUtilities } from '../actions_config';
 import { getGlobalExecutionLogRoute } from './get_global_execution_logs';
 import { getGlobalExecutionKPIRoute } from './get_global_execution_kpi';
+import { axiosTestRoute } from './connector/axios_test';
 
 export interface RouteOptions {
   router: IRouter<ActionsRequestHandlerContext>;
@@ -40,6 +41,7 @@ export function defineRoutes(opts: RouteOptions) {
   updateConnectorRoute(router, licenseState);
   listTypesRoute(router, licenseState);
   executeConnectorRoute(router, licenseState);
+  axiosTestRoute(router, licenseState);
   getGlobalExecutionLogRoute(router, licenseState);
   getGlobalExecutionKPIRoute(router, licenseState);
 

--- a/x-pack/platform/plugins/shared/actions/server/types.ts
+++ b/x-pack/platform/plugins/shared/actions/server/types.ts
@@ -191,11 +191,12 @@ export interface ActionType<
   minimumLicenseRequired: LicenseType;
   supportedFeatureIds: string[];
   validate: {
-    params: ValidatorType<Params>;
+    params?: ValidatorType<Params>;
     config: ValidatorType<Config>;
     secrets: ValidatorType<Secrets>;
     connector?: (config: Config, secrets: Secrets) => string | null;
   };
+  uiFields?: Record<string, unknown>;
   isSystemActionType?: boolean;
   subFeature?: SubFeature;
   isDeprecated?: boolean;
@@ -215,7 +216,7 @@ export interface ActionType<
     source?: ActionExecutionSourceType;
   }) => string[];
   renderParameterTemplates?: RenderParameterTemplates<Params>;
-  executor: ExecutorType<Config, Secrets, Params, ExecutorResultData>;
+  executor?: ExecutorType<Config, Secrets, Params, ExecutorResultData>;
   getService?: (params: ServiceParams<Config, Secrets>) => SubActionConnector<Config, Secrets>;
   preSaveHook?: (params: PreSaveConnectorHookParams<Config, Secrets>) => Promise<void>;
   postSaveHook?: (params: PostSaveConnectorHookParams<Config, Secrets>) => Promise<void>;

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/register_yaml_connectors.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/register_yaml_connectors.ts
@@ -5,67 +5,58 @@
  * 2.0.
  */
 
-import type { PluginSetupContract as ActionsPluginSetupContract } from '@kbn/actions-plugin/server';
+// @ts-nocheck
 
+import type { PluginSetupContract as ActionsPluginSetupContract } from '@kbn/actions-plugin/server';
+import { z } from '@kbn/zod';
 import yaml from 'js-yaml';
 import fs from 'fs';
-
-import { z } from '@kbn/zod';
 
 export function registerYAMLConnectors({ actions }: { actions: ActionsPluginSetupContract }) {
   const dirname =
     'x-pack/platform/plugins/shared/stack_connectors/server/connector_types/yaml_connectors/';
-  fs.readdir(
-    dirname,
-    // @ts-ignore
-    function (err, filenames) {
-      if (err) {
-        return;
+  fs.readdir(dirname, function (err, filenames) {
+    if (err) {
+      return;
+    }
+
+    filenames.forEach(function (filename: string) {
+      const yamlConnector = yaml.load(fs.readFileSync(dirname + filename, 'utf8'));
+      let secrets;
+
+      if (yamlConnector.authenticators.includes('BasicAuth')) {
+        secrets = {
+          schema: z.object({
+            username: z.string().nullable().default(null),
+            password: z.string().nullable().default(null),
+          }),
+        };
       }
 
-      filenames.forEach(function (filename: string) {
-        const yamlConnector = yaml.load(fs.readFileSync(dirname + filename, 'utf8'));
-        let secrets;
-
-        // @ts-ignore
-        if (yamlConnector.authenticators.includes('BasicAuth')) {
-          secrets = {
+      const connectorFromYAML = {
+        id: yamlConnector.id,
+        name: yamlConnector.displayName,
+        minimumLicenseRequired: 'gold',
+        supportedFeatureIds: ['alerting'],
+        uiFields: {
+          iconClass: yamlConnector.icon,
+          selectMessage: yamlConnector.description,
+          actionTypeTitle: yamlConnector.displayName,
+        },
+        validate: {
+          config: {
             schema: z.object({
-              username: z.string().nullable().default(null),
-              password: z.string().nullable().default(null),
+              url: z.string(),
+              method: z.string(),
+              headers: z.optional(z.record(z.string(), z.string())),
+              hasAuth: z.boolean().default(false),
             }),
-          };
-        }
-
-        const connectorFromYAML = {
-          id: yamlConnector.id,
-          name: yamlConnector.displayName,
-          minimumLicenseRequired: 'gold',
-          supportedFeatureIds: ['alerting'],
-          // @ts-ignore
-          uiFields: {
-            iconClass: yamlConnector.icon,
-            selectMessage: yamlConnector.description,
-            actionTypeTitle: yamlConnector.displayName,
           },
-          validate: {
-            config: {
-              schema: z.object({
-                url: z.string(),
-                method: z.string(),
-                headers: z.optional(z.record(z.string(), z.string())),
-                hasAuth: z.boolean().default(false),
-              }),
-            },
-            secrets,
-            // params: {},
-          },
-          // renderParameterTemplates,
-          // executor: async () => {},
-        };
+          secrets,
+        },
+      };
 
-        actions.registerType(connectorFromYAML);
-      });
-    }
-  );
+      actions.registerType(connectorFromYAML);
+    });
+  });
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/register_yaml_connectors.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/register_yaml_connectors.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginSetupContract as ActionsPluginSetupContract } from '@kbn/actions-plugin/server';
+
+import yaml from 'js-yaml';
+import fs from 'fs';
+
+import { z } from '@kbn/zod';
+
+export function registerYAMLConnectors({ actions }: { actions: ActionsPluginSetupContract }) {
+  const dirname =
+    'x-pack/platform/plugins/shared/stack_connectors/server/connector_types/yaml_connectors/';
+  fs.readdir(
+    dirname,
+    // @ts-ignore
+    function (err, filenames) {
+      if (err) {
+        return;
+      }
+
+      filenames.forEach(function (filename: string) {
+        const yamlConnector = yaml.load(fs.readFileSync(dirname + filename, 'utf8'));
+        let secrets;
+
+        // @ts-ignore
+        if (yamlConnector.authenticators.includes('BasicAuth')) {
+          secrets = {
+            schema: z.object({
+              username: z.string().nullable().default(null),
+              password: z.string().nullable().default(null),
+            }),
+          };
+        }
+
+        const connectorFromYAML = {
+          id: yamlConnector.id,
+          name: yamlConnector.displayName,
+          minimumLicenseRequired: 'gold',
+          supportedFeatureIds: ['alerting'],
+          // @ts-ignore
+          uiFields: {
+            iconClass: yamlConnector.icon,
+            selectMessage: yamlConnector.description,
+            actionTypeTitle: yamlConnector.displayName,
+          },
+          validate: {
+            config: {
+              schema: z.object({
+                url: z.string(),
+                method: z.string(),
+                headers: z.optional(z.record(z.string(), z.string())),
+                hasAuth: z.boolean().default(false),
+              }),
+            },
+            secrets,
+            // params: {},
+          },
+          // renderParameterTemplates,
+          // executor: async () => {},
+        };
+
+        actions.registerType(connectorFromYAML);
+      });
+    }
+  );
+}

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/yaml_connectors/first_connector.yaml
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/yaml_connectors/first_connector.yaml
@@ -1,0 +1,20 @@
+id: .yaml-connector
+displayName: YAML Connector
+icon: logoSlack
+description: Some YAML connector
+documentation: The connector documentation URL
+authenticators: # one (at most) is required
+  - BasicAuth
+  # - headers:
+  #     X-API-KEY:
+  #       displayName: API Key
+  #       description: The API key to authenticate with Slack
+  #       documentation?: URL
+  #       hint?: string
+  #       type: string # or url/enum(select)/checkbox/toggle/...more primitives
+  #       sensitive: true
+  #       hidden: false
+  #       required: true
+  # - jwt:
+  #   ...
+  # - oauth2:

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/yaml_connectors/second_connector.yaml
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/yaml_connectors/second_connector.yaml
@@ -1,0 +1,20 @@
+id: .yaml-connector-2
+displayName: YAML Connector 2
+icon: logoWebhook
+description: Another YAML connector
+documentation: The connector documentation URL
+authenticators: # one (at most) is required
+  - BasicAuth
+  # - headers:
+  #     X-API-KEY:
+  #       displayName: API Key
+  #       description: The API key to authenticate with Slack
+  #       documentation?: URL
+  #       hint?: string
+  #       type: string # or url/enum(select)/checkbox/toggle/...more primitives
+  #       sensitive: true
+  #       hidden: false
+  #       required: true
+  # - jwt:
+  #   ...
+  # - oauth2:

--- a/x-pack/platform/plugins/shared/stack_connectors/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/plugin.ts
@@ -23,6 +23,7 @@ import {
 import type { ExperimentalFeatures } from '../common/experimental_features';
 import { parseExperimentalConfigValue } from '../common/experimental_features';
 import type { ConfigSchema as StackConnectorsConfigType } from './config';
+import { registerYAMLConnectors } from './connector_types/register_yaml_connectors';
 export interface ConnectorsPluginsSetup {
   actions: ActionsPluginSetupContract;
   usageCollection?: UsageCollectionSetup;
@@ -61,6 +62,10 @@ export class StackConnectorsPlugin
       actions,
       publicBaseUrl: core.http.basePath.publicBaseUrl,
       experimentalFeatures: this.experimentalFeatures,
+    });
+
+    registerYAMLConnectors({
+      actions,
     });
 
     if (plugins.usageCollection) {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
@@ -106,6 +106,7 @@ export const ActionTypeMenu = ({
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
   const registeredActionTypes = Object.entries(actionTypesIndex ?? [])
     .filter(([id, details]) => {
       const actionTypeModel = actionTypeRegistry.has(id) ? actionTypeRegistry.get(id) : undefined;
@@ -116,15 +117,26 @@ export const ActionTypeMenu = ({
       return details.enabledInConfig === true && !shouldHideInUi;
     })
     .map(([id, actionType]) => {
-      const actionTypeModel = actionTypeRegistry.get(id);
-      return {
-        iconClass: actionTypeModel ? actionTypeModel.iconClass : '',
-        selectMessage: actionTypeModel ? actionTypeModel.selectMessage : '',
-        actionType,
-        name: actionType.name,
-        isExperimental: actionTypeModel.isExperimental,
-        isDeprecated: actionType.isDeprecated,
-      };
+      if (actionTypeRegistry.has(id)) {
+        const actionTypeModel = actionTypeRegistry.get(id);
+        return {
+          iconClass: actionTypeModel ? actionTypeModel.iconClass : '',
+          selectMessage: actionTypeModel ? actionTypeModel.selectMessage : '',
+          actionType,
+          name: actionType.name,
+          isExperimental: actionTypeModel.isExperimental,
+          isDeprecated: actionType.isDeprecated,
+        };
+      } else {
+        return {
+          iconClass: actionType.ui_fields.iconClass,
+          selectMessage: actionType.ui_fields.selectMessage,
+          actionType,
+          name: actionType.name,
+          isExperimental: false,
+          isDeprecated: false,
+        };
+      }
     });
 
   const filteredConnectors = useMemo(


### PR DESCRIPTION
## Summary

Implements https://github.com/elastic/response-ops-team/issues/469

This PR explores the possibility of defining connector types via YAML.

To register a new connector, add a new YAML file to the folder `x-pack/platform/plugins/shared/stack_connectors/server/connector_types/yaml_connectors/second_connector.yaml`.

It should follow the format below.

```
id: .yaml-connector-2
displayName: YAML Connector 2
icon: logoWebhook
description: Another YAML connector
documentation: The connector documentation URL
authenticators: # At the moment, only the `BasicAuth` authenticator type is defined.
  - BasicAuth
```

This connector should now be visible in the UI for connector creation.

<img width="745" height="337" alt="Screenshot 2025-10-29 at 17 36 33" src="https://github.com/user-attachments/assets/aa6310cf-df02-4740-bb6e-e694b9861357" />

To create a connector of this type, you can use the connectors API as such:

```
curl --location 'https://localhost:5601/api/actions/connector' \
--header 'kbn-xsrf: true' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
--data '{
    "name": "YAML connector test",
    "connector_type_id": ".yaml-connector",
    "config": {
        "url": "https://webhook.site/aafd3df2-3222-4177-91e9-48ddbc1f5f7c",
        "method": "post"
    },
    "secrets": {}
}'
```

For an example of how to retrieve an axios instance configured to send requests to this connector, you can look at the code in `x-pack/platform/plugins/shared/actions/server/routes/connector/axios_test/axios_test.ts`.
