### PR TITLE
[9.2] [Metrics][Discover] Discover input$ observable emission lost fix (#241092)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.tsx
@@ -22,7 +22,7 @@ import {
   useEuiTheme,
   type EuiFlexGridProps,
 } from '@elastic/eui';
-import { Subject } from 'rxjs';
+import { Subject, shareReplay } from 'rxjs';
 import { PAGE_SIZE } from '../common/constants';
 import { MetricsGrid } from './metrics_grid';
 import { Pagination } from './pagination';
@@ -62,10 +62,17 @@ export const MetricsExperienceGrid = ({
     [originalInput$]
   );
 
-  const discoverFetch$ = useFetch({
+  const baseFetch$ = useFetch({
     input$,
     beforeFetch: updateTimeRange,
   });
+
+  const discoverFetch$ = useMemo(
+    // Buffer and replay emissions to child components that subscribe in later useEffects
+    // without this, child components would miss emissions that occurred before they subscribed
+    () => baseFetch$.pipe(shareReplay({ bufferSize: 1, refCount: false })),
+    [baseFetch$]
+  );
 
   const indexPattern = useMemo(() => dataView?.getIndexPattern() ?? 'metrics-*', [dataView]);
   const { data: fields = [], isFetching: isFieldsLoading } = useMetricFieldsQuery({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Metrics][Discover] Discover input$ observable emission lost fix (#241092)](https://github.com/elastic/kibana/pull/241092)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-29T12:01:59Z","message":"[Metrics][Discover] Discover input$ observable emission lost fix (#241092)\n\nfixes [240429](https://github.com/elastic/kibana/issues/240429)\n\n## Summary\n\nThis PR fixes a bug where the Discover `input# Backport

This will backport the following commits from `main` to `9.2`:
{{{{raw}}}} - [[Metrics][Discover] Discover input$ observable emission lost fix (#241092)](https://github.com/elastic/kibana/pull/241092){{{{/raw}}}}