### PR TITLE
[9.2] [Console] Fix code scanning alert (#241231)

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.test.ts
@@ -99,7 +99,11 @@ describe('useSetInitialValue', () => {
       );
     });
 
-    expect(fetch).toHaveBeenCalledWith(new URL('https://www.elastic.co/some-data'));
+    // Verify fetch was called with the correct URL
+    expect(fetch).toHaveBeenCalled();
+    const fetchCall = (fetch as jest.Mock).mock.calls[0];
+    expect(fetchCall[0].href).toBe('https://www.elastic.co/docs/some-data');
+
     // The remote data should be appended to the initial value in the editor
     expect(setValueMock).toHaveBeenCalledWith('initial value\n\nremote data');
   });

--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.ts
@@ -15,6 +15,9 @@ import { i18n } from '@kbn/i18n';
 import { useEffect, useRef } from 'react';
 import { DEFAULT_INPUT_VALUE } from '../../../../../common/constants';
 
+const httpsProtocol = 'https:';
+const elasticHostname = 'www.elastic.co';
+
 interface QueryParams {
   load_from: string;
 }
@@ -60,7 +63,12 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
         // Parse the URL to avoid issues with spaces and other special characters.
         const parsedURL = new URL(url);
         if (parsedURL.origin === 'https://www.elastic.co') {
-          const resp = await fetch(parsedURL);
+          // Construct a safe URL from validated components to prevent request forgery
+          const safeURL = new URL(parsedURL.href);
+          safeURL.protocol = httpsProtocol;
+          safeURL.hostname = elasticHostname;
+
+          const resp = await fetch(safeURL);
           const data = await resp.text();
           setValue(`${localStorageValue ?? ''}\n\n${data}`);
         } else {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Console] Fix code scanning alert (#241231)](https://github.com/elastic/kibana/pull/241231)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sonia Sanz Vivas","email":"sonia.sanzvivas@elastic.co"},"sourceCommit":{"committedDate":"2025-10-30T14:50:25Z","message":"[Console] Fix code scanning alert (#241231)\n\nFixes https://github.com/elastic/kibana/security/code-scanning/620\n\n## Summary\nThis was already addressed in\nhttps://github.com/elastic/kibana/pull/237599 but we had the alert\nagain. For trying to fix it, I re-build the url with the validated\nprotocol and hostname. Also, I updated the tests so it validates the\nhref, the previous implementation was returning true for all URLs.\n\n### How to test:\n\nTry loading the following URL (making the necessary replacement in the\nURL) and verify that the data is correctly loaded into the editor and\nvalue can be edited:\n\n\n`http://localhost:5601/<REPLACE-THIS>/app/dev_tools#/console?load_from=data:text/plain,AoeQygKgBA9A+gRwK4FMBOBPGBDAzhgOwGMB+AEzQHsAHOApAGwbiMoaQFsDcAoAbx5QoAImToMwgFwiAZgCVKAWShoUHSgBcUAWgBUkgJYEyKAB4pcwgDSCRDSkWwMUUkSgLXbwmQYZa0rgJCQsIARpRsgbbBIhxIuBquANoAujYxIT5+6Mlp0cHCuAAWlIxkuekZwnEJdJq5+QC+ts2NQA`\n\n\n\n`http://localhost:5601/<REPLACE-THIS>/app/dev_tools#/console?load_from=https://www.elastic.co/guide/en/elasticsearch/reference/current/snippets/86.console`","sha":"56e1585269cc92deefb6596991db4519643a68e2","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","backport:version","v9.0.6","v9.3.0","v9.1.7","v9.2.1"],"title":"[Console] Fix code scanning alert","number":241231,"url":"https://github.com/elastic/kibana/pull/241231","mergeCommit":{"message":"[Console] Fix code scanning alert (#241231)\n\nFixes https://github.com/elastic/kibana/security/code-scanning/620\n\n## Summary\nThis was already addressed in\nhttps://github.com/elastic/kibana/pull/237599 but we had the alert\nagain. For trying to fix it, I re-build the url with the validated\nprotocol and hostname. Also, I updated the tests so it validates the\nhref, the previous implementation was returning true for all URLs.\n\n### How to test:\n\nTry loading the following URL (making the necessary replacement in the\nURL) and verify that the data is correctly loaded into the editor and\nvalue can be edited:\n\n\n`http://localhost:5601/<REPLACE-THIS>/app/dev_tools#/console?load_from=data:text/plain,AoeQygKgBA9A+gRwK4FMBOBPGBDAzhgOwGMB+AEzQHsAHOApAGwbiMoaQFsDcAoAbx5QoAImToMwgFwiAZgCVKAWShoUHSgBcUAWgBUkgJYEyKAB4pcwgDSCRDSkWwMUUkSgLXbwmQYZa0rgJCQsIARpRsgbbBIhxIuBquANoAujYxIT5+6Mlp0cHCuAAWlIxkuekZwnEJdJq5+QC+ts2NQA`\n\n\n\n`http://localhost:5601/<REPLACE-THIS>/app/dev_tools#/console?load_from=https://www.elastic.co/guide/en/elasticsearch/reference/current/snippets/86.console`","sha":"56e1585269cc92deefb6596991db4519643a68e2"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","9.1","9.2"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241231","number":241231,"mergeCommit":{"message":"[Console] Fix code scanning alert (#241231)\n\nFixes https://github.com/elastic/kibana/security/code-scanning/620\n\n## Summary\nThis was already addressed in\nhttps://github.com/elastic/kibana/pull/237599 but we had the alert\nagain. For trying to fix it, I re-build the url with the validated\nprotocol and hostname. Also, I updated the tests so it validates the\nhref, the previous implementation was returning true for all URLs.\n\n### How to test:\n\nTry loading the following URL (making the necessary replacement in the\nURL) and verify that the data is correctly loaded into the editor and\nvalue can be edited:\n\n\n`http://localhost:5601/<REPLACE-THIS>/app/dev_tools#/console?load_from=data:text/plain,AoeQygKgBA9A+gRwK4FMBOBPGBDAzhgOwGMB+AEzQHsAHOApAGwbiMoaQFsDcAoAbx5QoAImToMwgFwiAZgCVKAWShoUHSgBcUAWgBUkgJYEyKAB4pcwgDSCRDSkWwMUUkSgLXbwmQYZa0rgJCQsIARpRsgbbBIhxIuBquANoAujYxIT5+6Mlp0cHCuAAWlIxkuekZwnEJdJq5+QC+ts2NQA`\n\n\n\n`http://localhost:5601/<REPLACE-THIS>/app/dev_tools#/console?load_from=https://www.elastic.co/guide/en/elasticsearch/reference/current/snippets/86.console`","sha":"56e1585269cc92deefb6596991db4519643a68e2"}},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->