### PR TITLE
Fix the responsive issue for playground page

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/public/components/chat.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/chat.tsx
@@ -136,9 +136,9 @@ export const Chat = () => {
             css={{
               paddingTop: euiTheme.size.l,
               paddingBottom: euiTheme.size.l,
-              // don't allow the chat to shrink below 66.6% of the screen
+              // don't allow the chat to shrink below 700px
               flexBasis: 0,
-              minWidth: '66.6%',
+              minWidth: 700,
             }}
           >
             <EuiFlexGroup direction="column" className="eui-fullHeight">


### PR DESCRIPTION
## Summary

The playground page isn’t responsive when the window is resized. This PR fixes the issue by setting a minimum width for the playground body section.

### Before

<img width="934" height="834" alt="Screenshot 2025-10-30 at 1 14 19 PM" src="https://github.com/user-attachments/assets/e54890c5-87cc-4b97-8d52-6c89927a3c4b" />


### After

https://github.com/user-attachments/assets/c501ed7f-9bbd-47fe-a920-5b5b4875dffc


https://github.com/user-attachments/assets/fa9557f8-41c3-4728-9f86-18939ac9f0ce





### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



