### PR TITLE
[Fleet] fix flaky UI test

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
@@ -114,24 +114,17 @@ describe('When on integration detail', () => {
       await act(() => mockedApi.waitForApi());
     }, TESTS_TIMEOUT);
 
-    it('should NOT display policy usage count', async () => {
+    it('should display expected version and prerelease elements', async () => {
       expect(renderResult.queryByTestId('policyCount')).toBeNull();
-    });
-
-    it('should NOT display the Policies tab', async () => {
       expect(renderResult.queryByTestId('tab-policies')).toBeNull();
-    });
 
-    it('should display version select if prerelease setting enabled and prererelase version available', async () => {
       const versionSelect = renderResult.queryByTestId('versionSelect');
       expect(versionSelect?.textContent).toEqual('1.0.0-beta1.0.0');
       expect((versionSelect as any)?.value).toEqual('1.0.0-beta');
-    });
 
-    it('should display prerelease callout if prerelease setting enabled and prerelease version available', async () => {
       const calloutTitle = renderResult.getByTestId('prereleaseCallout');
       expect(calloutTitle).toBeInTheDocument();
-      const calloutGABtn = renderResult.getAllByTestId('switchToGABtn')[0];
+      const calloutGABtn = renderResult.getByTestId('switchToGABtn');
       expect((calloutGABtn as any)?.href).toEqual(
         'http://localhost/mock/app/integrations/detail/nginx-1.0.0/overview'
       );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
@@ -42,8 +42,7 @@ const TESTS_TIMEOUT = 8000;
 // @ts-ignore this saves us having to define all experimental features
 ExperimentalFeaturesService.init({});
 
-// Failing: See https://github.com/elastic/kibana/issues/237961
-describe.skip('When on integration detail', () => {
+describe('When on integration detail', () => {
   const pkgkey = 'nginx-0.3.7';
   const detailPageUrlPath = pagePathGetters.integration_details_overview({ pkgkey })[1];
   let testRenderer: TestRenderer;
@@ -61,9 +60,10 @@ describe.skip('When on integration detail', () => {
   };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     testRenderer = createIntegrationsTestRendererMock();
     mockedApi = mockApiCalls(testRenderer.startServices.http);
-    await act(() => testRenderer.mountHistory.push(detailPageUrlPath));
+    act(() => testRenderer.mountHistory.push(detailPageUrlPath));
   });
 
   describe('and the package is installed', () => {
@@ -131,7 +131,7 @@ describe.skip('When on integration detail', () => {
     it('should display prerelease callout if prerelease setting enabled and prerelease version available', async () => {
       const calloutTitle = renderResult.getByTestId('prereleaseCallout');
       expect(calloutTitle).toBeInTheDocument();
-      const calloutGABtn = renderResult.getByTestId('switchToGABtn');
+      const calloutGABtn = renderResult.getAllByTestId('switchToGABtn')[0];
       expect((calloutGABtn as any)?.href).toEqual(
         'http://localhost/mock/app/integrations/detail/nginx-1.0.0/overview'
       );
@@ -934,6 +934,16 @@ On Windows, the module was tested with Nginx installed from the Chocolatey repos
       }
       if (path === '/api/fleet/epm/verification_key_id') {
         return mockedApiInterface.responseProvider.getVerificationKeyId();
+      }
+      if (path === '/api/fleet/space_settings') {
+        return Promise.resolve({
+          item: {
+            allowed_namespace_prefixes: [],
+          },
+        });
+      }
+      if (path.endsWith('/changelog.yml')) {
+        return Promise.resolve();
       }
 
       const err = new Error(`API [GET ${path}] is not MOCKED!`);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
@@ -124,7 +124,7 @@ describe('When on integration detail', () => {
 
       const calloutTitle = renderResult.getByTestId('prereleaseCallout');
       expect(calloutTitle).toBeInTheDocument();
-      const calloutGABtn = renderResult.getByTestId('switchToGABtn');
+      const calloutGABtn = renderResult.getAllByTestId('switchToGABtn')[0];
       expect((calloutGABtn as any)?.href).toEqual(
         'http://localhost/mock/app/integrations/detail/nginx-1.0.0/overview'
       );


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/237961

Sometimes the UI test finds the prerelease callout rendered twice.
I couldn't figure out what is causing this, but it seems to help to remove the unnecessary renders by merging many testcases to one, where we are just asserting different things on the same component.
Also changed to use `getAllByTestId` in case the button is rendered twice to be on the safe side. 
Tested locally by running the test a few hundred times.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->