### PR TITLE
[Background search] Return error state when there are no searches

### DIFF
--- a/src/platform/plugins/shared/data/server/search/session/mocks.ts
+++ b/src/platform/plugins/shared/data/server/search/session/mocks.ts
@@ -10,6 +10,7 @@
 import moment from 'moment';
 import type { IScopedSearchSessionsClient } from './types';
 import type { SearchSessionsConfigSchema } from '../../config';
+import type { SearchSessionSavedObjectAttributes } from '../../../common';
 
 export function createSearchSessionsClientMock(): jest.Mocked<IScopedSearchSessionsClient> {
   return {
@@ -32,4 +33,17 @@ export function createSearchSessionsClientMock(): jest.Mocked<IScopedSearchSessi
         } as unknown as SearchSessionsConfigSchema)
     ),
   };
+}
+
+export function createSearchSessionSavedObjectAttributesMock(
+  overrides: Partial<SearchSessionSavedObjectAttributes> = {}
+) {
+  return {
+    sessionId: '1234',
+    created: moment().toISOString(),
+    expires: moment().add(7, 'days').toISOString(),
+    idMapping: {},
+    version: '9.2.0',
+    ...overrides,
+  } as SearchSessionSavedObjectAttributes;
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/240887

Right now if a background search has 0 searches it stays in the "In progress" state but that's not correct. If no searches are added to the background search it means that something went wrong. With this PR we will label as error the search sessions if they have 0 searches after being created for 30 seconds.

| Before | After |
|--------|------|
| <img width="716" height="89" alt="image" src="https://github.com/user-attachments/assets/1bb4b60a-20d3-488e-b4e9-9fd8cd4d0b24" /> | <img width="675" height="88" alt="image" src="https://github.com/user-attachments/assets/4befb6c0-5edb-4229-9919-e2b76ae90731" /> |


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->