### PR TITLE
[9.1] [Maps] Show labels after saving edits while staying on Vector tiles (… (#240728)

### DIFF
--- a/x-pack/platform/plugins/shared/maps/public/classes/layers/wizards/new_vector_layer_wizard/wizard.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/layers/wizards/new_vector_layer_wizard/wizard.tsx
@@ -10,8 +10,7 @@ import { EuiPanel, EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { createNewIndexAndPattern } from './create_new_index_pattern';
 import { RenderWizardArguments } from '../layer_wizard_registry';
-import { GeoJsonVectorLayer } from '../../vector_layer';
-import { ESSearchSource } from '../../../sources/es_search_source';
+import { createDefaultLayerDescriptor } from '../../../sources/es_search_source/es_documents_layer_wizard';
 import { ADD_LAYER_STEP_ID } from '../../../../connected_components/add_layer_panel/view';
 import { getFileUpload, getIndexNameFormComponent } from '../../../../kibana_services';
 
@@ -122,14 +121,13 @@ export class NewVectorLayerEditor extends Component<RenderWizardArguments, State
       return;
     }
     // Creates empty layer
-    const sourceDescriptor = ESSearchSource.createDescriptor({
-      indexPatternId,
-      geoField: 'coordinates',
-      filterByMapBounds: false,
-      applyGlobalQuery: false,
-    });
-    const layerDescriptor = GeoJsonVectorLayer.createDescriptor(
-      { sourceDescriptor },
+    const layerDescriptor = createDefaultLayerDescriptor(
+      {
+        indexPatternId,
+        geoField: 'coordinates',
+        filterByMapBounds: false,
+        applyGlobalQuery: false,
+      },
       this.props.mapColors
     );
     this.props.previewLayers([layerDescriptor]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Maps] Show labels after saving edits while staying on Vector tiles (… (#240728)](https://github.com/elastic/kibana/pull/240728)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jakob Malmo","email":"jakobmalmo@protonmail.com"},"sourceCommit":{"committedDate":"2025-10-30T03:10:46Z","message":"[Maps] Show labels after saving edits while staying on Vector tiles (… (#240728)\n\nCloses #240727 \n---\n\n## Summary\nWhen using **Maps → Create index (Draw shapes)**, the new layer defaults\nto **Scaling → Use vector tiles**.\nAdding label styling (Fixed or By value) previously did **not** display\nlabels until the user manually changed Scaling to **Limit results** and\nback.\nThis PR makes labels appear immediately (after styling or save) on\nvector-tiles layers by:\n\n- Requesting MVT tiles with **`with_labels=true`** when label styling is\nactive\n- **Refreshing** tile sources when label styling changes and after\nsaving edits\n- Properly routing **GEOJSON_VECTOR** layers with `scalingType: MVT`\nthrough the MVT pipeline\n\nElastic’s `_mvt` API returns suggested label points when\n`with_labels=true`; this wires Kibana to use that path and refresh tiles\naccordingly.\nKibana’s **Vector layer** docs describe the scaling modes this aligns\nwith.\n\n> 🧠 Investigation and solution developed with the help of the large\nlanguage model **Claude Sonnet 4.5**, used to analyze the root cause and\nassist in implementation.\n\n---\n\n### What changed (files)\n1.\n**`x-pack/platform/plugins/shared/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_vector_layer.tsx`**\n• Snapshots the current label descriptor and `hasLabels` flag into the\nsource request meta; any change invalidates the cached tiles and\nre-fetches through the MVT layer.\n\n2.\n**`x-pack/platform/plugins/shared/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_source_data.ts`**\n• Respect `isForceRefresh` (was checking only\n`forceRefreshDueToDrawing`).\n• Generate a new token only when `hasLabels` or buffer change (prevents\nloops).\n• Include **`with_labels=true`** in tile requests when label styling is\nactive (Elasticsearch `_mvt` label points).\n\n3.\n**`x-pack/platform/plugins/shared/maps/public/classes/layers/wizards/new_vector_layer_wizard/wizard.tsx`**\n• When Create index uses MVT scaling, emit an **MvtVectorLayer**\ndescriptor so the layer starts on the MVT pipeline and picks up the\nlabel-refresh logic.\n\n> **Note:** `geojson_vector_layer.tsx` is restored to match `main` (no\nMVT source added by GeoJSON). Vector-tile rendering remains owned by\n`MvtVectorLayer`.\n\nPer Elastic’s docs, the vector-tile search API can return suggested\nlabel points when `with_labels=true`; the Vector layer docs describe\nwhen to use **Use vector tiles** vs **Limit results**. This change wires\nKibana’s MVT path to request tiles with labels and refresh them when\nstyling/saving, so labels render without a scaling toggle.\n\n\n\n---\n\n### Why\nDuring the Create index workflow, vector-tiles scaling is the default.  \nTiles are built server-side from indexed data, so unsaved edits and\nlabel changes don’t show until tiles are refreshed.\nBy requesting tiles with labels and refreshing them on style or save,\nlabels now render as expected without a manual scaling toggle.\n\n---\n\n### Before / After\n| Before | After |\n|:--|:--|\n| Create index → Draw point → Add label → Label missing until Scaling\nchanged | Create index → Draw point → Add label → Label appears\ninstantly (no toggle needed) |\n\n**Before (GIF):**  \n\n![kibana_gif_not_working](https://github.com/user-attachments/assets/6295581d-a902-47a3-aeea-4f8dfb616793)\n\n**After (GIF):**  \n\n![kibana_working_gif](https://github.com/user-attachments/assets/e859c649-6eb1-4139-adea-6bd7ed5f7986)\n\n---\n\n### Testing\nThis change was verified manually; **no new unit or functional tests\nwere added** in this PR.\n\n**Manual validation steps**\n- Add layer → Create index\n- Draw a point or other shape\n- Add label styling (Fixed value and By value) → labels appear\nimmediately without toggling scaling\n- Modify label text → label updates in real time\n- Toggle labels on/off → tiles refresh correctly\n- Save edits → labels persist after saving\n- No crashes, flickering, or infinite refresh loops\n\n**Test coverage note**\nExisting Jest tests for Maps layers and source syncing still pass.  \nPotential follow-ups:\n- Label style change triggers `isForceRefresh=true`\n- `with_labels=true` included in MVT tile requests when labels are\nactive\n- GeoJSON→MVT rendering path switching works without regression\n\n---\n\n## Release note\n**Fix:** Labels in the **Create index** flow now render with the default\n**Use vector tiles** scaling as soon as label styling is applied (or\nafter save), without requiring a scaling toggle.\n\n---\n\n### Checklist\n- [x] No new UI strings (i18n N/A); follows EUI sentence case  \n- [x] No HTTP API or security changes  \n- [ ] Unit tests updated/added *(none in this PR; validated manually)*  \n- [x] Include release note  \n- [ ] Labels (`release_note:*`, `backport:*`, `review`, `community`)\nwill be applied by maintainers during triage\n\n---\n\n### Identify risks\n- **Scope:** Limited to Create index / MVT-scaling render path  \n- **Performance:** `with_labels` adds small label points per tile; only\nused when labels are enabled\n- **Mitigation:** Refresh is scoped to the affected layer; token\ngeneration avoids loops\n\n---\n\n### Validation\n```bash\nnvm use 22.17.1\nyarn kbn bootstrap\nyarn lint\nyarn test:jest x-pack/platform/plugins/shared/maps\nyarn es snapshot --license trial\nyarn start\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3b3adac2e24a84f216bec2d0884114013b03854a","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","💝community","Feature:Maps","backport:version","v9.3.0","v8.19.7","v9.1.7","v9.2.1"],"title":"[Maps] Show labels after saving edits while staying on Vector tiles (…","number":240728,"url":"https://github.com/elastic/kibana/pull/240728","mergeCommit":{"message":"[Maps] Show labels after saving edits while staying on Vector tiles (… (#240728)\n\nCloses #240727 \n---\n\n## Summary\nWhen using **Maps → Create index (Draw shapes)**, the new layer defaults\nto **Scaling → Use vector tiles**.\nAdding label styling (Fixed or By value) previously did **not** display\nlabels until the user manually changed Scaling to **Limit results** and\nback.\nThis PR makes labels appear immediately (after styling or save) on\nvector-tiles layers by:\n\n- Requesting MVT tiles with **`with_labels=true`** when label styling is\nactive\n- **Refreshing** tile sources when label styling changes and after\nsaving edits\n- Properly routing **GEOJSON_VECTOR** layers with `scalingType: MVT`\nthrough the MVT pipeline\n\nElastic’s `_mvt` API returns suggested label points when\n`with_labels=true`; this wires Kibana to use that path and refresh tiles\naccordingly.\nKibana’s **Vector layer** docs describe the scaling modes this aligns\nwith.\n\n> 🧠 Investigation and solution developed with the help of the large\nlanguage model **Claude Sonnet 4.5**, used to analyze the root cause and\nassist in implementation.\n\n---\n\n### What changed (files)\n1.\n**`x-pack/platform/plugins/shared/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_vector_layer.tsx`**\n• Snapshots the current label descriptor and `hasLabels` flag into the\nsource request meta; any change invalidates the cached tiles and\nre-fetches through the MVT layer.\n\n2.\n**`x-pack/platform/plugins/shared/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_source_data.ts`**\n• Respect `isForceRefresh` (was checking only\n`forceRefreshDueToDrawing`).\n• Generate a new token only when `hasLabels` or buffer change (prevents\nloops).\n• Include **`with_labels=true`** in tile requests when label styling is\nactive (Elasticsearch `_mvt` label points).\n\n3.\n**`x-pack/platform/plugins/shared/maps/public/classes/layers/wizards/new_vector_layer_wizard/wizard.tsx`**\n• When Create index uses MVT scaling, emit an **MvtVectorLayer**\ndescriptor so the layer starts on the MVT pipeline and picks up the\nlabel-refresh logic.\n\n> **Note:** `geojson_vector_layer.tsx` is restored to match `main` (no\nMVT source added by GeoJSON). Vector-tile rendering remains owned by\n`MvtVectorLayer`.\n\nPer Elastic’s docs, the vector-tile search API can return suggested\nlabel points when `with_labels=true`; the Vector layer docs describe\nwhen to use **Use vector tiles** vs **Limit results**. This change wires\nKibana’s MVT path to request tiles with labels and refresh them when\nstyling/saving, so labels render without a scaling toggle.\n\n\n\n---\n\n### Why\nDuring the Create index workflow, vector-tiles scaling is the default.  \nTiles are built server-side from indexed data, so unsaved edits and\nlabel changes don’t show until tiles are refreshed.\nBy requesting tiles with labels and refreshing them on style or save,\nlabels now render as expected without a manual scaling toggle.\n\n---\n\n### Before / After\n| Before | After |\n|:--|:--|\n| Create index → Draw point → Add label → Label missing until Scaling\nchanged | Create index → Draw point → Add label → Label appears\ninstantly (no toggle needed) |\n\n**Before (GIF):**  \n\n![kibana_gif_not_working](https://github.com/user-attachments/assets/6295581d-a902-47a3-aeea-4f8dfb616793)\n\n**After (GIF):**  \n\n![kibana_working_gif](https://github.com/user-attachments/assets/e859c649-6eb1-4139-adea-6bd7ed5f7986)\n\n---\n\n### Testing\nThis change was verified manually; **no new unit or functional tests\nwere added** in this PR.\n\n**Manual validation steps**\n- Add layer → Create index\n- Draw a point or other shape\n- Add label styling (Fixed value and By value) → labels appear\nimmediately without toggling scaling\n- Modify label text → label updates in real time\n- Toggle labels on/off → tiles refresh correctly\n- Save edits → labels persist after saving\n- No crashes, flickering, or infinite refresh loops\n\n**Test coverage note**\nExisting Jest tests for Maps layers and source syncing still pass.  \nPotential follow-ups:\n- Label style change triggers `isForceRefresh=true`\n- `with_labels=true` included in MVT tile requests when labels are\nactive\n- GeoJSON→MVT rendering path switching works without regression\n\n---\n\n## Release note\n**Fix:** Labels in the **Create index** flow now render with the default\n**Use vector tiles** scaling as soon as label styling is applied (or\nafter save), without requiring a scaling toggle.\n\n---\n\n### Checklist\n- [x] No new UI strings (i18n N/A); follows EUI sentence case  \n- [x] No HTTP API or security changes  \n- [ ] Unit tests updated/added *(none in this PR; validated manually)*  \n- [x] Include release note  \n- [ ] Labels (`release_note:*`, `backport:*`, `review`, `community`)\nwill be applied by maintainers during triage\n\n---\n\n### Identify risks\n- **Scope:** Limited to Create index / MVT-scaling render path  \n- **Performance:** `with_labels` adds small label points per tile; only\nused when labels are enabled\n- **Mitigation:** Refresh is scoped to the affected layer; token\ngeneration avoids loops\n\n---\n\n### Validation\n```bash\nnvm use 22.17.1\nyarn kbn bootstrap\nyarn lint\nyarn test:jest x-pack/platform/plugins/shared/maps\nyarn es snapshot --license trial\nyarn start\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3b3adac2e24a84f216bec2d0884114013b03854a"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/240728","number":240728,"mergeCommit":{"message":"[Maps] Show labels after saving edits while staying on Vector tiles (… (#240728)\n\nCloses #240727 \n---\n\n## Summary\nWhen using **Maps → Create index (Draw shapes)**, the new layer defaults\nto **Scaling → Use vector tiles**.\nAdding label styling (Fixed or By value) previously did **not** display\nlabels until the user manually changed Scaling to **Limit results** and\nback.\nThis PR makes labels appear immediately (after styling or save) on\nvector-tiles layers by:\n\n- Requesting MVT tiles with **`with_labels=true`** when label styling is\nactive\n- **Refreshing** tile sources when label styling changes and after\nsaving edits\n- Properly routing **GEOJSON_VECTOR** layers with `scalingType: MVT`\nthrough the MVT pipeline\n\nElastic’s `_mvt` API returns suggested label points when\n`with_labels=true`; this wires Kibana to use that path and refresh tiles\naccordingly.\nKibana’s **Vector layer** docs describe the scaling modes this aligns\nwith.\n\n> 🧠 Investigation and solution developed with the help of the large\nlanguage model **Claude Sonnet 4.5**, used to analyze the root cause and\nassist in implementation.\n\n---\n\n### What changed (files)\n1.\n**`x-pack/platform/plugins/shared/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_vector_layer.tsx`**\n• Snapshots the current label descriptor and `hasLabels` flag into the\nsource request meta; any change invalidates the cached tiles and\nre-fetches through the MVT layer.\n\n2.\n**`x-pack/platform/plugins/shared/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_source_data.ts`**\n• Respect `isForceRefresh` (was checking only\n`forceRefreshDueToDrawing`).\n• Generate a new token only when `hasLabels` or buffer change (prevents\nloops).\n• Include **`with_labels=true`** in tile requests when label styling is\nactive (Elasticsearch `_mvt` label points).\n\n3.\n**`x-pack/platform/plugins/shared/maps/public/classes/layers/wizards/new_vector_layer_wizard/wizard.tsx`**\n• When Create index uses MVT scaling, emit an **MvtVectorLayer**\ndescriptor so the layer starts on the MVT pipeline and picks up the\nlabel-refresh logic.\n\n> **Note:** `geojson_vector_layer.tsx` is restored to match `main` (no\nMVT source added by GeoJSON). Vector-tile rendering remains owned by\n`MvtVectorLayer`.\n\nPer Elastic’s docs, the vector-tile search API can return suggested\nlabel points when `with_labels=true`; the Vector layer docs describe\nwhen to use **Use vector tiles** vs **Limit results**. This change wires\nKibana’s MVT path to request tiles with labels and refresh them when\nstyling/saving, so labels render without a scaling toggle.\n\n\n\n---\n\n### Why\nDuring the Create index workflow, vector-tiles scaling is the default.  \nTiles are built server-side from indexed data, so unsaved edits and\nlabel changes don’t show until tiles are refreshed.\nBy requesting tiles with labels and refreshing them on style or save,\nlabels now render as expected without a manual scaling toggle.\n\n---\n\n### Before / After\n| Before | After |\n|:--|:--|\n| Create index → Draw point → Add label → Label missing until Scaling\nchanged | Create index → Draw point → Add label → Label appears\ninstantly (no toggle needed) |\n\n**Before (GIF):**  \n\n![kibana_gif_not_working](https://github.com/user-attachments/assets/6295581d-a902-47a3-aeea-4f8dfb616793)\n\n**After (GIF):**  \n\n![kibana_working_gif](https://github.com/user-attachments/assets/e859c649-6eb1-4139-adea-6bd7ed5f7986)\n\n---\n\n### Testing\nThis change was verified manually; **no new unit or functional tests\nwere added** in this PR.\n\n**Manual validation steps**\n- Add layer → Create index\n- Draw a point or other shape\n- Add label styling (Fixed value and By value) → labels appear\nimmediately without toggling scaling\n- Modify label text → label updates in real time\n- Toggle labels on/off → tiles refresh correctly\n- Save edits → labels persist after saving\n- No crashes, flickering, or infinite refresh loops\n\n**Test coverage note**\nExisting Jest tests for Maps layers and source syncing still pass.  \nPotential follow-ups:\n- Label style change triggers `isForceRefresh=true`\n- `with_labels=true` included in MVT tile requests when labels are\nactive\n- GeoJSON→MVT rendering path switching works without regression\n\n---\n\n## Release note\n**Fix:** Labels in the **Create index** flow now render with the default\n**Use vector tiles** scaling as soon as label styling is applied (or\nafter save), without requiring a scaling toggle.\n\n---\n\n### Checklist\n- [x] No new UI strings (i18n N/A); follows EUI sentence case  \n- [x] No HTTP API or security changes  \n- [ ] Unit tests updated/added *(none in this PR; validated manually)*  \n- [x] Include release note  \n- [ ] Labels (`release_note:*`, `backport:*`, `review`, `community`)\nwill be applied by maintainers during triage\n\n---\n\n### Identify risks\n- **Scope:** Limited to Create index / MVT-scaling render path  \n- **Performance:** `with_labels` adds small label points per tile; only\nused when labels are enabled\n- **Mitigation:** Refresh is scoped to the affected layer; token\ngeneration avoids loops\n\n---\n\n### Validation\n```bash\nnvm use 22.17.1\nyarn kbn bootstrap\nyarn lint\nyarn test:jest x-pack/platform/plugins/shared/maps\nyarn es snapshot --license trial\nyarn start\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3b3adac2e24a84f216bec2d0884114013b03854a"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241219","number":241219,"state":"MERGED","mergeCommit":{"sha":"7e6660eee2c149744580221d02a1a4987f5ea51c","message":"[9.2] [Maps] Show labels after saving edits while staying on Vector tiles (… (#240728) (#241219)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Maps] Show labels after saving edits while staying on Vector tiles\n(… (#240728)](https://github.com/elastic/kibana/pull/240728)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jakob Malmo <jakobmalmo@protonmail.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}}]}] BACKPORT-->