### PR TITLE
[ObsUx][Hosts]Add missing "There are hosts available in another schema" message

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/schema_selector.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/schema_selector.tsx
@@ -238,7 +238,7 @@ export const SchemaSelector = ({
           })}
           css={{ minWidth: isHostsView ? '400px' : '300px' }}
           helpText={
-            options.length > 1 &&
+            (options.length > 1 || (options.length === 1 && isInvalid)) &&
             i18n.translate('xpack.infra.schemaSelector.select.helpText', {
               defaultMessage: 'There are hosts available in another schema',
             })


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/239691

## Summary

When someone runs a query in the Hosts UI, if there are hosts available in another schema, there should be wording to tell them to switch the schema.

BEFORE

<img width="1218" height="571" alt="Screenshot 2025-10-30 at 12 13 08" src="https://github.com/user-attachments/assets/c3eead5a-e66e-45ed-b7da-4f03af449a75" />


AFTER

<img width="1218" height="571" alt="Screenshot 2025-10-30 at 11 57 08" src="https://github.com/user-attachments/assets/0aade972-565e-48a6-93c9-5b15fc759478" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->