### PR TITLE
[Cases] Enable case feature flag overrides with ENV vars

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -268,8 +268,14 @@ kibana_vars=(
     xpack.banners.placement
     xpack.banners.textColor
     xpack.banners.textContent
+    xpack.cases.enabled
+    xpack.cases.analytics.index.enabled
+    xpack.cases.incrementalId.enabled
+    xpack.cases.incrementalId.taskIntervalMinutes
+    xpack.cases.incrementalId.taskStartDelayMinutes
     xpack.cases.files.allowedMimeTypes
     xpack.cases.files.maxSize
+    xpack.cases.stack.enabled
     xpack.code.disk.thresholdEnabled
     xpack.code.disk.watermarkLow
     xpack.code.indexRepoFrequencyMs


### PR DESCRIPTION
## Summary

Adding our feature flags to the env var override config. For more info, check out [the documentation on env var overrides](https://www.elastic.co/docs/deploy-manage/deploy/self-managed/install-kibana-with-docker#environment-variable-config).


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->