### PR TITLE
[Kibana Search] Promote Observability Alerts higher in the global search

### DIFF
--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
@@ -62,7 +62,23 @@ export const scoreApp = (term: string, appLink: AppLink): number => {
   ];
   const appScoreByKeywords = scoreAppByKeywords(term, keywords);
 
-  return Math.max(appScoreByTerms, appScoreByKeywords);
+  const baseScore = Math.max(appScoreByTerms, appScoreByKeywords);
+
+  // Boost for Observability Alerts
+  const OBSERVABILITY_ALERTS_LINK_ID = 'observability-overview-alerts';
+  const isAlertSearchTerm =
+    term.startsWith('aler') || term.includes('alert') || term.includes('alerts');
+  const isObservabilityAlertsLink =
+    appLink.id === OBSERVABILITY_ALERTS_LINK_ID ||
+    (appLink.app.id === 'observability' &&
+      appLink.subLinkTitles.join(' ').toLowerCase().startsWith('aler')); // needs adjusting?
+
+  if (isAlertSearchTerm && isObservabilityAlertsLink) {
+    const ALERTS_BOOST = 20;
+    return Math.min(100, baseScore + ALERTS_BOOST);
+  }
+
+  return baseScore;
 };
 
 const scoreAppByTerms = (term: string, title: string): number => {

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
@@ -64,19 +64,19 @@ export const scoreApp = (term: string, appLink: AppLink): number => {
 
   const baseScore = Math.max(appScoreByTerms, appScoreByKeywords);
 
-  // Boost for Observability Alerts
-  const OBSERVABILITY_ALERTS_LINK_ID = 'observability-overview-alerts';
-  const isAlertSearchTerm =
-    term.startsWith('aler') || term.includes('alert') || term.includes('alerts');
-  const isObservabilityAlertsLink =
-    appLink.id === OBSERVABILITY_ALERTS_LINK_ID ||
-    (appLink.app.id === 'observability' &&
-      appLink.subLinkTitles.join(' ').toLowerCase().startsWith('aler')); // needs adjusting?
+  // // Boost for Observability Alerts
+  // const OBSERVABILITY_ALERTS_LINK_ID = 'observability-overview-alerts';
+  // const isAlertSearchTerm =
+  //   term.startsWith('aler') || term.includes('alert') || term.includes('alerts');
+  // const isObservabilityAlertsLink =
+  //   appLink.id === OBSERVABILITY_ALERTS_LINK_ID ||
+  //   (appLink.app.id === 'observability' &&
+  //     appLink.subLinkTitles.join(' ').toLowerCase().startsWith('aler')); // needs adjusting?
 
-  if (isAlertSearchTerm && isObservabilityAlertsLink) {
-    const ALERTS_BOOST = 20;
-    return Math.min(100, baseScore + ALERTS_BOOST);
-  }
+  // if (isAlertSearchTerm && isObservabilityAlertsLink) {
+  //   const ALERTS_BOOST = 20;
+  //   return Math.min(100, baseScore + ALERTS_BOOST);
+  // }
 
   return baseScore;
 };

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
@@ -62,23 +62,7 @@ export const scoreApp = (term: string, appLink: AppLink): number => {
   ];
   const appScoreByKeywords = scoreAppByKeywords(term, keywords);
 
-  const baseScore = Math.max(appScoreByTerms, appScoreByKeywords);
-
-  // // Boost for Observability Alerts
-  // const OBSERVABILITY_ALERTS_LINK_ID = 'observability-overview-alerts';
-  // const isAlertSearchTerm =
-  //   term.startsWith('aler') || term.includes('alert') || term.includes('alerts');
-  // const isObservabilityAlertsLink =
-  //   appLink.id === OBSERVABILITY_ALERTS_LINK_ID ||
-  //   (appLink.app.id === 'observability' &&
-  //     appLink.subLinkTitles.join(' ').toLowerCase().startsWith('aler')); // needs adjusting?
-
-  // if (isAlertSearchTerm && isObservabilityAlertsLink) {
-  //   const ALERTS_BOOST = 20;
-  //   return Math.min(100, baseScore + ALERTS_BOOST);
-  // }
-
-  return baseScore;
+  return Math.max(appScoreByTerms, appScoreByKeywords);
 };
 
 const scoreAppByTerms = (term: string, title: string): number => {

--- a/x-pack/solutions/observability/plugins/observability/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/plugin.ts
@@ -215,6 +215,16 @@ export class Plugin
           visibleIn: [],
         },
       ],
+      keywords: [
+        'alerts',
+        'observability',
+        'alert',
+        'alerting',
+        'overview',
+        'actions',
+        'rule',
+        'rules',
+      ],
     },
   ];
 

--- a/x-pack/solutions/observability/plugins/observability/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/plugin.ts
@@ -215,16 +215,7 @@ export class Plugin
           visibleIn: [],
         },
       ],
-      keywords: [
-        'alerts',
-        'observability',
-        'alert',
-        'alerting',
-        'overview',
-        'actions',
-        'rule',
-        'rules',
-      ],
+      keywords: ['alerts', 'observability', 'rules'],
     },
   ];
 

--- a/x-pack/solutions/observability/plugins/observability/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/plugin.ts
@@ -215,7 +215,7 @@ export class Plugin
           visibleIn: [],
         },
       ],
-      keywords: ['alerts', 'observability', 'rules'],
+      keywords: ['alerts', 'rules'],
     },
   ];
 


### PR DESCRIPTION
Resolves #176678 

This PR adds keywords to the Observability Plugin deeplink to make Alerts show higher in the global search when user is looking for 'Alerts'