### PR TITLE
[9.2] [Fleet] Fix delete by query conflict (#241001)

### DIFF
--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/helpers.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/helpers.ts
@@ -7,6 +7,8 @@
 
 import type { Client } from '@elastic/elasticsearch';
 import expect from '@kbn/expect';
+import { asyncForEach } from '@kbn/std';
+import pRetry from 'p-retry';
 
 import {
   AGENT_ACTIONS_INDEX,
@@ -16,9 +18,10 @@ import {
   type FleetServerAgent,
 } from '@kbn/fleet-plugin/common';
 import { ENROLLMENT_API_KEYS_INDEX } from '@kbn/fleet-plugin/common/constants';
-import { asyncForEach } from '@kbn/std';
 
 const ES_INDEX_OPTIONS = { headers: { 'X-elastic-product-origin': 'fleet' } };
+
+const DELETE_RETRIES = 3;
 
 export async function expectToRejectWithNotFound(fn: any) {
   await expectToRejectWithError(fn, /404 "Not Found"/);
@@ -37,68 +40,89 @@ export async function expectToRejectWithError(fn: any, errRegexp: RegExp) {
 
 export async function cleanFleetIndices(esClient: Client) {
   await Promise.all([
-    esClient.deleteByQuery({
-      index: ENROLLMENT_API_KEYS_INDEX,
-      q: '*',
-      ignore_unavailable: true,
-      refresh: true,
-      conflicts: 'proceed',
-    }),
-    esClient.deleteByQuery({
-      index: AGENTS_INDEX,
-      q: '*',
-      ignore_unavailable: true,
-      refresh: true,
-      conflicts: 'proceed',
-    }),
-    esClient.deleteByQuery({
-      index: AGENT_ACTIONS_INDEX,
-      q: '*',
-      ignore_unavailable: true,
-      refresh: true,
-      conflicts: 'proceed',
-    }),
+    pRetry(
+      () =>
+        esClient.deleteByQuery({
+          index: ENROLLMENT_API_KEYS_INDEX,
+          q: '*',
+          ignore_unavailable: true,
+          refresh: true,
+        }),
+      { retries: DELETE_RETRIES }
+    ),
+    pRetry(
+      () =>
+        esClient.deleteByQuery({
+          index: AGENTS_INDEX,
+          q: '*',
+          ignore_unavailable: true,
+          refresh: true,
+        }),
+      { retries: DELETE_RETRIES }
+    ),
+    pRetry(
+      () =>
+        esClient.deleteByQuery({
+          index: AGENT_ACTIONS_INDEX,
+          q: '*',
+          ignore_unavailable: true,
+          refresh: true,
+        }),
+      { retries: DELETE_RETRIES }
+    ),
   ]);
 }
 
 export async function cleanFleetAgents(esClient: Client) {
-  await esClient.deleteByQuery({
-    index: AGENTS_INDEX,
-    q: '*',
-    ignore_unavailable: true,
-    refresh: true,
-    conflicts: 'proceed',
-  });
+  await pRetry(
+    () =>
+      esClient.deleteByQuery({
+        index: AGENTS_INDEX,
+        q: '*',
+        ignore_unavailable: true,
+        refresh: true,
+      }),
+    { retries: DELETE_RETRIES }
+  );
 }
 
 export async function cleanFleetAgentPolicies(esClient: Client) {
-  await esClient.deleteByQuery({
-    index: AGENT_POLICY_INDEX,
-    q: '*',
-    refresh: true,
-    ignore_unavailable: true,
-    conflicts: 'proceed',
-  });
+  await pRetry(
+    () =>
+      esClient.deleteByQuery({
+        index: AGENT_POLICY_INDEX,
+        q: '*',
+        refresh: true,
+        ignore_unavailable: true,
+      }),
+    { retries: DELETE_RETRIES }
+  );
 }
 
 export async function cleanFleetActionIndices(esClient: Client) {
   try {
     await Promise.all([
-      esClient.deleteByQuery({
-        index: AGENT_ACTIONS_INDEX,
-        q: '*',
-        ignore_unavailable: true,
-        refresh: true,
-        conflicts: 'proceed',
-      }),
-      esClient.deleteByQuery(
-        {
-          index: AGENT_ACTIONS_RESULTS_INDEX,
-          q: '*',
-          refresh: true,
-          conflicts: 'proceed',
-        },
-        ES_INDEX_OPTIONS
+      pRetry(
+        () =>
+          esClient.deleteByQuery({
+            index: AGENT_ACTIONS_INDEX,
+            q: '*',
+            ignore_unavailable: true,
+            refresh: true,
+          }),
+        { retries: DELETE_RETRIES }
+      ),
+      pRetry(
+        () =>
+          esClient.deleteByQuery(
+            {
+              index: AGENT_ACTIONS_RESULTS_INDEX,
+              q: '*',
+              refresh: true,
+            },
+            ES_INDEX_OPTIONS
+          ),
+        { retries: DELETE_RETRIES }
       ),
     ]);
   } catch (error) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Fleet] Fix delete by query conflict (#241001)](https://github.com/elastic/kibana/pull/241001)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-10-29T07:46:23Z","message":"[Fleet] Fix delete by query conflict (#241001)","sha":"1109b60f11d012f293d2a2b693c19a41c734b237","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.3.0","v9.1.7","v9.2.1"],"title":"[Fleet] Fix delete by query conflict","number":241001,"url":"https://github.com/elastic/kibana/pull/241001","mergeCommit":{"message":"[Fleet] Fix delete by query conflict (#241001)","sha":"1109b60f11d012f293d2a2b693c19a41c734b237"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241001","number":241001,"mergeCommit":{"message":"[Fleet] Fix delete by query conflict (#241001)","sha":"1109b60f11d012f293d2a2b693c19a41c734b237"}},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->