### PR TITLE
[9.0] [Obs AI Assistant] Fix bug with kibana tool when using a proxy (#236653)

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AxiosRequestConfig } from 'axios';
+import axios from 'axios';
+import { registerKibanaFunction } from './kibana';
+import type { FunctionRegistrationParameters } from '.';
+
+jest.mock('axios');
+const mockedAxios = jest.mocked(axios);
+
+function registerFunction(overrides: {
+  publicBaseUrl?: string;
+  requestUrl?: URL;
+  rewrittenUrl?: URL;
+  headers?: Record<string, string>;
+}) {
+  const logger = { info: jest.fn(), error: jest.fn() };
+  const coreStart = {
+    http: {
+      basePath: {
+        publicBaseUrl: overrides.publicBaseUrl ?? 'https://kibana.example.com:5601',
+        serverBasePath: '',
+        get: jest.fn(),
+      },
+    },
+  };
+
+  const resources = {
+    request: {
+      url:
+        overrides.requestUrl ??
+        new URL('https://source.example/internal/observability_ai_assistant/chat/complete'),
+      rewrittenUrl: overrides.rewrittenUrl,
+      headers: {
+        'content-type': 'application/json',
+        host: 'attacker.example',
+        origin: 'https://attacker.example',
+        ...(overrides.headers ?? {}),
+      },
+    },
+    logger,
+    plugins: {
+      core: {
+        start: jest.fn().mockResolvedValue(coreStart),
+      },
+    },
+  };
+
+  const functions = { registerFunction: jest.fn() };
+  registerKibanaFunction({ functions, resources } as unknown as FunctionRegistrationParameters);
+
+  return {
+    handler: functions.registerFunction.mock.calls[0][1],
+    coreStart,
+    resources,
+  };
+}
+
+describe('kibana tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAxios.mockResolvedValue({ data: { ok: true } });
+  });
+
+  it('forwards requests to the configured publicBaseUrl host only', async () => {
+    const { handler } = registerFunction({
+      headers: {
+        host: 'malicious-host:9200',
+        origin: 'https://malicious-host:9200',
+        'x-forwarded-host': 'another-host',
+      },
+    });
+
+    await handler({
+      arguments: {
+        method: 'GET',
+        pathname: '/api/saved_objects/_find',
+        query: { type: 'dashboard' },
+      },
+    });
+
+    const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
+    expect(forwardedRequest.url).toBe(
+      'https://kibana.example.com:5601/api/saved_objects/_find?type=dashboard'
+    );
+    expect(forwardedRequest.url).not.toContain('malicious-host');
+  });
+
+  it('builds the forwarded url using the space from the incoming request path', async () => {
+    const { handler } = registerFunction({
+      requestUrl: new URL(
+        'https://source.example/s/my-space/internal/observability_ai_assistant/chat/complete'
+      ),
+    });
+
+    await handler({
+      arguments: {
+        method: 'POST',
+        pathname: '/api/apm/agent_keys',
+        body: { foo: 'bar' },
+      },
+    });
+
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://kibana.example.com:5601/s/my-space/api/apm/agent_keys',
+        data: JSON.stringify({ foo: 'bar' }),
+      })
+    );
+  });
+
+  it('throws when server.publicBaseUrl is not configured', async () => {
+    const { handler, coreStart } = registerFunction({});
+    coreStart.http.basePath.publicBaseUrl = undefined as any;
+
+    await expect(
+      handler({
+        arguments: {
+          method: 'GET',
+          pathname: '/api/saved_objects/_find',
+          query: { type: 'dashboard' },
+        },
+      })
+    ).rejects.toThrow(
+      'Cannot invoke Kibana tool: "server.publicBaseUrl" must be configured in kibana.yml'
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.ts
@@ -6,9 +6,10 @@
  */
 
 import axios from 'axios';
-import { format, parse } from 'url';
-import { castArray, first, pick, pickBy } from 'lodash';
+import { format } from 'url';
+import { pickBy } from 'lodash';
 import type { KibanaRequest } from '@kbn/core/server';
+import { addSpaceIdToPath, getSpaceIdFromPath } from '@kbn/spaces-plugin/common';
 import type { FunctionRegistrationParameters } from '.';
 
 export function registerKibanaFunction({
@@ -47,23 +48,42 @@ export function registerKibanaFunction({
         required: ['method', 'pathname'] as const,
       },
     },
-    ({ arguments: { method, pathname, body, query } }, signal) => {
-      const { request } = resources;
+    async ({ arguments: { method, pathname, body, query } }, signal) => {
+      const { request, logger } = resources;
+      const requestUrl = request.rewrittenUrl || request.url;
+      const core = await resources.plugins.core.start();
 
-      const { protocol, host, pathname: pathnameFromRequest } = request.rewrittenUrl || request.url;
+      function getParsedPublicBaseUrl() {
+        const { publicBaseUrl } = core.http.basePath;
+        if (!publicBaseUrl) {
+          const errorMessage = `Cannot invoke Kibana tool: "server.publicBaseUrl" must be configured in kibana.yml`;
+          logger.error(errorMessage);
+          throw new Error(errorMessage);
+        }
+        const parsedBaseUrl = new URL(publicBaseUrl);
+        return parsedBaseUrl;
+      }
 
-      const origin = first(castArray(request.headers.origin));
+      function getPathnameWithSpaceId() {
+        const { serverBasePath } = core.http.basePath;
+        const { spaceId } = getSpaceIdFromPath(requestUrl.pathname, serverBasePath);
+        const pathnameWithSpaceId = addSpaceIdToPath(serverBasePath, spaceId, pathname);
+        return pathnameWithSpaceId;
+      }
 
+      const parsedPublicBaseUrl = getParsedPublicBaseUrl();
       const nextUrl = {
-        host,
-        protocol,
-        ...(origin ? pick(parse(origin), 'host', 'protocol') : {}),
-        pathname: pathnameFromRequest.replace(
-          '/internal/observability_ai_assistant/chat/complete',
-          pathname
-        ),
+        host: parsedPublicBaseUrl.host,
+        protocol: parsedPublicBaseUrl.protocol,
+        pathname: getPathnameWithSpaceId(),
         query: query ? (query as Record<string, string>) : undefined,
       };
+
+      logger.info(
+        `Calling Kibana API by forwarding request from "${requestUrl}" to: "${method} ${format(
+          nextUrl
+        )}"`
+      );
 
       const copiedHeaderNames = [
         'accept-encoding',
@@ -87,15 +107,19 @@ export function registerKibanaFunction({
         );
       });
 
-      return axios({
-        method,
-        headers,
-        url: format(nextUrl),
-        data: body ? JSON.stringify(body) : undefined,
-        signal,
-      }).then((response) => {
+      try {
+        const response = await axios({
+          method,
+          headers,
+          url: format(nextUrl),
+          data: body ? JSON.stringify(body) : undefined,
+          signal,
+        });
         return { content: response.data };
-      });
+      } catch (e) {
+        logger.error(`Error calling Kibana API: ${method} ${format(nextUrl)}. Failed with ${e}`);
+        throw e;
+      }
     }
   );
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Obs AI Assistant] Fix bug with kibana tool when using a proxy (#236653)](https://github.com/elastic/kibana/pull/236653)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Søren Louv-Jansen","email":"soren.louv@elastic.co"},"sourceCommit":{"committedDate":"2025-10-29T09:25:11Z","message":"[Obs AI Assistant] Fix bug with kibana tool when using a proxy (#236653)\n\nCloses https://github.com/elastic/kibana/issues/240349\n\nThis fixed issues around forwarding requests based on the origin header\nand `request.url`. Instead the kibana tool now uses the configured\n`server.publicBaseUrl`.\n\nNote: Setting `server.publicBaseUrl: \"http://localhost:5601\"` in\nkibana.yml is now required in order to use the kibana tool.\n\n**To reviewers:**\nPlease follow these steps to reproduce the problem:\nhttps://github.com/elastic/kibana/issues/240349\n\n---------\n\nCo-authored-by: Viduni Wickramarachchi <viduni.ushanka@gmail.com>","sha":"21404eab290159dfc0b95a6ff1e6e1d0a9b800a0","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","ci:build-cloud-image","ci:cloud-deploy","ci:build-serverless-image","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v9.3.0","v9.2.1"],"title":"[Obs AI Assistant] Fix bug with kibana tool when using a proxy","number":236653,"url":"https://github.com/elastic/kibana/pull/236653","mergeCommit":{"message":"[Obs AI Assistant] Fix bug with kibana tool when using a proxy (#236653)\n\nCloses https://github.com/elastic/kibana/issues/240349\n\nThis fixed issues around forwarding requests based on the origin header\nand `request.url`. Instead the kibana tool now uses the configured\n`server.publicBaseUrl`.\n\nNote: Setting `server.publicBaseUrl: \"http://localhost:5601\"` in\nkibana.yml is now required in order to use the kibana tool.\n\n**To reviewers:**\nPlease follow these steps to reproduce the problem:\nhttps://github.com/elastic/kibana/issues/240349\n\n---------\n\nCo-authored-by: Viduni Wickramarachchi <viduni.ushanka@gmail.com>","sha":"21404eab290159dfc0b95a6ff1e6e1d0a9b800a0"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236653","number":236653,"mergeCommit":{"message":"[Obs AI Assistant] Fix bug with kibana tool when using a proxy (#236653)\n\nCloses https://github.com/elastic/kibana/issues/240349\n\nThis fixed issues around forwarding requests based on the origin header\nand `request.url`. Instead the kibana tool now uses the configured\n`server.publicBaseUrl`.\n\nNote: Setting `server.publicBaseUrl: \"http://localhost:5601\"` in\nkibana.yml is now required in order to use the kibana tool.\n\n**To reviewers:**\nPlease follow these steps to reproduce the problem:\nhttps://github.com/elastic/kibana/issues/240349\n\n---------\n\nCo-authored-by: Viduni Wickramarachchi <viduni.ushanka@gmail.com>","sha":"21404eab290159dfc0b95a6ff1e6e1d0a9b800a0"}},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241088","number":241088,"state":"MERGED","mergeCommit":{"sha":"f31cf2e3384b77b4b39d5ec018317df7e1a94b0d","message":"[9.2] [Obs AI Assistant] Fix bug with kibana tool when using a proxy (#236653) (#241088)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Obs AI Assistant] Fix bug with kibana tool when using a proxy\n(#236653)](https://github.com/elastic/kibana/pull/236653)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Søren Louv-Jansen <soren.louv@elastic.co>\nCo-authored-by: Viduni Wickramarachchi <viduni.ushanka@gmail.com>"}}]}] BACKPORT-->