### PR TITLE
Scout reporting - add build trigger details

### DIFF
--- a/src/platform/packages/private/kbn-scout-reporting/src/datasources/buildkite.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/datasources/buildkite.ts
@@ -39,6 +39,11 @@ export interface BuildkiteMetadata {
     label?: string;
   };
   command?: string;
+  triggered_from_build: {
+    id?: string;
+    number?: string;
+    pipeline_slug?: string;
+  };
 }
 
 /**
@@ -77,6 +82,11 @@ export const buildkite: BuildkiteMetadata =
           label: process.env.BUILDKITE_LABEL,
         },
         command: process.env.BUILDKITE_COMMAND,
+        triggered_from_build: {
+          id: process.env.BUILDKITE_TRIGGERED_FROM_BUILD_ID,
+          number: process.env.BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER,
+          pipeline_slug: process.env.BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG,
+        },
       }
     : {
         build: {},
@@ -84,4 +94,5 @@ export const buildkite: BuildkiteMetadata =
         agent: {},
         group: {},
         step: {},
+        triggered_from_build: {},
       };

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
@@ -18,7 +18,7 @@ import {
 
 export const buildkiteMappings: ClusterPutComponentTemplateRequest = {
   name: 'scout-test-event.mappings.buildkite',
-  version: 1,
+  version: 2,
   template: {
     mappings: {
       properties: {

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
@@ -45,7 +45,7 @@ export const buildkiteProperties: Record<PropertyName, MappingProperty> = {
         type: 'text',
       },
       slug: {
-        type: 'wildcard',
+        type: 'keyword',
       },
     },
   },
@@ -103,7 +103,7 @@ export const buildkiteProperties: Record<PropertyName, MappingProperty> = {
         type: 'integer',
       },
       pipeline_slug: {
-        type: 'wildcard',
+        type: 'keyword',
       },
     },
   },

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
@@ -93,6 +93,20 @@ export const buildkiteProperties: Record<PropertyName, MappingProperty> = {
       },
     },
   },
+  triggered_from_build: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'wildcard',
+      },
+      number: {
+        type: 'integer',
+      },
+      pipeline_slug: {
+        type: 'wildcard',
+      },
+    },
+  },
 };
 
 export const fileInfoProperties: Record<PropertyName, MappingProperty> = {


### PR DESCRIPTION
## Summary

This PR adds build trigger information to our test result reporting by including buildkite's `BUILDKITE_TRIGGERED_FROM_BUILD*` environment variables.

This will help to e.g. filter test results for quality gate runs.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->