### PR TITLE
[CI] Increase scout test generation timeout

### DIFF
--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -66,7 +66,7 @@ steps:
     agents:
       machineType: n2-standard-4
     key: build_scout_tests
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     depends_on:
       - build
     env:

--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -64,7 +64,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
     key: build_scout_tests
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     depends_on:
       - build
     env:

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -54,7 +54,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
     key: build_scout_tests
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     depends_on:
       - build
     env:

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -201,7 +201,7 @@ steps:
       machineType: n2-standard-4
       diskSizeGb: 100
     key: build_scout_tests
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     depends_on:
       - build
     env:

--- a/.buildkite/pipelines/pointer_compression.yml
+++ b/.buildkite/pipelines/pointer_compression.yml
@@ -59,7 +59,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
     key: build_scout_tests
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     depends_on:
       - build
     env:

--- a/.buildkite/pipelines/pull_request/scout_tests.yml
+++ b/.buildkite/pipelines/pull_request/scout_tests.yml
@@ -4,15 +4,15 @@ steps:
     agents:
       machineType: n2-standard-4
     key: build_scout_tests
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     depends_on:
       - build
-      - quick_checks 
-      - checks 
-      - linting 
-      - linting_with_types 
-      - check_types 
-      - check_oas_snapshot 
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_types
+      - check_oas_snapshot
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:


### PR DESCRIPTION
## Summary
increase timeout 10->15m, we've seen several cases where this step finishes right around 10m, causing inconsistent reports

Stats showing recent "Scout Test Run Builder" runs - not always tightly, but dancing close to the timeout (600s), and it wouldn't make sense to crash a build because of this.
<img width="1399" height="672" alt="Screenshot 2025-10-31 at 11 17 07" src="https://github.com/user-attachments/assets/fa5e6abe-7ec8-4fa8-883f-6ec3bbbcc6e3" />



<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->