### PR TITLE
[CI] increase onechat bundle limits to 22883

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -117,7 +117,7 @@ pageLoadAssetSize:
   observabilityLogsExplorer: 4918
   observabilityOnboarding: 12872
   observabilityShared: 75115
-  onechat: 20161
+  onechat: 22883
   osquery: 47422
   painlessLab: 6299
   presentationPanel: 11484


### PR DESCRIPTION
## Summary
On-merge is blocked by the bundle-size slipping over the previous limit