### PR TITLE
[ResponseOps][Rules] Save button in settings flyout should remain disabled until settings are modified

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/rules_setting/rules_settings_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/rules_setting/rules_settings_flyout.test.tsx
@@ -509,4 +509,17 @@ describe('rules_settings_flyout', () => {
 
     expect(result.queryByTestId('alert-delete-open-modal-button')).toBe(null);
   });
+
+  test('save button is disabled on initial load and enabled when user changes a setting', async () => {
+    const result = render(<RulesSettingsFlyoutWithProviders {...flyoutProps} />);
+    await waitForFlyoutLoad();
+
+    const saveButton = result.getByTestId('rulesSettingsFlyoutSaveButton');
+    expect(saveButton).toBeDisabled();
+
+    const lookBackWindowInput = result.getByTestId('lookBackWindowRangeInput');
+    fireEvent.change(lookBackWindowInput, { target: { value: 20 } });
+
+    expect(saveButton).not.toBeDisabled();
+  });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/rules_setting/rules_settings_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/rules_setting/rules_settings_flyout.test.tsx
@@ -511,13 +511,13 @@ describe('rules_settings_flyout', () => {
   });
 
   test('save button is disabled on initial load and enabled when user changes a setting', async () => {
-    const result = render(<RulesSettingsFlyoutWithProviders {...flyoutProps} />);
+    render(<RulesSettingsFlyoutWithProviders {...flyoutProps} />);
     await waitForFlyoutLoad();
 
-    const saveButton = result.getByTestId('rulesSettingsFlyoutSaveButton');
+    const saveButton = screen.getByTestId('rulesSettingsFlyoutSaveButton');
     expect(saveButton).toBeDisabled();
 
-    const lookBackWindowInput = result.getByTestId('lookBackWindowRangeInput');
+    const lookBackWindowInput = screen.getByTestId('lookBackWindowRangeInput');
     fireEvent.change(lookBackWindowInput, { target: { value: 20 } });
 
     expect(saveButton).not.toBeDisabled();

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/rules_setting/rules_settings_flyout.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/rules_setting/rules_settings_flyout.tsx
@@ -80,8 +80,12 @@ const useResettableState: <T>(
   };
   const updateValue = (next: typeof value, shouldUpdateInitialValue = false) => {
     setValue(next);
-    setHasChanged(true);
-    if (shouldUpdateInitialValue) initialValueRef.current = next;
+    if (shouldUpdateInitialValue) {
+      initialValueRef.current = next;
+      setHasChanged(false);
+    } else {
+      setHasChanged(true);
+    }
   };
   return [value, hasChanged, updateValue, reset];
 };
@@ -171,6 +175,10 @@ export const RulesSettingsFlyout = memo((props: RulesSettingsFlyoutProps) => {
   const canWriteQueryDelaySettings = writeQueryDelaySettingsUI && !hasQueryDelayError;
   const canShowQueryDelaySettings = readQueryDelaySettingsUI;
   const canShowAlertDeleteSettings = readAlertDeleteSettingsUI;
+
+  const shouldDisableSaveButton =
+    (!canWriteFlappingSettings && !canWriteQueryDelaySettings) ||
+    (!hasFlappingChanged && !hasQueryDelayChanged);
 
   const handleSettingsChange = (
     setting: keyof RulesSettingsProperties,
@@ -324,7 +332,7 @@ export const RulesSettingsFlyout = memo((props: RulesSettingsFlyoutProps) => {
               fill
               data-test-subj="rulesSettingsFlyoutSaveButton"
               onClick={handleSave}
-              disabled={!canWriteFlappingSettings && !canWriteQueryDelaySettings}
+              disabled={shouldDisableSaveButton}
             >
               <FormattedMessage
                 id="xpack.triggersActionsUI.rulesSettings.flyout.saveButton"

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/rules_setting/rules_settings_flyout.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/rules_setting/rules_settings_flyout.tsx
@@ -176,9 +176,9 @@ export const RulesSettingsFlyout = memo((props: RulesSettingsFlyoutProps) => {
   const canShowQueryDelaySettings = readQueryDelaySettingsUI;
   const canShowAlertDeleteSettings = readAlertDeleteSettingsUI;
 
-  const shouldDisableSaveButton =
-    (!canWriteFlappingSettings && !canWriteQueryDelaySettings) ||
-    (!hasFlappingChanged && !hasQueryDelayChanged);
+  const isChanged = hasFlappingChanged || hasQueryDelayChanged;
+  const hasMinimumWritePermissions = canWriteFlappingSettings || canWriteQueryDelaySettings;
+  const shouldDisableSaveButton = !isChanged || !hasMinimumWritePermissions;
 
   const handleSettingsChange = (
     setting: keyof RulesSettingsProperties,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/238586

## Summary

- Fixed the save button enabled/disabled state in `Rules Settings Flyout`

**Problem**: the save button was enabled on flyout open, even when no changes were made

**Solution**:
-  updated the enable/disable logic to include `hasFlappingChanged` and `hasQueryDelayChanged` ensuring the save button is disabled until the user changes at least one setting. 
- updated the `useResettableState` hook so that loading initial values resets the `hasChanged` flag to `false` 


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->