### PR TITLE
[SharedUX] Update canvas-confetti renovate backport strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4740,7 +4740,7 @@
       "labels": [
         "Team:SharedUX",
         "release_note:skip",
-        "backport:current-major"
+        "backport:previous-minor"
       ],
       "minimumReleaseAge": "14 days",
       "enabled": true


### PR DESCRIPTION
## Summary

- Updated our backport strategy for recently added `canvas-confetti` dependency to `previous-minor` as advised on previous PR.

Related PR: https://github.com/elastic/kibana/pull/235175