### PR TITLE
[Streams] Fix invalid state for wired streams toggle

### DIFF
--- a/x-pack/platform/plugins/shared/streams/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/streams/public/plugin.test.ts
@@ -1,0 +1,274 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Plugin } from './plugin';
+import { coreMock } from '@kbn/core/public/mocks';
+import type { StreamsRepositoryClient } from './api';
+
+describe('Streams Plugin', () => {
+  let plugin: Plugin;
+  let mockRepositoryClient: jest.Mocked<StreamsRepositoryClient>;
+
+  beforeEach(() => {
+    plugin = new Plugin({
+      env: {
+        packageInfo: {
+          buildFlavor: 'traditional',
+        },
+      },
+      config: {
+        get: () => ({}),
+      },
+      logger: {
+        get: () => ({
+          error: jest.fn(),
+        }),
+      },
+    } as any);
+
+    mockRepositoryClient = {
+      fetch: jest.fn(),
+    } as any;
+
+    // @ts-expect-error accessing private property for testing
+    plugin.repositoryClient = mockRepositoryClient;
+  });
+
+  afterEach(() => {
+    plugin.stop();
+    jest.clearAllMocks();
+  });
+
+  describe('setup', () => {
+    it('should initialize repository client', () => {
+      const coreSetup = coreMock.createSetup();
+      const result = plugin.setup(coreSetup, {});
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('start', () => {
+    it('should return plugin API with required methods', () => {
+      const coreStart = coreMock.createStart();
+      const start = plugin.start(coreStart, {});
+
+      expect(start).toHaveProperty('streamsRepositoryClient');
+      expect(start).toHaveProperty('navigationStatus$');
+      expect(start).toHaveProperty('getWiredStatus');
+      expect(start).toHaveProperty('enableWiredMode');
+      expect(start).toHaveProperty('disableWiredMode');
+      expect(start).toHaveProperty('config$');
+
+      expect(typeof start.getWiredStatus).toBe('function');
+      expect(typeof start.enableWiredMode).toBe('function');
+      expect(typeof start.disableWiredMode).toBe('function');
+    });
+  });
+
+  describe('getWiredStatus', () => {
+    let getWiredStatus: () => Promise<any>;
+
+    beforeEach(() => {
+      const coreStart = coreMock.createStart();
+      const start = plugin.start(coreStart, {});
+      getWiredStatus = start.getWiredStatus;
+    });
+
+    it('should fetch wired status from API successfully', async () => {
+      const mockStatus = {
+        enabled: true,
+        can_manage: true,
+      };
+
+      mockRepositoryClient.fetch.mockResolvedValue(mockStatus);
+
+      const result = await getWiredStatus();
+
+      expect(mockRepositoryClient.fetch).toHaveBeenCalledWith(
+        'GET /api/streams/_status',
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        })
+      );
+      expect(result).toEqual(mockStatus);
+    });
+
+    it('should return disabled status when API returns enabled: false', async () => {
+      const mockStatus = {
+        enabled: false,
+        can_manage: true,
+      };
+
+      mockRepositoryClient.fetch.mockResolvedValue(mockStatus);
+
+      const result = await getWiredStatus();
+
+      expect(result).toEqual({
+        enabled: false,
+        can_manage: true,
+      });
+    });
+
+    it('should return UNKNOWN_STATUS on network error', async () => {
+      mockRepositoryClient.fetch.mockRejectedValue(new Error('Network error'));
+
+      const result = await getWiredStatus();
+
+      expect(result).toEqual({
+        enabled: 'unknown',
+        can_manage: false,
+      });
+    });
+
+    it('should return UNKNOWN_STATUS on 404 error', async () => {
+      mockRepositoryClient.fetch.mockRejectedValue({
+        response: { status: 404 },
+        message: 'Not found',
+      });
+
+      const result = await getWiredStatus();
+
+      expect(result).toEqual({
+        enabled: 'unknown',
+        can_manage: false,
+      });
+    });
+
+    it('should return UNKNOWN_STATUS on 500 error', async () => {
+      mockRepositoryClient.fetch.mockRejectedValue({
+        response: { status: 500 },
+        message: 'Internal server error',
+      });
+
+      const result = await getWiredStatus();
+
+      expect(result).toEqual({
+        enabled: 'unknown',
+        can_manage: false,
+      });
+    });
+
+    it('should log errors when fetch fails', async () => {
+      const mockError = new Error('Network failure');
+      const mockLogger = {
+        error: jest.fn(),
+      };
+      plugin.logger = mockLogger as any;
+
+      mockRepositoryClient.fetch.mockRejectedValue(mockError);
+
+      await getWiredStatus();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(mockError);
+    });
+
+    it('should create new AbortController for each call', async () => {
+      mockRepositoryClient.fetch.mockResolvedValue({
+        enabled: true,
+        can_manage: true,
+      });
+
+      await getWiredStatus();
+      await getWiredStatus();
+
+      expect(mockRepositoryClient.fetch).toHaveBeenCalledTimes(2);
+      const firstCallSignal = mockRepositoryClient.fetch.mock.calls[0][1].signal;
+      const secondCallSignal = mockRepositoryClient.fetch.mock.calls[1][1].signal;
+
+      // Each call should have its own signal
+      expect(firstCallSignal).toBeInstanceOf(AbortSignal);
+      expect(secondCallSignal).toBeInstanceOf(AbortSignal);
+    });
+  });
+
+  describe('enableWiredMode', () => {
+    let enableWiredMode: (signal: AbortSignal) => Promise<any>;
+
+    beforeEach(() => {
+      const coreStart = coreMock.createStart();
+      const start = plugin.start(coreStart, {});
+      enableWiredMode = start.enableWiredMode;
+    });
+
+    it('should call enable API endpoint', async () => {
+      const mockResponse = { acknowledged: true };
+      mockRepositoryClient.fetch.mockResolvedValue(mockResponse);
+
+      const signal = new AbortController().signal;
+      const result = await enableWiredMode(signal);
+
+      expect(mockRepositoryClient.fetch).toHaveBeenCalledWith(
+        'POST /api/streams/_enable 2023-10-31',
+        { signal }
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should propagate errors from API', async () => {
+      const mockError = new Error('Enable failed');
+      mockRepositoryClient.fetch.mockRejectedValue(mockError);
+
+      const signal = new AbortController().signal;
+
+      await expect(enableWiredMode(signal)).rejects.toThrow('Enable failed');
+    });
+
+    it('should respect abort signal', async () => {
+      const abortController = new AbortController();
+      mockRepositoryClient.fetch.mockImplementation(() => {
+        abortController.abort();
+        return Promise.reject(new Error('Aborted'));
+      });
+
+      await expect(enableWiredMode(abortController.signal)).rejects.toThrow();
+    });
+  });
+
+  describe('disableWiredMode', () => {
+    let disableWiredMode: (signal: AbortSignal) => Promise<any>;
+
+    beforeEach(() => {
+      const coreStart = coreMock.createStart();
+      const start = plugin.start(coreStart, {});
+      disableWiredMode = start.disableWiredMode;
+    });
+
+    it('should call disable API endpoint', async () => {
+      const mockResponse = { acknowledged: true };
+      mockRepositoryClient.fetch.mockResolvedValue(mockResponse);
+
+      const signal = new AbortController().signal;
+      const result = await disableWiredMode(signal);
+
+      expect(mockRepositoryClient.fetch).toHaveBeenCalledWith(
+        'POST /api/streams/_disable 2023-10-31',
+        { signal }
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should propagate errors from API', async () => {
+      const mockError = new Error('Disable failed');
+      mockRepositoryClient.fetch.mockRejectedValue(mockError);
+
+      const signal = new AbortController().signal;
+
+      await expect(disableWiredMode(signal)).rejects.toThrow('Disable failed');
+    });
+
+    it('should respect abort signal', async () => {
+      const abortController = new AbortController();
+      mockRepositoryClient.fetch.mockImplementation(() => {
+        abortController.abort();
+        return Promise.reject(new Error('Aborted'));
+      });
+
+      await expect(disableWiredMode(abortController.signal)).rejects.toThrow();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/public/plugin.ts
@@ -14,7 +14,7 @@ import type {
 import type { Logger } from '@kbn/logging';
 import { createRepositoryClient } from '@kbn/server-route-repository-client';
 import type { Observable } from 'rxjs';
-import { BehaviorSubject, of, from } from 'rxjs';
+import { of, from } from 'rxjs';
 import { map, catchError } from 'rxjs';
 import { once } from 'lodash';
 import type { StreamsPublicConfig } from '../common/config';
@@ -35,7 +35,6 @@ export class Plugin implements StreamsPluginClass {
 
   private repositoryClient!: StreamsRepositoryClient;
   private isServerless: boolean;
-  private wiredStatusSubject = new BehaviorSubject<WiredStreamsStatus>(UNKNOWN_STATUS);
 
   constructor(context: PluginInitializerContext<{}>) {
     this.config = context.config.get();
@@ -49,8 +48,6 @@ export class Plugin implements StreamsPluginClass {
   }
 
   start(core: CoreStart, pluginsStart: StreamsPluginStartDependencies): StreamsPluginStart {
-    this.refreshWiredStatus();
-
     return {
       streamsRepositoryClient: this.repositoryClient,
       navigationStatus$: createStreamsNavigationStatusObservable(
@@ -58,42 +55,28 @@ export class Plugin implements StreamsPluginClass {
         core.application,
         this.isServerless
       ),
-      wiredStatus$: this.wiredStatusSubject.asObservable(),
+      getWiredStatus: async () => {
+        try {
+          return await this.repositoryClient.fetch('GET /api/streams/_status', {
+            signal: new AbortController().signal,
+          });
+        } catch (error) {
+          this.logger.error(error);
+          return UNKNOWN_STATUS;
+        }
+      },
       enableWiredMode: async (signal: AbortSignal) => {
-        const response = await this.repositoryClient.fetch('POST /api/streams/_enable 2023-10-31', {
+        return await this.repositoryClient.fetch('POST /api/streams/_enable 2023-10-31', {
           signal,
         });
-        this.wiredStatusSubject.next({
-          ...this.wiredStatusSubject.value,
-          enabled: true,
-        });
-        return response;
       },
       disableWiredMode: async (signal: AbortSignal) => {
-        const response = await this.repositoryClient.fetch(
-          'POST /api/streams/_disable 2023-10-31',
-          { signal }
-        );
-        this.wiredStatusSubject.next({
-          ...this.wiredStatusSubject.value,
-          enabled: false,
+        return await this.repositoryClient.fetch('POST /api/streams/_disable 2023-10-31', {
+          signal,
         });
-        return response;
       },
       config$: of(this.config),
     };
-  }
-
-  private async refreshWiredStatus() {
-    try {
-      const response = await this.repositoryClient.fetch('GET /api/streams/_status', {
-        signal: new AbortController().signal,
-      });
-      this.wiredStatusSubject.next(response);
-    } catch (error) {
-      this.logger.error(error);
-      this.wiredStatusSubject.next(UNKNOWN_STATUS);
-    }
   }
 
   stop() {}

--- a/x-pack/platform/plugins/shared/streams/public/types.ts
+++ b/x-pack/platform/plugins/shared/streams/public/types.ts
@@ -28,7 +28,7 @@ export interface StreamsPluginSetup {}
 export interface StreamsPluginStart {
   streamsRepositoryClient: StreamsRepositoryClient;
   navigationStatus$: Observable<StreamsNavigationStatus>;
-  wiredStatus$: Observable<WiredStreamsStatus>;
+  getWiredStatus: () => Promise<WiredStreamsStatus>;
   enableWiredMode: (signal: AbortSignal) => Promise<EnableStreamsResponse>;
   disableWiredMode: (signal: AbortSignal) => Promise<DisableStreamsResponse>;
   config$: Observable<StreamsPublicConfig>;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.test.tsx
@@ -162,15 +162,10 @@ describe('StreamsSettingsFlyout', () => {
 
   describe('Enabling Wired Streams', () => {
     it('should enable wired mode when switch is clicked from disabled state', async () => {
-      mockGetWiredStatus
-        .mockResolvedValueOnce({
-          enabled: false,
-          can_manage: true,
-        })
-        .mockResolvedValueOnce({
-          enabled: true,
-          can_manage: true,
-        });
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: false,
+        can_manage: true,
+      });
 
       mockEnableWiredMode.mockResolvedValue({});
 
@@ -186,9 +181,10 @@ describe('StreamsSettingsFlyout', () => {
 
       await waitFor(() => {
         expect(mockEnableWiredMode).toHaveBeenCalled();
-        expect(mockGetWiredStatus).toHaveBeenCalledTimes(2); // Initial + after enable
+        expect(mockGetWiredStatus).toHaveBeenCalledTimes(1); // Only on initial mount
         expect(mockTrackWiredStreamsStatusChanged).toHaveBeenCalledWith({ is_enabled: true });
         expect(mockRefreshStreams).toHaveBeenCalled();
+        expect(screen.getByTestId('streamsWiredSwitch')).toBeChecked();
       });
     });
 
@@ -306,15 +302,10 @@ describe('StreamsSettingsFlyout', () => {
     });
 
     it('should disable wired streams when confirmed', async () => {
-      mockGetWiredStatus
-        .mockResolvedValueOnce({
-          enabled: true,
-          can_manage: true,
-        })
-        .mockResolvedValueOnce({
-          enabled: false,
-          can_manage: true,
-        });
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: true,
+        can_manage: true,
+      });
 
       mockDisableWiredMode.mockResolvedValue({});
 
@@ -337,9 +328,10 @@ describe('StreamsSettingsFlyout', () => {
 
       await waitFor(() => {
         expect(mockDisableWiredMode).toHaveBeenCalled();
-        expect(mockGetWiredStatus).toHaveBeenCalledTimes(2); // Initial + after disable
+        expect(mockGetWiredStatus).toHaveBeenCalledTimes(1); // Only on initial mount
         expect(mockTrackWiredStreamsStatusChanged).toHaveBeenCalledWith({ is_enabled: false });
         expect(mockRefreshStreams).toHaveBeenCalled();
+        expect(screen.getByTestId('streamsWiredSwitch')).not.toBeChecked();
       });
 
       // Modal should be closed

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.test.tsx
@@ -1,0 +1,425 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nProvider } from '@kbn/i18n-react';
+import { StreamsSettingsFlyout } from './streams_settings_flyout';
+import { useKibana } from '../../hooks/use_kibana';
+import { useStreamsPrivileges } from '../../hooks/use_streams_privileges';
+
+jest.mock('../../hooks/use_kibana');
+jest.mock('../../hooks/use_streams_privileges');
+jest.mock('@kbn/react-hooks', () => ({
+  useAbortController: () => ({ signal: new AbortController().signal }),
+}));
+
+const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
+const mockUseStreamsPrivileges = useStreamsPrivileges as jest.MockedFunction<
+  typeof useStreamsPrivileges
+>;
+
+// Helper to render with required providers
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(<I18nProvider>{ui}</I18nProvider>);
+};
+
+describe('StreamsSettingsFlyout', () => {
+  const mockGetWiredStatus = jest.fn();
+  const mockEnableWiredMode = jest.fn();
+  const mockDisableWiredMode = jest.fn();
+  const mockOnClose = jest.fn();
+  const mockRefreshStreams = jest.fn();
+  const mockAddError = jest.fn();
+  const mockTrackWiredStreamsStatusChanged = jest.fn();
+
+  const defaultKibanaMock = {
+    dependencies: {
+      start: {
+        streams: {
+          getWiredStatus: mockGetWiredStatus,
+          enableWiredMode: mockEnableWiredMode,
+          disableWiredMode: mockDisableWiredMode,
+        },
+      },
+    },
+    core: {
+      notifications: {
+        toasts: {
+          addError: mockAddError,
+        },
+      },
+      docLinks: {
+        links: {
+          observability: {
+            wiredStreams: 'https://example.com/docs',
+          },
+        },
+      },
+    },
+    services: {
+      telemetryClient: {
+        trackWiredStreamsStatusChanged: mockTrackWiredStreamsStatusChanged,
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseStreamsPrivileges.mockReturnValue({
+      ui: { manage: true },
+      features: {},
+    } as any);
+
+    mockUseKibana.mockReturnValue(defaultKibanaMock as any);
+  });
+
+  describe('Initial Load', () => {
+    it('should fetch wired status on mount', async () => {
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: true,
+        can_manage: true,
+      });
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(mockGetWiredStatus).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should show loading spinner initially', () => {
+      mockGetWiredStatus.mockImplementation(
+        () => new Promise(() => {}) // Never resolves
+      );
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('should display switch as checked when wired streams is enabled', async () => {
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: true,
+        can_manage: true,
+      });
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streamsWiredSwitch')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('streamsWiredSwitch')).toBeChecked();
+    });
+
+    it('should display switch as unchecked when wired streams is disabled', async () => {
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: false,
+        can_manage: true,
+      });
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streamsWiredSwitch')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('streamsWiredSwitch')).not.toBeChecked();
+    });
+
+    it('should handle fetch errors gracefully', async () => {
+      mockGetWiredStatus.mockRejectedValue(new Error('Network error'));
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(mockAddError).toHaveBeenCalledWith(
+          expect.any(Error),
+          expect.objectContaining({
+            title: 'Error fetching wired streams status',
+          })
+        );
+      });
+    });
+  });
+
+  describe('Enabling Wired Streams', () => {
+    it('should enable wired mode when switch is clicked from disabled state', async () => {
+      mockGetWiredStatus
+        .mockResolvedValueOnce({
+          enabled: false,
+          can_manage: true,
+        })
+        .mockResolvedValueOnce({
+          enabled: true,
+          can_manage: true,
+        });
+
+      mockEnableWiredMode.mockResolvedValue({});
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streamsWiredSwitch')).not.toBeChecked();
+      });
+
+      await userEvent.click(screen.getByTestId('streamsWiredSwitch'));
+
+      await waitFor(() => {
+        expect(mockEnableWiredMode).toHaveBeenCalled();
+        expect(mockGetWiredStatus).toHaveBeenCalledTimes(2); // Initial + after enable
+        expect(mockTrackWiredStreamsStatusChanged).toHaveBeenCalledWith({ is_enabled: true });
+        expect(mockRefreshStreams).toHaveBeenCalled();
+      });
+    });
+
+    it('should show error toast if enabling fails', async () => {
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: false,
+        can_manage: true,
+      });
+
+      mockEnableWiredMode.mockRejectedValue(new Error('Enable failed'));
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streamsWiredSwitch')).not.toBeChecked();
+      });
+
+      await userEvent.click(screen.getByTestId('streamsWiredSwitch'));
+
+      await waitFor(() => {
+        expect(mockAddError).toHaveBeenCalledWith(
+          expect.any(Error),
+          expect.objectContaining({
+            title: 'Error updating wired streams setting',
+          })
+        );
+      });
+    });
+  });
+
+  describe('Disabling Wired Streams - Confirmation Modal', () => {
+    it('should show confirmation modal when trying to disable wired streams', async () => {
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: true,
+        can_manage: true,
+      });
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streamsWiredSwitch')).toBeChecked();
+      });
+
+      // Click to disable (should show modal)
+      await userEvent.click(screen.getByTestId('streamsWiredSwitch'));
+
+      // Modal should be visible
+      expect(screen.getByTestId('streamsWiredDisableModal')).toBeInTheDocument();
+      expect(screen.getByText('Disable Wired Streams?')).toBeInTheDocument();
+
+      // Should NOT have called disable yet
+      expect(mockDisableWiredMode).not.toHaveBeenCalled();
+    });
+
+    it('should close modal when cancel button is clicked', async () => {
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: true,
+        can_manage: true,
+      });
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streamsWiredSwitch')).toBeChecked();
+      });
+
+      // Open modal
+      await userEvent.click(screen.getByTestId('streamsWiredSwitch'));
+      expect(screen.getByTestId('streamsWiredDisableModal')).toBeInTheDocument();
+
+      // Click cancel
+      await userEvent.click(screen.getByTestId('streamsWiredDisableCancelButton'));
+
+      // Modal should be closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('streamsWiredDisableModal')).not.toBeInTheDocument();
+      });
+
+      // Should NOT have disabled
+      expect(mockDisableWiredMode).not.toHaveBeenCalled();
+    });
+
+    it('should keep confirm button disabled until checkbox is checked', async () => {
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: true,
+        can_manage: true,
+      });
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streamsWiredSwitch')).toBeChecked();
+      });
+
+      // Open modal
+      await userEvent.click(screen.getByTestId('streamsWiredSwitch'));
+
+      // Confirm button should be disabled
+      const confirmButton = screen.getByTestId('streamsWiredDisableConfirmButton');
+      expect(confirmButton).toBeDisabled();
+
+      // Check the confirmation checkbox
+      await userEvent.click(screen.getByTestId('streamsWiredDisableConfirmCheckbox'));
+
+      // Now confirm button should be enabled
+      expect(confirmButton).not.toBeDisabled();
+    });
+
+    it('should disable wired streams when confirmed', async () => {
+      mockGetWiredStatus
+        .mockResolvedValueOnce({
+          enabled: true,
+          can_manage: true,
+        })
+        .mockResolvedValueOnce({
+          enabled: false,
+          can_manage: true,
+        });
+
+      mockDisableWiredMode.mockResolvedValue({});
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streamsWiredSwitch')).toBeChecked();
+      });
+
+      // Open modal
+      await userEvent.click(screen.getByTestId('streamsWiredSwitch'));
+
+      // Check confirmation
+      await userEvent.click(screen.getByTestId('streamsWiredDisableConfirmCheckbox'));
+
+      // Click confirm
+      await userEvent.click(screen.getByTestId('streamsWiredDisableConfirmButton'));
+
+      await waitFor(() => {
+        expect(mockDisableWiredMode).toHaveBeenCalled();
+        expect(mockGetWiredStatus).toHaveBeenCalledTimes(2); // Initial + after disable
+        expect(mockTrackWiredStreamsStatusChanged).toHaveBeenCalledWith({ is_enabled: false });
+        expect(mockRefreshStreams).toHaveBeenCalled();
+      });
+
+      // Modal should be closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('streamsWiredDisableModal')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show error toast if disabling fails', async () => {
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: true,
+        can_manage: true,
+      });
+
+      mockDisableWiredMode.mockRejectedValue(new Error('Disable failed'));
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streamsWiredSwitch')).toBeChecked();
+      });
+
+      // Open modal
+      await userEvent.click(screen.getByTestId('streamsWiredSwitch'));
+
+      // Check and confirm
+      await userEvent.click(screen.getByTestId('streamsWiredDisableConfirmCheckbox'));
+      await userEvent.click(screen.getByTestId('streamsWiredDisableConfirmButton'));
+
+      await waitFor(() => {
+        expect(mockAddError).toHaveBeenCalledWith(
+          expect.any(Error),
+          expect.objectContaining({
+            title: 'Error updating wired streams setting',
+          })
+        );
+      });
+    });
+  });
+
+  describe('Permissions', () => {
+    it('should disable switch when user lacks manage permissions', async () => {
+      mockUseStreamsPrivileges.mockReturnValue({
+        ui: { manage: false },
+        features: {},
+      } as any);
+
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: true,
+        can_manage: true,
+      });
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streamsWiredSwitch')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('streamsWiredSwitch')).toBeDisabled();
+    });
+
+    it('should disable switch when Elasticsearch permissions are insufficient', async () => {
+      mockGetWiredStatus.mockResolvedValue({
+        enabled: true,
+        can_manage: false, // No ES permissions
+      });
+
+      renderWithProviders(
+        <StreamsSettingsFlyout onClose={mockOnClose} refreshStreams={mockRefreshStreams} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streamsWiredSwitch')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('streamsWiredSwitch')).toBeDisabled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.tsx
@@ -98,10 +98,7 @@ export function StreamsSettingsFlyout({
         setLoading(true);
         await enableWiredMode(signal);
         telemetryClient.trackWiredStreamsStatusChanged({ is_enabled: true });
-        // Refetch status to ensure UI is in sync
-        const status = await getWiredStatus();
-        setWiredChecked(status.enabled === true);
-        setCanManageWiredElasticsearch(Boolean(status.can_manage));
+        setWiredChecked(true);
         refreshStreams();
       } catch (error) {
         core.notifications.toasts.addError(error, {
@@ -123,10 +120,7 @@ export function StreamsSettingsFlyout({
     try {
       await disableWiredMode(signal);
       telemetryClient.trackWiredStreamsStatusChanged({ is_enabled: false });
-      // Refetch status to ensure UI is in sync
-      const status = await getWiredStatus();
-      setWiredChecked(status.enabled === true);
-      setCanManageWiredElasticsearch(Boolean(status.can_manage));
+      setWiredChecked(false);
       refreshStreams();
       setShowDisableModal(false);
       setDisableConfirmChecked(false);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.tsx
@@ -424,6 +424,7 @@ output.elasticsearch:
             setDisableConfirmChecked(false);
           }}
           aria-labelledby="streamsWiredDisableModalTitle"
+          data-test-subj="streamsWiredDisableModal"
         >
           <EuiModalHeader>
             <EuiModalHeaderTitle id="streamsWiredDisableModalTitle">
@@ -445,6 +446,7 @@ output.elasticsearch:
               label={i18n.translate('xpack.streams.streamsSettingsFlyout.disableModalCheckbox', {
                 defaultMessage: 'I understand this will delete all data and configuration.',
               })}
+              data-test-subj="streamsWiredDisableConfirmCheckbox"
             />
           </EuiModalBody>
           <EuiModalFooter>
@@ -454,6 +456,7 @@ output.elasticsearch:
                 setDisableConfirmChecked(false);
               }}
               disabled={isDisabling}
+              data-test-subj="streamsWiredDisableCancelButton"
             >
               {i18n.translate('xpack.streams.streamsSettingsFlyout.disableModalCancel', {
                 defaultMessage: 'Cancel',


### PR DESCRIPTION
Closes #240450 

## Summary

Fixes the stale state issue in the Streams Settings flyout where the "Enable wired streams" toggle could show incorrect values after external API changes.

## Problem

The `wiredStatus` state in the Streams Settings flyout was only fetched once on initial mount. If the wired status was changed externally (e.g., via DevTools API calls), the UI would not reflect the updated state without a page refresh.

## Solution

As the flyout is the only consumer of the wiredStatus value, we are able to simplify the wired status management by replacing the reactive observable pattern with a direct async method:

- **Removed**: `BehaviorSubject` and `wiredStatus$` observable from the Streams plugin
- **Added**: `getWiredStatus()` async method that fetches fresh state on-demand
- **Updated**: Flyout now fetches wired status on component mount

This approach ensures the UI always displays the current state while keeping the code simple and maintainable.

### Tests
- **`streams/public/plugin.test.ts`**: Unit tests for `getWiredStatus`, `enableWiredMode`, and `disableWiredMode`
- **`streams_app/.../streams_settings_flyout.test.tsx`**: Integration tests covering user flows, loading states, error handling, and permission checks

## Testing

```bash
yarn test:jest x-pack/platform/plugins/shared/streams/public/plugin.test.ts
yarn test:jest x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.test.tsx
```