### PR TITLE
[ES|QL] Fixes the autocomplete of timeseries sources after comma

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/timeseries/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/timeseries/autocomplete.test.ts
@@ -81,6 +81,13 @@ describe('TS Autocomplete', () => {
       ]);
     });
 
+    test('can suggest timeseries after one already selected', async () => {
+      const suggestions = await suggest('TS timeseries_index,  ');
+      const labels = suggestions.map((s) => s.label);
+
+      expect(labels).toEqual(['timeseries_index_with_alias', 'time_series_index']);
+    });
+
     test('discriminates between indices and aliases', async () => {
       const suggestions = await suggest('TS ');
       const indices: string[] = suggestions

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/timeseries/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/timeseries/autocomplete.ts
@@ -74,13 +74,14 @@ export async function autocomplete(
   // TS something/
   // TS something, /
   else if (indexes.length) {
-    const sources = context?.sources ?? [];
+    const timeSeriesSources =
+      context?.timeSeriesSources?.map(({ name }) => ({ name, hidden: false })) ?? [];
     const recommendedQuerySuggestions = await getRecommendedQueriesSuggestions(
       context?.editorExtensions ?? { recommendedFields: [], recommendedQueries: [] }
     );
     const additionalSuggestions = await additionalSourcesSuggestions(
       innerText,
-      sources,
+      timeSeriesSources,
       indexes.map(({ name }) => name),
       recommendedQuerySuggestions
     );


### PR DESCRIPTION
## Summary

Fixes the suggestions of timeseries (instead of all indices) in TS command after one selected

<img width="580" height="145" alt="image" src="https://github.com/user-attachments/assets/0964262d-b0f7-43b9-93c5-18cec644bd96" />


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->