### PR TITLE
fix(workflows): allow skip ssl for HTTP steps

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -165,6 +165,16 @@ export const WaitStepSchema = BaseStepSchema.extend({
 });
 export type WaitStep = z.infer<typeof WaitStepSchema>;
 
+// Fetcher configuration for HTTP request customization (shared across formats)
+export const FetcherConfigSchema = z
+  .object({
+    skip_ssl_verification: z.boolean().optional(),
+    follow_redirects: z.boolean().optional(),
+    max_redirects: z.number().optional(),
+    keep_alive: z.boolean().optional(),
+  })
+  .optional();
+
 export const HttpStepSchema = BaseStepSchema.extend({
   type: z.literal('http'),
   with: z.object({
@@ -176,6 +186,7 @@ export const HttpStepSchema = BaseStepSchema.extend({
       .default({}),
     body: z.any().optional(),
     timeout: z.string().optional().default('30s'),
+    fetcher: FetcherConfigSchema,
   }),
 })
   .merge(StepWithIfConditionSchema)
@@ -216,16 +227,6 @@ export const ElasticsearchStepSchema = BaseStepSchema.extend({
   ]),
 });
 export type ElasticsearchStep = z.infer<typeof ElasticsearchStepSchema>;
-
-// Fetcher configuration for HTTP request customization (shared across formats)
-export const FetcherConfigSchema = z
-  .object({
-    skip_ssl_verification: z.boolean().optional(),
-    follow_redirects: z.boolean().optional(),
-    max_redirects: z.number().optional(),
-    keep_alive: z.boolean().optional(),
-  })
-  .optional();
 
 // Generic Kibana step schema for backend validation
 export const KibanaStepSchema = BaseStepSchema.extend({

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/http_step/http_step_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/http_step/http_step_impl.test.ts
@@ -125,6 +125,7 @@ describe('HttpStepImpl', () => {
         body: {
           id: '{{userId}}',
         },
+        fetcher: undefined,
       });
     });
 
@@ -470,6 +471,128 @@ describe('HttpStepImpl', () => {
         expect.objectContaining({
           url: 'https://any-host.com/test',
           method: 'GET',
+        })
+      );
+    });
+  });
+
+  describe('Fetcher configuration', () => {
+    beforeEach(() => {
+      mockContextManager.renderValueAccordingToContext = jest.fn().mockReturnValue({
+        url: 'https://api.example.com/users',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: { name: 'John Doe' },
+      });
+    });
+
+    it('should apply skip_ssl_verification option', async () => {
+      const input = {
+        url: 'https://api.example.com/users',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: { name: 'John Doe' },
+        fetcher: {
+          skip_ssl_verification: true,
+        },
+      };
+
+      (mockedAxios as any).mockResolvedValueOnce({ status: 200, data: { success: true } });
+
+      await (httpStep as any)._run(input);
+
+      expect(mockedAxios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          httpsAgent: expect.objectContaining({
+            options: expect.objectContaining({
+              rejectUnauthorized: false,
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should apply keep_alive option', async () => {
+      const input = {
+        url: 'https://api.example.com/users',
+        method: 'GET',
+        headers: {},
+        fetcher: {
+          keep_alive: true,
+        },
+      };
+
+      (mockedAxios as any).mockResolvedValueOnce({ status: 200, data: { success: true } });
+
+      await (httpStep as any)._run(input);
+
+      expect(mockedAxios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          httpsAgent: expect.objectContaining({
+            options: expect.objectContaining({
+              keepAlive: true,
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should apply max_redirects option', async () => {
+      const input = {
+        url: 'https://api.example.com/users',
+        method: 'GET',
+        headers: {},
+        fetcher: {
+          max_redirects: 5,
+        },
+      };
+
+      (mockedAxios as any).mockResolvedValueOnce({ status: 200, data: { success: true } });
+
+      await (httpStep as any)._run(input);
+
+      expect(mockedAxios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          maxRedirects: 5,
+        })
+      );
+    });
+
+    it('should disable redirects when follow_redirects is false', async () => {
+      const input = {
+        url: 'https://api.example.com/users',
+        method: 'GET',
+        headers: {},
+        fetcher: {
+          follow_redirects: false,
+        },
+      };
+
+      (mockedAxios as any).mockResolvedValueOnce({ status: 200, data: { success: true } });
+
+      await (httpStep as any)._run(input);
+
+      expect(mockedAxios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          maxRedirects: 0,
+        })
+      );
+    });
+
+    it('should work without fetcher options', async () => {
+      const input = {
+        url: 'https://api.example.com/users',
+        method: 'GET',
+        headers: {},
+      };
+
+      (mockedAxios as any).mockResolvedValueOnce({ status: 200, data: { success: true } });
+
+      await (httpStep as any)._run(input);
+
+      expect(mockedAxios).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          httpsAgent: expect.anything(),
         })
       );
     });


### PR DESCRIPTION
close https://github.com/elastic/security-team/issues/14486

## Summary

Adds flexible HTTP request configuration options for workflow HTTP steps, enabling customization of SSL verification, redirects, and connection keep-alive.


## Motivation

When executing workflows that make HTTP requests to external APIs, users need the ability to:
Skip SSL verification for development/self-signed certificates
Fine-tune connection settings for performance (keep-alive, redirect behavior)
Previously, these options were hardcoded in HTTP steps, making it difficult to handle various network configurations and development environments. This brings HTTP steps to feature parity with Kibana action steps (implemented in #241090).

## Changes

- Schema (schema.ts): Added FetcherConfigSchema to HttpStepSchema with support for SSL, redirect, and keep-alive configuration
 - Implementation (http_step_impl.ts):
 - Extract fetcher configuration from step input
 - Configure HTTPS agent with custom options (SSL verification, keep-alive)
 - Configure axios redirect behavior based on fetcher options
 
## Tests 
(http_step_impl.test.ts): Added comprehensive test coverage for all fetcher configuration options