### PR TITLE
[Context Security]  Fix Agent-Based Failing to produce data 

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_setup.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_setup.tsx
@@ -151,7 +151,9 @@ const CloudIntegrationSetup = memo<CloudIntegrationSetupProps>(
         <ProviderSelector
           selectedProvider={selectedProvider}
           setSelectedProvider={(provider) => {
-            const showCloudConnectors = isCloudConnectorsEnabledForProvider(provider);
+            const showCloudConnectors =
+              isCloudConnectorsEnabledForProvider(provider) &&
+              setupTechnology === SetupTechnology.AGENTLESS;
             setEnabledPolicyInput(provider, showCloudConnectors);
           }}
           disabled={isEditPage}
@@ -247,19 +249,26 @@ const CloudIntegrationSetup = memo<CloudIntegrationSetupProps>(
               useDescribedFormGroup={false}
               onSetupTechnologyChange={(value) => {
                 updateSetupTechnology(value);
-                const showCloudConnectors = isCloudConnectorsEnabledForProvider(selectedProvider);
+                const showCloudConnectors =
+                  isCloudConnectorsEnabledForProvider(selectedProvider) &&
+                  value === SetupTechnology.AGENTLESS;
                 updatePolicy({
-                  updatedPolicy: updatePolicyWithInputs(
-                    newPolicy,
-                    config.providers[selectedProvider].type,
-                    getDefaultCloudCredentialsType(
-                      value === SetupTechnology.AGENTLESS,
-                      selectedProvider,
-                      packageInfo,
-                      showCloudConnectors,
-                      templateName
-                    )
-                  ),
+                  updatedPolicy: {
+                    ...updatePolicyWithInputs(
+                      newPolicy,
+                      config.providers[selectedProvider].type,
+                      getDefaultCloudCredentialsType(
+                        value === SetupTechnology.AGENTLESS,
+                        selectedProvider,
+                        packageInfo,
+                        showCloudConnectors,
+                        templateName
+                      )
+                    ),
+                    supports_cloud_connector:
+                      showCloudConnectors && value === SetupTechnology.AGENTLESS,
+                    cloud_connector_id: undefined,
+                  },
                 });
               }}
             />

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.test.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.test.ts
@@ -14,10 +14,15 @@ import {
   getCloudShellDefaultValue,
   findVariableDef,
   getDefaultAwsCredentialsType,
+  getDefaultAwsCredentialConfig,
   getDefaultAzureCredentialsConfig,
   getDefaultGcpHiddenVars,
 } from './utils';
 import { AWS_PROVIDER } from './constants';
+import {
+  CLOUD_FORMATION_TEMPLATE_URL_CLOUD_CONNECTORS,
+  ARM_TEMPLATE_URL_CLOUD_CONNECTORS,
+} from './cloud_connector/constants';
 
 // Internal test mocks
 const TEMPLATE_NAME = 'cspm';
@@ -341,8 +346,150 @@ describe('getDefaultAwsCredentialsType', () => {
     const result = getDefaultAwsCredentialsType(packageInfo, false, TEMPLATE_NAME, setupTechnology);
     expect(result).toBe('cloud_formation');
   });
+
+  it('should return "cloud_connectors" for agentless, when cloud connectors template is available and showCloudConnectors is true', () => {
+    const setupTechnology = SetupTechnology.AGENTLESS;
+    packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: CLOUD_FORMATION_TEMPLATE_URL_CLOUD_CONNECTORS,
+                  default: 'http://example.com/cloud_formation_cloud_connectors_template',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+
+    const result = getDefaultAwsCredentialsType(packageInfo, true, TEMPLATE_NAME, setupTechnology);
+
+    expect(result).toBe('cloud_connectors');
+  });
 });
 
+describe('getDefaultAwsCredentialsConfig', () => {
+  it('should return "cloud_connectors" for agentless, when cloud connectors template is available and showCloudConnectors is true', () => {
+    const packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: CLOUD_FORMATION_TEMPLATE_URL_CLOUD_CONNECTORS,
+                  default: 'http://example.com/cloud_formation_cloud_connectors_template',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+    const result = getDefaultAwsCredentialConfig({
+      packageInfo,
+      templateName: TEMPLATE_NAME,
+      isAgentless: true,
+      showCloudConnectors: true,
+    });
+
+    expect(result['aws.credentials.type'].value).toBe('cloud_connectors');
+    expect(result['aws.supports_cloud_connectors'].value).toBe(true);
+  });
+
+  it('should return "cloud_formation" for agent-based, when cloud formation template is available', () => {
+    const packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: 'cloud_formation_template',
+                  default: 'http://example.com/cloud_formation_template',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+    const result = getDefaultAwsCredentialConfig({
+      packageInfo,
+      templateName: TEMPLATE_NAME,
+      isAgentless: false,
+      showCloudConnectors: false,
+    });
+
+    expect(result['aws.credentials.type'].value).toBe('cloud_formation');
+    expect(result['aws.supports_cloud_connectors'].value).toBe(false);
+  });
+
+  it('should return "assume_role" for agent-based, when cloud formation template is not available', () => {
+    const packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: 'cloud_shell',
+                  default: 'http://example.com/cloud_shell',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+    const result = getDefaultAwsCredentialConfig({
+      packageInfo,
+      templateName: TEMPLATE_NAME,
+      isAgentless: false,
+      showCloudConnectors: false,
+    });
+
+    expect(result['aws.credentials.type'].value).toBe('assume_role');
+    expect(result['aws.supports_cloud_connectors'].value).toBe(false);
+  });
+
+  it('should return "cloud_formation" for agent-based even with showCloudConnectors true, when cloud formation template is available', () => {
+    const packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: 'cloud_formation_template',
+                  default: 'http://example.com/cloud_formation_template',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+    const result = getDefaultAwsCredentialConfig({
+      packageInfo,
+      templateName: TEMPLATE_NAME,
+      isAgentless: false,
+      showCloudConnectors: true,
+    });
+
+    expect(result['aws.credentials.type'].value).toBe('cloud_formation');
+    expect(result['aws.supports_cloud_connectors'].value).toBe(true);
+  });
+});
 describe('getDefaultAzureCredentialsConfig', () => {
   let packageInfo: PackageInfo;
 
@@ -399,6 +546,56 @@ describe('getDefaultAzureCredentialsConfig', () => {
     const result = getDefaultAzureCredentialsConfig(packageInfo, TEMPLATE_NAME, false, false);
 
     expect(result['azure.credentials.type'].value).toBe('managed_identity');
+  });
+
+  it('should return "cloud_connectors" for agentless, when cloud connectors template is available and showCloudConnectors is true', () => {
+    packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: ARM_TEMPLATE_URL_CLOUD_CONNECTORS,
+                  default: 'http://example.com/arm_template_cloud_connectors_url',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+
+    const result = getDefaultAzureCredentialsConfig(packageInfo, TEMPLATE_NAME, true, true);
+
+    expect(result['azure.credentials.type'].value).toBe('cloud_connectors');
+    expect(result['azure.supports_cloud_connectors'].value).toBe(true);
+  });
+
+  it('should return "arm_template" for agent-based even with showCloudConnectors true, when arm_template is available', () => {
+    packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: 'arm_template_url',
+                  default: 'http://example.com/arm_template_url',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+
+    const result = getDefaultAzureCredentialsConfig(packageInfo, TEMPLATE_NAME, false, true);
+
+    expect(result['azure.credentials.type'].value).toBe('arm_template');
+    expect(result['azure.supports_cloud_connectors'].value).toBe(true);
   });
 });
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.test.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.test.ts
@@ -14,7 +14,7 @@ import {
   getCloudShellDefaultValue,
   findVariableDef,
   getDefaultAwsCredentialsType,
-  getDefaultAzureCredentialsType,
+  getDefaultAzureCredentialsConfig,
   getDefaultGcpHiddenVars,
 } from './utils';
 import { AWS_PROVIDER } from './constants';
@@ -325,7 +325,12 @@ describe('getDefaultAwsCredentialsType', () => {
       ],
     } as PackageInfo;
 
-    const result = getDefaultAwsCredentialsType({} as PackageInfo, false, setupTechnology);
+    const result = getDefaultAwsCredentialsType(
+      {} as PackageInfo,
+      false,
+      TEMPLATE_NAME,
+      setupTechnology
+    );
 
     expect(result).toBe('assume_role');
   });
@@ -338,7 +343,7 @@ describe('getDefaultAwsCredentialsType', () => {
   });
 });
 
-describe('getDefaultAzureCredentialsType', () => {
+describe('getDefaultAzureCredentialsConfig', () => {
   let packageInfo: PackageInfo;
 
   beforeEach(() => {
@@ -362,31 +367,18 @@ describe('getDefaultAzureCredentialsType', () => {
   });
 
   it('should return "service_principal_with_client_secret" for agentless', () => {
-    const setupTechnology = SetupTechnology.AGENTLESS;
-    const result = getDefaultAzureCredentialsType(
-      packageInfo,
-      TEMPLATE_NAME,
-      setupTechnology,
-      false
-    );
+    const result = getDefaultAzureCredentialsConfig(packageInfo, TEMPLATE_NAME, true, false);
 
     expect(result['azure.credentials.type'].value).toBe('service_principal_with_client_secret');
   });
 
   it('should return "arm_template" for agent-based, when arm_template is available', () => {
-    const setupTechnology = SetupTechnology.AGENT_BASED;
-    const result = getDefaultAzureCredentialsType(
-      packageInfo,
-      TEMPLATE_NAME,
-      setupTechnology,
-      false
-    );
+    const result = getDefaultAzureCredentialsConfig(packageInfo, TEMPLATE_NAME, false, false);
 
     expect(result['azure.credentials.type'].value).toBe('arm_template');
   });
 
   it('should return "managed_identity" for agent-based, when arm_template is not available', () => {
-    const setupTechnology = SetupTechnology.AGENT_BASED;
     packageInfo = {
       policy_templates: [
         {
@@ -404,13 +396,7 @@ describe('getDefaultAzureCredentialsType', () => {
         },
       ],
     } as PackageInfo;
-
-    const result = getDefaultAzureCredentialsType(
-      packageInfo,
-      TEMPLATE_NAME,
-      setupTechnology,
-      false
-    );
+    const result = getDefaultAzureCredentialsConfig(packageInfo, TEMPLATE_NAME, false, false);
 
     expect(result['azure.credentials.type'].value).toBe('managed_identity');
   });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.ts
@@ -241,7 +241,7 @@ export const getDefaultCloudCredentialsType = (
         type: 'text',
       },
     },
-    azure: getDefaultAzureCredentialConfig(
+    azure: getDefaultAzureCredentialsConfig(
       packageInfo,
       templateName,
       isAgentless,

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.ts
@@ -202,12 +202,10 @@ const getDefaultAwsCredentialConfig = ({
       value: credentialsType,
       type: 'text',
     },
-    ...(showCloudConnectors && {
-      'aws.supports_cloud_connectors': {
-        value: showCloudConnectors,
-        type: 'bool',
-      },
-    }),
+    'aws.supports_cloud_connectors': {
+      value: showCloudConnectors,
+      type: 'bool',
+    },
   };
 
   return config;
@@ -243,14 +241,12 @@ export const getDefaultCloudCredentialsType = (
         type: 'text',
       },
     },
-    azure: {
-      'azure.credentials.type': {
-        value: isAgentless
-          ? AZURE_CREDENTIALS_TYPE.SERVICE_PRINCIPAL_WITH_CLIENT_SECRET
-          : AZURE_CREDENTIALS_TYPE.ARM_TEMPLATE,
-        type: 'text',
-      },
-    },
+    azure: getDefaultAzureCredentialConfig(
+      packageInfo,
+      templateName,
+      isAgentless,
+      showCloudConnectors
+    ),
   };
 
   return credentialsTypes[provider];
@@ -376,10 +372,10 @@ export const getInputHiddenVars = (
         templateName,
       });
     case AZURE_PROVIDER:
-      return getDefaultAzureCredentialsType(
+      return getDefaultAzureCredentialsConfig(
         packageInfo,
         templateName,
-        setupTechnology,
+        setupTechnology === SetupTechnology.AGENTLESS,
         showCloudConnectors
       );
     case GCP_PROVIDER:
@@ -433,10 +429,10 @@ export const getArmTemplateUrlFromPackage = (
   return armTemplateUrl;
 };
 
-export const getDefaultAzureCredentialsType = (
+export const getDefaultAzureCredentialsConfig = (
   packageInfo: PackageInfo,
   templateName: string,
-  setupTechnology: SetupTechnology,
+  isAgentless: boolean,
   showCloudConnectors: boolean
 ): {
   [key: string]: {
@@ -444,7 +440,6 @@ export const getDefaultAzureCredentialsType = (
     type: 'text' | 'bool';
   };
 } => {
-  const isAgentless = setupTechnology === SetupTechnology.AGENTLESS;
   const hasArmTemplateUrl = !!getArmTemplateUrlFromPackage(packageInfo, templateName);
 
   let credentialType: AzureCredentialsType = AZURE_CREDENTIALS_TYPE.MANAGED_IDENTITY;
@@ -467,12 +462,10 @@ export const getDefaultAzureCredentialsType = (
       value: credentialType,
       type: 'text',
     },
-    ...(showCloudConnectors && {
-      'azure.supports_cloud_connectors': {
-        value: showCloudConnectors,
-        type: 'bool',
-      },
-    }),
+    'azure.supports_cloud_connectors': {
+      value: showCloudConnectors,
+      type: 'bool',
+    },
   };
 
   return config;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.ts
@@ -170,7 +170,7 @@ export const getCloudFormationDefaultValue = (
   return cloudFormationTemplate;
 };
 
-const getDefaultAwsCredentialConfig = ({
+export const getDefaultAwsCredentialConfig = ({
   isAgentless,
   showCloudConnectors,
   packageInfo,


### PR DESCRIPTION
## Summary
In `9.2.0` AWS ECH environment, we introduce a regression when enabled the Advanced Settings  by default `EnabledCloudConnector:true`  and if the user switches from `Agentless` to `Agentbased`.  This results in CSPM and Asset Inventory unable to ingest data.

**Root Cause:**
1. **Enabled by default in Cloud Connector**
<img width="720" height="244" alt="image" src="https://github.com/user-attachments/assets/1cab451b-c568-4a89-b61f-8c88fd0f01b3" />

2. Selecting `Agent-based` updates Package policy api contract still persists `aws.supports_cloud_connectors`

```
streams": {
        "cloud_security_posture.findings": {
          "enabled": true,
          "vars": {
            "aws.credentials.type": "cloud_connectors",
            "aws.account_type": "single-account",
            "aws.supports_cloud_connectors": true
          }
        }
      }
```

3. This results in cloudbeat error logs and  CSPM/Asset Inventory fails to produce Findings and Asset data

**Solution Fix**
1.  Change the default setting` showCloudConnectors` to include `isAgentless` flag
 ```const showCloudConnectors =
                  isCloudConnectorsEnabledForProvider(selectedProvider) &&
                  value === SetupTechnology.AGENTLESS;
  ```
                  
  2.  Update `aws.supports_cloud_connectors: showCloudConnectors` || `azure.supports_cloud_connectors: showCloudConnectors` 
  
https://github.com/user-attachments/assets/25d54857-cf52-43f0-85e5-291f50c037a0




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->