### PR TITLE
Expose an optional 'headers' prop for generic es steps

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/common/elasticsearch_request_builder.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/elasticsearch_request_builder.ts
@@ -21,16 +21,18 @@ export function buildRequestFromConnector(
   path: string;
   body?: Record<string, unknown>;
   params?: Record<string, string>;
+  headers?: Record<string, string>;
 } {
   // console.log('DEBUG - Input params:', JSON.stringify(params, null, 2));
 
   // Special case: elasticsearch.request type uses raw API format at top level
   if (stepType === 'elasticsearch.request') {
-    const { method = 'GET', path, body } = params;
+    const { method = 'GET', path, body, headers } = params;
     return {
       method: method as string,
       path: path as string,
       body: body as Record<string, unknown>,
+      headers: headers as Record<string, string> | undefined,
     };
   }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/elasticsearch_action_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/elasticsearch_action_step.ts
@@ -102,8 +102,8 @@ export class ElasticsearchActionStepImpl extends BaseAtomicNodeImplementation<El
       return esClient.transport.request({ method, path, body });
     } else if (stepType === 'elasticsearch.request') {
       // Special case: elasticsearch.request type uses raw API format at top level
-      const { method = 'GET', path, body } = params;
-      return esClient.transport.request({ method, path, body });
+      const { method = 'GET', path, body, headers } = params;
+      return esClient.transport.request({ method, path, body }, headers ? { headers } : {});
     } else {
       // Use generated connector definitions to determine method and path (covers all 568+ ES APIs)
       const {

--- a/src/platform/plugins/shared/workflows_management/common/schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/schema.ts
@@ -646,6 +646,7 @@ const staticConnectors: ConnectorContractUnion[] = [
       path: z.string(),
       body: z.any().optional(),
       params: z.any().optional(),
+      headers: z.any().optional(),
     }),
     outputSchema: z.any(),
     description: i18n.translate('workflows.connectors.elasticsearch.request.description', {


### PR DESCRIPTION
## Summary

Without this, a step like:
```
      - name: rerank
        type: elasticsearch.request
        with:
          method: "POST"
          path: "_inference/rerank/my-rerank-model"
          headers:
            content-type: application/json
          body: |
           {
            "query": "{{ inputs.originalQuestion }}",
            "input": {{ steps.formup.output | json_parse }}
           }
```

Was resulting in errors like:
```
{"error":"Content-Type header [text/plain] is not supported","status":406}
```

<img width="1388" height="732" alt="Screenshot 2025-10-30 at 3 34 24 PM" src="https://github.com/user-attachments/assets/b35efba4-65ce-4cef-ab89-1ecffd105c15" />


This PR adds support for a headers prop so that you can pass JSON as a string to the `body` prop like this 🤞 


