### PR TITLE
🌊 Streams: Strip managed properties from template

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_unwired_stream_pipeline_actions.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_unwired_stream_pipeline_actions.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import type { IndicesGetIndexTemplateIndexTemplateItem, IngestPipeline } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  IndicesGetIndexTemplateIndexTemplateItem,
+  IngestPipeline,
+} from '@elastic/elasticsearch/lib/api/types';
 import type { IScopedClusterClient } from '@kbn/core/server';
 import { isNotFoundError } from '@kbn/es-errors';
 import { castArray, groupBy, omit, uniq } from 'lodash';
@@ -359,7 +362,10 @@ async function getIndexTemplate(name: string, scopedClusterClient: IScopedCluste
   const indexTemplates = await scopedClusterClient.asCurrentUser.indices.getIndexTemplate({
     name,
   });
-  const template = omit(indexTemplates.index_templates[0], ['created_date_millis', 'modified_date_millis']);
+  const template = omit(indexTemplates.index_templates[0], [
+    'created_date_millis',
+    'modified_date_millis',
+  ]);
 
   return template as IndicesGetIndexTemplateIndexTemplateItem;
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_unwired_stream_pipeline_actions.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_unwired_stream_pipeline_actions.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { IngestPipeline } from '@elastic/elasticsearch/lib/api/types';
+import type { IndicesGetIndexTemplateIndexTemplateItem, IngestPipeline } from '@elastic/elasticsearch/lib/api/types';
 import type { IScopedClusterClient } from '@kbn/core/server';
 import { isNotFoundError } from '@kbn/es-errors';
 import { castArray, groupBy, omit, uniq } from 'lodash';
@@ -359,7 +359,9 @@ async function getIndexTemplate(name: string, scopedClusterClient: IScopedCluste
   const indexTemplates = await scopedClusterClient.asCurrentUser.indices.getIndexTemplate({
     name,
   });
-  return indexTemplates.index_templates[0];
+  const template = omit(indexTemplates.index_templates[0], ['created_date_millis', 'modified_date_millis']);
+
+  return template as IndicesGetIndexTemplateIndexTemplateItem;
 }
 
 function assertOnlyAppendActions(


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/235000
Fixes https://github.com/elastic/kibana/issues/235001

Basically the same as https://github.com/elastic/kibana/pull/231394 , but for 8.19

Streams isn't even visible in 8.19, this is just to get the tests to pass.