### PR TITLE
[9.2] [ES|QL] Fixes the autocomplete of timeseries sources after comma (#241402)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/timeseries/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/timeseries/autocomplete.test.ts
@@ -66,6 +66,13 @@ describe('TS Autocomplete', () => {
       ]);
     });
 
+    test('can suggest timeseries after one already selected', async () => {
+      const suggestions = await suggest('TS timeseries_index,  ');
+      const labels = suggestions.map((s) => s.label);
+
+      expect(labels).toEqual(['timeseries_index_with_alias', 'time_series_index']);
+    });
+
     test('discriminates between indices and aliases', async () => {
       const suggestions = await suggest('TS ');
       const indices: string[] = suggestions

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/timeseries/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/timeseries/autocomplete.ts
@@ -68,10 +68,12 @@ export async function autocomplete(
   // TS something/
   // TS something, /
   else if (indexes.length) {
-    const sources = context?.sources ?? [];
+    const timeSeriesSources =
+      context?.timeSeriesSources?.map(({ name }) => ({ name, hidden: false })) ?? [];
+
     const additionalSuggestions = await additionalSourcesSuggestions(
       innerText,
-      sources,
+      timeSeriesSources,
       indexes.map(({ name }) => name),
       []
     );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ES|QL] Fixes the autocomplete of timeseries sources after comma (#241402)](https://github.com/elastic/kibana/pull/241402)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratou","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2025-10-31T10:29:08Z","message":"[ES|QL] Fixes the autocomplete of timeseries sources after comma (#241402)\n\n## Summary\n\nFixes the suggestions of timeseries (instead of all indices) in TS\ncommand after one selected\n\n<img width=\"580\" height=\"145\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0964262d-b0f7-43b9-93c5-18cec644bd96\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"3c9fadb499cb1c765d6823d25deaaf530b49ac14","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:ES|QL","Team:ESQL","backport:version","v9.3.0","v9.2.1"],"title":"[ES|QL] Fixes the autocomplete of timeseries sources after comma","number":241402,"url":"https://github.com/elastic/kibana/pull/241402","mergeCommit":{"message":"[ES|QL] Fixes the autocomplete of timeseries sources after comma (#241402)\n\n## Summary\n\nFixes the suggestions of timeseries (instead of all indices) in TS\ncommand after one selected\n\n<img width=\"580\" height=\"145\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0964262d-b0f7-43b9-93c5-18cec644bd96\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"3c9fadb499cb1c765d6823d25deaaf530b49ac14"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241402","number":241402,"mergeCommit":{"message":"[ES|QL] Fixes the autocomplete of timeseries sources after comma (#241402)\n\n## Summary\n\nFixes the suggestions of timeseries (instead of all indices) in TS\ncommand after one selected\n\n<img width=\"580\" height=\"145\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0964262d-b0f7-43b9-93c5-18cec644bd96\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"3c9fadb499cb1c765d6823d25deaaf530b49ac14"}},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->