### PR TITLE
[CI] Improve limits.yml overage message

### DIFF
--- a/packages/kbn-ci-stats-shipper-cli/ship_ci_stats_cli.ts
+++ b/packages/kbn-ci-stats-shipper-cli/ship_ci_stats_cli.ts
@@ -32,7 +32,7 @@ run(
     const reporter = CiStatsReporter.fromEnv(log);
 
     if (!reporter.isEnabled()) {
-      throw maybeFail('unable to initilize the CI Stats reporter');
+      throw maybeFail('unable to initialize the CI Stats reporter');
     }
 
     const overLimit: string[] = [];
@@ -51,7 +51,10 @@ run(
       for (const metric of metrics) {
         if (metric.limit !== undefined && metric.limit < metric.value) {
           overLimit.push(
-            `${metric.group} > ${metric.id} with value of ${metric.value} is greater than the limit of ${metric.limit}`
+            `${metric.group} for ${metric.id} plugin is greater than the limit of ${metric.limit}. The current value of ${metric.value}.
+            To update the limit, run the following command locally:
+            node scripts/build_kibana_platform_plugins --focus ${metric.id} --update-limits
+            `
           );
         }
       }

--- a/packages/kbn-ci-stats-shipper-cli/ship_ci_stats_cli.ts
+++ b/packages/kbn-ci-stats-shipper-cli/ship_ci_stats_cli.ts
@@ -51,10 +51,9 @@ run(
       for (const metric of metrics) {
         if (metric.limit !== undefined && metric.limit < metric.value) {
           overLimit.push(
-            `${metric.group} for ${metric.id} plugin is greater than the limit of ${metric.limit}. The current value is ${metric.value}.
-            To update the limit, run the following command locally:
-            node scripts/build_kibana_platform_plugins --focus ${metric.id} --update-limits
-            `
+            `${metric.group} for ${metric.id} plugin is greater than the limit of ${metric.limit}. The current value is ${metric.value}.`,
+            'To update the limit, run the following command locally:',
+            `node scripts/build_kibana_platform_plugins --focus ${metric.id} --update-limits`
           );
         }
       }

--- a/packages/kbn-ci-stats-shipper-cli/ship_ci_stats_cli.ts
+++ b/packages/kbn-ci-stats-shipper-cli/ship_ci_stats_cli.ts
@@ -51,7 +51,7 @@ run(
       for (const metric of metrics) {
         if (metric.limit !== undefined && metric.limit < metric.value) {
           overLimit.push(
-            `${metric.group} for ${metric.id} plugin is greater than the limit of ${metric.limit}. The current value of ${metric.value}.
+            `${metric.group} for ${metric.id} plugin is greater than the limit of ${metric.limit}. The current value is ${metric.value}.
             To update the limit, run the following command locally:
             node scripts/build_kibana_platform_plugins --focus ${metric.id} --update-limits
             `

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -11,7 +11,7 @@ pageLoadAssetSize:
   canvas: 15210
   cases: 153204
   charts: 40269
-  cloud: 9676
+  cloud: 10648
   cloudDataMigration: 5687
   cloudExperiments: 103984
   cloudFullStory: 4752

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -11,7 +11,7 @@ pageLoadAssetSize:
   canvas: 15210
   cases: 153204
   charts: 40269
-  cloud: 10648
+  cloud: 9676
   cloudDataMigration: 5687
   cloudExperiments: 103984
   cloudFullStory: 4752


### PR DESCRIPTION
## Summary

The current error message is a bit confusing, so this PR improves it and adds guidance to fix.
### New Error
```bash
Ship Kibana Distribution Metrics to CI Stats
 succ shipped metrics from target/optimizer_bundle_metrics.json
 succ shipped metrics from build/kibana/node_modules/@kbn/ui-shared-deps-src/shared_built_assets/metrics.json
ERROR Metric overages:
        page load bundle size for cloud plugin is greater than the limit of 9676. The current value is 9684.
        To update the limit, run the following command locally:
        node scripts/build_kibana_platform_plugins --focus cloud --update-limits
🚨 Error: The command exited with status 1
```

### Old Error
```bash
Ship Kibana Distribution Metrics to CI Stats
 succ shipped metrics from target/optimizer_bundle_metrics.json
 succ shipped metrics from build/kibana/node_modules/@kbn/ui-shared-deps-src/shared_built_assets/metrics.json
ERROR Metric overages:
        page load bundle size > cloud with value of 9684 is greater than the limit of 9676
🚨 Error: The command exited with status 1
```



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->