### PR TITLE
[SecuritySolution] Fix entity flyout Risk contributions tab link

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/index.tsx
@@ -59,6 +59,7 @@ export const UserDetailsPanel = ({
     user,
     tabs,
     path,
+    scopeId,
     hasMisconfigurationFindings,
     hasNonClosedAlerts
   );
@@ -84,6 +85,7 @@ const useSelectedTab = (
   user: UserParam,
   tabs: LeftPanelTabsType,
   path: PanelPath | undefined,
+  scopeId: string,
   hasMisconfigurationFindings?: boolean,
   hasNonClosedAlerts?: boolean
 ) => {
@@ -107,6 +109,7 @@ const useSelectedTab = (
         path: {
           tab: tabId,
         },
+        scopeId,
       },
     });
   };


### PR DESCRIPTION
## Summary

Fix: Unable to display data for Alerts Details flyout under the Risk contributions tab after navigating from the Insights tab

<img width="2984" height="1580" alt="Screenshot 2025-10-29 at 15 55 31" src="https://github.com/user-attachments/assets/3a80d384-7e44-42ad-9f45-e16bd9a69f73" />


### Steps
1. Navigate to `Security` > `Entity Analytics` -> `Overview` . 
2. Under `User Risk Scores` click on any available username to open details flyout.
3. Click on `Expand details` flyout option.
4. Open details flyout for any Alert present under the `Risk Contribution`.
5. Observe that details flyout will be opened successfully.
6. Navigate to `Insights` tab.
7. Open details flyout for any Alert present under the `Insights`.
8. Now again navigate to `Risk Contribution` tab.
9. Open details flyout for any other available Alert.
10. Observe that there will be an error on details flyout as `Unable to display data.`

### Checklist


- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->