### PR TITLE
[dashboard] fix dashboard references lost when dashboard updated from listing page

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
@@ -38,11 +38,9 @@ export const updateDashboardMeta = async ({
   await contentManagementService.client.update<DashboardUpdateIn, DashboardUpdateOut>({
     contentTypeId: DASHBOARD_CONTENT_ID,
     id,
-    data: { ...dashboard.attributes, title, description, tags },
+    data: { title, description, tags },
     options: {
       references: dashboard.references,
-      /** perform a "full" update instead, where the provided attributes will fully replace the existing ones */
-      mergeAttributes: false,
     },
   });
 

--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
@@ -39,7 +39,11 @@ export const updateDashboardMeta = async ({
     contentTypeId: DASHBOARD_CONTENT_ID,
     id,
     data: { ...dashboard.attributes, title, description, tags },
-    options: { references: dashboard.references },
+    options: {
+      references: dashboard.references,
+      /** perform a "full" update instead, where the provided attributes will fully replace the existing ones */
+      mergeAttributes: false,
+    },
   });
 
   getDashboardContentManagementCache().deleteDashboard(id);

--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
@@ -38,8 +38,8 @@ export const updateDashboardMeta = async ({
   await contentManagementService.client.update<DashboardUpdateIn, DashboardUpdateOut>({
     contentTypeId: DASHBOARD_CONTENT_ID,
     id,
-    data: { title, description, tags },
-    options: { references: [] },
+    data: { ...dashboard.attributes, title, description, tags },
+    options: { references: dashboard.references },
   });
 
   getDashboardContentManagementCache().deleteDashboard(id);

--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
@@ -35,8 +35,6 @@ export const updateDashboardMeta = async ({
     return;
   }
 
-  console.log('dashboard', dashboard);
-
   await contentManagementService.client.update<DashboardUpdateIn, DashboardUpdateOut>({
     contentTypeId: DASHBOARD_CONTENT_ID,
     id,

--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
@@ -35,12 +35,16 @@ export const updateDashboardMeta = async ({
     return;
   }
 
+  console.log('dashboard', dashboard);
+
   await contentManagementService.client.update<DashboardUpdateIn, DashboardUpdateOut>({
     contentTypeId: DASHBOARD_CONTENT_ID,
     id,
-    data: { title, description, tags },
+    data: { ...dashboard.attributes, title, description, tags },
     options: {
       references: dashboard.references,
+      /** perform a "full" update instead, where the provided attributes will fully replace the existing ones */
+      mergeAttributes: false,
     },
   });
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/241350

`update` endpoint does not support partial updates. This PR is as small as possible to resolve the regression by passing full state when updating dashboard state from listing page. Other `update` endpoint issues can be tracked in https://github.com/elastic/kibana/issues/241380.