### PR TITLE
[Search] Getting started upload file link

### DIFF
--- a/src/platform/plugins/shared/home/public/application/components/home_app.tsx
+++ b/src/platform/plugins/shared/home/public/application/components/home_app.tsx
@@ -47,7 +47,6 @@ export function HomeApp({ directories, solutions }: HomeAppProps) {
         addBasePath={addBasePath}
         openTab={tabId}
         isCloudEnabled={isCloudEnabled}
-        history={props.history}
       />
     );
   };

--- a/src/platform/plugins/shared/home/public/application/components/home_app.tsx
+++ b/src/platform/plugins/shared/home/public/application/components/home_app.tsx
@@ -47,6 +47,7 @@ export function HomeApp({ directories, solutions }: HomeAppProps) {
         addBasePath={addBasePath}
         openTab={tabId}
         isCloudEnabled={isCloudEnabled}
+        history={props.history}
       />
     );
   };

--- a/src/platform/plugins/shared/home/public/application/components/tutorial_directory.tsx
+++ b/src/platform/plugins/shared/home/public/application/components/tutorial_directory.tsx
@@ -32,6 +32,7 @@ interface TutorialDirectoryUiProps {
   openTab: string;
   isCloudEnabled: boolean;
   intl: InjectedIntl;
+  history?: any;
 }
 interface TutorialCard extends Pick<TutorialType, 'id' | 'category' | 'name'> {
   url: string;
@@ -186,6 +187,10 @@ class TutorialDirectoryUi extends React.Component<
     this.setState({
       selectedTabId: id,
     });
+    // Update URL to reflect the selected tab
+    if (this.props.history) {
+      this.props.history.push(`/tutorial_directory/${id}`);
+    }
   };
 
   getTabs = () => {

--- a/src/platform/plugins/shared/home/public/application/components/tutorial_directory.tsx
+++ b/src/platform/plugins/shared/home/public/application/components/tutorial_directory.tsx
@@ -32,7 +32,6 @@ interface TutorialDirectoryUiProps {
   openTab: string;
   isCloudEnabled: boolean;
   intl: InjectedIntl;
-  history?: any;
 }
 interface TutorialCard extends Pick<TutorialType, 'id' | 'category' | 'name'> {
   url: string;
@@ -155,6 +154,21 @@ class TutorialDirectoryUi extends React.Component<
     _prevProps: TutorialDirectoryUiProps,
     prevState: Readonly<TutorialDirectoryUiState>
   ) {
+    // Update selected tab when URL changes (e.g., browser back/forward)
+    if (_prevProps.openTab !== this.props.openTab) {
+      const newTab = this.props.openTab;
+      // Validate that the tab exists
+      const tabExists = this.tabs.some((tab) => tab.id === newTab);
+      if (!tabExists) {
+        // If the tab does not exist, redirect to the default tab
+        getServices().history.push(`#/tutorial_directory/${SAMPLE_DATA_TAB_ID}`);
+      } else if (newTab !== this.state.selectedTabId) {
+        this.setState({
+          selectedTabId: newTab,
+        });
+      }
+    }
+
     if (prevState.selectedTabId !== this.state.selectedTabId) {
       this.setBreadcrumbs();
     }
@@ -188,9 +202,7 @@ class TutorialDirectoryUi extends React.Component<
       selectedTabId: id,
     });
     // Update URL to reflect the selected tab
-    if (this.props.history) {
-      this.props.history.push(`/tutorial_directory/${id}`);
-    }
+    getServices().history.push(`#/tutorial_directory/${id}`);
   };
 
   getTabs = () => {

--- a/src/platform/plugins/shared/home/public/application/kibana_services.ts
+++ b/src/platform/plugins/shared/home/public/application/kibana_services.ts
@@ -17,6 +17,7 @@ import type {
   ApplicationStart,
   ThemeServiceStart,
   I18nStart,
+  AppMountParameters,
 } from '@kbn/core/public';
 import type { UiCounterMetricType } from '@kbn/analytics';
 import type { UrlForwardingStart } from '@kbn/url-forwarding-plugin/public';
@@ -57,6 +58,7 @@ export interface HomeKibanaServices {
   overlays: OverlayStart;
   theme: ThemeServiceStart;
   i18nStart: I18nStart;
+  history: AppMountParameters['history'];
 }
 
 let services: HomeKibanaServices | null = null;

--- a/src/platform/plugins/shared/home/public/plugin.ts
+++ b/src/platform/plugins/shared/home/public/plugin.ts
@@ -44,6 +44,7 @@ export interface HomePluginStartDependencies {
   urlForwarding: UrlForwardingStart;
   cloud: CloudStart;
   share: SharePluginStart;
+  history: AppMountParameters['history'];
 }
 
 export interface HomePluginSetupDependencies {
@@ -114,6 +115,7 @@ export class HomePublicPlugin
           theme: core.theme,
           i18nStart: coreStart.i18n,
           shareStart,
+          history: params.history,
         });
         coreStart.chrome.docTitle.change(
           i18n.translate('home.pageTitle', { defaultMessage: 'Home' })

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/header/add_data_button.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/header/add_data_button.tsx
@@ -32,7 +32,7 @@ export const AddDataButton: React.FC = () => {
       data-test-subj="gettingStartedUploadMenuItem"
       onClick={() => {
         closePopover();
-        application.navigateToApp('home', { path: '#/tutorial_directory/sampleData' });
+        application.navigateToApp('home', { path: '#/tutorial_directory/fileDataViz' });
       }}
     >
       {i18n.translate('xpack.search.gettingStarted.addDataButton.uploadFile', {

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/header/add_data_button.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/header/add_data_button.tsx
@@ -32,7 +32,7 @@ export const AddDataButton: React.FC = () => {
       data-test-subj="gettingStartedUploadMenuItem"
       onClick={() => {
         closePopover();
-        application.navigateToApp('ml', { path: 'filedatavisualizer' });
+        application.navigateToApp('home', { path: '#/tutorial_directory/sampleData' });
       }}
     >
       {i18n.translate('xpack.search.gettingStarted.addDataButton.uploadFile', {


### PR DESCRIPTION
## Summary

We will be updating the add data page here: [[Epic] [Getting Started] Add Data and Sample Data page](https://github.com/elastic/search-team/issues/11598#top)

## Changes:
- Upload file button goes to: `/app/home#/tutorial_directory/fileDataViz`
- Update tutorial directory page to push url path change when selecting a tab
- Tutorial page keeps selected tab in sync with url
- `history` set as a plugin start dependency for the Home plugin

## Screen Recording

https://github.com/user-attachments/assets/5cc1971e-ee85-440c-b394-b5fcd83d4c4c


