### PR TITLE
[APM] Fleet: Skip flaky test

### DIFF
--- a/x-pack/solutions/observability/test/apm_api_integration/tests/fleet/migration_check.spec.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/fleet/migration_check.spec.ts
@@ -38,8 +38,8 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
       });
     });
   });
-
-  registry.when('Fleet migration check - cloud', { config: 'cloud', archives: [] }, () => {
+  // Failing: See https://github.com/elastic/kibana/issues/229299
+  registry.when.skip('Fleet migration check - cloud', { config: 'cloud', archives: [] }, () => {
     before(async () => {
       await setupFleet(bettertest);
     });


### PR DESCRIPTION
Closes [229299](https://github.com/elastic/kibana/issues/229299)

## Summary

This PR skips the test for now until we find a better solution with the @elastic/fleet team. It will also prevent commits like this[523917d](https://github.com/NicholasPeretti/kibana/commit/523917d525a4d345537c0d9703a1f9aa9709c7c0), skipping the whole test suite.

<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->