### PR TITLE
[EDR Workflows] Fix redundant nesting in aggregations

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/server/search_strategy/osquery/factory/actions/results/query.action_results.dsl.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/search_strategy/osquery/factory/actions/results/query.action_results.dsl.ts
@@ -70,36 +70,31 @@ export const buildActionResultsQuery = ({
     index,
     ignore_unavailable: true,
     aggs: {
-      aggs: {
-        global: {},
+      responses_by_action_id: {
+        filter: {
+          bool: {
+            must: [
+              {
+                match: {
+                  action_id: actionId,
+                },
+              },
+            ],
+          },
+        },
         aggs: {
-          responses_by_action_id: {
-            filter: {
-              bool: {
-                must: [
-                  {
-                    match: {
-                      action_id: actionId,
-                    },
-                  },
-                ],
-              },
+          rows_count: {
+            sum: {
+              field: 'action_response.osquery.count',
             },
-            aggs: {
-              rows_count: {
-                sum: {
-                  field: 'action_response.osquery.count',
-                },
-              },
-              responses: {
-                terms: {
-                  script: {
-                    lang: 'painless',
-                    source:
-                      "if (doc['error.keyword'].size()==0) { return 'success' } else { return 'error' }",
-                  } as const,
-                },
-              },
+          },
+          responses: {
+            terms: {
+              script: {
+                lang: 'painless',
+                source:
+                  "if (doc['error.keyword'].size()==0) { return 'success' } else { return 'error' }",
+              } as const,
             },
           },
         },


### PR DESCRIPTION
This Elasticsearch aggregation query counts action responses for osquery queries to calculate status (pending/completed). It:

1. Filters documents by `action_id` (specific query action)
2. Counts total rows returned (`action_response.osquery.count`)
3. Categorizes responses as "success" or "error" based on error field presence
4. Returns aggregated counts used for status calculation

## The Bug: Malformed Nested Structure

### Before (Incorrect)
```typescript
aggs: {
  aggs: {                    // ❌ Extra 'aggs' wrapper
    global: {},              // ❌ Unnecessary global aggregation
    aggs: {                  // ❌ Another 'aggs' wrapper
      responses_by_action_id: {
        filter: { /* ... */ },
        aggs: {
          rows_count: { /* ... */ },
          responses: { /* ... */ }
        }
      }
    }
  }
}
```

### After (Correct)
```typescript
aggs: {
  responses_by_action_id: {  // ✅ Directly under top-level aggs
    filter: { /* ... */ },
    aggs: {
      rows_count: { /* ... */ },
      responses: { /* ... */ }
    }
  }
}
```
