### PR TITLE
[ES|QL] Add subqueries support for walker and visitor

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/contexts.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/contexts.ts
@@ -35,6 +35,7 @@ import type {
   ESQLMap,
   ESQLMapEntry,
   ESQLOrderExpression,
+  ESQLParens,
   ESQLSource,
   ESQLStringLiteral,
 } from '../types';
@@ -723,5 +724,22 @@ export class MapEntryExpressionVisitorContext<
     this.ctx.assertMethodExists('visitExpression');
 
     return this.visitExpression(this.value(), input as any);
+  }
+}
+
+export class ParensExpressionVisitorContext<
+  Methods extends VisitorMethods = VisitorMethods,
+  Data extends SharedData = SharedData
+> extends VisitorContext<Methods, Data, ESQLParens> {
+  public child(): ESQLAstExpression {
+    return this.node.child;
+  }
+
+  public visitChild(
+    input: VisitorInput<Methods, 'visitExpression'>
+  ): VisitorOutput<Methods, 'visitExpression'> {
+    this.ctx.assertMethodExists('visitExpression');
+
+    return this.visitExpression(this.child(), input as any);
   }
 }

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/global_visitor_context.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/global_visitor_context.ts
@@ -25,6 +25,7 @@ import type {
   ESQLMap,
   ESQLMapEntry,
   ESQLOrderExpression,
+  ESQLParens,
   ESQLSource,
 } from '../types';
 import type * as types from './types';
@@ -543,6 +544,10 @@ export class GlobalVisitorContext<
         if (!this.methods.visitQuery || expressionNode.type !== 'query') break;
         return this.visitQuery(parent, expressionNode, input as any);
       }
+      case 'parens': {
+        if (!this.methods.visitParensExpression) break;
+        return this.visitParensExpression(parent, expressionNode, input as any);
+      }
     }
     return this.visitExpressionGeneric(parent, expressionNode, input as any);
   }
@@ -644,6 +649,15 @@ export class GlobalVisitorContext<
   ): types.VisitorOutput<Methods, 'visitMapEntryExpression'> {
     const context = new contexts.MapEntryExpressionVisitorContext(this, node, parent);
     return this.visitWithSpecificContext('visitMapEntryExpression', context, input);
+  }
+
+  public visitParensExpression(
+    parent: contexts.VisitorContext | null,
+    node: ESQLParens,
+    input: types.VisitorInput<Methods, 'visitParensExpression'>
+  ): types.VisitorOutput<Methods, 'visitParensExpression'> {
+    const context = new contexts.ParensExpressionVisitorContext(this, node, parent);
+    return this.visitWithSpecificContext('visitParensExpression', context, input);
   }
 }
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/types.ts
@@ -63,7 +63,8 @@ export type ExpressionVisitorInput<Methods extends VisitorMethods> = AnyToVoid<
       VisitorInput<Methods, 'visitOrderExpression'> &
       VisitorInput<Methods, 'visitIdentifierExpression'> &
       VisitorInput<Methods, 'visitMapExpression'> &
-      VisitorInput<Methods, 'visitMapEntryExpression'>
+      VisitorInput<Methods, 'visitMapEntryExpression'> &
+      VisitorInput<Methods, 'visitParensExpression'>
 >;
 
 /**
@@ -81,7 +82,8 @@ export type ExpressionVisitorOutput<Methods extends VisitorMethods> =
   | VisitorOutput<Methods, 'visitOrderExpression'>
   | VisitorOutput<Methods, 'visitIdentifierExpression'>
   | VisitorOutput<Methods, 'visitMapExpression'>
-  | VisitorOutput<Methods, 'visitMapEntryExpression'>;
+  | VisitorOutput<Methods, 'visitMapEntryExpression'>
+  | VisitorOutput<Methods, 'visitParensExpression'>;
 
 /**
  * Input that satisfies any command visitor input constraints.
@@ -237,6 +239,11 @@ export interface VisitorMethods<
     any,
     any
   >;
+  visitParensExpression?: Visitor<
+    contexts.ParensExpressionVisitorContext<Visitors, Data>,
+    any,
+    any
+  >;
 }
 
 /**
@@ -268,6 +275,8 @@ export type AstNodeToVisitorName<Node extends VisitorAstNode> = Node extends ESQ
   ? 'visitMapExpression'
   : Node extends ast.ESQLMapEntry
   ? 'visitMapEntryExpression'
+  : Node extends ast.ESQLParens
+  ? 'visitParensExpression'
   : never;
 
 /**

--- a/src/platform/packages/shared/kbn-esql-ast/src/walker/walker.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/walker/walker.ts
@@ -90,6 +90,11 @@ export interface WalkerOptions {
     parent: types.ESQLProperNode | undefined,
     walker: WalkerVisitorApi
   ) => void;
+  visitParens?: (
+    node: types.ESQLParens,
+    parent: types.ESQLProperNode | undefined,
+    walker: WalkerVisitorApi
+  ) => void;
 
   /**
    * Called on every expression node.
@@ -703,6 +708,15 @@ export class Walker {
     }
   }
 
+  public walkParens(node: types.ESQLParens, parent: types.ESQLProperNode | undefined): void {
+    const { options } = this;
+    (options.visitParens ?? options.visitAny)?.(node, parent, this);
+
+    if (node.child) {
+      this.walkSingleAstItem(node.child, node);
+    }
+  }
+
   public walkQuery(
     node: types.ESQLAstQueryExpression,
     parent: types.ESQLProperNode | undefined
@@ -768,6 +782,10 @@ export class Walker {
       }
       case 'inlineCast': {
         this.walkInlineCast(node, parent);
+        break;
+      }
+      case 'parens': {
+        this.walkParens(node as types.ESQLParens, parent);
         break;
       }
       case 'identifier': {


### PR DESCRIPTION
## Summary
Part of https://github.com/elastic/kibana/issues/237401

Parens support for walker and visitor


