### PR TITLE
[Console] Fix code scanning alert

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.test.ts
@@ -118,7 +118,11 @@ describe('useSetInitialValue', () => {
       await new Promise((resolve) => setTimeout(resolve, 250));
     });
 
-    expect(fetch).toHaveBeenCalledWith(new URL('https://www.elastic.co/docs/some-data'));
+    // Verify fetch was called with the correct URL
+    expect(fetch).toHaveBeenCalled();
+    const fetchCall = (fetch as jest.Mock).mock.calls[0];
+    expect(fetchCall[0].href).toBe('https://www.elastic.co/docs/some-data');
+
     // The initial value should still be set
     expect(setValueMock).toHaveBeenCalledWith('initial value');
     // The dispatch should be called with the remote data

--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.ts
@@ -50,6 +50,9 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
   const isInitialValueSet = useRef<boolean>(false);
   const editorDispatch = useEditorActionContext();
 
+  const httpsProtocol = 'https:';
+  const elasticHostname = 'www.elastic.co';
+
   useEffect(() => {
     const ALLOWED_PATHS = ['/guide/', '/docs/'];
 
@@ -65,11 +68,16 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
         const parsedURL = new URL(url);
         // Validate protocol, hostname, and allowed path to prevent request forgery
         if (
-          parsedURL.protocol === 'https:' &&
-          parsedURL.hostname === 'www.elastic.co' &&
+          parsedURL.protocol === httpsProtocol &&
+          parsedURL.hostname === elasticHostname &&
           ALLOWED_PATHS.some((path) => parsedURL.pathname.startsWith(path))
         ) {
-          const resp = await fetch(parsedURL);
+          // Construct a safe URL from validated components to prevent request forgery
+          const safeURL = new URL(parsedURL.href);
+          safeURL.protocol = httpsProtocol;
+          safeURL.hostname = elasticHostname;
+
+          const resp = await fetch(safeURL);
           const data = await resp.text();
           editorDispatch({ type: 'setRequestToRestore', payload: { request: data } });
         } else {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.ts
@@ -16,6 +16,9 @@ import { useEffect, useRef } from 'react';
 import { DEFAULT_INPUT_VALUE } from '../../../../../common/constants';
 import { useEditorActionContext } from '../../../contexts';
 
+const httpsProtocol = 'https:';
+const elasticHostname = 'www.elastic.co';
+
 interface QueryParams {
   load_from: string;
 }
@@ -49,9 +52,6 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
   const { localStorageValue, setValue, toasts } = params;
   const isInitialValueSet = useRef<boolean>(false);
   const editorDispatch = useEditorActionContext();
-
-  const httpsProtocol = 'https:';
-  const elasticHostname = 'www.elastic.co';
 
   useEffect(() => {
     const ALLOWED_PATHS = ['/guide/', '/docs/'];


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/security/code-scanning/620

## Summary
This was already addressed in https://github.com/elastic/kibana/pull/237599 but we had the alert again. For trying to fix it, I re-build the url with the validated protocol and hostname. Also, I updated the tests so it validates the href, the previous implementation was returning true for all URLs.

### How to test:

Try loading the following URL (making the necessary replacement in the URL) and verify that the data is correctly loaded into the editor and value can be edited:

`http://localhost:5601/<REPLACE-THIS>/app/dev_tools#/console?load_from=data:text/plain,AoeQygKgBA9A+gRwK4FMBOBPGBDAzhgOwGMB+AEzQHsAHOApAGwbiMoaQFsDcAoAbx5QoAImToMwgFwiAZgCVKAWShoUHSgBcUAWgBUkgJYEyKAB4pcwgDSCRDSkWwMUUkSgLXbwmQYZa0rgJCQsIARpRsgbbBIhxIuBquANoAujYxIT5+6Mlp0cHCuAAWlIxkuekZwnEJdJq5+QC+ts2NQA`


`http://localhost:5601/<REPLACE-THIS>/app/dev_tools#/console?load_from=https://www.elastic.co/guide/en/elasticsearch/reference/current/snippets/86.console`






<!--ONMERGE {"backportTargets":["9.0","9.1","9.2"]} ONMERGE-->